### PR TITLE
Endless Terminals Environment Integration

### DIFF
--- a/environments/__init__.py
+++ b/environments/__init__.py
@@ -13,6 +13,7 @@ Core layers:
 Concrete environments:
     - terminal_test_env/: Simple file-creation tasks for testing the stack
     - hermes_swe_env/: SWE-bench style tasks with Modal sandboxes
+    - endless_terminals/: Terminal tasks from HuggingFace dataset with Apptainer containers
 
 Benchmarks (eval-only):
     - benchmarks/terminalbench_2/: Terminal-Bench 2.0 evaluation

--- a/environments/endless_terminals/__init__.py
+++ b/environments/endless_terminals/__init__.py
@@ -1,0 +1,5 @@
+"""Endless Terminals Environment - Terminal task training from HuggingFace dataset."""
+
+from .endless_terminals_env import EndlessTerminalsEnv, EndlessTerminalsEnvConfig
+
+__all__ = ["EndlessTerminalsEnv", "EndlessTerminalsEnvConfig"]

--- a/environments/endless_terminals/default.yaml
+++ b/environments/endless_terminals/default.yaml
@@ -41,10 +41,11 @@ env:
   test_timeout_s: 60
 
   # Training configuration
-  group_size: 4
-  total_steps: 1000
-  steps_per_eval: 100
-  
+  group_size: 8
+  total_steps: 10000
+  steps_per_eval: 500
+  num_eval_tasks: 10
+
   # Logging
   use_wandb: true
   wandb_name: "endless-terminals"

--- a/environments/endless_terminals/default.yaml
+++ b/environments/endless_terminals/default.yaml
@@ -32,7 +32,7 @@ env:
 
   # Dataset settings
   use_dataset: true
-  dataset_name: "obiwan96/endless-terminals-train"
+  dataset_name: "obiwan96/endless-terminals"
   dataset_split: "train"
   dataset_cache_dir: "~/.cache/huggingface/datasets"
   tasks_base_dir: ""  # Set to directory containing task_* folders (e.g., ~/endless-terminals-data)
@@ -44,11 +44,7 @@ env:
   group_size: 4
   total_steps: 1000
   steps_per_eval: 100
-
-  # Tool call parsing (for Phase 2 VLLM training)
-  tool_call_parser: "hermes"
-  tokenizer_name: "NousResearch/Hermes-3-Llama-3.1-8B"
-
+  
   # Logging
   use_wandb: true
   wandb_name: "endless-terminals"
@@ -61,8 +57,10 @@ env:
     and verify your solution works correctly before finishing.
 
 openai:
-  base_url: "http://localhost:8000/v1"
-  model_name: "NousResearch/Hermes-3-Llama-3.1-8B"
+  base_url: "https://openrouter.ai/api/v1"
+  model_name: "anthropic/claude-sonnet-4.5"
   server_type: "openai"
-  api_key: ""
+  api_key: ""  # Loaded from OPENROUTER_API_KEY env var
   health_check: false
+  timeout: 30  # 30 second timeout per request
+  max_retries: 2  # Only retry twice

--- a/environments/endless_terminals/default.yaml
+++ b/environments/endless_terminals/default.yaml
@@ -1,0 +1,66 @@
+# Endless Terminals Environment -- Default Configuration
+#
+# Trains agents on terminal tasks from the Endless Terminals HuggingFace dataset.
+# Each task includes a pre-built Apptainer container and pytest-based verification.
+#
+# Dataset: https://huggingface.co/datasets/obiwan96/endless-terminals-train
+#
+# Prerequisites:
+#   1. Download dataset: huggingface-cli download obiwan96/endless-terminals-train \
+#        --repo-type dataset --local-dir ~/endless-terminals-data \
+#        --local-dir-use-symlinks False
+#   2. Install Apptainer/Singularity (for test execution)
+#   3. Set TASKS_BASE_DIR environment variable or configure tasks_base_dir below
+#
+# Usage:
+#   python environments/endless_terminals/endless_terminals_env.py process \
+#       --config environments/endless_terminals/default.yaml
+
+env:
+  # Toolsets
+  enabled_toolsets: ["terminal", "file"]
+
+  # Agent configuration
+  max_agent_turns: 32
+  max_token_length: 4096
+  agent_temperature: 1.0
+
+  # Terminal backend
+  terminal_backend: "local"  # Change to "modal" or "docker" for cloud isolation
+
+  # Dataset settings
+  use_dataset: true
+  dataset_name: "obiwan96/endless-terminals-train"
+  dataset_split: "train"
+  dataset_cache_dir: "~/.cache/huggingface/datasets"
+  tasks_base_dir: ""  # Set to directory containing task_* folders (e.g., ~/endless-terminals-data)
+
+  # Test execution
+  test_timeout_s: 60
+
+  # Training configuration
+  group_size: 4
+  total_steps: 1000
+  steps_per_eval: 100
+
+  # Tool call parsing (for Phase 2 VLLM training)
+  tool_call_parser: "hermes"
+  tokenizer_name: "NousResearch/Hermes-3-Llama-3.1-8B"
+
+  # Logging
+  use_wandb: true
+  wandb_name: "endless-terminals"
+
+  # System prompt
+  system_prompt: >
+    You are a skilled Linux system administrator and programmer.
+    You have access to a terminal and file tools to complete system administration
+    and programming tasks. Use the tools effectively to solve the given task,
+    and verify your solution works correctly before finishing.
+
+openai:
+  base_url: "http://localhost:8000/v1"
+  model_name: "NousResearch/Hermes-3-Llama-3.1-8B"
+  server_type: "openai"
+  api_key: ""
+  health_check: false

--- a/environments/endless_terminals/default.yaml
+++ b/environments/endless_terminals/default.yaml
@@ -1,7 +1,8 @@
 # Endless Terminals Environment -- Default Configuration
 #
 # Trains agents on terminal tasks from the Endless Terminals HuggingFace dataset.
-# Each task includes a pre-built Apptainer container and pytest-based verification.
+# Uses hermes-agent backends (modal/docker/local) with per-task Docker images.
+# Tests run in the same sandbox the agent used (no separate containers needed).
 #
 # Dataset: https://huggingface.co/datasets/obiwan96/endless-terminals-train
 #
@@ -9,8 +10,9 @@
 #   1. Download dataset: huggingface-cli download obiwan96/endless-terminals-train \
 #        --repo-type dataset --local-dir ~/endless-terminals-data \
 #        --local-dir-use-symlinks False
-#   2. Install Apptainer/Singularity (for test execution)
-#   3. Set TASKS_BASE_DIR environment variable or configure tasks_base_dir below
+#   2. Set TASKS_BASE_DIR environment variable or configure tasks_base_dir below
+#   3. For modal backend: Configure Modal CLI (modal token set)
+#   4. For docker backend: Install Docker
 #
 # Usage:
 #   python environments/endless_terminals/endless_terminals_env.py process \

--- a/environments/endless_terminals/default.yaml
+++ b/environments/endless_terminals/default.yaml
@@ -44,7 +44,9 @@ env:
   group_size: 8
   total_steps: 10000
   steps_per_eval: 500
+
   num_eval_tasks: 10
+  eval_split_ratio: 0.1
 
   # Logging
   use_wandb: true

--- a/environments/endless_terminals/endless_terminals_env.py
+++ b/environments/endless_terminals/endless_terminals_env.py
@@ -1,0 +1,257 @@
+"""
+Endless Terminals Environment for Hermes-Agent + Atropos RL.
+
+Loads pre-generated terminal tasks from HuggingFace dataset and scores
+agent performance using test execution in Apptainer containers.
+
+Dataset: https://huggingface.co/datasets/obiwan96/endless-terminals-train
+
+Run:
+  python environments/endless_terminals/endless_terminals_env.py process \
+    --config environments/endless_terminals/default.yaml
+"""
+
+import asyncio
+import os
+import random
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from pydantic import Field
+
+# Ensure hermes-agent root is on path
+_repo_root = Path(__file__).resolve().parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from atroposlib.envs.base import ScoredDataItem
+from atroposlib.type_definitions import Item
+
+from environments.hermes_base_env import HermesAgentBaseEnv, HermesAgentEnvConfig
+from environments.agent_loop import AgentResult
+from environments.tool_context import ToolContext
+
+# Add endless-terminals to path for imports
+ENDLESS_TERMINALS_PATH = os.getenv(
+    "ENDLESS_TERMINALS_PATH",
+    str(Path.home() / "Desktop" / "Projects" / "endless-terminals")
+)
+sys.path.insert(0, ENDLESS_TERMINALS_PATH)
+
+
+class EndlessTerminalsEnvConfig(HermesAgentEnvConfig):
+    """Configuration for Endless Terminals environment."""
+
+    # Dataset settings
+    use_dataset: bool = Field(
+        default=True,
+        description="Load tasks from HuggingFace dataset (recommended). If False, generate procedurally."
+    )
+    dataset_name: str = Field(
+        default="obiwan96/endless-terminals-train",
+        description="HuggingFace dataset name"
+    )
+    dataset_split: str = Field(
+        default="train",
+        description="Dataset split to use"
+    )
+    dataset_cache_dir: str = Field(
+        default="~/.cache/huggingface/datasets",
+        description="HuggingFace datasets cache directory"
+    )
+    tasks_base_dir: str = Field(
+        default="",
+        description="Base directory containing task_* folders. If empty, uses paths from dataset."
+    )
+
+    # Test execution
+    test_timeout_s: int = Field(default=60, description="Test execution timeout (seconds)")
+
+    # Agent defaults
+    max_agent_turns: int = Field(default=32, description="Max turns for agent (increased for long traces)")
+
+
+class EndlessTerminalsEnv(HermesAgentBaseEnv[EndlessTerminalsEnvConfig]):
+    """
+    Endless Terminals environment using pre-generated HuggingFace dataset.
+
+    Loads terminal tasks from dataset, runs agent with terminal tools,
+    and scores by executing tests in Apptainer containers.
+    """
+
+    name = "endless_terminals_env"
+    env_config_cls = EndlessTerminalsEnvConfig
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._dataset = None
+        self._dataset_indices = []
+        self._current_index = 0
+
+    async def setup(self):
+        """Load HuggingFace dataset."""
+        if not self.config.use_dataset:
+            print("[EndlessTerminalsEnv] Using procedural task generation (not implemented yet)", flush=True)
+            return
+
+        print(f"[EndlessTerminalsEnv] Loading dataset: {self.config.dataset_name}", flush=True)
+
+        try:
+            from datasets import load_dataset
+
+            self._dataset = await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda: load_dataset(
+                    self.config.dataset_name,
+                    split=self.config.dataset_split,
+                    cache_dir=os.path.expanduser(self.config.dataset_cache_dir)
+                )
+            )
+
+            # Create shuffled indices
+            self._dataset_indices = list(range(len(self._dataset)))
+            random.shuffle(self._dataset_indices)
+            self._current_index = 0
+
+            print(f"[EndlessTerminalsEnv] Loaded {len(self._dataset)} tasks from dataset", flush=True)
+
+        except Exception as e:
+            print(f"[EndlessTerminalsEnv] ERROR loading dataset: {e}", flush=True)
+            raise
+
+    async def get_next_item(self) -> Item:
+        """Sample next task from dataset."""
+        if self._dataset is None:
+            raise RuntimeError("Dataset not loaded. Call setup() first.")
+
+        # Get next task (with wraparound)
+        idx = self._dataset_indices[self._current_index]
+        task = self._dataset[idx]
+
+        # Advance to next task
+        self._current_index += 1
+        if self._current_index >= len(self._dataset_indices):
+            # Reshuffle for next epoch
+            random.shuffle(self._dataset_indices)
+            self._current_index = 0
+            print("[EndlessTerminalsEnv] Reshuffled dataset (completed one epoch)", flush=True)
+
+        # Extract task directory path
+        task_dir = task.get("extra_info", {}).get("task_dir")
+        if not task_dir:
+            task_dir = task.get("reward_spec", {}).get("ground_truth")
+
+        # If tasks_base_dir is configured, reconstruct path
+        if self.config.tasks_base_dir:
+            original_path = Path(task_dir)
+            task_name = original_path.name
+            task_dir_path = Path(self.config.tasks_base_dir) / task_name
+        else:
+            task_dir_path = Path(task_dir)
+
+        # Verify directory exists
+        if not task_dir_path.exists():
+            print(f"[EndlessTerminalsEnv] WARNING: Task dir not found: {task_dir_path}", flush=True)
+            print(f"[EndlessTerminalsEnv] Hint: Set tasks_base_dir to directory containing task_* folders", flush=True)
+            return await self.get_next_item()  # Try next task
+
+        container_sif = task_dir_path / "container.sif"
+        final_test = task_dir_path / "test_final_state.py"
+
+        # Verify files exist
+        if not container_sif.exists() or not final_test.exists():
+            print(f"[EndlessTerminalsEnv] WARNING: Missing files in {task_dir_path}", flush=True)
+            return await self.get_next_item()
+
+        return {
+            "task_id": f"{task_dir_path.name}",
+            "description": task.get("description", ""),
+            "task_dir": str(task_dir_path),
+            "container_sif": str(container_sif),
+            "final_test": str(final_test),
+            "dataset_index": idx,
+        }
+
+    def format_prompt(self, item: Item) -> str:
+        """Return the task description for the agent."""
+        return str(item.get("description", ""))
+
+    async def compute_reward(
+        self,
+        item: Item,
+        result: AgentResult,
+        ctx: ToolContext
+    ) -> float:
+        """
+        Run final tests in container and return binary reward.
+
+        Returns 1.0 if tests pass, 0.0 otherwise.
+        """
+        task_id = item.get("task_id", "unknown")
+        container_sif = Path(item.get("container_sif", ""))
+        final_test = Path(item.get("final_test", ""))
+
+        if not container_sif.exists() or not final_test.exists():
+            print(f"[EndlessTerminalsEnv] ERROR: Missing test files for {task_id}", flush=True)
+            return 0.0
+
+        print(f"[EndlessTerminalsEnv] Running tests for {task_id}...", flush=True)
+
+        try:
+            # Run final tests in container
+            success = await self._run_tests_in_container(container_sif, final_test)
+            score = 1.0 if success else 0.0
+
+            print(f"[EndlessTerminalsEnv] Task {task_id} score: {score}", flush=True)
+            return score
+
+        except Exception as e:
+            print(f"[EndlessTerminalsEnv] ERROR scoring {task_id}: {e}", flush=True)
+            return 0.0
+
+    async def _run_tests_in_container(
+        self,
+        container_sif: Path,
+        final_test_path: Path
+    ) -> bool:
+        """Run pytest in Apptainer container."""
+        loop = asyncio.get_event_loop()
+
+        try:
+            result = await loop.run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    [
+                        "apptainer", "exec",
+                        "--fakeroot",
+                        "--userns",
+                        "--writable-tmpfs",
+                        "--cleanenv",
+                        str(container_sif),
+                        "pytest", "-q",
+                        str(final_test_path.name),
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=self.config.test_timeout_s,
+                    cwd=str(final_test_path.parent),
+                )
+            )
+            return result.returncode == 0
+
+        except subprocess.TimeoutExpired:
+            print(f"[EndlessTerminalsEnv] Test timeout for {final_test_path}", flush=True)
+            return False
+        except Exception as e:
+            print(f"[EndlessTerminalsEnv] Test execution error: {e}", flush=True)
+            return False
+
+    async def evaluate(self):
+        """Periodic evaluation (optional)."""
+        return {}
+
+
+if __name__ == "__main__":
+    EndlessTerminalsEnv.cli()

--- a/environments/endless_terminals/endless_terminals_env.py
+++ b/environments/endless_terminals/endless_terminals_env.py
@@ -625,6 +625,13 @@ class EndlessTerminalsEnv(HermesAgentBaseEnv):
         """Periodic evaluation (optional)."""
         return {}
 
+    async def wandb_log(self, wandb_metrics: Optional[Dict] = None):
+        """Log Endless Terminals specific metrics to wandb."""
+        if wandb_metrics is None:
+            wandb_metrics = {}
+
+        await super().wandb_log(wandb_metrics)
+
 
 if __name__ == "__main__":
     EndlessTerminalsEnv.cli()

--- a/environments/endless_terminals/endless_terminals_env.py
+++ b/environments/endless_terminals/endless_terminals_env.py
@@ -404,6 +404,8 @@ class EndlessTerminalsEnv(HermesAgentBaseEnv):
 
             # Run the agent loop
             result: AgentResult
+            managed_state: Optional[Dict[str, Any]] = None
+
             if self._use_managed_server():
                 # Phase 2: ManagedServer with parser
                 from environments.tool_call_parsers import get_parser
@@ -432,6 +434,9 @@ class EndlessTerminalsEnv(HermesAgentBaseEnv):
                             extra_body=self.config.extra_body,
                         )
                         result = await agent.run(messages)
+
+                        # Get state directly from managed server while still in context
+                        managed_state = managed.get_state()
                 except NotImplementedError:
                     # DummyManagedServer not allowed
                     logger.warning("ManagedServer not available. Falling back to direct server mode.")
@@ -466,10 +471,11 @@ class EndlessTerminalsEnv(HermesAgentBaseEnv):
             )
             if result.turns_used == 0 or only_system_and_user:
                 logger.warning(
-                    "Agent loop produced no output (turns=%d). Skipping reward.",
+                    "Agent loop produced no output (turns=%d). Skipping trajectory.",
                     result.turns_used,
                 )
-                reward = 0.0
+                # Return None to skip this trajectory (likely an API failure)
+                return None, []
             else:
                 # Compute reward using ToolContext
                 ctx = ToolContext(task_id)
@@ -504,26 +510,49 @@ class EndlessTerminalsEnv(HermesAgentBaseEnv):
 
             self._metrics_buffer.append(task_metrics)
 
-            # Build ScoredDataItem from ManagedServer state
-            # Phase 2: real tokens/masks/logprobs from SequenceNodes
-            # Phase 1: placeholder tokens
-            nodes = (result.managed_state or {}).get("nodes", [])
+            # ============================================================================
+            # Build ScoredDataGroup from ManagedServer state
+            # ============================================================================
+            # Phase 2: Extract pre-computed data from SequenceNodes
+            # We may have multiple trajectories in the nodes due to how interesting
+            # agents can be, so iterate through all nodes and return multiple sequences.
+            #
+            # Each SequenceNode contains:
+            # - tokens: Full unmasked token sequence [1, 2, 3, ..., N]
+            # - masked_tokens: Training format [-100, -100, ..., -100, actual, actual, ...]
+            # - logprobs: Training format [1.0, 1.0, ..., 1.0, -0.5, -0.3, ...]
+            # - full_text: Complete text (prompt + all completions)
+            #
+            # Phase 1: Create placeholder tokens for OpenAI-style servers
+            # ============================================================================
+            nodes = (managed_state or {}).get("nodes", []) if managed_state else []
+
+            # Create ScoredDataGroup with lists for multiple trajectories
+            scored_group = ScoredDataGroup()
+            scored_group["tokens"] = []
+            scored_group["masks"] = []
+            scored_group["scores"] = []
+            scored_group["messages"] = []
+            scored_group["inference_logprobs"] = []
 
             if nodes:
-                # Phase 2: use actual node data
-                # nodes[-1] contains the full accumulated trajectory from all turns
-                node = nodes[-1]
-                scored_item: Dict[str, Any] = {
-                    "tokens": node.tokens,
-                    "masks": node.masked_tokens,
-                    "scores": reward,
-                }
-                if hasattr(node, "logprobs") and node.logprobs:
-                    scored_item["logprobs"] = node.logprobs
-                    scored_item["advantages"] = None
-                    scored_item["ref_logprobs"] = None
+                # Phase 2: iterate through all nodes (may have multiple trajectories)
+                for i, node in enumerate(nodes):
+                    scored_group["tokens"].append(node.tokens)
+                    scored_group["masks"].append(node.masked_tokens)
+                    scored_group["scores"].append(reward)
+                    scored_group["messages"].append(result.messages)
+
+                    if hasattr(node, "logprobs") and node.logprobs:
+                        scored_group["inference_logprobs"].append(node.logprobs)
+                    else:
+                        # Placeholder logprobs if not available
+                        scored_group["inference_logprobs"].append([1.0] * len(node.tokens))
+
+                    logger.debug(f"Added trajectory {i+1}/{len(nodes)} with {len(node.tokens)} tokens")
+
             else:
-                # Phase 1: create placeholder tokens
+                # Phase 1: create placeholder tokens for OpenAI-style servers
                 full_text = "\n".join(
                     msg.get("content", "") for msg in result.messages if msg.get("content")
                 )
@@ -532,16 +561,18 @@ class EndlessTerminalsEnv(HermesAgentBaseEnv):
                 else:
                     tokens = list(range(min(len(full_text) // 4, 128)))
 
-                scored_item = {
-                    "tokens": tokens,
-                    "masks": [-100] + tokens[1:],
-                    "scores": reward,
-                }
+                scored_group["tokens"].append(tokens)
+                scored_group["masks"].append([-100] + tokens[1:])
+                scored_group["scores"].append(reward)
+                scored_group["messages"].append(result.messages)
+                scored_group["inference_logprobs"].append([1.0] * len(tokens))
 
-            # Include messages for wandb rollout display
-            scored_item["messages"] = result.messages
+            # Return None if no trajectories collected
+            if len(scored_group["tokens"]) == 0:
+                return None, []
 
-            return scored_item, []
+            logger.debug(f"Returning ScoredDataGroup with {len(scored_group['tokens'])} trajectories")
+            return scored_group, []
 
         finally:
             # Clean up task overrides and sandbox

--- a/environments/endless_terminals/endless_terminals_env.py
+++ b/environments/endless_terminals/endless_terminals_env.py
@@ -95,6 +95,10 @@ class EndlessTerminalsEnvConfig(HermesAgentEnvConfig):
         default=10,
         description="Number of tasks to run during periodic evaluation"
     )
+    eval_split_ratio: float = Field(
+        default=0.1,
+        description="Fraction of dataset to hold out for evaluation (0.0-1.0)"
+    )
 
 
 class EndlessTerminalsEnv(HermesAgentBaseEnv):
@@ -144,6 +148,8 @@ class EndlessTerminalsEnv(HermesAgentBaseEnv):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._dataset = None
+        self._train_dataset = None
+        self._eval_dataset = None
         self._dataset_indices = []
         self._current_index = 0
 
@@ -197,12 +203,9 @@ class EndlessTerminalsEnv(HermesAgentBaseEnv):
                 for task_dir in task_dirs
             ]
 
-            # Create shuffled indices
-            self._dataset_indices = list(range(len(self._dataset)))
-            random.shuffle(self._dataset_indices)
-            self._current_index = 0
-
             logger.info(f"Loaded {len(self._dataset)} tasks from local directory")
+
+            self._split_dataset()
             return
 
         # Otherwise, load from HuggingFace
@@ -220,25 +223,54 @@ class EndlessTerminalsEnv(HermesAgentBaseEnv):
                 )
             )
 
-            # Create shuffled indices
-            self._dataset_indices = list(range(len(self._dataset)))
-            random.shuffle(self._dataset_indices)
-            self._current_index = 0
-
             logger.info(f"Loaded {len(self._dataset)} tasks from HuggingFace")
+
+            self._split_dataset()
 
         except Exception as e:
             logger.error(f"ERROR loading dataset: {e}")
             raise
 
+    def _split_dataset(self):
+        """Split dataset into train and eval sets based on eval_split_ratio."""
+        if self._dataset is None or len(self._dataset) == 0:
+            raise RuntimeError("Cannot split empty dataset")
+
+        total_size = len(self._dataset)
+        eval_size = int(total_size * self.config.eval_split_ratio)
+        train_size = total_size - eval_size
+
+        all_indices = list(range(total_size))
+        random.shuffle(all_indices)
+
+        train_indices = all_indices[:train_size]
+        eval_indices = all_indices[train_size:]
+
+        if isinstance(self._dataset, list):
+            self._train_dataset = [self._dataset[i] for i in train_indices]
+            self._eval_dataset = [self._dataset[i] for i in eval_indices]
+        else:
+            self._train_dataset = self._dataset.select(train_indices)
+            self._eval_dataset = self._dataset.select(eval_indices)
+
+        self._dataset_indices = list(range(len(self._train_dataset)))
+        random.shuffle(self._dataset_indices)
+        self._current_index = 0
+
+        logger.info(
+            f"Split dataset: {len(self._train_dataset)} train, "
+            f"{len(self._eval_dataset)} eval "
+            f"(ratio={self.config.eval_split_ratio:.1%})"
+        )
+
     async def get_next_item(self) -> Item:
-        """Sample next task from dataset."""
-        if self._dataset is None:
+        """Sample next task from training dataset."""
+        if self._train_dataset is None:
             raise RuntimeError("Dataset not loaded. Call setup() first.")
 
         # Get next task (with wraparound)
         idx = self._dataset_indices[self._current_index]
-        task = self._dataset[idx]
+        task = self._train_dataset[idx]
 
         # Advance to next task
         self._current_index += 1
@@ -677,16 +709,22 @@ class EndlessTerminalsEnv(HermesAgentBaseEnv):
 
     async def evaluate(self):
         """
-        Periodic evaluation on a fixed set of tasks.
+        Periodic evaluation on holdout eval set.
 
-        Runs the agent on num_eval_tasks tasks and measures performance
-        without affecting training. Returns metrics for wandb logging.
+        Runs the agent on num_eval_tasks from the held-out eval set
+        (never seen during training). Returns metrics for wandb logging.
         """
-        if self._dataset is None:
-            logger.warning("Cannot evaluate: dataset not loaded")
+        if self._eval_dataset is None:
+            logger.warning("Cannot evaluate: eval dataset not loaded")
             return {}
 
-        logger.info(f"Starting evaluation on {self.config.num_eval_tasks} tasks...")
+        if len(self._eval_dataset) == 0:
+            logger.warning("Eval dataset is empty")
+            return {}
+
+        # Use min of num_eval_tasks and actual eval set size
+        num_tasks = min(self.config.num_eval_tasks, len(self._eval_dataset))
+        logger.info(f"Starting evaluation on {num_tasks} held-out tasks...")
 
         eval_metrics = {
             "rewards": [],
@@ -695,12 +733,12 @@ class EndlessTerminalsEnv(HermesAgentBaseEnv):
             "natural_finishes": [],
         }
 
-        # Sample eval tasks randomly
+        # Sample from eval set (holdout)
         import random
-        eval_indices = random.sample(range(len(self._dataset)), min(self.config.num_eval_tasks, len(self._dataset)))
+        eval_indices = random.sample(range(len(self._eval_dataset)), num_tasks)
 
         for idx in eval_indices:
-            task = self._dataset[idx]
+            task = self._eval_dataset[idx]
 
             # Build item using same logic as get_next_item
             task_dir = task.get("extra_info", {}).get("task_dir")


### PR DESCRIPTION
This PR covers the first implementation of endless-terminals [dataset](https://huggingface.co/collections/obiwan96/endless-terminals) [repo](https://github.com/kanishkg/endless-terminals) [paper](https://arxiv.org/abs/2601.16443)

To run this, simply point your atropos environment to the `./environments/endless_terminals/endless_terminals_env.py` environment.

## Download Tasks
```
huggingface-cli download obiwan96/endless-terminals-train --repo-type dataset --local-dir ~/endless-terminals-data --local-dir-use-symlinks False
```

## Testing the environment
```
python environments/endless_terminals/endless_terminals_env.py process --env.tasks_base_dir /path/to/endless-terminals --env.total_steps 1 --env.group_size 1 --env.use_wandb false --openai.model_name "anthropic/claude-sonnet-4.5" --openai.base_url "https://openrouter.ai/api/v1" --openai.server_type "openai" --openai.api_key "$OPENROUTER_API_KEY"

```