### PR TITLE
feat(cli): add first-class z.ai/GLM, Kimi, MiniMax direct API provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,14 +2,44 @@
 # Copy this file to .env and fill in your API keys
 
 # =============================================================================
-# LLM PROVIDER (OpenRouter)
+# LLM PROVIDERS
 # =============================================================================
-# OpenRouter provides access to many models through one API
-# All LLM calls go through OpenRouter - no direct provider keys needed
+# Configure one or more providers. Auto mode resolves in this order:
+# OPENAI_BASE_URL (custom endpoint) -> OPENROUTER_API_KEY -> GLM/ZAI -> KIMI -> MINIMAX -> MINIMAX_CN.
+# Use HERMES_INFERENCE_PROVIDER to force selection per session.
+
+# OpenRouter (recommended default)
 # Get your key at: https://openrouter.ai/keys
 OPENROUTER_API_KEY=
 
-# Default model to use (OpenRouter format: provider/model)
+# zAI / GLM (GLM_API_KEY preferred, ZAI_API_KEY and Z_AI_API_KEY accepted as fallback aliases)
+GLM_API_KEY=
+# ZAI_API_KEY=
+# Z_AI_API_KEY=
+
+# Kimi Coding
+KIMI_API_KEY=
+
+# MiniMax (Global)
+MINIMAX_API_KEY=
+
+# MiniMax (China)
+MINIMAX_CN_API_KEY=
+
+# Optional provider base URL overrides (leave unset to use defaults)
+# GLM_BASE_URL=https://api.z.ai/api/coding/paas/v4
+# KIMI_BASE_URL=https://api.kimi.com/coding/v1
+# MINIMAX_BASE_URL=https://api.minimax.io/v1
+# MINIMAX_CN_BASE_URL=https://api.minimaxi.com/v1
+
+# Optional custom OpenAI-compatible endpoint (enables custom provider mode)
+# OPENAI_BASE_URL=http://localhost:8000/v1
+# OPENAI_API_KEY=your-openai-compatible-key
+
+# Optional provider override: auto | openrouter | nous | zai | kimi-coding | minimax | minimax-cn
+# HERMES_INFERENCE_PROVIDER=auto
+
+# Default model ID (legacy field; active profile model takes precedence in CLI config)
 # Examples: anthropic/claude-opus-4.6, openai/gpt-4o, google/gemini-2.0-flash, zhipuai/glm-4-plus
 LLM_MODEL=anthropic/claude-opus-4.6
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -6,19 +6,56 @@
 # Model Configuration
 # =============================================================================
 model:
-  # Default model to use (can be overridden with --model flag)
+  # Legacy fields (default/provider/base_url) remain supported and are
+  # auto-synced from the active profile for backward compatibility.
   default: "anthropic/claude-opus-4.6"
-  
-  # Inference provider selection:
-  #   "auto"       - Use Nous Portal if logged in, otherwise OpenRouter/env vars (default)
-  #   "openrouter" - Always use OpenRouter API key from OPENROUTER_API_KEY
-  #   "nous"       - Always use Nous Portal (requires: hermes login)
-  # Can also be overridden with --provider flag or HERMES_INFERENCE_PROVIDER env var.
-  provider: "auto"
-  
-  # API configuration (falls back to OPENROUTER_API_KEY env var)
-  # api_key: "your-key-here"  # Uncomment to set here instead of .env
   base_url: "https://openrouter.ai/api/v1"
+  # Provider choices:
+  #   "auto" (default) | "openrouter" | "nous" | "zai" | "kimi-coding" | "minimax" | "minimax-cn"
+  # "custom" is inferred from OPENAI_BASE_URL (not passed via --provider).
+  # Per-session override: --provider or HERMES_INFERENCE_PROVIDER.
+  # API keys in .env:
+  #   OPENROUTER_API_KEY | GLM_API_KEY (or ZAI_API_KEY/Z_AI_API_KEY) | KIMI_API_KEY | MINIMAX_API_KEY | MINIMAX_CN_API_KEY
+  # Optional base URL overrides:
+  #   GLM_BASE_URL | KIMI_BASE_URL | MINIMAX_BASE_URL | MINIMAX_CN_BASE_URL
+  provider: "auto"
+
+  # Multi-provider profile configuration.
+  profiles:
+    - name: "openrouter-default"
+      provider: "openrouter"
+      model: "anthropic/claude-opus-4.6"
+      base_url: "https://openrouter.ai/api/v1"
+      enabled: true
+    - name: "glm-fast"
+      provider: "zai"
+      model: "glm-4.7"
+      base_url: "https://api.z.ai/api/coding/paas/v4"
+      enabled: true
+    - name: "kimi-reasoning"
+      provider: "kimi-coding"
+      model: "kimi-k2-thinking"
+      base_url: "https://api.kimi.com/coding/v1"
+      enabled: true
+    - name: "minimax-global"
+      provider: "minimax"
+      model: "MiniMax-M2.5"
+      base_url: "https://api.minimax.io/v1"
+      enabled: true
+    - name: "minimax-cn"
+      provider: "minimax-cn"
+      model: "MiniMax-M2.1"
+      base_url: "https://api.minimaxi.com/v1"
+      enabled: false
+
+  # Default profile for new CLI sessions.
+  active_profile: "openrouter-default"
+
+  # Optional subset used by scoped profile-selection workflows.
+  scoped_profiles:
+    - "openrouter-default"
+    - "glm-fast"
+    - "kimi-reasoning"
 
 # =============================================================================
 # Terminal Tool Configuration

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -24,7 +24,12 @@ if _env_path.exists():
 load_dotenv(PROJECT_ROOT / ".env", override=False)
 
 from hermes_cli.colors import Colors, color
-from hermes_constants import OPENROUTER_MODELS_URL
+from hermes_cli.provider_registry import (
+    get_provider,
+    list_provider_ids,
+    resolve_provider_api_key,
+    resolve_provider_base_url,
+)
 
 def check_ok(text: str, detail: str = ""):
     print(f"  {color('✓', Colors.GREEN)} {text}" + (f" {color(detail, Colors.DIM)}" if detail else ""))
@@ -122,14 +127,31 @@ def run_doctor(args):
     env_path = HERMES_HOME / '.env'
     if env_path.exists():
         check_ok("~/.hermes/.env file exists")
-        
-        # Check for common issues
-        content = env_path.read_text()
-        if "OPENROUTER_API_KEY" in content or "ANTHROPIC_API_KEY" in content:
-            check_ok("API key configured")
+
+        provider_ids = list_provider_ids(include_oauth=False, include_api_key=True, include_custom=True)
+        has_api_provider = any(
+            bool(resolve_provider_base_url(pid)) if pid == "custom" else bool(resolve_provider_api_key(pid))
+            for pid in provider_ids
+        )
+
+        has_oauth_provider = False
+        auth_file = HERMES_HOME / "auth.json"
+        if auth_file.exists():
+            try:
+                import json
+                auth = json.loads(auth_file.read_text())
+                active = auth.get("active_provider")
+                if active:
+                    state = auth.get("providers", {}).get(active, {})
+                    has_oauth_provider = bool(state.get("access_token") or state.get("refresh_token"))
+            except Exception:
+                has_oauth_provider = False
+
+        if has_api_provider or has_oauth_provider:
+            check_ok("Inference provider configured")
         else:
-            check_warn("No API key found in ~/.hermes/.env")
-            issues.append("Run 'hermes setup' to configure API keys")
+            check_warn("No provider credentials found in ~/.hermes/.env/auth.json")
+            issues.append("Run 'hermes setup' to configure an inference provider")
     else:
         # Also check project root as fallback
         fallback_env = PROJECT_ROOT / '.env'
@@ -340,58 +362,115 @@ def run_doctor(args):
             check_warn("agent-browser not installed", "(run: npm install)")
     else:
         check_warn("Node.js not found", "(optional, needed for browser tools)")
+
+    # =========================================================================
+    # Check: Inference provider credentials
+    # =========================================================================
+    print()
+    print(color("◆ Inference Provider Credentials", Colors.CYAN, Colors.BOLD))
+
+    provider_ids = list_provider_ids(include_oauth=False, include_api_key=True, include_custom=True)
+    for provider_id in provider_ids:
+        meta = get_provider(provider_id)
+        if not meta:
+            continue
+
+        api_key = resolve_provider_api_key(provider_id) or ""
+        base_url = resolve_provider_base_url(provider_id) or ""
+        key_vars = ", ".join(meta.api_key_env_vars) if meta.api_key_env_vars else "(none)"
+
+        if provider_id == "custom":
+            if base_url:
+                check_ok(f"{meta.label} base URL configured")
+            else:
+                check_warn(f"{meta.label} base URL not configured", "(set OPENAI_BASE_URL)")
+        else:
+            if api_key:
+                check_ok(f"{meta.label} API key configured", f"({key_vars})")
+            else:
+                check_warn(f"{meta.label} API key not configured", f"({key_vars})")
+
+        if base_url:
+            check_info(f"{meta.label} base URL: {base_url}")
     
     # =========================================================================
     # Check: API connectivity
     # =========================================================================
     print()
     print(color("◆ API Connectivity", Colors.CYAN, Colors.BOLD))
-    
-    openrouter_key = os.getenv("OPENROUTER_API_KEY")
-    if openrouter_key:
-        print("  Checking OpenRouter API...", end="", flush=True)
-        try:
-            import httpx
-            response = httpx.get(
-                OPENROUTER_MODELS_URL,
-                headers={"Authorization": f"Bearer {openrouter_key}"},
-                timeout=10
-            )
-            if response.status_code == 200:
-                print(f"\r  {color('✓', Colors.GREEN)} OpenRouter API                          ")
-            elif response.status_code == 401:
-                print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color('(invalid API key)', Colors.DIM)}                ")
-                issues.append("Check OPENROUTER_API_KEY in .env")
-            else:
-                print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color(f'(HTTP {response.status_code})', Colors.DIM)}                ")
-        except Exception as e:
-            print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color(f'({e})', Colors.DIM)}                ")
-            issues.append("Check network connectivity")
+
+    try:
+        import httpx
+    except Exception as exc:
+        check_warn("HTTPX unavailable", f"({exc})")
     else:
-        check_warn("OpenRouter API", "(not configured)")
-    
-    anthropic_key = os.getenv("ANTHROPIC_API_KEY")
-    if anthropic_key:
-        print("  Checking Anthropic API...", end="", flush=True)
-        try:
-            import httpx
-            response = httpx.get(
-                "https://api.anthropic.com/v1/models",
-                headers={
-                    "x-api-key": anthropic_key,
-                    "anthropic-version": "2023-06-01"
-                },
-                timeout=10
-            )
-            if response.status_code == 200:
-                print(f"\r  {color('✓', Colors.GREEN)} Anthropic API                           ")
-            elif response.status_code == 401:
-                print(f"\r  {color('✗', Colors.RED)} Anthropic API {color('(invalid API key)', Colors.DIM)}                 ")
-            else:
-                msg = "(couldn't verify)"
-                print(f"\r  {color('⚠', Colors.YELLOW)} Anthropic API {color(msg, Colors.DIM)}                 ")
-        except Exception as e:
-            print(f"\r  {color('⚠', Colors.YELLOW)} Anthropic API {color(f'({e})', Colors.DIM)}                 ")
+        for provider_id in provider_ids:
+            meta = get_provider(provider_id)
+            if not meta or not meta.supports_openai_chat:
+                continue
+
+            api_key = resolve_provider_api_key(provider_id) or ""
+            base_url = resolve_provider_base_url(provider_id) or ""
+
+            if provider_id != "custom" and not api_key:
+                check_warn(f"{meta.label} chat endpoint", "(skipped; API key not configured)")
+                continue
+            if not base_url:
+                check_warn(f"{meta.label} chat endpoint", "(skipped; base URL not configured)")
+                continue
+
+            print(f"  Checking {meta.label} chat endpoint...", end="", flush=True)
+            endpoint = f"{base_url.rstrip('/')}/chat/completions"
+            headers = {"Content-Type": "application/json"}
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+            payload = {
+                "model": "hermes-healthcheck",
+                "messages": [{"role": "user", "content": "ping"}],
+                "max_tokens": 1,
+            }
+
+            try:
+                response = httpx.post(endpoint, headers=headers, json=payload, timeout=10)
+                status_code = response.status_code
+                if status_code == 200:
+                    print(f"\r  {color('✓', Colors.GREEN)} {meta.label} chat endpoint reachable            ")
+                elif status_code in (400, 422, 429):
+                    print(
+                        f"\r  {color('✓', Colors.GREEN)} {meta.label} endpoint reachable "
+                        f"{color('(OpenAI-compatible response)', Colors.DIM)}"
+                    )
+                elif status_code in (401, 403):
+                    if provider_id == "custom" and not api_key:
+                        print(
+                            f"\r  {color('⚠', Colors.YELLOW)} {meta.label} endpoint requires auth "
+                            f"{color('(set OPENAI_API_KEY if needed)', Colors.DIM)}"
+                        )
+                    else:
+                        print(
+                            f"\r  {color('✗', Colors.RED)} {meta.label} auth failed "
+                            f"{color('(invalid API key)', Colors.DIM)}"
+                        )
+                        if meta.api_key_env_vars:
+                            issues.append(f"Check {meta.api_key_env_vars[0]} for {meta.label}")
+                elif status_code in (404, 405):
+                    print(
+                        f"\r  {color('✗', Colors.RED)} {meta.label} endpoint not found "
+                        f"{color('(check base URL)', Colors.DIM)}"
+                    )
+                    if meta.base_url_env_var:
+                        issues.append(f"Check {meta.base_url_env_var} for {meta.label}")
+                else:
+                    print(
+                        f"\r  {color('✗', Colors.RED)} {meta.label} chat endpoint "
+                        f"{color(f'(HTTP {status_code})', Colors.DIM)}"
+                    )
+            except Exception as exc:
+                print(
+                    f"\r  {color('✗', Colors.RED)} {meta.label} chat endpoint "
+                    f"{color(f'({exc})', Colors.DIM)}"
+                )
+                issues.append(f"Check network connectivity to {meta.label}")
     
     # =========================================================================
     # Check: Submodules

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -42,20 +42,54 @@ if env_path.exists():
 import logging
 
 from hermes_cli import __version__
-from hermes_constants import OPENROUTER_BASE_URL
+from hermes_cli.model_profiles import (
+    get_active_profile,
+    normalize_model_config,
+    remove_profile,
+    set_active_profile,
+    sync_legacy_model_fields,
+    upsert_profile,
+)
+from hermes_cli.provider_registry import (
+    get_curated_models,
+    get_provider,
+    list_provider_ids,
+    list_model_picker_provider_ids,
+    provider_cli_choices,
+    resolve_provider_api_key,
+    resolve_provider_base_url,
+)
 
 logger = logging.getLogger(__name__)
 
 
 def _has_any_provider_configured() -> bool:
     """Check if at least one inference provider is usable."""
-    from hermes_cli.config import get_env_path, get_hermes_home
+    from hermes_cli.config import get_env_path, get_hermes_home, load_config
 
-    # Check env vars (may be set by .env or shell)
-    if os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY") or os.getenv("ANTHROPIC_API_KEY"):
-        return True
+    api_provider_ids = list_provider_ids(include_oauth=False, include_api_key=True, include_custom=True)
 
-    # Check .env file for keys
+    # Check resolved environment state first.
+    for provider_id in api_provider_ids:
+        key = resolve_provider_api_key(provider_id)
+        base_url = resolve_provider_base_url(provider_id)
+        if provider_id == "custom":
+            if base_url:
+                return True
+            continue
+        if key:
+            return True
+
+    # Check ~/.hermes/.env for provider env vars that may not be loaded yet.
+    provider_env_vars = set()
+    for provider_id in api_provider_ids:
+        meta = get_provider(provider_id)
+        if not meta:
+            continue
+        provider_env_vars.update(meta.api_key_env_vars)
+        if meta.base_url_env_var:
+            provider_env_vars.add(meta.base_url_env_var)
+
     env_file = get_env_path()
     if env_file.exists():
         try:
@@ -65,10 +99,31 @@ def _has_any_provider_configured() -> bool:
                     continue
                 key, _, val = line.partition("=")
                 val = val.strip().strip("'\"")
-                if key.strip() in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY") and val:
+                if key.strip() in provider_env_vars and val:
                     return True
         except Exception:
             pass
+
+    # Check configured profiles with provider-aware key/base resolution.
+    try:
+        config = load_config()
+        model_cfg = normalize_model_config(config.get("model"))
+        for profile in model_cfg.get("profiles", []):
+            provider_id = str(profile.get("provider") or "").strip()
+            if not provider_id:
+                continue
+            key = resolve_provider_api_key(provider_id)
+            base_url = profile.get("base_url") or resolve_provider_base_url(provider_id)
+            if provider_id == "custom":
+                if base_url:
+                    return True
+                continue
+            if provider_id == "nous":
+                continue
+            if key and base_url:
+                return True
+    except Exception:
+        pass
 
     # Check for Nous Portal OAuth credentials
     auth_file = get_hermes_home() / "auth.json"
@@ -137,83 +192,129 @@ def cmd_setup(args):
 
 
 def cmd_model(args):
-    """Select default model — starts with provider selection, then model picker."""
-    from hermes_cli.auth import (
-        resolve_provider, get_provider_auth_state, PROVIDER_REGISTRY,
-        _prompt_model_selection, _save_model_choice, _update_config_for_provider,
-        resolve_nous_runtime_credentials, fetch_nous_models, AuthError, format_auth_error,
-        _login_nous, ProviderConfig,
-    )
-    from hermes_cli.config import load_config, save_config, get_env_value, save_env_value
+    """Manage model/provider profiles and active selection."""
+    from hermes_cli.config import load_config, save_config
 
     config = load_config()
-    current_model = config.get("model")
-    if isinstance(current_model, dict):
-        current_model = current_model.get("default", "")
-    current_model = current_model or "(not set)"
+    model_cfg = normalize_model_config(config.get("model"))
+    active_profile = get_active_profile(model_cfg)
 
-    # Read effective provider the same way the CLI does at startup:
-    # config.yaml model.provider > env var > auto-detect
-    import os
-    config_provider = None
-    model_cfg = config.get("model")
-    if isinstance(model_cfg, dict):
-        config_provider = model_cfg.get("provider")
+    print()
+    print(f"  Active profile:   {active_profile.get('name')}")
+    print(f"  Current model:    {model_cfg.get('default', '(not set)')}")
+    print(f"  Active provider:  {active_profile.get('provider', '(not set)')}")
+    print()
 
-    effective_provider = (
-        os.getenv("HERMES_INFERENCE_PROVIDER")
-        or config_provider
-        or "auto"
+    profile_items = []
+    for profile in model_cfg.get("profiles", []):
+        marker = "  ← active" if profile.get("name") == model_cfg.get("active_profile") else ""
+        profile_items.append(
+            (
+                profile.get("name"),
+                f"Use profile: {profile.get('name')} [{profile.get('provider')}/{profile.get('model')}]"
+                f"{marker}",
+            )
+        )
+
+    menu_items = (
+        profile_items
+        + [
+            ("add", "Add or update provider profile"),
+            ("scoped", "Configure scoped profiles"),
+            ("remove", "Remove a profile"),
+            ("cancel", "Cancel"),
+        ]
     )
-    active = resolve_provider(effective_provider)
 
-    # Detect custom endpoint
-    if active == "openrouter" and get_env_value("OPENAI_BASE_URL"):
-        active = "custom"
+    choice = _prompt_provider_choice([label for _, label in menu_items])
+    if choice is None:
+        print("No change.")
+        return
+    action = menu_items[choice][0]
 
-    provider_labels = {
-        "openrouter": "OpenRouter",
-        "nous": "Nous Portal",
-        "custom": "Custom endpoint",
-    }
-    active_label = provider_labels.get(active, active)
-
-    print()
-    print(f"  Current model:    {current_model}")
-    print(f"  Active provider:  {active_label}")
-    print()
-
-    # Step 1: Provider selection — put active provider first with marker
-    providers = [
-        ("openrouter", "OpenRouter (100+ models, pay-per-use)"),
-        ("nous", "Nous Portal (Nous Research subscription)"),
-        ("custom", "Custom endpoint (self-hosted / VLLM / etc.)"),
-    ]
-
-    # Reorder so the active provider is at the top
-    active_key = active if active in ("openrouter", "nous") else "custom"
-    ordered = []
-    for key, label in providers:
-        if key == active_key:
-            ordered.insert(0, (key, f"{label}  ← currently active"))
-        else:
-            ordered.append((key, label))
-    ordered.append(("cancel", "Cancel"))
-
-    provider_idx = _prompt_provider_choice([label for _, label in ordered])
-    if provider_idx is None or ordered[provider_idx][0] == "cancel":
+    if action == "cancel":
         print("No change.")
         return
 
-    selected_provider = ordered[provider_idx][0]
+    if action == "scoped":
+        updated_scoped = _prompt_scoped_profiles(model_cfg)
+        if updated_scoped:
+            model_cfg["scoped_profiles"] = updated_scoped
+            model_cfg = sync_legacy_model_fields(model_cfg)
+            config["model"] = model_cfg
+            save_config(config)
+            print(f"Scoped profiles set: {', '.join(updated_scoped)}")
+        else:
+            print("No change.")
+        return
 
-    # Step 2: Provider-specific setup + model selection
-    if selected_provider == "openrouter":
-        _model_flow_openrouter(config, current_model)
-    elif selected_provider == "nous":
-        _model_flow_nous(config, current_model)
-    elif selected_provider == "custom":
-        _model_flow_custom(config)
+    if action == "remove":
+        names = [p.get("name") for p in model_cfg.get("profiles", [])]
+        if len(names) <= 1:
+            print("Cannot remove the only profile.")
+            return
+        idx = _prompt_provider_choice([f"Remove {name}" for name in names] + ["Cancel"])
+        if idx is None or idx == len(names):
+            print("No change.")
+            return
+        to_remove = names[idx]
+        model_cfg = remove_profile(model_cfg, to_remove)
+        model_cfg = sync_legacy_model_fields(model_cfg)
+        config["model"] = model_cfg
+        save_config(config)
+        print(f"Removed profile: {to_remove}")
+        return
+
+    if action == "add":
+        provider_id = _choose_provider_for_profile()
+        if not provider_id:
+            print("No change.")
+            return
+        existing = next((p for p in model_cfg.get("profiles", []) if p.get("provider") == provider_id), None)
+        base_name = provider_id.replace("-", "_")
+        if existing and existing.get("name"):
+            profile_name = existing["name"]
+        else:
+            existing_names = {p.get("name") for p in model_cfg.get("profiles", [])}
+            profile_name = f"{base_name}-profile"
+            suffix = 2
+            while profile_name in existing_names:
+                profile_name = f"{base_name}-profile-{suffix}"
+                suffix += 1
+        seed = existing or {"name": profile_name, "provider": provider_id, "model": "", "enabled": True}
+        updated = _configure_provider_profile(seed)
+        if not updated:
+            print("No change.")
+            return
+        model_cfg = upsert_profile(model_cfg, updated)
+        model_cfg = set_active_profile(model_cfg, updated["name"])
+        model_cfg = sync_legacy_model_fields(model_cfg)
+        config["model"] = model_cfg
+        save_config(config)
+        print(
+            f"Active profile set to: {updated['name']} "
+            f"[{updated['provider']}/{updated['model']}]"
+        )
+        return
+
+    # Existing profile selected.
+    selected_profile = next((p for p in model_cfg.get("profiles", []) if p.get("name") == action), None)
+    if not selected_profile:
+        print("No change.")
+        return
+    updated = _configure_provider_profile(selected_profile)
+    if not updated:
+        print("No change.")
+        return
+    model_cfg = upsert_profile(model_cfg, updated)
+    model_cfg = set_active_profile(model_cfg, updated["name"])
+    model_cfg = sync_legacy_model_fields(model_cfg)
+    config["model"] = model_cfg
+    save_config(config)
+    print(
+        f"Active profile set to: {updated['name']} "
+        f"[{updated['provider']}/{updated['model']}]"
+    )
 
 
 def _prompt_provider_choice(choices):
@@ -255,68 +356,139 @@ def _prompt_provider_choice(choices):
             return None
 
 
-def _model_flow_openrouter(config, current_model=""):
-    """OpenRouter provider: ensure API key, then pick model."""
-    from hermes_cli.auth import _prompt_model_selection, _save_model_choice, deactivate_provider
-    from hermes_cli.config import get_env_value, save_env_value
+def _choose_provider_for_profile() -> str | None:
+    provider_ids = list_model_picker_provider_ids()
+    labels = []
+    for pid in provider_ids:
+        meta = get_provider(pid)
+        label = meta.label if meta else pid
+        labels.append(f"{label} ({pid})")
+    labels.append("Cancel")
+    idx = _prompt_provider_choice(labels)
+    if idx is None or idx >= len(provider_ids):
+        return None
+    return provider_ids[idx]
 
-    api_key = get_env_value("OPENROUTER_API_KEY")
-    if not api_key:
-        print("No OpenRouter API key configured.")
-        print("Get one at: https://openrouter.ai/keys")
+
+def _prompt_scoped_profiles(model_cfg: dict) -> list[str]:
+    profiles = model_cfg.get("profiles", [])
+    names = [p.get("name") for p in profiles if p.get("enabled", True)]
+    if not names:
+        return []
+    current = set(model_cfg.get("scoped_profiles", []))
+    print()
+    print("Scoped profile selection:")
+    for i, name in enumerate(names, 1):
+        mark = "x" if name in current else " "
+        print(f"  {i}. [{mark}] {name}")
+    print("Enter comma-separated profile numbers (blank = keep current)")
+    try:
+        raw = input("Scoped profiles: ").strip()
+    except (KeyboardInterrupt, EOFError):
         print()
+        return []
+    if not raw:
+        return list(current)
+    selected: list[str] = []
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if not part.isdigit():
+            continue
+        idx = int(part) - 1
+        if 0 <= idx < len(names):
+            selected.append(names[idx])
+    if not selected:
+        selected = [model_cfg.get("active_profile")] if model_cfg.get("active_profile") else []
+    return list(dict.fromkeys(selected))
+
+
+def _configure_provider_profile(profile: dict) -> dict | None:
+    provider = profile.get("provider")
+    if provider == "nous":
+        return _configure_nous_profile(profile)
+    if provider == "custom":
+        return _configure_custom_profile(profile)
+    return _configure_api_key_profile(profile)
+
+
+def _configure_api_key_profile(profile: dict) -> dict | None:
+    from hermes_cli.auth import _prompt_model_selection
+    from hermes_cli.config import save_env_value
+    from hermes_cli.models import model_ids as openrouter_model_ids
+
+    provider = profile.get("provider", "openrouter")
+    meta = get_provider(provider)
+    if not meta:
+        print(f"Unknown provider: {provider}")
+        return None
+
+    # Save into the first canonical env var for this provider.
+    key_env = meta.api_key_env_vars[0] if meta.api_key_env_vars else ""
+    existing_key = resolve_provider_api_key(provider) or ""
+    if key_env and not existing_key:
+        print(f"No {meta.label} API key configured.")
         try:
-            key = input("OpenRouter API key (or Enter to cancel): ").strip()
+            key = input(f"{key_env} (or Enter to cancel): ").strip()
         except (KeyboardInterrupt, EOFError):
             print()
-            return
+            return None
         if not key:
-            print("Cancelled.")
-            return
-        save_env_value("OPENROUTER_API_KEY", key)
-        print("API key saved.")
+            return None
+        save_env_value(key_env, key)
+
+    current_url = profile.get("base_url") or resolve_provider_base_url(provider) or ""
+    prompt_default = current_url or "https://api.example.com/v1"
+    try:
+        base_url = input(f"Base URL [{prompt_default}]: ").strip() or current_url
+    except (KeyboardInterrupt, EOFError):
         print()
+        return None
+    if not isinstance(base_url, str) or not base_url.startswith(("http://", "https://")):
+        print("Invalid URL (must start with http:// or https://)")
+        return None
+    if meta.base_url_env_var:
+        save_env_value(meta.base_url_env_var, base_url.rstrip("/"))
 
-    from hermes_cli.models import model_ids
-    openrouter_models = model_ids()
-
-    selected = _prompt_model_selection(openrouter_models, current_model=current_model)
-    if selected:
-        # Clear any custom endpoint and set provider to openrouter
-        if get_env_value("OPENAI_BASE_URL"):
-            save_env_value("OPENAI_BASE_URL", "")
-            save_env_value("OPENAI_API_KEY", "")
-        _save_model_choice(selected)
-
-        # Update config provider and deactivate any OAuth provider
-        from hermes_cli.config import load_config, save_config
-        cfg = load_config()
-        model = cfg.get("model")
-        if isinstance(model, dict):
-            model["provider"] = "openrouter"
-            model["base_url"] = OPENROUTER_BASE_URL
-        save_config(cfg)
-        deactivate_provider()
-        print(f"Default model set to: {selected} (via OpenRouter)")
+    if provider == "openrouter":
+        candidates = openrouter_model_ids()
     else:
-        print("No change.")
+        candidates = get_curated_models(provider)
+    if candidates:
+        selected = _prompt_model_selection(candidates, current_model=profile.get("model", ""))
+    else:
+        try:
+            selected = input("Model ID (or Enter to cancel): ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return None
+    if not selected:
+        return None
+
+    updated = dict(profile)
+    updated["model"] = selected
+    updated["base_url"] = base_url.rstrip("/")
+    updated["enabled"] = True
+    return updated
 
 
-def _model_flow_nous(config, current_model=""):
-    """Nous Portal provider: ensure logged in, then pick model."""
+def _configure_nous_profile(profile: dict) -> dict | None:
     from hermes_cli.auth import (
-        get_provider_auth_state, _prompt_model_selection, _save_model_choice,
-        _update_config_for_provider, resolve_nous_runtime_credentials,
-        fetch_nous_models, AuthError, format_auth_error,
-        _login_nous, PROVIDER_REGISTRY,
+        AuthError,
+        PROVIDER_REGISTRY,
+        _login_nous,
+        _prompt_model_selection,
+        fetch_nous_models,
+        format_auth_error,
+        get_provider_auth_state,
+        resolve_nous_runtime_credentials,
     )
-    from hermes_cli.config import get_env_value, save_env_value
     import argparse
 
     state = get_provider_auth_state("nous")
     if not state or not state.get("access_token"):
         print("Not logged into Nous Portal. Starting login...")
-        print()
         try:
             mock_args = argparse.Namespace(
                 portal_url=None, inference_url=None, client_id=None,
@@ -326,100 +498,69 @@ def _model_flow_nous(config, current_model=""):
             _login_nous(mock_args, PROVIDER_REGISTRY["nous"])
         except SystemExit:
             print("Login cancelled or failed.")
-            return
+            return None
         except Exception as exc:
             print(f"Login failed: {exc}")
-            return
-        # login_nous already handles model selection + config update
-        return
+            return None
 
-    # Already logged in — fetch models and select
     print("Fetching models from Nous Portal...")
     try:
         creds = resolve_nous_runtime_credentials(min_key_ttl_seconds=5 * 60)
-        model_ids = fetch_nous_models(
+        nous_models = fetch_nous_models(
             inference_base_url=creds.get("base_url", ""),
             api_key=creds.get("api_key", ""),
         )
     except Exception as exc:
         msg = format_auth_error(exc) if isinstance(exc, AuthError) else str(exc)
         print(f"Could not fetch models: {msg}")
-        return
+        return None
 
-    if not model_ids:
-        print("No models returned by the inference API.")
-        return
+    selected = _prompt_model_selection(nous_models, current_model=profile.get("model", ""))
+    if not selected:
+        return None
 
-    selected = _prompt_model_selection(model_ids, current_model=current_model)
-    if selected:
-        _save_model_choice(selected)
-        # Reactivate Nous as the provider and update config
-        inference_url = creds.get("base_url", "")
-        _update_config_for_provider("nous", inference_url)
-        # Clear any custom endpoint that might conflict
-        if get_env_value("OPENAI_BASE_URL"):
-            save_env_value("OPENAI_BASE_URL", "")
-            save_env_value("OPENAI_API_KEY", "")
-        print(f"Default model set to: {selected} (via Nous Portal)")
-    else:
-        print("No change.")
+    updated = dict(profile)
+    updated["model"] = selected
+    updated["base_url"] = (creds.get("base_url") or "").rstrip("/")
+    updated["enabled"] = True
+    return updated
 
 
-def _model_flow_custom(config):
-    """Custom endpoint: collect URL, API key, and model name."""
-    from hermes_cli.auth import _save_model_choice, deactivate_provider
-    from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
+def _configure_custom_profile(profile: dict) -> dict | None:
+    from hermes_cli.config import save_env_value
 
-    current_url = get_env_value("OPENAI_BASE_URL") or ""
-    current_key = get_env_value("OPENAI_API_KEY") or ""
+    current_url = profile.get("base_url") or os.getenv("OPENAI_BASE_URL") or ""
+    current_model = profile.get("model") or ""
+    current_key = os.getenv("OPENAI_API_KEY") or ""
 
     print("Custom OpenAI-compatible endpoint configuration:")
-    if current_url:
-        print(f"  Current URL: {current_url}")
-    if current_key:
-        print(f"  Current key: {current_key[:8]}...")
-    print()
-
     try:
-        base_url = input(f"API base URL [{current_url or 'e.g. https://api.example.com/v1'}]: ").strip()
-        api_key = input(f"API key [{current_key[:8] + '...' if current_key else 'optional'}]: ").strip()
-        model_name = input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
+        base_url = input(f"API base URL [{current_url or 'https://api.example.com/v1'}]: ").strip()
+        model_name = input(f"Model name [{current_model or 'gpt-4o'}]: ").strip()
+        api_key = input(f"OPENAI_API_KEY [{current_key[:8] + '...' if current_key else 'optional'}]: ").strip()
     except (KeyboardInterrupt, EOFError):
-        print("\nCancelled.")
-        return
+        print()
+        return None
 
-    if not base_url and not current_url:
-        print("No URL provided. Cancelled.")
-        return
-
-    # Validate URL format
     effective_url = base_url or current_url
-    if not effective_url.startswith(("http://", "https://")):
-        print(f"Invalid URL: {effective_url} (must start with http:// or https://)")
-        return
+    if not effective_url or not effective_url.startswith(("http://", "https://")):
+        print("Invalid URL (must start with http:// or https://)")
+        return None
+    effective_model = model_name or current_model
+    if not effective_model:
+        print("Model name is required.")
+        return None
 
-    if base_url:
-        save_env_value("OPENAI_BASE_URL", base_url)
+    save_env_value("OPENAI_BASE_URL", effective_url)
     if api_key:
         save_env_value("OPENAI_API_KEY", api_key)
 
-    if model_name:
-        _save_model_choice(model_name)
-
-        # Update config and deactivate any OAuth provider
-        cfg = load_config()
-        model = cfg.get("model")
-        if isinstance(model, dict):
-            model["provider"] = "auto"
-            model["base_url"] = effective_url
-        save_config(cfg)
-        deactivate_provider()
-
-        print(f"Default model set to: {model_name} (via {effective_url})")
-    else:
-        if base_url or api_key:
-            deactivate_provider()
-        print("Endpoint saved. Use `/model` in chat or `hermes model` to set a model.")
+    updated = dict(profile)
+    updated["provider"] = "custom"
+    updated["model"] = effective_model
+    updated["base_url"] = effective_url.rstrip("/")
+    updated["enabled"] = True
+    return updated
 
 
 def cmd_login(args):
@@ -675,7 +816,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous"],
+        choices=provider_cli_choices(include_auto=True),
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/model_profiles.py
+++ b/hermes_cli/model_profiles.py
@@ -1,0 +1,244 @@
+"""
+Model profile helpers for multi-provider model configuration.
+
+This module normalizes legacy model config formats and provides utilities
+for profile CRUD and active-profile synchronization.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import OPENROUTER_BASE_URL
+from hermes_cli.provider_registry import (
+    get_provider,
+    normalize_provider_id,
+    resolve_provider_base_url,
+)
+
+DEFAULT_MODEL_ID = "anthropic/claude-opus-4.6"
+DEFAULT_PROFILE_NAME = "default-openrouter"
+
+
+def _normalize_profile(raw: Any, idx: int) -> Optional[Dict[str, Any]]:
+    if not isinstance(raw, dict):
+        return None
+
+    name = str(raw.get("name") or f"profile-{idx+1}").strip()
+    provider = normalize_provider_id(str(raw.get("provider") or "openrouter").strip(), default="openrouter")
+    model = str(raw.get("model") or raw.get("default") or DEFAULT_MODEL_ID).strip() or DEFAULT_MODEL_ID
+    enabled = bool(raw.get("enabled", True))
+
+    base_url = raw.get("base_url")
+    if isinstance(base_url, str):
+        base_url = base_url.strip().rstrip("/")
+    else:
+        base_url = None
+
+    if not base_url:
+        base_url = resolve_provider_base_url(provider) or OPENROUTER_BASE_URL
+
+    return {
+        "name": name,
+        "provider": provider,
+        "model": model,
+        "base_url": base_url,
+        "enabled": enabled,
+    }
+
+
+def normalize_model_config(model_cfg: Any) -> Dict[str, Any]:
+    """
+    Convert model config (string or dict) into a normalized dict format.
+
+    Normalized keys:
+    - default
+    - provider
+    - base_url
+    - profiles
+    - active_profile
+    - scoped_profiles
+    """
+    if isinstance(model_cfg, str):
+        legacy_model = model_cfg.strip() or DEFAULT_MODEL_ID
+        normalized: Dict[str, Any] = {
+            "default": legacy_model,
+            "provider": "openrouter",
+            "base_url": OPENROUTER_BASE_URL,
+            "profiles": [
+                {
+                    "name": DEFAULT_PROFILE_NAME,
+                    "provider": "openrouter",
+                    "model": legacy_model,
+                    "base_url": OPENROUTER_BASE_URL,
+                    "enabled": True,
+                }
+            ],
+            "active_profile": DEFAULT_PROFILE_NAME,
+            "scoped_profiles": [DEFAULT_PROFILE_NAME],
+        }
+        return normalized
+
+    cfg = deepcopy(model_cfg) if isinstance(model_cfg, dict) else {}
+
+    default_model = str(cfg.get("default") or DEFAULT_MODEL_ID).strip() or DEFAULT_MODEL_ID
+    provider = normalize_provider_id(str(cfg.get("provider") or "openrouter").strip(), default="openrouter")
+
+    base_url = cfg.get("base_url")
+    if isinstance(base_url, str):
+        base_url = base_url.strip().rstrip("/")
+    else:
+        base_url = None
+    if not base_url:
+        base_url = resolve_provider_base_url(provider) or OPENROUTER_BASE_URL
+
+    raw_profiles = cfg.get("profiles")
+    profiles: List[Dict[str, Any]] = []
+    if isinstance(raw_profiles, list):
+        for idx, entry in enumerate(raw_profiles):
+            profile = _normalize_profile(entry, idx)
+            if profile:
+                profiles.append(profile)
+
+    if not profiles:
+        # Synthesize from legacy fields
+        profiles = [
+            {
+                "name": DEFAULT_PROFILE_NAME,
+                "provider": provider,
+                "model": default_model,
+                "base_url": base_url,
+                "enabled": True,
+            }
+        ]
+
+    # Ensure unique profile names (stable suffixing)
+    seen = set()
+    for idx, p in enumerate(profiles):
+        base_name = p["name"]
+        candidate = base_name
+        suffix = 2
+        while candidate in seen:
+            candidate = f"{base_name}-{suffix}"
+            suffix += 1
+        p["name"] = candidate
+        seen.add(candidate)
+
+    active_profile = str(cfg.get("active_profile") or "").strip()
+    active_names = {p["name"] for p in profiles if p.get("enabled", True)}
+    if not active_profile or active_profile not in active_names:
+        active_profile = profiles[0]["name"]
+
+    scoped_profiles_raw = cfg.get("scoped_profiles")
+    scoped_profiles: List[str] = []
+    if isinstance(scoped_profiles_raw, list):
+        for value in scoped_profiles_raw:
+            name = str(value).strip()
+            if name and any(p["name"] == name for p in profiles):
+                scoped_profiles.append(name)
+    if not scoped_profiles:
+        scoped_profiles = [active_profile]
+
+    normalized = {
+        "default": default_model,
+        "provider": provider,
+        "base_url": base_url,
+        "profiles": profiles,
+        "active_profile": active_profile,
+        "scoped_profiles": scoped_profiles,
+    }
+    return sync_legacy_model_fields(normalized)
+
+
+def _active_profile_from_normalized(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    active_name = cfg["active_profile"]
+    for p in cfg["profiles"]:
+        if p["name"] == active_name:
+            return p
+    return cfg["profiles"][0]
+
+
+def get_active_profile(model_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    cfg = normalize_model_config(model_cfg)
+    return _active_profile_from_normalized(cfg)
+
+
+def sync_legacy_model_fields(model_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    cfg = deepcopy(model_cfg)
+    profiles = cfg.get("profiles", [])
+    if not isinstance(profiles, list) or not profiles:
+        return cfg
+
+    active = _active_profile_from_normalized(cfg)
+    cfg["default"] = active.get("model") or cfg.get("default") or DEFAULT_MODEL_ID
+    cfg["provider"] = active.get("provider") or cfg.get("provider") or "openrouter"
+    cfg["base_url"] = (
+        active.get("base_url")
+        or resolve_provider_base_url(cfg["provider"])
+        or cfg.get("base_url")
+        or OPENROUTER_BASE_URL
+    )
+    return cfg
+
+
+def upsert_profile(model_cfg: Dict[str, Any], profile: Dict[str, Any]) -> Dict[str, Any]:
+    cfg = normalize_model_config(model_cfg)
+    entry = _normalize_profile(profile, 0)
+    if not entry:
+        return cfg
+
+    updated = False
+    for idx, existing in enumerate(cfg["profiles"]):
+        if existing.get("name") == entry["name"]:
+            cfg["profiles"][idx] = entry
+            updated = True
+            break
+    if not updated:
+        cfg["profiles"].append(entry)
+
+    if entry.get("enabled", True):
+        cfg["active_profile"] = entry["name"]
+    if entry["name"] not in cfg["scoped_profiles"]:
+        cfg["scoped_profiles"].append(entry["name"])
+    return sync_legacy_model_fields(cfg)
+
+
+def remove_profile(model_cfg: Dict[str, Any], profile_name: str) -> Dict[str, Any]:
+    cfg = normalize_model_config(model_cfg)
+    cfg["profiles"] = [p for p in cfg["profiles"] if p.get("name") != profile_name]
+    cfg["scoped_profiles"] = [n for n in cfg.get("scoped_profiles", []) if n != profile_name]
+    if not cfg["profiles"]:
+        cfg["profiles"] = [
+            {
+                "name": DEFAULT_PROFILE_NAME,
+                "provider": "openrouter",
+                "model": DEFAULT_MODEL_ID,
+                "base_url": OPENROUTER_BASE_URL,
+                "enabled": True,
+            }
+        ]
+    if cfg.get("active_profile") == profile_name:
+        cfg["active_profile"] = cfg["profiles"][0]["name"]
+    if not cfg["scoped_profiles"]:
+        cfg["scoped_profiles"] = [cfg["active_profile"]]
+    return sync_legacy_model_fields(cfg)
+
+
+def set_active_profile(model_cfg: Dict[str, Any], profile_name: str) -> Dict[str, Any]:
+    cfg = normalize_model_config(model_cfg)
+    if any(p.get("name") == profile_name for p in cfg["profiles"]):
+        cfg["active_profile"] = profile_name
+        if profile_name not in cfg["scoped_profiles"]:
+            cfg["scoped_profiles"].append(profile_name)
+    return sync_legacy_model_fields(cfg)
+
+
+def get_profile_names(model_cfg: Dict[str, Any], *, enabled_only: bool = False) -> List[str]:
+    cfg = normalize_model_config(model_cfg)
+    names: List[str] = []
+    for p in cfg["profiles"]:
+        if enabled_only and not p.get("enabled", True):
+            continue
+        names.append(p["name"])
+    return names

--- a/hermes_cli/provider_registry.py
+++ b/hermes_cli/provider_registry.py
@@ -1,0 +1,255 @@
+"""
+Central provider registry for Hermes CLI inference providers.
+
+This module is intentionally lightweight and dependency-safe so multiple
+CLI surfaces (setup, model picker, auth resolution, diagnostics) can share
+the same provider metadata and resolution behavior.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+from hermes_constants import OPENROUTER_BASE_URL
+
+EnvGetter = Callable[[str], Optional[str]]
+
+
+@dataclass(frozen=True)
+class ProviderMeta:
+    id: str
+    label: str
+    auth_type: str  # "oauth" or "api_key"
+    default_base_url: str = ""
+    api_key_env_vars: Tuple[str, ...] = ()
+    base_url_env_var: Optional[str] = None
+    curated_models: Tuple[str, ...] = ()
+    aliases: Tuple[str, ...] = ()
+    show_in_setup: bool = True
+    show_in_model_picker: bool = True
+    supports_openai_chat: bool = True
+
+
+PROVIDERS: Dict[str, ProviderMeta] = {
+    "openrouter": ProviderMeta(
+        id="openrouter",
+        label="OpenRouter",
+        auth_type="api_key",
+        default_base_url=OPENROUTER_BASE_URL,
+        api_key_env_vars=("OPENROUTER_API_KEY",),
+        base_url_env_var="OPENROUTER_BASE_URL",
+        curated_models=(
+            "anthropic/claude-opus-4.6",
+            "anthropic/claude-sonnet-4.5",
+            "openai/gpt-5.2",
+            "google/gemini-3-pro-preview",
+        ),
+    ),
+    "nous": ProviderMeta(
+        id="nous",
+        label="Nous Portal",
+        auth_type="oauth",
+        show_in_setup=True,
+        show_in_model_picker=True,
+    ),
+    "zai": ProviderMeta(
+        id="zai",
+        label="GLM (z.ai)",
+        auth_type="api_key",
+        default_base_url="https://api.z.ai/api/coding/paas/v4",
+        api_key_env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
+        base_url_env_var="GLM_BASE_URL",
+        curated_models=(
+            "glm-4.5-flash",
+            "glm-4.5-air",
+            "glm-4.5v",
+            "glm-4.6",
+            "glm-4.7",
+            "glm-5",
+        ),
+        aliases=("glm", "z-ai"),
+    ),
+    "kimi-coding": ProviderMeta(
+        id="kimi-coding",
+        label="Kimi Coding",
+        auth_type="api_key",
+        default_base_url="https://api.kimi.com/coding/v1",
+        api_key_env_vars=("KIMI_API_KEY",),
+        base_url_env_var="KIMI_BASE_URL",
+        curated_models=("kimi-k2-thinking", "k2p5"),
+        aliases=("kimi",),
+    ),
+    "minimax": ProviderMeta(
+        id="minimax",
+        label="MiniMax",
+        auth_type="api_key",
+        default_base_url="https://api.minimax.io/v1",
+        api_key_env_vars=("MINIMAX_API_KEY",),
+        base_url_env_var="MINIMAX_BASE_URL",
+        curated_models=("MiniMax-M2.1", "MiniMax-M2.5"),
+    ),
+    "minimax-cn": ProviderMeta(
+        id="minimax-cn",
+        label="MiniMax (China)",
+        auth_type="api_key",
+        default_base_url="https://api.minimaxi.com/v1",
+        api_key_env_vars=("MINIMAX_CN_API_KEY",),
+        base_url_env_var="MINIMAX_CN_BASE_URL",
+        curated_models=("MiniMax-M2.1", "MiniMax-M2.5"),
+    ),
+    "custom": ProviderMeta(
+        id="custom",
+        label="Custom endpoint",
+        auth_type="api_key",
+        default_base_url="",
+        api_key_env_vars=("OPENAI_API_KEY",),
+        base_url_env_var="OPENAI_BASE_URL",
+        curated_models=(),
+        show_in_setup=True,
+        show_in_model_picker=True,
+    ),
+}
+
+_ALIAS_TO_PROVIDER: Dict[str, str] = {}
+for _pid, _meta in PROVIDERS.items():
+    _ALIAS_TO_PROVIDER[_pid] = _pid
+    for _alias in _meta.aliases:
+        _ALIAS_TO_PROVIDER[_alias.lower()] = _pid
+
+
+def normalize_provider_id(provider_id: Optional[str], default: str = "auto") -> str:
+    """Normalize a provider ID or alias to a canonical ID."""
+    if not provider_id:
+        return default
+    key = provider_id.strip().lower()
+    if not key:
+        return default
+    return _ALIAS_TO_PROVIDER.get(key, key)
+
+
+def get_provider(provider_id: str) -> Optional[ProviderMeta]:
+    return PROVIDERS.get(normalize_provider_id(provider_id))
+
+
+def list_provider_ids(
+    *,
+    include_oauth: bool = True,
+    include_api_key: bool = True,
+    include_custom: bool = True,
+) -> List[str]:
+    ids: List[str] = []
+    for pid, meta in PROVIDERS.items():
+        if meta.auth_type == "oauth" and not include_oauth:
+            continue
+        if meta.auth_type == "api_key" and not include_api_key:
+            continue
+        if pid == "custom" and not include_custom:
+            continue
+        ids.append(pid)
+    return ids
+
+
+def list_setup_provider_ids() -> List[str]:
+    return [pid for pid, meta in PROVIDERS.items() if meta.show_in_setup]
+
+
+def list_model_picker_provider_ids() -> List[str]:
+    return [pid for pid, meta in PROVIDERS.items() if meta.show_in_model_picker]
+
+
+def iter_api_key_env_vars(provider_id: str) -> Iterable[str]:
+    meta = get_provider(provider_id)
+    if not meta:
+        return ()
+    return meta.api_key_env_vars
+
+
+def resolve_provider_api_key(
+    provider_id: str,
+    *,
+    env_get: EnvGetter = os.getenv,
+    explicit_api_key: Optional[str] = None,
+) -> Optional[str]:
+    if explicit_api_key:
+        return explicit_api_key
+    for env_var in iter_api_key_env_vars(provider_id):
+        value = env_get(env_var)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def resolve_provider_base_url(
+    provider_id: str,
+    *,
+    env_get: EnvGetter = os.getenv,
+    explicit_base_url: Optional[str] = None,
+) -> Optional[str]:
+    if explicit_base_url:
+        return explicit_base_url.strip()
+    meta = get_provider(provider_id)
+    if not meta:
+        return None
+    if meta.base_url_env_var:
+        env_value = env_get(meta.base_url_env_var)
+        if isinstance(env_value, str) and env_value.strip():
+            return env_value.strip().rstrip("/")
+    if meta.default_base_url:
+        return meta.default_base_url.rstrip("/")
+    return None
+
+
+def has_any_provider_key(provider_id: str, *, env_get: EnvGetter = os.getenv) -> bool:
+    for env_var in iter_api_key_env_vars(provider_id):
+        value = env_get(env_var)
+        if isinstance(value, str) and value.strip():
+            return True
+    return False
+
+
+def get_curated_models(provider_id: str) -> List[str]:
+    meta = get_provider(provider_id)
+    if not meta:
+        return []
+    return list(meta.curated_models)
+
+
+def is_supported_provider(provider_id: str) -> bool:
+    return normalize_provider_id(provider_id) in PROVIDERS
+
+
+def detect_auto_provider(*, env_get: EnvGetter = os.getenv) -> str:
+    """
+    Detect the best API-key provider from environment variables.
+
+    Priority:
+    1) Custom endpoint when OPENAI_BASE_URL is set
+    2) OpenRouter
+    3) zAI
+    4) Kimi Coding
+    5) MiniMax
+    6) MiniMax CN
+    7) fallback openrouter
+    """
+    openai_base_url = env_get("OPENAI_BASE_URL")
+    if isinstance(openai_base_url, str) and openai_base_url.strip():
+        return "custom"
+
+    for pid in ("openrouter", "zai", "kimi-coding", "minimax", "minimax-cn"):
+        if has_any_provider_key(pid, env_get=env_get):
+            return pid
+    return "openrouter"
+
+
+def provider_cli_choices(*, include_auto: bool = True) -> List[str]:
+    choices: List[str] = []
+    if include_auto:
+        choices.append("auto")
+    # Keep custom out of --provider; custom is inferred from OPENAI_BASE_URL.
+    choices.extend(
+        pid
+        for pid in list_provider_ids(include_oauth=True, include_api_key=True, include_custom=False)
+    )
+    return choices

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -43,6 +43,7 @@ from hermes_cli.provider_registry import (
     list_setup_provider_ids,
     resolve_provider_api_key,
     resolve_provider_base_url,
+    should_clear_custom_endpoint_env,
 )
 
 def print_header(title: str):
@@ -691,6 +692,7 @@ def run_setup_wizard(args):
     from hermes_cli.auth import (
         AuthError,
         PROVIDER_REGISTRY,
+        deactivate_provider,
         _login_nous,
         fetch_nous_models,
         format_auth_error,
@@ -847,7 +849,7 @@ def run_setup_wizard(args):
                 save_env_value(meta.base_url_env_var, selected_base_url)
                 print_success(f"{meta.base_url_env_var} saved")
 
-        if selected_provider == "openrouter" and get_env_value("OPENAI_BASE_URL"):
+        if should_clear_custom_endpoint_env(selected_provider) and get_env_value("OPENAI_BASE_URL"):
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
 
@@ -1641,5 +1643,8 @@ def run_setup_wizard(args):
     # =========================================================================
     # Save config and show summary
     # =========================================================================
+    if selected_provider and selected_provider != "nous":
+        deactivate_provider()
+
     save_config(config)
     _print_setup_summary(config, hermes_home)

--- a/tests/test_cli_first_run.py
+++ b/tests/test_cli_first_run.py
@@ -1,0 +1,127 @@
+"""Unit tests for hermes_cli.main._has_any_provider_configured."""
+
+import json
+import sys
+import types
+
+import pytest
+
+import hermes_cli.config as config_module
+
+if "dotenv" not in sys.modules:
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+import hermes_cli.main as main
+
+
+PROVIDER_ENV_VARS = (
+    "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "GLM_API_KEY",
+    "ZAI_API_KEY",
+    "Z_AI_API_KEY",
+    "KIMI_API_KEY",
+    "MINIMAX_API_KEY",
+    "MINIMAX_CN_API_KEY",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_env(monkeypatch):
+    for key in PROVIDER_ENV_VARS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _patch_config_paths(monkeypatch, tmp_path, *, env_text=None, auth_payload=None):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+
+    env_path = hermes_home / ".env"
+    if env_text is not None:
+        env_path.write_text(env_text)
+
+    auth_path = hermes_home / "auth.json"
+    if auth_payload is not None:
+        auth_path.write_text(json.dumps(auth_payload))
+
+    monkeypatch.setattr(config_module, "get_env_path", lambda: env_path)
+    monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
+
+
+def test_has_any_provider_configured_uses_runtime_env_keys(monkeypatch, tmp_path):
+    _patch_config_paths(monkeypatch, tmp_path)
+    monkeypatch.setenv("GLM_API_KEY", "glm-live-key")
+
+    def _unexpected_load_config():
+        raise AssertionError("load_config should not run on early env-key detection")
+
+    monkeypatch.setattr(config_module, "load_config", _unexpected_load_config)
+    assert main._has_any_provider_configured() is True
+
+
+def test_has_any_provider_configured_reads_provider_vars_from_dotenv_file(monkeypatch, tmp_path):
+    _patch_config_paths(
+        monkeypatch,
+        tmp_path,
+        env_text="\n# comments are ignored\nKIMI_API_KEY='from-dotenv'\n",
+    )
+
+    def _unexpected_load_config():
+        raise AssertionError("load_config should not run when .env already has provider key")
+
+    monkeypatch.setattr(config_module, "load_config", _unexpected_load_config)
+    assert main._has_any_provider_configured() is True
+
+
+def test_has_any_provider_configured_uses_configured_custom_profile(monkeypatch, tmp_path):
+    _patch_config_paths(monkeypatch, tmp_path, env_text="UNRELATED_KEY=1\n")
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {
+            "model": {
+                "profiles": [
+                    {
+                        "name": "custom-profile",
+                        "provider": "custom",
+                        "model": "my-model",
+                        "base_url": "http://localhost:8000/v1",
+                        "enabled": True,
+                    }
+                ],
+                "active_profile": "custom-profile",
+                "scoped_profiles": ["custom-profile"],
+            }
+        },
+    )
+    assert main._has_any_provider_configured() is True
+
+
+def test_has_any_provider_configured_uses_auth_file_tokens_when_config_unavailable(monkeypatch, tmp_path):
+    _patch_config_paths(
+        monkeypatch,
+        tmp_path,
+        auth_payload={
+            "active_provider": "nous",
+            "providers": {"nous": {"refresh_token": "refresh-token"}},
+        },
+    )
+
+    def _load_config_failure():
+        raise RuntimeError("config not available")
+
+    monkeypatch.setattr(config_module, "load_config", _load_config_failure)
+    assert main._has_any_provider_configured() is True
+
+
+def test_has_any_provider_configured_returns_false_when_no_sources_are_present(monkeypatch, tmp_path):
+    _patch_config_paths(monkeypatch, tmp_path, env_text="UNRELATED_KEY=1\n")
+
+    def _load_config_failure():
+        raise RuntimeError("config not available")
+
+    monkeypatch.setattr(config_module, "load_config", _load_config_failure)
+    assert main._has_any_provider_configured() is False

--- a/tests/test_cli_model_save.py
+++ b/tests/test_cli_model_save.py
@@ -1,0 +1,59 @@
+"""Regression tests for CLI config persistence helpers."""
+
+from pathlib import Path
+
+import yaml
+
+import cli
+
+
+def test_save_config_value_updates_active_profile_when_setting_model_default(monkeypatch, tmp_path):
+    fake_home = tmp_path / "home"
+    config_dir = fake_home / ".hermes"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.yaml"
+
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "legacy-old",
+                    "provider": "openrouter",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "profiles": [
+                        {
+                            "name": "work",
+                            "provider": "zai",
+                            "model": "glm-old",
+                            "base_url": "https://profile.example/v1",
+                            "enabled": True,
+                        },
+                        {
+                            "name": "fallback",
+                            "provider": "openrouter",
+                            "model": "anthropic/claude-opus-4.6",
+                            "base_url": "https://openrouter.ai/api/v1",
+                            "enabled": True,
+                        },
+                    ],
+                    "active_profile": "work",
+                    "scoped_profiles": ["work", "fallback"],
+                }
+            },
+            sort_keys=False,
+        )
+    )
+
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    assert cli.save_config_value("model.default", "glm-new") is True
+
+    persisted = yaml.safe_load(config_path.read_text())
+    model_cfg = persisted["model"]
+
+    active = next(p for p in model_cfg["profiles"] if p["name"] == model_cfg["active_profile"])
+    assert active["name"] == "work"
+    assert active["model"] == "glm-new"
+    assert model_cfg["default"] == "glm-new"
+    assert model_cfg["provider"] == "zai"
+    assert model_cfg["base_url"] == "https://profile.example/v1"

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -203,3 +203,35 @@ def test_set_active_profile_switches_active_profile_and_preserves_unknown_reques
     unchanged = mp.set_active_profile(switched, "missing")
     assert unchanged["active_profile"] == "b"
     assert unchanged["scoped_profiles"] == ["a", "b"]
+
+
+def test_get_profile_names_can_filter_to_enabled_profiles_only():
+    cfg = mp.normalize_model_config(
+        {
+            "profiles": [
+                {"name": "enabled-a", "provider": "openrouter", "model": "m-a", "enabled": True},
+                {"name": "disabled-b", "provider": "zai", "model": "m-b", "enabled": False},
+            ],
+            "active_profile": "enabled-a",
+            "scoped_profiles": ["enabled-a", "disabled-b"],
+        }
+    )
+
+    assert mp.get_profile_names(cfg, enabled_only=False) == ["enabled-a", "disabled-b"]
+    assert mp.get_profile_names(cfg, enabled_only=True) == ["enabled-a"]
+
+
+def test_custom_provider_without_base_url_does_not_silently_fallback_to_openrouter():
+    cfg = mp.normalize_model_config(
+        {
+            "profiles": [
+                {"name": "custom-profile", "provider": "custom", "model": "local-model", "enabled": True},
+            ],
+            "active_profile": "custom-profile",
+            "scoped_profiles": ["custom-profile"],
+        }
+    )
+
+    assert cfg["provider"] == "custom"
+    assert cfg["base_url"] == ""
+    assert cfg["profiles"][0]["base_url"] == ""

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -1,0 +1,205 @@
+"""Unit tests for hermes_cli.model_profiles."""
+
+from hermes_constants import OPENROUTER_BASE_URL
+from hermes_cli import model_profiles as mp
+
+
+def _base_model_config():
+    return {
+        "default": "anthropic/claude-opus-4.6",
+        "provider": "openrouter",
+        "base_url": OPENROUTER_BASE_URL,
+        "profiles": [
+            {
+                "name": mp.DEFAULT_PROFILE_NAME,
+                "provider": "openrouter",
+                "model": "anthropic/claude-opus-4.6",
+                "base_url": OPENROUTER_BASE_URL,
+                "enabled": True,
+            }
+        ],
+        "active_profile": mp.DEFAULT_PROFILE_NAME,
+        "scoped_profiles": [mp.DEFAULT_PROFILE_NAME],
+    }
+
+
+def test_normalize_model_config_migrates_legacy_string():
+    cfg = mp.normalize_model_config("  openai/gpt-5.2  ")
+
+    assert cfg["default"] == "openai/gpt-5.2"
+    assert cfg["provider"] == "openrouter"
+    assert cfg["base_url"] == OPENROUTER_BASE_URL
+    assert cfg["active_profile"] == mp.DEFAULT_PROFILE_NAME
+    assert cfg["scoped_profiles"] == [mp.DEFAULT_PROFILE_NAME]
+    assert cfg["profiles"] == [
+        {
+            "name": mp.DEFAULT_PROFILE_NAME,
+            "provider": "openrouter",
+            "model": "openai/gpt-5.2",
+            "base_url": OPENROUTER_BASE_URL,
+            "enabled": True,
+        }
+    ]
+
+
+def test_normalize_model_config_migrates_legacy_fields_and_syncs_active_profile():
+    cfg = mp.normalize_model_config(
+        {
+            "default": "glm-5",
+            "provider": " GLM ",
+            "base_url": " https://endpoint.example/v1/ ",
+        }
+    )
+
+    profile = cfg["profiles"][0]
+    assert profile["name"] == mp.DEFAULT_PROFILE_NAME
+    assert profile["provider"] == "zai"
+    assert profile["model"] == "glm-5"
+    assert profile["base_url"] == "https://endpoint.example/v1"
+    assert cfg["active_profile"] == mp.DEFAULT_PROFILE_NAME
+    assert cfg["scoped_profiles"] == [mp.DEFAULT_PROFILE_NAME]
+    assert cfg["provider"] == "zai"
+    assert cfg["default"] == "glm-5"
+    assert cfg["base_url"] == "https://endpoint.example/v1"
+
+
+def test_normalize_model_config_repairs_duplicate_profile_names_and_scoped_profiles():
+    cfg = mp.normalize_model_config(
+        {
+            "profiles": [
+                {"name": "work", "provider": "openrouter", "model": "model-a", "enabled": True},
+                {"name": "work", "provider": "kimi", "model": "k2p5", "enabled": True},
+            ],
+            "active_profile": "missing-profile",
+            "scoped_profiles": ["work", "missing-profile", " work-2 "],
+        }
+    )
+
+    assert [p["name"] for p in cfg["profiles"]] == ["work", "work-2"]
+    assert cfg["profiles"][1]["provider"] == "kimi-coding"
+    assert cfg["active_profile"] == "work"
+    assert cfg["scoped_profiles"] == ["work", "work-2"]
+    assert cfg["default"] == "model-a"
+    assert cfg["provider"] == "openrouter"
+
+
+def test_sync_legacy_model_fields_uses_provider_resolver_when_active_base_url_missing(monkeypatch):
+    monkeypatch.setattr(mp, "resolve_provider_base_url", lambda provider: f"https://{provider}.example/v1")
+    synced = mp.sync_legacy_model_fields(
+        {
+            "default": "old-model",
+            "provider": "openrouter",
+            "base_url": None,
+            "profiles": [
+                {
+                    "name": "zai-profile",
+                    "provider": "zai",
+                    "model": "glm-4.6",
+                    "base_url": "",
+                    "enabled": True,
+                }
+            ],
+            "active_profile": "zai-profile",
+            "scoped_profiles": ["zai-profile"],
+        }
+    )
+
+    assert synced["default"] == "glm-4.6"
+    assert synced["provider"] == "zai"
+    assert synced["base_url"] == "https://zai.example/v1"
+
+
+def test_upsert_profile_adds_profile_sets_active_and_syncs_legacy_fields():
+    updated = mp.upsert_profile(
+        _base_model_config(),
+        {
+            "name": "work",
+            "provider": "kimi",
+            "model": "k2p5",
+            "enabled": True,
+        },
+    )
+
+    assert any(p["name"] == "work" and p["provider"] == "kimi-coding" for p in updated["profiles"])
+    assert updated["active_profile"] == "work"
+    assert "work" in updated["scoped_profiles"]
+    assert updated["default"] == "k2p5"
+    assert updated["provider"] == "kimi-coding"
+
+
+def test_upsert_profile_disabled_entry_does_not_take_active_slot():
+    updated = mp.upsert_profile(
+        _base_model_config(),
+        {
+            "name": "disabled-zai",
+            "provider": "zai",
+            "model": "glm-5",
+            "enabled": False,
+        },
+    )
+
+    assert updated["active_profile"] == mp.DEFAULT_PROFILE_NAME
+    assert "disabled-zai" in updated["scoped_profiles"]
+    assert updated["default"] == "anthropic/claude-opus-4.6"
+    assert updated["provider"] == "openrouter"
+
+
+def test_remove_profile_reassigns_active_profile_and_scoped_profiles():
+    cfg = mp.normalize_model_config(
+        {
+            "profiles": [
+                {"name": "a", "provider": "openrouter", "model": "model-a", "enabled": True},
+                {"name": "b", "provider": "glm", "model": "model-b", "enabled": True},
+            ],
+            "active_profile": "a",
+            "scoped_profiles": ["a", "b"],
+        }
+    )
+    updated = mp.remove_profile(cfg, "a")
+
+    assert [p["name"] for p in updated["profiles"]] == ["b"]
+    assert updated["active_profile"] == "b"
+    assert updated["scoped_profiles"] == ["b"]
+    assert updated["default"] == "model-b"
+    assert updated["provider"] == "zai"
+
+
+def test_remove_profile_recreates_default_profile_when_last_profile_is_removed():
+    cfg = mp.normalize_model_config(
+        {
+            "profiles": [{"name": "solo", "provider": "zai", "model": "glm-5", "enabled": True}],
+            "active_profile": "solo",
+            "scoped_profiles": ["solo"],
+        }
+    )
+    updated = mp.remove_profile(cfg, "solo")
+
+    assert [p["name"] for p in updated["profiles"]] == [mp.DEFAULT_PROFILE_NAME]
+    assert updated["active_profile"] == mp.DEFAULT_PROFILE_NAME
+    assert updated["scoped_profiles"] == [mp.DEFAULT_PROFILE_NAME]
+    assert updated["default"] == mp.DEFAULT_MODEL_ID
+    assert updated["provider"] == "openrouter"
+    assert updated["base_url"] == OPENROUTER_BASE_URL
+
+
+def test_set_active_profile_switches_active_profile_and_preserves_unknown_requests():
+    cfg = mp.normalize_model_config(
+        {
+            "profiles": [
+                {"name": "a", "provider": "openrouter", "model": "model-a", "enabled": True},
+                {"name": "b", "provider": "zai", "model": "model-b", "enabled": True},
+            ],
+            "active_profile": "a",
+            "scoped_profiles": ["a"],
+        }
+    )
+
+    switched = mp.set_active_profile(cfg, "b")
+    assert switched["active_profile"] == "b"
+    assert switched["scoped_profiles"] == ["a", "b"]
+    assert switched["default"] == "model-b"
+    assert switched["provider"] == "zai"
+
+    unchanged = mp.set_active_profile(switched, "missing")
+    assert unchanged["active_profile"] == "b"
+    assert unchanged["scoped_profiles"] == ["a", "b"]

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,0 +1,89 @@
+"""Unit tests for hermes_cli.provider_registry."""
+
+import pytest
+
+from hermes_constants import OPENROUTER_BASE_URL
+from hermes_cli import provider_registry as pr
+
+
+def _env(mapping):
+    return lambda key: mapping.get(key)
+
+
+def test_normalize_provider_id_aliases_defaults_and_unknowns():
+    assert pr.normalize_provider_id(" GLM ") == "zai"
+    assert pr.normalize_provider_id("z-AI") == "zai"
+    assert pr.normalize_provider_id("kimi") == "kimi-coding"
+    assert pr.normalize_provider_id("", default="openrouter") == "openrouter"
+    assert pr.normalize_provider_id(None, default="openrouter") == "openrouter"
+    assert pr.normalize_provider_id("  Unknown-Provider  ") == "unknown-provider"
+
+
+def test_resolve_provider_api_key_prefers_explicit_then_first_non_empty_env_var():
+    env = {"GLM_API_KEY": " glm-primary ", "ZAI_API_KEY": "zai-secondary"}
+    assert (
+        pr.resolve_provider_api_key(
+            "zai",
+            env_get=_env(env),
+            explicit_api_key="explicit-key",
+        )
+        == "explicit-key"
+    )
+    assert pr.resolve_provider_api_key("zai", env_get=_env(env)) == "glm-primary"
+
+    env["GLM_API_KEY"] = "   "
+    assert pr.resolve_provider_api_key("zai", env_get=_env(env)) == "zai-secondary"
+
+    env["ZAI_API_KEY"] = "   "
+    env["Z_AI_API_KEY"] = "zai-underscore-alias"
+    assert pr.resolve_provider_api_key("zai", env_get=_env(env)) == "zai-underscore-alias"
+
+
+def test_resolve_provider_base_url_precedence_and_normalization():
+    env = {"GLM_BASE_URL": " https://api.example.test/v4/// "}
+
+    assert (
+        pr.resolve_provider_base_url(
+            "zai",
+            env_get=_env(env),
+            explicit_base_url=" https://override.example/v1/ ",
+        )
+        == "https://override.example/v1/"
+    )
+    assert pr.resolve_provider_base_url("zai", env_get=_env(env)) == "https://api.example.test/v4"
+    assert pr.resolve_provider_base_url("openrouter", env_get=_env({})) == OPENROUTER_BASE_URL
+    assert pr.resolve_provider_base_url("missing-provider", env_get=_env({})) is None
+
+
+def test_provider_cli_choices_and_list_filters():
+    choices = pr.provider_cli_choices(include_auto=True)
+    assert "auto" in choices
+    assert "zai" in choices
+    assert "custom" not in choices
+
+    api_only = pr.list_provider_ids(include_oauth=False, include_api_key=True, include_custom=False)
+    assert "nous" not in api_only
+    assert "openrouter" in api_only
+
+
+def test_has_any_provider_key_checks_all_configured_env_vars():
+    env = {"GLM_API_KEY": "   ", "ZAI_API_KEY": "   ", "Z_AI_API_KEY": "legacy-zai-key"}
+    assert pr.has_any_provider_key("zai", env_get=_env(env)) is True
+    assert pr.has_any_provider_key("minimax", env_get=_env(env)) is False
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        ({"OPENAI_BASE_URL": " https://custom-endpoint/v1 ", "OPENROUTER_API_KEY": "or-key"}, "custom"),
+        ({"OPENROUTER_API_KEY": "or-key", "GLM_API_KEY": "glm-key"}, "openrouter"),
+        ({"ZAI_API_KEY": "zai-key"}, "zai"),
+        ({"Z_AI_API_KEY": "z-ai-key"}, "zai"),
+        ({"KIMI_API_KEY": "kimi-key"}, "kimi-coding"),
+        ({"MINIMAX_API_KEY": "minimax-key", "MINIMAX_CN_API_KEY": "cn-key"}, "minimax"),
+        ({"MINIMAX_CN_API_KEY": "cn-key"}, "minimax-cn"),
+        ({}, "openrouter"),
+    ],
+)
+def test_detect_auto_provider_priority_order(env, expected):
+    assert pr.detect_auto_provider(env_get=_env(env)) == expected


### PR DESCRIPTION
## Summary

This PR adds Pi-aligned multi-provider support to Hermes CLI with first-class support for:

- `zai` (GLM)
- `kimi-coding`
- `minimax`
- `minimax-cn`

It also introduces a centralized provider abstraction and multi-profile model configuration flow so users can configure and switch across providers/models more ergonomically in setup + model picker + CLI overrides.

## What Changed

### 1) Provider abstraction (Pi-aligned)

- Added central provider registry: `hermes_cli/provider_registry.py`
- Canonical provider IDs and aliases
- Per-provider metadata:
  - default base URL
  - env var resolution order
  - optional base URL env override
  - curated model list
- Added support for zAI key aliases:
  - `GLM_API_KEY` (preferred)
  - `ZAI_API_KEY`
  - `Z_AI_API_KEY`

### 2) Multi-provider model profiles (backward compatible)

- Added profile helpers: `hermes_cli/model_profiles.py`
- Extended config behavior to support:
  - `model.profiles`
  - `model.active_profile`
  - `model.scoped_profiles`
- Legacy fields remain supported and synchronized:
  - `model.default`
  - `model.provider`
  - `model.base_url`

### 3) Runtime/provider resolution updates

- Refactored provider resolution in CLI/auth/main flows to use registry helpers
- Unified precedence across CLI args, config, env vars, and provider defaults
- Preserved Nous OAuth path
- Added provider choices to CLI/provider detection paths

### 4) Setup/model picker/status/doctor parity

- Setup wizard now supports all providers and provider-aware key/base URL prompts
- Model picker supports multi-provider/profile workflows and active profile updates
- `status`, `doctor`, and `config` outputs include new providers and profile state

### 5) Documentation/examples

Updated:

- `README.md`
- `docs/cli.md`
- `cli-config.yaml.example`
- `.env.example`

Docs now include provider IDs, env vars, profile schema, model selection examples, and provider override behavior.

## Tests

Added new tests:

- `tests/test_provider_registry.py`
- `tests/test_model_profiles.py`
- `tests/test_cli_first_run.py`

Executed locally:

```bash
.venv/bin/python -m pytest tests/test_provider_registry.py tests/test_model_profiles.py tests/test_cli_first_run.py -q
```

Result: `27 passed`

Also smoke-tested CLI startup:

```bash
.venv/bin/python cli.py --list-tools
```

## Notes

- Provider naming and abstraction follow Pi-style canonical IDs and registry-based resolution.
- OpenRouter behavior remains unchanged for features that independently rely on OpenRouter tooling.
