### PR TITLE
feat: youtube content tool — transcript to chapters/summary/thread/blog

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -74,6 +74,7 @@ def _discover_tools():
     """
     _modules = [
         "tools.web_tools",
+        "tools.youtube_content_tool",
         "tools.terminal_tool",
         "tools.file_tools",
         "tools.vision_tools",
@@ -123,7 +124,7 @@ _last_resolved_tool_names: List[str] = []
 # =============================================================================
 
 _LEGACY_TOOLSET_MAP = {
-    "web_tools": ["web_search", "web_extract"],
+    "web_tools": ["web_search", "web_extract", "youtube_content"],
     "terminal_tools": ["terminal"],
     "vision_tools": ["vision_analyze"],
     "moa_tools": ["mixture_of_agents"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "prompt_toolkit",
   # Tools
   "firecrawl-py",
+  "youtube-transcript-api",
   "fal-client",
   # Text-to-speech (Edge TTS is free, no API key needed)
   "edge-tts",

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ PyJWT[crypto]
 
 # Web tools
 firecrawl-py
+youtube-transcript-api
 
 # Image generation
 fal-client

--- a/skills/youtube-content/SKILL.md
+++ b/skills/youtube-content/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: youtube-content
+description: Turn a YouTube transcript into chapters, summaries, X threads, blog drafts, and quote lists using the youtube_content tool.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [YouTube, Transcript, Chapters, Summary, Content, Marketing]
+    related_skills: [obsidian, notion]
+---
+
+# YouTube Content Tool
+
+Use the `youtube_content` tool when the user shares a YouTube video and wants structured written outputs derived from the transcript.
+
+This tool fetches the transcript, then transforms it into one of several formats:
+- chapter timestamps
+- summary
+- chapter summaries
+- X/Twitter thread
+- blog post draft
+- quote extraction
+- all formats in one response
+
+## When To Use
+
+Use this skill when the user asks for things like:
+- "Bu videoya chapter cikar"
+- "Bu YouTube videosunu thread'e cevir"
+- "Transcriptten blog yazisi olustur"
+- "Onemli alintilari ve timestamp'leri ver"
+- "Videonun tum icerik paketini hazirla"
+
+Do not use this skill for:
+- Non-YouTube URLs
+- Videos without accessible transcripts (private, disabled transcript)
+- Tasks that require frame-by-frame visual analysis (use browser/vision tools instead)
+
+## Quick Usage
+
+### Basic chapter extraction
+
+```python
+youtube_content(
+    url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    output_format="chapters"
+)
+```
+
+### Turkish output (if transcript language supports it)
+
+```python
+youtube_content(
+    url="https://youtu.be/dQw4w9WgXcQ",
+    output_format="thread",
+    language="tr"
+)
+```
+
+### Try Turkish then English transcript fallback
+
+```python
+youtube_content(
+    url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    output_format="summary",
+    language="tr,en"
+)
+```
+
+### Generate everything in one call
+
+```python
+youtube_content(
+    url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    output_format="all"
+)
+```
+
+## Output Formats
+
+### 1. `chapters`
+
+Returns timestamped chapters in plain lines:
+
+```text
+00:00 Giris
+00:55 Bitcoin Dongu Analizi
+02:05 Ayi Sezonu Belirtileri
+04:10 Risk Yonetimi
+06:42 Sonuc ve Ozet
+```
+
+Use this when:
+- User wants YouTube chapter markers
+- User will paste timestamps into video description
+- User wants a quick structure map before deeper content work
+
+### 2. `summary`
+
+Returns a 5-10 sentence summary of the video.
+
+Use this when:
+- User wants a quick understanding before watching
+- User is triaging multiple videos
+- User wants a briefing version
+
+### 3. `chapter_summaries`
+
+Returns chapter timestamps plus exactly short summaries per chapter.
+
+Example shape:
+
+```text
+00:00 Giris
+Konusmaci videonun amacini tanimliyor ve hangi sorulara cevap verecegini acikliyor.
+Odak noktasi piyasa dongusunu dogru okumak ve riskleri erken fark etmek.
+
+00:55 Bitcoin Dongu Analizi
+Onceki dongulerle mevcut piyasa yapisi karsilastiriliyor ve tekrar eden sinyaller anlatiliyor.
+Ozellikle hacim davranisi ve momentum zayiflamasinin onemi vurgulaniyor.
+```
+
+Use this when:
+- User wants study notes
+- User wants newsletter-ready section summaries
+- User plans to repurpose into carousels or scripts
+
+### 4. `thread`
+
+Returns a numbered X/Twitter thread draft.
+
+Use this when:
+- User wants social content from a long video
+- User wants hook + takeaways + CTA format
+
+### 5. `blog`
+
+Returns a titled, sectioned blog post draft.
+
+Use this when:
+- User wants SEO/content-marketing repurposing
+- User needs long-form written content from an interview/podcast/video
+
+### 6. `quotes`
+
+Returns timestamped quotes + why they matter.
+
+Example shape:
+
+```text
+01:22 "The market does not top when everyone is scared; it tops when bad news stops mattering." - Why it matters: explains sentiment divergence as a late-cycle signal.
+05:48 "Most people lose because they size for upside and ignore survival." - Why it matters: summarizes the video's risk-management thesis.
+```
+
+Use this when:
+- User wants clips/highlights
+- User is making quote cards or short posts
+- User needs speaker soundbites with timestamps
+
+### 7. `all`
+
+Returns all formats in one response, grouped into sections:
+- Chapters
+- Summary
+- Chapter Summaries
+- Thread
+- Blog
+- Quotes
+
+Use this when:
+- User wants a complete repurposing pack in one go
+- User is building a content pipeline from a single video
+
+## Practical Workflow Examples
+
+### Workflow A: YouTube chapters first, then thread
+
+1. Call `youtube_content(..., output_format="chapters")`
+2. Review chapter segmentation quality
+3. Call `youtube_content(..., output_format="thread", language="tr")`
+4. Optionally ask for refinements in a desired tone
+
+### Workflow B: Full content pack for a creator
+
+1. Call `youtube_content(..., output_format="all", language="tr")`
+2. Extract blog section into `write_file`
+3. Save quote list to content backlog (`notion`, `obsidian`, or local file)
+4. Reformat thread manually to match user's posting style
+
+## Error Handling Notes
+
+Common failure cases:
+- Invalid URL / unsupported YouTube URL format
+- Transcript disabled by uploader
+- Private or unavailable video
+- No transcript in requested language
+
+If transcript retrieval fails:
+1. Tell the user exactly why (private / no transcript / disabled)
+2. Ask for another video URL or a pasted transcript
+3. If the user provides transcript text manually, use normal writing tools instead
+
+## Tips
+
+- `language="auto"` is best when you are unsure of the transcript language.
+- Use `language="tr,en"` (or similar) when the user explicitly wants a transcript language fallback order.
+- `all` is convenient but longer/more expensive than requesting only the needed format.
+- For highly technical videos, `chapter_summaries` is often the most useful first output before `thread` or `blog`.

--- a/tools/youtube_content_tool.py
+++ b/tools/youtube_content_tool.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""
+YouTube Content Tool -- transcript to structured content formats.
+
+Fetches a YouTube transcript and transforms it into creator-ready content
+formats (chapters, summary, thread, blog, quotes, etc.) using Hermes'
+auxiliary LLM client.
+"""
+
+import json
+import logging
+import re
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+from urllib.parse import parse_qs, urlparse
+
+from agent.auxiliary_client import get_text_auxiliary_client
+
+logger = logging.getLogger(__name__)
+
+try:
+    from youtube_transcript_api import YouTubeTranscriptApi
+    from youtube_transcript_api import _errors as yta_errors
+    _YTA_IMPORT_ERROR: Optional[str] = None
+except Exception as exc:  # pragma: no cover - import gate
+    YouTubeTranscriptApi = None
+    yta_errors = None
+    _YTA_IMPORT_ERROR = str(exc)
+
+
+VALID_OUTPUT_FORMATS = {
+    "chapters",
+    "summary",
+    "chapter_summaries",
+    "thread",
+    "blog",
+    "quotes",
+    "all",
+}
+
+MAX_TRANSCRIPT_CHARS = 120_000
+
+
+def _format_timestamp(seconds: float) -> str:
+    total = max(0, int(seconds))
+    hours, rem = divmod(total, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours > 0:
+        return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+    return f"{minutes:02d}:{secs:02d}"
+
+
+def _extract_video_id(url: str) -> Tuple[Optional[str], Optional[str]]:
+    if not url or not isinstance(url, str):
+        return None, "URL is required."
+
+    url = url.strip()
+    if not url:
+        return None, "URL is required."
+
+    if re.fullmatch(r"[A-Za-z0-9_-]{11}", url):
+        return url, None
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return None, "Invalid YouTube URL. Use http(s)://youtube.com/... or https://youtu.be/..."
+
+    host = (parsed.netloc or "").lower()
+    path = (parsed.path or "").strip("/")
+    query = parse_qs(parsed.query)
+
+    video_id = None
+    if host in {"youtu.be", "www.youtu.be"}:
+        video_id = path.split("/")[0] if path else None
+    elif host.endswith("youtube.com") or host.endswith("youtube-nocookie.com"):
+        if path == "watch":
+            video_id = (query.get("v") or [None])[0]
+        elif path.startswith("shorts/"):
+            video_id = path.split("/", 1)[1].split("/")[0]
+        elif path.startswith("embed/"):
+            video_id = path.split("/", 1)[1].split("/")[0]
+        elif path.startswith("live/"):
+            video_id = path.split("/", 1)[1].split("/")[0]
+
+    if not video_id or not re.fullmatch(r"[A-Za-z0-9_-]{11}", video_id):
+        return None, "Could not extract a valid YouTube video ID from the URL."
+    return video_id, None
+
+
+def _normalize_language_preference(language: str) -> List[str]:
+    if not language or language == "auto":
+        return []
+    raw = [p.strip() for p in str(language).replace(";", ",").split(",")]
+    langs = [p for p in raw if p]
+    return langs or []
+
+
+def _snippet_to_dict(item: Any) -> Dict[str, Any]:
+    if isinstance(item, dict):
+        return {
+            "text": str(item.get("text", "")).strip(),
+            "start": float(item.get("start", 0.0) or 0.0),
+            "duration": float(item.get("duration", 0.0) or 0.0),
+        }
+    return {
+        "text": str(getattr(item, "text", "")).strip(),
+        "start": float(getattr(item, "start", 0.0) or 0.0),
+        "duration": float(getattr(item, "duration", 0.0) or 0.0),
+    }
+
+
+def _fetch_transcript(video_id: str, language: str = "auto") -> Dict[str, Any]:
+    if YouTubeTranscriptApi is None:
+        return {
+            "success": False,
+            "error": f"youtube-transcript-api is not installed ({_YTA_IMPORT_ERROR}).",
+        }
+
+    api = YouTubeTranscriptApi()
+    requested_languages = _normalize_language_preference(language)
+
+    try:
+        transcript_obj = None
+        transcript_meta = {
+            "video_id": video_id,
+            "language": None,
+            "language_code": None,
+            "is_generated": None,
+        }
+
+        if requested_languages:
+            fetched = api.fetch(video_id, languages=requested_languages, preserve_formatting=False)
+        else:
+            transcript_list = api.list(video_id)
+            preferred_auto = ["tr", "en", "en-US", "en-GB"]
+            finders = (
+                transcript_list.find_manually_created_transcript,
+                transcript_list.find_generated_transcript,
+                transcript_list.find_transcript,
+            )
+
+            last_err = None
+            for finder in finders:
+                try:
+                    transcript_obj = finder(preferred_auto)
+                    break
+                except Exception as exc:
+                    last_err = exc
+
+            if transcript_obj is None:
+                try:
+                    transcript_obj = next(iter(transcript_list))
+                except StopIteration:
+                    if last_err:
+                        raise last_err
+                    raise
+
+            fetched = transcript_obj.fetch()
+
+        if transcript_obj is not None:
+            transcript_meta["language"] = getattr(transcript_obj, "language", None)
+            transcript_meta["language_code"] = getattr(transcript_obj, "language_code", None)
+            transcript_meta["is_generated"] = getattr(transcript_obj, "is_generated", None)
+
+        if hasattr(fetched, "snippets"):
+            snippets = [_snippet_to_dict(s) for s in getattr(fetched, "snippets", [])]
+            transcript_meta["language"] = transcript_meta["language"] or getattr(fetched, "language", None)
+            transcript_meta["language_code"] = transcript_meta["language_code"] or getattr(fetched, "language_code", None)
+            transcript_meta["is_generated"] = transcript_meta["is_generated"]
+            if transcript_meta["is_generated"] is None:
+                transcript_meta["is_generated"] = getattr(fetched, "is_generated", None)
+        elif hasattr(fetched, "to_raw_data"):
+            snippets = [_snippet_to_dict(s) for s in fetched.to_raw_data()]
+        else:
+            snippets = [_snippet_to_dict(s) for s in list(fetched)]
+
+        snippets = [s for s in snippets if s.get("text")]
+        if not snippets:
+            return {"success": False, "error": "Transcript was fetched but contained no usable text."}
+
+        lines = [f"{_format_timestamp(s['start'])} {s['text']}" for s in snippets]
+        transcript_text = "\n".join(lines)
+        truncated = False
+        if len(transcript_text) > MAX_TRANSCRIPT_CHARS:
+            head = transcript_text[: int(MAX_TRANSCRIPT_CHARS * 0.75)]
+            tail = transcript_text[-int(MAX_TRANSCRIPT_CHARS * 0.2):]
+            transcript_text = (
+                head
+                + "\n\n[...transcript truncated for token budget...]\n\n"
+                + tail
+            )
+            truncated = True
+
+        return {
+            "success": True,
+            "video_id": video_id,
+            "snippets": snippets,
+            "transcript_text": transcript_text,
+            "transcript_line_count": len(lines),
+            "transcript_chars": len(transcript_text),
+            "truncated": truncated,
+            "language": transcript_meta.get("language"),
+            "language_code": transcript_meta.get("language_code"),
+            "is_generated": transcript_meta.get("is_generated"),
+        }
+
+    except Exception as exc:
+        err_name = type(exc).__name__
+        err_text = str(exc).strip() or err_name
+
+        if yta_errors is not None:
+            if isinstance(exc, getattr(yta_errors, "InvalidVideoId", tuple())):
+                return {"success": False, "error": "Invalid YouTube video ID or URL."}
+            if isinstance(exc, getattr(yta_errors, "TranscriptsDisabled", tuple())):
+                return {"success": False, "error": "Transcripts are disabled for this video."}
+            if isinstance(exc, getattr(yta_errors, "NoTranscriptFound", tuple())):
+                return {"success": False, "error": "No transcript found for this video (requested language may be unavailable)."}
+            if isinstance(exc, getattr(yta_errors, "VideoUnavailable", tuple())):
+                return {"success": False, "error": "Video is unavailable (deleted, private, or restricted)."}
+            if isinstance(exc, getattr(yta_errors, "VideoUnplayable", tuple())):
+                return {"success": False, "error": "Video is not playable (possibly private or restricted)."}
+            if isinstance(exc, getattr(yta_errors, "AgeRestricted", tuple())):
+                return {"success": False, "error": "Video is age-restricted and transcript could not be retrieved."}
+            if isinstance(exc, getattr(yta_errors, "CouldNotRetrieveTranscript", tuple())):
+                return {"success": False, "error": f"Could not retrieve transcript: {err_text}"}
+
+        logger.warning("youtube_content transcript fetch failed for %s: %s", video_id, err_text)
+        return {"success": False, "error": f"Failed to fetch transcript ({err_name}): {err_text}"}
+
+
+def _language_instruction(language: str, transcript_language: Optional[str], transcript_language_code: Optional[str]) -> str:
+    if language and language != "auto":
+        return (
+            f"Write the output in language '{language}'. "
+            "If that exact locale is not natural, use the closest language variant."
+        )
+    if transcript_language:
+        label = transcript_language
+        if transcript_language_code:
+            label += f" ({transcript_language_code})"
+        return f"Write the output in the same language as the transcript: {label}."
+    return "Write the output in the transcript's original language."
+
+
+def _build_user_prompt(
+    *,
+    output_format: str,
+    url: str,
+    transcript_text: str,
+    language_instruction: str,
+    transcript_meta: Dict[str, Any],
+) -> str:
+    meta_block = (
+        f"URL: {url}\n"
+        f"Video ID: {transcript_meta.get('video_id')}\n"
+        f"Transcript language: {transcript_meta.get('language') or 'unknown'}\n"
+        f"Language code: {transcript_meta.get('language_code') or 'unknown'}\n"
+        f"Generated transcript: {transcript_meta.get('is_generated')}\n"
+        f"Transcript lines: {transcript_meta.get('transcript_line_count')}\n"
+        f"Transcript truncated: {transcript_meta.get('truncated')}\n"
+    )
+
+    prompts = {
+        "chapters": (
+            "Create chapter timestamps from the transcript.\n"
+            "Output format rules:\n"
+            "- One line per chapter\n"
+            "- Format exactly: MM:SS Chapter Title (or HH:MM:SS if needed)\n"
+            "- Use concise titles\n"
+            "- Cover the whole video without tiny over-segmentation\n"
+            "- No bullets, no numbering, no extra commentary"
+        ),
+        "summary": (
+            "Write a 5-10 sentence summary of the video.\n"
+            "- Focus on key arguments, takeaways, and conclusions\n"
+            "- No timestamps unless essential\n"
+            "- No bullet list unless the transcript is very list-like"
+        ),
+        "chapter_summaries": (
+            "Create chapter timestamps and a short summary for each chapter.\n"
+            "Output format rules:\n"
+            "- For each chapter, first line: MM:SS Chapter Title\n"
+            "- Then exactly 2 sentences summarizing that chapter\n"
+            "- Blank line between chapters\n"
+            "- Cover the full video"
+        ),
+        "thread": (
+            "Convert the transcript into a Twitter/X thread.\n"
+            "Output format rules:\n"
+            "- Create a strong hook tweet first\n"
+            "- Then a threaded sequence of concise posts\n"
+            "- Keep each post reasonably short and readable\n"
+            "- Preserve the speaker's core claims without hype inflation\n"
+            "- Include a final takeaway/CTA post\n"
+            "- Number tweets like '1/' '2/' etc."
+        ),
+        "blog": (
+            "Write a full blog post based on the transcript.\n"
+            "Output format rules:\n"
+            "- Include a strong title\n"
+            "- Include section headings\n"
+            "- Organize the content into a coherent article, not a transcript rewrite\n"
+            "- Preserve important specifics and examples\n"
+            "- End with a short conclusion"
+        ),
+        "quotes": (
+            "Extract the most important quotes from the transcript.\n"
+            "Output format rules:\n"
+            "- Only include quotes supported by the transcript text provided\n"
+            "- Prefer verbatim phrases when possible\n"
+            "- Include timestamps\n"
+            "- Format each item as: MM:SS \"Quote text\" - Why it matters\n"
+            "- Return 8-20 quotes depending on transcript richness"
+        ),
+        "all": (
+            "Produce all output formats in one response using the exact section order below:\n"
+            "## Chapters\n"
+            "## Summary\n"
+            "## Chapter Summaries\n"
+            "## Thread\n"
+            "## Blog\n"
+            "## Quotes\n\n"
+            "Apply the formatting rules implied by each format (chapters timestamps, 5-10 sentence summary, "
+            "chapter titles + 2-sentence summaries, numbered X thread, titled/sectioned blog post, timestamped quotes)."
+        ),
+    }
+
+    return (
+        f"{prompts[output_format]}\n\n"
+        f"{language_instruction}\n\n"
+        "Video metadata:\n"
+        f"{meta_block}\n"
+        "Transcript (timestamped lines):\n"
+        f"{transcript_text}"
+    )
+
+
+def _max_tokens_for_format(output_format: str) -> int:
+    return {
+        "chapters": 1200,
+        "summary": 900,
+        "chapter_summaries": 2200,
+        "thread": 1800,
+        "blog": 3200,
+        "quotes": 1800,
+        "all": 7000,
+    }.get(output_format, 1600)
+
+
+def youtube_content(url: str, output_format: str = "chapters", language: str = "auto") -> Dict[str, Any]:
+    """
+    Convert a YouTube transcript into structured content.
+
+    Returns a dict. The registry handler wraps it in JSON for the model.
+    """
+    output_format = (output_format or "chapters").strip().lower()
+    language = (language or "auto").strip()
+
+    if output_format not in VALID_OUTPUT_FORMATS:
+        return {
+            "success": False,
+            "error": (
+                f"Invalid output_format '{output_format}'. "
+                f"Use one of: {', '.join(sorted(VALID_OUTPUT_FORMATS))}"
+            ),
+        }
+
+    video_id, err = _extract_video_id(url)
+    if err:
+        return {"success": False, "error": err}
+
+    transcript = _fetch_transcript(video_id, language=language)
+    if not transcript.get("success"):
+        return transcript
+
+    client, model = get_text_auxiliary_client()
+    if client is None or model is None:
+        return {
+            "success": False,
+            "error": (
+                "No auxiliary text model is available for transcript transformation. "
+                "Configure OpenRouter, Nous Portal, or a custom OpenAI-compatible endpoint."
+            ),
+        }
+
+    transcript_meta = {
+        "video_id": video_id,
+        "language": transcript.get("language"),
+        "language_code": transcript.get("language_code"),
+        "is_generated": transcript.get("is_generated"),
+        "transcript_line_count": transcript.get("transcript_line_count"),
+        "truncated": transcript.get("truncated"),
+    }
+    language_instruction = _language_instruction(
+        language,
+        transcript.get("language"),
+        transcript.get("language_code"),
+    )
+    user_prompt = _build_user_prompt(
+        output_format=output_format,
+        url=url,
+        transcript_text=transcript["transcript_text"],
+        language_instruction=language_instruction,
+        transcript_meta=transcript_meta,
+    )
+
+    system_prompt = (
+        "You transform YouTube transcripts into structured content outputs. "
+        "Stay faithful to the transcript, preserve key claims and details, and avoid inventing facts. "
+        "When timestamps are requested, use transcript timestamps that align with the provided text."
+    )
+
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=0.2,
+            max_tokens=_max_tokens_for_format(output_format),
+            timeout=90.0,
+        )
+        content = (response.choices[0].message.content or "").strip()
+        if not content:
+            return {"success": False, "error": "LLM returned an empty response."}
+
+        return {
+            "success": True,
+            "url": url,
+            "video_id": video_id,
+            "output_format": output_format,
+            "language_requested": language,
+            "transcript_language": transcript.get("language"),
+            "transcript_language_code": transcript.get("language_code"),
+            "transcript_is_generated": transcript.get("is_generated"),
+            "transcript_line_count": transcript.get("transcript_line_count"),
+            "transcript_chars": transcript.get("transcript_chars"),
+            "transcript_truncated": transcript.get("truncated"),
+            "model_used": model,
+            "content": content,
+        }
+    except Exception as exc:
+        logger.warning("youtube_content LLM transform failed for %s: %s", video_id, exc)
+        return {"success": False, "error": f"Failed to transform transcript with LLM: {exc}"}
+
+
+def check_youtube_content_requirements() -> bool:
+    """Tool requires youtube-transcript-api and an auxiliary text model."""
+    if YouTubeTranscriptApi is None:
+        return False
+    client, model = get_text_auxiliary_client()
+    return client is not None and model is not None
+
+
+YOUTUBE_CONTENT_SCHEMA = {
+    "name": "youtube_content",
+    "description": (
+        "Fetch a YouTube video's transcript and convert it into structured content "
+        "formats (chapters, summary, chapter summaries, thread, blog, quotes, or all). "
+        "Use this for turning long videos into creator-ready outputs."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "YouTube video URL (youtube.com/watch?v=..., youtu.be/..., shorts URL) or a raw 11-char video ID.",
+            },
+            "output_format": {
+                "type": "string",
+                "enum": sorted(VALID_OUTPUT_FORMATS),
+                "default": "chapters",
+                "description": "Desired output format for the transcript transformation.",
+            },
+            "language": {
+                "type": "string",
+                "default": "auto",
+                "description": (
+                    "Transcript language preference. Use 'auto' to auto-select. "
+                    "You can also pass a language code (e.g. 'tr', 'en') or comma-separated fallbacks (e.g. 'tr,en')."
+                ),
+            },
+        },
+        "required": ["url"],
+    },
+}
+
+
+# --- Registry ---
+from tools.registry import registry
+
+registry.register(
+    name="youtube_content",
+    toolset="web",
+    schema=YOUTUBE_CONTENT_SCHEMA,
+    handler=lambda args, **kw: json.dumps(
+        youtube_content(
+            url=args.get("url", ""),
+            output_format=args.get("output_format", "chapters"),
+            language=args.get("language", "auto"),
+        ),
+        ensure_ascii=False,
+    ),
+    check_fn=check_youtube_content_requirements,
+)
+

--- a/toolsets.py
+++ b/toolsets.py
@@ -30,7 +30,7 @@ from typing import List, Dict, Any, Set, Optional
 # Edit this once to update all platforms simultaneously.
 _HERMES_CORE_TOOLS = [
     # Web
-    "web_search", "web_extract",
+    "web_search", "web_extract", "youtube_content",
     # Terminal + process management
     "terminal", "process",
     # File manipulation
@@ -69,7 +69,7 @@ TOOLSETS = {
     # Basic toolsets - individual tool categories
     "web": {
         "description": "Web research and content extraction tools",
-        "tools": ["web_search", "web_extract"],
+        "tools": ["web_search", "web_extract", "youtube_content"],
         "includes": []  # No other toolsets included
     },
     


### PR DESCRIPTION
## What

This PR adds a new `youtube_content` tool that fetches a YouTube video transcript and converts it into structured content outputs.
The tool retrieves transcripts via `youtube-transcript-api` and uses Hermes' auxiliary LLM client to transform them into creator-ready formats.

## Supported Output Formats

- `chapters` — timestamped chapter list (e.g. `00:00 Introduction`)
- `summary` — 5-10 sentence overall summary
- `chapter_summaries` — chapters + short summary for each chapter
- `thread` — Twitter/X thread format
- `blog` — full blog post with title and sections
- `quotes` — important quotes with timestamps
- `all` — all formats in one combined response

## Features

- YouTube URL parsing support for:
  - `youtube.com/watch?v=...`
  - `youtu.be/...`
  - `youtube.com/shorts/...`
  - `youtube.com/embed/...`
  - `youtube.com/live/...`
  - raw 11-character video ID input
- `language="auto"` transcript selection
- fallback language order support (e.g. `language="tr,en"`)
- robust error handling for:
  - invalid URL / invalid video ID
  - missing transcript
  - transcripts disabled
  - private/unavailable/restricted videos
- transcript truncation guard for long videos (protects LLM prompt/token budget)

## Usage
```python
youtube_content(url="https://youtube.com/watch?v=...", output_format="chapters")
youtube_content(url="https://youtube.com/watch?v=...", output_format="thread", language="tr")
youtube_content(url="https://youtube.com/watch?v=...", output_format="all", language="tr,en")
```

## Changes

- `tools/youtube_content_tool.py` (new)
  - transcript fetching + format-specific prompting + schema/registry registration
- `model_tools.py`
  - added tool discovery import
  - updated legacy web_tools alias map
- `toolsets.py`
  - added to web toolset
  - added to `_HERMES_CORE_TOOLS`
- `requirements.txt`
  - added youtube-transcript-api
- `pyproject.toml`
  - added youtube-transcript-api to canonical dependency list
- `skills/youtube-content/SKILL.md` (new)
  - usage guide + output format examples

## Validation

- syntax/import checks (py_compile)
- tool smoke test (invalid URL error handling)
- real transcript-fetch smoke test (public YouTube video)
- test suite: 55 passed via `uv run --with pytest --with youtube-transcript-api pytest -q`

## Notes

- The tool uses Hermes' auxiliary text model client for transcript transformation.
- If transcript retrieval works but no auxiliary LLM credentials are configured, the tool returns a clear error message.