### PR TITLE
fix: gateway provider resolution and model config parity with CLI

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -202,7 +202,7 @@ class GatewayRunner:
             or "auto"
         )
 
-        # Update model from the same priority chain as the CLI.
+        # Update model: env vars > config.yaml > fallback
         self._model = (
             os.getenv("HERMES_MODEL")
             or os.getenv("LLM_MODEL")
@@ -986,6 +986,17 @@ class GatewayRunner:
             return f"🤖 **Current model:** `{self._model}`\n\nTo change: `/model provider/model-name`"
 
         self._model = args
+        # Persist to config.yaml + .env — same as CLI (hermes_cli/auth.py:964-969)
+        try:
+            from cli import save_config_value
+            save_config_value("model.default", args)
+        except Exception:
+            pass
+        try:
+            from hermes_cli.config import save_env_value
+            save_env_value("LLM_MODEL", args)
+        except Exception:
+            pass
         return f"🤖 Model changed to `{args}`\n_(takes effect on next message)_"
     
     async def _handle_personality_command(self, event: MessageEvent) -> str:


### PR DESCRIPTION
## Summary

The gateway was hardcoding OpenRouter as the LLM provider, ignoring the `provider` setting in `config.yaml` and Nous OAuth credentials. This brings the gateway in line with how the CLI resolves providers, models, and credentials. 

- **Provider resolution**: Gateway now calls `resolve_provider()` from `hermes_cli.auth`, supporting both Nous OAuth and OpenRouter
- **Nous OAuth support**: Added `_ensure_runtime_credentials()` that refreshes access tokens and mints agent keys before each AIAgent creation
- **Model resolution**: Matches CLI priority chain (`HERMES_MODEL` > `LLM_MODEL` > `config.yaml model.default`)
- **Hot-reload feat from @teknium1 preserved**: Re-reads `.env` and `config.yaml` per message (builds on 55a0178) so credential/config changes are picked up without gateway restart 
- **Both AIAgent call sites fixed**: Main message handler + memory flush on `/reset`
- **`/model` command**: Now uses centralized `self._model` state instead of env var

## 👇 Thats a table (Summary of changes)

| Aspect | Before | After |
|--------|--------|-------|
| Provider | OpenRouter (hardcoded) | Respects `config.yaml` provider setting |
| Nous OAuth | Ignored (sad)| Full support (token refresh + agent key minting) |
| Model source | Only `HERMES_MODEL` env var | `HERMES_MODEL` > `LLM_MODEL` > `config.yaml`  |
| Memory flush agent | No `api_key`/`base_url` passed | Uses resolved credentials |
| `/model` command | Set env var only | Updates `self._model` directly |

## Test plan

- [x] Set `provider: nous` in `config.yaml`, verify gateway uses Nous inference endpoint
- [x] Set `provider: openrouter` (or remove provider), verify gateway uses OpenRouter
- [x] Change `LLM_MODEL` in `.env` without restart, verify gateway picks it up on next message
- [x] Test `/model` command shows and changes the active model
- [ ] Test `/reset` command (memory flush agent uses correct provider)