### PR TITLE
Fix Docker backend on macOS and subagent auth for Nous Portal

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -381,7 +381,14 @@ def execute_code(
         rpc_thread.start()
 
         # --- Spawn child process ---
-        child_env = os.environ.copy()
+        # Filter out secret env vars to prevent exfiltration from sandbox
+        _SECRET_PATTERNS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL",
+                            "API_KEY", "OPENROUTER", "ANTHROPIC", "OPENAI",
+                            "AWS_SECRET", "GITHUB_TOKEN")
+        child_env = {
+            k: v for k, v in os.environ.items()
+            if not any(pat in k.upper() for pat in _SECRET_PATTERNS)
+        }
         child_env["HERMES_RPC_SOCKET"] = sock_path
         child_env["PYTHONDONTWRITEBYTECODE"] = "1"
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -99,8 +99,14 @@ def _run_single_child(
     child_prompt = _build_child_system_prompt(goal, context)
 
     try:
+        # Extract parent's API key so subagents inherit auth (e.g. Nous Portal)
+        parent_api_key = None
+        if hasattr(parent_agent, '_client_kwargs'):
+            parent_api_key = parent_agent._client_kwargs.get("api_key")
+
         child = AIAgent(
             base_url=parent_agent.base_url,
+            api_key=parent_api_key,
             model=model or parent_agent.model,
             max_iterations=max_iterations,
             enabled_toolsets=child_toolsets,

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -43,6 +43,7 @@ INSTALL_POLICY = {
     "builtin":       ("allow",  "allow",   "allow"),
     "trusted":       ("allow",  "allow",   "block"),
     "community":     ("allow",  "block",   "block"),
+    "agent-created": ("allow",  "block",   "block"),
 }
 
 VERDICT_INDEX = {"safe": 0, "caution": 1, "dangerous": 2}


### PR DESCRIPTION
## Summary
### Docker backend fixes (macOS)
- Fix undefined `effective_image` variable in Docker backend — only the Modal backend defines this; use `image` directly
- Skip `--storage-opt size=N` on macOS — Docker Desktop doesn't support this flag (requires overlay2 with xfs backing)
- Fix invalid working directory `~` — Docker requires absolute paths for `-w`; default to `/root` and translate `~` from callers

### Subagent auth fix (Nous Portal)
- Propagate parent API key to child agents in `delegate_task` — without this, subagents fall back to the empty `OPENROUTER_API_KEY` env var when using Nous Portal, causing "No pricing available" / "Unknown model" errors on every delegation

## Test plan
- [ ] Verify `hermes` with `terminal.backend: docker` works on macOS (Docker Desktop)
- [ ] Verify Docker backend still works on Linux (where `--storage-opt` is supported)
- [ ] Verify persistent and non-persistent container modes both start successfully
- [ ] Verify subagent delegation works with Nous Portal provider
- [ ] Verify subagent delegation still works with OpenRouter provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)