### PR TITLE
fix: resolve .env and config paths from ~/.hermes/, not project root

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -33,14 +33,20 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
 
-# Load .env file
+# Load .env from ~/.hermes/.env first, then project root as dev fallback
 from dotenv import load_dotenv
-env_path = PROJECT_ROOT / '.env'
-if env_path.exists():
+from hermes_cli.config import get_env_path, get_hermes_home
+_user_env = get_env_path()
+if _user_env.exists():
     try:
-        load_dotenv(dotenv_path=env_path, encoding="utf-8")
+        load_dotenv(dotenv_path=_user_env, encoding="utf-8")
     except UnicodeDecodeError:
-        load_dotenv(dotenv_path=env_path, encoding="latin-1")
+        load_dotenv(dotenv_path=_user_env, encoding="latin-1")
+load_dotenv(dotenv_path=PROJECT_ROOT / '.env', override=False)
+
+# Point mini-swe-agent at ~/.hermes/ so it shares our config
+os.environ.setdefault("MSWEA_GLOBAL_CONFIG_DIR", str(get_hermes_home()))
+os.environ.setdefault("MSWEA_SILENT_STARTUP", "1")
 
 import logging
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -12,6 +12,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
 from hermes_cli.colors import Colors, color
+from hermes_cli.config import get_env_path, get_env_value
 from hermes_constants import OPENROUTER_MODELS_URL
 
 def check_mark(ok: bool) -> str:
@@ -65,7 +66,7 @@ def show_status(args):
     print(f"  Project:      {PROJECT_ROOT}")
     print(f"  Python:       {sys.version.split()[0]}")
     
-    env_path = PROJECT_ROOT / '.env'
+    env_path = get_env_path()
     print(f"  .env file:    {check_mark(env_path.exists())} {'exists' if env_path.exists() else 'not found'}")
     
     # =========================================================================
@@ -88,7 +89,7 @@ def show_status(args):
     }
     
     for name, env_var in keys.items():
-        value = os.getenv(env_var, "")
+        value = get_env_value(env_var) or ""
         has_key = bool(value)
         display = redact_key(value) if not show_all else value
         print(f"  {name:<12}  {check_mark(has_key)} {display}")


### PR DESCRIPTION
## Summary
- `.env` and `config.yaml` are now loaded from `~/.hermes/` (HERMES_HOME) as the primary source, with the project root as a dev fallback
- All entry points (`main.py`, `run_agent.py`, `doctor.py`) use consistent path resolution via `hermes_cli.config` utilities
- `status` and `doctor` commands now report correct file locations and detect API keys from `~/.hermes/.env`
- Fixed `doctor.py` skills hub path, GitHub token detection, and `missing_vars`/`env_vars` key handling

## Context
The install script places config at `~/.hermes/.env` and `~/.hermes/config.yaml`, but the code was looking for them at the project root (`~/.hermes/hermes-agent/.env`). This caused API keys to appear missing in `status`/`doctor` and required users to duplicate their `.env` file.

## Test plan
- [ ] `hermes status` shows `.env file: ✓ exists` pointing to `~/.hermes/.env`
- [ ] `hermes config` shows correct paths under Paths section
- [ ] `hermes doctor` detects API keys from `~/.hermes/.env`
- [ ] `hermes chat` loads API keys and gets a response
- [ ] Dev fallback: works with `.env` in project root when `~/.hermes/.env` doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)