### PR TITLE
Add initial Notion integration scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1537,3 +1537,4 @@ Common issues:
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details.
+WIP: Notion integration branch

--- a/model_tools.py
+++ b/model_tools.py
@@ -73,27 +73,28 @@ def _discover_tools():
     not installed) don't prevent the rest from loading.
     """
     _modules = [
-        "tools.web_tools",
-        "tools.terminal_tool",
-        "tools.file_tools",
-        "tools.vision_tools",
-        "tools.mixture_of_agents_tool",
-        "tools.image_generation_tool",
-        "tools.skills_tool",
-        "tools.skill_manager_tool",
-        "tools.browser_tool",
-        "tools.cronjob_tools",
-        "tools.rl_training_tool",
-        "tools.tts_tool",
-        "tools.todo_tool",
-        "tools.memory_tool",
-        "tools.session_search_tool",
-        "tools.clarify_tool",
-        "tools.code_execution_tool",
-        "tools.delegate_tool",
-        "tools.process_registry",
-        "tools.send_message_tool",
-    ]
+    "tools.web_tools",
+    "tools.terminal_tool",
+    "tools.file_tools",
+    "tools.vision_tools",
+    "tools.mixture_of_agents_tool",
+    "tools.image_generation_tool",
+    "tools.skills_tool",
+    "tools.skill_manager_tool",
+    "tools.browser_tool",
+    "tools.cronjob_tools",
+    "tools.rl_training_tool",
+    "tools.tts_tool",
+    "tools.todo_tool",
+    "tools.memory_tool",
+    "tools.session_search_tool",
+    "tools.clarify_tool",
+    "tools.code_execution_tool",
+    "tools.delegate_tool",
+    "tools.process_registry",
+    "tools.send_message_tool",
+    "tools.hello_tool",   # 👈 BU ŞART
+]
     import importlib
     for mod_name in _modules:
         try:

--- a/tools/hello_tool.py
+++ b/tools/hello_tool.py
@@ -1,0 +1,31 @@
+from tools.registry import registry
+
+def hello_handler(args: dict, **kwargs) -> str:
+    name = args.get("name", "world")
+    return f"Hello {name}"
+
+hello_schema = {
+    "name": "hello",
+    "description": "Say hello to someone.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Name to greet"
+            }
+        },
+        "required": []
+    }
+}
+
+registry.register(
+    name="hello",
+    toolset="custom",
+    schema=hello_schema,
+    handler=hello_handler,
+    check_fn=None,
+    requires_env=[],
+    is_async=False,
+    description="Simple hello test tool"
+)


### PR DESCRIPTION
This PR introduces the initial scaffolding for Notion integration into Hermes Agent.

Changes:
- Created new integration branch
- Added hello tool example under tools/
- Preparing integration structure for Notion tools
- Setup groundwork for tool registration extension

This is the first step toward full Notion support (read, create, update, query database, etc.).

Further tool implementations and tests will follow in subsequent commits.