### PR TITLE
fix: consistent HERMES_HOME and .env path resolution across all entry points

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,9 +28,12 @@ from typing import Dict, Optional, Any, List
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+# Resolve Hermes home directory (respects HERMES_HOME override)
+_hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+
 # Load environment variables from ~/.hermes/.env first
 from dotenv import load_dotenv
-_env_path = Path.home() / '.hermes' / '.env'
+_env_path = _hermes_home / '.env'
 if _env_path.exists():
     try:
         load_dotenv(_env_path, encoding="utf-8")
@@ -41,7 +44,7 @@ load_dotenv()
 
 # Bridge config.yaml values into the environment so os.getenv() picks them up.
 # Values already set in the environment (from .env or shell) take precedence.
-_config_path = Path.home() / '.hermes' / 'config.yaml'
+_config_path = _hermes_home / 'config.yaml'
 if _config_path.exists():
     try:
         import yaml as _yaml
@@ -141,7 +144,7 @@ class GatewayRunner:
         if not file_path:
             try:
                 import yaml as _y
-                cfg_path = Path.home() / ".hermes" / "config.yaml"
+                cfg_path = _hermes_home / "config.yaml"
                 if cfg_path.exists():
                     with open(cfg_path) as _f:
                         cfg = _y.safe_load(_f) or {}
@@ -152,7 +155,7 @@ class GatewayRunner:
             return []
         path = Path(file_path).expanduser()
         if not path.is_absolute():
-            path = Path.home() / ".hermes" / path
+            path = _hermes_home / path
         if not path.exists():
             logger.warning("Prefill messages file not found: %s", path)
             return []
@@ -179,7 +182,7 @@ class GatewayRunner:
             return prompt
         try:
             import yaml as _y
-            cfg_path = Path.home() / ".hermes" / "config.yaml"
+            cfg_path = _hermes_home / "config.yaml"
             if cfg_path.exists():
                 with open(cfg_path) as _f:
                     cfg = _y.safe_load(_f) or {}
@@ -200,7 +203,7 @@ class GatewayRunner:
         if not effort:
             try:
                 import yaml as _y
-                cfg_path = Path.home() / ".hermes" / "config.yaml"
+                cfg_path = _hermes_home / "config.yaml"
                 if cfg_path.exists():
                     with open(cfg_path) as _f:
                         cfg = _y.safe_load(_f) or {}
@@ -884,7 +887,7 @@ class GatewayRunner:
         
         try:
             import yaml
-            config_path = Path.home() / '.hermes' / 'config.yaml'
+            config_path = _hermes_home / 'config.yaml'
             if config_path.exists():
                 with open(config_path, 'r') as f:
                     config = yaml.safe_load(f) or {}
@@ -981,7 +984,7 @@ class GatewayRunner:
         # Save to config.yaml
         try:
             import yaml
-            config_path = Path.home() / '.hermes' / 'config.yaml'
+            config_path = _hermes_home / 'config.yaml'
             user_config = {}
             if config_path.exists():
                 with open(config_path) as f:
@@ -1243,7 +1246,7 @@ class GatewayRunner:
         # Try to load platform_toolsets from config
         platform_toolsets_config = {}
         try:
-            config_path = Path.home() / '.hermes' / 'config.yaml'
+            config_path = _hermes_home / 'config.yaml'
             if config_path.exists():
                 import yaml
                 with open(config_path, 'r') as f:
@@ -1405,7 +1408,7 @@ class GatewayRunner:
 
             try:
                 import yaml as _y
-                _cfg_path = Path.home() / ".hermes" / "config.yaml"
+                _cfg_path = _hermes_home / "config.yaml"
                 if _cfg_path.exists():
                     with open(_cfg_path) as _f:
                         _cfg = _y.safe_load(_f) or {}
@@ -1697,7 +1700,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None) -> bool:
     A False return causes a non-zero exit code so systemd can auto-restart.
     """
     # Configure rotating file log so gateway output is persisted for debugging
-    log_dir = Path.home() / '.hermes' / 'logs'
+    log_dir = _hermes_home / 'logs'
     log_dir.mkdir(parents=True, exist_ok=True)
     file_handler = RotatingFileHandler(
         log_dir / 'gateway.log',

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -181,7 +181,7 @@ def run_doctor(args):
     print()
     print(color("◆ Directory Structure", Colors.CYAN, Colors.BOLD))
     
-    hermes_home = Path.home() / ".hermes"
+    hermes_home = HERMES_HOME
     if hermes_home.exists():
         check_ok("~/.hermes directory exists")
     else:

--- a/rl_cli.py
+++ b/rl_cli.py
@@ -27,19 +27,25 @@ from pathlib import Path
 import fire
 import yaml
 
-# Load environment variables from .env file
+# Load .env from ~/.hermes/.env first, then project root as dev fallback
 from dotenv import load_dotenv
 
-# Load from ~/.hermes/.env first, then local .env
-hermes_env_path = Path.home() / '.hermes' / '.env'
-local_env_path = Path(__file__).parent / '.env'
+_hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+_user_env = _hermes_home / ".env"
+_project_env = Path(__file__).parent / '.env'
 
-if hermes_env_path.exists():
-    load_dotenv(dotenv_path=hermes_env_path)
-    print(f"✅ Loaded environment variables from {hermes_env_path}")
-elif local_env_path.exists():
-    load_dotenv(dotenv_path=local_env_path)
-    print(f"✅ Loaded environment variables from {local_env_path}")
+if _user_env.exists():
+    try:
+        load_dotenv(dotenv_path=_user_env, encoding="utf-8")
+    except UnicodeDecodeError:
+        load_dotenv(dotenv_path=_user_env, encoding="latin-1")
+    print(f"✅ Loaded environment variables from {_user_env}")
+elif _project_env.exists():
+    try:
+        load_dotenv(dotenv_path=_project_env, encoding="utf-8")
+    except UnicodeDecodeError:
+        load_dotenv(dotenv_path=_project_env, encoding="latin-1")
+    print(f"✅ Loaded environment variables from {_project_env}")
 
 # Set terminal working directory to tinker-atropos submodule
 # This ensures terminal commands run in the right context for RL work
@@ -77,7 +83,7 @@ def load_hermes_config() -> dict:
     Returns:
         dict: Configuration with model, base_url, etc.
     """
-    config_path = Path.home() / '.hermes' / 'config.yaml'
+    config_path = _hermes_home / 'config.yaml'
     
     config = {
         "model": DEFAULT_MODEL,


### PR DESCRIPTION
## Summary
- **cli.py**: Load `~/.hermes/.env` first (respecting `HERMES_HOME`), project `.env` as fallback. Removed redundant second `load_dotenv` call inside `load_cli_config()`. Added `MSWEA_GLOBAL_CONFIG_DIR` setup.
- **gateway/run.py**: Replace all hardcoded `Path.home() / ".hermes"` with `_hermes_home` (`.env`, `config.yaml`, logs, prefill messages, personality/reasoning config).
- **cron/scheduler.py**: Replace hardcoded `~/.hermes` paths with `_hermes_home` for `.env` reload, `config.yaml`, and lock directory.
- **rl_cli.py**: Respect `HERMES_HOME`, add UTF-8 → latin-1 encoding fallback on `load_dotenv`.
- **hermes_cli/doctor.py**: Use existing `HERMES_HOME` constant instead of hardcoded `Path.home()` in directory check.

## Test plan
- [x] All modified files pass `py_compile` syntax check
- [x] Path resolution logic verified: default `~/.hermes`, custom `HERMES_HOME` override, derived paths
- [ ] Manual test: run `hermes status` / `hermes doctor` with default config
- [ ] Manual test: run with `HERMES_HOME=/tmp/test-hermes` to verify override

🤖 Generated with [Claude Code](https://claude.com/claude-code)