### PR TITLE
Fix SystemExit traceback during atexit cleanup on Ctrl+C

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -617,7 +617,10 @@ def _stop_cleanup_thread():
     global _cleanup_running
     _cleanup_running = False
     if _cleanup_thread is not None:
-        _cleanup_thread.join(timeout=5)
+        try:
+            _cleanup_thread.join(timeout=5)
+        except (SystemExit, KeyboardInterrupt):
+            pass
 
 
 def get_active_environments_info() -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- Fixes unhandled `SystemExit` traceback when pressing Ctrl+C during shutdown
- The browser_tool signal handler calls `sys.exit(130)` which can fire during `terminal_tool._stop_cleanup_thread()` → `_cleanup_thread.join()`, producing a noisy traceback
- Wraps the `join()` in a try/except for `SystemExit`/`KeyboardInterrupt` to suppress the race

## Test plan
- [ ] Press Ctrl+C during an active agent session — should exit cleanly without traceback
- [ ] Verify normal shutdown (no Ctrl+C) still cleans up sandboxes properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)