### PR TITLE
fix: add SSH backend to terminal requirements check

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1068,6 +1068,10 @@ def check_terminal_requirements() -> bool:
                 result = subprocess.run([executable, "--version"], capture_output=True, timeout=5)
                 return result.returncode == 0
             return False
+        elif env_type == "ssh":
+            from tools.environments.ssh import SSHEnvironment
+            # Check that host and user are configured
+            return bool(config.get("ssh_host")) and bool(config.get("ssh_user"))
         elif env_type == "modal":
             from minisweagent.environments.extra.swerex_modal import SwerexModalEnvironment
             # Check for modal token


### PR DESCRIPTION
## Summary
- `check_terminal_requirements()` had no `elif env_type == "ssh"` branch
- When `TERMINAL_ENV=ssh`, the check fell through to `return False`, silently disabling both terminal and file tools
- Adds the missing SSH case — verifies `ssh_host` and `ssh_user` are configured

## Context
The terminal and file tools both depend on `check_terminal_requirements()` to determine availability. Every other backend (local, docker, singularity, modal) had a check — SSH was the only one missing.

With this bug, users who configured `TERMINAL_ENV=ssh` got a working hermes session but with no terminal or file tools available — only `execute_code` (which runs locally, defeating the purpose of SSH isolation).

## Test plan
- [x] `check_terminal_requirements()` returns `False` when SSH host/user not set
- [x] `check_terminal_requirements()` returns `True` when SSH host/user configured
- [x] End-to-end: `hermes chat -q` with SSH backend runs commands on remote host
- [x] End-to-end: `read_file` works over SSH backend
- [x] Other backends unaffected (local still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)