### PR TITLE
fix(security): prevent shell injection in sudo password piping

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -319,7 +319,9 @@ def _transform_sudo_command(command: str) -> str:
         # Replace 'sudo' with password-piped version
         # The -S flag makes sudo read password from stdin
         # The -p '' suppresses the password prompt
-        return f"echo '{sudo_password}' | sudo -S -p ''"
+        # Use shlex.quote() to prevent shell injection via password content
+        import shlex
+        return f"echo {shlex.quote(sudo_password)} | sudo -S -p ''"
     
     # Match 'sudo' at word boundaries (not 'visudo' or 'sudoers')
     # This handles: sudo, sudo -flag, etc.


### PR DESCRIPTION
## Problem

The sudo password in `_transform_sudo_command()` was embedded in a shell command using single-quote interpolation:

```python
return f"echo '{sudo_password}' | sudo -S -p ''"
```

If the password contained shell metacharacters (single quotes, `$()`, backticks), they would escape the quoting and be interpreted by the shell — enabling **arbitrary command execution**.

**Example** — a password like `test'; rm -rf / #` produces:
```
echo 'test'; rm -rf / #' | sudo -S -p ''
       ^^^^^^^^^^^ executed as a separate command
```

## Fix

Use `shlex.quote()` which properly handles all shell-special characters:

```python
import shlex
return f"echo {shlex.quote(sudo_password)} | sudo -S -p ''"
```

The same attack payload now produces:
```
echo 'test'"'"'; rm -rf / #' | sudo -S -p ''
      ^^^^^^^^^^^^^^^^^^^^^^^^ entire string treated as echo argument
```

## Scope

Single file, 3-line change in `tools/terminal_tool.py`. No behavior change for normal passwords — `shlex.quote()` is a no-op for simple alphanumeric strings.