### PR TITLE
fix: prevent false positives in recursive delete detection

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -93,3 +93,65 @@ class TestApproveAndCheckSession:
         approve_session(key, "rm")
         clear_session(key)
         assert is_approved(key, "rm") is False
+
+
+class TestRmFalsePositiveFix:
+    """Regression tests: filenames starting with 'r' must NOT trigger recursive delete."""
+
+    def test_rm_readme_not_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm readme.txt")
+        assert is_dangerous is False, f"'rm readme.txt' should be safe, got: {desc}"
+
+    def test_rm_requirements_not_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm requirements.txt")
+        assert is_dangerous is False, f"'rm requirements.txt' should be safe, got: {desc}"
+
+    def test_rm_report_not_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm report.csv")
+        assert is_dangerous is False, f"'rm report.csv' should be safe, got: {desc}"
+
+    def test_rm_results_not_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm results.json")
+        assert is_dangerous is False, f"'rm results.json' should be safe, got: {desc}"
+
+    def test_rm_robots_not_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm robots.txt")
+        assert is_dangerous is False, f"'rm robots.txt' should be safe, got: {desc}"
+
+    def test_rm_run_not_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm run.sh")
+        assert is_dangerous is False, f"'rm run.sh' should be safe, got: {desc}"
+
+    def test_rm_force_readme_not_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm -f readme.txt")
+        assert is_dangerous is False, f"'rm -f readme.txt' should be safe, got: {desc}"
+
+    def test_rm_verbose_readme_not_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm -v readme.txt")
+        assert is_dangerous is False, f"'rm -v readme.txt' should be safe, got: {desc}"
+
+
+class TestRmRecursiveFlagVariants:
+    """Ensure all recursive delete flag styles are still caught."""
+
+    def test_rm_r(self):
+        assert detect_dangerous_command("rm -r mydir")[0] is True
+
+    def test_rm_rf(self):
+        assert detect_dangerous_command("rm -rf /tmp/test")[0] is True
+
+    def test_rm_rfv(self):
+        assert detect_dangerous_command("rm -rfv /var/log")[0] is True
+
+    def test_rm_fr(self):
+        assert detect_dangerous_command("rm -fr .")[0] is True
+
+    def test_rm_irf(self):
+        assert detect_dangerous_command("rm -irf somedir")[0] is True
+
+    def test_rm_recursive_long(self):
+        assert detect_dangerous_command("rm --recursive /tmp")[0] is True
+
+    def test_sudo_rm_rf(self):
+        assert detect_dangerous_command("sudo rm -rf /tmp")[0] is True
+

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 DANGEROUS_PATTERNS = [
     (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
-    (r'\brm\s+(-[^\s]*)?r', "recursive delete"),
+    (r'\brm\s+-[^\s]*r', "recursive delete"),
     (r'\brm\s+--recursive\b', "recursive delete (long flag)"),
     (r'\bchmod\s+(-[^\s]*\s+)*777\b', "world-writable permissions"),
     (r'\bchmod\s+--recursive\b.*777', "recursive world-writable (long flag)"),


### PR DESCRIPTION
## Problem

The regex pattern for detecting recursive delete commands in `tools/approval.py` produces false positives for any `rm` command where the filename starts with the letter `r`.

**Root cause:** The pattern `\brm\s+(-[^\s]*)?r` makes the dash-flag group `(-[^\s]*)?` optional. When the filename doesn't start with `-`, the group matches nothing, and the trailing `r` matches the first character of the filename instead of a flag.

**Examples of false positives:**
| Command | Expected | Actual |
|---------|----------|--------|
| `rm readme.txt` | ✅ Safe | ❌ Flagged as 'recursive delete' |
| `rm requirements.txt` | ✅ Safe | ❌ Flagged |
| `rm report.csv` | ✅ Safe | ❌ Flagged |
| `rm README.md` | ✅ Safe | ❌ Flagged |
| `rm results.json` | ✅ Safe | ❌ Flagged |
| `rm robots.txt` | ✅ Safe | ❌ Flagged |

This causes unnecessary approval prompts for the user when the agent tries to delete files whose names start with 'r'.

## Fix

Make the dash mandatory so only actual flags are matched:

```diff
- (r'\brm\s+(-[^\s]*)?r', "recursive delete"),
+ (r'\brm\s+-[^\s]*r', "recursive delete"),
```

The change from `(-[^\s]*)?` (optional group) to `-[^\s]*` (required dash) ensures the `r` is always part of a CLI flag like `-r`, `-rf`, `-rfv`, or `-fr` — never part of a filename.

## Tests Added

Added 15 new tests in `tests/tools/test_approval.py` across two classes:

**`TestRmFalsePositiveFix`** (8 regression tests):
- Verifies that `rm readme.txt`, `rm requirements.txt`, `rm report.csv`, `rm results.json`, `rm robots.txt`, `rm run.sh`, `rm -f readme.txt`, `rm -v readme.txt` are all correctly identified as safe

**`TestRmRecursiveFlagVariants`** (7 tests):
- Verifies that `rm -r`, `rm -rf`, `rm -rfv`, `rm -fr`, `rm -irf`, `rm --recursive`, `sudo rm -rf` are all still correctly caught as dangerous

```
29 passed in 0.53s (14 existing + 15 new, 0 failures)
```

## Scope

- `tools/approval.py`: 1-line regex fix (line 25)
- `tests/tools/test_approval.py`: 15 new regression tests
- No behavior change for actual recursive delete commands