### PR TITLE
fix: prevent silent abort in piped install when interactive prompts fail (#69)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,6 +38,15 @@ USE_VENV=true
 RUN_SETUP=true
 BRANCH="main"
 
+# Detect non-interactive mode (e.g. curl | bash)
+# When stdin is not a terminal, read -p will fail with EOF,
+# causing set -e to silently abort the entire script.
+if [ -t 0 ]; then
+    IS_INTERACTIVE=true
+else
+    IS_INTERACTIVE=false
+fi
+
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -467,15 +476,20 @@ install_system_packages() {
             fi
         # sudo needs password — ask once for everything
         elif command -v sudo &> /dev/null; then
-            echo ""
-            read -p "Install ${description}? (requires sudo) [y/N] " -n 1 -r
-            echo
-            if [[ $REPLY =~ ^[Yy]$ ]]; then
-                if sudo $install_cmd; then
-                    [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
-                    [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
-                    return 0
+            if [ "$IS_INTERACTIVE" = true ]; then
+                echo ""
+                read -p "Install ${description}? (requires sudo) [y/N] " -n 1 -r
+                echo
+                if [[ $REPLY =~ ^[Yy]$ ]]; then
+                    if sudo $install_cmd; then
+                        [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
+                        [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+                        return 0
+                    fi
                 fi
+            else
+                log_warn "Non-interactive mode: cannot prompt for sudo password"
+                log_info "Install missing packages manually: sudo $install_cmd"
             fi
         fi
     fi
@@ -771,6 +785,11 @@ run_setup_wizard() {
         return 0
     fi
 
+    if [ "$IS_INTERACTIVE" = false ]; then
+        log_info "Setup wizard skipped (non-interactive). Run 'hermes setup' after install."
+        return 0
+    fi
+
     echo ""
     log_info "Starting setup wizard..."
     echo ""
@@ -813,17 +832,26 @@ maybe_start_gateway() {
     WHATSAPP_VAL=$(grep "^WHATSAPP_ENABLED=" "$ENV_FILE" 2>/dev/null | cut -d'=' -f2-)
     WHATSAPP_SESSION="$HERMES_HOME/whatsapp/session/creds.json"
     if [ "$WHATSAPP_VAL" = "true" ] && [ ! -f "$WHATSAPP_SESSION" ]; then
-        echo ""
-        log_info "WhatsApp is enabled but not yet paired."
-        log_info "Running 'hermes whatsapp' to pair via QR code..."
-        echo ""
-        read -p "Pair WhatsApp now? [Y/n] " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
-            HERMES_CMD="$HOME/.local/bin/hermes"
-            [ ! -x "$HERMES_CMD" ] && HERMES_CMD="hermes"
-            $HERMES_CMD whatsapp || true
+        if [ "$IS_INTERACTIVE" = true ]; then
+            echo ""
+            log_info "WhatsApp is enabled but not yet paired."
+            log_info "Running 'hermes whatsapp' to pair via QR code..."
+            echo ""
+            read -p "Pair WhatsApp now? [Y/n] " -n 1 -r
+            echo
+            if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+                HERMES_CMD="$HOME/.local/bin/hermes"
+                [ ! -x "$HERMES_CMD" ] && HERMES_CMD="hermes"
+                $HERMES_CMD whatsapp || true
+            fi
+        else
+            log_info "WhatsApp pairing skipped (non-interactive). Run 'hermes whatsapp' to pair."
         fi
+    fi
+
+    if [ "$IS_INTERACTIVE" = false ]; then
+        log_info "Gateway setup skipped (non-interactive). Run 'hermes gateway install' later."
+        return 0
     fi
 
     echo ""


### PR DESCRIPTION
Fixes #69

## Problem

The install script silently aborts when run via `curl | bash` on systems where `sudo` requires a password (e.g. fresh Debian 12 without ripgrep).

**Root cause:** The script uses `set -e` (line 16) which exits on any non-zero return code. When running via `curl | bash`, stdin is a pipe — not a terminal. The `read -p` command at line 471 (sudo package install prompt) hits EOF on the piped stdin and returns exit code 1. Under `set -e`, this silently kills the entire script before `clone_repo`, `setup_path`, etc. ever run.

**Result:** `uv` gets installed but `hermes` is never set up. No error message is shown.

### Reproduction
```bash
# Simulates the exact failure:
bash -c 'set -e; echo "before read"; read -p "prompt: " -n 1 -r < /dev/null; echo "NEVER REACHED"'
# Output: "before read" then silent exit with code 1
```

## Fix

Detect non-interactive mode at script start using the standard POSIX test `[ -t 0 ]` (checks if stdin is a terminal). When running in piped mode, skip all interactive prompts and show clear messages telling the user what to run manually.

```bash
if [ -t 0 ]; then
    IS_INTERACTIVE=true
else
    IS_INTERACTIVE=false
fi
```

This is the same approach used by `rustup`, `nvm`, and `oh-my-zsh` install scripts.

### Guarded prompts

| Location | Prompt | Non-interactive behavior |
|----------|--------|--------------------------|
| `install_system_packages` | sudo password for ripgrep/ffmpeg | Shows `sudo apt install ...` command to run manually |
| `run_setup_wizard` | interactive `hermes setup` | Skips, shows `hermes setup` to run after install |
| `maybe_start_gateway` | WhatsApp QR pairing | Skips, shows `hermes whatsapp` to run later |
| `maybe_start_gateway` | gateway service install | Skips, shows `hermes gateway install` to run later |

The sudo prompt (row 1) is the direct cause of #69. The other three use the same `read -p` pattern and would fail identically in piped mode, so they are guarded for completeness.

## Verification

```bash
# Before fix (silent abort):
bash -c 'set -e; read -p "test: " -n 1 -r < /dev/null; echo "OK"'
# Output: (nothing) — exit code 1

# After fix (completes successfully):
bash -c 'set -e; if [ -t 0 ]; then read -p "test: " -n 1 -r; else echo "skipped"; fi; echo "OK"' < /dev/null
# Output: "skipped" then "OK" — exit code 0
```

## Scope

Single file: `scripts/install.sh`. No changes to Python code or agent behavior. Normal interactive installs (`bash install.sh`) are completely unaffected — the prompts work exactly as before when stdin is a terminal.