### PR TITLE
fix(whatsapp): multi-user session isolation and bridge message handling

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -529,7 +529,12 @@ class GatewayRunner:
             return await self._handle_set_home_command(event)
         
         # Check for pending exec approval responses
-        session_key_preview = f"agent:main:{source.platform.value}:{source.chat_type}:{source.chat_id}" if source.chat_type != "dm" else f"agent:main:{source.platform.value}:dm"
+        if source.chat_type != "dm":
+            session_key_preview = f"agent:main:{source.platform.value}:{source.chat_type}:{source.chat_id}"
+        elif source.platform and source.platform.value == "whatsapp" and source.chat_id:
+            session_key_preview = f"agent:main:{source.platform.value}:dm:{source.chat_id}"
+        else:
+            session_key_preview = f"agent:main:{source.platform.value}:dm"
         if session_key_preview in self._pending_approvals:
             user_text = event.text.strip().lower()
             if user_text in ("yes", "y", "approve", "ok", "go", "do it"):

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -154,6 +154,12 @@ def build_session_context_prompt(context: SessionContext) -> str:
         lines.append(f"**Source:** {platform_name} (the machine running this agent)")
     else:
         lines.append(f"**Source:** {platform_name} ({context.source.description})")
+
+    # User identity (especially useful for WhatsApp where multiple people DM)
+    if context.source.user_name:
+        lines.append(f"**User:** {context.source.user_name}")
+    elif context.source.user_id:
+        lines.append(f"**User ID:** {context.source.user_id}")
     
     # Connected platforms
     platforms_list = ["local (files on this machine)"]
@@ -323,8 +329,12 @@ class SessionStore:
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
         platform = source.platform.value
-        
+
         if source.chat_type == "dm":
+            # WhatsApp DMs come from different people, each needs its own session.
+            # Other platforms (Telegram, Discord) have a single DM with the bot owner.
+            if platform == "whatsapp" and source.chat_id:
+                return f"agent:main:{platform}:dm:{source.chat_id}"
             return f"agent:main:{platform}:dm"
         else:
             return f"agent:main:{platform}:{source.chat_type}:{source.chat_id}"

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -111,10 +111,15 @@ async function startSocket() {
       const senderNumber = senderId.replace(/@.*/, '');
 
       // Skip own messages UNLESS it's a self-chat ("Message Yourself")
-      // Self-chat JID ends with the user's own number
-      if (msg.key.fromMe && !chatId.includes('status') && isGroup) continue;
-      // In non-group chats, fromMe means we sent it — skip unless allowed user sent to themselves
-      if (msg.key.fromMe && !isGroup && ALLOWED_USERS.length > 0 && !ALLOWED_USERS.includes(senderNumber)) continue;
+      if (msg.key.fromMe) {
+        // Always skip in groups and status
+        if (isGroup || chatId.includes('status')) continue;
+        // In DMs: only allow self-chat (remoteJid matches our own number)
+        const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
+        const chatNumber = chatId.replace(/@.*/, '');
+        const isSelfChat = myNumber && chatNumber === myNumber;
+        if (!isSelfChat) continue;
+      }
 
       // Check allowlist for messages from others
       if (!msg.key.fromMe && ALLOWED_USERS.length > 0 && !ALLOWED_USERS.includes(senderNumber)) {


### PR DESCRIPTION
I opened #31 about WhatsApp not working, and after the bridge was added and the gateway auth was fixed I started testing and found three issues. So I patched them locally and it's been working well. Sharing in case it's useful to merge upstream. Awesome project btw.

## Summary

- **scripts/whatsapp-bridge/bridge.js**: When `WHATSAPP_ALLOWED_USERS` is empty, `fromMe` messages in DMs were never filtered. Every agent reply got picked up as a new incoming message, causing interrupts and feedback loops. Fix: skip all `fromMe` except self-chat, detected by comparing `remoteJid` to `sock.user.id`.

- **gateway/session.py**: `_generate_session_key()` returned `agent:main:whatsapp:dm` for every DM regardless of who's writing. Two people messaging at the same time shared conversation history and interrupted each other. Fix: WhatsApp DM keys now include the `chat_id` (`agent:main:whatsapp:dm:{chat_id}`). Other platforms unchanged.

- **gateway/session.py** + **gateway/run.py**: Added user name/ID to the session context prompt so the agent knows who it's talking to. Updated approval session key to match the new format.

Also noticed that `provider: auto` in `config.yaml` isn't handled by the gateway credential resolution in `run.py` — it only checks `provider == "nous"`, so `auto` falls through to OpenRouter. Didn't include that here since it's a different flow.

## Test plan
- Two different phone numbers messaging simultaneously get independent sessions
- Agent responses don't trigger new message events in the bridge
- Self-chat ("Message Yourself") still works
- Telegram/Discord DM sessions unchanged
- WhatsApp group chats unchanged