### PR TITLE
fix(cli): prevent crash in save_config_value when model is a string

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -708,7 +708,7 @@ def save_config_value(key_path: str, value: any) -> bool:
         keys = key_path.split('.')
         current = config
         for key in keys[:-1]:
-            if key not in current:
+            if key not in current or not isinstance(current[key], dict):
                 current[key] = {}
             current = current[key]
         current[keys[-1]] = value


### PR DESCRIPTION
## Summary

- `save_config_value()` crashes with `TypeError` when the config file uses the string model format (`model: "anthropic/claude-opus-4"`) because it assumes all intermediate keys are dicts
- Added an `isinstance(current[key], dict)` check so non-dict values are replaced with a fresh dict before descending

## Reproduction

1. Set `~/.hermes/config.yaml` to:
   ```yaml
   model: "anthropic/claude-opus-4"
   ```
2. Run the CLI and type `/model some-other-model`
3. **Before fix:** `TypeError: 'str' object does not support item assignment`
4. **After fix:** Model saved correctly as `model: {default: "some-other-model"}`