### PR TITLE
fix(cli): prevent paste detection from destroying multi-line input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2225,13 +2225,17 @@ class HermesCLI:
 
         # Paste collapsing: detect large pastes and save to temp file
         _paste_counter = [0]
+        _prev_text_len = [0]
 
         def _on_text_changed(buf):
             """Detect large pastes and collapse them to a file reference."""
             text = buf.text
             line_count = text.count('\n')
-            # Heuristic: if text jumps to 5+ lines in one change, it's a paste
-            if line_count >= 5 and not text.startswith('/'):
+            chars_added = len(text) - _prev_text_len[0]
+            _prev_text_len[0] = len(text)
+            # Heuristic: a real paste adds many characters at once (not just a
+            # single newline from Alt+Enter) AND the result has 5+ lines.
+            if line_count >= 5 and chars_added > 1 and not text.startswith('/'):
                 _paste_counter[0] += 1
                 # Save to temp file
                 paste_dir = Path(os.path.expanduser("~/.hermes/pastes"))


### PR DESCRIPTION
## Summary

- The paste detection heuristic in `_on_text_changed` triggers whenever the buffer has 5+ newlines, regardless of how those lines were entered
- Typing manually with Alt+Enter (one newline at a time) eventually reaches the threshold and silently replaces the user's input with a file reference — causing data loss
- Fix: track previous buffer length and only treat a change as a paste when more than one character is added in a single event

## Reproduction

1. Start the CLI (`python cli.py`)
2. Type a line, press Alt+Enter, type another line, repeat 6 times
3. **Before fix:** On the 6th line, the entire input is silently replaced with `[Pasted text #1: 6 lines → ~/.hermes/pastes/...]`
4. **After fix:** Multi-line input is preserved; only actual pastes (many characters at once) are collapsed