### PR TITLE
fix(cli): respect explicit --max-turns value even when it equals default

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -742,14 +742,14 @@ class HermesCLI:
         provider: str = None,
         api_key: str = None,
         base_url: str = None,
-        max_turns: int = 60,
+        max_turns: int = None,
         verbose: bool = False,
         compact: bool = False,
         resume: str = None,
     ):
         """
         Initialize the Hermes CLI.
-        
+
         Args:
             model: Model to use (default: from env or claude-sonnet)
             toolsets: List of toolsets to enable (default: all)
@@ -792,7 +792,7 @@ class HermesCLI:
         self._nous_key_expires_at: Optional[str] = None
         self._nous_key_source: Optional[str] = None
         # Max turns priority: CLI arg > env var > config file (agent.max_turns or root max_turns) > default
-        if max_turns != 60:  # CLI arg was explicitly set
+        if max_turns is not None:
             self.max_turns = max_turns
         elif os.getenv("HERMES_MAX_ITERATIONS"):
             self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS"))
@@ -2642,7 +2642,7 @@ def main(
     provider: str = None,
     api_key: str = None,
     base_url: str = None,
-    max_turns: int = 60,
+    max_turns: int = None,
     verbose: bool = False,
     compact: bool = False,
     list_tools: bool = False,


### PR DESCRIPTION
## Summary

- `--max-turns` used `60` as both the default value and the sentinel to detect whether the flag was passed ([cli.py:795](https://github.com/NousResearch/hermes-agent/blob/main/cli.py#L795))
- This contradicts the documented priority order at [cli.py:794](https://github.com/NousResearch/hermes-agent/blob/main/cli.py#L794): `CLI arg > env var > config file > default`
- Running `--max-turns 60` was indistinguishable from not passing the flag, so `HERMES_MAX_ITERATIONS` env var would silently override the explicit CLI value
- Changed the default to `None` so any user-supplied value always takes priority

## Reproduction

1. Set `HERMES_MAX_ITERATIONS=30`
2. Run `python cli.py --max-turns 60`
3. **Before fix:** `max_turns` is set to 30 (env var overrides explicit CLI arg)
4. **After fix:** `max_turns` is set to 60 (CLI arg respected)