### PR TITLE
fix(cli): show correct config file path in /config command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1139,7 +1139,12 @@ class HermesCLI:
         terminal_cwd = os.getenv("TERMINAL_CWD", os.getcwd())
         terminal_timeout = os.getenv("TERMINAL_TIMEOUT", "60")
         
-        config_path = Path(__file__).parent / 'cli-config.yaml'
+        user_config_path = Path.home() / '.hermes' / 'config.yaml'
+        project_config_path = Path(__file__).parent / 'cli-config.yaml'
+        if user_config_path.exists():
+            config_path = user_config_path
+        else:
+            config_path = project_config_path
         config_status = "(loaded)" if config_path.exists() else "(not found)"
         
         api_key_display = '********' + self.api_key[-4:] if self.api_key and len(self.api_key) > 4 else 'Not set!'
@@ -1171,7 +1176,7 @@ class HermesCLI:
         print()
         print("  -- Session --")
         print(f"  Started:     {self.session_start.strftime('%Y-%m-%d %H:%M:%S')}")
-        print(f"  Config File: cli-config.yaml {config_status}")
+        print(f"  Config File: {config_path} {config_status}")
         print()
     
     def show_history(self):


### PR DESCRIPTION
## Summary

- `/config` command always checked `cli-config.yaml` in the project directory ([cli.py:1142](https://github.com/NousResearch/hermes-agent/blob/main/cli.py#L1142))
- But `load_cli_config()` first looks at `~/.hermes/config.yaml` ([cli.py:140](https://github.com/NousResearch/hermes-agent/blob/main/cli.py#L140))
- When user config existed at `~/.hermes/config.yaml`, `/config` would display `cli-config.yaml (not found)` even though configuration was loaded successfully
- Fix: use the same lookup order as `load_cli_config()` and display the actual resolved path

## Reproduction

1. Create `~/.hermes/config.yaml` with any config
2. Run the CLI and type `/config`
3. **Before fix:** `Config File: cli-config.yaml (not found)`
4. **After fix:** `Config File: /home/user/.hermes/config.yaml (loaded)`