### PR TITLE
fix(cli): reduce spinner flickering under patch_stdout

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -182,8 +182,9 @@ class KawaiiSpinner:
             frame = self.spinner_frames[self.frame_idx % len(self.spinner_frames)]
             elapsed = time.time() - self.start_time
             line = f"  {frame} {self.message} ({elapsed:.1f}s)"
-            clear = '\r' + ' ' * self.last_line_len + '\r'
-            self._write(clear + line, end='', flush=True)
+            # Use \r + ANSI erase-to-EOL in a single write to avoid the
+            # two-phase clear+redraw that flickers under patch_stdout.
+            self._write(f"\r\033[K{line}", end='', flush=True)
             self.last_line_len = len(line)
             self.frame_idx += 1
             time.sleep(0.12)
@@ -203,7 +204,7 @@ class KawaiiSpinner:
         self.running = False
         if self.thread:
             self.thread.join(timeout=0.5)
-        self._write('\r' + ' ' * (self.last_line_len + 5) + '\r', end='', flush=True)
+        self._write('\r\033[K', end='', flush=True)
         if final_message:
             self._write(f"  {final_message}", flush=True)
 


### PR DESCRIPTION
## Summary

- `KawaiiSpinner._animate()` used a two-phase approach to update spinner frames: first `\r` + spaces to blank the line, then `\r` + new content ([agent/display.py:185](https://github.com/NousResearch/hermes-agent/blob/main/agent/display.py#L185))
- Under prompt_toolkit's `patch_stdout` proxy, each write can trigger a separate UI repaint, so the blank-then-redraw cycle causes visible flickering every 120ms
- Spinners run during every API call and every tool execution, so the flickering is constant while the agent is working
- Replace with `\r\033[K` (carriage return + ANSI erase-to-end-of-line) in a single write so the clear and redraw happen atomically

## Reproduction

1. Start the CLI and send any message that triggers tool calls
2. **Before fix:** Spinner line visibly flickers/blinks during tool execution and API calls
3. **After fix:** Spinner animates smoothly without blank-frame flashes