### PR TITLE
feat(cli): add /verbose slash command to toggle debug output at runtime

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1653,12 +1653,34 @@ class HermesCLI:
             self._handle_skills_command(cmd_original)
         elif cmd_lower == "/platforms" or cmd_lower == "/gateway":
             self._show_gateway_status()
+        elif cmd_lower == "/verbose":
+            self._toggle_verbose()
         else:
             self.console.print(f"[bold red]Unknown command: {cmd_lower}[/]")
             self.console.print("[dim #B8860B]Type /help for available commands[/]")
         
         return True
     
+    def _toggle_verbose(self):
+        """Toggle verbose mode on/off at runtime."""
+        self.verbose = not self.verbose
+
+        if self.agent:
+            self.agent.verbose_logging = self.verbose
+            self.agent.quiet_mode = not self.verbose
+
+        # Reconfigure logging level to match new state
+        if self.verbose:
+            logging.getLogger().setLevel(logging.DEBUG)
+            for noisy in ('openai', 'openai._base_client', 'httpx', 'httpcore', 'asyncio', 'hpack', 'grpc', 'modal'):
+                logging.getLogger(noisy).setLevel(logging.WARNING)
+            self.console.print("[bold green]Verbose mode ON[/] — tool calls, parameters, and results will be shown.")
+        else:
+            logging.getLogger().setLevel(logging.INFO)
+            for quiet_logger in ('tools', 'minisweagent', 'run_agent', 'trajectory_compressor', 'cron', 'hermes_cli'):
+                logging.getLogger(quiet_logger).setLevel(logging.ERROR)
+            self.console.print("[dim]Verbose mode OFF[/] — returning to normal display.")
+
     def _clarify_callback(self, question, choices):
         """
         Platform callback for the clarify tool. Called from the agent thread.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -25,6 +25,7 @@ COMMANDS = {
     "/cron": "Manage scheduled tasks (list, add, remove)",
     "/skills": "Search, install, inspect, or manage skills from online registries",
     "/platforms": "Show gateway/messaging platform status",
+    "/verbose": "Toggle verbose mode (show tool calls, parameters, and results)",
     "/quit": "Exit the CLI (also: /exit, /q)",
 }
 


### PR DESCRIPTION
Closes #77.

## What this adds

A `/verbose` slash command that toggles verbose mode on and off **without restarting** the CLI.

## Behaviour

| State | What you see |
|-------|-------------|
| **ON** | Full tool call parameters, results, and DEBUG logs |
| **OFF** | Normal kawaii spinner display (default) |

## How it works

- Toggles `self.verbose` on `HermesCLI`
- Updates the live agent's `verbose_logging` and `quiet_mode` flags in real-time
- Reconfigures Python logging levels to match the new state
- Status is reflected in `/config` output (existing `Verbose:` line)
- `/help` lists the command automatically via the shared `COMMANDS` dict

## Changes

- `hermes_cli/commands.py` — added `/verbose` entry to `COMMANDS`
- `cli.py` — added `/verbose` dispatch in `process_command()` + `_toggle_verbose()` method

## Testing

```
$ hermes
> /verbose
Verbose mode ON — tool calls, parameters, and results will be shown.
> /verbose
Verbose mode OFF — returning to normal display.
> /config
  Verbose:    False
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)