### PR TITLE
Add web page cache with search and list capabilities

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -20,6 +20,9 @@ from .web_tools import (
     web_search_tool,
     web_extract_tool,
     web_crawl_tool,
+    web_list_pages_tool,
+    web_search_pages_tool,
+    web_get_page_tool,
     check_firecrawl_api_key
 )
 
@@ -166,6 +169,9 @@ __all__ = [
     'web_search_tool',
     'web_extract_tool',
     'web_crawl_tool',
+    'web_list_pages_tool',
+    'web_search_pages_tool',
+    'web_get_page_tool',
     'check_firecrawl_api_key',
     # Terminal tools (mini-swe-agent backend)
     'terminal_tool',


### PR DESCRIPTION
This PR implements a web page caching system that automatically saves pages scraped via web_extract and web_crawl tools to ~/.hermes/web_cache/, and adds three new tools: web_list_pages to list all cached pages with metadata, web_search_pages to search through cached pages by URL, title, or content with relevance scoring, and web_get_page to retrieve full page content from cache by ID or URL. This addresses the TODO items in web_tools.py by providing search capabilities over scraped pages, persistent storage, and a way to see what pages are available. The implementation reduces API calls by allowing agents to search previously scraped content, enables offline access to cached pages, and requires no API key for cache operations. All pages are stored as JSON files with URL, title, content, saved timestamp, and metadata.