### PR TITLE
feat(cli): add --plain output for hermes chat -q

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1958,7 +1958,9 @@ class HermesCLI:
             else:
                 duration_str = f"{seconds}s"
             
-            print(f"Resume this session with:")
+            if not os.getenv("HERMES_PLAIN_OUTPUT"):
+            
+                print(f"Resume this session with:")
             print(f"  hermes --resume {self.session_id}")
             print()
             print(f"Session:        {self.session_id}")
@@ -1970,7 +1972,8 @@ class HermesCLI:
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
         self.show_banner()
-        self.console.print("[#FFF8DC]Welcome to Hermes Agent! Type your message or /help for commands.[/]")
+        if not os.getenv("HERMES_PLAIN_OUTPUT"):
+            self.console.print("[#FFF8DC]Welcome to Hermes Agent! Type your message or /help for commands.[/]")
         self.console.print()
         
         # State for async operation

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -112,6 +112,13 @@ def _resolve_last_cli_session() -> Optional[str]:
 
 
 def cmd_chat(args):
+    # Plain output for scripting
+    if getattr(args, 'plain', False):
+        import os
+        os.environ['HERMES_PLAIN_OUTPUT'] = '1'
+        os.environ['HERMES_TOOL_PROGRESS'] = 'false'
+        os.environ['HERMES_TOOL_PROGRESS_MODE'] = 'new'
+
     """Run interactive chat CLI."""
     # Resolve --continue into --resume with the latest CLI session
     if getattr(args, "continue_last", False) and not getattr(args, "resume", None):
@@ -856,6 +863,12 @@ For more help on a command:
         default=False,
         help="Resume the most recent CLI session"
     )
+    chat_parser.add_argument(
+        "--plain",
+        action="store_true",
+        help="Print only the assistant text (no banners/metadata/tool progress). Useful for scripting.",
+    )
+
     chat_parser.set_defaults(func=cmd_chat)
 
     # =========================================================================
@@ -1387,6 +1400,12 @@ For more help on a command:
     
     # Execute the command
     if hasattr(args, 'func'):
+        # Plain output mode (useful for scripting)
+        if getattr(args, "plain", False):
+            os.environ["HERMES_PLAIN_OUTPUT"] = "1"
+            os.environ["HERMES_TOOL_PROGRESS"] = "false"
+            os.environ["HERMES_TOOL_PROGRESS_MODE"] = "new"
+
         args.func(args)
     else:
         parser.print_help()


### PR DESCRIPTION
Adds --plain flag for hermes chat -q to support scripting/automation.

Suppresses banners/metadata and disables tool progress output.

Fixes noisy CLI output when piping hermes chat -q into other tools (e.g., video/file pipelines).

Test:

python -m hermes_cli.main chat -q "Say ONLY: hello" --plain