### PR TITLE
fix(gateway): move pairing_store and hooks init back into __init__

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -148,10 +148,18 @@ class GatewayRunner:
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str}
         self._pending_approvals: Dict[str, Dict[str, str]] = {}
-        
+
+        # DM pairing store for code-based user authorization
+        from gateway.pairing import PairingStore
+        self.pairing_store = PairingStore()
+
+        # Event hook system
+        from gateway.hooks import HookRegistry
+        self.hooks = HookRegistry()
+
     def _flush_memories_before_reset(self, old_entry):
         """Prompt the agent to save memories/skills before an auto-reset.
-        
+
         Called synchronously by SessionStore before destroying an expired session.
         Loads the transcript, gives the agent a real turn with memory + skills
         tools, and explicitly asks it to preserve anything worth keeping.
@@ -209,14 +217,6 @@ class GatewayRunner:
         except Exception as e:
             logger.debug("Pre-reset save failed for session %s: %s", old_entry.session_id, e)
 
-        # DM pairing store for code-based user authorization
-        from gateway.pairing import PairingStore
-        self.pairing_store = PairingStore()
-        
-        # Event hook system
-        from gateway.hooks import HookRegistry
-        self.hooks = HookRegistry()
-    
     @staticmethod
     def _load_prefill_messages() -> List[Dict[str, Any]]:
         """Load ephemeral prefill messages from config or env var.


### PR DESCRIPTION
## Summary
quick small fix - for error when  running `hermes gateway` command, - gateway restart command makes it fail silently. please confirm issue on your end before merging by running `hermes gateway` and testing! 🙏
- Fixes `AttributeError: 'GatewayRunner' object has no attribute 'hooks'` crash on gateway startup
- Moves `pairing_store` and `hooks` initialization from inside `_flush_memories_before_reset()` back into `__init__()` where they belong

## Root Cause
Commit 588cdac ("feat(session): implement session reset policy for messaging platforms") inserted `_flush_memories_before_reset()` above the `pairing_store` and `hooks` init lines in `__init__`. Due to Python's indentation-based scoping, those lines became part of the new method instead of remaining in `__init__`. This means `self.hooks` and `self.pairing_store` are never set during construction — they only get assigned when `_flush_memories_before_reset` happens to run (on session auto-reset), which is too late.

Resolves #110

