### PR TITLE
fix(gateway): Move hooks and pairing_store init to __init__

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -157,6 +157,14 @@ class GatewayRunner:
         except Exception as e:
             logger.debug("SQLite session store not available: %s", e)
         
+        # DM pairing store for code-based user authorization
+        from gateway.pairing import PairingStore
+        self.pairing_store = PairingStore()
+        
+        # Event hook system
+        from gateway.hooks import HookRegistry
+        self.hooks = HookRegistry()
+        
     def _flush_memories_before_reset(self, old_entry):
         """Prompt the agent to save memories/skills before an auto-reset.
         
@@ -216,14 +224,6 @@ class GatewayRunner:
             logger.info("Pre-reset save completed for session %s", old_entry.session_id)
         except Exception as e:
             logger.debug("Pre-reset save failed for session %s: %s", old_entry.session_id, e)
-
-        # DM pairing store for code-based user authorization
-        from gateway.pairing import PairingStore
-        self.pairing_store = PairingStore()
-        
-        # Event hook system
-        from gateway.hooks import HookRegistry
-        self.hooks = HookRegistry()
     
     @staticmethod
     def _load_prefill_messages() -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
Fixes #110

## Problem
The `pairing_store` and `hooks` initialization was accidentally placed inside `_flush_memories_before_reset()` instead of `__init__()`, causing the gateway to crash on startup with:

```
AttributeError: 'GatewayRunner' object has no attribute 'hooks'
```

This affected fresh installs where the gateway service would fail immediately when calling `self.hooks.discover_and_load()` in `start()`.

## Solution
Moved the initialization to the proper location at the end of `GatewayRunner.__init__()`.

## Testing
- Verified Python syntax is valid
- The fix matches exactly what the issue reporter identified as the solution