### PR TITLE
fix: move pairing_store and hooks init into GatewayRunner.__init__

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -148,7 +148,15 @@ class GatewayRunner:
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str}
         self._pending_approvals: Dict[str, Dict[str, str]] = {}
-        
+
+        # DM pairing store for code-based user authorization
+        from gateway.pairing import PairingStore
+        self.pairing_store = PairingStore()
+
+        # Event hook system
+        from gateway.hooks import HookRegistry
+        self.hooks = HookRegistry()
+
     def _flush_memories_before_reset(self, old_entry):
         """Prompt the agent to save memories/skills before an auto-reset.
         
@@ -209,14 +217,6 @@ class GatewayRunner:
         except Exception as e:
             logger.debug("Pre-reset save failed for session %s: %s", old_entry.session_id, e)
 
-        # DM pairing store for code-based user authorization
-        from gateway.pairing import PairingStore
-        self.pairing_store = PairingStore()
-        
-        # Event hook system
-        from gateway.hooks import HookRegistry
-        self.hooks = HookRegistry()
-    
     @staticmethod
     def _load_prefill_messages() -> List[Dict[str, Any]]:
         """Load ephemeral prefill messages from config or env var.


### PR DESCRIPTION
## Summary

Fixes #110.

`PairingStore` and `HookRegistry` were initialised inside `_flush_memories_before_reset()`, which only runs when a session expires. Since `start()` calls `self.hooks.discover_and_load()` unconditionally on every startup, `GatewayRunner` crashed with:

```
AttributeError: 'GatewayRunner' object has no attribute 'hooks'
```

on every fresh gateway start before any session had ever expired.

## Root cause

A recent refactor (hooks system added ~Feb 16, follow-up commits Feb 23–27) accidentally left the initialisation block inside the wrong method.

## Fix

Move the two blocks to the end of `__init__()` where they belong, and remove the duplicate from `_flush_memories_before_reset()`. No logic changes — purely moving 6 lines to the correct scope.

```python
# __init__() — after self._pending_approvals
from gateway.pairing import PairingStore
self.pairing_store = PairingStore()

from gateway.hooks import HookRegistry
self.hooks = HookRegistry()
```

## Test plan

- [ ] `hermes gateway start` completes without `AttributeError`
- [ ] `hermes gateway status` shows the service active
- [ ] Session auto-reset (`_flush_memories_before_reset`) still works as before — `self.hooks` and `self.pairing_store` are now available throughout the object lifetime