### PR TITLE
fix(cli): Correct /tools display alignment and truncation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1096,10 +1096,10 @@ class HermesCLI:
             print("(;_;) No tools available")
             return
         
-        # Header
+        # Header - centered in 78-char box (28 + 22 + 28 = 78)
         print()
         print("+" + "-" * 78 + "+")
-        print("|" + " " * 25 + "(^_^)/ Available Tools" + " " * 30 + "|")
+        print("|" + " " * 28 + "(^_^)/ Available Tools" + " " * 28 + "|")
         print("+" + "-" * 78 + "+")
         print()
         
@@ -1115,6 +1115,10 @@ class HermesCLI:
             desc = desc.split("\n")[0]
             if ". " in desc:
                 desc = desc[:desc.index(". ") + 1]
+            # Truncate description to fit 80-char terminal (6 indent + 20 name + 3 sep = 29, leaving ~48)
+            max_desc_len = 48
+            if len(desc) > max_desc_len:
+                desc = desc[:max_desc_len - 3] + "..."
             toolsets[toolset].append((name, desc))
         
         # Display by toolset


### PR DESCRIPTION
## Summary
Fixes #37

## Issues Fixed

### 1. Header alignment off by 1 space
The header line had incorrect padding:
```python
# Before: 25 + 22 + 30 = 77 chars (box interior is 78)
print("|" + " " * 25 + "(^_^)/ Available Tools" + " " * 30 + "|")

# After: 28 + 22 + 28 = 78 chars (properly centered)
print("|" + " " * 28 + "(^_^)/ Available Tools" + " " * 28 + "|")
```

### 2. Tool descriptions overflow terminal width
On 80-column terminals, long descriptions would get cut off. Added truncation:
- Line prefix: `    * ` (6 chars)
- Tool name: 20 chars (padded)
- Separator: ` - ` (3 chars)
- Available for description: ~48 chars

Descriptions longer than 48 chars are now truncated with `...`

## Before
```
+------------------------------------------------------------------------------+
|                         (^_^)/ Available Tools                              |   <- off by 1
+------------------------------------------------------------------------------+

  [clarify]
    * clarify              - Ask the user a question when you need clarification, feedbac
```

## After
```
+------------------------------------------------------------------------------+
|                            (^_^)/ Available Tools                            |   <- centered
+------------------------------------------------------------------------------+

  [clarify]
    * clarify              - Ask the user a question when you need clari...
```

## Testing
- Verified Python syntax is valid
- Confirmed header alignment: border and header both 80 chars
- Truncation tested on long descriptions