### PR TITLE
fix: sanitize internal fields from API messages

### DIFF
--- a/tests/agent/test_sanitize_api.py
+++ b/tests/agent/test_sanitize_api.py
@@ -1,0 +1,123 @@
+"""Tests for AIAgent._sanitize_for_api — whitelist-based message sanitization."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from run_agent import AIAgent
+
+
+@pytest.fixture
+def agent():
+    """Create a minimal AIAgent with mocked dependencies."""
+    with patch("run_agent.OpenAI"), \
+         patch("run_agent.get_tool_definitions", return_value=[]), \
+         patch("run_agent.check_toolset_requirements", return_value={}):
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://api.mistral.ai/v1",
+            quiet_mode=True,
+        )
+
+
+class TestSanitizeForApi:
+    """Tests for the _sanitize_for_api whitelist sanitizer."""
+
+    def test_finish_reason_stripped(self, agent):
+        """finish_reason must not leak to the API (the actual Mistral 422 bug)."""
+        msg = {
+            "role": "assistant",
+            "content": "Hello!",
+            "finish_reason": "stop",
+        }
+        result = agent._sanitize_for_api(msg)
+        assert "finish_reason" not in result
+        assert result["content"] == "Hello!"
+        assert result["role"] == "assistant"
+
+    def test_reasoning_becomes_reasoning_content(self, agent):
+        """Internal 'reasoning' field should be converted to 'reasoning_content'."""
+        msg = {
+            "role": "assistant",
+            "content": "Answer.",
+            "reasoning": "Thinking step by step...",
+            "finish_reason": "stop",
+        }
+        result = agent._sanitize_for_api(msg)
+        assert "reasoning" not in result
+        assert "finish_reason" not in result
+        assert result["reasoning_content"] == "Thinking step by step..."
+
+    def test_reasoning_content_not_added_when_empty(self, agent):
+        """No reasoning_content if reasoning is None/empty."""
+        msg = {
+            "role": "assistant",
+            "content": "Hello!",
+            "reasoning": None,
+            "finish_reason": "stop",
+        }
+        result = agent._sanitize_for_api(msg)
+        assert "reasoning_content" not in result
+
+    def test_flush_sentinel_stripped(self, agent):
+        """Internal _flush_sentinel on user messages must not leak."""
+        msg = {
+            "role": "user",
+            "content": "Please save memories.",
+            "_flush_sentinel": "__flush_12345",
+        }
+        result = agent._sanitize_for_api(msg)
+        assert "_flush_sentinel" not in result
+        assert result["content"] == "Please save memories."
+
+    def test_standard_assistant_fields_preserved(self, agent):
+        """Standard API fields (content, tool_calls, reasoning_details) pass through."""
+        tool_calls = [{"id": "tc_1", "type": "function", "function": {"name": "search", "arguments": "{}"}}]
+        reasoning_details = [{"type": "reasoning.summary", "text": "...", "signature": "abc"}]
+        msg = {
+            "role": "assistant",
+            "content": "Let me search.",
+            "tool_calls": tool_calls,
+            "reasoning_details": reasoning_details,
+            "finish_reason": "tool_calls",
+            "reasoning": "I should search.",
+        }
+        result = agent._sanitize_for_api(msg)
+        assert result["tool_calls"] == tool_calls
+        assert result["reasoning_details"] == reasoning_details
+        assert result["reasoning_content"] == "I should search."
+        assert "finish_reason" not in result
+        assert "reasoning" not in result
+
+    def test_tool_message_preserves_tool_call_id(self, agent):
+        """Tool messages keep tool_call_id and name, drop anything extra."""
+        msg = {
+            "role": "tool",
+            "content": '{"result": "ok"}',
+            "tool_call_id": "tc_1",
+            "name": "search",
+            "some_internal_field": True,
+        }
+        result = agent._sanitize_for_api(msg)
+        assert result["tool_call_id"] == "tc_1"
+        assert result["name"] == "search"
+        assert "some_internal_field" not in result
+
+    def test_system_message_minimal(self, agent):
+        """System messages only keep role and content."""
+        msg = {
+            "role": "system",
+            "content": "You are an assistant.",
+            "extra": "should be dropped",
+        }
+        result = agent._sanitize_for_api(msg)
+        assert result == {"role": "system", "content": "You are an assistant."}
+
+    def test_unknown_role_defaults_to_role_content(self, agent):
+        """Unknown roles fall back to keeping just role + content."""
+        msg = {
+            "role": "developer",
+            "content": "Some content.",
+            "extra": "dropped",
+        }
+        result = agent._sanitize_for_api(msg)
+        assert result == {"role": "developer", "content": "Some content."}


### PR DESCRIPTION
Fixes #134

## Problem

When using Mistral (or any strict OpenAI-compatible provider) as a direct API endpoint, the second message always fails with:

```
Error code: 422 - {'detail': [{'type': 'extra_forbidden',
  'loc': ['body', 'messages', 2, 'assistant', 'finish_reason'],
  'msg': 'Extra inputs are not permitted', 'input': 'stop'}]}
```

The first message works fine because there's no assistant message in history yet. On the second turn, the previous assistant response — carrying internal fields like `finish_reason` — gets sent back to the API, which rejects it.

## Root Cause

`_build_assistant_message()` adds `finish_reason` and `reasoning` to every assistant message dict for trajectory saving and session logging. The API preparation code stripped `reasoning` but **forgot `finish_reason`**. Additionally, `_handle_max_iterations()` sent messages with **no sanitization at all**.

This is a broader design issue: the code used a fragile blacklist (manually popping individual fields), which breaks whenever a new internal field is added.

## Fix

Added a **whitelist-based** `_sanitize_for_api()` helper that keeps only standard OpenAI-compatible fields per message role:

```python
_API_FIELDS_BY_ROLE = {
    "system":    {"role", "content"},
    "user":      {"role", "content", "name"},
    "assistant": {"role", "content", "tool_calls", "name", "refusal",
                  "reasoning_content", "reasoning_details"},
    "tool":      {"role", "content", "tool_call_id", "name"},
}
```

Applied consistently across all 3 API call sites:
1. **Main conversation loop** — replaced inline blacklist
2. **Memory flush** — replaced inline blacklist  
3. **Max iterations summary** — was completely unsanitized (also fixed)

`reasoning_content` and `reasoning_details` are kept in the whitelist for providers that support multi-turn reasoning (OpenRouter, Moonshot AI). The original `messages` list is unchanged, so trajectory saving, session DB logging, and display continue to work.

## Testing

Added 8 tests in `tests/agent/test_sanitize_api.py`:

| Test | What it verifies |
|---|---|
| `test_finish_reason_stripped` | The actual bug — `finish_reason` removed |
| `test_reasoning_becomes_reasoning_content` | `reasoning` → `reasoning_content` conversion |
| `test_reasoning_content_not_added_when_empty` | No spurious field when reasoning is None |
| `test_flush_sentinel_stripped` | Internal `_flush_sentinel` on user msgs removed |
| `test_standard_assistant_fields_preserved` | `tool_calls`, `reasoning_details` pass through |
| `test_tool_message_preserves_tool_call_id` | Tool msgs keep `tool_call_id`, drop extras |
| `test_system_message_minimal` | System msgs only keep `role` + `content` |
| `test_unknown_role_defaults_to_role_content` | Unknown roles get safe defaults |

```
$ python3 -m pytest tests/agent/test_sanitize_api.py -v
8 passed in 3.13s

$ python3 -m pytest tests/ -v
626 passed, 1 failed (pre-existing, unrelated), 9 deselected
```