### PR TITLE
docs: add slash commands reference

### DIFF
--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -1,0 +1,75 @@
+# Slash Commands Reference
+
+Quick reference for all CLI slash commands in Hermes Agent.
+
+## Navigation & Control
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show available commands |
+| `/quit` | Exit the CLI (aliases: `/exit`, `/q`) |
+| `/clear` | Clear screen and reset conversation |
+| `/new` | Start a new conversation |
+| `/reset` | Reset conversation (keep screen) |
+
+## Tools & Configuration
+
+| Command | Description |
+|---------|-------------|
+| `/tools` | List all available tools |
+| `/toolsets` | List available toolsets |
+| `/model` | Show or change the current model |
+| `/model <name>` | Switch to a different model |
+| `/config` | Show current configuration |
+| `/prompt` | View/set custom system prompt |
+| `/personality` | Set a predefined personality |
+
+## Conversation
+
+| Command | Description |
+|---------|-------------|
+| `/history` | Show conversation history |
+| `/retry` | Retry the last message |
+| `/undo` | Remove the last user/assistant exchange |
+| `/save` | Save the current conversation |
+
+## Advanced
+
+| Command | Description |
+|---------|-------------|
+| `/cron` | Manage scheduled tasks |
+| `/skills` | Search, install, or manage skills |
+| `/platforms` | Show gateway/messaging platform status |
+
+## Examples
+
+### Changing Models
+
+```
+/model anthropic/claude-sonnet-4
+```
+
+### Setting a Custom Prompt
+
+```
+/prompt You are a helpful coding assistant specializing in Python.
+```
+
+### Managing Toolsets
+
+Run with specific toolsets:
+```bash
+python cli.py --toolsets web,terminal
+```
+
+Then check enabled toolsets:
+```
+/toolsets
+```
+
+## Tips
+
+- Commands are case-insensitive (`/HELP` = `/help`)
+- Use Tab for autocomplete
+- Most commands work mid-conversation
+- `/clear` is useful for starting fresh without restarting


### PR DESCRIPTION
Adds a comprehensive reference for all CLI slash commands.

## Contents

### Navigation & Control
- /help, /quit, /clear, /new, /reset

### Tools & Configuration  
- /tools, /toolsets, /model, /config, /prompt, /personality

### Conversation
- /history, /retry, /undo, /save

### Advanced
- /cron, /skills, /platforms

## Also Includes
- Usage examples
- Tips for new users
- Command aliases

## Why
The CLI has many useful commands, but they're not all documented in one place. This makes it easier for new users to discover what's available.