### PR TITLE
fix(process): escape single quotes in spawn_via_env bg_command

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -227,8 +227,9 @@ class ProcessRegistry:
         # Run the command in the sandbox with output capture
         log_path = f"/tmp/hermes_bg_{session.id}.log"
         pid_path = f"/tmp/hermes_bg_{session.id}.pid"
+        safe_command = command.replace("'", "'\''")
         bg_command = (
-            f"nohup bash -c '{command}' > {log_path} 2>&1 & "
+            f"nohup bash -c '{safe_command}' > {log_path} 2>&1 & "
             f"echo $! > {pid_path} && cat {pid_path}"
         )
 


### PR DESCRIPTION
Commands with single quotes in them silently break when run via `spawn_via_env` — e.g. `python3 -c 'print("hello")'` produces unexpected behavior because `command` is embedded inside single quotes without escaping.

Fix: escape single quotes with the standard bash idiom (`'` → `'\''`) before building the shell string.