### PR TITLE
Fix memory tool entry parsing when content contains section sign

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -345,7 +345,9 @@ class MemoryStore:
         if not raw.strip():
             return []
 
-        entries = [e.strip() for e in raw.split("§")]
+        # Use ENTRY_DELIMITER for consistency with _write_file. Splitting by "§"
+        # alone would incorrectly split entries that contain "§" in their content.
+        entries = [e.strip() for e in raw.split(ENTRY_DELIMITER)]
         return [e for e in entries if e]
 
     @staticmethod


### PR DESCRIPTION
This PR fixes a bug in the memory tool's _read_file method where entries were incorrectly split using a single "§" character instead of the ENTRY_DELIMITER ("\n§\n"). When a memory entry contained the section sign character (e.g., "User prefers § for sections"), the parser would wrongly split it into multiple entries. The fix aligns the read logic with the write logic, which uses ENTRY_DELIMITER.join() for consistency. This ensures entries containing "§" in their content are parsed correctly and prevents data corruption when loading MEMORY.md or USER.md files.