### PR TITLE
fix: strip <think> blocks from final response to users

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2567,7 +2567,8 @@ class AIAgent:
                                             tool_names.append(fn.get("name", "unknown"))
                                         msg["content"] = f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
                                         break
-                                final_response = fallback
+                                # Strip <think> blocks from fallback content for user display
+                                final_response = self._strip_think_blocks(fallback).strip()
                                 break
                             
                             # No fallback -- append the empty message as-is
@@ -2595,6 +2596,9 @@ class AIAgent:
                     # Reset retry counter on successful content
                     if hasattr(self, '_empty_content_retries'):
                         self._empty_content_retries = 0
+                    
+                    # Strip <think> blocks from user-facing response (keep raw in messages for trajectory)
+                    final_response = self._strip_think_blocks(final_response).strip()
                     
                     final_msg = self._build_assistant_message(assistant_message, finish_reason)
                     


### PR DESCRIPTION
## Summary

Fixes #149

The `_strip_think_blocks()` method existed but was not being called on the `final_response` in the normal completion path. This caused `<think>...</think>` XML tags to leak into user-facing responses on all platforms (CLI, Telegram, Discord, Slack, WhatsApp).

## Changes

1. **Normal completion path** (line ~2600): Strip think blocks from `final_response` before breaking from the loop
2. **Fallback path** (line ~2570): Strip think blocks from fallback content when salvaging from prior `tool_calls` turn

## Notes

- Raw content with think blocks is **preserved** in `messages[]` for trajectory export — this fix only affects the user-facing `final_response`
- The `_has_content_after_think_block()` check still uses raw content before stripping, which is correct for detecting think-only responses
- Uses the existing, well-tested `_strip_think_blocks()` method

## Testing

- Verified syntax with `ast.parse()`
- The `_strip_think_blocks()` method already has comprehensive unit tests in `test_run_agent.py`
- Manually verified regex handles single-line, multi-line, and edge cases