### PR TITLE
fix(install): ignore commented lines when checking for PATH

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -723,7 +723,7 @@ setup_path() {
         PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
 
         for SHELL_CONFIG in "${SHELL_CONFIGS[@]}"; do
-            if ! grep -q '\.local/bin' "$SHELL_CONFIG" 2>/dev/null; then
+            if ! grep -v '^[[:space:]]*#' "$SHELL_CONFIG" 2>/dev/null | grep -qE 'PATH=.*\.local/bin'; then
                 echo "" >> "$SHELL_CONFIG"
                 echo "# Hermes Agent — ensure ~/.local/bin is on PATH" >> "$SHELL_CONFIG"
                 echo "$PATH_LINE" >> "$SHELL_CONFIG"


### PR DESCRIPTION
Bug: 
Adding to path got skipped. `setup_path` function only matched with `.local bin`. 

In my case the line was commented, so hermes was not added. 

Function: `setup_path()` in _scripts/install.sh_

1. Old: Matched any line with _.local/bin_
2. Effect: Falsely matched commented lines, skipped adding PATH
3. Fix: Filter out comments first, then check PATH assignment

Thanks. 