### PR TITLE
fix(security): catch multi-word prompt injection bypass in skills_guard

### DIFF
--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -157,7 +157,7 @@ THREAT_PATTERNS = [
      "markdown link with variable interpolation"),
 
     # ── Prompt injection ──
-    (r'ignore\s+(previous|all|above|prior)\s+instructions',
+    (r'ignore\s+(?:\w+\s+)*(previous|all|above|prior)\s+instructions',
      "prompt_injection_ignore", "critical", "injection",
      "prompt injection: ignore previous instructions"),
     (r'you\s+are\s+now\s+',


### PR DESCRIPTION
## Summary
- The prompt injection regex in `skills_guard.py` only matched a single word between "ignore" and "instructions" (e.g. `ignore previous instructions`)
- Multi-word variants like `ignore all prior instructions` or `ignore the above instructions` bypassed the scanner entirely
- Fixed by changing `\s+` to `\s+(?:\w+\s+)*` to allow arbitrary intermediate words before the keyword