### PR TITLE
fix(agent): strip <think> blocks from final response before displaying to user

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2314,7 +2314,7 @@ class AIAgent:
                 
                 else:
                     # No tool calls - this is the final response
-                    final_response = assistant_message.content or ""
+                    final_response = self._strip_think_blocks(assistant_message.content or "").strip()
                     
                     # Check if response only has think block with no actual content after it
                     if not self._has_content_after_think_block(final_response):

--- a/skills/energy-maintenance/blade-inspection/SKILL.md
+++ b/skills/energy-maintenance/blade-inspection/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: wind-turbine-blade-inspection
+description: Assesses wind turbine blade condition from visual inspection data. Classifies damage type and severity (1-5) across seven failure modes and recommends repair or operational actions.
+version: 1.0.0
+author: Sertug17
+license: MIT
+metadata:
+  hermes:
+    tags: [Energy, Maintenance, Wind-Turbine, Blade, Drone-Inspection, Erosion, Lightning, Structural, Debonding]
+    related_skills: [wind-turbine-gearbox]
+---
+
+# Wind Turbine Blade Inspection Intelligence
+
+Evaluates blade condition from drone or ground-based visual inspection and produces a structured damage assessment across seven failure modes.
+
+## When to Use
+
+Load this skill when the user wants to:
+- Assess blade health from drone inspection images or written findings
+- Classify damage type and severity on a 1-5 scale per blade and per zone
+- Determine whether a turbine should continue operating, be scheduled for repair, or shut down
+- Generate a structured blade inspection report with repair recommendations
+
+## Blade Zones
+
+| Zone | Span     | Description |
+|------|----------|-------------|
+| Root | 0-33%    | Highest structural loads, bolted connection area |
+| Mid  | 33-66%   | Transition zone, moderate aerodynamic load |
+| Tip  | 66-100%  | Highest velocity, most erosion-prone, lightning receptor area |
+
+Surfaces: Leading Edge (LE), Trailing Edge (TE), Suction Side (SS), Pressure Side (PS)
+
+## Damage Type Definitions
+
+| Damage Type            | Description                                          | Typical Location        |
+|------------------------|------------------------------------------------------|-------------------------|
+| Surface crack          | Gelcoat or laminate cracks, linear fractures         | LE, TE, root transition |
+| Erosion / wear         | Material loss, pitting, roughening                   | LE tip zone             |
+| Lightning damage       | Burn marks, punctures, receptor damage               | Tip, receptor area      |
+| Lamination/structural  | Delamination, fiber exposure, buckling, dents        | Any zone                |
+| Debonding              | Bond line separation at LE, TE, or shear web         | LE, TE, internal        |
+| Ice accumulation       | Ice buildup on surface or edges                      | Any zone                |
+| General visual anomaly | Discoloration, contamination, coating loss           | Any zone                |
+
+## Severity Scale
+
+| Severity | Label       | Description                                         | Action                            |
+|----------|-------------|-----------------------------------------------------|-----------------------------------|
+| 1        | Healthy     | No damage or cosmetic marks only                    | Continue normal operation         |
+| 2        | Minor       | Early erosion, superficial cracks, coating loss     | Increase inspection frequency     |
+| 3        | Moderate    | Gelcoat breach, early debonding, defined damage     | Repair within 1-3 months          |
+| 4        | Significant | Structural involvement, active debonding, lightning | Repair within 2-4 weeks           |
+| 5        | Critical    | Fiber exposure, structural breach, delamination     | Immediate shutdown required       |
+
+## Procedure
+
+1. Collect inputs: blade IDs, inspection method, findings per blade per zone per surface.
+2. Classify each finding by damage type.
+3. Assign severity per finding using the severity scale.
+4. Determine overall blade severity as the highest finding for that blade.
+5. Determine turbine-level severity as the highest across all blades.
+6. Apply damage-specific rules:
+   - Lightning damage: minimum Severity 4 until OEM confirms otherwise.
+   - Debonding at LE or TE over 300 mm: escalate to Severity 4.
+   - Any confirmed fiber exposure: minimum Severity 4.
+   - Erosion with full gelcoat loss over 500 mm span at tip: Severity 4.
+   - Active ice accumulation: always Severity 4.
+7. Generate output report using the format below.
+
+## Output Format
+
+=== BLADE INSPECTION REPORT ===
+
+ASSET        : [Turbine ID]
+SITE         : [Site name]
+INSPECTION   : [Date / Method]
+BLADES       : [Number inspected]
+
+BLADE [ID]:
+  Zone/Surface  : [e.g., Tip / Leading Edge]
+  Damage Type   : [e.g., Erosion]
+  Description   : [e.g., Deep pitting ~600 mm span, gelcoat fully lost]
+  Severity      : [1-5] - [Label]
+
+BLADE [ID] OVERALL SEVERITY: [1-5] - [Label]
+
+TURBINE-LEVEL SEVERITY : [1-5] - [Label]
+SHUTDOWN RECOMMENDATION: [Yes / No / Conditional]
+
+REPAIR PRIORITY:
+  - [e.g., Blade 2 tip LE erosion - schedule LEP repair within 6 weeks]
+
+MONITORING STRATEGY:
+  - [e.g., Monthly drone re-inspection for all blades]
+
+ESCALATION TRIGGERS:
+  - [e.g., Debond length exceeds 500 mm - shutdown for repair]
+  - [e.g., SCADA vibration or imbalance alarms - ground turbine]
+
+## Damage-Specific Guidance
+
+Erosion: Progresses from roughening to pitting to gelcoat loss to fiber exposure. Repair with Leading Edge Protection (LEP) tape or coating. Severity 3-4 causes measurable energy production loss.
+
+Lightning: Always notify OEM. Minor visible damage may hide internal delamination. Do not assume safe to operate until specialist confirms.
+
+Debonding: LE debonding causes aerodynamic noise and vibration. TE debonding starts at tip and progresses toward root. Bond line gap over 300 mm is Severity 4.
+
+Lamination/Structural: Fiber exposure is always Severity 4 minimum. Dents or buckling without fiber exposure is Severity 3.
+
+Ice: Active ice requires immediate grounding due to rotor imbalance and ice throw risk. After melting, inspect surface for underlying damage.
+
+## Pitfalls
+
+- Do not classify erosion from low-resolution images. Ask for close-up zone-specific photos.
+- Lightning damage is always higher priority than it looks. Treat as Severity 4 until proven otherwise.
+- Debonding can be invisible from drone imagery. If SCADA shows imbalance alarms, flag potential hidden debonding.
+- Active ice is a safety hazard. Recommend immediate grounding.
+- Assess each blade independently. Damage distribution is rarely uniform across all three blades.
+
+## Verification
+
+After generating the report, confirm with the user:
+- Does the severity match the inspector's on-site assessment?
+- Are all three blades accounted for?
+- Are there SCADA alarms (vibration, imbalance, power curve deviation) correlating with findings?
+- Is there a previous inspection report for trend comparison?

--- a/skills/energy-maintenance/gearbox/SKILL.md
+++ b/skills/energy-maintenance/gearbox/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: wind-turbine-gearbox
+description: Assesses wind turbine gearbox health from multi-sensor and inspection data. Classifies damage severity (1-5), identifies root cause, and recommends shutdown or monitoring actions.
+version: 1.0.0
+author: Sertug17
+license: MIT
+metadata:
+  hermes:
+    tags: [Energy, Maintenance, Wind-Turbine, Gearbox, Condition-Monitoring, Predictive-Maintenance, Vibration, Acoustics]
+    related_skills: []
+---
+
+# Wind Turbine Gearbox Intelligence
+
+Evaluates gearbox condition using five input parameters and produces a structured maintenance report.
+
+## When to Use
+
+Load this skill when the user wants to:
+- Assess gearbox health from on-site inspection or sensor data
+- Classify damage severity on a 1-5 scale
+- Determine whether a turbine should be shut down or kept running under monitoring
+- Generate a structured maintenance or escalation plan
+
+## Quick Reference
+
+| Input Parameter   | What to Collect                                            |
+|-------------------|------------------------------------------------------------|
+| Visual inspection | Surface cracks, pitting, spalling, discoloration, debris   |
+| Oil iron (Fe ppm) | Iron particle concentration in gear oil (ppm)              |
+| Temperature (C)   | Bearing/gear temperature, normalized to baseline           |
+| Vibration         | RMS or peak-to-peak acceleration (g), frequency anomalies |
+| Acoustic / Sound  | Noise type: grinding, knocking, whining, clicking          |
+
+## Fault Thresholds (Reference)
+
+| Parameter           | Normal        | Warning        | Critical       |
+|---------------------|---------------|----------------|----------------|
+| Oil Fe (ppm)        | < 100         | 100 - 300      | > 300          |
+| Temp above baseline | < 5 C         | 5 - 15 C       | > 15 C         |
+| Vibration RMS (g)   | < 0.5         | 0.5 - 1.5      | > 1.5          |
+| Acoustic            | No anomaly    | Intermittent   | Continuous     |
+| Visual              | Clean surface | Minor pitting  | Spalling/crack |
+
+## Common Failure Modes
+
+| Failure Mode     | Typical Indicators                                            |
+|------------------|---------------------------------------------------------------|
+| Micropitting     | High Fe ppm, slight vibration increase, no visible cracks    |
+| Spalling         | High Fe ppm, elevated vibration, visible surface damage       |
+| Fatigue crack    | Knocking sound, vibration spike at gear mesh frequency        |
+| Bearing wear     | Whining noise, high temperature, broadband vibration increase |
+| Oil contamination| Very high Fe ppm, discolored oil, possible foaming            |
+
+## Procedure
+
+1. Collect inputs across all five parameters. If any are unavailable, note as "not measured" and proceed.
+2. Evaluate each parameter against the thresholds table. Flag Warning or Critical zones.
+3. Cross-correlate symptoms:
+   - Fe ppm + vibration increase → wear / spalling progression
+   - Knocking sound + vibration spike → fatigue crack
+   - Temperature + whining sound → bearing failure
+   - Multiple Critical flags → Severity 5
+4. Assign severity:
+   - 1 Healthy: All parameters normal. No action required.
+   - 2 Early wear: 1-2 parameters in warning zone. Increase monitoring frequency.
+   - 3 Moderate damage: 2-3 parameters in warning/critical. Inspect within 2 weeks.
+   - 4 Significant damage: Multiple critical flags. Plan shutdown within 48-72 hours.
+   - 5 Critical: Imminent failure risk. Immediate shutdown required.
+5. Determine root cause from the failure modes table.
+6. Generate the output report using the format below.
+
+## Output Format
+
+=== GEARBOX HEALTH REPORT ===
+
+ROOT CAUSE : [e.g., Progressive spalling on intermediate shaft gear]
+SEVERITY   : [1-5] - [Healthy / Early Wear / Moderate / Significant / Critical]
+SHUTDOWN   : [Yes / No / Conditional]
+
+MONITORING STRATEGY:
+  - [e.g., Repeat oil sample in 72 hours]
+  - [e.g., Daily vibration trend monitoring for 1 week]
+
+ESCALATION TRIGGERS:
+  - [e.g., Fe ppm exceeds 400 - immediate shutdown]
+  - [e.g., Vibration RMS exceeds 2.0 g - immediate shutdown]
+
+## Pitfalls
+
+- Never assign Severity 5 based on one parameter alone. Cross-validate with at least two sources.
+- Temperature readings can be misleading in extreme ambient conditions. Ask for baseline-normalized values.
+- Acoustic descriptions are subjective. Ask for noise type and whether continuous or intermittent.
+- If sensor data is unavailable, rely on visual and oil condition as primary indicators.
+- Do not conflate oil change interval with oil health. New oil can still show high Fe ppm.
+
+## Verification
+
+After generating the report, confirm with the user:
+- Does the severity match their on-site observations?
+- Are escalation thresholds feasible for their monitoring setup?
+- Are there additional data points (CMS trending, historical Fe ppm) that could refine the assessment?

--- a/skills/energy-maintenance/vibration-analysis/SKILL.md
+++ b/skills/energy-maintenance/vibration-analysis/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: wind-turbine-vibration-analysis
+description: Analyzes wind turbine drivetrain vibration data (main bearing, gearbox, generator) from CMS trends, RMS/peak values, frequency spectrum, and SCADA alarms. Classifies severity (1-5) and recommends shutdown or monitoring actions.
+version: 1.0.0
+author: Sertug17
+license: MIT
+metadata:
+  hermes:
+    tags: [Energy, Maintenance, Wind-Turbine, Vibration, CMS, Drivetrain, Gearbox, Generator, Bearing, Spectrum-Analysis]
+    related_skills: [wind-turbine-gearbox, wind-turbine-blade-inspection]
+---
+
+# Wind Turbine Drivetrain Vibration Analysis
+
+Evaluates drivetrain vibration health across three subsystems: main bearing, gearbox, and generator.
+
+## When to Use
+
+Load this skill when the user wants to:
+- Assess drivetrain vibration health from CMS or SCADA data
+- Interpret RMS, peak-to-peak, or spectral findings for main bearing, gearbox, or generator
+- Correlate vibration alarms with operational events
+- Decide whether to continue operating, increase monitoring, or shut down
+
+## Drivetrain Components
+
+| Component | Sensor Location | Key Frequencies |
+|-----------|----------------|-----------------|
+| Main Bearing | Non-drive end, drive end | BPFO, BPFI, BSF, FTF |
+| Gearbox LSS | Low speed shaft | Gear mesh (LSS x teeth), bearing defect freqs |
+| Gearbox IMS | Intermediate shaft | IMS gear mesh harmonics |
+| Gearbox HSS | High speed shaft | HSS gear mesh, bearing defect freqs |
+| Generator NDE | Non-drive end bearing | Electrical harmonics, bearing defect freqs |
+| Generator DE | Drive end bearing | Bearing defect freqs, rotor unbalance |
+
+## Vibration Thresholds (ISO 10816 / CMS Reference)
+
+| Location | Normal | Warning | Critical |
+|----------|--------|---------|----------|
+| Main Bearing RMS (g) | < 0.3 | 0.3 - 0.8 | > 0.8 |
+| Gearbox HSS RMS (g) | < 0.5 | 0.5 - 1.5 | > 1.5 |
+| Gearbox LSS/IMS RMS (g) | < 0.3 | 0.3 - 1.0 | > 1.0 |
+| Generator RMS (g) | < 0.5 | 0.5 - 1.2 | > 1.2 |
+| Peak-to-peak step change | < 10% | 10-30% | > 30% |
+
+Note: Always evaluate against site-specific baseline. A 20% rise from stable baseline is more significant than an absolute value alone.
+
+## Frequency Fault Signatures
+
+| Fault | Frequency Signature |
+|-------|-------------------|
+| Bearing outer race (BPFO) | (N/2) x (1 - d/D x cos a) x RPM |
+| Bearing inner race (BPFI) | (N/2) x (1 + d/D x cos a) x RPM |
+| Gear mesh | number of teeth x shaft RPM |
+| Gear mesh sidebands | GMF +/- shaft frequency |
+| Rotor unbalance | 1x RPM dominant |
+| Misalignment | 2x RPM dominant, axial component |
+| Looseness | Sub-harmonics (0.5x, 1.5x) or high harmonic content |
+
+## Severity Scale
+
+| Severity | Label | Description | Action |
+|----------|-------|-------------|--------|
+| 1 | Healthy | All values normal, stable trend | Continue normal operation |
+| 2 | Early warning | 1-2 parameters in warning zone, stable | Increase CMS polling frequency |
+| 3 | Moderate | Multiple warning flags or single critical | Inspect within 2 weeks |
+| 4 | Significant | Critical zone or rapid trend growth | Plan shutdown within 48-72 hours |
+| 5 | Critical | Multiple critical flags, step-change | Immediate shutdown required |
+
+## Procedure
+
+1. Collect inputs: CMS trend (last 30-90 days), current RMS and peak-to-peak per component, frequency spectrum findings, SCADA alarms, operational context.
+2. Evaluate RMS values against thresholds. Flag Warning or Critical zones.
+3. Analyze trend:
+   - Stable: value in warning zone but flat for >30 days = lower urgency
+   - Gradual rise: value increasing steadily = schedule inspection
+   - Step change: sudden jump >30% = treat as Critical regardless of absolute value
+4. Interpret frequency spectrum if available:
+   - Match dominant peaks to fault signatures table
+   - Note sidebands around gear mesh frequencies
+   - Note sub-harmonics or 1x/2x dominance
+5. Correlate with SCADA alarms and operational events.
+6. Assign severity per component, then determine drivetrain-level severity as highest.
+7. Generate output report using the format below.
+
+## Output Format
+
+=== DRIVETRAIN VIBRATION REPORT ===
+
+ASSET        : [Turbine ID]
+SITE         : [Site name]
+DATA PERIOD  : [Date range of CMS/SCADA data]
+MISSING DATA : [List any unavailable inputs]
+
+MAIN BEARING:
+  RMS          : [value] g - [Normal / Warning / Critical]
+  Trend        : [Stable / Gradual rise / Step change]
+  Spectrum     : [Key findings or not available]
+  SCADA Alarms : [Count and type]
+  Severity     : [1-5] - [Label]
+
+GEARBOX (LSS / IMS / HSS):
+  RMS          : LSS [value] g / IMS [value] g / HSS [value] g
+  Trend        : [per shaft]
+  Spectrum     : [Key findings]
+  SCADA Alarms : [Count and type]
+  Severity     : [1-5] - [Label]
+
+GENERATOR (DE / NDE):
+  RMS          : DE [value] g / NDE [value] g
+  Trend        : [per bearing]
+  Spectrum     : [Key findings]
+  SCADA Alarms : [Count and type]
+  Severity     : [1-5] - [Label]
+
+DRIVETRAIN SEVERITY : [1-5] - [Label]
+SHUTDOWN            : [Yes / No / Conditional]
+
+FAULT HYPOTHESIS:
+  - [e.g., HSS bearing outer race defect - BPFO peak confirmed at X Hz]
+  - [e.g., Gear mesh sideband modulation - possible gear wear or load variation]
+
+RECOMMENDED ACTIONS:
+  - [e.g., Increase CMS polling to daily for HSS channel]
+  - [e.g., Oil sample with ferrography within 72 hours]
+  - [e.g., Plan HSS bearing replacement at next scheduled outage]
+
+ESCALATION TRIGGERS:
+  - [e.g., RMS exceeds 1.5 g on HSS - immediate shutdown]
+  - [e.g., Step change >30% on any channel - treat as critical]
+  - [e.g., New BPFO or BPFI peak confirmed in spectrum - escalate to Severity 4]
+
+## Cross-Skill Correlation
+
+If gearbox visual data is available, load wind-turbine-gearbox skill and cross-correlate:
+- High Fe ppm + rising HSS vibration = active wear confirmation
+- Spalling in borescope + BPFO peak in spectrum = bearing failure progression
+- Normal oil + rising vibration = early fault not yet generating debris (higher urgency)
+
+If blade inspection data is available, check for rotor imbalance:
+- 1x RPM dominant in main bearing spectrum + blade damage = aerodynamic imbalance
+- Asymmetric blade damage across A/B/C = mass or aerodynamic imbalance source
+
+## Pitfalls
+
+- Do not evaluate vibration in isolation. Cross-reference with oil analysis and visual inspection.
+- A single high RMS reading during a storm or grid fault is not a fault indicator. Check operational context.
+- Spectrum analysis requires RPM-normalized data. Raw frequency peaks are meaningless without shaft RPM.
+- Generator electrical faults can appear as vibration. Check electrical data before attributing to mechanical cause.
+- Stable high RMS is less urgent than rapidly rising moderate RMS. Trend rate matters more than absolute value.
+
+## Verification
+
+After generating the report, confirm with the user:
+- Does the severity match CMS system alerts or OEM recommendations?
+- Is shaft RPM data available to normalize spectrum frequencies?
+- Are there recent maintenance events that could explain vibration changes?
+- Is SCADA power curve deviation consistent with vibration findings?


### PR DESCRIPTION
## Problem

Fixes #149

When using reasoning models (DeepSeek, QwQ, Hermes 4), `<think>...</think>` blocks leak into the final user-facing response. The `_strip_think_blocks()` method already existed in the codebase but was not being called when setting `final_response`.

## Root Cause

In `run_agent.py`, the final response was set as:
```python
final_response = assistant_message.content or ""
```

The existing `_strip_think_blocks()` method was only used in the summary/max-iterations path (line 1644) but not in the main response path.

## Fix

One-line fix — call `_strip_think_blocks()` when setting the final response:
```python
final_response = self._strip_think_blocks(assistant_message.content or "").strip()
```

## Testing

Tested with a reasoning model that produces `<think>` blocks — output is now clean with only the actual response visible to the user.