### PR TITLE
fix: align _apply_delete comment with actual behavior

### DIFF
--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -324,8 +324,7 @@ def _apply_delete(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
         # File doesn't exist, nothing to delete
         return True, f"# {op.file_path} already deleted or doesn't exist"
     
-    # Delete by writing empty and then removing
-    # Use shell command via the underlying environment
+    # Delete directly via shell command using the underlying environment
     rm_result = file_ops._exec(f"rm -f {file_ops._escape_shell_arg(op.file_path)}")
     
     if rm_result.exit_code != 0:


### PR DESCRIPTION
<!-- Why were these changes needed? -->
The comment in `_apply_delete`https://github.com/NousResearch/hermes-agent/blob/7b23dbfe6841002328f96e8d97980e1d11410db5/tools/patch_parser.py#L318-L335 said the file is first emptied and then removed, but the implementation only performs direct removal via `rm -f`. This mismatch was misleading during maintenance and code review.

<!-- What changes are included in this PR? -->
Updated the `_apply_delete` comment to accurately describe the real behavior: direct deletion through the underlying shell environment. No functional code changes were made.