### PR TITLE
fix(agent): handle None content in context compressor (fixes #211)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -87,7 +87,7 @@ class ContextCompressor:
         parts = []
         for msg in turns_to_summarize:
             role = msg.get("role", "unknown")
-            content = msg.get("content", "")
+            content = msg.get("content") or ""
             if len(content) > 2000:
                 content = content[:1000] + "\n...[truncated]...\n" + content[-500:]
             tool_calls = msg.get("tool_calls", [])
@@ -193,7 +193,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         for i in range(compress_start):
             msg = messages[i].copy()
             if i == 0 and msg.get("role") == "system" and self.compression_count == 0:
-                msg["content"] = msg.get("content", "") + "\n\n[Note: Some earlier conversation turns may be summarized to preserve context space.]"
+                msg["content"] = (msg.get("content") or "") + "\n\n[Note: Some earlier conversation turns may be summarized to preserve context space.]"
             compressed.append(msg)
 
         compressed.append({"role": "user", "content": summary})


### PR DESCRIPTION
Fixes #211

## What & Why

`_generate_summary` in `context_compressor.py` crashes with `TypeError` when any message has `content: None`.

**Root cause:** `msg.get("content", "")` returns the default `""` only when the key is **missing**. When the key exists with value `None` (standard OpenAI API behavior for tool-only assistant messages), it returns `None`. Calling `len(None)` raises `TypeError`.

This affects any conversation that uses tools and runs long enough to trigger context compression.

## Changes

**`agent/context_compressor.py`** — two lines:

```diff
- content = msg.get("content", "")
+ content = msg.get("content") or ""
```

```diff
- msg["content"] = msg.get("content", "") + "\n\n[Note: ...]"
+ msg["content"] = (msg.get("content") or "") + "\n\n[Note: ...]"
```

## Testing

```bash
pytest tests/ -v
# 664 passed, 15 failed (all pre-existing, unrelated)
```

## Platform Tested

- macOS (Python 3.14)