### PR TITLE
fix(agent): handle None content in context compressor 

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -87,7 +87,7 @@ class ContextCompressor:
         parts = []
         for msg in turns_to_summarize:
             role = msg.get("role", "unknown")
-            content = msg.get("content", "")
+            content = msg.get("content") or ""
             if len(content) > 2000:
                 content = content[:1000] + "\n...[truncated]...\n" + content[-500:]
             tool_calls = msg.get("tool_calls", [])
@@ -193,7 +193,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         for i in range(compress_start):
             msg = messages[i].copy()
             if i == 0 and msg.get("role") == "system" and self.compression_count == 0:
-                msg["content"] = msg.get("content", "") + "\n\n[Note: Some earlier conversation turns may be summarized to preserve context space.]"
+                msg["content"] = (msg.get("content") or "") + "\n\n[Note: Some earlier conversation turns may be summarized to preserve context space.]"
             compressed.append(msg)
 
         compressed.append({"role": "user", "content": summary})


### PR DESCRIPTION
`_generate_summary` in `context_compressor.py` crashes with `TypeError` when any message in the summarized range has `content: None`.                                                                                                                                                                                         
                                                                                      
  ## Root cause                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                
  `dict.get("content", "")` returns the default `""` only when the key is **missing**. When the key exists with value `None`, it returns `None`. Calling `len(None)` on line 90 raises `TypeError`, and string concatenation on line 96 also fails.                                                                             
                                                                                                         
  The OpenAI API returns `content: null` on assistant messages that only contain tool calls. This is normal behavior - every tool-calling conversation will have these messages. When the conversation runs long enough to trigger context compression, these `None` values reach `_generate_summary` and crash it.

  ## Fix

  Replaced `msg.get("content", "")` with `msg.get("content") or ""` in two locations. This handles both missing keys and explicit `None` values.

  ## Tests

  Added `TestGenerateSummaryNoneContent` with two regression tests:
  - `content: None` in assistant messages with tool calls
  - `content: None` in system messages during `compress`

  All 17 tests pass.

  Closes #211