### PR TITLE
fix(gateway): persist transcript changes in /retry, /undo and fix /reset attribute 

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -901,13 +901,12 @@ class GatewayRunner:
         source = event.source
         
         # Get existing session key
-        session_key = f"agent:main:{source.platform.value}:" + \
-                      (f"dm" if source.chat_type == "dm" else f"{source.chat_type}:{source.chat_id}")
+        session_key = self.session_store._generate_session_key(source)
         
         # Memory flush before reset: load the old transcript and let a
         # temporary agent save memories before the session is wiped.
         try:
-            old_entry = self.session_store._sessions.get(session_key)
+            old_entry = self.session_store._entries.get(session_key)
             if old_entry:
                 old_history = self.session_store.load_transcript(old_entry.session_id)
                 if old_history:
@@ -1135,7 +1134,7 @@ class GatewayRunner:
         
         # Truncate history to before the last user message
         truncated = history[:last_user_idx]
-        session_entry.conversation_history = truncated
+        self.session_store.rewrite_transcript(session_entry.session_id, truncated)
         
         # Re-send by creating a fake text event with the old message
         retry_event = MessageEvent(
@@ -1167,7 +1166,7 @@ class GatewayRunner:
         
         removed_msg = history[last_user_idx].get("content", "")
         removed_count = len(history) - last_user_idx
-        session_entry.conversation_history = history[:last_user_idx]
+        self.session_store.rewrite_transcript(session_entry.session_id, history[:last_user_idx])
         
         preview = removed_msg[:40] + "..." if len(removed_msg) > 40 else removed_msg
         return f"↩️ Undid {removed_count} message(s).\nRemoved: \"{preview}\""

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -567,6 +567,37 @@ class SessionStore:
         with open(transcript_path, "a") as f:
             f.write(json.dumps(message, ensure_ascii=False) + "\n")
     
+    def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+        """Replace a session's transcript with the given messages."""
+        # Rewrite SQLite
+        if self._db:
+            try:
+                self._db._conn.execute(
+                    "DELETE FROM messages WHERE session_id = ?", (session_id,)
+                )
+                self._db._conn.execute(
+                    "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
+                    (session_id,),
+                )
+                self._db._conn.commit()
+                for msg in messages:
+                    self._db.append_message(
+                        session_id=session_id,
+                        role=msg.get("role", "unknown"),
+                        content=msg.get("content"),
+                        tool_name=msg.get("tool_name"),
+                        tool_calls=msg.get("tool_calls"),
+                        tool_call_id=msg.get("tool_call_id"),
+                    )
+            except Exception as e:
+                logger.debug("Session DB rewrite failed: %s", e)
+
+        # Rewrite legacy JSONL
+        transcript_path = self.get_transcript_path(session_id)
+        with open(transcript_path, "w") as f:
+            for msg in messages:
+                f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript."""
         # Try SQLite first


### PR DESCRIPTION
`/retry` and `/undo` set `session_entry.conversation_history` which does not exist on `SessionEntry`. The truncated history was never written to disk, so the next message reload picked up the full unmodified transcript - both commands appeared to work but did nothing.                                                  
                                                                                                         
  `/reset` accessed `self.session_store._sessions` which does not exist on `SessionStore` (the correct attribute is `_entries`). The resulting `AttributeError` was caught by a bare except, silently skipping the memory flush before reset.

  ## Changes

  - Added `SessionStore.rewrite_transcript()` that persists changes to both the JSONL file and SQLite database
  - Updated `/retry` and `/undo` to call `rewrite_transcript()` instead of setting a non-existent attribute
  - Fixed `/reset` to use `_entries` instead of `_sessions`

  ## Tests

  Added 3 regression tests to `tests/gateway/test_session.py`:
  - `rewrite_transcript` replaces JSONL content correctly
  - `rewrite_transcript` with empty list clears transcript
  - `SessionStore` has `_entries` attribute, not `_sessions`

  All 20 tests pass.

  Closes #210