### PR TITLE
fix: correct off-by-one in retry exhaustion checks 

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2092,7 +2092,7 @@ class AIAgent:
                         print(f"{self.log_prefix}   📝 Provider message: {error_msg[:200]}")
                         print(f"{self.log_prefix}   ⏱️  Response time: {api_duration:.2f}s (fast response often indicates rate limiting)")
                         
-                        if retry_count > max_retries:
+                        if retry_count >= max_retries:
                             print(f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
                             logging.error(f"{self.log_prefix}Invalid API response after {max_retries} retries.")
                             self._persist_session(messages, conversation_history)
@@ -2323,7 +2323,7 @@ class AIAgent:
                                 "partial": True
                             }
                     
-                    if retry_count > max_retries:
+                    if retry_count >= max_retries:
                         print(f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded. Giving up.")
                         logging.error(f"{self.log_prefix}API call failed after {max_retries} retries. Last error: {api_error}")
                         logging.error(f"{self.log_prefix}Request details - Messages: {len(api_messages)}, Approx tokens: {approx_tokens:,}")


### PR DESCRIPTION
When API retries are exhausted due to invalid responses (empty/null `choices`) or repeated errors, the agent crashes with `IndexError` instead of returning a proper error.

## Changes

Changed `>` to `>=` in two retry exhaustion checks in `run_agent.py`:

- **Line 2095** - invalid response retries (empty/null choices)
- **Line 2326** - API error retries

The while loop condition is `retry_count < max_retries`, so `retry_count` maxes out at `max_retries` after increment. The old check `retry_count > max_retries` could never be true inside the loop, making it dead code. The loop would exit and fall through to `response.choices[0]` on an invalid response, crashing with `IndexError`.

## Tests

Added `TestRetryExhaustion` to `tests/test_run_agent.py` with 2 regression tests:
- Invalid response (empty choices) returns error dict instead of crashing
- API errors raise after retries instead of falling through

All 74 tests pass.

Closes #222
