### PR TITLE
fix: preserve empty content in ReadResult.to_dict() 

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -67,9 +67,17 @@ class TestReadResult:
     def test_to_dict_omits_defaults(self):
         r = ReadResult()
         d = r.to_dict()
-        assert "content" not in d  # empty string omitted
         assert "error" not in d    # None omitted
         assert "similar_files" not in d  # empty list omitted
+
+    def test_to_dict_preserves_empty_content(self):
+        """Empty file should still have content key in the dict."""
+        r = ReadResult(content="", total_lines=0, file_size=0)
+        d = r.to_dict()
+        assert "content" in d
+        assert d["content"] == ""
+        assert d["total_lines"] == 0
+        assert d["file_size"] == 0
 
     def test_to_dict_includes_values(self):
         r = ReadResult(content="hello", total_lines=10, file_size=50, truncated=True)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -107,7 +107,7 @@ class ReadResult:
     similar_files: List[str] = field(default_factory=list)
     
     def to_dict(self) -> dict:
-        return {k: v for k, v in self.__dict__.items() if v is not None and v != [] and v != ""}
+        return {k: v for k, v in self.__dict__.items() if v is not None and v != []}
 
 
 @dataclass


### PR DESCRIPTION
Removed `and v != ""` from the `ReadResult.to_dict()` filter in `tools/file_operations.py`. Empty `content` is now preserved in the output dict.

The filter `v != ""` was intended to skip unset fields, but `content=""` is valid for empty files. Other string fields use `Optional[str] = None` so they are already handled by the `v is not None` check.

### Tests

Updated `tests/tools/test_file_operations.py`:
- Updated `test_to_dict_omits_defaults` to reflect the fix
- Added `test_to_dict_preserves_empty_content` - verifies empty file content is kept in the dict

All 37 tests pass.

Closes #224 