### PR TITLE
fix(agent): strip _flush_sentinel from API messages

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1430,6 +1430,7 @@ class AIAgent:
                     if reasoning:
                         api_msg["reasoning_content"] = reasoning
                 api_msg.pop("reasoning", None)
+                api_msg.pop("_flush_sentinel", None)
                 api_messages.append(api_msg)
 
             if self._cached_system_prompt:


### PR DESCRIPTION
Added `api_msg.pop("_flush_sentinel", None)` next to the existing `api_msg.pop("reasoning", None)` in the flush API message building loop. This strips the internal marker before sending messages to the API.

### Test

Added `TestFlushSentinelNotLeaked` to `tests/test_run_agent.py` that verifies no message sent to the API contains `_flush_sentinel`. Test confirmed the leak exists without the fix and passes with it.

Closes #226 