### PR TITLE
fix(agent): copy conversation_history to avoid mutating caller's list

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1842,8 +1842,8 @@ class AIAgent:
         self._turns_since_memory = 0
         self._iters_since_skill = 0
         
-        # Initialize conversation
-        messages = conversation_history or []
+        # Initialize conversation (copy to avoid mutating the caller's list)
+        messages = list(conversation_history) if conversation_history else []
         
         # Hydrate todo store from conversation history (gateway creates a fresh
         # AIAgent per message, so the in-memory store is empty -- we need to


### PR DESCRIPTION
Changed `messages = conversation_history or []` to `messages = list(conversation_history) if conversation_history else []` in `run_conversation()`. This creates a shallow copy so the caller's list is never mutated.

The result dict already returns the updated `messages` list, so callers who need the full conversation can use `result["messages"]`.

### Test

Added `TestConversationHistoryNotMutated` to `tests/test_run_agent.py` that passes a 2-item history list, runs a conversation, and verifies the original list still has exactly 2 items. Without the fix, it grows to 4 (the 2 originals + new user message + assistant response).

Closes #228 