### PR TITLE
fix: copy conversation_history to prevent caller mutation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2569,7 +2569,7 @@ class AIAgent:
         self._iters_since_skill = 0
         
         # Initialize conversation
-        messages = conversation_history or []
+        messages = list(conversation_history) if conversation_history else []
         
         # Hydrate todo store from conversation history (gateway creates a fresh
         # AIAgent per message, so the in-memory store is empty -- we need to


### PR DESCRIPTION
## Problem

`run_conversation()` in `run_agent.py` creates an alias instead of a copy of the `conversation_history` parameter:

```python
messages = conversation_history or []
```

Since `messages` is the same object as the caller's list, every `messages.append()` during the conversation also modifies the caller's original list. This is a classic Python mutable argument pitfall.

Reported in #228.

## Solution

```python
messages = list(conversation_history) if conversation_history else []
```

This creates a shallow copy when a non-empty list is passed, preserving the caller's original list. When `conversation_history` is `None` or empty, a new list is created as before.

## Changes

- `run_agent.py` line 2572: 1 line changed

## Testing

- Shallow copy preserves message objects (no deep copy overhead)
- `None` and `[]` inputs still produce an empty list
- No behavioral change for the internal conversation flow

Closes #228