### PR TITLE
fix: strip _flush_sentinel from API messages before sending

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2136,6 +2136,7 @@ class AIAgent:
                     if reasoning:
                         api_msg["reasoning_content"] = reasoning
                 api_msg.pop("reasoning", None)
+                api_msg.pop("_flush_sentinel", None)
                 api_messages.append(api_msg)
 
             if self._cached_system_prompt:


### PR DESCRIPTION
## Problem

During memory flush before context compression, `flush_memories()` adds an internal `_flush_sentinel` marker to the flush message:

```python
flush_msg = {"role": "user", "content": flush_content, "_flush_sentinel": _sentinel}
```

When building `api_messages` for the flush API call, the loop strips `reasoning` but **not** `_flush_sentinel`. The sentinel value (containing Python `id()` and `time.monotonic()` output) gets sent to the external API provider.

Reported in #226.

## Solution

Add `api_msg.pop("_flush_sentinel", None)` alongside the existing `reasoning` strip:

```python
api_msg.pop("reasoning", None)
api_msg.pop("_flush_sentinel", None)  # added
```

## Changes

- `run_agent.py`: +1 line

## Testing

- The sentinel is only used locally in the `finally` block for cleanup (matching against `messages`, not `api_messages`)
- Stripping it from `api_messages` has no effect on the cleanup logic
- No behavioral change to the flush flow

Closes #226