### PR TITLE
fix: preserve empty string content in ReadResult.to_dict()

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -107,7 +107,7 @@ class ReadResult:
     similar_files: List[str] = field(default_factory=list)
     
     def to_dict(self) -> dict:
-        return {k: v for k, v in self.__dict__.items() if v is not None and v != [] and v != ""}
+        return {k: v for k, v in self.__dict__.items() if v is not None and v != []}
 
 
 @dataclass


### PR DESCRIPTION
## Problem

`ReadResult.to_dict()` filters out empty strings from the output dict:

```python
return {k: v for k, v in self.__dict__.items() if v is not None and v != [] and v != ""}
```

When reading an empty file, `content` is legitimately `""`. The `v != ""` filter drops it from the dict entirely, making it impossible to distinguish "file was read successfully but is empty" from "content was never set".

Reported in #224.

## Solution

Remove the `v != ""` check:

```python
return {k: v for k, v in self.__dict__.items() if v is not None and v != []}
```

The `v != []` filter for `similar_files` is kept since empty list has different semantics. All other optional string fields use `Optional[str] = None` and are already handled by the `v is not None` check.

## Changes

- `tools/file_operations.py` line 110: remove `and v != ""` from dict comprehension

Closes #224