### PR TITLE
fix(honcho): auto-enable when API key is present

### DIFF
--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -97,15 +97,27 @@ class HonchoClientConfig:
         )
         linked_hosts = host_block.get("linkedHosts", [])
 
+        api_key = raw.get("apiKey") or os.environ.get("HONCHO_API_KEY")
+
+        # Auto-enable when API key is present (unless explicitly disabled)
+        # This matches user expectations: setting an API key should activate the feature.
+        explicit_enabled = raw.get("enabled")
+        if explicit_enabled is None:
+            # Not explicitly set in config -> auto-enable if API key exists
+            enabled = bool(api_key)
+        else:
+            # Respect explicit setting
+            enabled = explicit_enabled
+
         return cls(
             host=host,
             workspace_id=workspace,
-            api_key=raw.get("apiKey") or os.environ.get("HONCHO_API_KEY"),
+            api_key=api_key,
             environment=raw.get("environment", "production"),
             peer_name=raw.get("peerName"),
             ai_peer=ai_peer,
             linked_hosts=linked_hosts,
-            enabled=raw.get("enabled", False),
+            enabled=enabled,
             save_messages=raw.get("saveMessages", True),
             context_tokens=raw.get("contextTokens") or host_block.get("contextTokens"),
             session_strategy=raw.get("sessionStrategy", "per-directory"),

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -1,0 +1,105 @@
+"""Tests for Honcho client configuration."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from honcho_integration.client import HonchoClientConfig
+
+
+class TestHonchoClientConfigAutoEnable:
+    """Test auto-enable behavior when API key is present."""
+
+    def test_auto_enables_when_api_key_present_no_explicit_enabled(self, tmp_path):
+        """When API key exists and enabled is not set, should auto-enable."""
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "apiKey": "test-api-key-12345",
+            # Note: no "enabled" field
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.api_key == "test-api-key-12345"
+        assert cfg.enabled is True  # Auto-enabled because API key exists
+
+    def test_respects_explicit_enabled_false(self, tmp_path):
+        """When enabled is explicitly False, should stay disabled even with API key."""
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "apiKey": "test-api-key-12345",
+            "enabled": False,  # Explicitly disabled
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.api_key == "test-api-key-12345"
+        assert cfg.enabled is False  # Respects explicit setting
+
+    def test_respects_explicit_enabled_true(self, tmp_path):
+        """When enabled is explicitly True, should be enabled."""
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "apiKey": "test-api-key-12345",
+            "enabled": True,
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.api_key == "test-api-key-12345"
+        assert cfg.enabled is True
+
+    def test_disabled_when_no_api_key_and_no_explicit_enabled(self, tmp_path):
+        """When no API key and enabled not set, should be disabled."""
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "workspace": "test",
+            # No apiKey, no enabled
+        }))
+
+        # Clear env var if set
+        env_key = os.environ.pop("HONCHO_API_KEY", None)
+        try:
+            cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+            assert cfg.api_key is None
+            assert cfg.enabled is False  # No API key = not enabled
+        finally:
+            if env_key:
+                os.environ["HONCHO_API_KEY"] = env_key
+
+    def test_auto_enables_with_env_var_api_key(self, tmp_path, monkeypatch):
+        """When API key is in env var (not config), should auto-enable."""
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "workspace": "test",
+            # No apiKey in config
+        }))
+
+        monkeypatch.setenv("HONCHO_API_KEY", "env-api-key-67890")
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.api_key == "env-api-key-67890"
+        assert cfg.enabled is True  # Auto-enabled from env var API key
+
+    def test_from_env_always_enabled(self, monkeypatch):
+        """from_env() should always set enabled=True."""
+        monkeypatch.setenv("HONCHO_API_KEY", "env-test-key")
+
+        cfg = HonchoClientConfig.from_env()
+
+        assert cfg.api_key == "env-test-key"
+        assert cfg.enabled is True
+
+    def test_falls_back_to_env_when_no_config_file(self, tmp_path, monkeypatch):
+        """When config file doesn't exist, should fall back to from_env()."""
+        nonexistent = tmp_path / "nonexistent.json"
+        monkeypatch.setenv("HONCHO_API_KEY", "fallback-key")
+
+        cfg = HonchoClientConfig.from_global_config(config_path=nonexistent)
+
+        assert cfg.api_key == "fallback-key"
+        assert cfg.enabled is True  # from_env() sets enabled=True


### PR DESCRIPTION
## Summary

Fixes #241 — Honcho integration appears inactive after API key setup.

## The Problem

When users run `hermes config set HONCHO_API_KEY <key>`, they expect Honcho to activate. However:
1. The `enabled` flag in `HonchoClientConfig.from_global_config()` defaulted to `False`
2. Users weren't aware they also needed to explicitly enable Honcho
3. This caused the "no automatic conversation ingestion" behavior reported in #241

## The Fix

Auto-enable Honcho when:
- An API key is present (from config file OR environment variable)
- AND `enabled` is not explicitly set to `false` in the config

This matches user expectations: **setting an API key should activate the feature**.

Users who want to disable Honcho while keeping the API key can still set `enabled: false` in their `~/.honcho/config.json`.

## Changes

- `honcho_integration/client.py`: Modified `from_global_config()` to auto-enable when API key exists
- `tests/test_honcho_client_config.py`: Added unit tests for auto-enable behavior

## Testing

Added 7 test cases covering:
- Auto-enable with API key present (no explicit enabled)
- Respects explicit `enabled: false`
- Respects explicit `enabled: true`
- Disabled when no API key and no explicit enabled
- Auto-enables with env var API key
- `from_env()` always enabled
- Fallback to env when config file missing