### PR TITLE
feat(agent): support full OpenRouter provider routing options

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -21,6 +21,22 @@ model:
   base_url: "https://openrouter.ai/api/v1"
 
 # =============================================================================
+# OpenRouter Provider Routing Options
+# =============================================================================
+# Advanced routing controls for OpenRouter endpoints. 
+# See https://openrouter.ai/docs/provider-routing for details.
+openrouter:
+  provider:
+    # order: ["Anthropic", "OpenAI"]      # Try these providers first in this order
+    # ignore: ["Google"]                  # Never use these providers
+    # allow_fallbacks: true               # Allow falling back to other providers (default: true)
+    # require_parameters: false           # Require providers that support all parameters (default: false)
+    # data_collection: "deny"             # "deny" or "allow"
+    # quantized: false                    # Allow/deny quantized models
+    # sort: "price"                       # "price", "throughput", or "latency"
+
+
+# =============================================================================
 # Terminal Tool Configuration
 # =============================================================================
 # Choose ONE of the following terminal configurations by uncommenting it.

--- a/cli.py
+++ b/cli.py
@@ -1003,6 +1003,7 @@ class HermesCLI:
                 pass
         
         try:
+            openrouter_providers = self.config.get("openrouter", {}).get("provider", {})
             self.agent = AIAgent(
                 model=self.model,
                 api_key=self.api_key,
@@ -1021,6 +1022,7 @@ class HermesCLI:
                 session_db=self._session_db,
                 clarify_callback=self._clarify_callback,
                 honcho_session_key=self.session_id,
+                openrouter_providers=openrouter_providers,
             )
             return True
         except Exception as e:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -135,8 +135,13 @@ DEFAULT_CONFIG = {
     # Permanently allowed dangerous command patterns (added via "always" approval)
     "command_allowlist": [],
     
+    # OpenRouter provider routing options
+    "openrouter": {
+        "provider": {}
+    },
+    
     # Config schema version - bump this when adding new required fields
-    "_config_version": 4,
+    "_config_version": 5,
 }
 
 # =============================================================================

--- a/run_agent.py
+++ b/run_agent.py
@@ -126,6 +126,7 @@ class AIAgent:
         providers_ignored: List[str] = None,
         providers_order: List[str] = None,
         provider_sort: str = None,
+        openrouter_providers: Dict[str, Any] = None,
         session_id: str = None,
         tool_progress_callback: callable = None,
         clarify_callback: callable = None,
@@ -162,6 +163,7 @@ class AIAgent:
             providers_ignored (List[str]): OpenRouter providers to ignore (optional)
             providers_order (List[str]): OpenRouter providers to try in order (optional)
             provider_sort (str): Sort providers by price/throughput/latency (optional)
+            openrouter_providers (Dict): Full dict of OpenRouter provider routing options (optional, from config)
             session_id (str): Pre-generated session ID for logging (optional, auto-generated if not provided)
             tool_progress_callback (callable): Callback function(tool_name, args_preview) for progress notifications
             clarify_callback (callable): Callback function(question, choices) -> str for interactive user questions.
@@ -230,6 +232,7 @@ class AIAgent:
         self.providers_ignored = providers_ignored
         self.providers_order = providers_order
         self.provider_sort = provider_sort
+        self.openrouter_providers = openrouter_providers or {}
 
         # Store toolset filtering options
         self.enabled_toolsets = enabled_toolsets
@@ -2053,7 +2056,7 @@ class AIAgent:
 
             return kwargs
 
-        provider_preferences = {}
+        provider_preferences = self.openrouter_providers.copy() if self.openrouter_providers else {}
         if self.providers_allowed:
             provider_preferences["only"] = self.providers_allowed
         if self.providers_ignored:

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -493,6 +493,21 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["extra_body"]["provider"]["only"] == ["Anthropic"]
 
+    def test_openrouter_providers_injected(self, agent):
+        agent.openrouter_providers = {"allow_fallbacks": False, "data_collection": "deny"}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["extra_body"]["provider"]["allow_fallbacks"] is False
+        assert kwargs["extra_body"]["provider"]["data_collection"] == "deny"
+
+    def test_legacy_providers_override_openrouter_providers(self, agent):
+        agent.openrouter_providers = {"order": ["Google"], "allow_fallbacks": False}
+        agent.providers_order = ["Anthropic"]
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["extra_body"]["provider"]["order"] == ["Anthropic"]
+        assert kwargs["extra_body"]["provider"]["allow_fallbacks"] is False
+
     def test_reasoning_config_default_openrouter(self, agent):
         """Default reasoning config for OpenRouter should be xhigh."""
         messages = [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
Implements: #238 

Old:
- The agent only supported a subset of OpenRouter's provider routing options (only, ignore, order, sort) via individual explicit parameters.
- There was no way for CLI users to persistently configure provider routing preferences via config.yaml.

Changes:
- Added openrouter_providers dictionary to AIAgent to natively support all OpenRouter provider kwargs (e.g., allow_fallbacks, data_collection, quantized, require_parameters).
- Added an openrouter.provider block to DEFAULT_CONFIG in hermes_cli/config.py with bumped _config_version to 5 for auto-migration.
- Updated cli.py to read the new config block and pass it to the agent.
- Preserved legacy explicit parameters (providers_allowed, etc.) in _build_api_kwargs for backward compatibility with batch_runner.py and delegate_tool.py.

Expected:
- CLI users can now globally define advanced OpenRouter routing behaviors (like disabling fallbacks or opting out of data collection) directly in their ~/.hermes/config.yaml.
- Existing subagents and batch pipelines using explicit provider arguments continue to work identically without breaking.


Use of AI: 
- OpenCode used for support
