### PR TITLE
fix: use task-specific glob pattern in disk usage calculation

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -636,19 +636,19 @@ def get_active_environments_info() -> Dict[str, Any]:
         "workdirs": {},
     }
     
-    # Calculate total disk usage
+    # Calculate total disk usage (per-task to avoid double-counting)
     total_size = 0
     for task_id in _active_environments.keys():
-        # Check sandbox and workdir sizes
+        # Check sandbox and workdir sizes for this specific task
         scratch_dir = _get_scratch_dir()
-        for pattern in [f"hermes-*{task_id[:8]}*"]:
-            import glob
-            for path in glob.glob(str(scratch_dir / "hermes-*")):
-                try:
-                    size = sum(f.stat().st_size for f in Path(path).rglob('*') if f.is_file())
-                    total_size += size
-                except OSError:
-                    pass
+        pattern = f"hermes-*{task_id[:8]}*"
+        import glob
+        for path in glob.glob(str(scratch_dir / pattern)):
+            try:
+                size = sum(f.stat().st_size for f in Path(path).rglob('*') if f.is_file())
+                total_size += size
+            except OSError:
+                pass
     
     info["total_disk_usage_mb"] = round(total_size / (1024 * 1024), 2)
     return info


### PR DESCRIPTION
## Summary

Fixes #230

The `get_active_environments_info()` function was using a hardcoded `hermes-*` glob pattern instead of the task-specific pattern that was constructed.

## Bug

```python
for pattern in [f"hermes-*{task_id[:8]}*"]:
    for path in glob.glob(str(scratch_dir / "hermes-*")):  # <-- ignores pattern!
```

## Fix

```python
pattern = f"hermes-*{task_id[:8]}*"
for path in glob.glob(str(scratch_dir / pattern)):  # <-- uses pattern
```

## Impact

With N active environments, disk usage was being over-reported by N times because each loop iteration counted ALL hermes directories instead of just its own.

| Scenario | Before | After |
|----------|--------|-------|
| 2 envs @ 1 MB each | 4 MB | 2 MB |
| 5 envs @ 10 MB each | 250 MB | 50 MB |