### PR TITLE
fix(agent): strip finish_reason from assistant messages to fix Mistral 422 errors

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2233,6 +2233,7 @@ class AIAgent:
                     if reasoning:
                         api_msg["reasoning_content"] = reasoning
                 api_msg.pop("reasoning", None)
+                api_msg.pop("finish_reason", None)
                 api_messages.append(api_msg)
 
             if self._cached_system_prompt:
@@ -2860,6 +2861,9 @@ class AIAgent:
                 # We've copied it to 'reasoning_content' for the API above
                 if "reasoning" in api_msg:
                     api_msg.pop("reasoning")
+                # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
+                if "finish_reason" in api_msg:
+                    api_msg.pop("finish_reason")
                 # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
                 # The signature field helps maintain reasoning continuity
                 api_messages.append(api_msg)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2087,7 +2087,8 @@ class AIAgent:
         _is_openrouter = "openrouter" in self.base_url.lower()
         _is_nous = "nousresearch" in self.base_url.lower()
 
-        if _is_openrouter or _is_nous:
+        _is_mistral = "api.mistral.ai" in self.base_url.lower()
+        if (_is_openrouter or _is_nous) and not _is_mistral:
             if self.reasoning_config is not None:
                 extra_body["reasoning"] = self.reasoning_config
             else:


### PR DESCRIPTION
## Problem

Fixes #134

When using Mistral API directly (`api.mistral.ai`), the second message always fails with HTTP 422:
```
'loc': ['body', 'messages', 2, 'assistant', 'finish_reason'],
'msg': 'Extra inputs are not permitted'
```
## Root Cause

In `_build_assistant_message()`, a `finish_reason` field is stored on every assistant message dict for internal trajectory tracking. When these messages are replayed as conversation history in subsequent API calls, the `finish_reason` field is sent to the API.

Mistral's API strictly forbids extra fields in message objects and returns 422. The first message always works because there's no history yet — the error appears from the second message onward.

## Fix

Strip `finish_reason` and `reasoning` from assistant messages before sending them to the API, in both the main agent loop and the memory flush loop:
```python
if "reasoning" in api_msg:
    api_msg.pop("reasoning")
# Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
if "finish_reason" in api_msg:
    api_msg.pop("finish_reason")
```

## Testing

Verified that `finish_reason` is no longer present in outbound API message payloads.