### PR TITLE
feat(agent): use main model for context compression when no override is set

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -522,7 +522,9 @@ class AIAgent:
         # Configuration via config.yaml (compression section) or environment variables
         compression_threshold = float(os.getenv("CONTEXT_COMPRESSION_THRESHOLD", "0.85"))
         compression_enabled = os.getenv("CONTEXT_COMPRESSION_ENABLED", "true").lower() in ("true", "1", "yes")
-        compression_summary_model = os.getenv("CONTEXT_COMPRESSION_MODEL") or None
+        # If no compression model is explicitly set, fall back to the main model
+        # so that context compression uses the most capable available model.
+        compression_summary_model = os.getenv("CONTEXT_COMPRESSION_MODEL") or self.model
         
         self.context_compressor = ContextCompressor(
             model=self.model,


### PR DESCRIPTION
## Problem

Fixes #130

Context compression currently uses a small/fast auxiliary model (`google/gemini-3-flash-preview`) by default. As noted in the issue, compression is a fundamentally different task from quick summarization — it requires deep understanding of a long conversation to distill it without losing important context.

## Change

When `CONTEXT_COMPRESSION_MODEL` is not explicitly set, fall back to `self.model` (the main agent model) instead of the auxiliary client's default:
```python
# Before
compression_summary_model = os.getenv("CONTEXT_COMPRESSION_MODEL") or None

# After  
compression_summary_model = os.getenv("CONTEXT_COMPRESSION_MODEL") or self.model
```

## Behavior

- If `CONTEXT_COMPRESSION_MODEL` is set → use that model (no change)
- If not set → use the main agent model instead of defaulting to gemini-flash

This ensures the most capable available model handles compression by default, while still allowing users to override with a cheaper/faster model if they prefer.