### PR TITLE
chore: add ruff formatter configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 modal = ["swe-rex[modal]>=1.4.0"]
-dev = ["pytest", "pytest-asyncio"]
+dev = ["pytest", "pytest-asyncio", "ruff"]
 messaging = ["python-telegram-bot>=20.0", "discord.py>=2.0", "aiohttp>=3.9.0", "slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]
 cron = ["croniter"]
 slack = ["slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]
@@ -75,3 +75,15 @@ markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
 ]
 addopts = "-m 'not integration'"
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = ["E501"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
## Problem

Fixes #255

Code formatting is inconsistent across the codebase, making contributions harder — running a formatter produces noisy diffs that drown out actual changes.

## Change

Added `ruff` configuration to `pyproject.toml`:

- Line length: 120
- Target: Python 3.10+
- Lint rules: E, F, W, I (standard + isort)
- Format: double quotes, space indentation
- Added `ruff` to `dev` dependencies

## Why ruff?

- Fast (10-100x faster than black/flake8)
- Single tool for both linting and formatting
- Widely adopted in modern Python projects
- Config lives in `pyproject.toml` (already exists in repo)

## Next steps

Once this config is merged, contributors can run:
```
pip install ruff
ruff format .
ruff check .
```
A follow-up PR can apply the formatting to the existing codebase.