### PR TITLE
fix(auth): warn when Codex CLI is not installed after openai-codex login

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1417,6 +1417,16 @@ def _save_codex_provider_state(creds: Dict[str, Any]) -> None:
     print(f"  Auth state: {saved_to}")
     print(f"  Config updated: {config_path} (model.provider=openai-codex)")
 
+    # Check that the Codex CLI binary is available; warn the user if not.
+    import shutil
+    if shutil.which("codex") is None:
+        print()
+        print("  [93mWarning: Codex CLI not found in PATH.[0m")
+        print("  Hermes uses the Codex CLI to run openai-codex requests.")
+        print("  Install it with:")
+        print("    npm install -g @openai/codex")
+        print("  Then re-run Hermes.")
+
 
 def _codex_device_code_login() -> Dict[str, Any]:
     """Run the OpenAI device code login flow and return credentials dict."""


### PR DESCRIPTION
## Problem

Fixes #259

When a user completes ChatGPT OAuth for `openai-codex`, Hermes saves credentials and reports success — but does not check whether the Codex CLI binary is actually installed. If `codex` is absent from PATH, runtime fails silently with no actionable message.

## Change

After a successful `openai-codex` login, check for the `codex` binary using `shutil.which`. If not found, print a clear warning with the install command:
```
Warning: Codex CLI not found in PATH.
Hermes uses the Codex CLI to run openai-codex requests.
Install it with:
  npm install -g @openai/codex
Then re-run Hermes.
```

## Behavior

- If `codex` is in PATH → no change, login completes silently ✅
- If `codex` is missing → user sees a clear warning immediately after login ✅
- No hard failure — user can install and continue without re-authenticating ✅