### PR TITLE
Add codex app-server ChatGPT OAuth provider path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16,6 +16,7 @@ import logging
 import os
 import sys
 import json
+import webbrowser
 import atexit
 import uuid
 from pathlib import Path
@@ -495,7 +496,15 @@ def _get_available_skills() -> Dict[str, List[str]]:
     return skills_by_category
 
 
-def build_welcome_banner(console: Console, model: str, cwd: str, tools: List[dict] = None, enabled_toolsets: List[str] = None, session_id: str = None):
+def build_welcome_banner(
+    console: Console,
+    model: str,
+    cwd: str,
+    tools: List[dict] = None,
+    enabled_toolsets: List[str] = None,
+    session_id: str = None,
+    provider_label: str = None,
+):
     """
     Build and print a Claude Code-style welcome banner with caduceus on left and info on right.
     
@@ -506,6 +515,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str, tools: List[dic
         tools: List of tool definitions
         enabled_toolsets: List of enabled toolset names
         session_id: Unique session identifier for logging
+        provider_label: Optional provider label to display next to the model
     """
     from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
     
@@ -531,7 +541,8 @@ def build_welcome_banner(console: Console, model: str, cwd: str, tools: List[dic
     if len(model_short) > 28:
         model_short = model_short[:25] + "..."
     
-    left_lines.append(f"[#FFBF00]{model_short}[/] [dim #B8860B]·[/] [dim #B8860B]Nous Research[/]")
+    provider_text = provider_label or "Nous Research"
+    left_lines.append(f"[#FFBF00]{model_short}[/] [dim #B8860B]·[/] [dim #B8860B]{provider_text}[/]")
     left_lines.append(f"[dim #B8860B]{cwd}[/]")
     
     # Add session ID if provided
@@ -803,7 +814,7 @@ class HermesCLI:
         Args:
             model: Model to use (default: from env or claude-sonnet)
             toolsets: List of toolsets to enable (default: all)
-            provider: Inference provider ("auto", "openrouter", "nous", "openai-codex")
+            provider: Inference provider ("auto", "openrouter", "nous", "openai-codex", "codex-app-server")
             api_key: API key (default: from environment)
             base_url: API base URL (default: OpenRouter)
             max_turns: Maximum tool-calling iterations (default: 60)
@@ -843,6 +854,11 @@ class HermesCLI:
         self.api_key = api_key or os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
         self._nous_key_expires_at: Optional[str] = None
         self._nous_key_source: Optional[str] = None
+        self._app_server_bin: str = os.getenv("HERMES_CODEX_APP_SERVER_BIN", "codex")
+        self._codex_app_client = None
+        self._codex_thread_id: Optional[str] = None
+        self._codex_override_notice_shown = False
+        self._session_db = None
         # Max turns priority: CLI arg > env var > config file (agent.max_turns or root max_turns) > default
         if max_turns is not None:  # CLI arg was explicitly set
             self.max_turns = max_turns
@@ -901,6 +917,70 @@ class HermesCLI:
         # History file for persistent input recall across sessions
         self._history_file = Path.home() / ".hermes_history"
 
+    def _ensure_session_store(self) -> None:
+        """Initialize SQLite session store once."""
+        if self._session_db is not None:
+            return
+        try:
+            from hermes_state import SessionDB
+            self._session_db = SessionDB()
+        except Exception as e:
+            logger.debug("SQLite session store not available: %s", e)
+            self._session_db = None
+
+    def _restore_or_init_session(self) -> bool:
+        """Restore resumed sessions or create a fresh session row."""
+        self._ensure_session_store()
+        if not self._session_db:
+            return True
+
+        session_meta = self._session_db.get_session(self.session_id)
+        if self._resumed:
+            if not session_meta:
+                _cprint(f"\033[1;31mSession not found: {self.session_id}{_RST}")
+                _cprint(f"{_DIM}Use a session ID from a previous CLI run (hermes sessions list).{_RST}")
+                return False
+            restored = self._session_db.get_messages_as_conversation(self.session_id)
+            if restored:
+                self.conversation_history = restored
+                msg_count = len([m for m in restored if m.get("role") == "user"])
+                _cprint(
+                    f"{_GOLD}↻ Resumed session {_BOLD}{self.session_id}{_RST}{_GOLD} "
+                    f"({msg_count} user message{'s' if msg_count != 1 else ''}, "
+                    f"{len(restored)} total messages){_RST}"
+                )
+            else:
+                _cprint(f"{_GOLD}Session {self.session_id} found but has no messages. Starting fresh.{_RST}")
+            try:
+                self._session_db._conn.execute(
+                    "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
+                    (self.session_id,),
+                )
+                self._session_db._conn.commit()
+            except Exception:
+                pass
+            return True
+
+        if session_meta:
+            return True
+
+        try:
+            self._session_db.create_session(
+                session_id=self.session_id,
+                source="cli",
+                model=self.model,
+                model_config={
+                    "provider": self.provider,
+                    "api_mode": self.api_mode,
+                    "base_url": self.base_url,
+                    "max_turns": self.max_turns,
+                },
+                system_prompt=self.system_prompt or None,
+            )
+        except Exception as e:
+            logger.debug("Could not create SQLite session row: %s", e)
+        return True
+
     def _ensure_runtime_credentials(self) -> bool:
         """
         Ensure runtime credentials are resolved before agent use.
@@ -928,9 +1008,10 @@ class HermesCLI:
         base_url = runtime.get("base_url")
         resolved_provider = runtime.get("provider", "openrouter")
         resolved_api_mode = runtime.get("api_mode", self.api_mode)
-        if not isinstance(api_key, str) or not api_key:
-            self.console.print("[bold red]Provider resolver returned an empty API key.[/]")
-            return False
+        if resolved_provider != "codex-app-server":
+            if not isinstance(api_key, str) or not api_key:
+                self.console.print("[bold red]Provider resolver returned an empty API key.[/]")
+                return False
         if not isinstance(base_url, str) or not base_url:
             self.console.print("[bold red]Provider resolver returned an empty base URL.[/]")
             return False
@@ -945,12 +1026,202 @@ class HermesCLI:
         self._provider_source = runtime.get("source")
         self.api_key = api_key
         self.base_url = base_url
+        self._app_server_bin = runtime.get("app_server_bin", self._app_server_bin)
 
         # AIAgent/OpenAI client holds auth at init time, so rebuild if key rotated
         if (credentials_changed or routing_changed) and self.agent is not None:
             self.agent = None
+        if (credentials_changed or routing_changed) and self._codex_app_client is not None:
+            try:
+                self._codex_app_client.close()
+            except Exception:
+                pass
+            self._codex_app_client = None
+            self._codex_thread_id = None
 
         return True
+
+    def _init_codex_app_server(self) -> bool:
+        """Initialize codex app-server backend and ensure ChatGPT auth."""
+        if self._codex_app_client is not None and self._codex_thread_id:
+            return True
+
+        try:
+            from hermes_cli import __version__ as hermes_version
+            from hermes_cli.codex_app_server import (
+                CodexAppServerClient,
+                wait_for_notification,
+            )
+
+            client = CodexAppServerClient(binary=self._app_server_bin, cwd=os.getcwd())
+            client.start()
+            client.initialize(
+                client_name="hermes_agent",
+                client_title="Hermes Agent",
+                client_version=str(hermes_version),
+                experimental_api=False,
+            )
+
+            account = client.call("account/read", params={"refreshToken": False}, timeout=20.0)
+            account_info = account.get("account")
+            requires_auth = bool(account.get("requiresOpenaiAuth"))
+            if isinstance(account_info, dict):
+                account_type = account_info.get("type")
+                account_email = account_info.get("email")
+                if account_type == "chatgpt":
+                    if isinstance(account_email, str) and account_email:
+                        _cprint(f"{_DIM}codex app-server auth: using existing ChatGPT session ({account_email}){_RST}")
+                    else:
+                        _cprint(f"{_DIM}codex app-server auth: using existing ChatGPT session{_RST}")
+                elif account_type:
+                    _cprint(f"{_DIM}codex app-server auth: using existing session ({account_type}){_RST}")
+            if account_info is None and requires_auth:
+                login = client.call("account/login/start", params={"type": "chatgpt"}, timeout=20.0)
+                auth_url = login.get("authUrl", "")
+                login_id = login.get("loginId")
+                if isinstance(auth_url, str) and auth_url.strip():
+                    _cprint(f"{_GOLD}🔐 Sign in required for codex app-server{_RST}")
+                    _cprint(f"{_DIM}Open this URL to continue:{_RST} {auth_url.strip()}")
+                    try:
+                        webbrowser.open(auth_url.strip())
+                    except Exception:
+                        pass
+                if not isinstance(login_id, str) or not login_id:
+                    raise RuntimeError("app-server login did not return loginId.")
+
+                completed = wait_for_notification(
+                    client,
+                    method="account/login/completed",
+                    login_id=login_id,
+                    timeout=600.0,
+                )
+                if not completed.get("success"):
+                    detail = completed.get("error") or "unknown error"
+                    raise RuntimeError(f"ChatGPT login failed: {detail}")
+
+            thread_resp = client.call(
+                "thread/start",
+                params={
+                    "model": self.model,
+                    "cwd": os.getcwd(),
+                    "approvalPolicy": "never",
+                    "sandboxPolicy": {
+                        "type": "workspaceWrite",
+                        "writableRoots": [os.getcwd()],
+                        "networkAccess": True,
+                    },
+                },
+                timeout=30.0,
+            )
+            thread = thread_resp.get("thread", {})
+            thread_id = thread.get("id")
+            if not isinstance(thread_id, str) or not thread_id:
+                raise RuntimeError("app-server thread/start did not return thread id.")
+
+            self._codex_app_client = client
+            self._codex_thread_id = thread_id
+            if not self._codex_override_notice_shown:
+                _cprint(f"{_DIM}codex app-server overrides per turn: model, cwd, approvalPolicy=never, sandboxPolicy=workspaceWrite+networkEnabled{_RST}")
+                _cprint(f"{_DIM}other app-server behavior still follows your ~/.codex/config.toml settings{_RST}")
+                self._codex_override_notice_shown = True
+            return True
+        except (OSError, FileNotFoundError) as exc:
+            self.console.print(
+                "[bold red]Could not start codex app-server.[/] "
+                "Install Codex CLI or set HERMES_CODEX_APP_SERVER_BIN."
+            )
+            logger.debug("codex app-server startup failure: %s", exc)
+            return False
+        except Exception as exc:
+            self.console.print(f"[bold red]Failed to initialize codex app-server: {exc}[/]")
+            try:
+                if self._codex_app_client is not None:
+                    self._codex_app_client.close()
+            except Exception:
+                pass
+            self._codex_app_client = None
+            self._codex_thread_id = None
+            return False
+
+    def _chat_via_codex_app_server(self, message: str) -> Optional[str]:
+        """Run one turn through codex app-server and return final text."""
+        client = self._codex_app_client
+        thread_id = self._codex_thread_id
+        if client is None or not thread_id:
+            return None
+
+        try:
+            turn_resp = client.call(
+                "turn/start",
+                params={
+                    "threadId": thread_id,
+                    "input": [{"type": "text", "text": message}],
+                    "model": self.model,
+                    "approvalPolicy": "never",
+                    "sandboxPolicy": {
+                        "type": "workspaceWrite",
+                        "writableRoots": [os.getcwd()],
+                        "networkAccess": True,
+                    },
+                },
+                timeout=30.0,
+            )
+        except Exception as exc:
+            return f"Error: failed to start turn: {exc}"
+
+        turn = turn_resp.get("turn", {})
+        turn_id = turn.get("id")
+        if not isinstance(turn_id, str) or not turn_id:
+            return "Error: turn/start did not return a turn id."
+
+        chunks: List[str] = []
+        final_text: Optional[str] = None
+        turn_error: Optional[str] = None
+        deadline = datetime.now().timestamp() + 1800.0
+
+        while datetime.now().timestamp() < deadline:
+            msg = client.next_notification(timeout=0.2)
+            if not msg:
+                continue
+            method = msg.get("method")
+            params = msg.get("params", {})
+            if not isinstance(params, dict):
+                continue
+
+            if method == "item/agentMessage/delta":
+                delta = params.get("delta")
+                if not isinstance(delta, str):
+                    delta = params.get("textDelta")
+                if isinstance(delta, str) and delta:
+                    chunks.append(delta)
+                continue
+
+            if method == "item/completed":
+                item = params.get("item", {})
+                if isinstance(item, dict) and item.get("type") == "agentMessage":
+                    item_text = item.get("text")
+                    if isinstance(item_text, str):
+                        final_text = item_text
+                continue
+
+            if method == "turn/completed":
+                completed_turn = params.get("turn", {})
+                if not isinstance(completed_turn, dict) or completed_turn.get("id") != turn_id:
+                    continue
+                status = completed_turn.get("status")
+                if status == "failed":
+                    err = completed_turn.get("error", {})
+                    if isinstance(err, dict):
+                        turn_error = err.get("message") or str(err)
+                    else:
+                        turn_error = str(err)
+                break
+
+        if turn_error:
+            return f"Error: {turn_error}"
+        if final_text:
+            return final_text
+        return "".join(chunks).strip() or "(No response from codex app-server)"
 
     def _init_agent(self) -> bool:
         """
@@ -960,48 +1231,18 @@ class HermesCLI:
         Returns:
             bool: True if successful, False otherwise
         """
-        if self.agent is not None:
-            return True
-
         if not self._ensure_runtime_credentials():
             return False
 
-        # Initialize SQLite session store for CLI sessions
-        self._session_db = None
-        try:
-            from hermes_state import SessionDB
-            self._session_db = SessionDB()
-        except Exception as e:
-            logger.debug("SQLite session store not available: %s", e)
-        
-        # If resuming, validate the session exists and load its history
-        if self._resumed and self._session_db:
-            session_meta = self._session_db.get_session(self.session_id)
-            if not session_meta:
-                _cprint(f"\033[1;31mSession not found: {self.session_id}{_RST}")
-                _cprint(f"{_DIM}Use a session ID from a previous CLI run (hermes sessions list).{_RST}")
-                return False
-            restored = self._session_db.get_messages_as_conversation(self.session_id)
-            if restored:
-                self.conversation_history = restored
-                msg_count = len([m for m in restored if m.get("role") == "user"])
-                _cprint(
-                    f"{_GOLD}↻ Resumed session {_BOLD}{self.session_id}{_RST}{_GOLD} "
-                    f"({msg_count} user message{'s' if msg_count != 1 else ''}, "
-                    f"{len(restored)} total messages){_RST}"
-                )
-            else:
-                _cprint(f"{_GOLD}Session {self.session_id} found but has no messages. Starting fresh.{_RST}")
-            # Re-open the session (clear ended_at so it's active again)
-            try:
-                self._session_db._conn.execute(
-                    "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
-                    (self.session_id,),
-                )
-                self._session_db._conn.commit()
-            except Exception:
-                pass
-        
+        if not self._restore_or_init_session():
+            return False
+
+        if self.provider == "codex-app-server":
+            return self._init_codex_app_server()
+
+        if self.agent is not None:
+            return True
+
         try:
             self.agent = AIAgent(
                 model=self.model,
@@ -1029,6 +1270,10 @@ class HermesCLI:
     
     def show_banner(self):
         """Display the welcome banner in Claude Code style."""
+        try:
+            self._ensure_runtime_credentials()
+        except Exception:
+            pass
         self.console.clear()
         
         if self.compact:
@@ -1042,6 +1287,12 @@ class HermesCLI:
             cwd = os.getenv("TERMINAL_CWD", os.getcwd())
             
             # Build and display the banner
+            provider_labels = {
+                "openrouter": "OpenRouter",
+                "nous": "Nous Portal",
+                "openai-codex": "OpenAI Codex",
+                "codex-app-server": "Codex App Server",
+            }
             build_welcome_banner(
                 console=self.console,
                 model=self.model,
@@ -1049,6 +1300,7 @@ class HermesCLI:
                 tools=tools,
                 enabled_toolsets=self.enabled_toolsets,
                 session_id=self.session_id,
+                provider_label=provider_labels.get(self.provider, self.provider),
             )
         
         # Show tool availability warnings if any tools are disabled
@@ -1090,7 +1342,9 @@ class HermesCLI:
             model_short = model_short[:27] + "..."
         
         # Get API status indicator
-        if self.api_key:
+        if self.provider == "codex-app-server":
+            api_indicator = "[green bold]●[/]"
+        elif self.api_key:
             api_indicator = "[green bold]●[/]"
         else:
             api_indicator = "[red bold]●[/]"
@@ -1202,6 +1456,10 @@ class HermesCLI:
     
     def show_config(self):
         """Display current configuration with kawaii ASCII art."""
+        # Refresh runtime routing/auth details so displayed provider/base URL
+        # match what chat execution will actually use.
+        self._ensure_runtime_credentials()
+
         # Get terminal config from environment (which was set from cli-config.yaml)
         terminal_env = os.getenv("TERMINAL_ENV", "local")
         terminal_cwd = os.getenv("TERMINAL_CWD", os.getcwd())
@@ -1215,7 +1473,12 @@ class HermesCLI:
             config_path = project_config_path
         config_status = "(loaded)" if config_path.exists() else "(not found)"
         
-        api_key_display = '********' + self.api_key[-4:] if self.api_key and len(self.api_key) > 4 else 'Not set!'
+        if self.provider == "codex-app-server":
+            base_url_display = "stdio://codex-app-server"
+            api_key_display = "N/A (ChatGPT OAuth via app-server)"
+        else:
+            base_url_display = self.base_url
+            api_key_display = '********' + self.api_key[-4:] if self.api_key and len(self.api_key) > 4 else 'Not set!'
         
         print()
         title = "(^_^) Configuration"
@@ -1227,8 +1490,11 @@ class HermesCLI:
         print()
         print("  -- Model --")
         print(f"  Model:     {self.model}")
-        print(f"  Base URL:  {self.base_url}")
+        print(f"  Provider:  {self.provider}")
+        print(f"  Base URL:  {base_url_display}")
         print(f"  API Key:   {api_key_display}")
+        if self.provider == "codex-app-server":
+            print("  Overrides: model, cwd, approvalPolicy=never, sandboxPolicy=workspaceWrite+networkEnabled")
         print()
         print("  -- Terminal --")
         print(f"  Environment:  {terminal_env}")
@@ -2030,12 +2296,42 @@ class HermesCLI:
         
         # Add user message to history
         self.conversation_history.append({"role": "user", "content": message})
+        if self.provider == "codex-app-server" and self._session_db:
+            try:
+                self._session_db.append_message(
+                    session_id=self.session_id,
+                    role="user",
+                    content=message,
+                )
+            except Exception as e:
+                logger.debug("Could not persist user message for codex-app-server: %s", e)
         
         w = self.console.width
         _cprint(f"{_GOLD}{'─' * w}{_RST}")
         print(flush=True)
         
         try:
+            if self.provider == "codex-app-server":
+                response = self._chat_via_codex_app_server(message) or ""
+                if response:
+                    w = self.console.width
+                    label = " ⚕ Hermes "
+                    fill = w - 2 - len(label)
+                    top = f"{_GOLD}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}"
+                    bot = f"{_GOLD}╰{'─' * (w - 2)}╯{_RST}"
+                    _cprint(f"\n{top}\n{response}\n\n{bot}")
+                self.conversation_history.append({"role": "assistant", "content": response})
+                if self._session_db:
+                    try:
+                        self._session_db.append_message(
+                            session_id=self.session_id,
+                            role="assistant",
+                            content=response,
+                        )
+                    except Exception as e:
+                        logger.debug("Could not persist assistant message for codex-app-server: %s", e)
+                return response
+
             # Run the conversation with interrupt monitoring
             result = None
             
@@ -2821,11 +3117,18 @@ class HermesCLI:
             set_sudo_password_callback(None)
             set_approval_callback(None)
             # Close session in SQLite
-            if hasattr(self, '_session_db') and self._session_db and self.agent:
+            if self._session_db:
                 try:
-                    self._session_db.end_session(self.agent.session_id, "cli_close")
+                    self._session_db.end_session(self.session_id, "cli_close")
                 except Exception as e:
                     logger.debug("Could not close session in DB: %s", e)
+            if self._codex_app_client is not None:
+                try:
+                    self._codex_app_client.close()
+                except Exception:
+                    pass
+                self._codex_app_client = None
+                self._codex_thread_id = None
             _run_cleanup()
             self._print_exit_summary()
 
@@ -2858,7 +3161,7 @@ def main(
         q: Shorthand for --query
         toolsets: Comma-separated list of toolsets to enable (e.g., "web,terminal")
         model: Model to use (default: anthropic/claude-opus-4-20250514)
-        provider: Inference provider ("auto", "openrouter", "nous")
+        provider: Inference provider ("auto", "openrouter", "nous", "openai-codex", "codex-app-server")
         api_key: API key for authentication
         base_url: Base URL for the API
         max_turns: Maximum tool-calling iterations (default: 60)

--- a/hermes
+++ b/hermes
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
-"""Hermes Agent CLI launcher (argparse entrypoint)."""
+"""
+Hermes Agent CLI Launcher
+
+This is a convenience wrapper to launch the Hermes CLI.
+Usage: hermes [options]
+"""
 
 if __name__ == "__main__":
     from hermes_cli.main import main
-
     main()

--- a/hermes
+++ b/hermes
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
-"""
-Hermes Agent CLI Launcher
-
-This is a convenience wrapper to launch the Hermes CLI.
-Usage: ./hermes [options]
-"""
+"""Hermes Agent CLI launcher (argparse entrypoint)."""
 
 if __name__ == "__main__":
-    from cli import main
-    import fire
-    fire.Fire(main)
+    from hermes_cli.main import main
+
+    main()

--- a/hermes
+++ b/hermes
@@ -3,9 +3,10 @@
 Hermes Agent CLI Launcher
 
 This is a convenience wrapper to launch the Hermes CLI.
-Usage: hermes [options]
+Usage: ./hermes [options]
 """
 
 if __name__ == "__main__":
-    from hermes_cli.main import main
-    main()
+    from cli import main
+    import fire
+    fire.Fire(main)

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -103,6 +103,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
                          tools: List[dict] = None,
                          enabled_toolsets: List[str] = None,
                          session_id: str = None,
+                         provider_label: str = None,
                          get_toolset_for_tool=None):
     """Build and print a welcome banner with caduceus on left and info on right.
 
@@ -113,6 +114,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         tools: List of tool definitions.
         enabled_toolsets: List of enabled toolset names.
         session_id: Session identifier.
+        provider_label: Optional provider label to display next to the model.
         get_toolset_for_tool: Callable to map tool name -> toolset name.
     """
     from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
@@ -135,7 +137,8 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     model_short = model.split("/")[-1] if "/" in model else model
     if len(model_short) > 28:
         model_short = model_short[:25] + "..."
-    left_lines.append(f"[#FFBF00]{model_short}[/] [dim #B8860B]·[/] [dim #B8860B]Nous Research[/]")
+    provider_text = provider_label or "Nous Research"
+    left_lines.append(f"[#FFBF00]{model_short}[/] [dim #B8860B]·[/] [dim #B8860B]{provider_text}[/]")
     left_lines.append(f"[dim #B8860B]{cwd}[/]")
     if session_id:
         left_lines.append(f"[dim #8B8682]Session: {session_id}[/]")

--- a/hermes_cli/codex_app_server.py
+++ b/hermes_cli/codex_app_server.py
@@ -1,0 +1,248 @@
+"""Minimal stdio JSON-RPC client for `codex app-server`."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import subprocess
+import threading
+import time
+from datetime import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class CodexAppServerError(RuntimeError):
+    """Raised when codex app-server request/response fails."""
+
+
+@dataclass
+class RpcResponse:
+    result: Optional[Dict[str, Any]] = None
+    error: Optional[Dict[str, Any]] = None
+
+
+class CodexAppServerClient:
+    """JSON-RPC client for codex app-server over stdio."""
+
+    def __init__(self, *, binary: str = "codex", cwd: Optional[str] = None) -> None:
+        self.binary = binary
+        self.cwd = cwd
+        self._proc: Optional[subprocess.Popen] = None
+        self._reader_thread: Optional[threading.Thread] = None
+        self._stderr_thread: Optional[threading.Thread] = None
+        self._write_lock = threading.Lock()
+        self._pending_lock = threading.Lock()
+        self._next_id = 1
+        self._pending: Dict[int, queue.Queue] = {}
+        self._notifications: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+        self._closed = False
+        logs_dir = Path.home() / ".hermes" / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        self._stderr_log_path = logs_dir / "codex-app-server.log"
+        self._rpc_log_enabled = str(os.getenv("HERMES_CODEX_APP_SERVER_RPC_LOG", "")).strip().lower() in {"1", "true", "yes", "on"}
+        self._rpc_log_path = logs_dir / "codex-app-server-rpc.log"
+
+    def start(self) -> None:
+        if self._proc is not None:
+            return
+        self._proc = subprocess.Popen(
+            [self.binary, "app-server"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.cwd,
+            text=True,
+            bufsize=1,
+        )
+        self._reader_thread = threading.Thread(target=self._reader_loop, daemon=True)
+        self._reader_thread.start()
+        self._stderr_thread = threading.Thread(target=self._stderr_loop, daemon=True)
+        self._stderr_thread.start()
+
+    def close(self) -> None:
+        self._closed = True
+        proc = self._proc
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+        self._proc = None
+
+    def initialize(
+        self,
+        *,
+        client_name: str,
+        client_title: str,
+        client_version: str,
+        experimental_api: bool = False,
+    ) -> None:
+        caps: Dict[str, Any] = {}
+        if experimental_api:
+            caps["experimentalApi"] = True
+        params: Dict[str, Any] = {
+            "clientInfo": {
+                "name": client_name,
+                "title": client_title,
+                "version": client_version,
+            },
+        }
+        if caps:
+            params["capabilities"] = caps
+        self.call("initialize", params=params, timeout=15.0)
+        self.notify("initialized", params={})
+
+    def call(self, method: str, *, params: Optional[Dict[str, Any]] = None, timeout: float = 30.0) -> Dict[str, Any]:
+        req_id = self._allocate_id()
+        response_queue: "queue.Queue[RpcResponse]" = queue.Queue(maxsize=1)
+        with self._pending_lock:
+            self._pending[req_id] = response_queue
+        self._send({"method": method, "id": req_id, "params": params or {}})
+        try:
+            response = response_queue.get(timeout=max(0.1, timeout))
+        except queue.Empty as exc:
+            with self._pending_lock:
+                self._pending.pop(req_id, None)
+            raise CodexAppServerError(f"Timed out waiting for response to {method}") from exc
+        if response.error:
+            code = response.error.get("code")
+            message = response.error.get("message", "Unknown error")
+            raise CodexAppServerError(f"{method} failed ({code}): {message}")
+        return response.result or {}
+
+    def notify(self, method: str, *, params: Optional[Dict[str, Any]] = None) -> None:
+        self._send({"method": method, "params": params or {}})
+
+    def next_notification(self, timeout: float = 0.1) -> Optional[Dict[str, Any]]:
+        try:
+            return self._notifications.get(timeout=max(0.01, timeout))
+        except queue.Empty:
+            return None
+
+    def _allocate_id(self) -> int:
+        with self._pending_lock:
+            req_id = self._next_id
+            self._next_id += 1
+            return req_id
+
+    def _send(self, payload: Dict[str, Any]) -> None:
+        proc = self._proc
+        if proc is None or proc.stdin is None:
+            raise CodexAppServerError("codex app-server process is not running")
+        line = json.dumps(payload, ensure_ascii=False)
+        self._log_rpc(">>", payload)
+        with self._write_lock:
+            try:
+                proc.stdin.write(line + "\n")
+                proc.stdin.flush()
+            except Exception as exc:
+                raise CodexAppServerError("Failed writing to codex app-server stdin") from exc
+
+    def _reader_loop(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            return
+        try:
+            for raw_line in proc.stdout:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except Exception:
+                    logger.debug("Invalid app-server JSON line: %s", line)
+                    continue
+                self._dispatch_message(msg)
+        finally:
+            if not self._closed:
+                self._fail_all_pending("codex app-server stream closed")
+
+    def _stderr_loop(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stderr is None:
+            return
+        for raw_line in proc.stderr:
+            line = raw_line.rstrip()
+            if not line:
+                continue
+            logger.debug("codex app-server stderr: %s", line)
+            try:
+                ts = datetime.now().isoformat(timespec="seconds")
+                with self._stderr_log_path.open("a", encoding="utf-8") as f:
+                    f.write(f"{ts} {line}\n")
+            except Exception:
+                # Logging must never break the stderr reader loop.
+                pass
+
+    def _dispatch_message(self, msg: Dict[str, Any]) -> None:
+        if not isinstance(msg, dict):
+            return
+        self._log_rpc("<<", msg)
+        if "id" in msg and ("result" in msg or "error" in msg):
+            req_id = msg.get("id")
+            if not isinstance(req_id, int):
+                return
+            with self._pending_lock:
+                response_queue = self._pending.pop(req_id, None)
+            if response_queue is None:
+                return
+            response_queue.put(
+                RpcResponse(
+                    result=msg.get("result"),
+                    error=msg.get("error"),
+                )
+            )
+            return
+        if "method" in msg:
+            self._notifications.put(msg)
+
+    def _fail_all_pending(self, reason: str) -> None:
+        with self._pending_lock:
+            pending = list(self._pending.items())
+            self._pending.clear()
+        for _, response_queue in pending:
+            response_queue.put(RpcResponse(error={"code": -1, "message": reason}))
+
+    def _log_rpc(self, direction: str, payload: Dict[str, Any]) -> None:
+        if not self._rpc_log_enabled:
+            return
+        try:
+            ts = datetime.now().isoformat(timespec="seconds")
+            serialized = json.dumps(payload, ensure_ascii=False)
+            with self._rpc_log_path.open("a", encoding="utf-8") as f:
+                f.write(f"{ts} {direction} {serialized}\n")
+        except Exception:
+            pass
+
+
+def wait_for_notification(
+    client: CodexAppServerClient,
+    *,
+    method: str,
+    timeout: float,
+    login_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Wait for a specific notification method."""
+    deadline = time.time() + max(1.0, timeout)
+    while time.time() < deadline:
+        msg = client.next_notification(timeout=0.2)
+        if not msg:
+            continue
+        if msg.get("method") != method:
+            continue
+        params = msg.get("params", {})
+        if login_id is not None and params.get("loginId") != login_id:
+            continue
+        return params if isinstance(params, dict) else {}
+    raise TimeoutError(f"Timed out waiting for notification: {method}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -951,7 +951,7 @@ For more help on a command:
         help="Single query (non-interactive mode)"
     )
     chat_parser.add_argument(
-        "-m", "--model",
+        "--model",
         help="Model to use (e.g., anthropic/claude-sonnet-4)"
     )
     chat_parser.add_argument(

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -99,6 +99,17 @@ def resolve_runtime_provider(
     """Resolve runtime provider credentials for agent execution."""
     requested_provider = resolve_requested_provider(requested)
 
+    if requested_provider == "codex-app-server":
+        return {
+            "provider": "codex-app-server",
+            "api_mode": "codex_app_server",
+            "base_url": "stdio://codex-app-server",
+            "api_key": "",
+            "source": "local-codex-app-server",
+            "app_server_bin": os.getenv("HERMES_CODEX_APP_SERVER_BIN", "codex").strip() or "codex",
+            "requested_provider": requested_provider,
+        }
+
     provider = resolve_provider(
         requested_provider,
         explicit_api_key=explicit_api_key,

--- a/tests/test_codex_app_server_cli.py
+++ b/tests/test_codex_app_server_cli.py
@@ -1,0 +1,285 @@
+import importlib
+import sys
+import types
+from contextlib import nullcontext
+from unittest.mock import MagicMock
+
+
+def _install_prompt_toolkit_stubs():
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _Condition:
+        def __init__(self, func):
+            self.func = func
+
+        def __bool__(self):
+            return bool(self.func())
+
+    class _ANSI(str):
+        pass
+
+    root = types.ModuleType("prompt_toolkit")
+    history = types.ModuleType("prompt_toolkit.history")
+    styles = types.ModuleType("prompt_toolkit.styles")
+    patch_stdout = types.ModuleType("prompt_toolkit.patch_stdout")
+    application = types.ModuleType("prompt_toolkit.application")
+    layout = types.ModuleType("prompt_toolkit.layout")
+    processors = types.ModuleType("prompt_toolkit.layout.processors")
+    filters = types.ModuleType("prompt_toolkit.filters")
+    dimension = types.ModuleType("prompt_toolkit.layout.dimension")
+    menus = types.ModuleType("prompt_toolkit.layout.menus")
+    widgets = types.ModuleType("prompt_toolkit.widgets")
+    key_binding = types.ModuleType("prompt_toolkit.key_binding")
+    completion = types.ModuleType("prompt_toolkit.completion")
+    formatted_text = types.ModuleType("prompt_toolkit.formatted_text")
+
+    history.FileHistory = _Dummy
+    styles.Style = _Dummy
+    patch_stdout.patch_stdout = lambda *args, **kwargs: nullcontext()
+    application.Application = _Dummy
+    layout.Layout = _Dummy
+    layout.HSplit = _Dummy
+    layout.Window = _Dummy
+    layout.FormattedTextControl = _Dummy
+    layout.ConditionalContainer = _Dummy
+    processors.Processor = _Dummy
+    processors.Transformation = _Dummy
+    processors.PasswordProcessor = _Dummy
+    processors.ConditionalProcessor = _Dummy
+    filters.Condition = _Condition
+    dimension.Dimension = _Dummy
+    menus.CompletionsMenu = _Dummy
+    widgets.TextArea = _Dummy
+    key_binding.KeyBindings = _Dummy
+    completion.Completer = _Dummy
+    completion.Completion = _Dummy
+    formatted_text.ANSI = _ANSI
+    root.print_formatted_text = lambda *args, **kwargs: None
+
+    sys.modules.setdefault("prompt_toolkit", root)
+    sys.modules.setdefault("prompt_toolkit.history", history)
+    sys.modules.setdefault("prompt_toolkit.styles", styles)
+    sys.modules.setdefault("prompt_toolkit.patch_stdout", patch_stdout)
+    sys.modules.setdefault("prompt_toolkit.application", application)
+    sys.modules.setdefault("prompt_toolkit.layout", layout)
+    sys.modules.setdefault("prompt_toolkit.layout.processors", processors)
+    sys.modules.setdefault("prompt_toolkit.filters", filters)
+    sys.modules.setdefault("prompt_toolkit.layout.dimension", dimension)
+    sys.modules.setdefault("prompt_toolkit.layout.menus", menus)
+    sys.modules.setdefault("prompt_toolkit.widgets", widgets)
+    sys.modules.setdefault("prompt_toolkit.key_binding", key_binding)
+    sys.modules.setdefault("prompt_toolkit.completion", completion)
+    sys.modules.setdefault("prompt_toolkit.formatted_text", formatted_text)
+
+
+def _import_cli():
+    # Avoid importing heavyweight tool stacks (web_tools/firecrawl/etc.) in unit tests.
+    if "run_agent" not in sys.modules:
+        run_agent_stub = types.ModuleType("run_agent")
+
+        class _DummyAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        run_agent_stub.AIAgent = _DummyAgent
+        sys.modules["run_agent"] = run_agent_stub
+
+    if "model_tools" not in sys.modules:
+        model_tools_stub = types.ModuleType("model_tools")
+        model_tools_stub.get_tool_definitions = lambda *a, **k: []
+        model_tools_stub.get_toolset_for_tool = lambda *a, **k: "other"
+        model_tools_stub.check_tool_availability = lambda *a, **k: ([], [])
+        model_tools_stub.TOOLSET_REQUIREMENTS = {}
+        sys.modules["model_tools"] = model_tools_stub
+
+    if "tools" not in sys.modules:
+        tools_pkg = types.ModuleType("tools")
+        tools_pkg.__path__ = []  # mark as package
+        sys.modules["tools"] = tools_pkg
+
+    if "tools.terminal_tool" not in sys.modules:
+        terminal_stub = types.ModuleType("tools.terminal_tool")
+        terminal_stub.cleanup_all_environments = lambda: None
+        terminal_stub.set_sudo_password_callback = lambda cb: None
+        terminal_stub.set_approval_callback = lambda cb: None
+        sys.modules["tools.terminal_tool"] = terminal_stub
+
+    if "tools.browser_tool" not in sys.modules:
+        browser_stub = types.ModuleType("tools.browser_tool")
+        browser_stub._emergency_cleanup_all_sessions = lambda: None
+        sys.modules["tools.browser_tool"] = browser_stub
+
+    try:
+        importlib.import_module("prompt_toolkit")
+    except ModuleNotFoundError:
+        _install_prompt_toolkit_stubs()
+    if "cli" in sys.modules:
+        del sys.modules["cli"]
+    return importlib.import_module("cli")
+
+
+class _BaseFakeClient:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+        self.closed = False
+
+    def start(self):
+        return None
+
+    def initialize(self, **kwargs):
+        self.init_kwargs = kwargs
+        return None
+
+    def notify(self, method, params=None):
+        self.calls.append(("notify", method, params))
+
+    def close(self):
+        self.closed = True
+
+
+def test_codex_app_server_init_uses_existing_chatgpt_auth(monkeypatch):
+    cli = _import_cli()
+    fake_client_ref = {}
+
+    class FakeClient(_BaseFakeClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            fake_client_ref["client"] = self
+
+        def call(self, method, params=None, timeout=30.0):
+            self.calls.append(("call", method, params))
+            if method == "account/read":
+                return {
+                    "account": {"type": "chatgpt", "email": "user@example.com"},
+                    "requiresOpenaiAuth": True,
+                }
+            if method == "thread/start":
+                return {"thread": {"id": "thr_existing_auth"}}
+            raise AssertionError(f"Unexpected call: {method}")
+
+    monkeypatch.setattr("hermes_cli.codex_app_server.CodexAppServerClient", FakeClient)
+    monkeypatch.setattr("hermes_cli.codex_app_server.wait_for_notification", lambda *a, **k: {})
+    monkeypatch.setattr("cli._cprint", lambda *a, **k: None)
+
+    shell = cli.HermesCLI(model="gpt-5.3-codex", provider="codex-app-server", compact=True, max_turns=1)
+    assert shell._init_codex_app_server() is True
+    assert shell._codex_thread_id == "thr_existing_auth"
+
+    called_methods = [item[1] for item in fake_client_ref["client"].calls if item[0] == "call"]
+    assert "account/read" in called_methods
+    assert "thread/start" in called_methods
+    assert "account/login/start" not in called_methods
+
+
+def test_codex_app_server_init_runs_oauth_when_needed(monkeypatch):
+    cli = _import_cli()
+    fake_client_ref = {}
+    wait_calls = {"count": 0}
+    opened_urls = []
+
+    class FakeClient(_BaseFakeClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            fake_client_ref["client"] = self
+
+        def call(self, method, params=None, timeout=30.0):
+            self.calls.append(("call", method, params))
+            if method == "account/read":
+                return {"account": None, "requiresOpenaiAuth": True}
+            if method == "account/login/start":
+                return {"authUrl": "https://chatgpt.com/login-test", "loginId": "login_123"}
+            if method == "thread/start":
+                return {"thread": {"id": "thr_after_login"}}
+            raise AssertionError(f"Unexpected call: {method}")
+
+    def _wait_for_notification(client, *, method, timeout, login_id=None):
+        wait_calls["count"] += 1
+        assert method == "account/login/completed"
+        assert login_id == "login_123"
+        return {"loginId": "login_123", "success": True}
+
+    monkeypatch.setattr("hermes_cli.codex_app_server.CodexAppServerClient", FakeClient)
+    monkeypatch.setattr("hermes_cli.codex_app_server.wait_for_notification", _wait_for_notification)
+    monkeypatch.setattr("cli._cprint", lambda *a, **k: None)
+    monkeypatch.setattr("cli.webbrowser.open", lambda url: opened_urls.append(url))
+
+    shell = cli.HermesCLI(model="gpt-5.3-codex", provider="codex-app-server", compact=True, max_turns=1)
+    assert shell._init_codex_app_server() is True
+    assert shell._codex_thread_id == "thr_after_login"
+    assert wait_calls["count"] == 1
+    assert opened_urls == ["https://chatgpt.com/login-test"]
+
+    called_methods = [item[1] for item in fake_client_ref["client"].calls if item[0] == "call"]
+    assert called_methods[:2] == ["account/read", "account/login/start"]
+
+
+def test_codex_turn_lifecycle_parses_final_text(monkeypatch):
+    cli = _import_cli()
+    monkeypatch.setattr("cli._cprint", lambda *a, **k: None)
+
+    class FakeTurnClient:
+        def __init__(self):
+            self.notifications = [
+                {"method": "item/agentMessage/delta", "params": {"delta": "Hel"}},
+                {"method": "item/agentMessage/delta", "params": {"textDelta": "lo"}},
+                {"method": "item/completed", "params": {"item": {"type": "agentMessage", "text": "Hello final"}}},
+                {"method": "turn/completed", "params": {"turn": {"id": "turn_1", "status": "completed"}}},
+            ]
+
+        def call(self, method, params=None, timeout=30.0):
+            if method == "turn/start":
+                return {"turn": {"id": "turn_1"}}
+            raise AssertionError(f"Unexpected call: {method}")
+
+        def next_notification(self, timeout=0.2):
+            if self.notifications:
+                return self.notifications.pop(0)
+            return None
+
+    shell = cli.HermesCLI(model="gpt-5.3-codex", provider="codex-app-server", compact=True, max_turns=1)
+    shell._codex_app_client = FakeTurnClient()
+    shell._codex_thread_id = "thr_1"
+
+    response = shell._chat_via_codex_app_server("hello?")
+    assert response == "Hello final"
+
+
+def test_codex_app_server_process_failure_and_client_rotation(monkeypatch):
+    cli = _import_cli()
+
+    class FailingClient(_BaseFakeClient):
+        def start(self):
+            raise FileNotFoundError("codex not found")
+
+    monkeypatch.setattr("hermes_cli.codex_app_server.CodexAppServerClient", FailingClient)
+    monkeypatch.setattr("hermes_cli.codex_app_server.wait_for_notification", lambda *a, **k: {})
+    monkeypatch.setattr("cli._cprint", lambda *a, **k: None)
+
+    shell = cli.HermesCLI(model="gpt-5.3-codex", provider="codex-app-server", compact=True, max_turns=1)
+    assert shell._init_codex_app_server() is False
+
+    old_client = MagicMock()
+    shell._codex_app_client = old_client
+    shell.provider = "codex-app-server"
+    shell.api_mode = "codex_app_server"
+    shell.base_url = "stdio://codex-app-server"
+    shell.api_key = ""
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "test-key",
+            "source": "env/config",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+
+    assert shell._ensure_runtime_credentials() is True
+    old_client.close.assert_called_once()
+    assert shell._codex_app_client is None
+    assert shell.provider == "openrouter"


### PR DESCRIPTION
## Background
`codex app-server` is Codex’s stateful JSON-RPC integration surface for rich clients. Instead of calling model endpoints directly, a client talks to app-server, and app-server manages auth/account state, thread/turn lifecycle, streaming item events, approvals, and Codex config layering (`~/.codex/config.toml` + project `.codex/config.toml` in trusted repos).

Hermes historically ran through direct OpenAI-compatible client calls. This PR adds an explicit `codex-app-server` provider path so Hermes can operate as an app-server client.

## Why this change
- adds a first-class ChatGPT OAuth path via app-server auth endpoints
- aligns Hermes with Codex-native thread/turn/event model
- preserves existing providers and keeps this rollout opt-in (`--provider codex-app-server`)

## What changed
- Added runtime provider support for `codex-app-server`
- Added stdio JSON-RPC app-server client (`hermes_cli/codex_app_server.py`)
- CLI integration:
  - initialize handshake
  - account/read + ChatGPT login flow (if required)
  - thread/start + turn/start lifecycle
  - streamed deltas and final completion handling
- Added app-server logging:
  - stderr: `~/.hermes/logs/codex-app-server.log`
  - optional RPC transcript: `~/.hermes/logs/codex-app-server-rpc.log` (enable with `HERMES_CODEX_APP_SERVER_RPC_LOG=1`)
- Added session persistence for codex-app-server path in SQLite
- Added `hermes model` support for selecting `codex-app-server`
- Added `hermes setup` provider flow for `codex-app-server` (including model selection and keep-current detection)
- Gateway integration:
  - supports codex-app-server execution path (instead of attempting HTTP calls to `stdio://...`)
  - session-scoped app-server client/thread lifecycle
  - cleanup on gateway stop
- Tool progress integration for codex-app-server:
  - maps app-server `item/started` + `item/completed` events into Hermes progress modes (`off|new|all|verbose`) in CLI and gateway
- Reasoning effort integration for codex-app-server:
  - maps Hermes `agent.reasoning_effort` to app-server `turn/start.effort`
  - mapping: `xhigh -> high`, `minimal -> low`, `high|medium|low -> unchanged`, `none -> omit`
- CLI flag ambiguity fix:
  - `hermes chat` now uses `--model` only (removed `-m` alias) to avoid `model` vs `max_turns` ambiguity

## Compatibility note
Hermes currently sets these fields explicitly on app-server `thread/start`/`turn/start` requests:
- `model`
- `cwd`
- `approvalPolicy=never`
- `sandboxPolicy=workspaceWrite+networkEnabled`

If those are also configured in `~/.codex/config.toml`, Hermes request-level values win for those fields. Other Codex behavior still follows app-server config layering.

For reasoning effort:
- if `agent.reasoning_effort` is set in Hermes config, Hermes sends `effort` on turn/start
- if unset or `none`, Hermes omits `effort`, allowing Codex defaults/config layering to apply

## Tests
- `pytest -q tests/test_codex_app_server_cli.py`
- `pytest -q tests/test_codex_app_server_cli.py tests/test_cli_provider_resolution.py tests/test_runtime_provider_resolution.py tests/test_auth_codex_provider.py tests/test_codex_models.py tests/test_codex_execution_paths.py`
- `pytest -q tests/test_codex_models.py tests/test_runtime_provider_resolution.py`
- `pytest -q tests/test_runtime_provider_resolution.py tests/test_codex_app_server_cli.py tests/gateway/test_channel_directory.py`
- `pytest -q tests/test_codex_app_server_cli.py tests/test_runtime_provider_resolution.py tests/test_cli_provider_resolution.py tests/gateway/test_channel_directory.py`

Latest targeted run in this branch: 30 passed.
