### PR TITLE
fix(runtime): support Novita env aliases in runtime provider

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -56,6 +56,7 @@ def _resolve_openrouter_runtime(
     cfg_provider = cfg_provider.strip().lower()
 
     env_openai_base_url = os.getenv("OPENAI_BASE_URL", "").strip()
+    env_novita_base_url = os.getenv("NOVITA_BASE_URL", "").strip()
     env_openrouter_base_url = os.getenv("OPENROUTER_BASE_URL", "").strip()
 
     use_config_base_url = False
@@ -67,6 +68,7 @@ def _resolve_openrouter_runtime(
     base_url = (
         (explicit_base_url or "").strip()
         or env_openai_base_url
+        or env_novita_base_url
         or (cfg_base_url.strip() if use_config_base_url else "")
         or env_openrouter_base_url
         or OPENROUTER_BASE_URL
@@ -75,6 +77,7 @@ def _resolve_openrouter_runtime(
     api_key = (
         explicit_api_key
         or os.getenv("OPENAI_API_KEY")
+        or os.getenv("NOVITA_API_KEY")
         or os.getenv("OPENROUTER_API_KEY")
         or ""
     )

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -93,3 +93,20 @@ def test_resolve_requested_provider_precedence(monkeypatch):
     monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "nous")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openai-codex"})
     assert rp.resolve_requested_provider("openrouter") == "openrouter"
+
+
+def test_resolve_runtime_provider_uses_novita_env_aliases(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("NOVITA_BASE_URL", "https://api.novita.ai/openai/")
+    monkeypatch.setenv("NOVITA_API_KEY", "novita-test-key")
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["base_url"] == "https://api.novita.ai/openai"
+    assert resolved["api_key"] == "novita-test-key"


### PR DESCRIPTION
## Summary\n- allow  as an alias for custom OpenAI-compatible base URL\n- allow  as an alias for API key resolution\n- add regression test to verify Novita env vars are respected\n\n## Verification\n- ......                                                                   [100%]
6 passed in 0.12s\n