### PR TITLE
fix(setup): handle TerminalMenu init failures with safe fallback

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -100,28 +100,32 @@ def prompt_choice(question: str, choices: list, default: int = 0) -> int:
         return idx
         
     except (ImportError, NotImplementedError):
-        # Fallback to number-based selection (simple_term_menu doesn't support Windows)
-        for i, choice in enumerate(choices):
-            marker = "●" if i == default else "○"
-            if i == default:
-                print(color(f"  {marker} {choice}", Colors.GREEN))
-            else:
-                print(f"  {marker} {choice}")
-        
-        while True:
-            try:
-                value = input(color(f"  Select [1-{len(choices)}] ({default + 1}): ", Colors.DIM))
-                if not value:
-                    return default
-                idx = int(value) - 1
-                if 0 <= idx < len(choices):
-                    return idx
-                print_error(f"Please enter a number between 1 and {len(choices)}")
-            except ValueError:
-                print_error("Please enter a number")
-            except (KeyboardInterrupt, EOFError):
-                print()
-                sys.exit(1)
+        pass
+    except Exception as e:
+        print(f"  (Interactive menu unavailable: {e})")
+
+    # Fallback to number-based selection (simple_term_menu doesn't support Windows)
+    for i, choice in enumerate(choices):
+        marker = "●" if i == default else "○"
+        if i == default:
+            print(color(f"  {marker} {choice}", Colors.GREEN))
+        else:
+            print(f"  {marker} {choice}")
+
+    while True:
+        try:
+            value = input(color(f"  Select [1-{len(choices)}] ({default + 1}): ", Colors.DIM))
+            if not value:
+                return default
+            idx = int(value) - 1
+            if 0 <= idx < len(choices):
+                return idx
+            print_error(f"Please enter a number between 1 and {len(choices)}")
+        except ValueError:
+            print_error("Please enter a number")
+        except (KeyboardInterrupt, EOFError):
+            print()
+            sys.exit(1)
 
 def prompt_yes_no(question: str, default: bool = True) -> bool:
     """Prompt for yes/no."""


### PR DESCRIPTION
# What changed and why

`prompt_choice` crashes with a `CalledProcessError` when `simple_term_menu` can't query the terminal via `tput` — which happens whenever `TERM` is set to a value the host doesn't recognize (e.g. `xterm-ghostty` forwarded over SSH to a machine without Ghostty's `terminfo`).

The current except clause follows the project's critical rules for catching `ImportError` and `NotImplementedError` (Unix/Windows compatibility), but `TerminalMenu.__init__()` can also fail at runtime due to environment issues — unknown terminal types, missing `terminfo`, no TTY, etc. These aren't import or platform errors, so they slip through.

Added a second `except Exception as e` clause that prints a short diagnostic message and falls through to the same text-based fallback. The original `ImportError`/`NotImplementedError` handling is preserved per the project's critical rules.

# How to test

1. SSH into a machine that doesn't have Ghostty's `terminfo` installed, from a Ghostty terminal (so `TERM=xterm-ghostty` is forwarded)
2. Run `hermes setup`
3. Before fix: Python traceback — `subprocess.CalledProcessError` from tput lines
4. After fix: `(Interactive menu unavailable: ...)` message, then the numbered text menu renders normally

Alternatively, simulate it locally:

`TERM=fake-terminal hermes setup`

Platforms tested
- macOS 26.2 (Apple Silicon) — Ghostty (1.2.3) SSH from MacBook to Mac Mini

Related issues

- Ghostty terminfo documentation: https://ghostty.org/docs/help/terminfo
- Root cause is in simple_term_menu calling tput without handling unknown terminal types, but the fix belongs here since we already have a fallback path