### PR TITLE
fix(batch_runner): preserve traceback when batch worker fails during processing

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -914,6 +914,9 @@ class BatchRunner:
                     for result in pool.imap_unordered(_process_batch_worker, tasks):
                         results.append(result)
                         progress.update(task, advance=1)
+                except Exception as e:
+                    logger.error("Batch worker failed: %s", e, exc_info=True)
+                    raise
                 finally:
                     root_logger.setLevel(original_level)
         

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -125,7 +125,7 @@ class ToolRegistry:
                 return _run_async(entry.handler(args, **kwargs))
             return entry.handler(args, **kwargs)
         except Exception as e:
-            logger.error("Tool %s dispatch error: %s", name, e)
+            logger.exception("Tool %s dispatch error: %s", name, e)
             return json.dumps({"error": f"Tool execution failed: {type(e).__name__}: {e}"})
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
If any worker raises inside `pool.imap_unordered()`, the exception
propagates through the `for` loop and the `results` list is left
incomplete. The `finally` block correctly restores the log level but
the error is silently swallowed with no diagnostic information,
making it impossible to debug which worker failed and why.

## Fix
Added an explicit `except` block that logs the full traceback via
`exc_info=True` before re-raising. This preserves the existing
control flow while making batch worker failures visible in logs.