### PR TITLE
fix: handle None message content across codebase

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -81,7 +81,7 @@ class _CodexCompletionsAdapter:
         input_msgs: List[Dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role", "user")
-            content = msg.get("content", "")
+            content = msg.get("content") or ""
             if role == "system":
                 instructions = content
             else:

--- a/cli.py
+++ b/cli.py
@@ -1285,7 +1285,7 @@ class HermesCLI:
         
         for i, msg in enumerate(self.conversation_history, 1):
             role = msg.get("role", "unknown")
-            content = msg.get("content", "")
+            content = msg.get("content") or ""
             
             if role == "user":
                 print(f"\n  [You #{i}]")

--- a/honcho_integration/session.py
+++ b/honcho_integration/session.py
@@ -442,7 +442,7 @@ class HonchoSessionManager:
         for msg in messages:
             ts = msg.get("timestamp", "?")
             role = msg.get("role", "unknown")
-            content = msg.get("content", "")
+            content = msg.get("content") or ""
             lines.append(f"[{ts}] {role}: {content}")
 
         lines.append("")

--- a/run_agent.py
+++ b/run_agent.py
@@ -3441,7 +3441,7 @@ class AIAgent:
                     self._codex_incomplete_retries += 1
 
                     interim_msg = self._build_assistant_message(assistant_message, finish_reason)
-                    interim_has_content = bool(interim_msg.get("content", "").strip())
+                    interim_has_content = bool((interim_msg.get("content") or "").strip())
                     interim_has_reasoning = bool(interim_msg.get("reasoning", "").strip()) if isinstance(interim_msg.get("reasoning"), str) else False
 
                     if interim_has_content or interim_has_reasoning:


### PR DESCRIPTION
## Summary

Fixes #276

Follow-up to #211 (context compressor fix). The same `msg.get("content", "")` pattern exists in 4 more message-processing paths where `content: null` from the OpenAI API causes crashes.

## Changes

4 files, 4 lines changed (`msg.get("content", "")` → `msg.get("content") or ""`):

| File | Line | Impact |
|------|------|--------|
| `agent/auxiliary_client.py` | 84 | None passed as content to API calls |
| `cli.py` | 1288 | TypeError on `content[:200]` and `len(content)` in conversation display |
| `run_agent.py` | 3444 | TypeError on `None.strip()` in interim message check |
| `honcho_integration/session.py` | 445 | "None" rendered literally in transcript |

## Verification

- Audited all 23 instances of `.get("content", "")` in the target files
- 13 are safe by design (only process user/tool messages, already protected, or use safe patterns)
- 4 needed fixing (this PR)
- Full test suite: **1074 passed**, 0 failures
- Smoke tested with live CLI: tool-calling conversation completed without errors