### PR TITLE
fix: guard msg.get("content") against None across codebase

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -81,7 +81,7 @@ class _CodexCompletionsAdapter:
         input_msgs: List[Dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role", "user")
-            content = msg.get("content", "")
+            content = msg.get("content") or ""
             if role == "system":
                 instructions = content
             else:

--- a/agent/display.py
+++ b/agent/display.py
@@ -65,7 +65,7 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int = 40) -> str:
         action = args.get("action", "")
         target = args.get("target", "")
         if action == "add":
-            content = args.get("content", "")
+            content = args.get("content") or ""
             return f"+{target}: \"{content[:25]}{'...' if len(content) > 25 else ''}\""
         elif action == "replace":
             return f"~{target}: \"{args.get('old_text', '')[:20]}\""

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -146,7 +146,7 @@ def _extract_tool_stats(messages: List[Dict[str, Any]]) -> Dict[str, Dict[str, i
         # Track tool responses
         elif msg["role"] == "tool":
             tool_call_id = msg.get("tool_call_id", "")
-            content = msg.get("content", "")
+            content = msg.get("content") or ""
             
             # Determine if tool call was successful
             is_success = True

--- a/cli.py
+++ b/cli.py
@@ -1285,7 +1285,7 @@ class HermesCLI:
         
         for i, msg in enumerate(self.conversation_history, 1):
             role = msg.get("role", "unknown")
-            content = msg.get("content", "")
+            content = msg.get("content") or ""
             
             if role == "user":
                 print(f"\n  [You #{i}]")
@@ -1350,7 +1350,7 @@ class HermesCLI:
             return None
         
         # Extract the message text and remove everything from that point forward
-        last_message = self.conversation_history[last_user_idx].get("content", "")
+        last_message = self.conversation_history[last_user_idx].get("content") or ""
         self.conversation_history = self.conversation_history[:last_user_idx]
         
         print(f"(^_^)b Retrying: \"{last_message[:60]}{'...' if len(last_message) > 60 else ''}\"")
@@ -1379,7 +1379,7 @@ class HermesCLI:
         
         # Count how many messages we're removing
         removed_count = len(self.conversation_history) - last_user_idx
-        removed_msg = self.conversation_history[last_user_idx].get("content", "")
+        removed_msg = self.conversation_history[last_user_idx].get("content") or ""
         
         # Truncate history to before the last user message
         self.conversation_history = self.conversation_history[:last_user_idx]

--- a/environments/agent_loop.py
+++ b/environments/agent_loop.py
@@ -184,7 +184,7 @@ class HermesAgentLoop:
         _user_task = None
         for msg in messages:
             if msg.get("role") == "user":
-                content = msg.get("content", "")
+                content = msg.get("content") or ""
                 if isinstance(content, str) and content.strip():
                     _user_task = content.strip()[:500]  # Cap to avoid huge strings
                 break

--- a/environments/hermes_base_env.py
+++ b/environments/hermes_base_env.py
@@ -335,7 +335,7 @@ class HermesAgentBaseEnv(BaseEnv):
         parts = []
         for msg in messages:
             role = msg.get("role", "unknown")
-            content = msg.get("content", "")
+            content = msg.get("content") or ""
 
             if role == "system":
                 parts.append(f"[SYSTEM]\n{content}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1214,7 +1214,7 @@ class GatewayRunner:
         last_user_idx = None
         for i in range(len(history) - 1, -1, -1):
             if history[i].get("role") == "user":
-                last_user_msg = history[i].get("content", "")
+                last_user_msg = history[i].get("content") or ""
                 last_user_idx = i
                 break
         
@@ -1253,7 +1253,7 @@ class GatewayRunner:
         if last_user_idx is None:
             return "Nothing to undo."
         
-        removed_msg = history[last_user_idx].get("content", "")
+        removed_msg = history[last_user_idx].get("content") or ""
         removed_count = len(history) - last_user_idx
         self.session_store.rewrite_transcript(session_entry.session_id, history[:last_user_idx])
         
@@ -1916,7 +1916,7 @@ class GatewayRunner:
             _history_media_paths: set = set()
             for _hm in agent_history:
                 if _hm.get("role") in ("tool", "function"):
-                    _hc = _hm.get("content", "")
+                    _hc = _hm.get("content") or ""
                     if "MEDIA:" in _hc:
                         for _match in re.finditer(r'MEDIA:(\S+)', _hc):
                             _p = _match.group(1).strip().rstrip('",}')
@@ -1952,7 +1952,7 @@ class GatewayRunner:
                 has_voice_directive = False
                 for msg in result.get("messages", []):
                     if msg.get("role") in ("tool", "function"):
-                        content = msg.get("content", "")
+                        content = msg.get("content") or ""
                         if "MEDIA:" in content:
                             for match in re.finditer(r'MEDIA:(\S+)', content):
                                 path = match.group(1).strip().rstrip('",}')

--- a/honcho_integration/session.py
+++ b/honcho_integration/session.py
@@ -442,7 +442,7 @@ class HonchoSessionManager:
         for msg in messages:
             ts = msg.get("timestamp", "?")
             role = msg.get("role", "unknown")
-            content = msg.get("content", "")
+            content = msg.get("content") or ""
             lines.append(f"[{ts}] {role}: {content}")
 
         lines.append("")

--- a/run_agent.py
+++ b/run_agent.py
@@ -1221,7 +1221,7 @@ class AIAgent:
         for msg in reversed(history):
             if msg.get("role") != "tool":
                 continue
-            content = msg.get("content", "")
+            content = msg.get("content") or ""
             # Quick check: todo responses contain "todos" key
             if '"todos"' not in content:
                 continue
@@ -1461,7 +1461,7 @@ class AIAgent:
                 continue
 
             if role in {"user", "assistant"}:
-                content = msg.get("content", "")
+                content = msg.get("content") or ""
                 content_text = str(content) if content is not None else ""
 
                 if role == "assistant":
@@ -3441,7 +3441,7 @@ class AIAgent:
                     self._codex_incomplete_retries += 1
 
                     interim_msg = self._build_assistant_message(assistant_message, finish_reason)
-                    interim_has_content = bool(interim_msg.get("content", "").strip())
+                    interim_has_content = bool((interim_msg.get("content") or "").strip())
                     interim_has_reasoning = bool(interim_msg.get("reasoning", "").strip()) if isinstance(interim_msg.get("reasoning"), str) else False
 
                     if interim_has_content or interim_has_reasoning:


### PR DESCRIPTION
Fixes #276

## Problem

`msg.get("content", "")` returns `None` (not `""`) when the key exists with value `None`. The OpenAI API returns `content: null` on every assistant message that only contains tool calls — this is standard behavior, not an edge case.

Any string operation on the resulting `None` value crashes with `TypeError`: `len(None)`, `None + "string"`, `"text" in None`, etc.

## Fix

Replace `msg.get("content", "")` with `msg.get("content") or ""` in all 16 message-processing paths across 9 files:

| File | Fixes | Paths |
|---|---|---|
| `run_agent.py` | 3 | todo content lookup, message preparation, interim content check |
| `cli.py` | 3 | conversation display, `/retry`, `/undo` |
| `gateway/run.py` | 4 | `/retry`, `/undo`, history media scan, result processing |
| `batch_runner.py` | 1 | tool response extraction |
| `environments/hermes_base_env.py` | 1 | message formatting |
| `environments/agent_loop.py` | 1 | user task extraction |
| `agent/auxiliary_client.py` | 1 | Codex adapter message prep |
| `agent/display.py` | 1 | memory tool preview |
| `honcho_integration/session.py` | 1 | conversation formatting |

### Intentionally unchanged (already safe)

- `run_agent.py:1535` — `str(msg.get("content", "") or "")` — double-guarded
- `run_agent.py:1611` — explicit `if content is None: content = ""` on next line
- `batch_runner.py:216` — `msg.get("content", "") or ""` — already guarded
- `hermes_base_env.py:586` — `if msg.get("content")` filters None before use

### Not affected

Other `get("content", "")` instances process tool arguments, file content, or web results — never conversation messages where `content: null` occurs.

## Testing

Full test suite: **1017 passed**, 15 pre-existing failures (verified on clean `main`), 9 deselected.