### PR TITLE
fix: remove invalidate() calls from polling loops to fix terminal blinking

### DIFF
--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -45,8 +45,6 @@ def clarify_callback(cli, question, choices):
             remaining = cli._clarify_deadline - _time.monotonic()
             if remaining <= 0:
                 break
-            if hasattr(cli, '_app') and cli._app:
-                cli._app.invalidate()
 
     cli._clarify_state = None
     cli._clarify_freetext = False
@@ -90,8 +88,6 @@ def sudo_password_callback(cli) -> str:
             remaining = cli._sudo_deadline - _time.monotonic()
             if remaining <= 0:
                 break
-            if hasattr(cli, '_app') and cli._app:
-                cli._app.invalidate()
 
     cli._sudo_state = None
     cli._sudo_deadline = 0
@@ -134,8 +130,6 @@ def approval_callback(cli, command: str, description: str) -> str:
             remaining = cli._approval_deadline - _time.monotonic()
             if remaining <= 0:
                 break
-            if hasattr(cli, '_app') and cli._app:
-                cli._app.invalidate()
 
     cli._approval_state = None
     cli._approval_deadline = 0


### PR DESCRIPTION
Fixes #282

Terminal blinking was caused by cli._app.invalidate() being called 
on every polling loop iteration (every 1 second). 

Removed unnecessary invalidate() calls from the queue.Empty exception 
handlers in clarify, sudo, and approval callbacks. Now invalidate() 
is only called when state actually changes.