### PR TITLE
feat(bridge): add Hermes JSONL bridge with native/synthetic streaming…

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Toggle at runtime in the CLI with `/verbose` (cycles through all four modes).
 # Chat
 hermes                    # Interactive chat (default)
 hermes chat -q "Hello"    # Single query mode
+hermes bridge             # JSONL stdio bridge for host integrations
 hermes --continue         # Resume the most recent session (-c)
 hermes --resume <id>      # Resume a specific session (-r)
 
@@ -384,6 +385,37 @@ hermes cron status        # Check if cron scheduler is running
 hermes pairing list       # View/manage DM pairing codes
 hermes version            # Show version info
 ```
+
+### `hermes bridge` JSONL protocol (quick reference)
+
+`hermes bridge` reads one JSON request per stdin line and emits one JSON event per stdout line.
+
+**Sample requests**
+```jsonl
+{"type":"run","request_id":"req-1","session_id":"sess-1","message":"Summarize README.md","cwd":"D:/hermes-agent","assistant_delta":true,"assistant_delta_chunk_size":80,"native_stream":true,"native_assistant_delta":true}
+{"type":"interrupt","request_id":"req-2","session_id":"sess-1","message":"stop now"}
+{"type":"shutdown","request_id":"req-3"}
+```
+
+**Sample events**
+```jsonl
+{"type":"session","request_id":"req-1","session_id":"sess-1"}
+{"type":"assistant_delta","request_id":"req-1","session_id":"sess-1","delta":"First chunk...","delta_index":1,"native":true}
+{"type":"assistant_message_end","request_id":"req-1","session_id":"sess-1","delta_chunks":3,"native":true}
+{"type":"assistant_message","request_id":"req-1","session_id":"sess-1","content":"Full normalized assistant turn","has_tool_calls":false}
+{"type":"final","request_id":"req-1","session_id":"sess-1","text":"Done","api_calls":2,"completed":true}
+{"type":"interrupt_ack","request_id":"req-2","session_id":"sess-1","accepted":true}
+```
+
+`assistant_delta` delivery modes:
+- **Non-streaming** (`assistant_delta=false`, default): emits full-turn `assistant_message` events (no deltas).
+- **Native streaming** (`assistant_delta=true`, `native_stream=true`, `native_assistant_delta=true`): emits model-native `assistant_delta` (`native=true`) followed by `assistant_message_end`, then normalized `assistant_message`.
+- **Synthetic fallback** (`assistant_delta=true` but no native deltas available): bridge chunks a completed `assistant_message` into synthetic `assistant_delta` (`native=false`) + `assistant_message_end`. To avoid duplicate text, `assistant_message` is suppressed for that turn.
+
+Per-turn ordering is deterministic within each mode:
+- Native streaming: `assistant_delta*` → `assistant_message_end` → `assistant_message` → tool events (if any) → `final`.
+- Non-streaming: `assistant_message` → tool events (if any) → `final`.
+- Synthetic fallback: `assistant_delta*` → `assistant_message_end` → tool events (if any) → `final`.
 
 ### CLI Commands (inside chat)
 

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -3,6 +3,7 @@ Hermes CLI - Unified command-line interface for Hermes Agent.
 
 Provides subcommands for:
 - hermes chat          - Interactive chat (same as ./hermes)
+- hermes bridge        - JSONL stdio bridge mode for embedding
 - hermes gateway       - Run gateway in foreground
 - hermes gateway start - Start gateway service
 - hermes gateway stop  - Stop gateway service  

--- a/hermes_cli/bridge.py
+++ b/hermes_cli/bridge.py
@@ -1,0 +1,643 @@
+"""Stdio bridge for embedding Hermes in external hosts.
+
+The bridge reads JSON requests from stdin (one JSON object per line) and emits
+JSON events on stdout (also JSONL). This keeps transport deterministic for
+Electron/local-server integrations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import sys
+import threading
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TextIO
+
+from hermes_cli.config import get_env_value, load_config
+from hermes_constants import OPENROUTER_BASE_URL
+from run_agent import AIAgent
+
+
+@dataclass
+class BridgeDefaults:
+    model: str
+    base_url: str
+    api_key: Optional[str]
+    max_iterations: int
+    toolsets: Optional[List[str]]
+    disabled_toolsets: Optional[List[str]]
+
+
+@dataclass
+class BridgeRunOptions:
+    assistant_delta: bool
+    assistant_delta_chunk_size: int
+    native_assistant_delta: bool
+    native_stream: bool
+    stream_first_chunk_timeout_ms: Optional[int]
+    stream_idle_timeout_ms: Optional[int]
+
+
+class JsonlEmitter:
+    """Write JSON events to a stream as single-line JSON objects."""
+
+    def __init__(self, stream: TextIO):
+        self._stream = stream
+        self._lock = threading.Lock()
+
+    def emit(self, event: Dict[str, Any]) -> None:
+        with self._lock:
+            self._stream.write(json.dumps(_make_json_safe(event), ensure_ascii=False) + "\n")
+            self._stream.flush()
+
+
+def _make_json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _make_json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_make_json_safe(v) for v in value]
+    return str(value)
+
+
+def _parse_toolsets(raw: Any) -> Optional[List[str]]:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        items = [part.strip() for part in raw.split(",") if part.strip()]
+        return items or None
+    if isinstance(raw, (list, tuple, set)):
+        items = [str(x).strip() for x in raw if str(x).strip()]
+        return items or None
+    value = str(raw).strip()
+    return [value] if value else None
+
+
+def _resolve_max_iterations(raw: Any, fallback: int) -> int:
+    if raw in (None, ""):
+        return fallback
+    try:
+        value = int(raw)
+        return value if value > 0 else fallback
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _resolve_defaults(args: argparse.Namespace) -> BridgeDefaults:
+    config = load_config()
+
+    model_cfg = config.get("model")
+    if isinstance(model_cfg, dict):
+        config_model = model_cfg.get("default")
+        config_base_url = model_cfg.get("base_url")
+    else:
+        config_model = model_cfg
+        config_base_url = None
+
+    max_turns_cfg = config.get("max_turns", 60)
+    env_max_turns = os.getenv("HERMES_MAX_ITERATIONS")
+
+    toolsets = _parse_toolsets(args.toolsets)
+    if toolsets is None:
+        toolsets = _parse_toolsets(config.get("toolsets"))
+
+    disabled_toolsets = _parse_toolsets(args.disabled_toolsets)
+
+    base_url = (
+        args.base_url
+        or os.getenv("OPENAI_BASE_URL")
+        or os.getenv("OPENROUTER_BASE_URL")
+        or config_base_url
+        or OPENROUTER_BASE_URL
+    )
+
+    return BridgeDefaults(
+        model=args.model or config_model or "anthropic/claude-opus-4.6",
+        base_url=base_url,
+        api_key=args.api_key or get_env_value("OPENAI_API_KEY") or get_env_value("OPENROUTER_API_KEY"),
+        max_iterations=_resolve_max_iterations(
+            env_max_turns,
+            _resolve_max_iterations(args.max_iterations, int(max_turns_cfg or 60)),
+        ),
+        toolsets=toolsets,
+        disabled_toolsets=disabled_toolsets,
+    )
+
+
+def _resolve_run_options(request: Dict[str, Any], args: argparse.Namespace) -> BridgeRunOptions:
+    chunk_size = request.get("assistant_delta_chunk_size", getattr(args, "assistant_delta_chunk_size", 120))
+    try:
+        chunk_size_int = int(chunk_size)
+    except (TypeError, ValueError):
+        chunk_size_int = 120
+    if chunk_size_int <= 0:
+        chunk_size_int = 120
+
+    assistant_delta = bool(request.get("assistant_delta", getattr(args, "assistant_delta", False)))
+    native_assistant_delta = bool(
+        request.get("native_assistant_delta", getattr(args, "native_assistant_delta", True))
+    )
+    native_stream = bool(request.get("native_stream", getattr(args, "native_stream", False)))
+
+    first_chunk_timeout = request.get(
+        "stream_first_chunk_timeout_ms",
+        getattr(args, "stream_first_chunk_timeout_ms", None),
+    )
+    idle_timeout = request.get(
+        "stream_idle_timeout_ms",
+        getattr(args, "stream_idle_timeout_ms", None),
+    )
+
+    def _coerce_timeout(raw: Any) -> Optional[int]:
+        if raw in (None, ""):
+            return None
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return None
+        return value if value > 0 else None
+
+    return BridgeRunOptions(
+        assistant_delta=assistant_delta,
+        assistant_delta_chunk_size=chunk_size_int,
+        native_assistant_delta=native_assistant_delta,
+        native_stream=native_stream,
+        stream_first_chunk_timeout_ms=_coerce_timeout(first_chunk_timeout),
+        stream_idle_timeout_ms=_coerce_timeout(idle_timeout),
+    )
+
+
+@contextlib.contextmanager
+def _temporary_cwd(cwd: Optional[str]):
+    if not cwd:
+        yield
+        return
+
+    previous_cwd = os.getcwd()
+    os.chdir(cwd)
+    try:
+        yield
+    finally:
+        os.chdir(previous_cwd)
+
+
+@contextlib.contextmanager
+def _temporary_terminal_cwd(cwd: Optional[str]):
+    if not cwd:
+        yield
+        return
+
+    prev_terminal_cwd = os.environ.get("TERMINAL_CWD")
+    os.environ["TERMINAL_CWD"] = cwd
+    try:
+        yield
+    finally:
+        if prev_terminal_cwd is None:
+            os.environ.pop("TERMINAL_CWD", None)
+        else:
+            os.environ["TERMINAL_CWD"] = prev_terminal_cwd
+
+
+def _iter_chunks(text: str, chunk_size: int):
+    if not text:
+        return
+    for start in range(0, len(text), chunk_size):
+        yield text[start:start + chunk_size]
+
+
+def _emit_assistant_delta_events(
+    event: Dict[str, Any],
+    run_options: BridgeRunOptions,
+    request_id: str,
+    session_id: str,
+    emitter: JsonlEmitter,
+) -> bool:
+    """Synthetic assistant_delta fallback from assistant_message events only."""
+    if event.get("type") != "assistant_message" or not run_options.assistant_delta:
+        return False
+
+    content = event.get("content")
+    if not isinstance(content, str) or not content:
+        return False
+
+    total = 0
+    for idx, chunk in enumerate(_iter_chunks(content, run_options.assistant_delta_chunk_size), start=1):
+        total = idx
+        emitter.emit(
+            {
+                "type": "assistant_delta",
+                "request_id": request_id,
+                "session_id": session_id,
+                "timestamp": event.get("timestamp"),
+                "delta": chunk,
+                "delta_index": idx,
+                "native": False,
+            }
+        )
+
+    emitter.emit(
+        {
+            "type": "assistant_message_end",
+            "request_id": request_id,
+            "session_id": session_id,
+            "timestamp": event.get("timestamp"),
+            "delta_chunks": total,
+            "has_tool_calls": bool(event.get("has_tool_calls")),
+            "finish_reason": event.get("finish_reason"),
+            "reasoning_present": bool(event.get("reasoning_present")),
+            "native": False,
+        }
+    )
+    return True
+
+
+def _handle_run_request(
+    request: Dict[str, Any],
+    sessions: Dict[str, List[Dict[str, Any]]],
+    sessions_lock: threading.Lock,
+    active_agents: Dict[str, AIAgent],
+    active_lock: threading.Lock,
+    defaults: BridgeDefaults,
+    args: argparse.Namespace,
+    emitter: JsonlEmitter,
+    stderr: TextIO,
+) -> None:
+    request_id = str(request.get("request_id") or uuid.uuid4().hex)
+
+    user_message = request.get("message")
+    if not isinstance(user_message, str) or not user_message.strip():
+        emitter.emit(
+            {
+                "type": "error",
+                "request_id": request_id,
+                "stage": "request_validation",
+                "message": "Run request requires a non-empty 'message' string.",
+                "retryable": False,
+            }
+        )
+        return
+
+    session_id = str(request.get("session_id") or uuid.uuid4().hex)
+    resume = bool(request.get("resume", True))
+
+    seeded_history = request.get("conversation_history")
+    if isinstance(seeded_history, list):
+        history = seeded_history
+    elif resume:
+        with sessions_lock:
+            history = sessions.get(session_id, [])
+    else:
+        history = []
+
+    toolsets = _parse_toolsets(request.get("toolsets")) or defaults.toolsets
+    disabled_toolsets = _parse_toolsets(request.get("disabled_toolsets")) or defaults.disabled_toolsets
+
+    model = str(request.get("model") or defaults.model)
+    base_url = str(request.get("base_url") or defaults.base_url)
+    api_key = request.get("api_key") or defaults.api_key
+    max_iterations = _resolve_max_iterations(request.get("max_iterations"), defaults.max_iterations)
+    run_options = _resolve_run_options(request, args)
+
+    cwd_value = request.get("cwd") or args.cwd
+    cwd = str(cwd_value) if cwd_value else None
+
+    if cwd:
+        target = Path(cwd)
+        if not target.exists() or not target.is_dir():
+            emitter.emit(
+                {
+                    "type": "error",
+                    "request_id": request_id,
+                    "session_id": session_id,
+                    "stage": "request_validation",
+                    "message": f"Invalid cwd: '{cwd}'",
+                    "retryable": False,
+                }
+            )
+            return
+
+    with active_lock:
+        if session_id in active_agents:
+            emitter.emit(
+                {
+                    "type": "error",
+                    "request_id": request_id,
+                    "session_id": session_id,
+                    "stage": "request_validation",
+                    "message": "A run is already active for this session_id.",
+                    "retryable": True,
+                }
+            )
+            return
+
+    emitter.emit({"type": "session", "request_id": request_id, "session_id": session_id})
+
+    native_deltas_in_turn = {"seen": False}
+
+    def _forward_event(event: Dict[str, Any]) -> None:
+        event = dict(event or {})
+        event.setdefault("request_id", request_id)
+        event.setdefault("session_id", session_id)
+
+        event_type = event.get("type")
+
+        if event_type == "assistant_delta":
+            native_deltas_in_turn["seen"] = True
+            if run_options.assistant_delta and run_options.native_assistant_delta:
+                emitter.emit(event)
+            return
+
+        if event_type == "assistant_message_end":
+            if native_deltas_in_turn["seen"]:
+                if run_options.assistant_delta and run_options.native_assistant_delta:
+                    emitter.emit(event)
+                return
+            # suppress stray end markers when no prior deltas were forwarded
+            return
+
+        if event_type == "assistant_message":
+            # If native deltas were already emitted for this turn, avoid synthetic conversion.
+            if not native_deltas_in_turn["seen"]:
+                if _emit_assistant_delta_events(event, run_options, request_id, session_id, emitter):
+                    native_deltas_in_turn["seen"] = False
+                    return
+            native_deltas_in_turn["seen"] = False
+            emitter.emit(event)
+            return
+
+        emitter.emit(event)
+
+    agent = AIAgent(
+        model=model,
+        base_url=base_url,
+        api_key=api_key,
+        max_iterations=max_iterations,
+        enabled_toolsets=toolsets,
+        disabled_toolsets=disabled_toolsets,
+        quiet_mode=True,
+        verbose_logging=bool(getattr(args, "verbose", False)),
+        session_id=session_id,
+        event_callback=_forward_event,
+        reasoning_config={"enabled": True, "effort": "high"},
+        enable_native_streaming=run_options.native_stream,
+        emit_assistant_delta_events=run_options.assistant_delta and run_options.native_assistant_delta,
+        stream_first_chunk_timeout=(
+            (run_options.stream_first_chunk_timeout_ms / 1000.0)
+            if run_options.stream_first_chunk_timeout_ms
+            else None
+        ),
+        stream_idle_timeout=(
+            (run_options.stream_idle_timeout_ms / 1000.0)
+            if run_options.stream_idle_timeout_ms
+            else None
+        ),
+    )
+
+    with active_lock:
+        active_agents[session_id] = agent
+
+    try:
+        with _temporary_cwd(cwd), _temporary_terminal_cwd(cwd), contextlib.redirect_stdout(stderr):
+            result = agent.run_conversation(
+                user_message=user_message,
+                system_message=request.get("system_message"),
+                conversation_history=history,
+                task_id=request.get("task_id"),
+                request_id=request_id,
+            )
+    except Exception as exc:
+        emitter.emit(
+            {
+                "type": "error",
+                "request_id": request_id,
+                "session_id": session_id,
+                "stage": "bridge_run",
+                "message": str(exc),
+                "retryable": False,
+            }
+        )
+        return
+    finally:
+        with active_lock:
+            current = active_agents.get(session_id)
+            if current is agent:
+                active_agents.pop(session_id, None)
+
+    with sessions_lock:
+        sessions[session_id] = result.get("messages") or history
+
+    emitter.emit(
+        {
+            "type": "final",
+            "request_id": request_id,
+            "session_id": session_id,
+            "text": result.get("final_response"),
+            "api_calls": result.get("api_calls"),
+            "completed": bool(result.get("completed")),
+            "partial": bool(result.get("partial")),
+            "interrupted": bool(result.get("interrupted")),
+        }
+    )
+
+
+def _start_run_thread(
+    request: Dict[str, Any],
+    sessions: Dict[str, List[Dict[str, Any]]],
+    sessions_lock: threading.Lock,
+    active_agents: Dict[str, AIAgent],
+    active_lock: threading.Lock,
+    defaults: BridgeDefaults,
+    args: argparse.Namespace,
+    emitter: JsonlEmitter,
+    stderr: TextIO,
+) -> threading.Thread:
+    thread = threading.Thread(
+        target=_handle_run_request,
+        kwargs={
+            "request": request,
+            "sessions": sessions,
+            "sessions_lock": sessions_lock,
+            "active_agents": active_agents,
+            "active_lock": active_lock,
+            "defaults": defaults,
+            "args": args,
+            "emitter": emitter,
+            "stderr": stderr,
+        },
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+def _cleanup_finished_threads(threads: List[threading.Thread]) -> None:
+    alive = [t for t in threads if t.is_alive()]
+    threads[:] = alive
+
+
+def _interrupt_session(
+    request: Dict[str, Any],
+    active_agents: Dict[str, AIAgent],
+    active_lock: threading.Lock,
+    emitter: JsonlEmitter,
+) -> None:
+    request_id = request.get("request_id")
+    session_id = request.get("session_id")
+    if not session_id:
+        emitter.emit(
+            {
+                "type": "error",
+                "request_id": request_id,
+                "stage": "request_validation",
+                "message": "interrupt request requires 'session_id'.",
+                "retryable": False,
+            }
+        )
+        return
+
+    with active_lock:
+        agent = active_agents.get(str(session_id))
+
+    if not agent:
+        emitter.emit(
+            {
+                "type": "error",
+                "request_id": request_id,
+                "session_id": str(session_id),
+                "stage": "request_validation",
+                "message": "No active run for the provided session_id.",
+                "retryable": True,
+            }
+        )
+        return
+
+    agent.interrupt(message=request.get("message"))
+    emitter.emit(
+        {
+            "type": "interrupt_ack",
+            "request_id": request_id,
+            "session_id": str(session_id),
+            "accepted": True,
+        }
+    )
+
+
+def bridge_command(
+    args: argparse.Namespace,
+    stdin: Optional[TextIO] = None,
+    stdout: Optional[TextIO] = None,
+    stderr: Optional[TextIO] = None,
+) -> int:
+    """Run the Hermes JSONL stdio bridge."""
+
+    in_stream: TextIO = sys.stdin if stdin is None else stdin
+    out_stream: TextIO = sys.stdout if stdout is None else stdout
+    err_stream: TextIO = sys.stderr if stderr is None else stderr
+
+    defaults = _resolve_defaults(args)
+    emitter = JsonlEmitter(out_stream)
+    sessions: Dict[str, List[Dict[str, Any]]] = {}
+    active_agents: Dict[str, AIAgent] = {}
+    sessions_lock = threading.Lock()
+    active_lock = threading.Lock()
+    run_threads: List[threading.Thread] = []
+
+    for raw_line in in_stream:
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        _cleanup_finished_threads(run_threads)
+
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError as exc:
+            emitter.emit(
+                {
+                    "type": "error",
+                    "stage": "request_parse",
+                    "message": f"Invalid JSON input: {exc}",
+                    "retryable": True,
+                }
+            )
+            continue
+
+        req_type = str(request.get("type") or "run").lower()
+
+        if req_type == "ping":
+            emitter.emit({"type": "pong", "request_id": request.get("request_id")})
+            if args.once:
+                break
+            continue
+
+        if req_type == "interrupt":
+            _interrupt_session(request, active_agents, active_lock, emitter)
+            if args.once:
+                break
+            continue
+
+        if req_type in {"shutdown", "exit", "quit"}:
+            emitter.emit({"type": "shutdown_ack", "request_id": request.get("request_id")})
+            break
+
+        if req_type != "run":
+            emitter.emit(
+                {
+                    "type": "error",
+                    "request_id": request.get("request_id"),
+                    "stage": "request_validation",
+                    "message": f"Unsupported request type '{req_type}'.",
+                    "retryable": False,
+                }
+            )
+            if args.once:
+                break
+            continue
+
+        if args.once:
+            _handle_run_request(
+                request=request,
+                sessions=sessions,
+                sessions_lock=sessions_lock,
+                active_agents=active_agents,
+                active_lock=active_lock,
+                defaults=defaults,
+                args=args,
+                emitter=emitter,
+                stderr=err_stream,
+            )
+            break
+
+        run_threads.append(
+            _start_run_thread(
+                request=request,
+                sessions=sessions,
+                sessions_lock=sessions_lock,
+                active_agents=active_agents,
+                active_lock=active_lock,
+                defaults=defaults,
+                args=args,
+                emitter=emitter,
+                stderr=err_stream,
+            )
+        )
+
+    with active_lock:
+        running_agents = list(active_agents.values())
+
+    for agent in running_agents:
+        try:
+            agent.interrupt(message="bridge shutdown")
+        except Exception:
+            pass
+
+    for thread in run_threads:
+        thread.join(timeout=10)
+
+    return 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5,6 +5,7 @@ Hermes CLI - Main entry point.
 Usage:
     hermes                     # Interactive chat (default)
     hermes chat                # Interactive chat
+    hermes bridge              # JSONL stdio bridge mode for embedding
     hermes gateway             # Run gateway in foreground
     hermes gateway start       # Start gateway as service
     hermes gateway stop        # Stop gateway service
@@ -159,6 +160,12 @@ def cmd_chat(args):
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
     
     cli_main(**kwargs)
+
+
+def cmd_bridge(args):
+    """Run Hermes in JSONL stdio bridge mode."""
+    from hermes_cli.bridge import bridge_command
+    return bridge_command(args)
 
 
 def cmd_gateway(args):
@@ -363,7 +370,7 @@ def cmd_model(args):
         _model_flow_custom(config)
 
 
-def _prompt_provider_choice(choices):
+def _prompt_provider_choice(choices: list[str]) -> Optional[int]:
     """Show provider selection menu. Returns index or None."""
     try:
         from simple_term_menu import TerminalMenu
@@ -375,7 +382,12 @@ def _prompt_provider_choice(choices):
             cycle_cursor=True, clear_screen=False,
             title="Select provider:",
         )
-        idx = menu.show()
+        idx_raw = menu.show()
+        idx: Optional[int]
+        if isinstance(idx_raw, tuple):
+            idx = idx_raw[0] if idx_raw else None
+        else:
+            idx = idx_raw
         print()
         return idx
     except (ImportError, NotImplementedError):
@@ -795,6 +807,7 @@ def main():
 Examples:
     hermes                        Start interactive chat
     hermes chat -q "Hello"        Single query mode
+    hermes bridge                 Run JSONL stdio bridge
     hermes --continue             Resume the most recent session
     hermes --resume <session_id>  Resume a specific session
     hermes setup                  Run setup wizard
@@ -879,6 +892,94 @@ For more help on a command:
         help="Resume the most recent CLI session"
     )
     chat_parser.set_defaults(func=cmd_chat)
+
+    # =========================================================================
+    # bridge command
+    # =========================================================================
+    bridge_parser = subparsers.add_parser(
+        "bridge",
+        help="Run JSONL stdio bridge for embedding Hermes",
+        description="Read JSON requests from stdin and emit JSON events to stdout"
+    )
+    bridge_parser.add_argument(
+        "--model",
+        help="Default model to use when request does not override"
+    )
+    bridge_parser.add_argument(
+        "--base-url",
+        dest="base_url",
+        help="Default OpenAI-compatible base URL"
+    )
+    bridge_parser.add_argument(
+        "--api-key",
+        dest="api_key",
+        help="Default API key (otherwise loaded from environment/config)"
+    )
+    bridge_parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=None,
+        help="Default max tool-calling iterations"
+    )
+    bridge_parser.add_argument(
+        "--toolsets",
+        help="Default comma-separated toolsets"
+    )
+    bridge_parser.add_argument(
+        "--disabled-toolsets",
+        dest="disabled_toolsets",
+        help="Default comma-separated disabled toolsets"
+    )
+    bridge_parser.add_argument(
+        "--cwd",
+        help="Default working directory for requests that omit cwd"
+    )
+    bridge_parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Process a single request and exit"
+    )
+    bridge_parser.add_argument(
+        "--assistant-delta",
+        action="store_true",
+        help="Enable assistant_delta streaming events (native when available, synthetic fallback otherwise)"
+    )
+    bridge_parser.add_argument(
+        "--assistant-delta-chunk-size",
+        type=int,
+        default=120,
+        help="Chunk size for synthetic assistant_delta fallback conversion"
+    )
+    bridge_parser.add_argument(
+        "--native-assistant-delta",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Pass through native assistant_delta events from agent (default: on)"
+    )
+    bridge_parser.add_argument(
+        "--native-stream",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Enable model-native stream=True generation in the underlying agent"
+    )
+    bridge_parser.add_argument(
+        "--stream-first-chunk-timeout-ms",
+        type=int,
+        default=None,
+        help="Timeout waiting for first native stream chunk (milliseconds)"
+    )
+    bridge_parser.add_argument(
+        "--stream-idle-timeout-ms",
+        type=int,
+        default=None,
+        help="Max idle time between native stream chunks (milliseconds)"
+    )
+    bridge_parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable verbose logging in the underlying agent"
+    )
+    bridge_parser.set_defaults(func=cmd_bridge)
 
     # =========================================================================
     # model command

--- a/run_agent.py
+++ b/run_agent.py
@@ -30,8 +30,10 @@ import re
 import sys
 import time
 import threading
+import queue
 import uuid
-from typing import List, Dict, Any, Optional
+from types import SimpleNamespace
+from typing import List, Dict, Any, Optional, Callable, cast
 from openai import OpenAI
 import fire
 from datetime import datetime
@@ -104,34 +106,39 @@ class AIAgent:
     
     def __init__(
         self,
-        base_url: str = None,
-        api_key: str = None,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
         model: str = "anthropic/claude-opus-4.6",  # OpenRouter format
         max_iterations: int = 60,  # Default tool-calling iterations
         tool_delay: float = 1.0,
-        enabled_toolsets: List[str] = None,
-        disabled_toolsets: List[str] = None,
+        enabled_toolsets: Optional[List[str]] = None,
+        disabled_toolsets: Optional[List[str]] = None,
         save_trajectories: bool = False,
         verbose_logging: bool = False,
         quiet_mode: bool = False,
-        ephemeral_system_prompt: str = None,
+        ephemeral_system_prompt: Optional[str] = None,
         log_prefix_chars: int = 100,
         log_prefix: str = "",
-        providers_allowed: List[str] = None,
-        providers_ignored: List[str] = None,
-        providers_order: List[str] = None,
-        provider_sort: str = None,
-        session_id: str = None,
-        tool_progress_callback: callable = None,
-        clarify_callback: callable = None,
-        max_tokens: int = None,
-        reasoning_config: Dict[str, Any] = None,
-        prefill_messages: List[Dict[str, Any]] = None,
-        platform: str = None,
+        providers_allowed: Optional[List[str]] = None,
+        providers_ignored: Optional[List[str]] = None,
+        providers_order: Optional[List[str]] = None,
+        provider_sort: Optional[str] = None,
+        session_id: Optional[str] = None,
+        tool_progress_callback: Optional[Callable[[str, str], None]] = None,
+        clarify_callback: Optional[Callable[..., str]] = None,
+        event_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
+        max_tokens: Optional[int] = None,
+        reasoning_config: Optional[Dict[str, Any]] = None,
+        prefill_messages: Optional[List[Dict[str, Any]]] = None,
+        platform: Optional[str] = None,
         skip_context_files: bool = False,
         skip_memory: bool = False,
         session_db=None,
-        honcho_session_key: str = None,
+        honcho_session_key: Optional[str] = None,
+        enable_native_streaming: bool = False,
+        emit_assistant_delta_events: bool = True,
+        stream_first_chunk_timeout: Optional[float] = 30.0,
+        stream_idle_timeout: Optional[float] = 120.0,
     ):
         """
         Initialize the AI Agent.
@@ -158,6 +165,9 @@ class AIAgent:
             tool_progress_callback (callable): Callback function(tool_name, args_preview) for progress notifications
             clarify_callback (callable): Callback function(question, choices) -> str for interactive user questions.
                 Provided by the platform layer (CLI or gateway). If None, the clarify tool returns an error.
+            event_callback (callable): Optional callback(event_dict) invoked with structured
+                lifecycle events (conversation start/end, assistant messages, tool events, errors).
+                Useful for embedding Hermes in external hosts without parsing terminal output.
             max_tokens (int): Maximum tokens for model responses (optional, uses model default if not set)
             reasoning_config (Dict): OpenRouter reasoning configuration override (e.g. {"effort": "none"} to disable thinking).
                 If None, defaults to {"enabled": True, "effort": "xhigh"} for OpenRouter. Set to disable/customize reasoning.
@@ -171,6 +181,11 @@ class AIAgent:
                 polluting trajectories with user-specific persona or project instructions.
             honcho_session_key (str): Session key for Honcho integration (e.g., "telegram:123456" or CLI session_id).
                 When provided and Honcho is enabled in config, enables persistent cross-session user modeling.
+            enable_native_streaming (bool): Enable model-native stream=True chat completions.
+                Default False for conservative rollout.
+            emit_assistant_delta_events (bool): Emit assistant_delta events while streaming.
+            stream_first_chunk_timeout (float): Seconds to wait for first stream chunk before timing out.
+            stream_idle_timeout (float): Max idle seconds between stream chunks before timing out.
         """
         self.model = model
         self.max_iterations = max_iterations
@@ -195,6 +210,8 @@ class AIAgent:
             )
         self.tool_progress_callback = tool_progress_callback
         self.clarify_callback = clarify_callback
+        self.event_callback = event_callback
+        self._active_request_id = None
         self._last_reported_tool = None  # Track for "new tool" mode
         
         # Interrupt mechanism for breaking out of tool loops
@@ -219,6 +236,10 @@ class AIAgent:
         self.max_tokens = max_tokens  # None = use model default
         self.reasoning_config = reasoning_config  # None = use default (xhigh for OpenRouter)
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
+        self.enable_native_streaming = bool(enable_native_streaming)
+        self.emit_assistant_delta_events = bool(emit_assistant_delta_events)
+        self.stream_first_chunk_timeout = stream_first_chunk_timeout
+        self.stream_idle_timeout = stream_idle_timeout
         
         # Anthropic prompt caching: auto-enabled for Claude models via OpenRouter.
         # Reduces input costs by ~75% on multi-turn conversations by caching the
@@ -318,8 +339,8 @@ class AIAgent:
         
         # Get available tools with filtering
         self.tools = get_tool_definitions(
-            enabled_toolsets=enabled_toolsets,
-            disabled_toolsets=disabled_toolsets,
+            enabled_toolsets=cast(List[str], enabled_toolsets),
+            disabled_toolsets=cast(List[str], disabled_toolsets),
             quiet_mode=self.quiet_mode,
         )
         
@@ -515,6 +536,36 @@ class AIAgent:
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 
+    def _make_json_safe(self, value: Any):
+        """Best-effort conversion to JSON-serializable primitives."""
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+        if isinstance(value, dict):
+            return {str(k): self._make_json_safe(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple, set)):
+            return [self._make_json_safe(v) for v in value]
+        return str(value)
+
+    def _emit_event(self, event_type: str, **payload) -> None:
+        """Emit a structured lifecycle event to the optional callback."""
+        if not self.event_callback:
+            return
+
+        request_id = payload.get("request_id", self._active_request_id)
+        event: Dict[str, Any] = {
+            "type": event_type,
+            "session_id": self.session_id,
+            "timestamp": datetime.utcnow().isoformat(timespec="milliseconds") + "Z",
+        }
+        if request_id is not None:
+            event["request_id"] = self._make_json_safe(request_id)
+        if payload:
+            event.update({k: self._make_json_safe(v) for k, v in payload.items()})
+        try:
+            self.event_callback(event)
+        except Exception as cb_err:
+            logger.debug("Event callback error for %s: %s", event_type, cb_err)
+
     def _has_content_after_think_block(self, content: str) -> bool:
         """
         Check if content has actual text after any <think></think> blocks.
@@ -600,7 +651,7 @@ class AIAgent:
             if self.verbose_logging:
                 logging.warning(f"Failed to cleanup browser for task {task_id}: {e}")
 
-    def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
+    def _persist_session(self, messages: List[Dict[str, Any]], conversation_history: Optional[List[Dict[str, Any]]] = None):
         """Save session state to both JSON log and SQLite on any exit path.
 
         Ensures conversations are never lost, even on errors or early returns.
@@ -609,21 +660,14 @@ class AIAgent:
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
 
-    def _log_msg_to_db(self, msg: Dict):
+    def _log_msg_to_db(self, msg: Dict[str, Any]):
         """Log a single message to SQLite immediately. Called after each messages.append()."""
         if not self._session_db:
             return
         try:
             role = msg.get("role", "unknown")
             content = msg.get("content")
-            tool_calls_data = None
-            if hasattr(msg, "tool_calls") and msg.tool_calls:
-                tool_calls_data = [
-                    {"name": tc.function.name, "arguments": tc.function.arguments}
-                    for tc in msg.tool_calls
-                ]
-            elif isinstance(msg.get("tool_calls"), list):
-                tool_calls_data = msg["tool_calls"]
+            tool_calls_data = msg.get("tool_calls") if isinstance(msg.get("tool_calls"), list) else None
             self._session_db.append_message(
                 session_id=self.session_id,
                 role=role,
@@ -636,7 +680,11 @@ class AIAgent:
         except Exception as e:
             logger.debug("Session DB log_msg failed: %s", e)
 
-    def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
+    def _flush_messages_to_session_db(
+        self,
+        messages: List[Dict[str, Any]],
+        conversation_history: Optional[List[Dict[str, Any]]] = None,
+    ):
         """Persist any un-logged messages to the SQLite session store.
 
         Called both at the normal end of run_conversation and from every early-
@@ -650,14 +698,7 @@ class AIAgent:
             for msg in messages[start_idx:]:
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
-                tool_calls_data = None
-                if hasattr(msg, "tool_calls") and msg.tool_calls:
-                    tool_calls_data = [
-                        {"name": tc.function.name, "arguments": tc.function.arguments}
-                        for tc in msg.tool_calls
-                    ]
-                elif isinstance(msg.get("tool_calls"), list):
-                    tool_calls_data = msg["tool_calls"]
+                tool_calls_data = msg.get("tool_calls") if isinstance(msg.get("tool_calls"), list) else None
                 self._session_db.append_message(
                     session_id=self.session_id,
                     role=role,
@@ -670,7 +711,7 @@ class AIAgent:
         except Exception as e:
             logger.debug("Session DB append_message failed: %s", e)
 
-    def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
+    def _get_messages_up_to_last_assistant(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
         Get messages up to (but not including) the last assistant turn.
         
@@ -997,7 +1038,7 @@ class AIAgent:
         content = re.sub(r'(</think>)\n+', r'\1\n', content)
         return content.strip()
 
-    def _save_session_log(self, messages: List[Dict[str, Any]] = None):
+    def _save_session_log(self, messages: Optional[List[Dict[str, Any]]] = None):
         """
         Save the full raw session to a JSON file.
 
@@ -1040,7 +1081,7 @@ class AIAgent:
             if self.verbose_logging:
                 logging.warning(f"Failed to save session log: {e}")
     
-    def interrupt(self, message: str = None) -> None:
+    def interrupt(self, message: Optional[str] = None) -> None:
         """
         Request the agent to interrupt its current tool-calling loop.
         
@@ -1155,6 +1196,8 @@ class AIAgent:
         """
         if not content or not content.strip():
             return json.dumps({"success": False, "error": "Content cannot be empty."})
+        if not self._honcho or not self._honcho_session_key:
+            return json.dumps({"success": False, "error": "Honcho is not configured for this session."})
         try:
             session = self._honcho.get_or_create(self._honcho_session_key)
             session.add_message("user", f"[observation] {content.strip()}")
@@ -1180,7 +1223,7 @@ class AIAgent:
         except Exception as e:
             logger.debug("Honcho sync failed (non-fatal): %s", e)
 
-    def _build_system_prompt(self, system_message: str = None) -> str:
+    def _build_system_prompt(self, system_message: Optional[str] = None) -> str:
         """
         Assemble the full system prompt from all layers.
         
@@ -1257,16 +1300,17 @@ class AIAgent:
         if self._memory_store:
             self._memory_store.load_from_disk()
 
-    def _interruptible_api_call(self, api_kwargs: dict):
-        """
-        Run the API call in a background thread so the main conversation loop
-        can detect interrupts without waiting for the full HTTP round-trip.
-        
-        On interrupt, closes the HTTP client to cancel the in-flight request
-        (stops token generation and avoids wasting money), then rebuilds the
-        client for future calls.
-        """
-        result = {"response": None, "error": None}
+    def _obj_get(self, obj: Any, key: str, default: Any = None) -> Any:
+        """Read a field from either a dict-like or attribute object."""
+        if obj is None:
+            return default
+        if isinstance(obj, dict):
+            return obj.get(key, default)
+        return getattr(obj, key, default)
+
+    def _interruptible_non_stream_call(self, api_kwargs: dict):
+        """Run the (legacy) non-streaming API call in a background thread with interrupt support."""
+        result: Dict[str, Any] = {"response": None, "error": None}
 
         def _call():
             try:
@@ -1294,7 +1338,220 @@ class AIAgent:
             raise result["error"]
         return result["response"]
 
-    def _build_api_kwargs(self, api_messages: list) -> dict:
+    def _interruptible_stream_call(self, api_kwargs: dict, on_chunk: Callable[[Any], None]) -> None:
+        """Run a streaming API call with interrupt and timeout handling."""
+        q: "queue.Queue[tuple[str, Any]]" = queue.Queue()
+
+        def _stream_worker() -> None:
+            stream_obj = None
+            try:
+                stream_obj = self.client.chat.completions.create(**api_kwargs)
+                for chunk in stream_obj:
+                    q.put(("chunk", chunk))
+                q.put(("done", None))
+            except Exception as e:
+                q.put(("error", e))
+            finally:
+                if stream_obj is not None:
+                    try:
+                        close_fn = getattr(stream_obj, "close", None)
+                        if callable(close_fn):
+                            close_fn()
+                    except Exception:
+                        pass
+
+        t = threading.Thread(target=_stream_worker, daemon=True)
+        t.start()
+
+        start_ts = time.time()
+        last_chunk_ts = start_ts
+        first_chunk_seen = False
+
+        while True:
+            if self._interrupt_requested:
+                # Close connection
+                try:
+                    self.client.close()
+                except Exception:
+                    pass
+                # Rebuild the client for future calls (cheap, no network)
+                try:
+                    self.client = OpenAI(**self._client_kwargs)
+                except Exception:
+                    pass
+                raise InterruptedError("Agent interrupted during streaming API call")
+
+            try:
+                kind, payload = q.get(timeout=0.2)
+            except queue.Empty:
+                now = time.time()
+                if (not first_chunk_seen and self.stream_first_chunk_timeout is not None
+                        and (now - start_ts) > float(self.stream_first_chunk_timeout)):
+                    try:
+                        self.client.close()
+                    except Exception:
+                        pass
+                    raise TimeoutError(
+                        f"No first stream chunk received within {self.stream_first_chunk_timeout}s"
+                    )
+                if (first_chunk_seen and self.stream_idle_timeout is not None
+                        and (now - last_chunk_ts) > float(self.stream_idle_timeout)):
+                    try:
+                        self.client.close()
+                    except Exception:
+                        pass
+                    raise TimeoutError(
+                        f"Stream idle timeout after {self.stream_idle_timeout}s without chunks"
+                    )
+                continue
+
+            if kind == "chunk":
+                first_chunk_seen = True
+                last_chunk_ts = time.time()
+                on_chunk(payload)
+                continue
+            if kind == "error":
+                raise payload
+            if kind == "done":
+                return
+
+    def _interruptible_api_call(self, api_kwargs: dict):
+        """Backward-compatible non-stream call wrapper."""
+        return self._interruptible_non_stream_call(api_kwargs)
+
+    def _init_stream_turn_state(self) -> Dict[str, Any]:
+        # trying to support different providers/models
+        return {
+            "content_parts": [],
+            "reasoning_parts": [],
+            "reasoning_details": [],
+            "tool_calls_by_index": {},
+            "finish_reason": None,
+            "usage": None,
+            "delta_chunks": 0,
+        }
+
+    def _accumulate_tool_call_fragment(self, state: Dict[str, Any], tool_call_fragment: Any) -> None:
+        idx = self._obj_get(tool_call_fragment, "index")
+        if idx is None:
+            idx = len(state["tool_calls_by_index"])
+
+        entry = state["tool_calls_by_index"].setdefault(idx, {
+            "id": None,
+            "type": "function",
+            "name": None,
+            "arguments": "",
+        })
+
+        call_id = self._obj_get(tool_call_fragment, "id")
+        if call_id:
+            entry["id"] = call_id
+
+        call_type = self._obj_get(tool_call_fragment, "type")
+        if call_type:
+            entry["type"] = call_type
+
+        fn_delta = self._obj_get(tool_call_fragment, "function")
+        if fn_delta:
+            fn_name = self._obj_get(fn_delta, "name")
+            if fn_name:
+                entry["name"] = fn_name
+            args_delta = self._obj_get(fn_delta, "arguments")
+            if isinstance(args_delta, str):
+                entry["arguments"] += args_delta
+
+    def _consume_stream_chunk(self, chunk: Any, state: Dict[str, Any], *, request_id: Optional[str] = None) -> None:
+        usage = self._obj_get(chunk, "usage")
+        if usage is not None:
+            state["usage"] = usage
+
+        choices = self._obj_get(chunk, "choices") or []
+        if not choices:
+            return
+
+        choice = choices[0]
+        finish_reason = self._obj_get(choice, "finish_reason")
+        if finish_reason:
+            state["finish_reason"] = finish_reason
+
+        delta = self._obj_get(choice, "delta")
+        if delta is None:
+            return
+
+        text_delta = self._obj_get(delta, "content")
+        if isinstance(text_delta, str) and text_delta:
+            state["content_parts"].append(text_delta)
+            if self.emit_assistant_delta_events:
+                state["delta_chunks"] += 1
+                self._emit_event(
+                    "assistant_delta",
+                    request_id=request_id,
+                    delta=text_delta,
+                    delta_index=state["delta_chunks"],
+                    native=True,
+                )
+
+        reasoning_delta = self._obj_get(delta, "reasoning_content")
+        if reasoning_delta is None:
+            reasoning_delta = self._obj_get(delta, "reasoning")
+        if isinstance(reasoning_delta, str) and reasoning_delta:
+            state["reasoning_parts"].append(reasoning_delta)
+
+        reasoning_details_delta = self._obj_get(delta, "reasoning_details")
+        if isinstance(reasoning_details_delta, list):
+            state["reasoning_details"].extend(
+                d for d in reasoning_details_delta if isinstance(d, dict)
+            )
+
+        tool_calls_delta = self._obj_get(delta, "tool_calls")
+        if isinstance(tool_calls_delta, list):
+            for tc in tool_calls_delta:
+                self._accumulate_tool_call_fragment(state, tc)
+
+    def _finalize_stream_turn(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        content = "".join(state["content_parts"])
+        reasoning = "\\n".join(part for part in state["reasoning_parts"] if isinstance(part, str)).strip() or None
+
+        tool_calls = []
+        for idx in sorted(state["tool_calls_by_index"].keys()):
+            entry = state["tool_calls_by_index"][idx]
+            call_id = entry.get("id") or f"stream_tool_{idx}"
+            call_type = entry.get("type") or "function"
+            fn_name = entry.get("name") or "unknown"
+            args = entry.get("arguments") or ""
+            if not isinstance(args, str):
+                args = json.dumps(args)
+            if not args.strip():
+                args = "{}"
+
+            tool_calls.append(
+                SimpleNamespace(
+                    id=call_id,
+                    type=call_type,
+                    function=SimpleNamespace(name=fn_name, arguments=args),
+                )
+            )
+
+        assistant_message = SimpleNamespace(
+            content=content,
+            tool_calls=tool_calls,
+            reasoning=reasoning,
+        )
+        if state["reasoning_details"]:
+            assistant_message.reasoning_details = state["reasoning_details"]
+
+        usage = state.get("usage")
+        if isinstance(usage, dict):
+            usage = SimpleNamespace(**usage)
+
+        return {
+            "assistant_message": assistant_message,
+            "finish_reason": state.get("finish_reason"),
+            "usage": usage,
+            "delta_chunks": int(state.get("delta_chunks", 0) or 0),
+        }
+
+    def _build_api_kwargs(self, api_messages: list, *, stream: bool = False) -> dict:
         """Build the keyword arguments dict for the chat completions API call."""
         provider_preferences = {}
         if self.providers_allowed:
@@ -1312,6 +1569,9 @@ class AIAgent:
             "tools": self.tools if self.tools else None,
             "timeout": 900.0,
         }
+
+        if stream:
+            api_kwargs["stream"] = True
 
         if self.max_tokens is not None:
             api_kwargs.update(self._max_tokens_param(self.max_tokens))
@@ -1342,7 +1602,7 @@ class AIAgent:
 
         return api_kwargs
 
-    def _build_assistant_message(self, assistant_message, finish_reason: str) -> dict:
+    def _build_assistant_message(self, assistant_message, finish_reason: Optional[str]) -> dict:
         """Build a normalized assistant message dict from an API response message.
 
         Handles reasoning extraction, reasoning_details, and optional tool_calls
@@ -1356,34 +1616,36 @@ class AIAgent:
 
         msg = {
             "role": "assistant",
-            "content": assistant_message.content or "",
+            "content": (self._obj_get(assistant_message, "content") or ""),
             "reasoning": reasoning_text,
             "finish_reason": finish_reason,
         }
 
-        if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
+        reasoning_details = self._obj_get(assistant_message, "reasoning_details")
+        if reasoning_details:
             msg["reasoning_details"] = [
                 {"type": d.get("type"), "text": d.get("text"), "signature": d.get("signature")}
-                for d in assistant_message.reasoning_details
+                for d in reasoning_details
                 if isinstance(d, dict)
             ]
 
-        if assistant_message.tool_calls:
+        tool_calls = self._obj_get(assistant_message, "tool_calls") or []
+        if tool_calls:
             msg["tool_calls"] = [
                 {
-                    "id": tool_call.id,
-                    "type": tool_call.type,
+                    "id": self._obj_get(tool_call, "id"),
+                    "type": self._obj_get(tool_call, "type"),
                     "function": {
-                        "name": tool_call.function.name,
-                        "arguments": tool_call.function.arguments
+                        "name": self._obj_get(self._obj_get(tool_call, "function"), "name"),
+                        "arguments": self._obj_get(self._obj_get(tool_call, "function"), "arguments")
                     }
                 }
-                for tool_call in assistant_message.tool_calls
+                for tool_call in tool_calls
             ]
 
         return msg
 
-    def flush_memories(self, messages: list = None, min_turns: int = None):
+    def flush_memories(self, messages: Optional[list] = None, min_turns: Optional[int] = None):
         """Give the model one turn to persist memories before context is lost.
 
         Called before compression, session reset, or CLI exit. Injects a flush
@@ -1490,7 +1752,7 @@ class AIAgent:
             if messages and messages[-1].get("_flush_sentinel") == _sentinel:
                 messages.pop()
 
-    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None) -> tuple:
+    def _compress_context(self, messages: list, system_message: Optional[str], *, approx_tokens: Optional[int] = None) -> tuple:
         """Compress conversation context and split the session in SQLite.
 
         Returns:
@@ -1499,7 +1761,12 @@ class AIAgent:
         # Pre-compression memory flush: let the model save memories before they're lost
         self.flush_memories(messages, min_turns=0)
 
-        compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
+        current_tokens = (
+            approx_tokens
+            if approx_tokens is not None
+            else int(getattr(self.context_compressor, "last_prompt_tokens", 0) or 0)
+        )
+        compressed = self.context_compressor.compress(messages, current_tokens=current_tokens)
 
         todo_snapshot = self._todo_store.format_for_injection()
         if todo_snapshot:
@@ -1544,6 +1811,12 @@ class AIAgent:
                     }
                     messages.append(skip_msg)
                     self._log_msg_to_db(skip_msg)
+                    self._emit_event(
+                        "tool_skipped",
+                        tool_call_id=skipped_tc.id,
+                        name=getattr(getattr(skipped_tc, "function", None), "name", "unknown"),
+                        reason="interrupted",
+                    )
                 break
 
             function_name = tool_call.function.name
@@ -1554,11 +1827,31 @@ class AIAgent:
             elif function_name == "skill_manage":
                 self._iters_since_skill = 0
 
+            raw_arguments = getattr(getattr(tool_call, "function", None), "arguments", "{}")
+            if not isinstance(raw_arguments, str):
+                try:
+                    raw_arguments = json.dumps(raw_arguments)
+                except Exception:
+                    raw_arguments = "{}"
+            if not raw_arguments.strip():
+                raw_arguments = "{}"
+
             try:
-                function_args = json.loads(tool_call.function.arguments)
+                function_args = json.loads(raw_arguments)
+                if not isinstance(function_args, dict):
+                    logging.warning("Tool args must decode to an object; got %s", type(function_args).__name__)
+                    function_args = {}
             except json.JSONDecodeError as e:
                 logging.warning(f"Unexpected JSON error after validation: {e}")
                 function_args = {}
+
+            self._emit_event(
+                "tool_start",
+                tool_call_id=tool_call.id,
+                name=function_name,
+                arguments=function_args,
+                index=i,
+            )
 
             if not self.quiet_mode:
                 args_str = json.dumps(function_args, ensure_ascii=False)
@@ -1573,6 +1866,7 @@ class AIAgent:
                     logging.debug(f"Tool progress callback error: {cb_err}")
 
             tool_start_time = time.time()
+            tool_ok = True
 
             if function_name == "todo":
                 from tools.todo_tool import todo_tool as _todo_tool
@@ -1586,13 +1880,15 @@ class AIAgent:
                     print(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
             elif function_name == "session_search":
                 if not self._session_db:
+                    tool_ok = False
                     function_result = json.dumps({"success": False, "error": "Session database not available."})
                 else:
                     from tools.session_search_tool import session_search as _session_search
+                    role_filter = function_args.get("role_filter")
                     function_result = _session_search(
-                        query=function_args.get("query", ""),
-                        role_filter=function_args.get("role_filter"),
-                        limit=function_args.get("limit", 3),
+                        query=str(function_args.get("query", "")),
+                        role_filter=str(role_filter) if role_filter is not None else "",
+                        limit=int(function_args.get("limit", 3)),
                         db=self._session_db,
                     )
                 tool_duration = time.time() - tool_start_time
@@ -1602,10 +1898,10 @@ class AIAgent:
                 target = function_args.get("target", "memory")
                 from tools.memory_tool import memory_tool as _memory_tool
                 function_result = _memory_tool(
-                    action=function_args.get("action"),
-                    target=target,
-                    content=function_args.get("content"),
-                    old_text=function_args.get("old_text"),
+                    action=str(function_args.get("action", "")),
+                    target=str(target),
+                    content=str(function_args.get("content", "")),
+                    old_text=str(function_args.get("old_text", "")),
                     store=self._memory_store,
                 )
                 # Also send user observations to Honcho when active
@@ -1687,6 +1983,7 @@ class AIAgent:
                     function_result = handle_function_call(function_name, function_args, effective_task_id)
                     _spinner_result = function_result
                 except Exception as tool_error:
+                    tool_ok = False
                     function_result = f"Error executing tool '{function_name}': {tool_error}"
                     logger.error("handle_function_call raised for %s: %s", function_name, tool_error)
                 finally:
@@ -1697,6 +1994,7 @@ class AIAgent:
                 try:
                     function_result = handle_function_call(function_name, function_args, effective_task_id)
                 except Exception as tool_error:
+                    tool_ok = False
                     function_result = f"Error executing tool '{function_name}': {tool_error}"
                     logger.error("handle_function_call raised for %s: %s", function_name, tool_error)
                 tool_duration = time.time() - tool_start_time
@@ -1728,6 +2026,23 @@ class AIAgent:
             messages.append(tool_msg)
             self._log_msg_to_db(tool_msg)
 
+            self._emit_event(
+                "tool_result",
+                tool_call_id=tool_call.id,
+                name=function_name,
+                ok=tool_ok,
+                duration_ms=int(tool_duration * 1000),
+                content=function_result,
+            )
+            if not tool_ok:
+                self._emit_event(
+                    "error",
+                    stage="tool_execution",
+                    message=f"Tool '{function_name}' failed",
+                    retryable=False,
+                    tool_call_id=tool_call.id,
+                )
+
             if not self.quiet_mode:
                 response_preview = function_result[:self.log_prefix_chars] + "..." if len(function_result) > self.log_prefix_chars else function_result
                 print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s - {response_preview}")
@@ -1743,6 +2058,12 @@ class AIAgent:
                     }
                     messages.append(skip_msg)
                     self._log_msg_to_db(skip_msg)
+                    self._emit_event(
+                        "tool_skipped",
+                        tool_call_id=skipped_tc.id,
+                        name=getattr(getattr(skipped_tc, "function", None), "name", "unknown"),
+                        reason="interrupted",
+                    )
                 break
 
             if self.tool_delay > 0 and i < len(assistant_message.tool_calls):
@@ -1800,12 +2121,26 @@ class AIAgent:
                 final_response = summary_response.choices[0].message.content
                 if "<think>" in final_response:
                     final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
-                messages.append({"role": "assistant", "content": final_response})
+                summary_msg = {"role": "assistant", "content": final_response}
+                messages.append(summary_msg)
+                self._emit_event(
+                    "assistant_message",
+                    content=summary_msg.get("content"),
+                    has_tool_calls=False,
+                    finish_reason="max_iterations_summary",
+                    reasoning_present=False,
+                )
             else:
                 final_response = "I reached the iteration limit and couldn't generate a summary."
 
         except Exception as e:
             logging.warning(f"Failed to get summary response: {e}")
+            self._emit_event(
+                "error",
+                stage="max_iterations_summary",
+                message=str(e),
+                retryable=False,
+            )
             final_response = f"I reached the maximum iterations ({self.max_iterations}) but couldn't summarize. Error: {str(e)}"
 
         return final_response
@@ -1813,9 +2148,10 @@ class AIAgent:
     def run_conversation(
         self,
         user_message: str,
-        system_message: str = None,
-        conversation_history: List[Dict[str, Any]] = None,
-        task_id: str = None
+        system_message: Optional[str] = None,
+        conversation_history: Optional[List[Dict[str, Any]]] = None,
+        task_id: Optional[str] = None,
+        request_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run a complete conversation with tool calling until completion.
@@ -1825,6 +2161,7 @@ class AIAgent:
             system_message (str): Custom system message (optional, overrides ephemeral_system_prompt if provided)
             conversation_history (List[Dict]): Previous conversation messages (optional)
             task_id (str): Unique identifier for this task to isolate VMs between concurrent tasks (optional, auto-generated if not provided)
+            request_id (str): Optional external correlation ID (useful for bridge transports).
 
         Returns:
             Dict: Complete conversation result with final response and message history
@@ -1923,6 +2260,54 @@ class AIAgent:
         
         # Clear any stale interrupt state at start
         self.clear_interrupt()
+        self._active_request_id = request_id
+
+        def _finalize_result(payload: Dict[str, Any]) -> Dict[str, Any]:
+            error_msg = payload.get("error")
+            if error_msg:
+                self._emit_event(
+                    "error",
+                    request_id=request_id,
+                    stage=payload.get("error_stage", "run_conversation"),
+                    message=error_msg,
+                    retryable=payload.get("retryable", False),
+                )
+            self._emit_event(
+                "conversation_end",
+                request_id=request_id,
+                api_calls=payload.get("api_calls", api_call_count),
+                completed=payload.get("completed", False),
+                interrupted=payload.get("interrupted", False),
+                final_response_present=bool(payload.get("final_response")),
+                partial=payload.get("partial", False),
+                failed=payload.get("failed", False),
+            )
+            self._active_request_id = None
+            return payload
+
+        def _emit_assistant_turn_end_if_streamed() -> None:
+            if not stream_result:
+                return
+            delta_chunks = int(stream_result.get("delta_chunks") or 0)
+            if delta_chunks <= 0:
+                return
+            self._emit_event(
+                "assistant_message_end",
+                request_id=request_id,
+                delta_chunks=delta_chunks,
+                has_tool_calls=bool(getattr(assistant_message, "tool_calls", None)),
+                finish_reason=finish_reason,
+                reasoning_present=bool(self._extract_reasoning(assistant_message)),
+                native=True,
+            )
+
+        self._emit_event(
+            "conversation_start",
+            request_id=request_id,
+            user_message=user_message,
+            max_iterations=self.max_iterations,
+            resumed=bool(conversation_history),
+        )
         
         while api_call_count < self.max_iterations:
             # Check for interrupt request (e.g., user sent new message)
@@ -2018,15 +2403,40 @@ class AIAgent:
             api_start_time = time.time()
             retry_count = 0
             max_retries = 6  # Increased to allow longer backoff periods
+            api_kwargs: Dict[str, Any] = {}
+            response: Any = None
+            finish_reason: Optional[str] = None
+            stream_result: Optional[Dict[str, Any]] = None
+            native_stream_in_use = bool(self.enable_native_streaming)
 
             while retry_count < max_retries:
                 try:
-                    api_kwargs = self._build_api_kwargs(api_messages)
+                    stream_result = None
+                    api_kwargs = self._build_api_kwargs(api_messages, stream=native_stream_in_use)
 
                     if os.getenv("HERMES_DUMP_REQUESTS", "").strip().lower() in {"1", "true", "yes", "on"}:
                         self._dump_api_request_debug(api_kwargs, reason="preflight")
 
-                    response = self._interruptible_api_call(api_kwargs)
+                    if native_stream_in_use:
+                        stream_state: Dict[str, Any] = self._init_stream_turn_state()
+                        self._interruptible_stream_call(
+                            api_kwargs,
+                            lambda chunk, _state=stream_state: self._consume_stream_chunk(
+                                chunk,
+                                _state,
+                                request_id=request_id,
+                            ),
+                        )
+                        stream_result = self._finalize_stream_turn(stream_state)
+                        assistant_stream_msg = stream_result["assistant_message"]
+                        finish_reason = stream_result.get("finish_reason")
+                        response = SimpleNamespace(
+                            choices=[SimpleNamespace(message=assistant_stream_msg, finish_reason=finish_reason)],
+                            usage=stream_result.get("usage"),
+                            model=self.model,
+                        )
+                    else:
+                        response = self._interruptible_api_call(api_kwargs)
                     
                     api_duration = time.time() - api_start_time
                     
@@ -2094,13 +2504,13 @@ class AIAgent:
                             print(f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
                             logging.error(f"{self.log_prefix}Invalid API response after {max_retries} retries.")
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return _finalize_result({
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": f"Invalid API response (choices is None/empty). Likely rate limited by provider.",
                                 "failed": True  # Mark as failure for filtering
-                            }
+                            })
                         
                         # Longer backoff for rate limiting (likely cause of None choices)
                         wait_time = min(5 * (2 ** (retry_count - 1)), 120)  # 5s, 10s, 20s, 40s, 80s, 120s
@@ -2114,13 +2524,13 @@ class AIAgent:
                                 print(f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting.")
                                 self._persist_session(messages, conversation_history)
                                 self.clear_interrupt()
-                                return {
+                                return _finalize_result({
                                     "final_response": "Operation interrupted.",
                                     "messages": messages,
                                     "api_calls": api_call_count,
                                     "completed": False,
                                     "interrupted": True,
-                                }
+                                })
                             time.sleep(0.2)
                         continue  # Retry the API call
 
@@ -2139,26 +2549,26 @@ class AIAgent:
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
                             
-                            return {
+                            return _finalize_result({
                                 "final_response": None,
                                 "messages": rolled_back_messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
                                 "error": "Response truncated due to output length limit"
-                            }
+                            })
                         else:
                             # First message was truncated - mark as failed
                             print(f"{self.log_prefix}❌ First response truncated - cannot recover")
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return _finalize_result({
                                 "final_response": None,
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "failed": True,
                                 "error": "First response truncated due to output length limit"
-                            }
+                            })
                     
                     # Track actual token usage from response for context management
                     if hasattr(response, 'usage') and response.usage:
@@ -2199,6 +2609,14 @@ class AIAgent:
                     if thinking_spinner:
                         thinking_spinner.stop(f"(╥_╥) error, retrying...")
                         thinking_spinner = None
+
+                    self._emit_event(
+                        "error",
+                        request_id=request_id,
+                        stage="api_call",
+                        message=str(api_error),
+                        retryable=True,
+                    )
                     
                     retry_count += 1
                     elapsed_time = time.time() - api_start_time
@@ -2217,13 +2635,13 @@ class AIAgent:
                         print(f"{self.log_prefix}⚡ Interrupt detected during error handling, aborting retries.")
                         self._persist_session(messages, conversation_history)
                         self.clear_interrupt()
-                        return {
+                        return _finalize_result({
                             "final_response": "Operation interrupted.",
                             "messages": messages,
                             "api_calls": api_call_count,
                             "completed": False,
                             "interrupted": True,
-                        }
+                        })
                     
                     # Check for 413 payload-too-large BEFORE generic 4xx handler.
                     # A 413 is a payload-size error — the correct response is to
@@ -2251,13 +2669,13 @@ class AIAgent:
                             print(f"{self.log_prefix}❌ Payload too large and cannot compress further.")
                             logging.error(f"{self.log_prefix}413 payload too large. Cannot compress further.")
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return _finalize_result({
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": "Request payload too large (413). Cannot compress further.",
                                 "partial": True
-                            }
+                            })
 
                     # Check for non-retryable client errors (4xx HTTP status codes).
                     # These indicate a problem with the request itself (bad model ID,
@@ -2280,14 +2698,14 @@ class AIAgent:
                         print(f"{self.log_prefix}   💡 This type of error won't be fixed by retrying.")
                         logging.error(f"{self.log_prefix}Non-retryable client error: {api_error}")
                         self._persist_session(messages, conversation_history)
-                        return {
+                        return _finalize_result({
                             "final_response": None,
                             "messages": messages,
                             "api_calls": api_call_count,
                             "completed": False,
                             "failed": True,
                             "error": str(api_error),
-                        }
+                        })
                     
                     # Check for non-retryable errors (context length exceeded)
                     is_context_length_error = any(phrase in error_msg for phrase in [
@@ -2313,13 +2731,13 @@ class AIAgent:
                             print(f"{self.log_prefix}   💡 The conversation has accumulated too much content.")
                             logging.error(f"{self.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return _finalize_result({
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": f"Context length exceeded ({approx_tokens:,} tokens). Cannot compress further.",
                                 "partial": True
-                            }
+                            })
                     
                     if retry_count > max_retries:
                         print(f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded. Giving up.")
@@ -2341,18 +2759,36 @@ class AIAgent:
                             print(f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting.")
                             self._persist_session(messages, conversation_history)
                             self.clear_interrupt()
-                            return {
+                            return _finalize_result({
                                 "final_response": "Operation interrupted.",
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "interrupted": True,
-                            }
+                            })
                         time.sleep(0.2)  # Check interrupt every 200ms
             
             # If the API call was interrupted, skip response processing
             if interrupted:
                 break
+
+            if response is None or not getattr(response, "choices", None):
+                self._emit_event(
+                    "error",
+                    request_id=request_id,
+                    stage="response_processing",
+                    message="Missing response payload after retries",
+                    retryable=False,
+                )
+                self._persist_session(messages, conversation_history)
+                return _finalize_result({
+                    "final_response": None,
+                    "messages": messages,
+                    "api_calls": api_call_count,
+                    "completed": False,
+                    "failed": True,
+                    "error": "Missing response payload after retries",
+                })
 
             try:
                 assistant_message = response.choices[0].message
@@ -2383,14 +2819,14 @@ class AIAgent:
                         self._cleanup_task_resources(effective_task_id)
                         self._persist_session(messages, conversation_history)
                         
-                        return {
+                        return _finalize_result({
                             "final_response": None,
                             "messages": rolled_back_messages,
                             "api_calls": api_call_count,
                             "completed": False,
                             "partial": True,
                             "error": "Incomplete REASONING_SCRATCHPAD after 2 retries"
-                        }
+                        })
                 
                 # Reset incomplete scratchpad counter on clean response
                 if hasattr(self, '_incomplete_scratchpad_retries'):
@@ -2430,14 +2866,14 @@ class AIAgent:
                             # Return partial result - don't include the bad tool call in messages
                             self._invalid_tool_retries = 0
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return _finalize_result({
                                 "final_response": None,
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
                                 "error": f"Model generated invalid tool call: {invalid_preview}"
-                            }
+                            })
                     
                     # Reset retry counter on successful tool call validation
                     if hasattr(self, '_invalid_tool_retries'):
@@ -2506,6 +2942,14 @@ class AIAgent:
                     
                     messages.append(assistant_msg)
                     self._log_msg_to_db(assistant_msg)
+                    _emit_assistant_turn_end_if_streamed()
+                    self._emit_event(
+                        "assistant_message",
+                        content=assistant_msg.get("content"),
+                        has_tool_calls=bool(assistant_msg.get("tool_calls")),
+                        finish_reason=assistant_msg.get("finish_reason"),
+                        reasoning_present=bool(assistant_msg.get("reasoning")),
+                    )
                     
                     self._execute_tool_calls(assistant_message, messages, effective_task_id)
                     
@@ -2579,18 +3023,26 @@ class AIAgent:
                             }
                             messages.append(empty_msg)
                             self._log_msg_to_db(empty_msg)
+                            _emit_assistant_turn_end_if_streamed()
+                            self._emit_event(
+                                "assistant_message",
+                                content=empty_msg.get("content"),
+                                has_tool_calls=False,
+                                finish_reason=empty_msg.get("finish_reason"),
+                                reasoning_present=bool(empty_msg.get("reasoning")),
+                            )
                             
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
                             
-                            return {
+                            return _finalize_result({
                                 "final_response": final_response or None,
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
                                 "error": "Model generated only think blocks with no actual response after 3 retries"
-                            }
+                            })
                     
                     # Reset retry counter on successful content
                     if hasattr(self, '_empty_content_retries'):
@@ -2600,6 +3052,14 @@ class AIAgent:
                     
                     messages.append(final_msg)
                     self._log_msg_to_db(final_msg)
+                    _emit_assistant_turn_end_if_streamed()
+                    self._emit_event(
+                        "assistant_message",
+                        content=final_msg.get("content"),
+                        has_tool_calls=bool(final_msg.get("tool_calls")),
+                        finish_reason=final_msg.get("finish_reason"),
+                        reasoning_present=bool(final_msg.get("reasoning")),
+                    )
                     
                     if not self.quiet_mode:
                         print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
@@ -2607,6 +3067,13 @@ class AIAgent:
                 
             except Exception as e:
                 error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
+                self._emit_event(
+                    "error",
+                    request_id=request_id,
+                    stage="response_processing",
+                    message=error_msg,
+                    retryable=False,
+                )
                 print(f"❌ {error_msg}")
                 
                 if self.verbose_logging:
@@ -2692,7 +3159,7 @@ class AIAgent:
         # Clear interrupt state after handling
         self.clear_interrupt()
         
-        return result
+        return _finalize_result(result)
     
     def chat(self, message: str) -> str:
         """
@@ -2709,13 +3176,13 @@ class AIAgent:
 
 
 def main(
-    query: str = None,
+    query: Optional[str] = None,
     model: str = "anthropic/claude-opus-4.6",
-    api_key: str = None,
+    api_key: Optional[str] = None,
     base_url: str = "https://openrouter.ai/api/v1",
     max_turns: int = 10,
-    enabled_toolsets: str = None,
-    disabled_toolsets: str = None,
+    enabled_toolsets: Optional[str] = None,
+    disabled_toolsets: Optional[str] = None,
     list_tools: bool = False,
     save_trajectories: bool = False,
     save_sample: bool = False,

--- a/tests/hermes_cli/test_bridge.py
+++ b/tests/hermes_cli/test_bridge.py
@@ -1,0 +1,329 @@
+"""Tests for Hermes stdio bridge command."""
+
+import argparse
+import io
+import json
+import time
+from typing import Any, Callable, Optional, cast
+from unittest.mock import patch
+
+from hermes_cli.bridge import bridge_command
+from hermes_cli.main import cmd_bridge
+
+JsonDict = dict[str, Any]
+EventCallback = Callable[[JsonDict], None]
+
+
+def _bridge_args(**overrides: Any) -> argparse.Namespace:
+    base: JsonDict = {
+        "model": None,
+        "base_url": None,
+        "api_key": None,
+        "max_iterations": None,
+        "toolsets": None,
+        "disabled_toolsets": None,
+        "cwd": None,
+        "once": False,
+        "assistant_delta": False,
+        "assistant_delta_chunk_size": 120,
+        "native_assistant_delta": True,
+        "native_stream": False,
+        "stream_first_chunk_timeout_ms": None,
+        "stream_idle_timeout_ms": None,
+        "verbose": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_cmd_bridge_delegates_to_bridge_module() -> None:
+    args = _bridge_args()
+    with patch("hermes_cli.bridge.bridge_command", return_value=7) as mock_bridge:
+        result = cmd_bridge(args)
+
+    assert result == 7
+    mock_bridge.assert_called_once_with(args)
+
+
+def test_bridge_command_ping_roundtrip() -> None:
+    args = _bridge_args()
+    stdin = io.StringIO('{"type":"ping","request_id":"req-1"}\n')
+    stdout = io.StringIO()
+
+    rc = bridge_command(args, stdin=stdin, stdout=stdout, stderr=io.StringIO())
+
+    assert rc == 0
+    lines = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+    assert lines == [{"type": "pong", "request_id": "req-1"}]
+
+
+def test_bridge_command_run_missing_message_emits_validation_error() -> None:
+    args = _bridge_args(once=True)
+    stdin = io.StringIO('{"type":"run","request_id":"req-2"}\n')
+    stdout = io.StringIO()
+
+    rc = bridge_command(args, stdin=stdin, stdout=stdout, stderr=io.StringIO())
+
+    assert rc == 0
+    lines = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert lines[0]["type"] == "error"
+    assert lines[0]["request_id"] == "req-2"
+    assert lines[0]["stage"] == "request_validation"
+
+
+def test_bridge_command_interrupt_without_active_session_errors() -> None:
+    args = _bridge_args(once=True)
+    stdin = io.StringIO('{"type":"interrupt","request_id":"req-int","session_id":"s1"}\n')
+    stdout = io.StringIO()
+
+    rc = bridge_command(args, stdin=stdin, stdout=stdout, stderr=io.StringIO())
+
+    assert rc == 0
+    lines = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert lines[0]["type"] == "error"
+    assert lines[0]["request_id"] == "req-int"
+    assert lines[0]["stage"] == "request_validation"
+
+
+def test_bridge_command_assistant_delta_conversion() -> None:
+    args = _bridge_args(once=True)
+    stdin = io.StringIO(
+        '{"type":"run","request_id":"req-delta","session_id":"sess-1","message":"hello","assistant_delta":true,"assistant_delta_chunk_size":5}\n'
+    )
+    stdout = io.StringIO()
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            callback = kwargs.get("event_callback")
+            assert callable(callback)
+            self._event_callback: EventCallback = cast(EventCallback, callback)
+
+        def run_conversation(self, **kwargs: Any) -> JsonDict:
+            self._event_callback(
+                {
+                    "type": "assistant_message",
+                    "request_id": kwargs.get("request_id"),
+                    "session_id": kwargs.get("task_id") or "sess-1",
+                    "timestamp": "2026-01-01T00:00:00.000Z",
+                    "content": "hello world",
+                    "has_tool_calls": False,
+                    "finish_reason": "stop",
+                    "reasoning_present": False,
+                }
+            )
+            return {
+                "messages": [],
+                "final_response": "done",
+                "api_calls": 1,
+                "completed": True,
+                "partial": False,
+                "interrupted": False,
+            }
+
+    with patch("hermes_cli.bridge.AIAgent", FakeAIAgent):
+        rc = bridge_command(args, stdin=stdin, stdout=stdout, stderr=io.StringIO())
+
+    assert rc == 0
+    lines = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+    types = [entry["type"] for entry in lines]
+
+    assert "session" in types
+    assert "assistant_delta" in types
+    assert "assistant_message_end" in types
+    assert "final" in types
+    assert "assistant_message" not in types
+
+
+def test_bridge_command_interrupt_ack_for_active_session() -> None:
+    args = _bridge_args()
+    stdin = io.StringIO(
+        '{"type":"run","request_id":"req-run","session_id":"sess-int","message":"start"}\n'
+        '{"type":"interrupt","request_id":"req-stop","session_id":"sess-int","message":"stop"}\n'
+        '{"type":"shutdown","request_id":"req-shutdown"}\n'
+    )
+    stdout = io.StringIO()
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            self._interrupted = False
+
+        def interrupt(self, message: Optional[str] = None) -> None:
+            self._interrupted = True
+
+        def run_conversation(self, **kwargs: Any) -> JsonDict:
+            for _ in range(50):
+                if self._interrupted:
+                    break
+                time.sleep(0.01)
+            return {
+                "messages": [],
+                "final_response": "stopped" if self._interrupted else "done",
+                "api_calls": 1,
+                "completed": not self._interrupted,
+                "partial": False,
+                "interrupted": self._interrupted,
+            }
+
+    with patch("hermes_cli.bridge.AIAgent", FakeAIAgent):
+        rc = bridge_command(args, stdin=stdin, stdout=stdout, stderr=io.StringIO())
+
+    assert rc == 0
+    lines = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+    by_type: dict[str, list[JsonDict]] = {}
+    for line in lines:
+        by_type.setdefault(line["type"], []).append(line)
+
+    assert "interrupt_ack" in by_type
+    assert by_type["interrupt_ack"][0]["request_id"] == "req-stop"
+    assert by_type["interrupt_ack"][0]["accepted"] is True
+    assert "final" in by_type
+    assert by_type["final"][0]["interrupted"] is True
+
+
+def test_bridge_native_assistant_delta_passthrough_without_synthetic_duplication() -> None:
+    args = _bridge_args(once=True, assistant_delta=True, native_assistant_delta=True)
+    stdin = io.StringIO(
+        '{"type":"run","request_id":"req-native","session_id":"sess-native","message":"hello"}\n'
+    )
+    stdout = io.StringIO()
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            callback = kwargs.get("event_callback")
+            assert callable(callback)
+            self._event_callback: EventCallback = cast(EventCallback, callback)
+
+        def run_conversation(self, **kwargs: Any) -> JsonDict:
+            self._event_callback(
+                {
+                    "type": "assistant_delta",
+                    "delta": "hello ",
+                    "delta_index": 1,
+                    "native": True,
+                }
+            )
+            self._event_callback(
+                {
+                    "type": "assistant_delta",
+                    "delta": "world",
+                    "delta_index": 2,
+                    "native": True,
+                }
+            )
+            self._event_callback(
+                {
+                    "type": "assistant_message_end",
+                    "delta_chunks": 2,
+                    "native": True,
+                }
+            )
+            self._event_callback(
+                {
+                    "type": "assistant_message",
+                    "content": "hello world",
+                    "has_tool_calls": False,
+                    "finish_reason": "stop",
+                    "reasoning_present": False,
+                }
+            )
+            return {
+                "messages": [],
+                "final_response": "done",
+                "api_calls": 1,
+                "completed": True,
+                "partial": False,
+                "interrupted": False,
+            }
+
+    with patch("hermes_cli.bridge.AIAgent", FakeAIAgent):
+        rc = bridge_command(args, stdin=stdin, stdout=stdout, stderr=io.StringIO())
+
+    assert rc == 0
+    lines = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+    delta_events = [evt for evt in lines if evt.get("type") == "assistant_delta"]
+    end_events = [evt for evt in lines if evt.get("type") == "assistant_message_end"]
+    assert len(delta_events) == 2
+    assert len(end_events) == 1
+    assert [evt.get("delta") for evt in delta_events] == ["hello ", "world"]
+
+
+def test_bridge_assistant_delta_fallback_when_no_native_deltas() -> None:
+    args = _bridge_args(once=True, assistant_delta=True, native_assistant_delta=True)
+    stdin = io.StringIO(
+        '{"type":"run","request_id":"req-fallback","session_id":"sess-fallback","message":"hello"}\n'
+    )
+    stdout = io.StringIO()
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            callback = kwargs.get("event_callback")
+            assert callable(callback)
+            self._event_callback: EventCallback = cast(EventCallback, callback)
+
+        def run_conversation(self, **kwargs: Any) -> JsonDict:
+            self._event_callback(
+                {
+                    "type": "assistant_message",
+                    "timestamp": "2026-01-01T00:00:00.000Z",
+                    "content": "fallback text",
+                    "has_tool_calls": False,
+                    "finish_reason": "stop",
+                    "reasoning_present": False,
+                }
+            )
+            return {
+                "messages": [],
+                "final_response": "done",
+                "api_calls": 1,
+                "completed": True,
+                "partial": False,
+                "interrupted": False,
+            }
+
+    with patch("hermes_cli.bridge.AIAgent", FakeAIAgent):
+        rc = bridge_command(args, stdin=stdin, stdout=stdout, stderr=io.StringIO())
+
+    assert rc == 0
+    lines = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+    assert any(evt.get("type") == "assistant_delta" for evt in lines)
+    assert any(evt.get("type") == "assistant_message_end" for evt in lines)
+    assert not any(evt.get("type") == "assistant_message" for evt in lines)
+
+
+def test_bridge_event_order_native_deltas_before_final() -> None:
+    args = _bridge_args(once=True, assistant_delta=True, native_assistant_delta=True)
+    stdin = io.StringIO(
+        '{"type":"run","request_id":"req-order","session_id":"sess-order","message":"hello"}\n'
+    )
+    stdout = io.StringIO()
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            callback = kwargs.get("event_callback")
+            assert callable(callback)
+            self._event_callback: EventCallback = cast(EventCallback, callback)
+
+        def run_conversation(self, **kwargs: Any) -> JsonDict:
+            self._event_callback({"type": "assistant_delta", "delta": "a", "delta_index": 1, "native": True})
+            self._event_callback({"type": "assistant_message_end", "delta_chunks": 1, "native": True})
+            self._event_callback({"type": "assistant_message", "content": "a", "finish_reason": "stop"})
+            return {
+                "messages": [],
+                "final_response": "done",
+                "api_calls": 1,
+                "completed": True,
+                "partial": False,
+                "interrupted": False,
+            }
+
+    with patch("hermes_cli.bridge.AIAgent", FakeAIAgent):
+        rc = bridge_command(args, stdin=stdin, stdout=stdout, stderr=io.StringIO())
+
+    assert rc == 0
+    lines = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+    types = [evt.get("type") for evt in lines]
+    assert types.index("assistant_delta") < types.index("assistant_message_end")
+    assert types.index("assistant_message_end") < types.index("assistant_message")
+    assert types.index("assistant_message") < types.index("final")

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -758,3 +758,136 @@ class TestRunConversation:
             )
             result = agent.run_conversation("search something")
         mock_compress.assert_called_once()
+
+
+def _stream_tool_fragment(index=0, call_id=None, name=None, arguments=None, call_type="function"):
+    fn = SimpleNamespace(name=name, arguments=arguments)
+    return SimpleNamespace(index=index, id=call_id, type=call_type, function=fn)
+
+
+def _stream_chunk(*, content=None, tool_calls=None, finish_reason=None, usage=None, reasoning=None):
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls, reasoning=reasoning)
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+class TestRunConversationNativeStreaming:
+    def _setup_streaming_agent(self, agent):
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        agent.enable_native_streaming = True
+        agent.emit_assistant_delta_events = True
+
+    def test_stream_text_only_final_turn(self, agent):
+        self._setup_streaming_agent(agent)
+        events = []
+        agent.event_callback = lambda evt: events.append(evt)
+
+        def stream_call(_kwargs, on_chunk):
+            on_chunk(_stream_chunk(content="Hello "))
+            on_chunk(_stream_chunk(content="world", finish_reason="stop", usage={"prompt_tokens": 11, "completion_tokens": 3, "total_tokens": 14}))
+
+        with (
+            patch.object(agent, "_interruptible_stream_call", side_effect=stream_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Hello world"
+        delta_types = [evt["type"] for evt in events if evt.get("type") in {"assistant_delta", "assistant_message_end", "assistant_message"}]
+        assert "assistant_delta" in delta_types
+        assert "assistant_message_end" in delta_types
+        assert "assistant_message" in delta_types
+
+    def test_stream_tool_call_with_fragmented_args(self, agent):
+        self._setup_streaming_agent(agent)
+
+        def stream_call(_kwargs, on_chunk):
+            # Turn 1: tool call assembly
+            if not hasattr(stream_call, "count"):
+                stream_call.count = 0
+            stream_call.count += 1
+            if stream_call.count == 1:
+                on_chunk(
+                    _stream_chunk(
+                        tool_calls=[_stream_tool_fragment(index=0, call_id="c1", name="web_search", arguments='{"q":"he')]
+                    )
+                )
+                on_chunk(
+                    _stream_chunk(
+                        tool_calls=[_stream_tool_fragment(index=0, arguments='rmes"}')],
+                        finish_reason="tool_calls",
+                    )
+                )
+                return
+
+            # Turn 2: final response
+            on_chunk(_stream_chunk(content="Done", finish_reason="stop"))
+
+        with (
+            patch.object(agent, "_interruptible_stream_call", side_effect=stream_call),
+            patch("run_agent.handle_function_call", return_value="search result") as mock_tool,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search")
+
+        assert result["final_response"] == "Done"
+        mock_tool.assert_called_once()
+        assert mock_tool.call_args[0][0] == "web_search"
+        assert mock_tool.call_args[0][1] == {"q": "hermes"}
+
+    def test_stream_interrupted_mid_generation(self, agent):
+        self._setup_streaming_agent(agent)
+
+        with (
+            patch.object(agent, "_interruptible_stream_call", side_effect=InterruptedError("stop")),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["interrupted"] is True
+
+    def test_stream_finish_reason_length_returns_partial(self, agent):
+        self._setup_streaming_agent(agent)
+
+        def stream_call(_kwargs, on_chunk):
+            on_chunk(_stream_chunk(content="truncated", finish_reason="length"))
+
+        with (
+            patch.object(agent, "_interruptible_stream_call", side_effect=stream_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result.get("failed") is True
+        assert "truncated" in (result.get("error") or "")
+
+    def test_stream_usage_capture_updates_context_compressor(self, agent):
+        self._setup_streaming_agent(agent)
+
+        def stream_call(_kwargs, on_chunk):
+            on_chunk(_stream_chunk(content="ok", finish_reason="stop", usage={"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}))
+
+        with (
+            patch.object(agent, "_interruptible_stream_call", side_effect=stream_call),
+            patch.object(agent.context_compressor, "update_from_response") as mock_update,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "ok"
+        mock_update.assert_called_once()


### PR DESCRIPTION
## Title
**feat(bridge): add JSONL stdio bridge with native/synthetic streaming support, docs, and tests**

## Summary

This PR adds a new `hermes bridge` mode for embedding Hermes in external hosts (Electron apps, local servers, custom frontends, etc.) using a deterministic JSONL protocol over stdio.

It supports **both streaming and non-streaming consumers**:

- **Native streaming path** (`native_stream=true` + `native_assistant_delta=true`)
- **Synthetic streaming fallback** (bridge chunks full assistant turn into `assistant_delta`)
- **Non-streaming path** (full-turn `assistant_message` + `final` events)

## Why

Host integrations currently need a stable, machine-readable transport.  
This introduces a first-class bridge protocol so frontends can consume Hermes output without scraping TUI text.

## What’s included

### New
- `hermes_cli/bridge.py`
  - JSONL stdin request loop / stdout event emitter
  - Request types:
    - `run`
    - `ping` → `pong`
    - `interrupt` → `interrupt_ack`
    - `shutdown` / `exit` / `quit` → `shutdown_ack`
  - Session tracking + resume support
  - Active-run protection per `session_id`
  - Optional per-request/default `cwd` handling
  - JSON-safe event serialization

### Updated
- `hermes_cli/main.py`
  - Added `hermes bridge` command + args:
    - `--model`, `--base-url`, `--api-key`, `--max-iterations`
    - `--toolsets`, `--disabled-toolsets`
    - `--cwd`, `--once`, `--verbose`
    - `--assistant-delta`, `--assistant-delta-chunk-size`
    - `--native-assistant-delta`, `--native-stream`
    - stream timeout knobs

- `run_agent.py`
  - Bridge-facing event flow wired for tool/lifecycle/finalization + assistant delta streaming path

- `README.md`
  - Added bridge command docs and JSONL quick reference
  - Documented native vs synthetic `assistant_delta`

### Tests
- `tests/hermes_cli/test_bridge.py`
  - command delegation
  - ping/pong
  - request validation errors
  - interrupt behavior + ack
  - native delta passthrough
  - synthetic fallback behavior
  - event ordering guarantees
- `tests/test_run_agent.py`
  - additional native streaming and tool-call loop coverage

## Protocol behavior notes

- Deterministic turn ordering is enforced.
- With **native deltas**, clients receive deltas + end marker + full assistant message.
- With **synthetic fallback**, deltas are emitted from completed assistant content (to avoid duplication behavior is tested and documented).

## Backward compatibility

- No behavior changes to existing `hermes` / `hermes chat` flows.
- Bridge mode is additive (`hermes bridge` only).

## How to test

```bash
python -m pytest tests/hermes_cli/test_bridge.py -v
python -m pytest tests/test_run_agent.py -v
```

Manual smoke:
```jsonl
{"type":"run","request_id":"req-1","session_id":"sess-1","message":"Summarize README.md","assistant_delta":true,"native_stream":true,"native_assistant_delta":true}
{"type":"interrupt","request_id":"req-2","session_id":"sess-1","message":"stop now"}
{"type":"shutdown","request_id":"req-3"}
```

Branch may drift due to active upstream updates; happy to rebase/sync once review feedback is in.