### PR TITLE
fix: prioritize OPENROUTER_API_KEY over OPENAI_API_KEY

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -847,7 +847,7 @@ class HermesCLI:
             or os.getenv("OPENAI_BASE_URL")
             or os.getenv("OPENROUTER_BASE_URL", CLI_CONFIG["model"]["base_url"])
         )
-        self.api_key = api_key or os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
+        self.api_key = api_key or os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY")
         self._nous_key_expires_at: Optional[str] = None
         self._nous_key_source: Optional[str] = None
         # Max turns priority: CLI arg > config file > env var > default


### PR DESCRIPTION
## Problem
When `OPENAI_API_KEY` is set in the environment (e.g. `.bashrc`), 
it was being used instead of `OPENROUTER_API_KEY` when making 
requests to OpenRouter, causing authentication failures.

## Fix
Changed the key resolution order in `cli.py` line 850:

**Before:**
```python
self.api_key = api_key or os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
```

**After:**
```python
self.api_key = api_key or os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY")
```

Fixes #289