### PR TITLE
fix(cron): close lock_fd on failed flock to prevent fd leak

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -280,6 +280,7 @@ def tick(verbose: bool = True) -> int:
     _LOCK_DIR.mkdir(parents=True, exist_ok=True)
 
     # Cross-platform file locking: fcntl on Unix, msvcrt on Windows
+    lock_fd = None
     try:
         lock_fd = open(_LOCK_FILE, "w")
         if fcntl:
@@ -288,6 +289,8 @@ def tick(verbose: bool = True) -> int:
             msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
     except (OSError, IOError):
         logger.debug("Tick skipped — another instance holds the lock")
+        if lock_fd is not None:
+            lock_fd.close()
         return 0
 
     try:


### PR DESCRIPTION
`tick()` opens `lock_fd` before the `try` block, so if `fcntl.flock()` raises `BlockingIOError`, the except clause returns without closing it. In a long-running gateway process where concurrent tick attempts are normal, this leaks a file descriptor on every skipped tick.

Fix: initialize `lock_fd = None` before the try block and close it in the except clause if it was opened.