### PR TITLE
docs: bump year to 2026 in landing page

### DIFF
--- a/landingpage/index.html
+++ b/landingpage/index.html
@@ -462,7 +462,7 @@ hermes gateway install</code></pre>
             </div>
 
             <div class="footer-bottom">
-                <p>Built by <a href="https://nousresearch.com" target="_blank" rel="noopener">Nous Research</a> · MIT License · 2025</p>
+                <p>Built by <a href="https://nousresearch.com" target="_blank" rel="noopener">Nous Research</a> · MIT License · 2026</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
Updated the copyright year in the landing page footer to reflect the current year (2026)