### PR TITLE
fix: correct typo 'Grup' -> 'Group' in test section headers

### DIFF
--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -121,7 +121,7 @@ def _mock_response(content="Hello", finish_reason="stop", tool_calls=None,
 
 
 # ===================================================================
-# Grup 1: Pure Functions
+# Group 1: Pure Functions
 # ===================================================================
 
 
@@ -273,7 +273,7 @@ class TestMaskApiKey:
 
 
 # ===================================================================
-# Grup 2: State / Structure Methods
+# Group 2: State / Structure Methods
 # ===================================================================
 
 
@@ -569,7 +569,7 @@ class TestFormatToolsForSystemMessage:
 
 
 # ===================================================================
-# Grup 3: Conversation Loop Pieces (OpenAI mock)
+# Group 3: Conversation Loop Pieces (OpenAI mock)
 # ===================================================================
 
 


### PR DESCRIPTION
Three section header comments in tests/test_run_agent.py used 'Grup' instead of 'Group':

- Line 124: # Grup 1: Pure Functions
- Line 276: # Grup 2: State / Structure Methods
- Line 572: # Grup 3: Conversation Loop Pieces (OpenAI mock)