### PR TITLE
chore: add Ruff linter and formatter configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,40 @@ hermes chat -q "Hello"
 pytest tests/ -v
 ```
 
+### Code formatting
+
+We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Install it with the dev extras:
+
+```bash
+uv pip install -e ".[dev]"
+```
+
+Run the linter to check for issues:
+
+```bash
+ruff check .
+```
+
+Auto-fix safe issues:
+
+```bash
+ruff check --fix .
+```
+
+Format code:
+
+```bash
+ruff format .
+```
+
+**Before submitting a PR:**
+
+1. Run `ruff check .` and fix any errors
+2. Run `ruff format .` to ensure consistent formatting
+3. Both commands should report no changes needed
+
+The configuration is in `pyproject.toml`. We use a conservative rule set to avoid overwhelming diffs while catching common issues.
+
 ---
 
 ## Project Structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 modal = ["swe-rex[modal]>=1.4.0"]
-dev = ["pytest", "pytest-asyncio"]
+dev = ["pytest", "pytest-asyncio", "ruff>=0.4.0"]
 messaging = ["python-telegram-bot>=20.0", "discord.py>=2.0", "aiohttp>=3.9.0", "slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]
 cron = ["croniter"]
 slack = ["slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]
@@ -77,3 +77,47 @@ markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
 ]
 addopts = "-m 'not integration'"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ruff - Python linter and formatter (https://docs.astral.sh/ruff/)
+# ─────────────────────────────────────────────────────────────────────────────
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+
+[tool.ruff.lint]
+# Start with a conservative rule set to avoid overwhelming diffs
+select = [
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "F",     # pyflakes
+    "I",     # isort (import sorting)
+    "UP",    # pyupgrade (modernize Python syntax)
+    "B",     # flake8-bugbear (common bugs)
+    "C4",    # flake8-comprehensions
+    "PIE",   # flake8-pie (misc lints)
+    "SIM",   # flake8-simplify
+]
+ignore = [
+    "E501",  # line-too-long (let formatter handle this)
+    "E731",  # lambda assignment (common pattern in codebase)
+    "B008",  # function-call-in-default-argument (Fire uses this pattern)
+    "B905",  # zip-without-explicit-strict (Python 3.10+ only)
+    "SIM108", # ternary-if-else (can reduce readability)
+    "SIM105", # suppressible-exception (contextlib.suppress not always clearer)
+]
+# Allow unused variables when underscore-prefixed
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.isort]
+known-first-party = ["hermes_cli", "tools", "gateway", "cron", "honcho_integration"]
+
+[tool.ruff.format]
+# Use double quotes (matches existing style)
+quote-style = "double"
+# Indent with spaces
+indent-style = "space"
+# Respect magic trailing commas
+skip-magic-trailing-comma = false
+# Unix line endings
+line-ending = "auto"


### PR DESCRIPTION
## Summary

Addresses #255

Adds [Ruff](https://docs.astral.sh/ruff/) configuration for consistent code formatting and linting.

## Changes

- **pyproject.toml**: Added `[tool.ruff]` config sections with conservative rule set
- **pyproject.toml**: Added ruff to dev dependencies
- **CONTRIBUTING.md**: Added code formatting section with usage instructions

## Configuration Details

| Setting | Value | Rationale |
|---------|-------|-----------|
| Line length | 120 | Matches existing longer lines, modern standard |
| Target version | Python 3.10 | Matches `requires-python` |
| Lint rules | E, W, F, I, UP, B, C4, PIE, SIM | Conservative set: errors, warnings, pyflakes, isort, pyupgrade, bugbear, comprehensions, misc |
| Ignored | E501, E731, B008, B905, SIM108, SIM105 | Avoid breaking existing patterns |

## Current State

Running `ruff check .` on the current codebase:
- **6,210 issues found**
- **5,146 auto-fixable** with `--fix`

This PR intentionally does NOT fix existing issues — that should be done in follow-up PRs to keep diffs reviewable.

## Usage

```bash
# Install
uv pip install -e '.[dev]'

# Check for issues
ruff check .

# Auto-fix safe issues
ruff check --fix .

# Format code
ruff format .
```

## Follow-up Work

1. Add ruff to CI (GitHub Actions)
2. Fix existing issues in batches (separate PRs)
3. Consider adding pre-commit hook