### PR TITLE
fix(setup): improve shell config detection for PATH setup

### DIFF
--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -215,17 +215,28 @@ mkdir -p "$HOME/.local/bin"
 ln -sf "$HERMES_BIN" "$HOME/.local/bin/hermes"
 echo -e "${GREEN}✓${NC} Symlinked hermes → ~/.local/bin/hermes"
 
-# Ensure ~/.local/bin is on PATH in shell config
+# Determine the appropriate shell config file
 SHELL_CONFIG=""
-if [ -f "$HOME/.zshrc" ]; then
+if [[ "$SHELL" == *"zsh"* ]]; then
     SHELL_CONFIG="$HOME/.zshrc"
-elif [ -f "$HOME/.bashrc" ]; then
+elif [[ "$SHELL" == *"bash"* ]]; then
     SHELL_CONFIG="$HOME/.bashrc"
-elif [ -f "$HOME/.bash_profile" ]; then
-    SHELL_CONFIG="$HOME/.bash_profile"
+    [ ! -f "$SHELL_CONFIG" ] && SHELL_CONFIG="$HOME/.bash_profile"
+else
+    # Fallback to checking existing files
+    if [ -f "$HOME/.zshrc" ]; then
+        SHELL_CONFIG="$HOME/.zshrc"
+    elif [ -f "$HOME/.bashrc" ]; then
+        SHELL_CONFIG="$HOME/.bashrc"
+    elif [ -f "$HOME/.bash_profile" ]; then
+        SHELL_CONFIG="$HOME/.bash_profile"
+    fi
 fi
 
 if [ -n "$SHELL_CONFIG" ]; then
+    # Touch the file just in case it doesn't exist yet but was selected
+    touch "$SHELL_CONFIG" 2>/dev/null || true
+    
     if ! echo "$PATH" | tr ':' '\n' | grep -q "^$HOME/.local/bin$"; then
         if ! grep -q '\.local/bin' "$SHELL_CONFIG" 2>/dev/null; then
             echo "" >> "$SHELL_CONFIG"


### PR DESCRIPTION
## Summary
Addresses aspects of #202 (improve installer scripts)

**Problem:**
The previous version of [setup-hermes.sh](cci:7://file:///Users/mehmetkar/HERMES/hermes-agent/setup-hermes.sh:0:0-0:0) relied solely on checking if `.zshrc`, `.bashrc`, or `.bash_profile` existed on the system to append the `~/.local/bin` PATH. On environments (like macOS) where multiple shell configs might exist simultaneously, this occasionally led to the PATH being exported to the wrong config file, causing the `hermes` command to remain unrecognized upon shell reload.

**Fix/Implementation:**
- Improved the logic (lines 218-241) to actively assess the `$SHELL` environment variable first.
- The script now accurately targets `.zshrc` when running a ZSH environment, or `.bashrc` / `.bash_profile` for Bash environments, rather than just checking file existence sequentially.
- Automatically handles the creation of the config file using `touch` if it was selected but didn't exist yet, serving as a cleaner and more robust fallback mechanism.
