### PR TITLE
fix: key priority based on active endpoint, not fixed order

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -853,7 +853,13 @@ class HermesCLI:
             or os.getenv("OPENAI_BASE_URL")
             or os.getenv("OPENROUTER_BASE_URL", CLI_CONFIG["model"]["base_url"])
         )
-        self.api_key = api_key or os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY")
+        _openrouter_base = (os.getenv("OPENROUTER_BASE_URL") or OPENROUTER_BASE_URL).rstrip("/")
+        _on_openrouter = (self.base_url or "").rstrip("/") == _openrouter_base
+        self.api_key = (
+            api_key
+            or os.getenv("OPENROUTER_API_KEY" if _on_openrouter else "OPENAI_API_KEY")
+            or os.getenv("OPENAI_API_KEY" if _on_openrouter else "OPENROUTER_API_KEY")
+        )
         self._nous_key_expires_at: Optional[str] = None
         self._nous_key_source: Optional[str] = None
         # Max turns priority: CLI arg > config file > env var > default

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -72,10 +72,11 @@ def _resolve_openrouter_runtime(
         or OPENROUTER_BASE_URL
     ).rstrip("/")
 
+    openrouter_base = (env_openrouter_base_url or OPENROUTER_BASE_URL).rstrip("/")
     api_key = (
         explicit_api_key
-        or os.getenv("OPENROUTER_API_KEY")
-        or os.getenv("OPENAI_API_KEY")
+        or os.getenv("OPENROUTER_API_KEY" if base_url == openrouter_base else "OPENAI_API_KEY")
+        or os.getenv("OPENAI_API_KEY" if base_url == openrouter_base else "OPENROUTER_API_KEY")
         or ""
     )
 

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -121,6 +121,39 @@ def test_openai_key_used_when_no_openrouter_key(monkeypatch):
     assert resolved["api_key"] == "sk-openai-fallback"
 
 
+def test_openai_key_wins_on_custom_endpoint(monkeypatch):
+    """OPENAI_API_KEY should win when OPENAI_BASE_URL points to a custom endpoint.
+
+    Regression test: PR #295 inverted key priority globally, causing OPENROUTER_API_KEY
+    (even empty) to override OPENAI_API_KEY when users point hermes at a non-OpenRouter
+    provider via OPENAI_BASE_URL.
+    """
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.custom-provider.example/v1")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-custom-should-win")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-should-lose")
+
+    resolved = rp.resolve_runtime_provider(requested="auto")
+
+    assert resolved["api_key"] == "sk-custom-should-win"
+
+
+def test_openai_key_wins_on_custom_endpoint_even_when_openrouter_key_empty(monkeypatch):
+    """Empty OPENROUTER_API_KEY must not override a valid OPENAI_API_KEY on custom endpoints."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.z.ai/api/v1")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-zai-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "")
+
+    resolved = rp.resolve_runtime_provider(requested="auto")
+
+    assert resolved["api_key"] == "sk-zai-key"
+
+
 def test_resolve_requested_provider_precedence(monkeypatch):
     monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "nous")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openai-codex"})


### PR DESCRIPTION
## Summary

PR #295 fixed #289 by swapping key priority globally, but introduced a regression: if `OPENROUTER_API_KEY` is present in the environment (even empty, e.g. a docker-compose stanza with `OPENROUTER_API_KEY: ""`), it wins over `OPENAI_API_KEY` when hermes is pointing at a custom endpoint via `OPENAI_BASE_URL`.

Fix: resolve key priority based on the active base URL. When hitting OpenRouter, `OPENROUTER_API_KEY` wins (preserving the #289 fix). On any other endpoint, `OPENAI_API_KEY` wins.

Applied in both `hermes_cli/runtime_provider.py` and `cli.py`.

## Test plan

- [x] `test_openrouter_key_takes_priority_over_openai_key` — existing test passes (OpenRouter endpoint, OR key wins)
- [x] `test_openai_key_used_when_no_openrouter_key` — existing fallback test passes
- [x] `test_openai_key_wins_on_custom_endpoint` — new: both keys set, custom `OPENAI_BASE_URL`, OpenAI key wins
- [x] `test_openai_key_wins_on_custom_endpoint_even_when_openrouter_key_empty` — new: empty `OPENROUTER_API_KEY` doesn't override valid `OPENAI_API_KEY` on custom endpoint

Fixes #289