### PR TITLE
feat(tools): notification_tool clean rebuild

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -85,6 +85,7 @@ def _discover_tools():
         "tools.cronjob_tools",
         "tools.rl_training_tool",
         "tools.tts_tool",
+        "tools.notification_tool",
         "tools.todo_tool",
         "tools.memory_tool",
         "tools.session_search_tool",

--- a/tests/test_notification_tool.py
+++ b/tests/test_notification_tool.py
@@ -1,0 +1,234 @@
+"""
+Tests for notification_tool.
+Run: python -m pytest tests/test_notification_tool.py -v
+"""
+
+import importlib
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Insert repo root
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Save real module if already loaded
+_real_registry = sys.modules.get("tools.registry")
+
+# Install stub
+_registry_stub = MagicMock()
+_registry_mod = types.ModuleType("tools.registry")
+_registry_mod.registry = _registry_stub
+sys.modules["tools.registry"] = _registry_mod
+
+# Import notification_tool with stub active
+import tools.notification_tool as _nt
+from tools.notification_tool import (
+    _handle_notify,
+    _handle_notify_sound,
+    _applescript_escape,
+    _check_notify,
+    _check_sound,
+    _is_headless,
+)
+
+# Restore real registry module so other tests are not affected
+if _real_registry is not None:
+    sys.modules["tools.registry"] = _real_registry
+else:
+    del sys.modules["tools.registry"]
+
+
+class TestAppleScriptEscape(unittest.TestCase):
+    def test_plain_string(self):
+        assert _applescript_escape("Hello") == "Hello"
+
+    def test_double_quote_escaped(self):
+        assert '\\"' in _applescript_escape('Say "hi"')
+
+    def test_backslash_escaped(self):
+        assert "\\\\" in _applescript_escape("a\\b")
+
+    def test_single_quote_untouched(self):
+        assert "it's done" in _applescript_escape("it's done")
+
+
+class TestIsHeadless(unittest.TestCase):
+    def test_ssh_connection_env(self):
+        with patch.dict(os.environ, {"SSH_CONNECTION": "1.2.3.4 22 5.6.7.8 22"}):
+            assert _is_headless() is True
+
+    def test_ssh_tty_env(self):
+        with patch.dict(os.environ, {"SSH_TTY": "/dev/pts/0"}):
+            assert _is_headless() is True
+
+    @patch("sys.platform", "linux")
+    def test_linux_no_display(self):
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("DISPLAY", "WAYLAND_DISPLAY", "SSH_CONNECTION", "SSH_TTY")}
+        with patch.dict(os.environ, env, clear=True):
+            assert _is_headless() is True
+
+    @patch("sys.platform", "linux")
+    def test_linux_with_display(self):
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("SSH_CONNECTION", "SSH_TTY")}
+        env["DISPLAY"] = ":0"
+        with patch.dict(os.environ, env, clear=True):
+            assert _is_headless() is False
+
+
+class TestHandleNotifySSH(unittest.TestCase):
+    @patch("tools.notification_tool._is_headless", return_value=True)
+    @patch("builtins.print")
+    def test_ssh_falls_back_to_bell(self, mock_print, _):
+        result = _handle_notify({"title": "Done", "message": "Finished"})
+        assert result["success"] is True
+        assert result["backend"] == "terminal_bell"
+        mock_print.assert_called_with("\a", end="", flush=True)
+
+
+class TestHandleNotifyLinux(unittest.TestCase):
+    @patch("tools.notification_tool._is_headless", return_value=False)
+    @patch("sys.platform", "linux")
+    @patch("shutil.which", return_value="/usr/bin/notify-send")
+    @patch("subprocess.run")
+    def test_linux_success(self, mock_run, *_):
+        mock_run.return_value = MagicMock(returncode=0)
+        result = _handle_notify({"title": "Done", "message": "Task finished"})
+        assert result["success"] is True
+        assert result["backend"] == "linux"
+        call_args = mock_run.call_args[0][0]
+        assert "Done" in call_args and "Task finished" in call_args
+
+    @patch("tools.notification_tool._is_headless", return_value=False)
+    @patch("sys.platform", "linux")
+    @patch("shutil.which", return_value=None)
+    @patch("builtins.print")
+    def test_linux_fallback_to_bell(self, mock_print, *_):
+        result = _handle_notify({"title": "Done", "message": "Hi"})
+        assert result["success"] is True
+        assert result["backend"] == "terminal_bell"
+        mock_print.assert_called_with("\a", end="", flush=True)
+
+
+class TestHandleNotifyMacOS(unittest.TestCase):
+    @patch("tools.notification_tool._is_headless", return_value=False)
+    @patch("sys.platform", "darwin")
+    @patch("subprocess.run")
+    def test_macos_uses_osascript_stdin(self, mock_run, _):
+        mock_run.return_value = MagicMock(returncode=0)
+        result = _handle_notify({"title": "Done", "message": "Task finished"})
+        assert result["success"] is True
+        assert result["backend"] == "darwin"
+        assert mock_run.call_args[0][0] == ["osascript"]
+        stdin_input = mock_run.call_args[1].get("input", b"")
+        assert b"Done" in stdin_input and b"Task finished" in stdin_input
+
+    @patch("tools.notification_tool._is_headless", return_value=False)
+    @patch("sys.platform", "darwin")
+    @patch("subprocess.run")
+    def test_macos_special_chars_escaped(self, mock_run, _):
+        mock_run.return_value = MagicMock(returncode=0)
+        _handle_notify({"title": 'It\'s "done"', "message": 'Result: "OK"'})
+        stdin_input = mock_run.call_args[1].get("input", b"")
+        assert b'\\"' in stdin_input
+
+
+class TestHandleNotifyWindows(unittest.TestCase):
+    @patch("tools.notification_tool._is_headless", return_value=False)
+    @patch("sys.platform", "win32")
+    @patch("subprocess.run")
+    def test_windows_uses_encoded_command(self, mock_run, _):
+        mock_run.return_value = MagicMock(returncode=0)
+        result = _handle_notify({"title": "Done", "message": "Finished"})
+        assert result["success"] is True
+        call_args = mock_run.call_args[0][0]
+        assert "-EncodedCommand" in call_args
+        assert "Done" in call_args
+        assert "Finished" in call_args
+
+    @patch("tools.notification_tool._is_headless", return_value=False)
+    @patch("sys.platform", "win32")
+    @patch("subprocess.run")
+    def test_windows_injection_safe(self, mock_run, _):
+        import base64
+        mock_run.return_value = MagicMock(returncode=0)
+        evil = '"; Remove-Item -Recurse C:\\ #'
+        _handle_notify({"title": evil, "message": "ok"})
+        call_args = mock_run.call_args[0][0]
+        encoded_idx = call_args.index("-EncodedCommand") + 1
+        decoded = base64.b64decode(call_args[encoded_idx]).decode("utf-16-le")
+        assert evil not in decoded
+
+
+class TestHandleSound(unittest.TestCase):
+    @patch("sys.platform", "darwin")
+    @patch("subprocess.run")
+    def test_macos_sound_complete(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        result = _handle_notify_sound({"sound": "complete"})
+        assert result["success"] is True
+        assert "Glass.aiff" in mock_run.call_args[0][0][1]
+
+    @patch("sys.platform", "darwin")
+    @patch("subprocess.run")
+    def test_macos_sound_error(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        result = _handle_notify_sound({"sound": "error"})
+        assert "Basso.aiff" in mock_run.call_args[0][0][1]
+
+    @patch("sys.platform", "linux")
+    @patch("shutil.which", return_value=None)
+    @patch("builtins.print")
+    def test_linux_no_player_fallback(self, mock_print, *_):
+        result = _handle_notify_sound({})
+        assert result["success"] is True
+        assert result["backend"] == "terminal_bell"
+
+    @patch("sys.platform", "win32")
+    @patch("subprocess.run")
+    def test_windows_sound_encoded_command(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        result = _handle_notify_sound({"sound": "default"})
+        assert result["success"] is True
+        assert "-EncodedCommand" in mock_run.call_args[0][0]
+
+
+class TestUrgencyValidation(unittest.TestCase):
+    @patch("tools.notification_tool._is_headless", return_value=False)
+    @patch("sys.platform", "linux")
+    @patch("shutil.which", return_value="/usr/bin/notify-send")
+    @patch("subprocess.run")
+    def test_invalid_urgency_defaults_to_normal(self, mock_run, *_):
+        mock_run.return_value = MagicMock(returncode=0)
+        _handle_notify({"title": "Hi", "message": "Hello", "urgency": "INVALID"})
+        call_args = mock_run.call_args[0][0]
+        assert call_args[call_args.index("--urgency") + 1] == "normal"
+
+
+class TestCheckFunctions(unittest.TestCase):
+    @patch("tools.notification_tool._is_headless", return_value=True)
+    def test_check_notify_headless_true(self, _):
+        assert _check_notify() is True
+
+    @patch("tools.notification_tool._is_headless", return_value=False)
+    @patch("sys.platform", "linux")
+    @patch("shutil.which", return_value="/usr/bin/notify-send")
+    def test_check_notify_linux_available(self, *_):
+        assert _check_notify() is True
+
+    @patch("tools.notification_tool._is_headless", return_value=False)
+    @patch("sys.platform", "linux")
+    @patch("shutil.which", return_value=None)
+    def test_check_notify_linux_unavailable(self, *_):
+        assert _check_notify() is False
+
+    @patch("sys.platform", "darwin")
+    def test_check_notify_macos_always_true(self):
+        assert _check_notify() is True
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/notification_tool.py
+++ b/tools/notification_tool.py
@@ -1,0 +1,244 @@
+"""
+notification_tool — Send desktop notifications and alert sounds when Hermes
+finishes long-running tasks. Works locally and degrades gracefully over SSH.
+"""
+
+import base64
+import os
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+from tools.registry import registry
+
+
+def _is_headless() -> bool:
+    """Return True when running over SSH or without a display server."""
+    if os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY"):
+        return True
+    if sys.platform == "linux":
+        return not (
+            os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
+        )
+    return False
+
+
+def _check_notify() -> bool:
+    if _is_headless():
+        return True  # terminal bell fallback always works
+    if sys.platform == "linux":
+        return shutil.which("notify-send") is not None
+    if sys.platform in ("darwin", "win32"):
+        return True
+    return False
+
+
+def _check_sound() -> bool:
+    if sys.platform == "linux":
+        return (
+            shutil.which("paplay") is not None
+            or shutil.which("aplay") is not None
+            or True  # terminal bell fallback
+        )
+    if sys.platform in ("darwin", "win32"):
+        return True
+    return False
+
+
+def _applescript_escape(value: str) -> str:
+    """Escape a string for safe embedding in an AppleScript quoted string."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _handle_notify(args: dict[str, Any], **kwargs) -> dict[str, Any]:
+    title   = str(args.get("title",   "Hermes"))
+    message = str(args.get("message", "Task complete."))
+    urgency = str(args.get("urgency", "normal"))
+
+    if urgency not in ("low", "normal", "critical"):
+        urgency = "normal"
+
+    # SSH / headless — terminal bell only
+    if _is_headless():
+        print("\a", end="", flush=True)
+        return {"success": True, "backend": "terminal_bell",
+                "note": "SSH/headless session; used terminal bell"}
+
+    try:
+        if sys.platform == "linux":
+            if shutil.which("notify-send"):
+                subprocess.run(
+                    ["notify-send", "--urgency", urgency, "--", title, message],
+                    check=True, capture_output=True,
+                )
+            else:
+                print("\a", end="", flush=True)
+                return {"success": True, "backend": "terminal_bell",
+                        "note": "notify-send not found; used terminal bell"}
+
+        elif sys.platform == "darwin":
+            # Pass via stdin to avoid any shell interpolation
+            script = (
+                f'display notification "{_applescript_escape(message)}" '
+                f'with title "{_applescript_escape(title)}"'
+            )
+            subprocess.run(
+                ["osascript"], input=script.encode(), check=True, capture_output=True
+            )
+
+        elif sys.platform == "win32":
+            # Use -EncodedCommand so title/message never touch the PS command string
+            ps_raw = (
+                "param([string]$T,[string]$M);"
+                "Add-Type -AssemblyName System.Windows.Forms;"
+                "$n=New-Object System.Windows.Forms.NotifyIcon;"
+                "$n.Icon=[System.Drawing.SystemIcons]::Information;"
+                "$n.Visible=$true;"
+                "$n.ShowBalloonTip(5000,$T,$M,[System.Windows.Forms.ToolTipIcon]::None);"
+                "Start-Sleep -Seconds 6;$n.Dispose()"
+            )
+            encoded = base64.b64encode(ps_raw.encode("utf-16-le")).decode("ascii")
+            subprocess.run(
+                ["powershell", "-NoProfile", "-EncodedCommand", encoded,
+                 "-T", title, "-M", message],
+                check=True, capture_output=True,
+            )
+
+        else:
+            print("\a", end="", flush=True)
+            return {"success": True, "backend": "terminal_bell"}
+
+        return {"success": True, "backend": sys.platform}
+
+    except subprocess.CalledProcessError as e:
+        print("\a", end="", flush=True)
+        return {
+            "success": True,
+            "backend": "terminal_bell",
+            "note": f"Primary backend failed ({e}); used terminal bell",
+        }
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+def _handle_notify_sound(args: dict[str, Any], **kwargs) -> dict[str, Any]:
+    sound = str(args.get("sound", "default"))
+
+    try:
+        if sys.platform == "linux":
+            candidates = [
+                "/usr/share/sounds/freedesktop/stereo/complete.oga",
+                "/usr/share/sounds/freedesktop/stereo/message.oga",
+                "/usr/share/sounds/alsa/Front_Center.wav",
+            ]
+            player = shutil.which("paplay") or shutil.which("aplay")
+            played = False
+            if player:
+                for path in candidates:
+                    if not os.path.exists(path):
+                        continue
+                    try:
+                        subprocess.run([player, path], check=True, capture_output=True)
+                        played = True
+                        break
+                    except subprocess.CalledProcessError:
+                        continue
+            if not played:
+                print("\a", end="", flush=True)
+                return {"success": True, "backend": "terminal_bell"}
+
+        elif sys.platform == "darwin":
+            sound_map = {"default": "Ping", "error": "Basso", "complete": "Glass"}
+            sound_name = sound_map.get(sound, "Ping")
+            subprocess.run(
+                ["afplay", f"/System/Library/Sounds/{sound_name}.aiff"],
+                check=True, capture_output=True,
+            )
+
+        elif sys.platform == "win32":
+            freq = {"default": 800, "error": 400, "complete": 1000}.get(sound, 800)
+            ps_cmd = f"[System.Media.SystemSounds]::Beep.Play(); [console]::beep({freq},400)"
+            encoded = base64.b64encode(ps_cmd.encode("utf-16-le")).decode("ascii")
+            subprocess.run(
+                ["powershell", "-NoProfile", "-EncodedCommand", encoded],
+                check=True, capture_output=True,
+            )
+
+        else:
+            print("\a", end="", flush=True)
+            return {"success": True, "backend": "terminal_bell"}
+
+        return {"success": True, "backend": sys.platform}
+
+    except subprocess.CalledProcessError as e:
+        print("\a", end="", flush=True)
+        return {
+            "success": True,
+            "backend": "terminal_bell",
+            "note": f"Primary backend failed ({e}); used terminal bell",
+        }
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+registry.register(
+    name="notify",
+    toolset="notification",
+    schema={
+        "name": "notify",
+        "description": (
+            "Send a desktop notification to the user. "
+            "Falls back to a terminal bell when running over SSH or "
+            "when no display server is available."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Notification title, e.g. 'Task Complete'",
+                },
+                "message": {
+                    "type": "string",
+                    "description": "Notification body text",
+                },
+                "urgency": {
+                    "type": "string",
+                    "enum": ["low", "normal", "critical"],
+                    "description": "Urgency level (Linux only). Default: normal",
+                    "default": "normal",
+                },
+            },
+            "required": ["title", "message"],
+        },
+    },
+    handler=lambda args, **kw: _handle_notify(args, **kw),
+    check_fn=_check_notify,
+)
+
+registry.register(
+    name="notify_sound",
+    toolset="notification",
+    schema={
+        "name": "notify_sound",
+        "description": (
+            "Play a system alert sound. "
+            "Falls back to a terminal bell on headless / SSH environments."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "sound": {
+                    "type": "string",
+                    "enum": ["default", "error", "complete"],
+                    "description": "Sound style hint. Default: default",
+                    "default": "default",
+                },
+            },
+            "required": [],
+        },
+    },
+    handler=lambda args, **kw: _handle_notify_sound(args, **kw),
+    check_fn=_check_sound,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -148,6 +148,12 @@ TOOLSETS = {
         "includes": []
     },
     
+    "notification": {
+        "description": "Desktop notifications and alert sounds (notify-send, osascript, PowerShell). Falls back to terminal bell over SSH.",
+        "tools": ["notify", "notify_sound"],
+        "includes": []
+    },
+
     "tts": {
         "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, or OpenAI",
         "tools": ["text_to_speech"],


### PR DESCRIPTION
Clean rebuild addressing all review feedback from #170, and all requirements from #318.
Changes:
	∙	Correct module-level registry.register() pattern (matches tts_tool.py)
	∙	Handler signature: (args: dict, **kwargs) with lambda wrappers
	∙	No string interpolation — subprocess.run() with list args throughout
	∙	macOS: script passed via stdin (no -e shell interpolation)
	∙	Windows: -EncodedCommand (base64) — title/message passed as -T/-M params, never interpolated into PS script
	∙	_is_headless() — detects $SSH\_CONNECTION, $SSH_TTY, $DISPLAY, $WAYLAND_DISPLAY
	∙	SSH/headless automatic fallback to terminal bell on all platforms
	∙	Distro-agnostic sound paths with fallback
	∙	Registered in model_tools.py _discover_tools()
	∙	"notification" toolset added to toolsets.py — works with hermes tools enable/disable
	∙	24 tests covering all platforms, SSH fallback, Windows injection safety, urgency validation
Files changed:
	∙	tools/notification_tool.py
	∙	tests/test_notification_tool.py
	∙	model_tools.py
	∙	toolsets.py