### PR TITLE
feat(tools): add translation tool with 100+ language support

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -95,6 +95,7 @@ def _discover_tools():
         "tools.send_message_tool",
         "tools.honcho_tools",
         "tools.homeassistant_tool",
+        "tools.translation_tool",
     ]
     import importlib
     for mod_name in _modules:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
   "platformdirs",
   # Skills Hub (GitHub App JWT auth — optional, only needed for bot identity)
   "PyJWT[crypto]",
+  # Translation (Google Translate, no API key needed)
+  "deep-translator",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,9 @@ platformdirs
 # Text-to-speech (Edge TTS is free, no API key needed)
 edge-tts
 
+# Translation (Google Translate, no API key needed)
+deep-translator
+
 # Optional: For cron expression parsing (cronjob scheduling)
 croniter
 

--- a/tools/translation_tool.py
+++ b/tools/translation_tool.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Translation Tool Module - Multi-language Text Translation
+
+Provides text translation between 100+ languages using the deep-translator
+library (Google Translate backend, no API key required).
+
+The agent can translate user messages, documents, or any text on the fly,
+making Hermes useful for international and multilingual users.
+
+Usage:
+    translate_tool(text="Hello world", target="tr")          # -> "Merhaba dünya"
+    translate_tool(text="Bonjour", source="fr", target="en") # -> "Hello"
+    translate_tool(action="languages")                        # -> list of supported languages
+"""
+
+import json
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Lazy-loaded translator to avoid import errors if deep-translator isn't installed
+_translator_available = None
+
+
+def _check_translator():
+    """Check if deep-translator is installed."""
+    global _translator_available
+    if _translator_available is None:
+        try:
+            from deep_translator import GoogleTranslator
+            _translator_available = True
+        except ImportError:
+            _translator_available = False
+    return _translator_available
+
+
+def check_translation_requirements() -> bool:
+    """Check if translation tool dependencies are available."""
+    return _check_translator()
+
+
+def translate_tool(
+    text: Optional[str] = None,
+    target: str = "en",
+    source: str = "auto",
+    action: str = "translate",
+) -> str:
+    """
+    Translate text between languages or list supported languages.
+
+    Args:
+        text: The text to translate.
+        target: Target language code (e.g., 'en', 'tr', 'fr', 'de', 'ja').
+        source: Source language code or 'auto' for auto-detection.
+        action: 'translate' to translate text, 'languages' to list supported languages.
+
+    Returns:
+        JSON string with translation result or language list.
+    """
+    if not _check_translator():
+        return json.dumps({
+            "error": "deep-translator is not installed. Run: pip install deep-translator"
+        }, ensure_ascii=False)
+
+    from deep_translator import GoogleTranslator
+
+    try:
+        if action == "languages":
+            langs = GoogleTranslator().get_supported_languages(as_dict=True)
+            return json.dumps({
+                "action": "languages",
+                "languages": langs,
+                "count": len(langs),
+            }, ensure_ascii=False)
+
+        if not text or not text.strip():
+            return json.dumps({"error": "No text provided for translation."}, ensure_ascii=False)
+
+        translator = GoogleTranslator(source=source, target=target)
+        translated = translator.translate(text)
+
+        return json.dumps({
+            "action": "translate",
+            "source_language": source,
+            "target_language": target,
+            "original_text": text,
+            "translated_text": translated,
+        }, ensure_ascii=False)
+
+    except Exception as e:
+        logger.error("Translation error: %s", e)
+        return json.dumps({
+            "error": f"Translation failed: {type(e).__name__}: {e}"
+        }, ensure_ascii=False)
+
+
+# =============================================================================
+# OpenAI Function-Calling Schema
+# =============================================================================
+
+TRANSLATE_SCHEMA = {
+    "name": "translate",
+    "description": (
+        "Translate text between 100+ languages using Google Translate. "
+        "No API key required. Supports auto-detection of source language.\n\n"
+        "Actions:\n"
+        "- translate: Translate text from source to target language\n"
+        "- languages: List all supported language codes\n\n"
+        "Common language codes: en (English), tr (Turkish), fr (French), "
+        "de (German), es (Spanish), it (Italian), pt (Portuguese), "
+        "ru (Russian), ja (Japanese), ko (Korean), zh-CN (Chinese Simplified), "
+        "ar (Arabic), hi (Hindi), nl (Dutch), sv (Swedish)\n\n"
+        "Example: translate(text='Hello world', target='tr') -> 'Merhaba dünya'"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {
+                "type": "string",
+                "description": "The text to translate. Required for 'translate' action."
+            },
+            "target": {
+                "type": "string",
+                "description": (
+                    "Target language code (e.g., 'en', 'tr', 'fr', 'de', 'ja'). "
+                    "Defaults to 'en'."
+                ),
+                "default": "en"
+            },
+            "source": {
+                "type": "string",
+                "description": (
+                    "Source language code or 'auto' for automatic detection. "
+                    "Defaults to 'auto'."
+                ),
+                "default": "auto"
+            },
+            "action": {
+                "type": "string",
+                "enum": ["translate", "languages"],
+                "description": (
+                    "'translate' to translate text (default), "
+                    "'languages' to list all supported language codes."
+                ),
+                "default": "translate"
+            }
+        },
+        "required": []
+    }
+}
+
+
+# --- Registry ---
+from tools.registry import registry
+
+registry.register(
+    name="translate",
+    toolset="translation",
+    schema=TRANSLATE_SCHEMA,
+    handler=lambda args, **kw: translate_tool(
+        text=args.get("text"),
+        target=args.get("target", "en"),
+        source=args.get("source", "auto"),
+        action=args.get("action", "translate"),
+    ),
+    check_fn=check_translation_requirements,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -64,6 +64,8 @@ _HERMES_CORE_TOOLS = [
     "query_user_context",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+    # Translation (gated on deep-translator via check_fn)
+    "translate",
 ]
 
 
@@ -202,6 +204,11 @@ TOOLSETS = {
         "includes": []
     },
 
+    "translation": {
+        "description": "Multi-language text translation (100+ languages, no API key needed)",
+        "tools": ["translate"],
+        "includes": []
+    },
 
     # Scenario-specific toolsets
     


### PR DESCRIPTION
## Summary

- Adds a new `translate` tool powered by **deep-translator** (Google Translate backend)
- Supports **133 languages** with automatic source language detection
- **No API key required** — works out of the box, zero configuration
- Fully integrated into the existing tool registry, toolset system, and all platform toolsets (CLI, Telegram, Discord, Slack, WhatsApp)

## What it does

Users can ask Hermes to translate any text between languages:

```
"Translate 'Hello world' to Turkish"  →  "Merhaba dünya"
"What does 'Bonjour le monde' mean?"  →  auto-detects French, translates
"List supported languages"            →  returns all 133 language codes
```

## Changes

| File | Change |
|------|--------|
| `tools/translation_tool.py` | **New** — tool handler, OpenAI function schema, registry registration |
| `model_tools.py` | Added `tools.translation_tool` to discovery list |
| `toolsets.py` | Added `translate` to `_HERMES_CORE_TOOLS` + new `translation` toolset |
| `requirements.txt` | Added `deep-translator` |
| `pyproject.toml` | Added `deep-translator` to dependencies |

## Design decisions

- Follows the exact same pattern as existing tools (`todo_tool.py`, `tts_tool.py`)
- Lazy-loads `deep-translator` with `check_fn` gating — if the package isn't installed, the tool is silently disabled without affecting other tools
- Uses `ensure_ascii=False` in JSON output to preserve Unicode characters
- Minimal footprint: single file, single dependency, no external API keys

## Test plan

- [x] Translate English → Turkish
- [x] Translate Turkish → English
- [x] Auto-detect French → Turkish
- [x] Translate to Japanese (Unicode handling)
- [x] List supported languages (133 returned)
- [x] Empty text error handling
- [x] `check_fn` returns True when installed