### PR TITLE
feat(tools): MCP sampling Phase 2 — spec coverage, governance & audit

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -525,3 +525,235 @@ Each MCP server's tools are automatically grouped into a toolset named `mcp-{ser
 ### Thread Safety
 
 The MCP subsystem is fully thread-safe. A dedicated background event loop runs in a daemon thread, and all server state is protected by a lock. This works correctly even with Python 3.13+ free-threading builds.
+
+## Sampling (Server-Initiated LLM Requests)
+
+MCP's `sampling/createMessage` capability allows MCP servers to request LLM completions through the Hermes agent. This is a powerful feature that enables agent-in-the-loop workflows where servers can leverage the LLM for tasks like:
+
+- **Data analysis**: A database server asks the LLM to interpret query results
+- **Content generation**: A CMS server requests the LLM to generate or summarize content
+- **Decision making**: A workflow server asks the LLM to decide the next step
+- **Code review**: A code analysis server asks the LLM to review findings
+
+### How It Works
+
+```
+MCP Server --[sampling/createMessage]--> ClientSession
+  --> sampling callback (async, on MCP background loop)
+    --> asyncio.to_thread(sync LLM call)   # non-blocking
+    --> CreateMessageResult | ErrorData returned to server
+```
+
+The sampling callback:
+
+1. Validates the request against configurable rate limits
+2. Resolves the model to use (config override > server hint > default)
+3. Converts MCP messages to OpenAI-compatible format (text + images)
+4. Adds system prompt if provided by the server
+5. Offloads the LLM call to a thread via `asyncio.to_thread()` (non-blocking)
+6. Applies a configurable timeout to the LLM call
+7. Sanitizes the response (credential stripping)
+8. Returns a `CreateMessageResult` on success or `ErrorData` on failure
+
+### Configuration
+
+Sampling is **enabled by default** for all configured MCP servers. No additional setup is needed — if you have an auxiliary LLM client configured (OpenRouter, Nous Portal, or custom endpoint), sampling works automatically.
+
+#### Per-Server Sampling Config
+
+```yaml
+mcp_servers:
+  analysis_server:
+    command: "npx"
+    args: ["-y", "my-analysis-server"]
+    sampling:
+      enabled: true           # default: true
+      model: "gemini-3-flash" # override model (optional)
+      max_tokens_cap: 4096    # max tokens per request (default: 4096)
+      timeout: 30             # LLM call timeout in seconds (default: 30)
+      max_rpm: 10             # max requests per minute (default: 10)
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `sampling.enabled` | bool | `true` | Enable or disable sampling for this server |
+| `sampling.model` | string | (auto) | Force a specific model for sampling requests |
+| `sampling.max_tokens_cap` | int | `4096` | Maximum tokens a server can request |
+| `sampling.timeout` | int | `30` | Timeout in seconds for each LLM call |
+| `sampling.max_rpm` | int | `10` | Maximum sampling requests per minute |
+| `sampling.allowed_models` | list | `[]` | Model whitelist (empty = allow all) |
+| `sampling.max_tool_rounds` | int | `5` | Max consecutive tool use rounds (0 = disable tool loops) |
+| `sampling.log_level` | string | `"info"` | Audit log verbosity: `"debug"`, `"info"`, or `"warning"` |
+
+#### Model Resolution
+
+The model used for sampling is resolved in this order:
+
+1. **Config override** (`sampling.model`) — always used if set
+2. **Server hint** (`modelPreferences.hints[].name`) — from the server's request
+3. **Default** — the auxiliary client's default model
+
+### Security
+
+Sampling introduces a vector where MCP servers can trigger LLM calls, so several safeguards are in place:
+
+#### Non-Blocking Execution
+
+The sync LLM client call is offloaded to a thread via `asyncio.to_thread()`. This prevents blocking the MCP background event loop, which also serves tool calls and other server connections.
+
+#### LLM Call Timeout
+
+Each LLM call has a configurable timeout (default: 30 seconds) enforced via `asyncio.wait_for()`. If the LLM provider is slow or unresponsive, the call is cancelled and an `ErrorData` is returned to the server.
+
+#### Rate Limiting
+
+Each server is limited to `max_rpm` sampling requests per minute (default: 10). Exceeding this limit returns a structured `ErrorData` to the server. This prevents a runaway or malicious server from draining LLM credits.
+
+```yaml
+# Increase rate limit for a trusted high-throughput server
+sampling:
+  max_rpm: 30
+```
+
+#### Token Cap
+
+The `max_tokens_cap` config (default: 4096) limits how many tokens a server can request per sampling call. Even if a server requests `maxTokens: 100000`, it will be capped to the configured limit.
+
+#### Credential Stripping
+
+LLM responses are sanitized through `_sanitize_error()` before being returned to the MCP server, removing any credential-like patterns (API keys, tokens, passwords) that the LLM might accidentally include.
+
+#### Typed Error Responses
+
+All error conditions (rate limit, timeout, no provider, LLM errors) return structured `ErrorData` objects per the MCP specification, rather than raw exceptions. This gives servers a predictable error format they can handle gracefully.
+
+#### Backward Compatibility
+
+Sampling types (`CreateMessageResult`, `TextContent`, `ErrorData`) are imported in a separate `try/except` block. If the installed MCP SDK version doesn't have these types, sampling is silently disabled while all other MCP features continue working normally.
+
+#### Human-in-the-Loop Considerations
+
+The MCP specification recommends that clients provide human review of sampling requests. Currently, Hermes Agent auto-approves sampling within the configured safety limits. For untrusted servers, the recommended approach is to disable sampling entirely:
+
+```yaml
+mcp_servers:
+  untrusted:
+    command: "npx"
+    args: ["-y", "untrusted-server"]
+    sampling:
+      enabled: false    # Server cannot make LLM requests
+```
+
+### Tool Use in Sampling
+
+MCP servers can include `tools` and `toolChoice` in their sampling requests, enabling multi-turn tool-augmented workflows within a single sampling session.
+
+#### How Tool Use Works
+
+1. The server sends a `sampling/createMessage` request with `tools` (tool definitions) and optionally `toolChoice` (auto/required/none)
+2. The sampling callback forwards these to the LLM as OpenAI-compatible function definitions
+3. If the LLM responds with `tool_calls`, the callback returns a `CreateMessageResult` with `stopReason: "toolUse"` and tool use content blocks
+4. The server executes the tools and sends another sampling request with the results
+5. This loop continues until the LLM returns a text response or the `max_tool_rounds` limit is reached
+
+#### Tool Loop Governance
+
+To prevent runaway tool loops (a server and LLM endlessly bouncing tool calls), the `max_tool_rounds` config limits consecutive tool use rounds per server:
+
+```yaml
+sampling:
+  max_tool_rounds: 5   # default: 5 consecutive tool rounds max
+```
+
+- **max_tool_rounds: 5** (default) — allows up to 5 consecutive rounds where the LLM requests tool use
+- **max_tool_rounds: 0** — disables tool loops entirely; tool use responses are rejected
+- The counter resets when the LLM returns a normal text response (endTurn)
+- Exceeding the limit returns an `ErrorData` to the server
+
+#### Content Block Conversion
+
+The sampling callback handles all MCP content block types:
+
+| MCP Content Block | OpenAI Format |
+|------------------|---------------|
+| `TextContent` | `{"role": "...", "content": "text"}` |
+| `ImageContent` | `{"type": "image_url", ...}` |
+| `ToolUseContent` | `{"tool_calls": [...]}` on assistant message |
+| `ToolResultContent` | `{"role": "tool", "tool_call_id": "..."}` |
+
+### Per-Server Sampling Policy
+
+Different MCP servers have different trust levels. Use per-server sampling config to enforce appropriate policies:
+
+```yaml
+mcp_servers:
+  # Trusted internal server: full access
+  internal_analytics:
+    command: "npx"
+    args: ["-y", "analytics-server"]
+    sampling:
+      enabled: true
+      max_rpm: 30
+      max_tool_rounds: 10
+      log_level: "debug"        # verbose audit trail
+
+  # Semi-trusted: restricted model access
+  community_server:
+    command: "npx"
+    args: ["-y", "community-server"]
+    sampling:
+      enabled: true
+      allowed_models: ["gemini-3-flash"]  # only cheap models
+      max_tool_rounds: 3
+      max_tokens_cap: 2048
+
+  # Untrusted: no sampling at all
+  experimental:
+    command: "npx"
+    args: ["-y", "experimental-server"]
+    sampling:
+      enabled: false
+```
+
+#### Audit Metrics
+
+Each server's sampling activity is tracked with structured metrics exposed via `get_mcp_status()`:
+
+- **requests**: total successful sampling requests
+- **errors**: total failed requests (rate limit, timeout, model blocked, etc.)
+- **tokens_used**: total tokens consumed across all sampling calls
+- **tool_use_count**: total responses where the LLM requested tool use
+
+### Troubleshooting
+
+**"No LLM provider available for sampling"**
+
+No auxiliary LLM client is configured. Set up one of:
+- `OPENROUTER_API_KEY` environment variable
+- Nous Portal authentication (`hermes auth`)
+- Custom endpoint (`OPENAI_BASE_URL` + `OPENAI_API_KEY`)
+
+**"Sampling rate limit exceeded"**
+
+The server is making too many sampling requests. Increase `max_rpm` if this is expected behavior:
+
+```yaml
+sampling:
+  max_rpm: 30   # Increase from default 10
+```
+
+**"Sampling LLM call timed out"**
+
+The LLM provider is too slow. Increase the timeout:
+
+```yaml
+sampling:
+  timeout: 60   # Increase from default 30
+```
+
+**Server receives error responses**
+
+Check the Hermes logs (`hermes --verbose`) for sampling request/response details. Common issues:
+- LLM API errors (auth, quota)
+- Invalid message format from the server
+- Model not available

--- a/skills/mcp/native-mcp/SKILL.md
+++ b/skills/mcp/native-mcp/SKILL.md
@@ -321,6 +321,78 @@ mcp_servers:
 
 All tools from all servers are registered and available simultaneously. Each server's tools are prefixed with its name to avoid collisions.
 
+## Sampling Support (Server-Initiated LLM Requests)
+
+Hermes Agent supports MCP's `sampling/createMessage` capability, allowing MCP servers to request LLM completions through the agent. This enables agent-in-the-loop scenarios where a server can ask the LLM for help during tool execution (e.g., data analysis, content generation, decision-making).
+
+### How It Works
+
+When an MCP server sends a `sampling/createMessage` request:
+
+1. The sampling callback intercepts the request
+2. Converts MCP message format to OpenAI-compatible format
+3. Forwards to the agent's auxiliary LLM client
+4. Returns the LLM response back to the MCP server
+
+### Configuration
+
+Sampling is **enabled by default** for all MCP servers. You can customize behavior per server:
+
+```yaml
+mcp_servers:
+  my_server:
+    command: "npx"
+    args: ["-y", "my-mcp-server"]
+    sampling:
+      enabled: true           # default: true
+      model: "gemini-3-flash" # model override (optional)
+      max_tokens_cap: 4096    # max tokens per request (default: 4096)
+      timeout: 30             # LLM call timeout in seconds (default: 30)
+      max_rpm: 10             # max requests per minute (default: 10)
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `true` | Enable/disable sampling for this server |
+| `model` | (auto) | Override model selection (uses auxiliary client default if not set) |
+| `max_tokens_cap` | `4096` | Maximum tokens the server can request per sampling call |
+| `timeout` | `30` | Timeout in seconds for each LLM call |
+| `max_rpm` | `10` | Maximum sampling requests per minute per server |
+| `allowed_models` | `[]` | Model whitelist (empty = allow all) |
+| `max_tool_rounds` | `5` | Max consecutive tool use rounds (0 = disable tool loops) |
+| `log_level` | `"info"` | Audit log verbosity: `"debug"`, `"info"`, or `"warning"` |
+
+### Tool Use in Sampling
+
+Servers can include `tools` and `toolChoice` in sampling requests for multi-turn tool-augmented workflows. The callback converts these to OpenAI function-calling format, handles tool use responses with `stopReason: "toolUse"`, and enforces a configurable `max_tool_rounds` limit (default: 5) to prevent infinite tool loops. Per-server audit metrics (requests, errors, tokens, tool use count) are tracked and exposed via `get_mcp_status()`.
+
+### Security
+
+- **Non-blocking execution**: LLM calls are offloaded to a separate thread via `asyncio.to_thread()` so they don't block the MCP event loop or other server operations
+- **Rate limiting**: Each server is limited to `max_rpm` sampling requests per minute (default: 10)
+- **LLM timeout**: Each LLM call has a configurable timeout (default: 30s) to prevent runaway requests
+- **Token cap**: Servers cannot request more tokens than `max_tokens_cap` (default: 4096)
+- **Model whitelist**: `allowed_models` restricts which models a server can use (empty = allow all)
+- **Tool loop limit**: `max_tool_rounds` caps consecutive tool use rounds (default: 5, 0 = disable)
+- **Credential stripping**: LLM responses are sanitized to remove credential-like patterns before returning to the server
+- **Typed errors**: Errors return structured `ErrorData` objects (per MCP spec) instead of raw exceptions
+- **Audit logging**: Configurable `log_level` controls sampling audit verbosity
+
+> **Note on human-in-the-loop**: The MCP spec recommends clients provide human review of sampling requests. Currently, Hermes Agent auto-approves sampling within the configured safety limits (rate limit, token cap, timeout). For untrusted servers, disable sampling entirely via `sampling.enabled: false`.
+
+### Disabling Sampling
+
+To disable sampling for a specific server:
+
+```yaml
+mcp_servers:
+  untrusted_server:
+    command: "npx"
+    args: ["-y", "untrusted-server"]
+    sampling:
+      enabled: false
+```
+
 ## Notes
 
 - MCP tools are called synchronously from the agent's perspective but run asynchronously on a dedicated background event loop

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -6,10 +6,45 @@ All tests use mocks -- no real MCP servers or subprocesses are started.
 import asyncio
 import json
 import os
+import sys
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+# ---------------------------------------------------------------------------
+# Mock MCP types if mcp package is not installed
+# ---------------------------------------------------------------------------
+
+try:
+    from mcp.types import CreateMessageResult, TextContent, ErrorData
+except ImportError:
+    # Create lightweight stand-ins so that _make_sampling_callback can be tested
+    # without the real mcp package installed.
+    class TextContent:
+        def __init__(self, type="text", text=""):
+            self.type = type
+            self.text = text
+
+    class CreateMessageResult:
+        def __init__(self, role="", content=None, model="", stopReason=""):
+            self.role = role
+            self.content = content
+            self.model = model
+            self.stopReason = stopReason
+
+    class ErrorData:
+        def __init__(self, code=0, message=""):
+            self.code = code
+            self.message = message
+
+    # Inject into the mcp_tool module namespace so the callback can use them
+    import tools.mcp_tool as _mcp_mod
+    _mcp_mod.CreateMessageResult = CreateMessageResult
+    _mcp_mod.TextContent = TextContent
+    _mcp_mod.ErrorData = ErrorData
+    _mcp_mod._MCP_SAMPLING_TYPES = True
 
 
 # ---------------------------------------------------------------------------
@@ -1489,3 +1524,1662 @@ class TestUtilityToolRegistration:
         assert entry.check_fn() is False
 
         _servers.pop("chk", None)
+
+
+# ---------------------------------------------------------------------------
+# Sampling helpers
+# ---------------------------------------------------------------------------
+
+def _make_sampling_params(
+    messages=None,
+    max_tokens=1024,
+    system_prompt=None,
+    model_preferences=None,
+    temperature=None,
+    stop_sequences=None,
+    tools=None,
+    tool_choice=None,
+):
+    """Create a fake MCP CreateMessageRequestParams object."""
+    if messages is None:
+        messages = [SimpleNamespace(
+            role="user",
+            content=SimpleNamespace(text="Hello"),
+        )]
+    params = SimpleNamespace(
+        messages=messages,
+        maxTokens=max_tokens,
+        systemPrompt=system_prompt,
+        modelPreferences=model_preferences,
+        temperature=temperature,
+        stopSequences=stop_sequences,
+    )
+    if tools is not None:
+        params.tools = tools
+    if tool_choice is not None:
+        params.toolChoice = tool_choice
+    return params
+
+
+def _make_llm_response(content="LLM response", model="test-model", finish_reason="stop",
+                        tool_calls=None):
+    """Create a fake OpenAI-style chat completion response."""
+    message = SimpleNamespace(content=content)
+    if tool_calls is not None:
+        message.tool_calls = tool_calls
+    choice = SimpleNamespace(
+        message=message,
+        finish_reason=finish_reason,
+    )
+    return SimpleNamespace(
+        choices=[choice],
+        model=model,
+        usage=SimpleNamespace(total_tokens=42),
+    )
+
+
+def _make_llm_tool_response(tool_calls_data=None, model="test-model"):
+    """Create a fake OpenAI-style response with tool_calls.
+
+    Args:
+        tool_calls_data: list of (id, name, arguments) tuples.
+        model: model name.
+    """
+    if tool_calls_data is None:
+        tool_calls_data = [("call_1", "get_weather", '{"city": "London"}')]
+    tc_objects = []
+    for call_id, name, args in tool_calls_data:
+        tc_objects.append(SimpleNamespace(
+            id=call_id,
+            function=SimpleNamespace(name=name, arguments=args),
+        ))
+    message = SimpleNamespace(content=None, tool_calls=tc_objects)
+    choice = SimpleNamespace(message=message, finish_reason="tool_calls")
+    return SimpleNamespace(
+        choices=[choice],
+        model=model,
+        usage=SimpleNamespace(total_tokens=55),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sampling callback tests
+# ---------------------------------------------------------------------------
+
+class TestSamplingHelpers:
+    """Tests for sampling helper functions."""
+
+    def test_resolve_model_config_override(self):
+        """Config model override takes precedence over hints."""
+        from tools.mcp_tool import _resolve_model
+
+        prefs = SimpleNamespace(hints=[SimpleNamespace(name="gpt-4")])
+        result = _resolve_model(prefs, {"model": "gemini-3-flash"})
+        assert result == "gemini-3-flash"
+
+    def test_resolve_model_server_hint(self):
+        """Server model hints are resolved when no config override."""
+        from tools.mcp_tool import _resolve_model
+
+        prefs = SimpleNamespace(hints=[SimpleNamespace(name="gpt-4")])
+        result = _resolve_model(prefs, {})
+        assert result == "gpt-4"
+
+    def test_resolve_model_no_preferences(self):
+        """Returns None when no preferences and no config."""
+        from tools.mcp_tool import _resolve_model
+
+        result = _resolve_model(None, {})
+        assert result is None
+
+    def test_resolve_model_empty_hints(self):
+        """Returns None when hints list is empty."""
+        from tools.mcp_tool import _resolve_model
+
+        prefs = SimpleNamespace(hints=[])
+        result = _resolve_model(prefs, {})
+        assert result is None
+
+    def test_convert_sampling_messages_text(self):
+        """Text content messages are converted correctly."""
+        from tools.mcp_tool import _convert_sampling_messages
+
+        params = SimpleNamespace(messages=[
+            SimpleNamespace(role="user", content=SimpleNamespace(text="Hello")),
+            SimpleNamespace(role="assistant", content=SimpleNamespace(text="Hi")),
+        ])
+        result = _convert_sampling_messages(params)
+        assert len(result) == 2
+        assert result[0] == {"role": "user", "content": "Hello"}
+        assert result[1] == {"role": "assistant", "content": "Hi"}
+
+    def test_convert_sampling_messages_image(self):
+        """Image content blocks are converted to OpenAI format."""
+        from tools.mcp_tool import _convert_sampling_messages
+
+        image_block = SimpleNamespace(
+            data="base64data==",
+            mimeType="image/png",
+        )
+        params = SimpleNamespace(messages=[
+            SimpleNamespace(role="user", content=[
+                SimpleNamespace(text="What's in this image?"),
+                image_block,
+            ]),
+        ])
+        result = _convert_sampling_messages(params)
+        assert len(result) == 1
+        parts = result[0]["content"]
+        assert len(parts) == 2
+        assert parts[0] == {"type": "text", "text": "What's in this image?"}
+        assert parts[1]["type"] == "image_url"
+        assert "data:image/png;base64,base64data==" in parts[1]["image_url"]["url"]
+
+    def test_convert_sampling_messages_fallback(self):
+        """Non-text, non-list content falls back to str()."""
+        from tools.mcp_tool import _convert_sampling_messages
+
+        params = SimpleNamespace(messages=[
+            SimpleNamespace(role="user", content=12345),
+        ])
+        result = _convert_sampling_messages(params)
+        assert result[0]["content"] == "12345"
+
+    def test_map_stop_reason_stop(self):
+        from tools.mcp_tool import _map_stop_reason
+        assert _map_stop_reason("stop") == "endTurn"
+
+    def test_map_stop_reason_length(self):
+        from tools.mcp_tool import _map_stop_reason
+        assert _map_stop_reason("length") == "maxTokens"
+
+    def test_map_stop_reason_tool_calls(self):
+        from tools.mcp_tool import _map_stop_reason
+        assert _map_stop_reason("tool_calls") == "toolUse"
+
+    def test_map_stop_reason_unknown(self):
+        from tools.mcp_tool import _map_stop_reason
+        assert _map_stop_reason("content_filter") == "endTurn"
+
+    def test_rate_limit_allows_under_limit(self):
+        """Requests under the limit are allowed."""
+        from tools.mcp_tool import _check_rate_limit, _sampling_counters
+
+        _sampling_counters.pop("test_rl_allow", None)
+        assert _check_rate_limit("test_rl_allow", 10) is True
+        _sampling_counters.pop("test_rl_allow", None)
+
+    def test_rate_limit_blocks_over_limit(self):
+        """Requests over the limit are blocked."""
+        from tools.mcp_tool import _check_rate_limit, _sampling_counters, _DEFAULT_SAMPLING_RATE_LIMIT
+
+        _sampling_counters["test_rl_block"] = [time.time() for _ in range(_DEFAULT_SAMPLING_RATE_LIMIT)]
+        assert _check_rate_limit("test_rl_block", _DEFAULT_SAMPLING_RATE_LIMIT) is False
+        _sampling_counters.pop("test_rl_block", None)
+
+    def test_rate_limit_expires_old_entries(self):
+        """Old entries outside the window are expired."""
+        from tools.mcp_tool import _check_rate_limit, _sampling_counters, _DEFAULT_SAMPLING_RATE_LIMIT
+
+        # All timestamps from 2 minutes ago -- should be expired
+        _sampling_counters["test_rl_expire"] = [
+            time.time() - 120 for _ in range(_DEFAULT_SAMPLING_RATE_LIMIT)
+        ]
+        assert _check_rate_limit("test_rl_expire", _DEFAULT_SAMPLING_RATE_LIMIT) is True
+        _sampling_counters.pop("test_rl_expire", None)
+
+    def test_rate_limit_custom_max_rpm(self):
+        """Custom max_rpm value is respected."""
+        from tools.mcp_tool import _check_rate_limit, _sampling_counters
+
+        _sampling_counters["test_rl_custom"] = [time.time() for _ in range(3)]
+        assert _check_rate_limit("test_rl_custom", 3) is False  # At limit
+        assert _check_rate_limit("test_rl_custom", 5) is True   # Under higher limit
+        _sampling_counters.pop("test_rl_custom", None)
+
+
+class TestSamplingCallback:
+    """Tests for MCP sampling/createMessage support."""
+
+    def setup_method(self):
+        """Clear sampling rate limit counters between tests."""
+        from tools.mcp_tool import _sampling_counters
+        _sampling_counters.clear()
+
+    def test_basic_text_sampling(self):
+        """Sampling callback returns LLM response for text message."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response("Hi there!")
+
+        callback = _make_sampling_callback("test_srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "default-model")):
+            result = asyncio.run(callback(None, params))
+
+        assert result.role == "assistant"
+        assert result.content.text == "Hi there!"
+        assert result.model == "test-model"
+        assert result.stopReason == "endTurn"
+
+    def test_max_tokens_cap(self):
+        """Max tokens capped to config limit."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {"max_tokens_cap": 256})
+        params = _make_sampling_params(max_tokens=8192)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["max_tokens"] == 256
+
+    def test_max_tokens_server_under_cap(self):
+        """Server requests fewer tokens than cap -- use server value."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {"max_tokens_cap": 4096})
+        params = _make_sampling_params(max_tokens=100)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["max_tokens"] == 100
+
+    def test_config_model_override(self):
+        """Config model override takes precedence over server hints."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {"model": "my-custom-model"})
+        prefs = SimpleNamespace(hints=[SimpleNamespace(name="gpt-4")])
+        params = _make_sampling_params(model_preferences=prefs)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "default")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "my-custom-model"
+
+    def test_model_hint_used(self):
+        """Server model hint used when no config override."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {})
+        prefs = SimpleNamespace(hints=[SimpleNamespace(name="gpt-4o")])
+        params = _make_sampling_params(model_preferences=prefs)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "fallback")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "gpt-4o"
+
+    def test_system_prompt_passed(self):
+        """System prompt from server is included in LLM call."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params(system_prompt="You are a helpful assistant")
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        messages = call_kwargs["messages"]
+        assert messages[0] == {"role": "system", "content": "You are a helpful assistant"}
+        assert messages[1]["role"] == "user"
+
+    def test_no_provider_returns_error(self):
+        """Returns ErrorData when no LLM provider available."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(None, None)):
+            result = asyncio.run(callback(None, params))
+
+        assert isinstance(result, ErrorData)
+        assert "No LLM provider" in result.message
+
+    def test_rate_limit_exceeded(self):
+        """Returns ErrorData when rate limit exceeded."""
+        from tools.mcp_tool import _make_sampling_callback, _sampling_counters, _DEFAULT_SAMPLING_RATE_LIMIT
+
+        callback = _make_sampling_callback("rl_test_srv", {})
+        params = _make_sampling_params()
+
+        _sampling_counters["rl_test_srv"] = [time.time() for _ in range(_DEFAULT_SAMPLING_RATE_LIMIT)]
+
+        try:
+            result = asyncio.run(callback(None, params))
+            assert isinstance(result, ErrorData)
+            assert "rate limit exceeded" in result.message.lower()
+        finally:
+            _sampling_counters.pop("rl_test_srv", None)
+
+    def test_stop_reason_mapping_in_callback(self):
+        """OpenAI finish_reason mapped to MCP stopReason in callback."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response(
+            finish_reason="length"
+        )
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            result = asyncio.run(callback(None, params))
+
+        assert result.stopReason == "maxTokens"
+
+    def test_sampling_disabled_config(self):
+        """Callback is None when sampling disabled in config."""
+        from tools.mcp_tool import MCPServerTask
+
+        target_server = None
+        original_run_stdio = MCPServerTask._run_stdio
+
+        async def patched_run_stdio(self_srv, config):
+            if target_server is not self_srv:
+                return await original_run_stdio(self_srv, config)
+            self_srv.session = MagicMock()
+            self_srv._tools = []
+            self_srv._ready.set()
+            await self_srv._shutdown_event.wait()
+
+        async def _test():
+            nonlocal target_server
+            server = MCPServerTask("test_srv")
+            target_server = server
+
+            with patch.object(MCPServerTask, "_run_stdio", patched_run_stdio):
+                task = asyncio.ensure_future(
+                    server.run({"command": "test", "sampling": {"enabled": False}})
+                )
+                await server._ready.wait()
+                assert server._sampling_callback is None
+                server._shutdown_event.set()
+                await task
+
+        asyncio.run(_test())
+
+    def test_sampling_enabled_by_default(self):
+        """Sampling callback is set when no sampling config (default enabled)."""
+        from tools.mcp_tool import MCPServerTask
+
+        target_server = None
+        original_run_stdio = MCPServerTask._run_stdio
+
+        async def patched_run_stdio(self_srv, config):
+            if target_server is not self_srv:
+                return await original_run_stdio(self_srv, config)
+            self_srv.session = MagicMock()
+            self_srv._tools = []
+            self_srv._ready.set()
+            await self_srv._shutdown_event.wait()
+
+        async def _test():
+            nonlocal target_server
+            server = MCPServerTask("test_srv")
+            target_server = server
+
+            with patch.object(MCPServerTask, "_run_stdio", patched_run_stdio):
+                task = asyncio.ensure_future(
+                    server.run({"command": "test"})
+                )
+                await server._ready.wait()
+                assert server._sampling_callback is not None
+                assert callable(server._sampling_callback)
+                server._shutdown_event.set()
+                await task
+
+        asyncio.run(_test())
+
+    def test_credential_stripping_in_response(self):
+        """Credentials stripped from LLM response text."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response(
+            content="Here is your key: ghp_secrettoken123"
+        )
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            result = asyncio.run(callback(None, params))
+
+        assert "ghp_" not in result.content.text
+        assert "[REDACTED]" in result.content.text
+
+    def test_llm_api_error_returns_error_data(self):
+        """API errors return ErrorData with sanitized message."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = RuntimeError(
+            "Auth failed with key sk-secret123"
+        )
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            result = asyncio.run(callback(None, params))
+
+        assert isinstance(result, ErrorData)
+        assert "Sampling LLM call failed" in result.message
+        assert "sk-" not in result.message  # Credential sanitized
+
+    def test_temperature_passthrough(self):
+        """Temperature from server request passed to LLM."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params(temperature=0.7)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["temperature"] == 0.7
+
+    def test_temperature_none_not_passed(self):
+        """None temperature is not included in LLM call kwargs."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params(temperature=None)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert "temperature" not in call_kwargs
+
+    def test_multiple_messages(self):
+        """Multi-turn conversation messages converted correctly."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params(messages=[
+            SimpleNamespace(role="user", content=SimpleNamespace(text="Hello")),
+            SimpleNamespace(role="assistant", content=SimpleNamespace(text="Hi!")),
+            SimpleNamespace(role="user", content=SimpleNamespace(text="How are you?")),
+        ])
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        messages = call_kwargs["messages"]
+        assert len(messages) == 3
+        assert messages[0]["content"] == "Hello"
+        assert messages[1]["content"] == "Hi!"
+        assert messages[2]["content"] == "How are you?"
+
+    def test_stop_sequences_passed(self):
+        """Stop sequences from server request passed to LLM."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params(stop_sequences=["###", "END"])
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["stop"] == ["###", "END"]
+
+    def test_callback_passed_to_session_stdio(self):
+        """ClientSession receives sampling_callback parameter for stdio transport."""
+        from tools.mcp_tool import MCPServerTask
+
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[])
+        )
+
+        mock_read, mock_write = MagicMock(), MagicMock()
+        mock_stdio_cm = MagicMock()
+        mock_stdio_cm.__aenter__ = AsyncMock(return_value=(mock_read, mock_write))
+        mock_stdio_cm.__aexit__ = AsyncMock(return_value=False)
+
+        mock_cs_cm = MagicMock()
+        mock_cs_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_cs_cm.__aexit__ = AsyncMock(return_value=False)
+
+        async def _test_with_shutdown():
+            with patch("tools.mcp_tool.StdioServerParameters", create=True), \
+                 patch("tools.mcp_tool.stdio_client", create=True, return_value=mock_stdio_cm), \
+                 patch("tools.mcp_tool.ClientSession", create=True, return_value=mock_cs_cm) as mock_cs_cls:
+                server = MCPServerTask("test_srv")
+                server._sampling_callback = MagicMock()
+                server._shutdown_event.set()  # So it doesn't block
+                await server._run_stdio({"command": "test", "args": []})
+
+                call_kwargs = mock_cs_cls.call_args
+                assert "sampling_callback" in call_kwargs.kwargs
+
+        asyncio.run(_test_with_shutdown())
+
+    def test_llm_call_uses_to_thread(self):
+        """LLM call is offloaded via asyncio.to_thread (non-blocking)."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params()
+
+        # Only mock to_thread; let wait_for properly await the coroutine
+        # to avoid unawaited coroutine warnings.
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")), \
+             patch("tools.mcp_tool.asyncio.to_thread", new_callable=AsyncMock,
+                   return_value=_make_llm_response("threaded")) as mock_to_thread:
+            result = asyncio.run(callback(None, params))
+
+        assert result.content.text == "threaded"
+        mock_to_thread.assert_called_once()
+
+    def test_llm_timeout_returns_error_data(self):
+        """LLM call timeout returns ErrorData."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+
+        callback = _make_sampling_callback("srv", {"timeout": 1})
+        params = _make_sampling_params()
+
+        async def slow_to_thread(fn, **kwargs):
+            await asyncio.sleep(10)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")), \
+             patch("tools.mcp_tool.asyncio.to_thread", side_effect=slow_to_thread):
+            result = asyncio.run(callback(None, params))
+
+        assert isinstance(result, ErrorData)
+        assert "timed out" in result.message.lower()
+
+    def test_custom_timeout_config(self):
+        """Custom timeout from config is used."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {"timeout": 60})
+        params = _make_sampling_params()
+
+        captured_timeout = None
+
+        async def capturing_wait_for(coro, *, timeout=None):
+            nonlocal captured_timeout
+            captured_timeout = timeout
+            return await coro  # Properly await to avoid coroutine warning
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")), \
+             patch("tools.mcp_tool.asyncio.to_thread", new_callable=AsyncMock,
+                   return_value=_make_llm_response()), \
+             patch("tools.mcp_tool.asyncio.wait_for",
+                   side_effect=capturing_wait_for):
+            asyncio.run(callback(None, params))
+
+        # Verify wait_for was called with timeout=60
+        assert captured_timeout == 60
+
+    def test_custom_max_rpm_config(self):
+        """Custom max_rpm from config is respected."""
+        from tools.mcp_tool import _make_sampling_callback, _sampling_counters
+
+        # Set rate limit to 2 RPM
+        callback = _make_sampling_callback("rpm_test", {"max_rpm": 2})
+        params = _make_sampling_params()
+
+        _sampling_counters["rpm_test"] = [time.time(), time.time()]
+
+        try:
+            result = asyncio.run(callback(None, params))
+            assert isinstance(result, ErrorData)
+            assert "rate limit" in result.message.lower()
+        finally:
+            _sampling_counters.pop("rpm_test", None)
+
+    def test_sampling_disabled_when_types_unavailable(self):
+        """Sampling callback is None when _MCP_SAMPLING_TYPES is False."""
+        from tools.mcp_tool import MCPServerTask
+
+        target_server = None
+        original_run_stdio = MCPServerTask._run_stdio
+
+        async def patched_run_stdio(self_srv, config):
+            if target_server is not self_srv:
+                return await original_run_stdio(self_srv, config)
+            self_srv.session = MagicMock()
+            self_srv._tools = []
+            self_srv._ready.set()
+            await self_srv._shutdown_event.wait()
+
+        async def _test():
+            nonlocal target_server
+            server = MCPServerTask("test_srv")
+            target_server = server
+
+            with patch.object(MCPServerTask, "_run_stdio", patched_run_stdio), \
+                 patch("tools.mcp_tool._MCP_SAMPLING_TYPES", False):
+                task = asyncio.ensure_future(
+                    server.run({"command": "test"})
+                )
+                await server._ready.wait()
+                assert server._sampling_callback is None
+                server._shutdown_event.set()
+                await task
+
+        asyncio.run(_test())
+
+    # -- Config type coercion tests ------------------------------------------
+
+    def test_string_max_rpm_coerced_to_int(self):
+        """String max_rpm value (e.g. from YAML) is coerced to int."""
+        from tools.mcp_tool import _make_sampling_callback, _sampling_counters
+
+        # Use string "2" instead of int 2
+        callback = _make_sampling_callback("str_rpm_srv", {"max_rpm": "2"})
+        params = _make_sampling_params()
+
+        _sampling_counters["str_rpm_srv"] = [time.time(), time.time()]
+
+        try:
+            result = asyncio.run(callback(None, params))
+            assert isinstance(result, ErrorData)
+            assert "rate limit" in result.message.lower()
+        finally:
+            _sampling_counters.pop("str_rpm_srv", None)
+
+    def test_string_max_tokens_cap_coerced_to_int(self):
+        """String max_tokens_cap value is coerced to int."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        # Pass string "512" -- should be coerced to int(512)
+        callback = _make_sampling_callback("srv", {"max_tokens_cap": "512"})
+        params = _make_sampling_params(max_tokens=1024)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["max_tokens"] == 512  # capped to 512
+
+    def test_string_timeout_coerced_to_float(self):
+        """String timeout value is coerced to float."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        # Pass string "45" -- should be coerced to float(45)
+        callback = _make_sampling_callback("srv", {"timeout": "45"})
+        params = _make_sampling_params()
+
+        captured_timeout = None
+
+        async def capturing_wait_for(coro, *, timeout=None):
+            nonlocal captured_timeout
+            captured_timeout = timeout
+            return await coro
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")), \
+             patch("tools.mcp_tool.asyncio.to_thread", new_callable=AsyncMock,
+                   return_value=_make_llm_response()), \
+             patch("tools.mcp_tool.asyncio.wait_for",
+                   side_effect=capturing_wait_for):
+            asyncio.run(callback(None, params))
+
+        assert captured_timeout == 45.0
+
+    def test_invalid_config_values_fallback_to_defaults(self):
+        """Invalid config values (e.g. 'abc') fall back to defaults."""
+        from tools.mcp_tool import (
+            _make_sampling_callback,
+            _DEFAULT_SAMPLING_RATE_LIMIT,
+            _DEFAULT_SAMPLING_MAX_TOKENS_CAP,
+            _DEFAULT_SAMPLING_TIMEOUT,
+            _check_rate_limit,
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("fallback_srv", {
+            "max_rpm": "abc",
+            "timeout": "not_a_number",
+            "max_tokens_cap": [],
+        })
+        params = _make_sampling_params(max_tokens=99999)
+
+        captured_timeout = None
+
+        async def capturing_wait_for(coro, *, timeout=None):
+            nonlocal captured_timeout
+            captured_timeout = timeout
+            return await coro
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")), \
+             patch("tools.mcp_tool.asyncio.wait_for",
+                   side_effect=capturing_wait_for):
+            result = asyncio.run(callback(None, params))
+
+        # Should succeed with defaults, not raise TypeError
+        assert result.content.text is not None
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["max_tokens"] == _DEFAULT_SAMPLING_MAX_TOKENS_CAP
+        # Verify timeout fell back to default
+        assert captured_timeout == _DEFAULT_SAMPLING_TIMEOUT
+        # Verify max_rpm fell back to default: fill counter to DEFAULT limit,
+        # then the next callback call must hit rate limit -- proving the
+        # callback actually uses _DEFAULT_SAMPLING_RATE_LIMIT (not some other value).
+        from tools.mcp_tool import _sampling_counters
+        _sampling_counters["fallback_srv"] = [
+            time.time() for _ in range(_DEFAULT_SAMPLING_RATE_LIMIT)
+        ]
+        try:
+            result2 = asyncio.run(callback(None, params))
+            assert isinstance(result2, ErrorData)
+            assert "rate limit" in result2.message.lower()
+        finally:
+            _sampling_counters.pop("fallback_srv", None)
+
+    def test_zero_and_negative_config_clamped(self):
+        """Zero/negative config values are clamped to minimum (1)."""
+        from tools.mcp_tool import _make_sampling_callback, _sampling_counters
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        # max_rpm=0 should be clamped to 1, not block everything
+        callback = _make_sampling_callback("clamp_srv", {
+            "max_rpm": 0,
+            "timeout": -5,
+            "max_tokens_cap": -1,
+        })
+        params = _make_sampling_params(max_tokens=2000)
+
+        _sampling_counters.pop("clamp_srv", None)
+
+        captured_timeout = None
+
+        async def capturing_wait_for(coro, *, timeout=None):
+            nonlocal captured_timeout
+            captured_timeout = timeout
+            return await coro
+
+        try:
+            with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                        return_value=(mock_client, "model")), \
+                 patch("tools.mcp_tool.asyncio.wait_for",
+                       side_effect=capturing_wait_for):
+                result = asyncio.run(callback(None, params))
+
+            # Should succeed -- max_rpm clamped to 1, first request allowed
+            assert result.content.text is not None
+            # timeout clamped to 1 (minimum)
+            assert captured_timeout == 1
+            # max_tokens_cap clamped to 1, so min(2000, 1) = 1
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            assert call_kwargs["max_tokens"] == 1
+        finally:
+            _sampling_counters.pop("clamp_srv", None)
+
+    def test_nan_timeout_fallback_to_default(self):
+        """NaN timeout value falls back to default."""
+        from tools.mcp_tool import _make_sampling_callback, _DEFAULT_SAMPLING_TIMEOUT
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {"timeout": float("nan")})
+        params = _make_sampling_params()
+
+        captured_timeout = None
+
+        async def capturing_wait_for(coro, *, timeout=None):
+            nonlocal captured_timeout
+            captured_timeout = timeout
+            return await coro
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")), \
+             patch("tools.mcp_tool.asyncio.to_thread", new_callable=AsyncMock,
+                   return_value=_make_llm_response()), \
+             patch("tools.mcp_tool.asyncio.wait_for",
+                   side_effect=capturing_wait_for):
+            asyncio.run(callback(None, params))
+
+        assert captured_timeout == _DEFAULT_SAMPLING_TIMEOUT
+
+    def test_inf_max_rpm_fallback_to_default(self):
+        """Infinity max_rpm value falls back to default."""
+        from tools.mcp_tool import (
+            _make_sampling_callback, _sampling_counters,
+            _DEFAULT_SAMPLING_RATE_LIMIT,
+        )
+
+        callback = _make_sampling_callback("inf_rpm_srv", {"max_rpm": float("inf")})
+        params = _make_sampling_params()
+
+        # Fill counters to default rate limit -- should block if default was used
+        _sampling_counters["inf_rpm_srv"] = [
+            time.time() for _ in range(_DEFAULT_SAMPLING_RATE_LIMIT)
+        ]
+
+        try:
+            result = asyncio.run(callback(None, params))
+            assert isinstance(result, ErrorData)
+            assert "rate limit" in result.message.lower()
+        finally:
+            _sampling_counters.pop("inf_rpm_srv", None)
+
+    def test_unsupported_content_block_skipped(self):
+        """Unknown content block types are skipped with a warning."""
+        from tools.mcp_tool import _convert_sampling_messages
+
+        unknown_block = SimpleNamespace(audio_data="raw_audio")  # no text, no data/mimeType
+        text_block = SimpleNamespace(text="Hello")
+
+        params = SimpleNamespace(messages=[
+            SimpleNamespace(role="user", content=[text_block, unknown_block]),
+        ])
+
+        import logging as _logging
+        with patch("tools.mcp_tool.logger") as mock_logger:
+            result = _convert_sampling_messages(params)
+
+        # Text block preserved, unknown block skipped
+        assert len(result) == 1
+        parts = result[0]["content"]
+        assert len(parts) == 1
+        assert parts[0] == {"type": "text", "text": "Hello"}
+        mock_logger.warning.assert_called_once()
+        assert "Unsupported" in mock_logger.warning.call_args[0][0]
+
+    def test_unsupported_content_block_all_skipped_gives_empty_string(self):
+        """All unknown content blocks produce empty string content."""
+        from tools.mcp_tool import _convert_sampling_messages
+
+        unknown_block = SimpleNamespace(audio_data="raw_audio")
+
+        params = SimpleNamespace(messages=[
+            SimpleNamespace(role="user", content=[unknown_block]),
+        ])
+
+        with patch("tools.mcp_tool.logger"):
+            result = _convert_sampling_messages(params)
+
+        assert result[0]["content"] == ""
+
+    def test_sampling_error_helper_returns_error_data(self):
+        """_sampling_error returns ErrorData when types are available."""
+        from tools.mcp_tool import _sampling_error
+
+        result = _sampling_error("test error", code=-42)
+        assert isinstance(result, ErrorData)
+        assert result.code == -42
+        assert result.message == "test error"
+
+    def test_sampling_error_helper_raises_without_types(self):
+        """_sampling_error raises Exception when MCP types unavailable."""
+        from tools.mcp_tool import _sampling_error
+
+        with patch("tools.mcp_tool._MCP_SAMPLING_TYPES", False):
+            with pytest.raises(Exception, match="fallback error"):
+                _sampling_error("fallback error")
+
+    def test_make_sampling_callback_returns_none_without_types(self):
+        """_make_sampling_callback returns None when sampling types unavailable."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        with patch("tools.mcp_tool._MCP_SAMPLING_TYPES", False):
+            result = _make_sampling_callback("srv", {})
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Tool content block conversion tests
+# ---------------------------------------------------------------------------
+
+class TestToolContentConversion:
+    """Tests for tool_result and tool_use content block handling."""
+
+    def test_convert_messages_tool_result_single(self):
+        """Single tool_result content converts to OpenAI tool role message."""
+        from tools.mcp_tool import _convert_sampling_messages
+
+        tool_result = SimpleNamespace(
+            toolUseId="call_123",
+            content=[SimpleNamespace(text="Result from tool")],
+        )
+        params = SimpleNamespace(messages=[
+            SimpleNamespace(role="user", content=tool_result),
+        ])
+        result = _convert_sampling_messages(params)
+        assert len(result) == 1
+        assert result[0]["role"] == "tool"
+        assert result[0]["tool_call_id"] == "call_123"
+        assert result[0]["content"] == "Result from tool"
+
+    def test_convert_messages_tool_result_multiple(self):
+        """List of tool_result blocks produces multiple tool role messages."""
+        from tools.mcp_tool import _convert_sampling_messages
+
+        results = [
+            SimpleNamespace(
+                toolUseId="call_1",
+                content=[SimpleNamespace(text="Result 1")],
+            ),
+            SimpleNamespace(
+                toolUseId="call_2",
+                content=[SimpleNamespace(text="Result 2")],
+            ),
+        ]
+        params = SimpleNamespace(messages=[
+            SimpleNamespace(role="user", content=results),
+        ])
+        result = _convert_sampling_messages(params)
+        assert len(result) == 2
+        assert result[0]["role"] == "tool"
+        assert result[0]["tool_call_id"] == "call_1"
+        assert result[1]["role"] == "tool"
+        assert result[1]["tool_call_id"] == "call_2"
+
+    def test_convert_messages_tool_use_content(self):
+        """tool_use content blocks convert to assistant message with tool_calls."""
+        from tools.mcp_tool import _convert_sampling_messages
+
+        tool_use = SimpleNamespace(
+            id="call_abc",
+            name="get_weather",
+            input={"city": "London"},
+        )
+        params = SimpleNamespace(messages=[
+            SimpleNamespace(role="assistant", content=[tool_use]),
+        ])
+        result = _convert_sampling_messages(params)
+        assert len(result) == 1
+        msg = result[0]
+        assert msg["role"] == "assistant"
+        assert "tool_calls" in msg
+        assert len(msg["tool_calls"]) == 1
+        tc = msg["tool_calls"][0]
+        assert tc["id"] == "call_abc"
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "get_weather"
+        assert json.loads(tc["function"]["arguments"]) == {"city": "London"}
+
+    def test_convert_messages_mixed_tool_use_and_text(self):
+        """Mixed tool_use and text blocks produce correct assistant message."""
+        from tools.mcp_tool import _convert_sampling_messages
+
+        tool_use = SimpleNamespace(
+            id="call_1",
+            name="search",
+            input={"q": "test"},
+        )
+        text_block = SimpleNamespace(text="Let me search for that")
+        params = SimpleNamespace(messages=[
+            SimpleNamespace(role="assistant", content=[text_block, tool_use]),
+        ])
+        result = _convert_sampling_messages(params)
+        assert len(result) == 1
+        msg = result[0]
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "Let me search for that"
+        assert len(msg["tool_calls"]) == 1
+        assert msg["tool_calls"][0]["function"]["name"] == "search"
+
+    def test_extract_tool_result_text_helper(self):
+        """_extract_tool_result_text extracts text from content list."""
+        from tools.mcp_tool import _extract_tool_result_text
+
+        block = SimpleNamespace(
+            content=[SimpleNamespace(text="line1"), SimpleNamespace(text="line2")],
+        )
+        assert _extract_tool_result_text(block) == "line1\nline2"
+
+    def test_extract_tool_result_text_empty(self):
+        """_extract_tool_result_text returns empty string for missing content."""
+        from tools.mcp_tool import _extract_tool_result_text
+
+        assert _extract_tool_result_text(SimpleNamespace(content=None)) == ""
+        assert _extract_tool_result_text(SimpleNamespace()) == ""
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Tools/toolChoice forwarding tests
+# ---------------------------------------------------------------------------
+
+class TestToolsForwarding:
+    """Tests for tools/toolChoice forwarding to LLM."""
+
+    def setup_method(self):
+        from tools.mcp_tool import _sampling_counters, _sampling_metrics, _tool_loop_counters
+        _sampling_counters.clear()
+        _sampling_metrics.clear()
+        _tool_loop_counters.clear()
+
+    def test_tools_forwarded_to_llm(self):
+        """Server-provided tools are forwarded to the LLM call."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        server_tools = [
+            SimpleNamespace(name="get_weather", description="Get weather", inputSchema={"type": "object"}),
+        ]
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params(tools=server_tools)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert "tools" in call_kwargs
+        assert len(call_kwargs["tools"]) == 1
+        assert call_kwargs["tools"][0]["function"]["name"] == "get_weather"
+
+    def test_tool_choice_auto(self):
+        """toolChoice mode=auto maps to tool_choice=auto."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        server_tools = [SimpleNamespace(name="t", description="", inputSchema={})]
+        tc = SimpleNamespace(mode="auto")
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params(tools=server_tools, tool_choice=tc)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["tool_choice"] == "auto"
+
+    def test_tool_choice_required(self):
+        """toolChoice mode=required maps to tool_choice=required."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        server_tools = [SimpleNamespace(name="t", description="", inputSchema={})]
+        tc = SimpleNamespace(mode="required")
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params(tools=server_tools, tool_choice=tc)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["tool_choice"] == "required"
+
+    def test_tool_choice_none(self):
+        """toolChoice mode=none maps to tool_choice=none."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        server_tools = [SimpleNamespace(name="t", description="", inputSchema={})]
+        tc = SimpleNamespace(mode="none")
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params(tools=server_tools, tool_choice=tc)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["tool_choice"] == "none"
+
+    def test_no_tools_backward_compat(self):
+        """No tools attribute in params -> no tools key in call_kwargs."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert "tools" not in call_kwargs
+
+    def test_tool_use_response_returns_tool_use_content(self):
+        """LLM tool_calls response produces CreateMessageResult with tool_use content."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_tool_response()
+
+        server_tools = [SimpleNamespace(name="get_weather", description="", inputSchema={})]
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params(tools=server_tools)
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            result = asyncio.run(callback(None, params))
+
+        assert result.role == "assistant"
+        assert result.stopReason == "toolUse"
+        assert isinstance(result.content, list)
+        assert len(result.content) == 1
+        assert result.content[0]["type"] == "tool_use"
+        assert result.content[0]["name"] == "get_weather"
+        assert result.content[0]["input"] == {"city": "London"}
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Audit metrics tests
+# ---------------------------------------------------------------------------
+
+class TestSamplingMetrics:
+    """Tests for _sampling_metrics audit tracking."""
+
+    def setup_method(self):
+        from tools.mcp_tool import _sampling_counters, _sampling_metrics, _tool_loop_counters
+        _sampling_counters.clear()
+        _sampling_metrics.clear()
+        _tool_loop_counters.clear()
+
+    def test_sampling_metrics_increment_on_success(self):
+        """Successful sampling increments requests counter."""
+        from tools.mcp_tool import _make_sampling_callback, _sampling_metrics
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("metrics_srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        assert "metrics_srv" in _sampling_metrics
+        assert _sampling_metrics["metrics_srv"]["requests"] == 1
+        assert _sampling_metrics["metrics_srv"]["tokens_used"] == 42
+
+    def test_sampling_metrics_increment_on_error(self):
+        """Error during sampling increments errors counter."""
+        from tools.mcp_tool import _make_sampling_callback, _sampling_metrics
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = RuntimeError("fail")
+
+        callback = _make_sampling_callback("err_srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        assert "err_srv" in _sampling_metrics
+        assert _sampling_metrics["err_srv"]["errors"] == 1
+
+    def test_sampling_metrics_tool_use_count(self):
+        """Tool use response increments tool_use_count."""
+        from tools.mcp_tool import _make_sampling_callback, _sampling_metrics
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_tool_response()
+
+        callback = _make_sampling_callback("tu_srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            asyncio.run(callback(None, params))
+
+        assert _sampling_metrics["tu_srv"]["tool_use_count"] == 1
+
+    def test_get_mcp_status_includes_sampling_metrics(self):
+        """get_mcp_status() includes sampling metrics when available."""
+        from tools.mcp_tool import get_mcp_status, _servers, _sampling_metrics
+
+        server = _make_mock_server("metric_srv", session=MagicMock(), tools=[])
+        _servers["metric_srv"] = server
+        _sampling_metrics["metric_srv"] = {
+            "requests": 5, "errors": 1, "tokens_used": 200, "tool_use_count": 2,
+        }
+
+        try:
+            with patch("tools.mcp_tool._load_mcp_config",
+                        return_value={"metric_srv": {"command": "test"}}):
+                status = get_mcp_status()
+
+            entry = next(s for s in status if s["name"] == "metric_srv")
+            assert "sampling" in entry
+            assert entry["sampling"]["requests"] == 5
+            assert entry["sampling"]["errors"] == 1
+        finally:
+            _servers.pop("metric_srv", None)
+            _sampling_metrics.pop("metric_srv", None)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: allowed_models tests
+# ---------------------------------------------------------------------------
+
+class TestAllowedModels:
+    """Tests for allowed_models whitelist governance."""
+
+    def setup_method(self):
+        from tools.mcp_tool import _sampling_counters, _sampling_metrics, _tool_loop_counters
+        _sampling_counters.clear()
+        _sampling_metrics.clear()
+        _tool_loop_counters.clear()
+
+    def test_allowed_models_empty_permits_any(self):
+        """Empty allowed_models list permits any model."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {"allowed_models": []})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "some-model")):
+            result = asyncio.run(callback(None, params))
+
+        assert result.role == "assistant"
+
+    def test_allowed_models_blocks_unlisted(self):
+        """Model not in allowed_models returns ErrorData."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        callback = _make_sampling_callback("srv", {
+            "allowed_models": ["gpt-4", "gemini-3-flash"],
+        })
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "not-allowed-model")):
+            result = asyncio.run(callback(None, params))
+
+        assert isinstance(result, ErrorData)
+        assert "not allowed" in result.message.lower()
+        assert "not-allowed-model" in result.message
+
+    def test_allowed_models_permits_listed(self):
+        """Model in allowed_models proceeds normally."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("srv", {
+            "allowed_models": ["gpt-4", "gemini-3-flash"],
+        })
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "gpt-4")):
+            result = asyncio.run(callback(None, params))
+
+        assert result.role == "assistant"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: max_tool_rounds tests
+# ---------------------------------------------------------------------------
+
+class TestMaxToolRounds:
+    """Tests for max_tool_rounds tool loop governance."""
+
+    def setup_method(self):
+        from tools.mcp_tool import _sampling_counters, _sampling_metrics, _tool_loop_counters
+        _sampling_counters.clear()
+        _sampling_metrics.clear()
+        _tool_loop_counters.clear()
+
+    def test_max_tool_rounds_enforced(self):
+        """Exceeding max_tool_rounds returns ErrorData."""
+        from tools.mcp_tool import _make_sampling_callback, _tool_loop_counters
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_tool_response()
+
+        callback = _make_sampling_callback("loop_srv", {"max_tool_rounds": 2})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            # Round 1 -- allowed
+            r1 = asyncio.run(callback(None, params))
+            assert r1.stopReason == "toolUse"
+            assert _tool_loop_counters.get("loop_srv") == 1
+
+            # Round 2 -- allowed
+            r2 = asyncio.run(callback(None, params))
+            assert r2.stopReason == "toolUse"
+            assert _tool_loop_counters.get("loop_srv") == 2
+
+            # Round 3 -- exceeds limit
+            r3 = asyncio.run(callback(None, params))
+            assert isinstance(r3, ErrorData)
+            assert "loop limit exceeded" in r3.message.lower()
+
+    def test_max_tool_rounds_zero_disables(self):
+        """max_tool_rounds=0 disables tool loops entirely."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_tool_response()
+
+        callback = _make_sampling_callback("no_loop_srv", {"max_tool_rounds": 0})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            result = asyncio.run(callback(None, params))
+
+        assert isinstance(result, ErrorData)
+        assert "disabled" in result.message.lower()
+
+    def test_max_tool_rounds_resets_on_end_turn(self):
+        """Tool loop counter resets when LLM returns a normal text response."""
+        from tools.mcp_tool import _make_sampling_callback, _tool_loop_counters
+
+        mock_client = MagicMock()
+
+        callback = _make_sampling_callback("reset_srv", {"max_tool_rounds": 5})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            # First call returns tool_calls
+            mock_client.chat.completions.create.return_value = _make_llm_tool_response()
+            asyncio.run(callback(None, params))
+            assert _tool_loop_counters.get("reset_srv") == 1
+
+            # Second call returns normal text -- should reset counter
+            mock_client.chat.completions.create.return_value = _make_llm_response()
+            asyncio.run(callback(None, params))
+            assert "reset_srv" not in _tool_loop_counters
+
+    def test_max_tool_rounds_default_5(self):
+        """Default max_tool_rounds is 5."""
+        from tools.mcp_tool import _make_sampling_callback, _tool_loop_counters
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_tool_response()
+
+        # No max_tool_rounds in config -> defaults to 5
+        callback = _make_sampling_callback("default_srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            # 5 rounds allowed
+            for i in range(5):
+                result = asyncio.run(callback(None, params))
+                assert result.stopReason == "toolUse", f"Round {i+1} should succeed"
+
+            # 6th round exceeds limit
+            result = asyncio.run(callback(None, params))
+            assert isinstance(result, ErrorData)
+            assert "loop limit exceeded" in result.message.lower()
+
+        _tool_loop_counters.pop("default_srv", None)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: log_level tests
+# ---------------------------------------------------------------------------
+
+class TestLogLevel:
+    """Tests for config-driven audit log level."""
+
+    def setup_method(self):
+        from tools.mcp_tool import _sampling_counters, _sampling_metrics, _tool_loop_counters
+        _sampling_counters.clear()
+        _sampling_metrics.clear()
+        _tool_loop_counters.clear()
+
+    def test_log_level_config_applied(self):
+        """Custom log_level changes the level of audit log messages."""
+        import logging as _logging
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_response()
+
+        callback = _make_sampling_callback("log_srv", {"log_level": "debug"})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")), \
+             patch("tools.mcp_tool.logger") as mock_logger:
+            asyncio.run(callback(None, params))
+
+        # logger.log should have been called with DEBUG level
+        log_calls = [c for c in mock_logger.log.call_args_list if c[0][0] == _logging.DEBUG]
+        assert len(log_calls) >= 1, "Expected at least one DEBUG-level log call"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 bug fixes: malformed args + mixed content list
+# ---------------------------------------------------------------------------
+
+class TestMalformedToolCallArgs:
+    """Tests for graceful handling of malformed tool_calls arguments from LLM."""
+
+    def setup_method(self):
+        from tools.mcp_tool import _sampling_counters, _sampling_metrics, _tool_loop_counters
+        _sampling_counters.clear()
+        _sampling_metrics.clear()
+        _tool_loop_counters.clear()
+
+    def test_malformed_json_args_does_not_crash(self):
+        """Malformed JSON in tool_calls arguments falls back to raw string."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        # Create a tool response with invalid JSON arguments
+        bad_args = "{not valid json"
+        mock_client.chat.completions.create.return_value = _make_llm_tool_response(
+            tool_calls_data=[("call_1", "search", bad_args)]
+        )
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            result = asyncio.run(callback(None, params))
+
+        # Should NOT crash -- returns CreateMessageResult with raw string input
+        assert result.role == "assistant"
+        assert result.stopReason == "toolUse"
+        assert result.content[0]["input"] == bad_args
+
+    def test_valid_json_args_parsed_normally(self):
+        """Valid JSON arguments are parsed as dict."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_llm_tool_response(
+            tool_calls_data=[("call_1", "search", '{"query": "test"}')]
+        )
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            result = asyncio.run(callback(None, params))
+
+        assert result.content[0]["input"] == {"query": "test"}
+
+    def test_dict_args_passed_through(self):
+        """Dict arguments (non-string) are passed through without parsing."""
+        from tools.mcp_tool import _make_sampling_callback
+
+        mock_client = MagicMock()
+        # Simulate args already being a dict (some providers do this)
+        tc = SimpleNamespace(
+            id="call_1",
+            function=SimpleNamespace(name="test", arguments={"key": "val"}),
+        )
+        message = SimpleNamespace(content=None, tool_calls=[tc])
+        choice = SimpleNamespace(message=message, finish_reason="tool_calls")
+        mock_client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[choice], model="m", usage=SimpleNamespace(total_tokens=10),
+        )
+
+        callback = _make_sampling_callback("srv", {})
+        params = _make_sampling_params()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                    return_value=(mock_client, "model")):
+            result = asyncio.run(callback(None, params))
+
+        assert result.content[0]["input"] == {"key": "val"}
+
+
+class TestMixedContentList:
+    """Tests for mixed content lists (text + tool_result) in message conversion."""
+
+    def test_mixed_text_and_tool_result(self):
+        """List with both text and tool_result blocks preserves both."""
+        from tools.mcp_tool import _convert_sampling_messages
+
+        text_block = SimpleNamespace(text="Context information")
+        tool_result = SimpleNamespace(
+            toolUseId="call_1",
+            content=[SimpleNamespace(text="Tool output")],
+        )
+        params = SimpleNamespace(messages=[
+            SimpleNamespace(role="user", content=[text_block, tool_result]),
+        ])
+        result = _convert_sampling_messages(params)
+
+        # Should produce 2 messages: one text, one tool
+        assert len(result) == 2
+        text_msgs = [m for m in result if m["role"] == "user"]
+        tool_msgs = [m for m in result if m["role"] == "tool"]
+        assert len(text_msgs) == 1
+        assert text_msgs[0]["content"] == "Context information"
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "call_1"
+        assert tool_msgs[0]["content"] == "Tool output"
+
+    def test_mixed_list_unknown_block_warned(self):
+        """Unknown block in mixed list is skipped with warning."""
+        from tools.mcp_tool import _convert_sampling_messages
+
+        tool_result = SimpleNamespace(
+            toolUseId="call_1",
+            content=[SimpleNamespace(text="Result")],
+        )
+        unknown = SimpleNamespace(audio_data="raw")
+        params = SimpleNamespace(messages=[
+            SimpleNamespace(role="user", content=[tool_result, unknown]),
+        ])
+
+        with patch("tools.mcp_tool.logger") as mock_logger:
+            result = _convert_sampling_messages(params)
+
+        # tool_result preserved, unknown skipped
+        assert len(result) == 1
+        assert result[0]["role"] == "tool"
+        mock_logger.warning.assert_called_once()
+
+    def test_pure_text_image_list_still_works(self):
+        """Pure text+image list (no tool_result) still works as before."""
+        from tools.mcp_tool import _convert_sampling_messages
+
+        text_block = SimpleNamespace(text="Describe this")
+        image_block = SimpleNamespace(data="base64==", mimeType="image/png")
+        params = SimpleNamespace(messages=[
+            SimpleNamespace(role="user", content=[text_block, image_block]),
+        ])
+        result = _convert_sampling_messages(params)
+
+        assert len(result) == 1
+        parts = result[0]["content"]
+        assert len(parts) == 2
+        assert parts[0] == {"type": "text", "text": "Describe this"}
+        assert parts[1]["type"] == "image_url"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -58,9 +58,11 @@ Thread safety:
 import asyncio
 import json
 import logging
+import math
 import os
 import re
 import threading
+import time
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -71,6 +73,7 @@ logger = logging.getLogger(__name__)
 
 _MCP_AVAILABLE = False
 _MCP_HTTP_AVAILABLE = False
+_MCP_SAMPLING_TYPES = False
 try:
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
@@ -80,6 +83,13 @@ try:
         _MCP_HTTP_AVAILABLE = True
     except ImportError:
         _MCP_HTTP_AVAILABLE = False
+    # Sampling types -- separated to avoid breaking MCP support on older SDK
+    # versions that may not have these types.
+    try:
+        from mcp.types import CreateMessageResult, TextContent, ErrorData
+        _MCP_SAMPLING_TYPES = True
+    except ImportError:
+        logger.debug("MCP sampling types not available -- sampling support disabled")
 except ImportError:
     logger.debug("mcp package not installed -- MCP tool support disabled")
 
@@ -91,6 +101,32 @@ _DEFAULT_TOOL_TIMEOUT = 120      # seconds for tool calls
 _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
 _MAX_RECONNECT_RETRIES = 5
 _MAX_BACKOFF_SECONDS = 60
+
+# Sampling defaults
+_DEFAULT_SAMPLING_MAX_TOKENS_CAP = 4096
+_DEFAULT_SAMPLING_RATE_LIMIT = 10   # max requests per minute per server
+_DEFAULT_SAMPLING_TIMEOUT = 30      # seconds for LLM call
+_sampling_counters: Dict[str, List[float]] = {}  # server_name -> [timestamps]
+_sampling_metrics: Dict[str, Dict[str, int]] = {}  # server_name -> {requests, errors, ...}
+_tool_loop_counters: Dict[str, int] = {}  # server_name -> consecutive tool rounds
+
+
+def _safe_numeric(value, default, coerce=int, minimum=1):
+    """Coerce a config value to a numeric type, returning *default* on failure.
+
+    Handles the case where YAML/JSON config values arrive as strings (e.g.
+    ``"10"`` instead of ``10``), or are set to an entirely invalid type.
+    Values below *minimum* are clamped to *minimum* to prevent nonsensical
+    config (e.g. ``max_rpm: 0`` blocking all requests, ``timeout: 0``
+    causing instant timeouts, or ``max_tokens_cap: -1``).
+    """
+    try:
+        result = coerce(value)
+        if isinstance(result, float) and not math.isfinite(result):
+            return default
+        return max(result, minimum)
+    except (TypeError, ValueError, OverflowError):
+        return default
 
 # Environment variables that are safe to pass to stdio subprocesses
 _SAFE_ENV_KEYS = frozenset({
@@ -146,6 +182,433 @@ def _sanitize_error(text: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Sampling helpers -- server-initiated LLM requests (MCP sampling/createMessage)
+# ---------------------------------------------------------------------------
+
+def _sampling_error(message: str, code: int = -1):
+    """Return ErrorData (MCP spec) or raise Exception as fallback."""
+    if _MCP_SAMPLING_TYPES:
+        return ErrorData(code=code, message=message)
+    raise Exception(message)
+
+
+def _check_rate_limit(server_name: str, max_rpm: int) -> bool:
+    """Check if a sampling request is within the per-server rate limit.
+
+    Returns True if the request is allowed, False if rate limit exceeded.
+    Uses a sliding 60-second window with max ``max_rpm`` requests.
+    """
+    now = time.time()
+    window = now - 60
+    timestamps = _sampling_counters.setdefault(server_name, [])
+    timestamps[:] = [t for t in timestamps if t > window]
+    if len(timestamps) >= max_rpm:
+        return False
+    timestamps.append(now)
+    return True
+
+
+def _resolve_model(preferences, sampling_config: dict):
+    """Resolve the model to use for a sampling request.
+
+    Priority: config override > server hint > None (use default).
+    """
+    if sampling_config.get("model"):
+        return sampling_config["model"]
+    if preferences and hasattr(preferences, "hints") and preferences.hints:
+        for hint in preferences.hints:
+            if hasattr(hint, "name") and hint.name:
+                return hint.name
+    return None
+
+
+def _extract_tool_result_text(block) -> str:
+    """Extract text from a tool_result content block."""
+    if not hasattr(block, "content") or block.content is None:
+        return ""
+    items = block.content if isinstance(block.content, list) else [block.content]
+    return "\n".join(item.text for item in items if hasattr(item, "text"))
+
+
+def _convert_sampling_messages(params) -> List[dict]:
+    """Convert MCP SamplingMessage list to OpenAI messages format.
+
+    Supports text, image, tool_result, and tool_use content blocks.
+    """
+    messages = []
+    for msg in params.messages:
+        content = msg.content
+        # Single text content
+        if hasattr(content, "text"):
+            messages.append({"role": msg.role, "content": content.text})
+        # Single tool_result content -> OpenAI tool role
+        elif hasattr(content, "toolUseId"):
+            messages.append({
+                "role": "tool",
+                "tool_call_id": content.toolUseId,
+                "content": _extract_tool_result_text(content),
+            })
+        elif isinstance(content, list):
+            # All blocks are tool_result -> multiple tool role messages
+            if all(hasattr(b, "toolUseId") for b in content):
+                for block in content:
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": block.toolUseId,
+                        "content": _extract_tool_result_text(block),
+                    })
+            # Any block has tool_use -> assistant message with tool_calls
+            elif any(
+                hasattr(b, "name") and hasattr(b, "input") for b in content
+            ):
+                tool_calls = []
+                text_parts = []
+                for block in content:
+                    if hasattr(block, "name") and hasattr(block, "input"):
+                        tool_calls.append({
+                            "id": getattr(block, "id", f"call_{len(tool_calls)}"),
+                            "type": "function",
+                            "function": {
+                                "name": block.name,
+                                "arguments": (
+                                    json.dumps(block.input)
+                                    if isinstance(block.input, dict)
+                                    else str(block.input)
+                                ),
+                            },
+                        })
+                    elif hasattr(block, "text"):
+                        text_parts.append(block.text)
+                msg_dict: dict = {"role": msg.role}
+                if text_parts:
+                    msg_dict["content"] = "\n".join(text_parts)
+                if tool_calls:
+                    msg_dict["tool_calls"] = tool_calls
+                messages.append(msg_dict)
+            # Mixed list: some blocks are tool_result, others are text/image
+            elif any(hasattr(b, "toolUseId") for b in content):
+                for block in content:
+                    if hasattr(block, "toolUseId"):
+                        messages.append({
+                            "role": "tool",
+                            "tool_call_id": block.toolUseId,
+                            "content": _extract_tool_result_text(block),
+                        })
+                    elif hasattr(block, "text"):
+                        messages.append({"role": msg.role, "content": block.text})
+                    else:
+                        block_type = type(block).__name__
+                        logger.warning(
+                            "Unsupported block in mixed tool_result list: %s (skipped)",
+                            block_type,
+                        )
+            else:
+                # Text + image + unknown handling
+                parts = []
+                for block in content:
+                    if hasattr(block, "text"):
+                        parts.append({"type": "text", "text": block.text})
+                    elif hasattr(block, "data") and hasattr(block, "mimeType"):
+                        parts.append({
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:{block.mimeType};base64,{block.data}",
+                            },
+                        })
+                    else:
+                        block_type = type(block).__name__
+                        logger.warning(
+                            "Unsupported sampling content block type: %s (skipped)",
+                            block_type,
+                        )
+                messages.append({"role": msg.role, "content": parts if parts else ""})
+        else:
+            messages.append({"role": msg.role, "content": str(content)})
+    return messages
+
+
+def _map_stop_reason(finish_reason: str) -> str:
+    """Map OpenAI finish_reason to MCP stopReason."""
+    mapping = {"stop": "endTurn", "length": "maxTokens", "tool_calls": "toolUse"}
+    return mapping.get(finish_reason, "endTurn")
+
+
+def _make_sampling_callback(server_name: str, sampling_config: dict):
+    """Return an async sampling callback for MCP server-initiated LLM requests.
+
+    The callback is invoked by the MCP SDK when a server sends a
+    ``sampling/createMessage`` request. It forwards the request to the
+    agent's auxiliary LLM client and returns the response.
+
+    Requires ``_MCP_SAMPLING_TYPES`` to be True (i.e. the MCP SDK sampling
+    types must be importable). Returns ``None`` otherwise to prevent
+    NameError on the success path where ``CreateMessageResult``/``TextContent``
+    are needed.
+
+    Key design choices:
+      - LLM call is offloaded to a thread via ``asyncio.to_thread()`` to
+        prevent blocking the MCP background event loop.
+      - Errors return ``ErrorData`` (per MCP spec) instead of raising
+        exceptions, giving the server a structured error it can handle.
+      - Per-server rate limit, LLM timeout, model whitelist, tool loop
+        limit, and audit log level are configurable.
+    """
+    if not _MCP_SAMPLING_TYPES:
+        return None
+
+    max_rpm = _safe_numeric(
+        sampling_config.get("max_rpm", _DEFAULT_SAMPLING_RATE_LIMIT),
+        _DEFAULT_SAMPLING_RATE_LIMIT, int,
+    )
+    llm_timeout = _safe_numeric(
+        sampling_config.get("timeout", _DEFAULT_SAMPLING_TIMEOUT),
+        _DEFAULT_SAMPLING_TIMEOUT, float,
+    )
+    max_tokens_cap = _safe_numeric(
+        sampling_config.get("max_tokens_cap", _DEFAULT_SAMPLING_MAX_TOKENS_CAP),
+        _DEFAULT_SAMPLING_MAX_TOKENS_CAP, int,
+    )
+    allowed_models = sampling_config.get("allowed_models", [])
+    max_tool_rounds = _safe_numeric(
+        sampling_config.get("max_tool_rounds", 5), 5, int, minimum=0,
+    )
+
+    _log_levels = {
+        "debug": logging.DEBUG,
+        "info": logging.INFO,
+        "warning": logging.WARNING,
+    }
+    audit_level = _log_levels.get(
+        str(sampling_config.get("log_level", "info")).lower(), logging.INFO,
+    )
+
+    async def _sampling_callback(context, params):
+        # Rate limit check
+        if not _check_rate_limit(server_name, max_rpm):
+            logger.warning(
+                "MCP server '%s' sampling rate limit exceeded (%d/min)",
+                server_name, max_rpm,
+            )
+            metrics = _sampling_metrics.setdefault(server_name, {
+                "requests": 0, "errors": 0, "tokens_used": 0, "tool_use_count": 0,
+            })
+            metrics["errors"] += 1
+            return _sampling_error(
+                f"Sampling rate limit exceeded for server '{server_name}' "
+                f"({max_rpm} requests/minute)"
+            )
+
+        max_tokens = min(params.maxTokens, max_tokens_cap)
+
+        model = _resolve_model(
+            getattr(params, "modelPreferences", None), sampling_config,
+        )
+
+        # Allowed models check
+        resolved_model_name = model  # will be resolved below with default
+        from agent.auxiliary_client import get_text_auxiliary_client
+        client, default_model = get_text_auxiliary_client()
+        if client is None:
+            msg = "No LLM provider available for sampling"
+            logger.error("MCP server '%s': %s", server_name, msg)
+            metrics = _sampling_metrics.setdefault(server_name, {
+                "requests": 0, "errors": 0, "tokens_used": 0, "tool_use_count": 0,
+            })
+            metrics["errors"] += 1
+            return _sampling_error(msg)
+
+        resolved_model_name = model or default_model
+        if allowed_models and resolved_model_name not in allowed_models:
+            logger.warning(
+                "MCP server '%s' requested model '%s' not in allowed_models",
+                server_name, resolved_model_name,
+            )
+            metrics = _sampling_metrics.setdefault(server_name, {
+                "requests": 0, "errors": 0, "tokens_used": 0, "tool_use_count": 0,
+            })
+            metrics["errors"] += 1
+            return _sampling_error(
+                f"Model '{resolved_model_name}' not allowed for server "
+                f"'{server_name}'. Allowed: {', '.join(allowed_models)}"
+            )
+
+        messages = _convert_sampling_messages(params)
+
+        if hasattr(params, "systemPrompt") and params.systemPrompt:
+            messages.insert(0, {"role": "system", "content": params.systemPrompt})
+
+        call_kwargs = {
+            "model": resolved_model_name,
+            "messages": messages,
+            "max_tokens": max_tokens,
+        }
+
+        if hasattr(params, "temperature") and params.temperature is not None:
+            call_kwargs["temperature"] = params.temperature
+
+        stop_sequences = getattr(params, "stopSequences", None)
+        if stop_sequences:
+            call_kwargs["stop"] = stop_sequences
+
+        # Forward tools/toolChoice from the server if present
+        server_tools = getattr(params, "tools", None)
+        if server_tools:
+            call_kwargs["tools"] = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": getattr(t, "name", ""),
+                        "description": getattr(t, "description", "") or "",
+                        "parameters": getattr(t, "inputSchema", {}) or {},
+                    },
+                }
+                for t in server_tools
+            ]
+            tool_choice = getattr(params, "toolChoice", None)
+            if tool_choice:
+                mode = getattr(tool_choice, "mode", "auto")
+                call_kwargs["tool_choice"] = {
+                    "auto": "auto", "required": "required", "none": "none",
+                }.get(mode, "auto")
+
+        logger.log(
+            audit_level,
+            "MCP server '%s' sampling request: model=%s, max_tokens=%d, messages=%d",
+            server_name, call_kwargs["model"], max_tokens, len(messages),
+        )
+
+        # Offload sync LLM call to a thread so we don't block the MCP
+        # event loop (which also serves tool calls and other servers).
+        def _sync_llm_call():
+            return client.chat.completions.create(**call_kwargs)
+
+        try:
+            response = await asyncio.wait_for(
+                asyncio.to_thread(_sync_llm_call),
+                timeout=llm_timeout,
+            )
+        except asyncio.TimeoutError:
+            msg = (
+                f"Sampling LLM call timed out after {llm_timeout}s "
+                f"for server '{server_name}'"
+            )
+            logger.error("MCP server '%s': %s", server_name, msg)
+            metrics = _sampling_metrics.setdefault(server_name, {
+                "requests": 0, "errors": 0, "tokens_used": 0, "tool_use_count": 0,
+            })
+            metrics["errors"] += 1
+            return _sampling_error(msg)
+        except Exception as exc:
+            msg = f"Sampling LLM call failed: {_sanitize_error(str(exc))}"
+            logger.error(
+                "MCP server '%s' sampling LLM call failed: %s",
+                server_name, exc,
+            )
+            metrics = _sampling_metrics.setdefault(server_name, {
+                "requests": 0, "errors": 0, "tokens_used": 0, "tool_use_count": 0,
+            })
+            metrics["errors"] += 1
+            return _sampling_error(msg)
+
+        choice = response.choices[0]
+
+        # Update audit metrics
+        metrics = _sampling_metrics.setdefault(server_name, {
+            "requests": 0, "errors": 0, "tokens_used": 0, "tool_use_count": 0,
+        })
+        metrics["requests"] += 1
+        total_tokens = getattr(
+            getattr(response, "usage", None), "total_tokens", 0,
+        )
+        if isinstance(total_tokens, int):
+            metrics["tokens_used"] += total_tokens
+
+        # Tool use response
+        if (
+            choice.finish_reason == "tool_calls"
+            and hasattr(choice.message, "tool_calls")
+            and choice.message.tool_calls
+        ):
+            metrics["tool_use_count"] += 1
+
+            # Tool loop limit enforcement
+            if max_tool_rounds == 0:
+                _tool_loop_counters.pop(server_name, None)
+                return _sampling_error(
+                    f"Tool loops disabled for server '{server_name}' "
+                    f"(max_tool_rounds=0)"
+                )
+
+            if max_tool_rounds > 0:
+                loop_count = _tool_loop_counters.get(server_name, 0) + 1
+                _tool_loop_counters[server_name] = loop_count
+                if loop_count > max_tool_rounds:
+                    _tool_loop_counters.pop(server_name, None)
+                    return _sampling_error(
+                        f"Tool loop limit exceeded for server '{server_name}' "
+                        f"(max {max_tool_rounds} rounds)"
+                    )
+
+            content_blocks = []
+            for tc in choice.message.tool_calls:
+                args = tc.function.arguments
+                if isinstance(args, str):
+                    try:
+                        parsed_args = json.loads(args)
+                    except (json.JSONDecodeError, ValueError):
+                        logger.warning(
+                            "MCP server '%s': malformed tool_calls arguments "
+                            "from LLM (using raw string): %.100s",
+                            server_name, args,
+                        )
+                        parsed_args = args
+                else:
+                    parsed_args = args
+                content_blocks.append({
+                    "type": "tool_use",
+                    "id": tc.id,
+                    "name": tc.function.name,
+                    "input": parsed_args,
+                })
+
+            logger.log(
+                audit_level,
+                "MCP server '%s' sampling response: model=%s, tokens=%s, tool_calls=%d",
+                server_name, response.model,
+                getattr(getattr(response, "usage", None), "total_tokens", "?"),
+                len(content_blocks),
+            )
+
+            return CreateMessageResult(
+                role="assistant",
+                content=content_blocks,
+                model=response.model,
+                stopReason="toolUse",
+            )
+
+        # Normal text response -- reset tool loop counter
+        _tool_loop_counters.pop(server_name, None)
+
+        response_text = choice.message.content or ""
+
+        logger.log(
+            audit_level,
+            "MCP server '%s' sampling response: model=%s, tokens=%s",
+            server_name, response.model,
+            getattr(getattr(response, "usage", None), "total_tokens", "?"),
+        )
+
+        return CreateMessageResult(
+            role="assistant",
+            content=TextContent(type="text", text=_sanitize_error(response_text)),
+            model=response.model,
+            stopReason=_map_stop_reason(choice.finish_reason),
+        )
+
+    return _sampling_callback
+
+
+# ---------------------------------------------------------------------------
 # Server task -- each MCP server lives in one long-lived asyncio Task
 # ---------------------------------------------------------------------------
 
@@ -162,6 +625,7 @@ class MCPServerTask:
     __slots__ = (
         "name", "session", "tool_timeout",
         "_task", "_ready", "_shutdown_event", "_tools", "_error", "_config",
+        "_sampling_callback",
     )
 
     def __init__(self, name: str):
@@ -174,10 +638,18 @@ class MCPServerTask:
         self._tools: list = []
         self._error: Optional[Exception] = None
         self._config: dict = {}
+        self._sampling_callback = None
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
         return "url" in self._config
+
+    def _build_session_kwargs(self) -> dict:
+        """Build keyword arguments for ClientSession."""
+        kwargs = {}
+        if self._sampling_callback is not None:
+            kwargs["sampling_callback"] = self._sampling_callback
+        return kwargs
 
     async def _run_stdio(self, config: dict):
         """Run the server using stdio transport."""
@@ -198,7 +670,9 @@ class MCPServerTask:
         )
 
         async with stdio_client(server_params) as (read_stream, write_stream):
-            async with ClientSession(read_stream, write_stream) as session:
+            async with ClientSession(
+                read_stream, write_stream, **self._build_session_kwargs(),
+            ) as session:
                 await session.initialize()
                 self.session = session
                 await self._discover_tools()
@@ -223,7 +697,9 @@ class MCPServerTask:
             headers=headers,
             timeout=float(connect_timeout),
         ) as (read_stream, write_stream, _get_session_id):
-            async with ClientSession(read_stream, write_stream) as session:
+            async with ClientSession(
+                read_stream, write_stream, **self._build_session_kwargs(),
+            ) as session:
                 await session.initialize()
                 self.session = session
                 await self._discover_tools()
@@ -249,6 +725,15 @@ class MCPServerTask:
         """
         self._config = config
         self.tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
+
+        # Set up sampling callback if enabled and SDK types are available
+        sampling_config = config.get("sampling", {})
+        if sampling_config.get("enabled", True) and _MCP_SAMPLING_TYPES:
+            self._sampling_callback = _make_sampling_callback(
+                self.name, sampling_config,
+            )
+        else:
+            self._sampling_callback = None
 
         # Validate: warn if both url and command are present
         if "url" in config and "command" in config:
@@ -974,20 +1459,27 @@ def get_mcp_status() -> List[dict]:
     for name, cfg in configured.items():
         transport = "http" if "url" in cfg else "stdio"
         server = active_servers.get(name)
+        metrics = _sampling_metrics.get(name)
         if server and server.session is not None:
-            result.append({
+            entry = {
                 "name": name,
                 "transport": transport,
                 "tools": len(server._tools),
                 "connected": True,
-            })
+            }
+            if metrics:
+                entry["sampling"] = dict(metrics)
+            result.append(entry)
         else:
-            result.append({
+            entry = {
                 "name": name,
                 "transport": transport,
                 "tools": 0,
                 "connected": False,
-            })
+            }
+            if metrics:
+                entry["sampling"] = dict(metrics)
+            result.append(entry)
 
     return result
 


### PR DESCRIPTION
## Summary

Extends the MCP `sampling/createMessage` implementation with full MCP spec compliance, per-server governance controls, and structured audit observability. Built on top of Phase 1 (PR #64).

### Spec Coverage
- **Bug fix**: `_map_stop_reason` now correctly maps `tool_calls` → `"toolUse"` (was incorrectly `"endTurn"`)
- **tools/toolChoice forwarding**: Server-provided tool definitions are forwarded to the LLM as OpenAI function-calling format, with `toolChoice` mode mapping (auto/required/none)
- **Tool content blocks**: Full support for `tool_use` and `tool_result` content blocks in `_convert_sampling_messages` — converts to OpenAI `tool_calls` and `role: "tool"` messages respectively
- **Tool use responses**: When LLM responds with `tool_calls`, returns `CreateMessageResult` with `stopReason: "toolUse"` and tool use content blocks
- **Malformed args safety**: `json.loads()` on tool call arguments is now wrapped in try/except — malformed JSON falls back to raw string instead of crashing the callback
- **Mixed content lists**: Content lists containing both text and `tool_result` blocks are now handled correctly (previously tool_results were silently dropped as "unsupported")

### Governance
- **`allowed_models`**: Per-server model whitelist. Empty list (default) permits any model. Non-listed models return structured `ErrorData`
- **`max_tool_rounds`**: Caps consecutive tool use rounds per server (default: 5). Prevents infinite tool loops between LLM and server. Set to 0 to disable tool loops entirely. Counter resets on normal text response

### Audit Observability
- **`_sampling_metrics`**: Per-server counters tracking `requests`, `errors`, `tokens_used`, and `tool_use_count`
- **`get_mcp_status()`**: Metrics exposed in server status for monitoring/debugging
- **`log_level`**: Config-driven audit verbosity (`"debug"`, `"info"`, `"warning"`)

### Config Schema (all backward-compatible)

```yaml
mcp_servers:
  my_server:
    sampling:
      # Existing (unchanged):
      enabled: true
      model: "gemini-3-flash"
      max_tokens_cap: 4096
      timeout: 30
      max_rpm: 10
      # New:
      allowed_models: []        # model whitelist (empty = all)
      max_tool_rounds: 5        # tool loop limit (0 = disable)
      log_level: "info"         # audit verbosity
```

All new fields have defaults — **zero breaking changes** for existing configurations.

## Files Changed

| File | Change | Delta |
|------|--------|-------|
| `tools/mcp_tool.py` | Bug fix, tool content conversion, tools/toolChoice forwarding, governance, metrics | +170 lines |
| `tests/tools/test_mcp_tool.py` | 31 new tests across 7 test classes | +560 lines |
| `docs/mcp.md` | Config table, Tool Use section, Per-Server Policy section | +90 lines |
| `skills/mcp/native-mcp/SKILL.md` | Config table, tool use reference | +15 lines |

## Test Plan

- [x] `pytest tests/tools/test_mcp_tool.py -q` → **151 passed**, 3 pre-existing fail (mcp pkg not installed)
- [x] `pytest tests/tools/test_mcp_tool.py -k Sampling -W error::RuntimeWarning` → 0 warnings
- [x] All 31 new tests pass: stopReason fix, tool content conversion (6), tools/toolChoice forwarding (6), audit metrics (4), allowed_models (3), max_tool_rounds (4), log_level (1), malformed args (3), mixed content list (3), existing test updated (1)
- [x] Backward compatibility: existing 120 tests unaffected
- [x] Tested on Windows 11 with Python 3.13.5

## Related

- Built on Phase 1 sampling implementation (PR #64)
- References MCP spec 2025-11-25 `sampling/createMessage`