### PR TITLE
fix: apply secret redaction to file tool outputs

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -7,6 +7,7 @@ import os
 import threading
 from typing import Optional
 from tools.file_operations import ShellFileOperations
+from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
@@ -125,6 +126,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
     try:
         file_ops = _get_file_ops(task_id)
         result = file_ops.read_file(path, offset, limit)
+        if result.content:
+            result.content = redact_sensitive_text(result.content)
         return json.dumps(result.to_dict(), ensure_ascii=False)
     except Exception as e:
         return json.dumps({"error": str(e)}, ensure_ascii=False)
@@ -177,6 +180,10 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             pattern=pattern, path=path, target=target, file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
+        if hasattr(result, 'matches'):
+            for m in result.matches:
+                if hasattr(m, 'content') and m.content:
+                    m.content = redact_sensitive_text(m.content)
         return json.dumps(result.to_dict(), ensure_ascii=False)
     except Exception as e:
         return json.dumps({"error": str(e)}, ensure_ascii=False)


### PR DESCRIPTION
Closes #363

Fixes the inconsistency where terminal output was redacted via `redact_sensitive_text()` but file tool outputs were not.

**Changes to `tools/file_tools.py`:**
- Added `from agent.redact import redact_sensitive_text` import
- `read_file_tool`: redacts `result.content` before returning
- `search_tool`: redacts `content` field on each match before returning

**Result:** Secrets that were already masked in terminal output (via `cat`) are now also masked when the agent uses `read_file` or `search_files`.

No new dependencies — reuses the existing `redact_sensitive_text()` from `agent/redact.py`.