### PR TITLE
feat: add PAHF personalization guidance to system prompt (Phase 1)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -81,6 +81,21 @@ SESSION_SEARCH_GUIDANCE = (
     "them to repeat themselves."
 )
 
+PERSONALIZATION_GUIDANCE = (
+    "You learn and adapt to each user's preferences over time using the PAHF loop: "
+    "(1) Pre-action: before tasks involving subjective choices, check your memory for "
+    "relevant user preferences first — if found, act directly without asking; if not "
+    "found and the task is ambiguous, use clarify to ask BEFORE acting, then summarize "
+    "the answer as a preference and save it to memory. "
+    "(2) Preference-grounded action: always retrieve relevant memories before making "
+    "choices that depend on user style, taste, or past decisions. "
+    "(3) Post-action feedback: if the user corrects you after completing a task, treat "
+    "the correction as a preference signal — summarize it and save to memory; if a "
+    "similar preference already exists, merge old and new into a coherent statement "
+    "that preserves context (e.g. 'used to prefer X, now prefers Y when Z'). "
+    "As your memory of the user grows, ask fewer clarifying questions and act more "
+    "confidently on stored preferences."
+)
 SKILLS_GUIDANCE = (
     "After completing a complex task (5+ tool calls), fixing a tricky error, "
     "or discovering a non-trivial workflow, consider saving the approach as a "

--- a/run_agent.py
+++ b/run_agent.py
@@ -77,7 +77,7 @@ from hermes_constants import OPENROUTER_BASE_URL, OPENROUTER_MODELS_URL
 # Agent internals extracted to agent/ package for modularity
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
-    MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
+    MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE, PERSONALIZATION_GUIDANCE,
 )
 from agent.model_metadata import (
     fetch_model_metadata, get_model_context_length,
@@ -1331,6 +1331,8 @@ class AIAgent:
             tool_guidance.append(SESSION_SEARCH_GUIDANCE)
         if "skill_manage" in self.valid_tool_names:
             tool_guidance.append(SKILLS_GUIDANCE)
+        if "memory" in self.valid_tool_names and "clarify" in self.valid_tool_names:
+            tool_guidance.append(PERSONALIZATION_GUIDANCE)
         if tool_guidance:
             prompt_parts.append(" ".join(tool_guidance))
 


### PR DESCRIPTION
Closes #362

Implements Phase 1 of the PAHF personalization loop — behavioral guidance via system prompt, no new tools required.

**Changes:**
- `agent/prompt_builder.py`: adds `PERSONALIZATION_GUIDANCE` constant with the three-step PAHF loop (pre-action clarification, preference-grounded action, post-action feedback integration)
- `run_agent.py`: injects `PERSONALIZATION_GUIDANCE` into the system prompt when both `memory` and `clarify` tools are loaded

**Behavior:**
- Agent checks memory for relevant preferences before making subjective choices
- Agent uses `clarify` only when memory lacks the preference (not every time)
- Agent summarizes corrections into preference statements and saves/merges them in memory
- As memory grows, agent asks fewer questions and acts more confidently

No new dependencies. Phases 2-3 (structured preference storage, automated detect-summarize-integrate pipeline) depend on #346 and are left for follow-up.