### PR TITLE
Fix hidden directory filter broken on Windows

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -27,7 +27,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
             return _skill_commands
         for skill_md in SKILLS_DIR.rglob("SKILL.md"):
             path_str = str(skill_md)
-            if '/.git/' in path_str or '/.github/' in path_str or '/.hub/' in path_str:
+            if any(part in ('.git', '.github', '.hub') for part in skill_md.parts):
                 continue
             try:
                 content = skill_md.read_text(encoding='utf-8')

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -197,7 +197,7 @@ def _find_all_skills() -> List[Dict[str, Any]]:
     
     for skill_md in SKILLS_DIR.rglob("SKILL.md"):
         path_str = str(skill_md)
-        if '/.git/' in path_str or '/.github/' in path_str or '/.hub/' in path_str:
+        if any(part in ('.git', '.github', '.hub') for part in skill_md.parts):
             continue
             
         skill_dir = skill_md.parent


### PR DESCRIPTION
Fixes #389

## Summary
- `_find_all_skills()` in `tools/skills_tool.py` and `scan_skill_commands()` in `agent/skill_commands.py` used hardcoded forward-slash strings (`'/.git/'`, `'/.hub/'`) to filter hidden directories
- On Windows, `str(Path(...))` returns backslash-separated paths, so the filter never matched
- This exposed quarantined skills (downloaded but not yet approved by security scanner) as installed and invocable on Windows

## Fix
Replaced string-based path check with `Path.parts` membership test, which is platform-independent:

```python
# Before (broken on Windows):
if '/.git/' in path_str or '/.github/' in path_str or '/.hub/' in path_str:

# After (works on all platforms):
if any(part in ('.git', '.github', '.hub') for part in skill_md.parts):
```

## Test plan
- [x] Verified with simulated Windows paths (`C:\Users\me\.hermes\skills\.hub\quarantine\...`) — correctly blocked
- [x] Verified with simulated Linux paths (`/home/me/.hermes/skills/.hub/...`) — correctly blocked
- [x] Legitimate skills not affected on either platform