### PR TITLE
Fix context overrun crash with local LLM backends

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3286,13 +3286,49 @@ class AIAgent:
                                 "partial": True
                             }
 
+                    # Check for context-length errors BEFORE generic 4xx handler.
+                    # Local backends (LM Studio, Ollama, llama.cpp) often return
+                    # HTTP 400 with messages like "Context size has been exceeded"
+                    # which must trigger compression, not an immediate abort.
+                    is_context_length_error = any(phrase in error_msg for phrase in [
+                        'context length', 'context size', 'maximum context',
+                        'token limit', 'too many tokens', 'reduce the length',
+                        'exceeds the limit', 'context window',
+                        'request entity too large',  # OpenRouter/Nous 413 safety net
+                    ])
+                    
+                    if is_context_length_error:
+                        print(f"{self.log_prefix}⚠️  Context length exceeded - attempting compression...")
+
+                        original_len = len(messages)
+                        messages, active_system_prompt = self._compress_context(
+                            messages, system_message, approx_tokens=approx_tokens
+                        )
+
+                        if len(messages) < original_len:
+                            print(f"{self.log_prefix}   🗜️  Compressed {original_len} → {len(messages)} messages, retrying...")
+                            continue  # Retry with compressed messages
+                        else:
+                            # Can't compress further
+                            print(f"{self.log_prefix}❌ Context length exceeded and cannot compress further.")
+                            print(f"{self.log_prefix}   💡 The conversation has accumulated too much content.")
+                            logging.error(f"{self.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")
+                            self._persist_session(messages, conversation_history)
+                            return {
+                                "messages": messages,
+                                "completed": False,
+                                "api_calls": api_call_count,
+                                "error": f"Context length exceeded ({approx_tokens:,} tokens). Cannot compress further.",
+                                "partial": True
+                            }
+
                     # Check for non-retryable client errors (4xx HTTP status codes).
                     # These indicate a problem with the request itself (bad model ID,
                     # invalid API key, forbidden, etc.) and will never succeed on retry.
-                    # Note: 413 is excluded — it's handled above via compression.
+                    # Note: 413 and context-length errors are excluded — handled above.
                     is_client_status_error = isinstance(status_code, int) and 400 <= status_code < 500 and status_code != 413
-                    is_client_error = is_client_status_error or any(phrase in error_msg for phrase in [
-                        'error code: 400', 'error code: 401', 'error code: 403',
+                    is_client_error = (is_client_status_error and not is_context_length_error) or any(phrase in error_msg for phrase in [
+                        'error code: 401', 'error code: 403',
                         'error code: 404', 'error code: 422',
                         'is not a valid model', 'invalid model', 'model not found',
                         'invalid api key', 'invalid_api_key', 'authentication',
@@ -3315,39 +3351,7 @@ class AIAgent:
                             "failed": True,
                             "error": str(api_error),
                         }
-                    
-                    # Check for non-retryable errors (context length exceeded)
-                    is_context_length_error = any(phrase in error_msg for phrase in [
-                        'context length', 'maximum context', 'token limit',
-                        'too many tokens', 'reduce the length', 'exceeds the limit',
-                        'request entity too large',  # OpenRouter/Nous 413 safety net
-                    ])
-                    
-                    if is_context_length_error:
-                        print(f"{self.log_prefix}⚠️  Context length exceeded - attempting compression...")
-                        
-                        original_len = len(messages)
-                        messages, active_system_prompt = self._compress_context(
-                            messages, system_message, approx_tokens=approx_tokens
-                        )
-                        
-                        if len(messages) < original_len:
-                            print(f"{self.log_prefix}   🗜️  Compressed {original_len} → {len(messages)} messages, retrying...")
-                            continue  # Retry with compressed messages
-                        else:
-                            # Can't compress further
-                            print(f"{self.log_prefix}❌ Context length exceeded and cannot compress further.")
-                            print(f"{self.log_prefix}   💡 The conversation has accumulated too much content.")
-                            logging.error(f"{self.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")
-                            self._persist_session(messages, conversation_history)
-                            return {
-                                "messages": messages,
-                                "completed": False,
-                                "api_calls": api_call_count,
-                                "error": f"Context length exceeded ({approx_tokens:,} tokens). Cannot compress further.",
-                                "partial": True
-                            }
-                    
+
                     if retry_count >= max_retries:
                         print(f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded. Giving up.")
                         logging.error(f"{self.log_prefix}API call failed after {max_retries} retries. Last error: {api_error}")


### PR DESCRIPTION
Fixes #348

## Problem

Local inference backends (LM Studio, Ollama, llama.cpp) return HTTP 400 with error messages like `"Context size has been exceeded"` when the context window is full. The context-length error phrase list did not include `"context size"` or `"context window"`, so these errors fell through to the generic 4xx abort handler — crashing the session instead of triggering compression.

Error flow **before** this fix:
```
LM Studio returns 400: "Context size has been exceeded"
  → 413 check: no match
  → 4xx abort check: status 400 matches (400 >= 400 and < 500)
  → ❌ "Non-retryable client error. Aborting immediately."
  → Session crashes, context never compressed
```

## Fix

1. **Moved context-length check above the generic 4xx handler** (same pattern as the existing 413 check) so context errors are caught before they reach the abort path
2. **Added missing phrases** to the detection list: `"context size"` (LM Studio), `"context window"` (Ollama)
3. **Guarded the 4xx handler** with `not is_context_length_error` so context-related 400s are never treated as non-retryable

Error flow **after** this fix:
```
LM Studio returns 400: "Context size has been exceeded"
  → 413 check: no match
  → Context-length check: "context size" matches!
  → ⚠️ "Context length exceeded - attempting compression..."
  → 🗜️ Compressed 42 → 18 messages, retrying...
  → ✅ Session continues
```

## Tested error messages

| Backend | HTTP | Error message | Result |
|---------|------|---------------|--------|
| LM Studio | 400 | "Context size has been exceeded" | COMPRESS |
| Ollama | 400 | "context window exceeded" | COMPRESS |
| llama.cpp | 400 | "the context size is too small" | COMPRESS |
| vLLM | 400 | "maximum context length is 8192" | COMPRESS |
| OpenAI | 400 | "maximum context length is 128000" | COMPRESS |
| Auth error | 401 | "invalid api key" | ABORT |
| Model error | 404 | "model not found" | ABORT |
| Generic 400 | 400 | "invalid json in request body" | ABORT |

## Test plan
- [x] Verified LM Studio's exact error message from #348 now triggers compression
- [x] Verified Ollama and llama.cpp error patterns also match
- [x] Verified non-context 4xx errors (auth, model, generic) still abort correctly
- [x] No changes to 413 handling (unchanged)