### PR TITLE
fix: respect OPENAI_BASE_URL when resolving API key priority

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -33,6 +33,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     "meta-llama/llama-3.3-70b-instruct": 131072,
     "deepseek/deepseek-chat-v3": 65536,
     "qwen/qwen-2.5-72b-instruct": 32768,
+    "glm-4.7": 202752,
+    "glm-5": 202752,
 }
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -72,12 +72,24 @@ def _resolve_openrouter_runtime(
         or OPENROUTER_BASE_URL
     ).rstrip("/")
 
-    api_key = (
-        explicit_api_key
-        or os.getenv("OPENROUTER_API_KEY")
-        or os.getenv("OPENAI_API_KEY")
-        or ""
-    )
+    # When base_url points to a non-OpenRouter endpoint (e.g. Z.ai, local LLM),
+    # prefer OPENAI_API_KEY so the correct credentials reach the correct provider.
+    # This allows OPENROUTER_API_KEY to coexist for auxiliary tasks (compression
+    # summaries, vision, session search) without hijacking main inference.
+    if base_url and "openrouter" not in base_url.lower():
+        api_key = (
+            explicit_api_key
+            or os.getenv("OPENAI_API_KEY")
+            or os.getenv("OPENROUTER_API_KEY")
+            or ""
+        )
+    else:
+        api_key = (
+            explicit_api_key
+            or os.getenv("OPENROUTER_API_KEY")
+            or os.getenv("OPENAI_API_KEY")
+            or ""
+        )
 
     source = "explicit" if (explicit_api_key or explicit_base_url) else "env/config"
 


### PR DESCRIPTION
## Summary

- **API key priority fix** (`hermes_cli/runtime_provider.py`): When `OPENAI_BASE_URL` points to a non-OpenRouter endpoint (e.g. Z.ai, local LLM), `OPENROUTER_API_KEY` incorrectly takes priority over `OPENAI_API_KEY`, sending wrong credentials to the inference provider. This causes 401 auth errors and forces users to comment out `OPENROUTER_API_KEY`, which then breaks auxiliary clients (compression, vision). Fix: check whether `base_url` contains "openrouter" and swap key priority accordingly.
- **GLM context lengths** (`agent/model_metadata.py`): Adds `glm-4.7` (202752) and `glm-5` (202752) to `DEFAULT_CONTEXT_LENGTHS` so compression thresholds are calculated correctly for these models (values from HuggingFace `max_position_embeddings`).

## Test plan

- [ ] Verify existing tests pass with `pytest tests/`
- [ ] Set both `OPENROUTER_API_KEY` and `OPENAI_API_KEY` in env, point `OPENAI_BASE_URL` to a non-OpenRouter provider — confirm main inference uses `OPENAI_API_KEY`
- [ ] Remove `OPENAI_BASE_URL` or point it to OpenRouter — confirm `OPENROUTER_API_KEY` is preferred
- [ ] Run agent with `glm-4.7` or `glm-5` model — confirm context length resolves to 202752 instead of default 128k