### PR TITLE
feat: add iteration budget pressure warnings

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -293,6 +293,15 @@ class AIAgent:
         self._use_prompt_caching = is_openrouter and is_claude
         self._cache_ttl = "5m"  # Default 5-minute TTL (1.25x write cost)
         
+        # Iteration budget pressure: warn the LLM as it approaches max_iterations.
+        # Inspired by Utah's budget pressure system. Thresholds are relative (0.0-1.0).
+        # - Caution tier: nudge the LLM to start wrapping up
+        # - Warning tier: urgent signal to provide final response immediately
+        # Messages are injected into api_messages only (not persisted to session history).
+        self._budget_caution_threshold = 0.7   # 70% of max_iterations
+        self._budget_warning_threshold = 0.9   # 90% of max_iterations
+        self._budget_pressure_enabled = True   # Can be disabled if needed
+        
         # Persistent error log -- always writes WARNING+ to ~/.hermes/logs/errors.log
         # so tool failures, API errors, etc. are inspectable after the fact.
         from agent.redact import RedactingFormatter
@@ -2885,6 +2894,48 @@ class AIAgent:
             if self.tool_delay > 0 and i < len(assistant_message.tool_calls):
                 time.sleep(self.tool_delay)
 
+    def _get_budget_warning_message(self, api_call_count: int) -> Optional[Dict[str, str]]:
+        """
+        Generate a budget pressure warning message if the agent is approaching max_iterations.
+        
+        Returns an ephemeral system message to inject into api_messages (not persisted),
+        or None if no warning is needed yet.
+        
+        Two-tier system inspired by Utah (github.com/inngest/utah):
+        - Caution tier (70%): nudge to start consolidating work
+        - Warning tier (90%): urgent signal to respond immediately
+        """
+        if not self._budget_pressure_enabled or self.max_iterations <= 0:
+            return None
+        
+        progress = api_call_count / self.max_iterations
+        remaining = self.max_iterations - api_call_count
+        
+        # Warning tier (90%+): urgent, must respond now
+        if progress >= self._budget_warning_threshold:
+            return {
+                "role": "system",
+                "content": (
+                    f"[BUDGET WARNING: Iteration {api_call_count}/{self.max_iterations}. "
+                    f"You have only {remaining} iteration(s) left. "
+                    "You MUST provide your final response NOW. "
+                    "Do not make additional tool calls unless absolutely critical.]"
+                ),
+            }
+        
+        # Caution tier (70%+): gentle nudge to wrap up
+        if progress >= self._budget_caution_threshold:
+            return {
+                "role": "system",
+                "content": (
+                    f"[BUDGET: Iteration {api_call_count}/{self.max_iterations}. "
+                    f"You have {remaining} iterations left. "
+                    "Start consolidating your work and prepare to provide a final response.]"
+                ),
+            }
+        
+        return None
+
     def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
         """Request a summary when max iterations are reached. Returns the final response text."""
         print(f"⚠️  Reached maximum iterations ({self.max_iterations}). Requesting summary...")
@@ -3273,6 +3324,18 @@ class AIAgent:
             if hasattr(self, 'context_compressor') and self.context_compressor:
                 api_messages = self.context_compressor._sanitize_tool_pairs(api_messages)
 
+            # Inject iteration budget pressure warnings as the agent approaches max_iterations.
+            # These ephemeral messages are injected at the END of api_messages (after any
+            # cached content) so they don't invalidate prompt caching prefixes.
+            # The LLM gets advance warning to wrap up before hitting the hard limit.
+            budget_warning = self._get_budget_warning_message(api_call_count)
+            if budget_warning:
+                api_messages.append(budget_warning)
+                if not self.quiet_mode:
+                    remaining = self.max_iterations - api_call_count
+                    tier = "⚠️  WARNING" if remaining <= self.max_iterations * 0.1 else "💡 CAUTION"
+                    print(f"{self.log_prefix}{tier}: {remaining} iterations remaining")
+            
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)
             approx_tokens = total_chars // 4  # Rough estimate: 4 chars per token

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1040,3 +1040,68 @@ class TestMaxTokensParam:
         agent.base_url = "https://openrouter.ai/api/v1/api.openai.com"
         result = agent._max_tokens_param(4096)
         assert result == {"max_tokens": 4096}
+
+
+# ---------------------------------------------------------------------------
+# Iteration budget pressure warnings
+# ---------------------------------------------------------------------------
+
+class TestBudgetPressure:
+    """Budget pressure warning system tests (issue #414)."""
+
+    def test_no_warning_below_caution_threshold(self, agent):
+        """No warning should be returned below 70% of max_iterations."""
+        agent.max_iterations = 60
+        # At 50% (30/60), no warning
+        msg = agent._get_budget_warning_message(30)
+        assert msg is None
+
+    def test_caution_tier_at_70_percent(self, agent):
+        """Caution message at 70% of max_iterations."""
+        agent.max_iterations = 60
+        msg = agent._get_budget_warning_message(42)  # 70% of 60
+        assert msg is not None
+        assert msg["role"] == "system"
+        assert "[BUDGET:" in msg["content"]
+        assert "18 iterations left" in msg["content"]
+        assert "Start consolidating" in msg["content"]
+
+    def test_warning_tier_at_90_percent(self, agent):
+        """Urgent warning at 90% of max_iterations."""
+        agent.max_iterations = 60
+        msg = agent._get_budget_warning_message(54)  # 90% of 60
+        assert msg is not None
+        assert "[BUDGET WARNING:" in msg["content"]
+        assert "MUST provide your final response NOW" in msg["content"]
+
+    def test_warning_at_last_iteration(self, agent):
+        """Warning should fire on the last iteration."""
+        agent.max_iterations = 60
+        msg = agent._get_budget_warning_message(59)
+        assert msg is not None
+        assert "[BUDGET WARNING:" in msg["content"]
+        assert "1 iteration(s) left" in msg["content"]
+
+    def test_disabled_budget_pressure_returns_none(self, agent):
+        """When budget pressure is disabled, no warnings are returned."""
+        agent.max_iterations = 60
+        agent._budget_pressure_enabled = False
+        msg = agent._get_budget_warning_message(55)
+        assert msg is None
+
+    def test_zero_max_iterations_returns_none(self, agent):
+        """Edge case: max_iterations=0 should not cause division by zero."""
+        agent.max_iterations = 0
+        msg = agent._get_budget_warning_message(0)
+        assert msg is None
+
+    def test_small_max_iterations(self, agent):
+        """Budget pressure should work with small max_iterations values."""
+        agent.max_iterations = 10
+        # At 70% (7/10), expect caution
+        msg = agent._get_budget_warning_message(7)
+        assert msg is not None
+        assert "[BUDGET:" in msg["content"]
+        # At 90% (9/10), expect warning
+        msg = agent._get_budget_warning_message(9)
+        assert "[BUDGET WARNING:" in msg["content"]


### PR DESCRIPTION
## Summary

Implements **issue #414** — a two-tier budget pressure system that warns the LLM as it approaches `max_iterations`, giving it the opportunity to wrap up before being cut off.

## Implementation

### Two-tier warning system
- **Caution tier (70%)**: Gentle nudge to start consolidating work
  ```
  [BUDGET: Iteration 42/60. You have 18 iterations left. Start consolidating your work and prepare to provide a final response.]
  ```
- **Warning tier (90%)**: Urgent signal to respond immediately  
  ```
  [BUDGET WARNING: Iteration 54/60. You have only 6 iteration(s) left. You MUST provide your final response NOW. Do not make additional tool calls unless absolutely critical.]
  ```

### Key design decisions

1. **Cache-friendly**: Messages are injected into `api_messages` AFTER prompt caching is applied, so cached prefixes are never invalidated
2. **Ephemeral**: Warnings are NOT persisted to session history — they exist only for that API call
3. **Configurable**: Thresholds can be adjusted via instance variables:
   - `_budget_caution_threshold` (default: 0.7)
   - `_budget_warning_threshold` (default: 0.9)
   - `_budget_pressure_enabled` (default: True)

### Code changes

- `run_agent.py`: Added `_get_budget_warning_message()` method and injection logic in the main conversation loop (~50 lines)
- `tests/test_run_agent.py`: Added `TestBudgetPressure` class with 7 tests

## Testing

All 85 tests pass (78 existing + 7 new):
```
============================= 85 passed in 5.76s ==============================
```

## References

- Issue: #414
- Inspiration: [Utah's budget pressure system](https://github.com/inngest/utah/blob/main/src/agent-loop.ts) (lines 207-223)
- Blog: [Your Agent Needs a Harness, Not a Framework](https://www.inngest.com/blog/your-agent-needs-a-harness-not-a-framework)