### PR TITLE
feat(telegram): location skill

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -252,6 +252,7 @@ def cleanup_document_cache(max_age_hours: int = 24) -> int:
 class MessageType(Enum):
     """Types of incoming messages."""
     TEXT = "text"
+    LOCATION = "location"
     PHOTO = "photo"
     VIDEO = "video"
     AUDIO = "audio"

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -117,6 +117,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._handle_command
             ))
             self._app.add_handler(TelegramMessageHandler(
+                filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
+                self._handle_location_message
+            ))
+            self._app.add_handler(TelegramMessageHandler(
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
             ))
@@ -440,6 +444,64 @@ class TelegramAdapter(BasePlatformAdapter):
         event = self._build_message_event(update.message, MessageType.COMMAND)
         await self.handle_message(event)
     
+
+    async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        '''Handle incoming location/venue messages.'''
+        if not update.message:
+            return
+
+        msg = update.message
+        event = self._build_message_event(msg, MessageType.LOCATION)
+
+        venue = getattr(msg, "venue", None)
+        if venue and getattr(venue, "location", None):
+            vloc = venue.location
+            title = getattr(venue, "title", None)
+            address = getattr(venue, "address", None)
+            lines = [
+                "[The user shared a venue via Telegram.]",
+                "Ask what they'd like you to do near this venue (e.g., restaurants/cafes, directions, hours) and any constraints like distance/open-now. For map links, prefer a coordinate-anchored Google Maps link (search centered at these coordinates, or directions using exact coordinates). Avoid name-only searches and avoid rounding/truncation.",
+                f"title: {title}" if title else "",
+                f"address: {address}" if address else "",
+                f"latitude: {getattr(vloc, 'latitude', None)}",
+                f"longitude: {getattr(vloc, 'longitude', None)}",
+            ]
+            fsq_id = getattr(venue, "foursquare_id", None)
+            if fsq_id:
+                lines.append(f"foursquare_id: {fsq_id}")
+            fsq_type = getattr(venue, "foursquare_type", None)
+            if fsq_type:
+                lines.append(f"foursquare_type: {fsq_type}")
+            event.text = "\n".join([ln for ln in lines if ln])
+            await self.handle_message(event)
+            return
+
+        loc = getattr(msg, "location", None)
+        if not loc:
+            return
+
+        lines = [
+            "[The user shared a location pin via Telegram.]",
+            "Ask what they'd like you to find near this location (e.g., restaurants) and any constraints like distance/open-now. For map links, prefer a coordinate-anchored Google Maps link (search centered at these coordinates, or directions using exact coordinates). Avoid name-only searches and avoid rounding/truncation.",
+            f"latitude: {getattr(loc, 'latitude', None)}",
+            f"longitude: {getattr(loc, 'longitude', None)}",
+        ]
+        ha = getattr(loc, "horizontal_accuracy", None)
+        if ha is not None:
+            lines.append(f"horizontal_accuracy_m: {ha}")
+        live = getattr(loc, "live_period", None)
+        if live is not None:
+            lines.append(f"live_period_s: {live}")
+        heading = getattr(loc, "heading", None)
+        if heading is not None:
+            lines.append(f"heading_deg: {heading}")
+        prox = getattr(loc, "proximity_alert_radius", None)
+        if prox is not None:
+            lines.append(f"proximity_alert_radius_m: {prox}")
+
+        event.text = "\n".join(lines)
+        await self.handle_message(event)
+
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
         if not update.message:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -460,7 +460,8 @@ class TelegramAdapter(BasePlatformAdapter):
             address = getattr(venue, "address", None)
             lines = [
                 "[The user shared a venue via Telegram.]",
-                "Ask what they'd like you to do near this venue (e.g., restaurants/cafes, directions, hours) and any constraints like distance/open-now. For map links, prefer a coordinate-anchored Google Maps link (search centered at these coordinates, or directions using exact coordinates). Avoid name-only searches and avoid rounding/truncation.",
+                "Ask what they'd like you to do near this venue (e.g., restaurants/cafes, directions, hours) and any constraints like distance/open-now.",
+                "Map links: use coordinate-anchored Google Maps URLs with exact coordinates. Pin: https://www.google.com/maps/search/?api=1&query=<LAT>,<LON> . Directions: https://www.google.com/maps/dir/?api=1&origin=<LAT>,<LON>&destination=<LAT>,<LON> . Avoid name-only searches; never swap/round/truncate coordinates.",
                 f"title: {title}" if title else "",
                 f"address: {address}" if address else "",
                 f"latitude: {getattr(vloc, 'latitude', None)}",
@@ -482,7 +483,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
         lines = [
             "[The user shared a location pin via Telegram.]",
-            "Ask what they'd like you to find near this location (e.g., restaurants) and any constraints like distance/open-now. For map links, prefer a coordinate-anchored Google Maps link (search centered at these coordinates, or directions using exact coordinates). Avoid name-only searches and avoid rounding/truncation.",
+            "Ask what they'd like you to find near this location (e.g., restaurants) and any constraints like distance/open-now.",
+            "Map links: use coordinate-anchored Google Maps URLs with exact coordinates. Pin: https://www.google.com/maps/search/?api=1&query=<LAT>,<LON> . Directions: https://www.google.com/maps/dir/?api=1&origin=<LAT>,<LON>&destination=<LAT>,<LON> . Avoid name-only searches; never swap/round/truncate coordinates.",
             f"latitude: {getattr(loc, 'latitude', None)}",
             f"longitude: {getattr(loc, 'longitude', None)}",
         ]

--- a/skills/productivity/telegram-location/SKILL.md
+++ b/skills/productivity/telegram-location/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: telegram-location
+description: Use shared coordinates (Telegram location/venue pins, or pasted lat/lon) to find nearby places (restaurants/cafes/etc.), optionally "open now", and return coordinate-anchored map links.
+version: 1.0.0
+author: community
+license: MIT
+metadata:
+  hermes:
+    tags: [telegram, location, nearby, restaurants, open-now, maps]
+    related_skills: [duckduckgo-search]
+---
+
+# Telegram Location (Nearby Places)
+
+Handle Telegram shared locations/venues by extracting `latitude`/`longitude`, asking for intent + constraints, and returning nearby recommendations with reliable, coordinate-anchored map links.
+
+## When to Use
+
+Use this skill when:
+
+- The user shares a Telegram **location pin**, **live location**, or **venue** (Hermes injects `latitude:` / `longitude:` lines).
+- The user says "near me" and you need them to share their location.
+- The user provides exact `lat, lon` and asks for nearby places.
+
+## Quick Reference
+
+`SKILL_DIR` is the directory containing this `SKILL.md`.
+
+```bash
+# Nearby restaurants within 1500m (no open-now filtering)
+python3 SKILL_DIR/scripts/nearby_places.py --lat <LAT> --lon <LON> \
+  --amenity restaurant \
+  --radius-m 1500 \
+  --limit 10
+
+# "Open now" (best-effort). Keep unknown-hours results so you can verify via web search.
+python3 SKILL_DIR/scripts/nearby_places.py --lat <LAT> --lon <LON> \
+  --amenity restaurant \
+  --radius-m 2000 \
+  --open-now --include-unknown-hours \
+  --limit 15
+
+# Multiple amenities (repeat --amenity)
+python3 SKILL_DIR/scripts/nearby_places.py --lat <LAT> --lon <LON> \
+  --amenity cafe --amenity bar \
+  --radius-m 1500 \
+  --limit 15
+```
+
+## Procedure
+
+1. Extract coordinates.
+- Look for `latitude: ...` / `longitude: ...` in the conversation.
+- If missing, ask the user to share a location pin (Telegram: Attach -> Location -> Send).
+
+2. Ask only for missing constraints.
+- What place type: `restaurant`, `cafe`, `bar`, `pharmacy`, etc.
+- Radius (meters) or a human constraint ("10 min walk") you convert to `radius_m`.
+- Whether "open now" is required.
+- Optional preferences: cuisine, budget, dietary, vibe.
+
+3. Fetch candidates via the helper script.
+- Use `--open-now --include-unknown-hours` when the user wants "open now".
+- If results are sparse, widen the radius (e.g., 1500 -> 3000m).
+
+4. Verify hours/details for high confidence (recommended).
+- The script uses OSM `opening_hours` and only handles simple formats.
+- For top candidates with `open_now=null` (unknown) or where hours matter, verify with `web_search` (or the `duckduckgo-search` skill if Firecrawl is unavailable).
+
+5. Respond with a short list + reliable links.
+- Include: name, distance, open status (open/closed/unknown).
+- Prefer **coordinate-anchored** links from the script output:
+  - `google_maps_url` (pin by coordinates)
+  - `google_maps_directions_url` (directions using exact coordinates)
+- Avoid name-only Google Maps searches, and never round/truncate coordinates.
+
+6. Ask one follow-up question.
+- Example: "Want me to filter by cuisine/price, or verify hours for any of these?"
+
+## Pitfalls
+
+- **Lat/lon mistakes**: swapped coordinates or rounded values can move results tens of kilometers.
+- **Google Maps name searches**: same-named places can resolve far away; use coordinate links.
+- **Overpass flakiness**: Overpass can rate limit or fail; the script falls back to Nominatim.
+- **"Open now" uncertainty**: OSM `opening_hours` is often missing or complex; treat `open_now=null` as unknown and verify via web search.
+
+## Verification
+
+- Confirm returned `distance_m` values are plausible for the chosen radius.
+- Open one of the `google_maps_url` links and confirm it lands in the same neighborhood as the shared pin.
+- If the user reports wrong locations, re-check that you used the exact shared coordinates and did not swap/round them.

--- a/skills/productivity/telegram-location/scripts/nearby_places.py
+++ b/skills/productivity/telegram-location/scripts/nearby_places.py
@@ -1,0 +1,753 @@
+#!/usr/bin/env python3
+"""Nearby places (OSM Overpass) helper for the "telegram-location" skill.
+
+- Dependency-free (Python stdlib only)
+- Prints JSON to stdout
+- Supports basic "open now" filtering via OSM `opening_hours` (simple cases only)
+
+Notes:
+- Overpass can be flaky; this tool falls back to Nominatim.
+- "Open now" requires local wall-clock time; we try timeapi.io. If that fails,
+  results are returned without filtering and `open_now` will be null.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import math
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+
+OVERPASS_ENDPOINTS = (
+    "https://overpass-api.de/api/interpreter",
+    "https://overpass.kumi.systems/api/interpreter",
+    "https://overpass.nchc.org.tw/api/interpreter",
+)
+NOMINATIM_SEARCH_URL = "https://nominatim.openstreetmap.org/search"
+TIMEAPI_COORD_URL = "https://timeapi.io/api/Time/current/coordinate"
+USER_AGENT = "hermes-skill-telegram-location/1.0"
+
+_KEEP_TAG_PREFIXES = ("addr:", "contact:")
+_KEEP_TAG_KEYS = {
+    "name",
+    "amenity",
+    "cuisine",
+    "opening_hours",
+    "website",
+    "phone",
+    "nominatim:category",
+    "nominatim:type",
+    "wheelchair",
+    "delivery",
+    "takeaway",
+    "outdoor_seating",
+    "reservation",
+}
+
+_DAY_TO_IDX = {"Mo": 0, "Tu": 1, "We": 2, "Th": 3, "Fr": 4, "Sa": 5, "Su": 6}
+
+
+def _die(msg: str, *, code: int = 2, extra: Optional[dict] = None) -> None:
+    payload: Dict[str, Any] = {"success": False, "error": msg}
+    if extra:
+        payload.update(extra)
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    raise SystemExit(code)
+
+
+def _print(data: Any) -> None:
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def _http_get_json(url: str, *, timeout: float) -> Dict[str, Any]:
+    value = _http_get_json_value(url, timeout=timeout)
+    if not isinstance(value, dict):
+        raise RuntimeError(f"Unexpected JSON type: {type(value).__name__}")
+    return value
+
+
+def _http_get_json_value(url: str, *, timeout: float) -> Any:
+    req = urllib.request.Request(
+        url,
+        method="GET",
+        headers={
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read()
+    text = raw.decode("utf-8", errors="replace")
+    try:
+        parsed = json.loads(text)
+    except Exception as e:
+        raise RuntimeError(f"Invalid JSON response: {e}: {text[:300]!r}")
+    return parsed
+
+
+def _http_post_form_json(url: str, *, form: Dict[str, str], timeout: float) -> Dict[str, Any]:
+    body = urllib.parse.urlencode(form).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+            "User-Agent": USER_AGENT,
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read()
+    text = raw.decode("utf-8", errors="replace")
+    try:
+        parsed = json.loads(text)
+    except Exception as e:
+        raise RuntimeError(f"Invalid JSON response: {e}: {text[:300]!r}")
+    if not isinstance(parsed, dict):
+        raise RuntimeError(f"Unexpected JSON type: {type(parsed).__name__}")
+    return parsed
+
+
+def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    r = 6371000.0
+    p1 = math.radians(lat1)
+    p2 = math.radians(lat2)
+    dp = math.radians(lat2 - lat1)
+    dl = math.radians(lon2 - lon1)
+    a = math.sin(dp / 2.0) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2.0) ** 2
+    c = 2.0 * math.atan2(math.sqrt(a), math.sqrt(1.0 - a))
+    return r * c
+
+
+def _sanitize_amenities(values: Sequence[str]) -> List[str]:
+    out: List[str] = []
+    for v in values:
+        s = v.strip().lower().replace("-", "_")
+        if not s:
+            continue
+        if not all(ch.isalnum() or ch == "_" for ch in s):
+            _die(f"Invalid amenity value: {v!r} (allowed: letters/digits/underscore only)")
+        out.append(s)
+    return sorted(set(out))
+
+
+def _overpass_query(lat: float, lon: float, *, radius_m: int, amenities: Sequence[str], require_name: bool) -> str:
+    # Use a strict regex to avoid OSM query injection (amenities are sanitized).
+    regex = "|".join(amenities) if amenities else "restaurant"
+    name_filter = '["name"]' if require_name else ""
+    # nwr = node/way/relation
+    return (
+        f"[out:json][timeout:25];"
+        f"(nwr[\"amenity\"~\"^({regex})$\"]{name_filter}(around:{radius_m},{lat},{lon}););"
+        f"out center tags;"
+    )
+
+
+def _fetch_overpass(query: str, *, timeout: float) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    errors: List[str] = []
+    for ep in OVERPASS_ENDPOINTS:
+        try:
+            data = _http_post_form_json(ep, form={"data": query}, timeout=timeout)
+            return data, {"endpoint": ep}
+        except Exception as e:
+            errors.append(f"{ep}: {type(e).__name__}: {e}")
+            continue
+    raise RuntimeError("All Overpass endpoints failed: " + " | ".join(errors))
+
+
+def _viewbox_for_radius(lat: float, lon: float, *, radius_m: int) -> Tuple[float, float, float, float]:
+    # Rough meters-to-degrees conversion for small radii.
+    lat_delta = radius_m / 111_320.0
+    cos_lat = math.cos(math.radians(lat))
+    lon_delta = radius_m / (111_320.0 * cos_lat) if abs(cos_lat) > 1e-6 else lat_delta
+    return (lon - lon_delta, lat - lat_delta, lon + lon_delta, lat + lat_delta)
+
+
+def _fetch_nominatim(
+    *,
+    lat: float,
+    lon: float,
+    radius_m: int,
+    amenities: Sequence[str],
+    limit: int,
+    timeout: float,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    # Nominatim doesn't support amenity filters the same way Overpass does; we query per amenity keyword
+    # and bound to a viewbox approximating the radius, then filter results client-side.
+    vb = _viewbox_for_radius(lat, lon, radius_m=radius_m)
+    viewbox = ",".join(str(x) for x in vb)
+
+    max_amenities = 3
+    if len(amenities) > max_amenities:
+        amenities = list(amenities)[:max_amenities]
+
+    per_query_limit = min(50, max(15, limit * 3))
+    all_results: List[Dict[str, Any]] = []
+    errors: List[str] = []
+
+    for a in amenities or ["restaurant"]:
+        params = {
+            "format": "jsonv2",
+            "q": a,
+            "bounded": "1",
+            "viewbox": viewbox,
+            "limit": str(per_query_limit),
+            "extratags": "1",
+        }
+        url = NOMINATIM_SEARCH_URL + "?" + urllib.parse.urlencode(params)
+        try:
+            value = _http_get_json_value(url, timeout=timeout)
+            if not isinstance(value, list):
+                raise RuntimeError(f"Unexpected JSON type: {type(value).__name__}")
+            for item in value:
+                if isinstance(item, dict):
+                    all_results.append(item)
+        except Exception as e:
+            errors.append(f"{a}: {type(e).__name__}: {e}")
+
+    if not all_results:
+        raise RuntimeError("Nominatim returned no results" + (f" ({' | '.join(errors)})" if errors else ""))
+
+    return all_results, {"provider": "nominatim", "url": NOMINATIM_SEARCH_URL, "errors": errors or None}
+
+
+def _nominatim_item_matches_amenities(item: Dict[str, Any], amenities: Sequence[str]) -> bool:
+    if not amenities:
+        return True
+
+    cat = item.get("category")
+    typ = item.get("type")
+    if isinstance(cat, str) and isinstance(typ, str):
+        if cat == "amenity" and typ in amenities:
+            return True
+
+    extratags = item.get("extratags")
+    if isinstance(extratags, dict):
+        a = extratags.get("amenity")
+        if isinstance(a, str) and a in amenities:
+            return True
+
+    return False
+
+
+def _nominatim_to_elements(items: Sequence[Dict[str, Any]], *, amenities: Sequence[str]) -> List[Dict[str, Any]]:
+    """Convert Nominatim search results into an Overpass-like element list.
+
+    Output element format: {type, id, lat, lon, tags}.
+    """
+    elements: List[Dict[str, Any]] = []
+    for item in items:
+        if not _nominatim_item_matches_amenities(item, amenities):
+            continue
+
+        osm_type = item.get("osm_type")
+        if osm_type not in ("node", "way", "relation"):
+            continue
+        try:
+            osm_id = int(item.get("osm_id"))
+            lat = float(item.get("lat"))
+            lon = float(item.get("lon"))
+        except Exception:
+            continue
+
+        tags: Dict[str, Any] = {}
+        if isinstance(item.get("name"), str) and item.get("name"):
+            tags["name"] = item["name"]
+        if isinstance(item.get("extratags"), dict):
+            tags.update(item["extratags"])
+        # Surface a hint about what Nominatim classified this as.
+        if isinstance(item.get("category"), str):
+            tags["nominatim:category"] = item["category"]
+        if isinstance(item.get("type"), str):
+            tags["nominatim:type"] = item["type"]
+
+        elements.append(
+            {
+                "type": osm_type,
+                "id": osm_id,
+                "lat": lat,
+                "lon": lon,
+                "tags": tags,
+            }
+        )
+    return elements
+
+
+def _osm_url(osm_type: str, osm_id: int) -> str:
+    return f"https://www.openstreetmap.org/{osm_type}/{osm_id}"
+
+
+def _google_maps_url(lat: float, lon: float) -> str:
+    # Unambiguous coordinate pin.
+    return f"https://www.google.com/maps/search/?api=1&query={lat},{lon}"
+
+
+def _google_maps_directions_url(
+    origin_lat: float,
+    origin_lon: float,
+    dest_lat: float,
+    dest_lon: float,
+    *,
+    travelmode: str = "walking",
+) -> str:
+    mode = (travelmode or "").strip().lower()
+    if mode not in ("walking", "driving", "transit", "bicycling"):
+        mode = "walking"
+    return (
+        "https://www.google.com/maps/dir/?api=1"
+        f"&origin={origin_lat},{origin_lon}"
+        f"&destination={dest_lat},{dest_lon}"
+        f"&travelmode={mode}"
+    )
+
+
+def _google_maps_place_search_url(query: str, *, near_lat: float, near_lon: float, zoom: int = 16) -> str:
+    """Build a Google Maps search URL that is biased to a nearby viewport.
+
+    This is a convenience link only. Google may still resolve to a same-named
+    business elsewhere. Prefer coordinate pins/directions for reliability.
+    """
+    q = (query or "").strip()
+    if not q:
+        return _google_maps_url(near_lat, near_lon)
+    encoded = urllib.parse.quote(q, safe="")
+    z = int(zoom)
+    if z < 10:
+        z = 10
+    if z > 20:
+        z = 20
+    return f"https://www.google.com/maps/search/{encoded}/@{near_lat},{near_lon},{z}z"
+
+
+def _build_maps_query(name: Optional[str], tags_raw: Dict[str, Any]) -> Optional[str]:
+    if not name:
+        return None
+    parts: List[str] = [str(name).strip()]
+
+    # Prefer a single full address if present.
+    addr_full = tags_raw.get("addr:full")
+    if isinstance(addr_full, str) and addr_full.strip():
+        parts.append(addr_full.strip())
+        return ", ".join([p for p in parts if p])
+
+    # Otherwise compose a minimal address.
+    housenum = tags_raw.get("addr:housenumber")
+    street = tags_raw.get("addr:street")
+    city = tags_raw.get("addr:city")
+    postcode = tags_raw.get("addr:postcode")
+
+    street_line = ""
+    if isinstance(street, str) and street.strip():
+        if isinstance(housenum, str) and housenum.strip():
+            street_line = f"{housenum.strip()} {street.strip()}"
+        else:
+            street_line = street.strip()
+    if street_line:
+        parts.append(street_line)
+    if isinstance(city, str) and city.strip():
+        parts.append(city.strip())
+    if isinstance(postcode, str) and postcode.strip():
+        parts.append(postcode.strip())
+
+    return ", ".join([p for p in parts if p])
+
+
+def _get_local_time(lat: float, lon: float, *, timeout: float) -> Dict[str, Any]:
+    url = TIMEAPI_COORD_URL + "?" + urllib.parse.urlencode({"latitude": str(lat), "longitude": str(lon)})
+    return _http_get_json(url, timeout=timeout)
+
+
+def _parse_time_hhmm(s: str) -> Optional[int]:
+    s = s.strip()
+    if not s:
+        return None
+    if s == "24:00":
+        return 24 * 60
+    parts = s.split(":")
+    if len(parts) != 2:
+        return None
+    try:
+        hh = int(parts[0])
+        mm = int(parts[1])
+    except ValueError:
+        return None
+    if not (0 <= hh <= 24 and 0 <= mm <= 59):
+        return None
+    if hh == 24 and mm != 0:
+        return None
+    return hh * 60 + mm
+
+
+def _expand_days(expr: str) -> Optional[List[int]]:
+    expr = expr.strip()
+    if not expr:
+        return None
+    if "PH" in expr or "SH" in expr:
+        return None
+
+    days: set[int] = set()
+    for chunk in expr.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if "-" in chunk:
+            start, end = [p.strip() for p in chunk.split("-", 1)]
+            if start not in _DAY_TO_IDX or end not in _DAY_TO_IDX:
+                return None
+            sidx = _DAY_TO_IDX[start]
+            eidx = _DAY_TO_IDX[end]
+            if sidx <= eidx:
+                for i in range(sidx, eidx + 1):
+                    days.add(i)
+            else:
+                # Wrap-around (e.g., Fr-Mo)
+                for i in range(sidx, 7):
+                    days.add(i)
+                for i in range(0, eidx + 1):
+                    days.add(i)
+        else:
+            if chunk not in _DAY_TO_IDX:
+                return None
+            days.add(_DAY_TO_IDX[chunk])
+
+    return sorted(days)
+
+
+def _parse_opening_hours_simple(oh: str) -> Optional[Dict[int, Optional[List[Tuple[int, int]]]]]:
+    """Parse a subset of OSM opening_hours into a weekly schedule.
+
+    Returns:
+      dict weekday_idx -> None (unknown) | [] (closed) | [(start_min, end_min), ...]
+
+    Notes:
+    - Supports day ranges/list + one or more HH:MM-HH:MM ranges.
+    - Does not support holidays (PH), date ranges, week numbers, "sunrise-sunset", etc.
+    """
+    oh = (oh or "").strip()
+    if not oh:
+        return None
+
+    if oh.lower() == "24/7":
+        return {i: [(0, 24 * 60)] for i in range(7)}
+
+    schedule: Dict[int, Optional[List[Tuple[int, int]]]] = {i: None for i in range(7)}
+    rules = [r.strip() for r in oh.split(";") if r.strip()]
+    if not rules:
+        return None
+
+    for rule in rules:
+        if "PH" in rule or "SH" in rule:
+            return None
+        if "sunrise" in rule or "sunset" in rule:
+            return None
+
+        if " " not in rule:
+            return None
+        day_part, time_part = rule.split(None, 1)
+        days = _expand_days(day_part)
+        if days is None:
+            return None
+
+        tp = time_part.strip()
+        if not tp:
+            return None
+        if tp.lower() in ("off", "closed"):
+            for d in days:
+                schedule[d] = []
+            continue
+        if tp.lower() == "24/7":
+            for d in days:
+                schedule[d] = [(0, 24 * 60)]
+            continue
+
+        ranges: List[Tuple[int, int]] = []
+        for part in [p.strip() for p in tp.split(",") if p.strip()]:
+            if "-" not in part:
+                return None
+            a, b = [x.strip() for x in part.split("-", 1)]
+            start = _parse_time_hhmm(a)
+            end = _parse_time_hhmm(b)
+            if start is None or end is None:
+                return None
+            ranges.append((start, end))
+
+        for d in days:
+            schedule[d] = ranges
+
+    return schedule
+
+
+def _opening_hours_open_now(oh: str, *, local_dt: _dt.datetime) -> Optional[bool]:
+    """Return True/False if parseable, otherwise None."""
+    sched = _parse_opening_hours_simple(oh)
+    if sched is None:
+        return None
+
+    wd = local_dt.weekday()
+    mins = local_dt.hour * 60 + local_dt.minute
+
+    todays = sched.get(wd)
+    if todays is None:
+        return None
+    if todays == []:
+        # Still may be open due to a crossing-midnight interval from yesterday.
+        pass
+    else:
+        for start, end in todays:
+            if start == end:
+                continue
+            if start < end:
+                if start <= mins < end:
+                    return True
+            else:
+                # Cross-midnight interval (e.g., 18:00-02:00)
+                if mins >= start or mins < end:
+                    return True
+
+    # Check crossing-midnight intervals from previous day that extend into today.
+    yday = (wd - 1) % 7
+    y = sched.get(yday)
+    if y:
+        for start, end in y:
+            if start > end and mins < end:
+                return True
+
+    return False
+
+
+def _pick_tags(raw: Dict[str, Any]) -> Dict[str, str]:
+    tags = raw or {}
+    out: Dict[str, str] = {}
+    for k, v in tags.items():
+        if not isinstance(k, str):
+            continue
+        if k in _KEEP_TAG_KEYS or k.startswith(_KEEP_TAG_PREFIXES):
+            out[k] = str(v)
+    return out
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="nearby_places.py",
+        description="Find nearby OSM places via Overpass API (optionally filter open-now). Prints JSON.",
+    )
+    p.add_argument("--lat", type=float, required=True, help="Latitude")
+    p.add_argument("--lon", type=float, required=True, help="Longitude")
+    p.add_argument("--radius-m", type=int, default=1500, help="Search radius in meters (default: 1500)")
+    p.add_argument("--amenity", action="append", default=["restaurant"], help="OSM amenity value (repeatable)")
+    p.add_argument("--limit", type=int, default=15, help="Max results to return (default: 15)")
+    p.add_argument("--no-require-name", action="store_true", help="Include items without a name tag")
+
+    p.add_argument("--travelmode", default="walking", help="Google Maps directions mode (walking|driving|transit|bicycling)")
+
+    p.add_argument("--open-now", action="store_true", help="Compute/filter open-now using `opening_hours` when possible")
+    p.add_argument(
+        "--include-unknown-hours",
+        action="store_true",
+        help="When --open-now is set and parsing is possible, keep items with unparseable/missing hours (open_now=null).",
+    )
+
+    p.add_argument("--http-timeout-seconds", type=float, default=30.0, help="Per-request timeout (default: 30)")
+    args = p.parse_args(argv)
+
+    if not (-90.0 <= args.lat <= 90.0) or not (-180.0 <= args.lon <= 180.0):
+        _die("Invalid coordinates")
+
+    radius_m = int(args.radius_m)
+    if radius_m <= 0:
+        _die("--radius-m must be > 0")
+    if radius_m > 20_000:
+        _die("--radius-m too large (max 20000)")
+
+    limit = int(args.limit)
+    if limit <= 0:
+        _die("--limit must be > 0")
+    if limit > 200:
+        _die("--limit too large (max 200)")
+
+    amenities = _sanitize_amenities(args.amenity or [])
+    require_name = not args.no_require_name
+
+    warnings: List[str] = []
+
+    local_time: Optional[dict] = None
+    local_dt: Optional[_dt.datetime] = None
+    local_time_error: Optional[str] = None
+
+    if args.open_now:
+        try:
+            local_time = _get_local_time(args.lat, args.lon, timeout=float(args.http_timeout_seconds))
+            # timeapi returns local wall-clock components; build a naive datetime.
+            local_dt = _dt.datetime(
+                int(local_time["year"]),
+                int(local_time["month"]),
+                int(local_time["day"]),
+                int(local_time["hour"]),
+                int(local_time["minute"]),
+                int(local_time.get("seconds", 0)),
+            )
+        except Exception as e:
+            local_time_error = f"{type(e).__name__}: {e}"
+            warnings.append("Failed to fetch local time from timeapi.io; open-now filtering was not applied.")
+
+    apply_open_now_filter = bool(args.open_now and local_dt is not None)
+
+    query = _overpass_query(args.lat, args.lon, radius_m=radius_m, amenities=amenities, require_name=require_name)
+
+    elements: List[Dict[str, Any]] = []
+    osm_search: Dict[str, Any] = {
+        "provider": "overpass",
+        "query": query,
+    }
+    overpass_error: Optional[str] = None
+    try:
+        overpass, overpass_meta = _fetch_overpass(query, timeout=float(args.http_timeout_seconds))
+        elems = overpass.get("elements")
+        if not isinstance(elems, list):
+            raise RuntimeError("Unexpected Overpass response (no elements list)")
+        elements = elems
+        osm_search.update({"provider": "overpass", **overpass_meta})
+    except Exception as e:
+        overpass_error = f"{type(e).__name__}: {e}"
+        try:
+            nomi_items, nomi_meta = _fetch_nominatim(
+                lat=args.lat,
+                lon=args.lon,
+                radius_m=radius_m,
+                amenities=amenities,
+                limit=limit,
+                timeout=float(args.http_timeout_seconds),
+            )
+            elements = _nominatim_to_elements(nomi_items, amenities=amenities)
+            if not elements:
+                raise RuntimeError("Nominatim returned no usable elements")
+            osm_search = {
+                "provider": "nominatim",
+                "overpass_error": overpass_error,
+                "viewbox": _viewbox_for_radius(args.lat, args.lon, radius_m=radius_m),
+                **nomi_meta,
+            }
+            warnings.append("Overpass failed; fell back to Nominatim (results may be less precise).")
+        except Exception as e2:
+            _die(
+                "Nearby search failed (Overpass and Nominatim)",
+                extra={
+                    "overpass_error": overpass_error,
+                    "nominatim_error": f"{type(e2).__name__}: {e2}",
+                },
+            )
+
+    results: List[Dict[str, Any]] = []
+    seen: set[tuple] = set()
+    for el in elements:
+        if not isinstance(el, dict):
+            continue
+        osm_type = el.get("type")
+        osm_id = el.get("id")
+        if osm_type not in ("node", "way", "relation"):
+            continue
+        if not isinstance(osm_id, int):
+            continue
+
+        lat = el.get("lat")
+        lon = el.get("lon")
+        if (lat is None or lon is None) and isinstance(el.get("center"), dict):
+            lat = el["center"].get("lat")
+            lon = el["center"].get("lon")
+        if not isinstance(lat, (int, float)) or not isinstance(lon, (int, float)):
+            continue
+
+        tags_raw = el.get("tags") if isinstance(el.get("tags"), dict) else {}
+        name = tags_raw.get("name")
+        if require_name and not name:
+            continue
+
+        dist_m = _haversine_m(args.lat, args.lon, float(lat), float(lon))
+        key = (name or "", round(float(lat), 6), round(float(lon), 6))
+        if key in seen:
+            continue
+        seen.add(key)
+
+        tags = _pick_tags(tags_raw)
+        opening_hours = tags_raw.get("opening_hours") if isinstance(tags_raw.get("opening_hours"), str) else None
+
+        open_now: Optional[bool] = None
+        if apply_open_now_filter and opening_hours:
+            open_now = _opening_hours_open_now(opening_hours, local_dt=local_dt)  # type: ignore[arg-type]
+
+        if apply_open_now_filter:
+            if open_now is True:
+                pass
+            elif open_now is None and args.include_unknown_hours:
+                pass
+            else:
+                continue
+
+        maps_query = _build_maps_query(str(name) if name else None, tags_raw) or (str(name) if name else "")
+
+        results.append(
+            {
+                "name": str(name) if name else None,
+                "distance_m": int(round(dist_m)),
+                "open_now": open_now,
+                "opening_hours": opening_hours,
+                "lat": float(lat),
+                "lon": float(lon),
+                "osm_type": osm_type,
+                "osm_id": osm_id,
+                "osm_url": _osm_url(osm_type, osm_id),
+                "google_maps_url": _google_maps_url(float(lat), float(lon)),
+                "google_maps_pin_url": _google_maps_url(float(lat), float(lon)),
+                "google_maps_directions_url": _google_maps_directions_url(
+                    float(args.lat),
+                    float(args.lon),
+                    float(lat),
+                    float(lon),
+                    travelmode=str(args.travelmode or "walking"),
+                ),
+                "google_maps_place_search_query": maps_query or None,
+                "google_maps_place_search_url": _google_maps_place_search_url(
+                    maps_query,
+                    near_lat=float(lat),
+                    near_lon=float(lon),
+                    zoom=17,
+                ),
+                "tags": tags,
+            }
+        )
+
+    results.sort(key=lambda r: (r.get("distance_m", 10**12), (r.get("name") or "")))
+    results = results[:limit]
+
+    out: Dict[str, Any] = {
+        "success": True,
+        "input": {
+            "lat": args.lat,
+            "lon": args.lon,
+            "radius_m": radius_m,
+            "amenity": amenities,
+            "limit": limit,
+            "require_name": require_name,
+            "travelmode": str(args.travelmode or "walking"),
+            "open_now_requested": bool(args.open_now),
+            "open_now_filter_applied": bool(apply_open_now_filter),
+            "include_unknown_hours": bool(args.include_unknown_hours),
+        },
+        "osm_search": osm_search,
+        "local_time": local_time if local_time else None,
+        "local_time_error": local_time_error,
+        "warnings": warnings or None,
+        "results": results,
+    }
+    _print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway/test_telegram_location.py
+++ b/tests/gateway/test_telegram_location.py
@@ -1,0 +1,146 @@
+"""Tests for Telegram location/venue handling in gateway/platforms/telegram.py.
+
+Covers: LOCATION message injection (lat/lon), venue vs pin handling, and
+ensures the gateway produces a MessageEvent with MessageType.LOCATION.
+
+Note: python-telegram-bot may not be installed in the test environment.
+We mock the telegram module at import time to avoid collection errors.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
+
+
+# ---------------------------------------------------------------------------
+# Mock the telegram package if it's not installed
+# ---------------------------------------------------------------------------
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    for name in ("telegram", "telegram.ext", "telegram.constants"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build mock Telegram objects
+# ---------------------------------------------------------------------------
+
+def _make_message(*, location=None, venue=None):
+    msg = MagicMock()
+    msg.message_id = 42
+    msg.text = ""
+    msg.date = None
+    msg.message_thread_id = None
+
+    msg.location = location
+    msg.venue = venue
+
+    msg.chat = MagicMock()
+    msg.chat.id = 100
+    msg.chat.type = "private"
+    msg.chat.title = None
+    msg.chat.full_name = "Test Chat"
+
+    msg.from_user = MagicMock()
+    msg.from_user.id = 1
+    msg.from_user.full_name = "Test User"
+
+    return msg
+
+
+def _make_update(msg):
+    update = MagicMock()
+    update.message = msg
+    return update
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def adapter():
+    config = PlatformConfig(enabled=True, token="fake-token")
+    a = TelegramAdapter(config)
+    a.handle_message = AsyncMock()
+    return a
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTelegramLocationHandling:
+    @pytest.mark.asyncio
+    async def test_location_pin_injected(self, adapter):
+        loc = MagicMock()
+        loc.latitude = 12.3456
+        loc.longitude = 56.789
+        loc.horizontal_accuracy = 25
+
+        msg = _make_message(location=loc)
+        update = _make_update(msg)
+
+        await adapter._handle_location_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.LOCATION
+        assert "[The user shared a location pin via Telegram.]" in event.text
+        assert "latitude: 12.3456" in event.text
+        assert "longitude: 56.789" in event.text
+        assert "horizontal_accuracy_m: 25" in event.text
+
+    @pytest.mark.asyncio
+    async def test_venue_injected(self, adapter):
+        vloc = MagicMock()
+        vloc.latitude = 40.7128
+        vloc.longitude = -74.006
+
+        venue = MagicMock()
+        venue.location = vloc
+        venue.title = "Test Venue"
+        venue.address = "123 Example St"
+        venue.foursquare_id = "abc123"
+
+        msg = _make_message(venue=venue)
+        update = _make_update(msg)
+
+        await adapter._handle_location_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.LOCATION
+        assert "[The user shared a venue via Telegram.]" in event.text
+        assert "title: Test Venue" in event.text
+        assert "address: 123 Example St" in event.text
+        assert "latitude: 40.7128" in event.text
+        assert "longitude: -74.006" in event.text
+        assert "foursquare_id: abc123" in event.text
+
+    @pytest.mark.asyncio
+    async def test_ignores_update_without_message(self, adapter):
+        update = MagicMock()
+        update.message = None
+        await adapter._handle_location_message(update, MagicMock())
+        adapter.handle_message.assert_not_called()


### PR DESCRIPTION
**Summary**

- **Feature:** Add first-class Telegram location/venue support so the agent can accept shared `lat/lon`, ask follow-up constraints (radius, “open now”, cuisine, etc.), and return nearby recommendations with coordinate-anchored map links.
- **Why:** Enables a natural Telegram flow: user shares a location pin → agent uses the coordinates as the search anchor → user asks for nearby places (e.g., restaurants open now).

**What changed**

- **Gateway**
  - `gateway/platforms/base.py`: add `MessageType.LOCATION`
  - `gateway/platforms/telegram.py`: handle Telegram `LOCATION` (and `VENUE` when available) messages via `_handle_location_message`, injecting `latitude:` / `longitude:` into the conversation context and guidance to use coordinate-anchored Google Maps URLs
  - `tests/gateway/test_telegram_location.py`: new unit tests for pin + venue handling (mocked telegram import)

- **Bundled skill**
  - `skills/productivity/telegram-location/SKILL.md`: new skill with When to Use / Quick Reference / Procedure / Pitfalls / Verification
  - `skills/productivity/telegram-location/scripts/nearby_places.py`: stdlib-only helper that queries Overpass (fallback Nominatim), optionally best-effort “open now”, and outputs distances + OSM URL + Google Maps coordinate pin + directions URLs

**How to test**

1. Unit tests:
   - `./venv/bin/python -m pytest -q tests/gateway/test_telegram_location.py`
2. Manual (Telegram):
   - Share a location pin to the bot.
   - Ask: “find restaurants close to that location that are open right now”.
   - Confirm returned links land near the shared pin and use coordinate-based URLs.