### PR TITLE
fix: add mcp to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 modal = ["swe-rex[modal]>=1.4.0"]
-dev = ["pytest", "pytest-asyncio"]
+dev = ["pytest", "pytest-asyncio", "mcp>=1.2.0"]
 messaging = ["python-telegram-bot>=20.0", "discord.py>=2.0", "aiohttp>=3.9.0", "slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]
 cron = ["croniter"]
 slack = ["slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]


### PR DESCRIPTION
## Problem

Running `pip install -e '.[dev]'` does not install the `mcp` package, causing 3 test failures in `tests/tools/test_mcp_tool.py::TestMCPServerTask`:

```
FAILED tests/tools/test_mcp_tool.py::TestMCPServerTask::test_start_connects_and_discovers_tools
FAILED tests/tools/test_mcp_tool.py::TestMCPServerTask::test_empty_env_gets_safe_defaults
FAILED tests/tools/test_mcp_tool.py::TestMCPServerTask::test_shutdown_signals_task_exit
```

Root cause: `mcp` is defined as an optional extra but not included in `dev` dependencies, so the MCP tests fail for any fresh dev setup.

## Fix

Added `mcp>=1.2.0` to the `dev` optional dependencies in `pyproject.toml`.

## Result after fix

```
4 passed in 1.98s
```