### PR TITLE
fix(gateway): bridge docker_volumes config to terminal env vars

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -75,11 +75,17 @@ if _config_path.exists():
                 "container_memory": "TERMINAL_CONTAINER_MEMORY",
                 "container_disk": "TERMINAL_CONTAINER_DISK",
                 "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
+                "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
             }
             for _cfg_key, _env_var in _terminal_env_map.items():
                 if _cfg_key in _terminal_cfg:
-                    os.environ[_env_var] = str(_terminal_cfg[_cfg_key])
+                    _val = _terminal_cfg[_cfg_key]
+                    if isinstance(_val, list):
+                        import json as _json
+                        os.environ[_env_var] = _json.dumps(_val)
+                    else:
+                        os.environ[_env_var] = str(_val)
         _compression_cfg = _cfg.get("compression", {})
         if _compression_cfg and isinstance(_compression_cfg, dict):
             _compression_env_map = {


### PR DESCRIPTION
## Summary

The gateway's `config.yaml` → environment variable bridge (`gateway/run.py`) is missing `docker_volumes` from its `_terminal_env_map`, so terminal sandboxes created from gateway sessions (Telegram, Discord, WhatsApp) never receive user-configured volume mounts. CLI sessions work correctly because `cli.py` includes this key in its bridge map.

This also fixes list serialization: the gateway uses `str()` for all config values, which produces Python repr (single quotes) for lists instead of valid JSON. Since `terminal_tool.py` deserializes with `json.loads()`, this would fail even if the key were present. Now uses `json.dumps()` for list values, matching `cli.py` behavior.

## Changes

- Add `"docker_volumes": "TERMINAL_DOCKER_VOLUMES"` to `_terminal_env_map` in `gateway/run.py`
- Fix list serialization: use `json.dumps()` instead of `str()` for list-type config values

## How to reproduce

1. Configure `docker_volumes` in `config.yaml`:
   ```yaml
   terminal:
     backend: docker
     docker_image: my-sandbox
     docker_volumes:
       - "/host/path:/container/path:ro"
   ```
2. Send a message via Telegram (gateway session)
3. Agent runs a terminal command → sandbox container has no user volumes mounted
4. Same command via `hermes chat` (CLI) → sandbox container has user volumes mounted

## Reference

- Feature added in PR #158 — `cli.py`, `terminal_tool.py`, `docker.py` were updated but `gateway/run.py` was missed
- `cli.py` lines 296, 310-312 — correct reference implementation