### PR TITLE
fix: use _max_tokens_param in max-iterations retry path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2740,7 +2740,7 @@ class AIAgent:
                         "messages": api_messages,
                     }
                     if self.max_tokens is not None:
-                        summary_kwargs["max_tokens"] = self.max_tokens
+                        summary_kwargs.update(self._max_tokens_param(self.max_tokens))
                     if summary_extra_body:
                         summary_kwargs["extra_body"] = summary_extra_body
 

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -913,3 +913,31 @@ class TestConversationHistoryNotMutated:
         )
         # Result should have more messages than the original history
         assert len(result["messages"]) > original_len
+
+
+# ---------------------------------------------------------------------------
+# _max_tokens_param consistency
+# ---------------------------------------------------------------------------
+
+class TestMaxTokensParam:
+    """Verify _max_tokens_param returns the correct key for each provider."""
+
+    def test_returns_max_completion_tokens_for_direct_openai(self, agent):
+        agent.base_url = "https://api.openai.com/v1"
+        result = agent._max_tokens_param(4096)
+        assert result == {"max_completion_tokens": 4096}
+
+    def test_returns_max_tokens_for_openrouter(self, agent):
+        agent.base_url = "https://openrouter.ai/api/v1"
+        result = agent._max_tokens_param(4096)
+        assert result == {"max_tokens": 4096}
+
+    def test_returns_max_tokens_for_local(self, agent):
+        agent.base_url = "http://localhost:11434/v1"
+        result = agent._max_tokens_param(4096)
+        assert result == {"max_tokens": 4096}
+
+    def test_not_tricked_by_openai_in_openrouter_url(self, agent):
+        agent.base_url = "https://openrouter.ai/api/v1/api.openai.com"
+        result = agent._max_tokens_param(4096)
+        assert result == {"max_tokens": 4096}


### PR DESCRIPTION
The retry summary in `_handle_max_iterations` hardcodes `max_tokens` instead of calling `_max_tokens_param()`. For direct OpenAI API users (gpt-4o, o-series), the correct parameter name is `max_completion_tokens`.

The first attempt (line ~2697) already uses `_max_tokens_param()` correctly, but the retry path (line ~2743) was missed.

### Fix

One-line change: replace `summary_kwargs["max_tokens"] = self.max_tokens` with `summary_kwargs.update(self._max_tokens_param(self.max_tokens))`.

### Tests

Added `TestMaxTokensParam` with 4 tests verifying `_max_tokens_param()` returns the correct key:
- Direct OpenAI -> `max_completion_tokens`
- OpenRouter -> `max_tokens`
- Local/custom -> `max_tokens`
- URL containing "openai.com" inside openrouter path -> `max_tokens` (not tricked)

Closes #435