### PR TITLE
fix: add missing empty-content guard after think-block stripping in retry path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2754,7 +2754,10 @@ class AIAgent:
                 if final_response:
                     if "<think>" in final_response:
                         final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
-                    messages.append({"role": "assistant", "content": final_response})
+                    if final_response:
+                        messages.append({"role": "assistant", "content": final_response})
+                    else:
+                        final_response = "I reached the iteration limit and couldn't generate a summary."
                 else:
                     final_response = "I reached the iteration limit and couldn't generate a summary."
 


### PR DESCRIPTION
## What does this PR do?

The retry path in `_handle_max_iterations` was missing the second `if final_response:` guard after stripping `<think>` blocks. If a reasoning model returned a think-only response on retry, the function would return an empty string and append an empty assistant message to conversation history, instead of using the fallback message.

The first attempt path already handles this correctly - the retry path just needed the same guard added to match.

## Related Issue

Fixes #437 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: Added second `if final_response:` guard after think-block stripping in the retry path of `_handle_max_iterations` (line 2757), matching the existing guard in the first attempt path (line 2725)

## How to Test

1. Review the first attempt path (lines 2722-2728) - it has a second `if final_response:` after `re.sub`
2. Review the retry path (lines 2754-2760 after fix) - now has the same guard
3. Both paths now behave identically when think-block stripping leaves an empty string

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- N/A (one-line logic fix, no docs/config/schema changes)
