### PR TITLE
fix(gateway): return response from /retry handler instead of discarding it

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1253,8 +1253,7 @@ class GatewayRunner:
         )
         
         # Let the normal message handler process it
-        await self._handle_message(retry_event)
-        return None  # Response sent through normal flow
+        return await self._handle_message(retry_event)
     
     async def _handle_undo_command(self, event: MessageEvent) -> str:
         """Handle /undo command - remove the last user/assistant exchange."""


### PR DESCRIPTION
## What does this PR do?

`_handle_retry_command` calls `await self._handle_message(retry_event)` to re-process the last user message, but discards the return value and returns `None`. The comment says "Response sent through normal flow" but that's incorrect - `_handle_message` returns the response string, it doesn't send it. Only the caller (`_process_message_background`) handles sending via `adapter.send()`.

This means after `/retry`, the agent runs successfully and tool progress is visible, but the final response is never delivered to the user.

The fix returns the inner handler's response so `_process_message_background` can send it normally.

## Related Issue

Fixes #440

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Changed `_handle_retry_command` to return the result of `await self._handle_message(retry_event)` instead of discarding it and returning `None`

## How to Test

1. Connect to any messaging platform
2. Send a message that triggers tool use
3. Send `/retry`
4. Verify the final response is now delivered (previously only tool progress was visible)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- N/A (one-line logic fix, no docs/config/schema changes)