### PR TITLE
fix(security): escape path in tilde expansion to prevent shell injection

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -28,6 +28,7 @@ Usage:
 import os
 import re
 import json
+import shlex
 import difflib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -401,7 +402,7 @@ class ShellFileOperations(FileOperations):
                 elif path.startswith('~/'):
                     return home + path[1:]  # Replace ~ with home
                 # ~username format - let shell expand it
-                expand_result = self._exec(f"echo {path}")
+                expand_result = self._exec(f"echo {shlex.quote(path)}")
                 if expand_result.exit_code == 0:
                     return expand_result.stdout.strip()
         


### PR DESCRIPTION
Changes Made:
tools/file_operations.py:
- import shlex added
- line 404: self._exec(f"echo {path}") → self._exec(f"echo {shlex.quote(path)}")

How to Test:
call read_file("~; rm -rf /tmp")
before: shell executes rm -rf /tmp
after: shlex.quote neutralizes the payload

