### PR TITLE
fix: add missing re.DOTALL flag to DeepSeek V3 tool call parser

### DIFF
--- a/environments/tool_call_parsers/deepseek_v3_parser.py
+++ b/environments/tool_call_parsers/deepseek_v3_parser.py
@@ -38,7 +38,8 @@ class DeepSeekV3ToolCallParser(ToolCallParser):
 
     # Regex captures: type, function_name, function_arguments
     PATTERN = re.compile(
-        r"<｜tool▁call▁begin｜>(?P<type>.*)<｜tool▁sep｜>(?P<function_name>.*)\n```json\n(?P<function_arguments>.*)\n```<｜tool▁call▁end｜>"
+        r"<｜tool▁call▁begin｜>(?P<type>.*)<｜tool▁sep｜>(?P<function_name>.*)\n```json\n(?P<function_arguments>.*)\n```<｜tool▁call▁end｜>",
+        re.DOTALL,
     )
 
     def parse(self, text: str) -> ParseResult:


### PR DESCRIPTION
## What does this PR do?

The DeepSeek V3 tool call parser regex was missing `re.DOTALL`, so `.*` couldn't match newlines in the `function_arguments` capture group. Since tool call JSON arguments are almost always multi-line, the parser silently failed on most real tool calls and returned raw text instead.

Every other parser in the codebase (hermes, mistral, glm45, glm47, qwen3_coder, kimi_k2, longcat) already uses `re.DOTALL` for their patterns.

## Related Issue

Fixes #443

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `environments/tool_call_parsers/deepseek_v3_parser.py`: Added `re.DOTALL` flag to `PATTERN` regex compilation

## How to Test

1. Check every other parser file in `environments/tool_call_parsers/` - all use `re.DOTALL`
2. Without the flag, this regex only matches single-line JSON: `{"query": "hello"}`
3. With the flag, multi-line JSON is matched correctly:
```json
{
  "query": "hello",
  "limit": 5
}
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- N/A (one flag added, no docs/config/schema changes)
