### PR TITLE
fix(cli): use correct visibility filter string in codex API model fetch

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -47,7 +47,7 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
         if item.get("supported_in_api") is False:
             continue
         visibility = item.get("visibility", "")
-        if isinstance(visibility, str) and visibility.strip().lower() == "hide":
+        if isinstance(visibility, str) and visibility.strip().lower() == "hidden":
             continue
         priority = item.get("priority")
         rank = int(priority) if isinstance(priority, (int, float)) else 10_000


### PR DESCRIPTION
## What does this PR do?

`_fetch_models_from_api` filters hidden Codex models with `visibility == "hide"`, but the correct value is `"hidden"` (as used by `_read_cache_models` and confirmed by the test suite). This means hidden models leak through when fetched live from the API.

Changed `"hide"` to `"hidden"` in `_fetch_models_from_api` to match the cache reader and test expectations.

## Related Issue

Fixes #445

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/codex_models.py`: Changed `"hide"` to `"hidden"` in `_fetch_models_from_api` visibility filter (line 50) to match `_read_cache_models` (line 102) and `test_codex_models.py` mock data

## How to Test

1. Run `pytest tests/test_codex_models.py` - all tests pass
2. Compare line 50 and line 102 in `hermes_cli/codex_models.py` - both now use `"hidden"`
3. `test_codex_models.py:17` uses `"visibility": "hidden"` confirming `"hidden"` is the correct API value

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- N/A (one-word fix, no docs/config/schema changes)
