### PR TITLE
fix(cli): use correct dict key for codex auth file path in status output

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -128,7 +128,7 @@ def show_status(args):
         f"  {'OpenAI Codex':<12}  {check_mark(codex_logged_in)} "
         f"{'logged in' if codex_logged_in else 'not logged in (run: hermes model)'}"
     )
-    codex_auth_file = codex_status.get("auth_file")
+    codex_auth_file = codex_status.get("auth_store")
     if codex_auth_file:
         print(f"    Auth file:  {codex_auth_file}")
     codex_last_refresh = _format_iso_timestamp(codex_status.get("last_refresh"))


### PR DESCRIPTION
## What does this PR do?

`hermes status` reads the Codex auth file path with `codex_status.get("auth_file")`, but `get_codex_auth_status()` in `auth.py` returns it under `"auth_store"`. This means the auth file path is silently dropped and never shown to the user.

Changed `"auth_file"` to `"auth_store"` in `status.py` to match the key returned by `auth.py`.

## Related Issue

Fixes #447 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/status.py`: Changed `codex_status.get("auth_file")` to `codex_status.get("auth_store")` (line 131) to match the dict key from `get_codex_auth_status()` in `auth.py` (line 1220)

## How to Test

1. Compare `status.py` line 131 with `auth.py` line 1220 - the dict key now matches
2. Run `hermes status` after logging in to Codex - "Auth file:" line should now appear

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- N/A (one-word fix, no docs/config/schema changes)
