### PR TITLE
fix: handle None args in build_tool_preview

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -22,6 +22,8 @@ _RESET = "\033[0m"
 
 def build_tool_preview(tool_name: str, args: dict, max_len: int = 40) -> str:
     """Build a short preview of a tool call's primary argument for display."""
+    if not args:
+        return None
     primary_args = {
         "terminal": "command", "web_search": "query", "web_extract": "urls",
         "read_file": "path", "write_file": "path", "patch": "path",


### PR DESCRIPTION
## Summary
- `build_tool_preview()` crashes with `TypeError: argument of type 'NoneType' is not iterable` when a model returns null/empty tool call arguments
- `json.loads("null")` produces `None`, which is passed to `build_tool_preview` where `fallback_key in args` fails
- Added early return when `args` is falsy