### PR TITLE
Use pywinpty for PTY support on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,10 @@ cron = ["croniter"]
 slack = ["slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]
 cli = ["simple-term-menu"]
 tts-premium = ["elevenlabs"]
-pty = ["ptyprocess>=0.7.0"]
+pty = [
+  "ptyprocess>=0.7.0; sys_platform != 'win32'",
+  "pywinpty>=2.0.0; sys_platform == 'win32'",
+]
 honcho = ["honcho-ai>=2.0.1"]
 mcp = ["mcp>=1.2.0"]
 homeassistant = ["aiohttp>=3.9.0"]

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -148,11 +148,14 @@ class ProcessRegistry:
         if use_pty:
             # Try PTY mode for interactive CLI tools
             try:
-                import ptyprocess
+                if _IS_WINDOWS:
+                    from winpty import PtyProcess as _PtyProcessCls
+                else:
+                    from ptyprocess import PtyProcess as _PtyProcessCls
                 user_shell = _find_shell()
                 pty_env = os.environ | (env_vars or {})
                 pty_env["PYTHONUNBUFFERED"] = "1"
-                pty_proc = ptyprocess.PtyProcess.spawn(
+                pty_proc = _PtyProcessCls.spawn(
                     [user_shell, "-lic", command],
                     cwd=session.cwd,
                     env=pty_env,


### PR DESCRIPTION
## Problem

`ptyprocess` depends on `fork()` and `openpty()`, which are Unix-only. On Windows, importing `ptyprocess` fails with `ImportError`, and background PTY processes (interactive CLI tools, Python REPL) silently fall back to pipe mode.

## Fix

- On Windows, import `winpty.PtyProcess` instead of `ptyprocess.PtyProcess`. pywinpty provides the same `.spawn()` interface using the Windows ConPTY API.
- Updated the `[pty]` extra in `pyproject.toml` with platform markers so `pip install hermes-agent[pty]` (or `[all]`) installs the right package automatically:
  - `ptyprocess>=0.7.0` on non-Windows
  - `pywinpty>=2.0.0` on Windows

## Testing

Verified PTY spawn works on Windows 11 with pywinpty. Process gets a PID, output is captured through the PTY handle.