### PR TITLE
Fall back to USERNAME env var in Singularity scratch path

### DIFF
--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -62,7 +62,7 @@ def _get_scratch_dir() -> Path:
 
     scratch = Path("/scratch")
     if scratch.exists() and os.access(scratch, os.W_OK):
-        user_scratch = scratch / os.getenv("USER", "hermes") / "hermes-agent"
+        user_scratch = scratch / os.getenv("USER", os.getenv("USERNAME", "hermes")) / "hermes-agent"
         user_scratch.mkdir(parents=True, exist_ok=True)
         logger.info("Using /scratch for sandboxes: %s", user_scratch)
         return user_scratch


### PR DESCRIPTION
## Problem

The Singularity environment uses `os.getenv("USER", "hermes")` to build the scratch directory path under `/scratch`. On Windows, the username is stored in `USERNAME`, not `USER`, so this always falls back to the hardcoded "hermes" default.

## Fix

Chain the fallback: `os.getenv("USER", os.getenv("USERNAME", "hermes"))`. This picks up the correct username on both Unix and Windows, and still falls back to "hermes" if neither is set.

One-line change.