### PR TITLE
feat(tools): add support for self-hosted firecrawl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -421,6 +421,7 @@ The system uses `_config_version` to detect outdated configs:
 API keys are loaded from `~/.hermes/.env`:
 - `OPENROUTER_API_KEY` - Main LLM API access (primary provider)
 - `FIRECRAWL_API_KEY` - Web search/extract tools
+- `FIRECRAWL_API_URL` - Self-hosted Firecrawl endpoint (optional)
 - `BROWSERBASE_API_KEY` / `BROWSERBASE_PROJECT_ID` - Browser automation
 - `FAL_KEY` - Image generation (FLUX model)
 - `NOUS_API_KEY` - Vision and Mixture-of-Agents tools

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -179,6 +179,14 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "FIRECRAWL_API_URL": {
+        "description": "Firecrawl API URL for self-hosted instances (optional)",
+        "prompt": "Firecrawl API URL (leave empty for cloud)",
+        "url": None,
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
     "BROWSERBASE_API_KEY": {
         "description": "Browserbase API key for browser automation",
         "prompt": "Browserbase API key",
@@ -821,7 +829,7 @@ def set_config_value(key: str, value: str):
     # Check if it's an API key (goes to .env)
     api_keys = [
         'OPENROUTER_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
-        'FIRECRAWL_API_KEY', 'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID',
+        'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL', 'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID',
         'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
         'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
         'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -1,0 +1,49 @@
+"""Tests for Firecrawl client configuration."""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestFirecrawlClientConfig:
+    """Test suite for Firecrawl client initialization with API URL support."""
+
+    def teardown_method(self):
+        """Reset client between tests."""
+        import tools.web_tools
+
+        tools.web_tools._firecrawl_client = None
+
+    def test_client_with_api_key_only(self):
+        """Test client initialization with only API key (no custom URL)."""
+        env_vars = {"FIRECRAWL_API_KEY": "test-key"}
+        env_vars.pop("FIRECRAWL_API_URL", None)
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Remove FIRECRAWL_API_URL from env if it exists
+            if "FIRECRAWL_API_URL" in os.environ:
+                del os.environ["FIRECRAWL_API_URL"]
+
+            with patch("tools.web_tools.Firecrawl") as mock_firecrawl:
+                from tools.web_tools import _get_firecrawl_client
+
+                _get_firecrawl_client()
+                mock_firecrawl.assert_called_once_with(api_key="test-key")
+
+    def test_client_with_api_key_and_url(self):
+        """Test client initialization with API key and custom URL."""
+        with patch.dict(
+            os.environ,
+            {
+                "FIRECRAWL_API_KEY": "test-key",
+                "FIRECRAWL_API_URL": "http://localhost:3002",
+            },
+            clear=False,
+        ):
+            with patch("tools.web_tools.Firecrawl") as mock_firecrawl:
+                from tools.web_tools import _get_firecrawl_client
+
+                _get_firecrawl_client()
+                mock_firecrawl.assert_called_once_with(
+                    api_key="test-key", api_url="http://localhost:3002"
+                )

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -62,7 +62,12 @@ def _get_firecrawl_client():
         api_key = os.getenv("FIRECRAWL_API_KEY")
         if not api_key:
             raise ValueError("FIRECRAWL_API_KEY environment variable not set")
-        _firecrawl_client = Firecrawl(api_key=api_key)
+        
+        api_url = os.getenv("FIRECRAWL_API_URL")
+        if api_url:
+            _firecrawl_client = Firecrawl(api_key=api_key, api_url=api_url)
+        else:
+            _firecrawl_client = Firecrawl(api_key=api_key)
     return _firecrawl_client
 
 DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION = 5000

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -164,6 +164,7 @@ OPENROUTER_API_KEY=sk-or-v1-your-key-here
 
 # Optional — enable additional tools:
 FIRECRAWL_API_KEY=fc-your-key          # Web search & scraping
+FIRECRAWL_API_URL=http://localhost:3002  # Self-hosted Firecrawl (optional)
 FAL_KEY=your-fal-key                   # Image generation (FLUX)
 ```
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -35,6 +35,7 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | Variable | Description |
 |----------|-------------|
 | `FIRECRAWL_API_KEY` | Web scraping ([firecrawl.dev](https://firecrawl.dev/)) |
+| `FIRECRAWL_API_URL` | Custom Firecrawl API endpoint for self-hosted instances (optional) |
 | `BROWSERBASE_API_KEY` | Browser automation ([browserbase.com](https://browserbase.com/)) |
 | `BROWSERBASE_PROJECT_ID` | Browserbase project ID |
 | `BROWSER_INACTIVITY_TIMEOUT` | Browser session inactivity timeout in seconds |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -79,6 +79,7 @@ Even when using Nous Portal, Codex, or a custom endpoint, some tools (vision, we
 | Feature | Provider | Env Variable |
 |---------|----------|--------------|
 | Web scraping | [Firecrawl](https://firecrawl.dev/) | `FIRECRAWL_API_KEY` |
+| Web scraping (self-hosted) | Firecrawl | `FIRECRAWL_API_URL` |
 | Browser automation | [Browserbase](https://browserbase.com/) | `BROWSERBASE_API_KEY`, `BROWSERBASE_PROJECT_ID` |
 | Image generation | [FAL](https://fal.ai/) | `FAL_KEY` |
 | Premium TTS voices | [ElevenLabs](https://elevenlabs.io/) | `ELEVENLABS_API_KEY` |


### PR DESCRIPTION
## What does this PR do?

Adds support for self-hosted Firecrawl instances by introducing an optional `FIRECRAWL_API_URL` environment variable. This allows users to point Hermes to their own Firecrawl deployment instead of the cloud service, while maintaining full backward compatibility with existing configurations.

**Why this approach:**
- Optional environment variable - no breaking changes
- Follows existing pattern for other optional API endpoints
- Minimal code changes - just adds conditional parameter to Firecrawl client initialization
- Backward compatible - defaults to cloud if URL not set

## Related Issue

N/A - No existing issue. This enables users who self-host Firecrawl to use Hermes with their own infrastructure.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py` - Added `FIRECRAWL_API_URL` to `OPTIONAL_ENV_VARS` with appropriate metadata (marked as advanced option)
- `tools/web_tools.py` - Updated `_get_firecrawl_client()` to accept optional `api_url` parameter when `FIRECRAWL_API_URL` is set
- `tests/tools/test_web_tools_config.py` - Added 2 focused tests for client initialization (with/without custom URL)
- `website/docs/reference/environment-variables.md` - Documented the new env var
- `website/docs/getting-started/installation.md` - Added to installation docs
- `website/docs/user-guide/configuration.md` - Added to configuration guide
- `AGENTS.md` - Updated developer guide with the new env var

## How to Test

**Prerequisites:**
- A Firecrawl API key (cloud or self-hosted)
- Optionally, a self-hosted Firecrawl instance

**Test 1: Default behavior (cloud Firecrawl)**
1. Set only `FIRECRAWL_API_KEY` in `~/.hermes/.env`
2. Run `hermes chat -q "Search the web for Python tutorials"`
3. Verify web_search tool works correctly

**Test 2: Self-hosted Firecrawl**
1. Set both `FIRECRAWL_API_KEY` and `FIRECRAWL_API_URL` in `~/.hermes/.env`:
   ```
   FIRECRAWL_API_KEY=your-key
   FIRECRAWL_API_URL=http://localhost:3002
   ```
2. Run `hermes chat -q "Search the web for Python tutorials"`
3. Verify requests go to your self-hosted instance (check your Firecrawl logs)

**Test 3: Unit tests**
```bash
cd hermes-agent
pytest tests/tools/test_web_tools_config.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tools): add support for self-hosted firecrawl`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (2 focused tests for client initialization)
- [x] I've tested on my platform: macOS (tested via unit tests)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - Updated 3 website docs pages + AGENTS.md
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A (env var, not config.yaml)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - Updated AGENTS.md
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - N/A (no platform-specific code, just env var handling)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A (no tool schema changes, just internal client initialization)

## Additional Notes

- This is a non-breaking change - existing users with only `FIRECRAWL_API_KEY` set will continue to use the cloud service
- The feature is marked as "advanced" in the config system to avoid confusing new users
- Tests are minimal and focused on the actual change (2 tests instead of 5+ to avoid over-testing)
