### PR TITLE
fix(config): route API keys and tokens to .env instead of config.yaml

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -828,15 +828,16 @@ def set_config_value(key: str, value: str):
     """Set a configuration value."""
     # Check if it's an API key (goes to .env)
     api_keys = [
-        'OPENROUTER_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
+        'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
         'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL', 'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID',
         'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
         'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
         'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
-        'GITHUB_TOKEN', 'HONCHO_API_KEY',
+        'GITHUB_TOKEN', 'HONCHO_API_KEY', 'NOUS_API_KEY', 'WANDB_API_KEY',
+        'TINKER_API_KEY',
     ]
     
-    if key.upper() in api_keys or key.upper().startswith('TERMINAL_SSH'):
+    if key.upper() in api_keys or key.upper().endswith('_API_KEY') or key.upper().endswith('_TOKEN') or key.upper().startswith('TERMINAL_SSH'):
         save_env_value(key.upper(), value)
         print(f"✓ Set {key} in {get_env_path()}")
         return


### PR DESCRIPTION
Fixes #465

## Problem
`hermes config set OPENAI_API_KEY sk-xxx` was saving the key to `config.yaml` instead of `.env`, despite docs stating secrets go to `.env`.

## Root Cause
The `api_keys` allowlist in `set_config_value()` was missing several common keys (`OPENAI_API_KEY`, `NOUS_API_KEY`, `WANDB_API_KEY`, `TINKER_API_KEY`) and had no catch-all pattern for future keys.

## Fix
- Added missing keys to the allowlist
- Added catch-all patterns: any key ending in `_API_KEY` or `_TOKEN` now automatically routes to `.env`
- This future-proofs the logic for any new API keys added to the project