### PR TITLE
fix: use _max_tokens_param() in max-iterations retry summary

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2743,7 +2743,7 @@ class AIAgent:
                         "messages": api_messages,
                     }
                     if self.max_tokens is not None:
-                        summary_kwargs["max_tokens"] = self.max_tokens
+                        summary_kwargs.update(self._max_tokens_param(self.max_tokens))
                     if summary_extra_body:
                         summary_kwargs["extra_body"] = summary_extra_body
 


### PR DESCRIPTION
## Summary

Fixes the max-iterations retry summary path to use `_max_tokens_param()` instead of hardcoded `max_tokens`.

## Problem

In `_handle_max_iterations()`, the first summary attempt correctly uses `_max_tokens_param()` (line ~2700), but the retry path hardcodes `max_tokens` (line ~2746). This causes issues for OpenAI models that require `max_completion_tokens` instead of `max_tokens` (gpt-4o, o-series).

## Root Cause

```python
# First attempt (correct)
summary_kwargs.update(self._max_tokens_param(self.max_tokens))

# Retry attempt (incorrect - before this fix)
summary_kwargs["max_tokens"] = self.max_tokens
```

The `_max_tokens_param()` helper exists specifically to handle the parameter name difference between OpenAI (max_completion_tokens) and other providers (max_tokens).

## Fix

Changed the retry path to use the same helper:

```python
summary_kwargs.update(self._max_tokens_param(self.max_tokens))
```

## Testing

- Fix follows the exact same pattern used in the first summary attempt and throughout the codebase
- Minimal, surgical change with no side effects

Fixes #435