### PR TITLE
fix: cross-platform orphaned process cleanup for WhatsApp bridge

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -61,6 +61,72 @@ def check_whatsapp_requirements() -> bool:
         return False
 
 
+def _kill_process_on_port(port: int) -> bool:
+    """
+    Kill any process listening on the given TCP port.
+    
+    Cross-platform implementation:
+    - Linux/macOS: Uses lsof (more portable than fuser)
+    - Windows: Uses netstat + taskkill
+    
+    Returns True if a process was found and killed, False otherwise.
+    """
+    try:
+        if _IS_WINDOWS:
+            # Windows: Use netstat to find PID, then taskkill
+            result = subprocess.run(
+                ["netstat", "-ano"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                return False
+            
+            # Parse netstat output to find the PID listening on our port
+            # Format: TCP    0.0.0.0:PORT    0.0.0.0:0    LISTENING    PID
+            for line in result.stdout.splitlines():
+                if f":{port}" in line and "LISTENING" in line:
+                    parts = line.split()
+                    if len(parts) >= 5:
+                        pid = parts[-1]
+                        try:
+                            subprocess.run(
+                                ["taskkill", "/F", "/PID", pid],
+                                capture_output=True,
+                                timeout=5,
+                            )
+                            return True
+                        except Exception:
+                            pass
+            return False
+        else:
+            # Unix: Use lsof (more portable than fuser, available on macOS and most Linux)
+            result = subprocess.run(
+                ["lsof", "-t", f"-i:{port}"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode != 0 or not result.stdout.strip():
+                return False
+            
+            # Kill each PID found
+            pids = result.stdout.strip().split('\n')
+            for pid in pids:
+                try:
+                    subprocess.run(
+                        ["kill", "-9", pid.strip()],
+                        capture_output=True,
+                        timeout=5,
+                    )
+                except Exception:
+                    pass
+            return True
+    except Exception:
+        return False
+
+
 class WhatsAppAdapter(BasePlatformAdapter):
     """
     WhatsApp adapter.
@@ -145,21 +211,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
             self._session_path.mkdir(parents=True, exist_ok=True)
             
             # Kill any orphaned bridge from a previous gateway run
-            try:
-                result = subprocess.run(
-                    ["fuser", f"{self._bridge_port}/tcp"],
-                    capture_output=True, timeout=5,
-                )
-                if result.returncode == 0:
-                    # Port is in use — kill the process
-                    subprocess.run(
-                        ["fuser", "-k", f"{self._bridge_port}/tcp"],
-                        capture_output=True, timeout=5,
-                    )
-                    import time
-                    time.sleep(2)
-            except Exception:
-                pass
+            if _kill_process_on_port(self._bridge_port):
+                import time
+                time.sleep(2)
             
             # Start the bridge process in its own process group.
             # Route output to a log file so QR codes, errors, and reconnection
@@ -293,13 +347,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 print(f"[{self.name}] Error stopping bridge: {e}")
         
         # Also kill any orphaned bridge processes on our port
-        try:
-            subprocess.run(
-                ["fuser", "-k", f"{self._bridge_port}/tcp"],
-                capture_output=True, timeout=5,
-            )
-        except Exception:
-            pass
+        _kill_process_on_port(self._bridge_port)
         
         self._running = False
         self._bridge_process = None


### PR DESCRIPTION
## Summary

Replaces Linux-only `fuser` command with a cross-platform helper function for cleaning up orphaned WhatsApp bridge processes.

## Problem

The WhatsApp adapter uses `fuser` to find and kill orphaned bridge processes on the configured port. `fuser` is Linux-only (part of the `psmisc` package) and fails silently on Windows due to the `except Exception: pass` wrapper.

This causes issues on Windows:
- After a crash or unclean shutdown, the bridge process stays alive
- Next `connect()` call fails with 'address already in use'
- The only workaround is manually killing the Node.js process

## Solution

Added a `_kill_process_on_port()` helper function that works cross-platform:

**Windows:**
- Uses `netstat -ano` to find the PID listening on the port
- Uses `taskkill /F /PID` to terminate it

**macOS/Linux:**
- Uses `lsof -t -i:PORT` (more portable than `fuser`, available on macOS)
- Uses `kill -9` to terminate found processes

## Changes

- Added `_kill_process_on_port(port: int) -> bool` helper function
- Replaced `fuser` calls in `connect()` (line ~150) and `disconnect()` (line ~298)
- Consistent with existing `_IS_WINDOWS` guards already in the codebase

## Testing

- Verified syntax and structure matches existing patterns in the codebase
- The helper follows the same error handling pattern (silent failure) as the original code
- Uses `lsof` which is available on both macOS and Linux (unlike `fuser` which is Linux-only)

Fixes #432