### PR TITLE
fix: skip manifest entry when skill copy fails

### DIFF
--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -123,6 +123,7 @@ def sync_skills(quiet: bool = False) -> dict:
         except (OSError, IOError) as e:
             if not quiet:
                 print(f"  ! Failed to copy {skill_name}: {e}")
+            continue
 
         manifest.add(skill_name)
 


### PR DESCRIPTION
## Summary

- When `shutil.copytree()` fails in `sync_skills()`, the except block logs the error but falls through to `manifest.add(skill_name)`
- This marks the skill as synced even though it was never copied
- Subsequent syncs skip it (already in manifest), leaving the skill permanently missing
- Fix: add `continue` to the except block so failed copies are not recorded in the manifest