### PR TITLE
fix: cron HERMES_HOME path mismatch, missing HomeAssistant toolset mapping, Daytona timeout drift

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -24,7 +24,7 @@ except ImportError:
 # Configuration
 # =============================================================================
 
-HERMES_DIR = Path.home() / ".hermes"
+HERMES_DIR = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
 CRON_DIR = HERMES_DIR / "cron"
 JOBS_FILE = CRON_DIR / "jobs.json"
 OUTPUT_DIR = CRON_DIR / "output"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1811,6 +1811,7 @@ class GatewayRunner:
             Platform.DISCORD: "hermes-discord",
             Platform.WHATSAPP: "hermes-whatsapp",
             Platform.SLACK: "hermes-slack",
+            Platform.HOMEASSISTANT: "hermes-homeassistant",
         }
         
         # Try to load platform_toolsets from config
@@ -1832,6 +1833,7 @@ class GatewayRunner:
             Platform.DISCORD: "discord",
             Platform.WHATSAPP: "whatsapp",
             Platform.SLACK: "slack",
+            Platform.HOMEASSISTANT: "homeassistant",
         }.get(source.platform, "telegram")
         
         # Use config override if present (list of toolsets), otherwise hardcoded default

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -6,6 +6,7 @@ and resumed on next creation, preserving the filesystem across sessions.
 """
 
 import logging
+import time
 import math
 import shlex
 import threading
@@ -142,10 +143,9 @@ class DaytonaEnvironment(BaseEnvironment):
         t = threading.Thread(target=_run, daemon=True)
         t.start()
         # Wait for timeout + generous buffer for network/SDK overhead
-        deadline = timeout + 10
+        deadline = time.monotonic() + timeout + 10
         while t.is_alive():
             t.join(timeout=0.2)
-            deadline -= 0.2
             if is_interrupted():
                 with self._lock:
                     try:
@@ -156,7 +156,7 @@ class DaytonaEnvironment(BaseEnvironment):
                     "output": "[Command interrupted - Daytona sandbox stopped]",
                     "returncode": 130,
                 }
-            if deadline <= 0:
+            if time.monotonic() > deadline:
                 # Shell timeout didn't fire and SDK is hung — force stop
                 with self._lock:
                     try:


### PR DESCRIPTION
## Summary

Three small independent fixes for inconsistencies found during code review:

### 1. `cron/jobs.py` — respect `HERMES_HOME` environment variable

- `scheduler.py:38` correctly resolves `HERMES_HOME`: `Path(os.getenv("HERMES_HOME", ...))`
- `jobs.py:27` hardcodes `Path.home() / ".hermes"`, ignoring the override
- When `HERMES_HOME` is set, the scheduler looks for its lock file in the custom location but `get_due_jobs()` reads from `~/.hermes/cron/jobs.json` — jobs are silently never found

### 2. `gateway/run.py` — add `Platform.HOMEASSISTANT` to toolset mappings

- `HomeAssistantAdapter` is created at line 524, `hermes-homeassistant` toolset is defined in `toolsets.py:258`
- But `default_toolset_map` and `platform_config_key` both omit `HOMEASSISTANT`
- HomeAssistant events silently fall back to `hermes-telegram` toolset

### 3. `tools/environments/daytona.py` — use `time.monotonic()` for timeout deadline

- All other backends (`docker.py:235`, `ssh.py:110`, `singularity.py:267`, `local.py:210`) use `time.monotonic()` with an absolute deadline
- Daytona uses `deadline -= 0.2` accumulator pattern which drifts because `t.join(0.2)` + interrupt checks + lock acquisition take more than 0.2s per iteration