### PR TITLE
feat: WebGPU client-side inference via browser bridge

### DIFF
--- a/web_client/__main__.py
+++ b/web_client/__main__.py
@@ -1,0 +1,3 @@
+from web_client.bridge import main
+
+main()

--- a/web_client/bridge.py
+++ b/web_client/bridge.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""WebGPU Bridge Server — connects browser-side WebLLM inference to Hermes Agent.
+
+The browser loads a model via WebGPU and connects over WebSocket.
+This bridge exposes an OpenAI-compatible HTTP endpoint that Hermes talks to.
+
+Usage:
+    python3 -m web_client.bridge              # Start bridge on default ports
+    python3 -m web_client.bridge --port 8801  # Custom WebSocket port
+
+Then open web_client/index.html in Chrome, load a model, and click Connect.
+Hermes connects via:
+    hermes --provider webgpu
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import time
+import uuid
+import webbrowser
+from pathlib import Path
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, HTMLResponse, StreamingResponse
+from starlette.routing import Route, WebSocketRoute
+from starlette.websockets import WebSocket, WebSocketDisconnect
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger("webgpu-bridge")
+
+# State
+_ws_client: WebSocket | None = None
+_pending: dict[str, asyncio.Future] = {}
+_client_model: str = "unknown"
+_stats = {"requests": 0, "start_time": time.time()}
+
+
+async def ws_endpoint(websocket: WebSocket):
+    """WebSocket endpoint for the browser client."""
+    global _ws_client, _client_model
+    await websocket.accept()
+    _ws_client = websocket
+    logger.info("Browser client connected")
+
+    try:
+        while True:
+            data = await websocket.receive_json()
+            msg_type = data.get("type")
+
+            if msg_type == "ready":
+                _client_model = data.get("model", "unknown")
+                logger.info(f"Client ready with model: {_client_model}")
+
+            elif msg_type == "pong":
+                pass
+
+            elif msg_type == "response":
+                req_id = data.get("id")
+                if req_id in _pending:
+                    _pending[req_id].set_result(data.get("data"))
+
+            elif msg_type == "chunk":
+                req_id = data.get("id")
+                if req_id in _pending and hasattr(_pending[req_id], "_chunks"):
+                    _pending[req_id]._chunks.put_nowait(data.get("data"))
+
+            elif msg_type == "done":
+                req_id = data.get("id")
+                if req_id in _pending and hasattr(_pending[req_id], "_chunks"):
+                    _pending[req_id]._chunks.put_nowait(None)  # sentinel
+
+            elif msg_type == "error":
+                req_id = data.get("id")
+                if req_id in _pending:
+                    _pending[req_id].set_exception(
+                        RuntimeError(data.get("error", "inference failed"))
+                    )
+
+    except WebSocketDisconnect:
+        logger.info("Browser client disconnected")
+        _ws_client = None
+        # Fail all pending requests
+        for fut in _pending.values():
+            if not fut.done():
+                fut.set_exception(RuntimeError("browser client disconnected"))
+        _pending.clear()
+
+
+async def chat_completions(request: Request):
+    """OpenAI-compatible /v1/chat/completions endpoint."""
+    if _ws_client is None:
+        return JSONResponse(
+            {"error": {"message": "No browser client connected. Open web_client/index.html and load a model."}},
+            status_code=503,
+        )
+
+    body = await request.json()
+    req_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+    stream = body.get("stream", False)
+    _stats["requests"] += 1
+
+    if stream:
+        return await _handle_streaming(req_id, body)
+    else:
+        return await _handle_non_streaming(req_id, body)
+
+
+async def _handle_non_streaming(req_id: str, body: dict):
+    """Non-streaming: send to browser, wait for response."""
+    fut = asyncio.get_event_loop().create_future()
+    _pending[req_id] = fut
+
+    await _ws_client.send_json({
+        "type": "inference",
+        "data": {"id": req_id, "stream": False, **body},
+    })
+
+    try:
+        result = await asyncio.wait_for(fut, timeout=300)
+        return JSONResponse(result)
+    except asyncio.TimeoutError:
+        return JSONResponse({"error": {"message": "inference timed out"}}, status_code=504)
+    except RuntimeError as e:
+        return JSONResponse({"error": {"message": str(e)}}, status_code=502)
+    finally:
+        _pending.pop(req_id, None)
+
+
+async def _handle_streaming(req_id: str, body: dict):
+    """Streaming: SSE response, chunks forwarded from browser."""
+    chunk_queue = asyncio.Queue()
+    fut = asyncio.get_event_loop().create_future()
+    fut._chunks = chunk_queue
+    _pending[req_id] = fut
+
+    await _ws_client.send_json({
+        "type": "inference",
+        "data": {"id": req_id, "stream": True, **body},
+    })
+
+    async def event_generator():
+        try:
+            while True:
+                chunk = await asyncio.wait_for(chunk_queue.get(), timeout=120)
+                if chunk is None:  # done sentinel
+                    yield "data: [DONE]\n\n"
+                    break
+                yield f"data: {json.dumps(chunk)}\n\n"
+        except asyncio.TimeoutError:
+            yield f'data: {json.dumps({"error": "stream timeout"})}\n\n'
+        finally:
+            _pending.pop(req_id, None)
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+
+async def models_list(request: Request):
+    """GET /v1/models — report the loaded model."""
+    return JSONResponse({
+        "object": "list",
+        "data": [
+            {
+                "id": _client_model,
+                "object": "model",
+                "owned_by": "webgpu-local",
+            }
+        ],
+    })
+
+
+async def health(request: Request):
+    """Health check."""
+    return JSONResponse({
+        "status": "ok" if _ws_client else "waiting_for_client",
+        "model": _client_model,
+        "requests_served": _stats["requests"],
+        "uptime_seconds": int(time.time() - _stats["start_time"]),
+    })
+
+
+async def serve_ui(request: Request):
+    """Serve the web client HTML."""
+    html_path = Path(__file__).parent / "index.html"
+    return HTMLResponse(html_path.read_text())
+
+
+app = Starlette(
+    routes=[
+        # Browser WebSocket
+        WebSocketRoute("/ws", ws_endpoint),
+        # OpenAI-compatible API (hermes talks to this)
+        Route("/v1/chat/completions", chat_completions, methods=["POST"]),
+        Route("/v1/models", models_list, methods=["GET"]),
+        Route("/health", health, methods=["GET"]),
+        # Serve the web UI
+        Route("/", serve_ui, methods=["GET"]),
+    ],
+)
+
+
+def main():
+    p = argparse.ArgumentParser(description="WebGPU bridge — browser inference for Hermes Agent")
+    p.add_argument("--port", type=int, default=8801, help="Port for both HTTP API and WebSocket (default: 8801)")
+    p.add_argument("--no-browser", action="store_true", help="Don't auto-open browser")
+    args = p.parse_args()
+
+    print(f"WebGPU Bridge Server")
+    print(f"  HTTP API:    http://127.0.0.1:{args.port}/v1")
+    print(f"  WebSocket:   ws://127.0.0.1:{args.port}/ws")
+    print(f"  Web UI:      http://127.0.0.1:{args.port}/")
+    print()
+    print(f"  Connect hermes:")
+    print(f"    hermes --provider webgpu")
+    print()
+
+    if not args.no_browser:
+        import threading
+        threading.Timer(1.0, lambda: webbrowser.open(f"http://127.0.0.1:{args.port}/")).start()
+
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=args.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/web_client/index.html
+++ b/web_client/index.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hermes Agent — WebGPU Inference</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background: #0a0a1a; color: #fff8dc; font-family: 'SF Mono', 'Fira Code', monospace; }
+  #app { max-width: 720px; margin: 0 auto; padding: 2rem 1rem; }
+  h1 { color: #ffd700; font-size: 1.4rem; margin-bottom: 0.5rem; }
+  .subtitle { color: #cd7f32; font-size: 0.85rem; margin-bottom: 1.5rem; }
+  #status { padding: 0.8rem 1rem; border-radius: 6px; margin-bottom: 1rem;
+            background: #1a1a2e; border: 1px solid #333355; font-size: 0.9rem; }
+  #status.loading { border-color: #cd7f32; }
+  #status.ready { border-color: #4caf50; color: #4caf50; }
+  #status.error { border-color: #f44336; color: #f44336; }
+  #progress-bar { height: 4px; background: #333355; border-radius: 2px; margin-top: 0.5rem; overflow: hidden; }
+  #progress-fill { height: 100%; background: #cd7f32; width: 0%; transition: width 0.3s; }
+  #model-select { width: 100%; padding: 0.6rem; background: #1a1a2e; color: #fff8dc;
+                   border: 1px solid #333355; border-radius: 4px; font-family: inherit;
+                   font-size: 0.9rem; margin-bottom: 1rem; }
+  #model-select option { background: #1a1a2e; }
+  button { padding: 0.6rem 1.2rem; background: #333355; color: #ffd700; border: 1px solid #cd7f32;
+           border-radius: 4px; cursor: pointer; font-family: inherit; font-size: 0.9rem; }
+  button:hover { background: #444466; }
+  button:disabled { opacity: 0.4; cursor: not-allowed; }
+  #log { margin-top: 1.5rem; background: #111122; border: 1px solid #222244; border-radius: 6px;
+         padding: 0.8rem; font-size: 0.8rem; max-height: 300px; overflow-y: auto; }
+  #log .entry { margin-bottom: 0.3rem; }
+  #log .time { color: #555; }
+  #log .info { color: #888; }
+  #log .ok { color: #4caf50; }
+  #log .err { color: #f44336; }
+  .controls { display: flex; gap: 0.5rem; align-items: center; }
+  .bridge-info { margin-top: 1rem; padding: 0.8rem; background: #1a1a2e; border: 1px solid #333355;
+                 border-radius: 6px; font-size: 0.85rem; display: none; }
+  .bridge-info code { color: #ffd700; }
+  .stats { display: flex; gap: 1.5rem; margin-top: 0.5rem; font-size: 0.8rem; color: #888; }
+</style>
+</head>
+<body>
+<div id="app">
+  <h1>Hermes Agent — WebGPU Inference</h1>
+  <p class="subtitle">Client-side model loading — runs on your GPU, nothing leaves your machine</p>
+
+  <select id="model-select">
+    <option value="Qwen/Qwen3-4B-q4f16_1-MLC">Qwen3 4B (q4f16, ~2.5GB VRAM)</option>
+    <option value="Qwen/Qwen2.5-3B-Instruct-q4f16_1-MLC">Qwen2.5 3B Instruct (q4f16, ~1.8GB)</option>
+    <option value="mlc-ai/Llama-3.1-8B-Instruct-q4f16_1-MLC">Llama 3.1 8B Instruct (q4f16, ~4.5GB)</option>
+    <option value="mlc-ai/Mistral-7B-Instruct-v0.3-q4f16_1-MLC">Mistral 7B v0.3 (q4f16, ~4GB)</option>
+    <option value="mlc-ai/SmolLM2-1.7B-Instruct-q4f16_1-MLC">SmolLM2 1.7B (q4f16, ~1GB)</option>
+  </select>
+
+  <div class="controls">
+    <button id="btn-load" onclick="loadModel()">Load Model</button>
+    <button id="btn-connect" onclick="connectBridge()" disabled>Connect to Hermes</button>
+  </div>
+
+  <div id="status">Select a model and click Load</div>
+  <div id="progress-bar"><div id="progress-fill"></div></div>
+  <div class="stats">
+    <span>Requests: <span id="stat-reqs">0</span></span>
+    <span>Tokens: <span id="stat-toks">0</span></span>
+    <span>Avg tok/s: <span id="stat-tps">-</span></span>
+  </div>
+
+  <div class="bridge-info" id="bridge-info">
+    Connected to bridge at <code id="bridge-url">ws://127.0.0.1:8801</code><br>
+    Hermes can now use: <code>hermes --provider webgpu</code>
+  </div>
+
+  <div id="log"></div>
+</div>
+
+<script type="module">
+import * as webllm from "https://esm.run/@mlc-ai/web-llm";
+
+let engine = null;
+let ws = null;
+let stats = { reqs: 0, toks: 0, totalTime: 0 };
+
+function log(msg, cls = "info") {
+  const el = document.getElementById("log");
+  const t = new Date().toLocaleTimeString();
+  el.innerHTML += `<div class="entry"><span class="time">${t}</span> <span class="${cls}">${msg}</span></div>`;
+  el.scrollTop = el.scrollHeight;
+}
+
+function setStatus(msg, cls = "") {
+  const el = document.getElementById("status");
+  el.textContent = msg;
+  el.className = cls;
+}
+
+function setProgress(pct) {
+  document.getElementById("progress-fill").style.width = pct + "%";
+}
+
+function updateStats() {
+  document.getElementById("stat-reqs").textContent = stats.reqs;
+  document.getElementById("stat-toks").textContent = stats.toks;
+  const avg = stats.totalTime > 0 ? (stats.toks / stats.totalTime).toFixed(1) : "-";
+  document.getElementById("stat-tps").textContent = avg;
+}
+
+window.loadModel = async function() {
+  const modelId = document.getElementById("model-select").value;
+  const btn = document.getElementById("btn-load");
+  btn.disabled = true;
+  setStatus("Checking WebGPU support...", "loading");
+
+  if (!navigator.gpu) {
+    setStatus("WebGPU not supported in this browser. Use Chrome 113+ or Edge 113+.", "error");
+    log("WebGPU not available", "err");
+    btn.disabled = false;
+    return;
+  }
+
+  log(`Loading ${modelId}...`);
+  setStatus(`Loading ${modelId}...`, "loading");
+
+  try {
+    engine = await webllm.CreateMLCEngine(modelId, {
+      initProgressCallback: (report) => {
+        setStatus(report.text, "loading");
+        setProgress(report.progress * 100);
+      },
+    });
+
+    setStatus(`Model ready: ${modelId}`, "ready");
+    setProgress(100);
+    log(`Model loaded: ${modelId}`, "ok");
+    document.getElementById("btn-connect").disabled = false;
+  } catch (e) {
+    setStatus(`Failed to load: ${e.message}`, "error");
+    log(`Load error: ${e.message}`, "err");
+    btn.disabled = false;
+  }
+};
+
+async function handleRequest(data) {
+  const messages = data.messages || [];
+  const id = data.id || "chatcmpl-" + Date.now();
+  const stream = data.stream || false;
+
+  stats.reqs++;
+  const t0 = performance.now();
+
+  try {
+    if (stream) {
+      // Streaming response
+      const chunks = await engine.chat.completions.create({
+        messages,
+        model: data.model || "default",
+        temperature: data.temperature ?? 0.7,
+        max_tokens: data.max_tokens ?? 4096,
+        tools: data.tools,
+        stream: true,
+      });
+
+      for await (const chunk of chunks) {
+        ws.send(JSON.stringify({ id, type: "chunk", data: chunk }));
+        const delta = chunk.choices?.[0]?.delta;
+        if (delta?.content) stats.toks += delta.content.length / 4; // rough estimate
+      }
+      ws.send(JSON.stringify({ id, type: "done" }));
+    } else {
+      // Non-streaming
+      const response = await engine.chat.completions.create({
+        messages,
+        model: data.model || "default",
+        temperature: data.temperature ?? 0.7,
+        max_tokens: data.max_tokens ?? 4096,
+        tools: data.tools,
+      });
+
+      const elapsed = (performance.now() - t0) / 1000;
+      const toks = response.usage?.completion_tokens || 0;
+      stats.toks += toks;
+      stats.totalTime += elapsed;
+      updateStats();
+
+      log(`Completed: ${toks} tokens in ${elapsed.toFixed(1)}s (${(toks/elapsed).toFixed(1)} tok/s)`, "ok");
+      ws.send(JSON.stringify({ id, type: "response", data: response }));
+    }
+  } catch (e) {
+    log(`Inference error: ${e.message}`, "err");
+    ws.send(JSON.stringify({ id, type: "error", error: e.message }));
+  }
+}
+
+window.connectBridge = function() {
+  const url = "ws://127.0.0.1:8801/ws";
+  document.getElementById("btn-connect").disabled = true;
+  log(`Connecting to bridge: ${url}`);
+
+  ws = new WebSocket(url);
+
+  ws.onopen = () => {
+    log("Bridge connected", "ok");
+    document.getElementById("bridge-info").style.display = "block";
+    ws.send(JSON.stringify({ type: "ready", model: document.getElementById("model-select").value }));
+  };
+
+  ws.onmessage = (event) => {
+    try {
+      const msg = JSON.parse(event.data);
+      if (msg.type === "inference") {
+        handleRequest(msg.data);
+      } else if (msg.type === "ping") {
+        ws.send(JSON.stringify({ type: "pong" }));
+      }
+    } catch (e) {
+      log(`Message error: ${e.message}`, "err");
+    }
+  };
+
+  ws.onclose = () => {
+    log("Bridge disconnected", "err");
+    document.getElementById("bridge-info").style.display = "none";
+    document.getElementById("btn-connect").disabled = false;
+  };
+
+  ws.onerror = (e) => {
+    log("Bridge connection failed — is the bridge server running?", "err");
+    document.getElementById("btn-connect").disabled = false;
+  };
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `web_client/` module for running inference directly in the browser using WebGPU
- Python WebSocket bridge server connects CLI to browser frontend
- HTML frontend loads models client-side for zero-latency local inference
- Self-contained module, no changes to existing code

## Files
- `web_client/bridge.py` — WebSocket bridge between CLI and browser
- `web_client/index.html` — WebGPU inference frontend
- `web_client/__init__.py`, `__main__.py` — module entry points

## Test plan
- [ ] Run `python -m web_client` and verify browser opens with WebGPU interface
- [ ] Test inference with a small model in a WebGPU-capable browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)