### PR TITLE
fix: ImageMagick fallback + dotenv override + clipboard robustness

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -59,14 +59,14 @@ _user_env = _hermes_home / ".env"
 _project_env = Path(__file__).parent / '.env'
 if _user_env.exists():
     try:
-        load_dotenv(dotenv_path=_user_env, encoding="utf-8")
+        load_dotenv(dotenv_path=_user_env, encoding="utf-8", override=True)
     except UnicodeDecodeError:
-        load_dotenv(dotenv_path=_user_env, encoding="latin-1")
-elif _project_env.exists():
+        load_dotenv(dotenv_path=_user_env, encoding="latin-1", override=True)
+if _project_env.exists():
     try:
-        load_dotenv(dotenv_path=_project_env, encoding="utf-8")
+        load_dotenv(dotenv_path=_project_env, encoding="utf-8", override=True)
     except UnicodeDecodeError:
-        load_dotenv(dotenv_path=_project_env, encoding="latin-1")
+        load_dotenv(dotenv_path=_project_env, encoding="latin-1", override=True)
 
 # Point mini-swe-agent at ~/.hermes/ so it shares our config
 os.environ.setdefault("MSWEA_GLOBAL_CONFIG_DIR", str(_hermes_home))

--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -288,17 +288,24 @@ def _convert_to_png(path: Path) -> bool:
     try:
         tmp = path.with_suffix(".bmp")
         path.rename(tmp)
-        r = subprocess.run(
-            ["convert", str(tmp), "png:" + str(path)],
-            capture_output=True, timeout=5,
-        )
-        tmp.unlink(missing_ok=True)
-        if r.returncode == 0 and path.exists() and path.stat().st_size > 0:
-            return True
-    except FileNotFoundError:
-        logger.debug("ImageMagick not installed — cannot convert BMP to PNG")
+        try:
+            r = subprocess.run(
+                ["convert", str(tmp), "png:" + str(path)],
+                capture_output=True, timeout=5,
+            )
+            tmp.unlink(missing_ok=True)
+            if r.returncode == 0 and path.exists() and path.stat().st_size > 0:
+                return True
+        except FileNotFoundError:
+            # ImageMagick not installed — restore original file
+            tmp.rename(path)
+            logger.debug("ImageMagick not installed — cannot convert BMP to PNG")
+        except Exception as e:
+            if tmp.exists() and not path.exists():
+                tmp.rename(path)
+            logger.debug("ImageMagick BMP→PNG conversion failed: %s", e)
     except Exception as e:
-        logger.debug("ImageMagick BMP→PNG conversion failed: %s", e)
+        logger.debug("BMP→PNG rename failed: %s", e)
 
     # Can't convert — BMP is still usable as-is for most APIs
     return path.exists() and path.stat().st_size > 0

--- a/run_agent.py
+++ b/run_agent.py
@@ -47,15 +47,15 @@ _user_env = _hermes_home / ".env"
 _project_env = Path(__file__).parent / '.env'
 if _user_env.exists():
     try:
-        load_dotenv(dotenv_path=_user_env, encoding="utf-8")
+        load_dotenv(dotenv_path=_user_env, encoding="utf-8", override=True)
     except UnicodeDecodeError:
-        load_dotenv(dotenv_path=_user_env, encoding="latin-1")
+        load_dotenv(dotenv_path=_user_env, encoding="latin-1", override=True)
     logger.info("Loaded environment variables from %s", _user_env)
 elif _project_env.exists():
     try:
-        load_dotenv(dotenv_path=_project_env, encoding="utf-8")
+        load_dotenv(dotenv_path=_project_env, encoding="utf-8", override=True)
     except UnicodeDecodeError:
-        load_dotenv(dotenv_path=_project_env, encoding="latin-1")
+        load_dotenv(dotenv_path=_project_env, encoding="latin-1", override=True)
     logger.info("Loaded environment variables from %s", _project_env)
 else:
     logger.info("No .env file found. Using system environment variables.")


### PR DESCRIPTION
## Summary
- **ImageMagick fallback**: restore original file when ImageMagick unavailable in BMP→PNG clipboard conversion
- **dotenv override**: use `override=True` so `.env` keys take precedence over stale shell environment variables
- **Dual .env loading**: load both `~/.hermes/.env` AND project `.env` (not either/or)

## Test plan
- [ ] Clipboard image paste works without ImageMagick installed
- [ ] `.env` values override shell environment variables
- [ ] Both global and project `.env` files are loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)