### PR TITLE
feat(checkpoint): filesystem checkpointing and rollback before destructive operations

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -95,6 +95,7 @@ def _discover_tools():
         "tools.send_message_tool",
         "tools.honcho_tools",
         "tools.homeassistant_tool",
+        "tools.checkpoint_tool",
     ]
     import importlib
     for mod_name in _modules:

--- a/tests/tools/test_checkpoint_tool.py
+++ b/tests/tools/test_checkpoint_tool.py
@@ -1,0 +1,411 @@
+"""Tests for tools/checkpoint_tool.py — CheckpointStore, dispatcher, and convenience wrapper."""
+
+import json
+import shutil
+import pytest
+from pathlib import Path
+
+from tools.checkpoint_tool import (
+    CheckpointStore,
+    checkpoint_tool,
+    check_checkpoint_requirements,
+    take_checkpoint,
+    _shadow_repo_path,
+    CHECKPOINT_BASE,
+    DEFAULT_EXCLUDES,
+)
+
+
+# =========================================================================
+# Fixtures
+# =========================================================================
+
+@pytest.fixture()
+def work_dir(tmp_path):
+    """A temporary working directory that acts as the user's project root."""
+    d = tmp_path / "project"
+    d.mkdir()
+    (d / "app.py").write_text("print('hello')\n")
+    return d
+
+
+@pytest.fixture()
+def checkpoint_base(tmp_path):
+    """Isolated checkpoint base directory — never writes to ~/.hermes/."""
+    return tmp_path / "checkpoints"
+
+
+@pytest.fixture()
+def store(work_dir, checkpoint_base, monkeypatch):
+    """A CheckpointStore with shadow repo redirected to tmp_path."""
+    monkeypatch.setattr("tools.checkpoint_tool.CHECKPOINT_BASE", checkpoint_base)
+    return CheckpointStore(str(work_dir))
+
+
+# =========================================================================
+# Shadow repo initialisation
+# =========================================================================
+
+class TestShadowRepoInit:
+    def test_shadow_repo_created_on_first_take(self, store):
+        result = store.take("initial commit")
+        assert result["success"] is True
+        assert (store.shadow_repo / "HEAD").exists()
+
+    def test_shadow_repo_path_is_deterministic(self, work_dir, checkpoint_base, monkeypatch):
+        monkeypatch.setattr("tools.checkpoint_tool.CHECKPOINT_BASE", checkpoint_base)
+        path1 = _shadow_repo_path(str(work_dir))
+        path2 = _shadow_repo_path(str(work_dir))
+        assert path1 == path2
+
+    def test_different_dirs_get_different_shadow_repos(self, tmp_path, checkpoint_base, monkeypatch):
+        monkeypatch.setattr("tools.checkpoint_tool.CHECKPOINT_BASE", checkpoint_base)
+        dir_a = tmp_path / "project_a"
+        dir_b = tmp_path / "project_b"
+        assert _shadow_repo_path(str(dir_a)) != _shadow_repo_path(str(dir_b))
+
+    def test_shadow_repo_does_not_contain_git_dir_in_project(self, work_dir, store):
+        store.take("initial commit")
+        # The user's working directory must not gain a .git folder
+        assert not (work_dir / ".git").exists()
+
+    def test_shadow_repo_has_info_exclude(self, store):
+        store.take("initial commit")
+        exclude_file = store.shadow_repo / "info" / "exclude"
+        assert exclude_file.exists()
+        content = exclude_file.read_text()
+        assert "node_modules/" in content
+        assert ".env" in content
+        assert "dist/" in content
+
+    def test_second_take_does_not_reinit(self, store):
+        store.take("first")
+        # Modify shadow repo's HEAD to detect if re-init would overwrite it
+        head_before = (store.shadow_repo / "HEAD").read_text()
+        store.take("second")
+        head_after = (store.shadow_repo / "HEAD").read_text()
+        assert head_before == head_after  # HEAD format unchanged by re-init
+
+
+# =========================================================================
+# CheckpointStore.take()
+# =========================================================================
+
+class TestCheckpointStoreTake:
+    def test_take_returns_success(self, store):
+        result = store.take("initial commit")
+        assert result["success"] is True
+
+    def test_take_returns_commit_hash(self, store):
+        result = store.take("initial commit")
+        assert "commit_hash" in result
+        # Short git hash: 7 hex chars by default, up to 16
+        assert len(result["commit_hash"]) >= 7
+        assert all(c in "0123456789abcdef" for c in result["commit_hash"])
+
+    def test_take_includes_working_dir(self, store, work_dir):
+        result = store.take("initial commit")
+        assert result["working_dir"] == str(work_dir)
+
+    def test_take_empty_reason_rejected(self, store):
+        result = store.take("")
+        assert result["success"] is False
+        assert "reason" in result["error"].lower()
+
+    def test_take_whitespace_reason_rejected(self, store):
+        result = store.take("   ")
+        assert result["success"] is False
+
+    def test_take_idempotent_no_change(self, store):
+        first = store.take("initial commit")
+        assert first["success"] is True
+        first_hash = first["commit_hash"]
+
+        # No files changed — second take should return the existing hash
+        second = store.take("nothing changed")
+        assert second["success"] is True
+        assert second["commit_hash"] == first_hash
+        assert second["files_changed"] == 0
+
+    def test_take_new_commit_after_file_change(self, store, work_dir):
+        first = store.take("initial")
+        (work_dir / "app.py").write_text("print('changed')\n")
+        second = store.take("after change")
+        assert second["success"] is True
+        assert second["commit_hash"] != first["commit_hash"]
+
+    def test_take_multiple_files_tracked(self, store, work_dir):
+        (work_dir / "utils.py").write_text("# utils\n")
+        (work_dir / "config.json").write_text('{"key": "value"}\n')
+        result = store.take("added utils and config")
+        assert result["success"] is True
+        assert result["files_changed"] >= 2
+
+    def test_take_excludes_node_modules(self, store, work_dir):
+        nm = work_dir / "node_modules" / "lodash"
+        nm.mkdir(parents=True)
+        (nm / "index.js").write_text("module.exports = {};\n")
+        result = store.take("with node_modules present")
+        assert result["success"] is True
+        # Restore and verify node_modules was not tracked:
+        # delete the dir, restore, it should remain absent
+        shutil.rmtree(str(work_dir / "node_modules"))
+        store.restore(result["commit_hash"])
+        assert not (work_dir / "node_modules").exists()
+
+    def test_take_excludes_dot_env(self, store, work_dir):
+        (work_dir / ".env").write_text("SECRET=hunter2\n")
+        result = store.take("with .env present")
+        assert result["success"] is True
+        (work_dir / ".env").unlink()
+        store.restore(result["commit_hash"])
+        # .env was excluded — restore should not recreate it
+        assert not (work_dir / ".env").exists()
+
+
+# =========================================================================
+# CheckpointStore.restore()
+# =========================================================================
+
+class TestCheckpointStoreRestore:
+    def test_restore_reverts_file_content(self, store, work_dir):
+        (work_dir / "app.py").write_text("version 1\n")
+        snapshot = store.take("version 1")
+        assert snapshot["success"] is True
+        commit_hash = snapshot["commit_hash"]
+
+        (work_dir / "app.py").write_text("version 2\n")
+        assert (work_dir / "app.py").read_text() == "version 2\n"
+
+        result = store.restore(commit_hash)
+        assert result["success"] is True
+        assert (work_dir / "app.py").read_text() == "version 1\n"
+
+    def test_restore_returns_commit_hash(self, store, work_dir):
+        snap = store.take("initial")
+        result = store.restore(snap["commit_hash"])
+        assert result["commit_hash"] == snap["commit_hash"]
+
+    def test_restore_includes_reason(self, store, work_dir):
+        snap = store.take("my restore reason")
+        result = store.restore(snap["commit_hash"])
+        assert result["success"] is True
+        assert "my restore reason" in result["reason"]
+
+    def test_restore_nonexistent_hash_fails(self, store, work_dir):
+        store.take("initial")
+        result = store.restore("deadbeef")
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_restore_empty_hash_fails(self, store):
+        result = store.restore("")
+        assert result["success"] is False
+        assert "commit_hash" in result["error"].lower()
+
+    def test_restore_whitespace_hash_fails(self, store):
+        result = store.restore("   ")
+        assert result["success"] is False
+
+    def test_restore_does_not_touch_excluded_paths(self, store, work_dir):
+        # .env exists before snapshot but is excluded
+        env_file = work_dir / ".env"
+        env_file.write_text("BEFORE=1\n")
+        snap = store.take("with env")
+        # Change .env after snapshot
+        env_file.write_text("AFTER=2\n")
+        store.restore(snap["commit_hash"])
+        # .env was never tracked so restore should not revert it
+        assert env_file.read_text() == "AFTER=2\n"
+
+    def test_restore_no_checkpoints_fails(self, store):
+        result = store.restore("abc1234")
+        assert result["success"] is False
+
+    def test_restore_reverts_deleted_file(self, store, work_dir):
+        snap = store.take("before delete")
+        (work_dir / "app.py").unlink()
+        store.restore(snap["commit_hash"])
+        assert (work_dir / "app.py").exists()
+
+    def test_restore_to_older_of_two_checkpoints(self, store, work_dir):
+        (work_dir / "app.py").write_text("state A\n")
+        snap_a = store.take("state A")
+
+        (work_dir / "app.py").write_text("state B\n")
+        store.take("state B")
+
+        store.restore(snap_a["commit_hash"])
+        assert (work_dir / "app.py").read_text() == "state A\n"
+
+
+# =========================================================================
+# CheckpointStore.list()
+# =========================================================================
+
+class TestCheckpointStoreList:
+    def test_list_empty_when_no_checkpoints(self, store):
+        result = store.list()
+        assert result["success"] is True
+        assert result["checkpoints"] == []
+        assert result["count"] == 0
+
+    def test_list_includes_working_dir(self, store, work_dir):
+        result = store.list()
+        assert result["working_dir"] == str(work_dir)
+
+    def test_list_returns_one_checkpoint(self, store):
+        store.take("only checkpoint")
+        result = store.list()
+        assert result["success"] is True
+        assert result["count"] == 1
+
+    def test_list_returns_newest_first(self, store, work_dir):
+        store.take("first checkpoint")
+        (work_dir / "app.py").write_text("changed\n")
+        store.take("second checkpoint")
+
+        result = store.list()
+        assert result["success"] is True
+        assert result["count"] == 2
+        # Newest first
+        assert result["checkpoints"][0]["reason"] == "second checkpoint"
+        assert result["checkpoints"][1]["reason"] == "first checkpoint"
+
+    def test_list_each_entry_has_required_fields(self, store):
+        store.take("test entry")
+        result = store.list()
+        entry = result["checkpoints"][0]
+        assert "commit_hash" in entry
+        assert "timestamp" in entry
+        assert "reason" in entry
+
+    def test_list_reason_matches_take_reason(self, store):
+        store.take("specific reason string")
+        result = store.list()
+        assert result["checkpoints"][0]["reason"] == "specific reason string"
+
+    def test_list_timestamp_is_iso_format(self, store):
+        store.take("timestamped")
+        result = store.list()
+        ts = result["checkpoints"][0]["timestamp"]
+        # ISO 8601 date starts with YYYY-
+        assert ts[:4].isdigit()
+        assert "-" in ts
+
+    def test_list_respects_limit(self, store, work_dir):
+        for i in range(5):
+            (work_dir / "app.py").write_text(f"version {i}\n")
+            store.take(f"checkpoint {i}")
+
+        result = store.list(limit=2)
+        assert result["success"] is True
+        assert len(result["checkpoints"]) == 2
+
+    def test_list_commit_hash_matches_take_hash(self, store):
+        snap = store.take("known hash")
+        result = store.list()
+        listed_hash = result["checkpoints"][0]["commit_hash"]
+        # The listed short hash should be a prefix of or equal to the take hash
+        assert snap["commit_hash"].startswith(listed_hash) or listed_hash.startswith(snap["commit_hash"])
+
+
+# =========================================================================
+# checkpoint_tool() dispatcher
+# =========================================================================
+
+class TestCheckpointToolDispatcher:
+    @pytest.fixture(autouse=True)
+    def _patch_base(self, checkpoint_base, monkeypatch):
+        monkeypatch.setattr("tools.checkpoint_tool.CHECKPOINT_BASE", checkpoint_base)
+
+    def test_unknown_action_returns_error(self, work_dir):
+        result = json.loads(checkpoint_tool("frobnicate", working_dir=str(work_dir)))
+        assert result["success"] is False
+        assert "Unknown action" in result["error"]
+
+    def test_take_requires_reason(self, work_dir):
+        result = json.loads(checkpoint_tool("take", working_dir=str(work_dir)))
+        assert result["success"] is False
+        assert "reason" in result["error"].lower()
+
+    def test_restore_requires_commit_hash(self, work_dir):
+        result = json.loads(checkpoint_tool("restore", working_dir=str(work_dir)))
+        assert result["success"] is False
+        assert "commit_hash" in result["error"].lower()
+
+    def test_nonexistent_working_dir_returns_error(self, tmp_path):
+        missing = str(tmp_path / "does_not_exist")
+        result = json.loads(checkpoint_tool("take", working_dir=missing, reason="test"))
+        assert result["success"] is False
+        assert "not a directory" in result["error"].lower() or "not exist" in result["error"].lower()
+
+    def test_working_dir_defaults_to_cwd(self, monkeypatch, work_dir):
+        monkeypatch.chdir(work_dir)
+        result = json.loads(checkpoint_tool("list"))
+        assert result["success"] is True
+        assert result["working_dir"] == str(work_dir)
+
+    def test_valid_take_returns_json(self, work_dir):
+        result = json.loads(checkpoint_tool("take", working_dir=str(work_dir), reason="via dispatcher"))
+        assert result["success"] is True
+        assert "commit_hash" in result
+
+    def test_valid_list_returns_json(self, work_dir):
+        checkpoint_tool("take", working_dir=str(work_dir), reason="first")
+        result = json.loads(checkpoint_tool("list", working_dir=str(work_dir)))
+        assert result["success"] is True
+        assert isinstance(result["checkpoints"], list)
+
+    def test_valid_restore_returns_json(self, work_dir):
+        snap = json.loads(checkpoint_tool("take", working_dir=str(work_dir), reason="to restore"))
+        result = json.loads(
+            checkpoint_tool("restore", working_dir=str(work_dir), commit_hash=snap["commit_hash"])
+        )
+        assert result["success"] is True
+
+    def test_list_limit_clamped_to_100(self, work_dir):
+        result = json.loads(checkpoint_tool("list", working_dir=str(work_dir), limit=9999))
+        # Should not error — limit is silently clamped
+        assert result["success"] is True
+
+
+# =========================================================================
+# check_checkpoint_requirements()
+# =========================================================================
+
+class TestCheckpointRequirements:
+    def test_available_when_git_installed(self):
+        # git is required to run the rest of this suite anyway
+        if not shutil.which("git"):
+            pytest.skip("git not installed")
+        assert check_checkpoint_requirements() is True
+
+    def test_unavailable_when_git_missing(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda _cmd: None)
+        assert check_checkpoint_requirements() is False
+
+
+# =========================================================================
+# take_checkpoint() convenience wrapper
+# =========================================================================
+
+class TestTakeCheckpointWrapper:
+    def test_does_not_raise_on_invalid_working_dir(self):
+        # Should silently swallow errors — never propagate to caller
+        take_checkpoint("/nonexistent/path/xyz", "reason")  # must not raise
+
+    def test_does_not_raise_on_empty_reason(self, work_dir, checkpoint_base, monkeypatch):
+        monkeypatch.setattr("tools.checkpoint_tool.CHECKPOINT_BASE", checkpoint_base)
+        take_checkpoint(str(work_dir), "")  # must not raise
+
+    def test_does_not_raise_when_git_missing(self, work_dir, checkpoint_base, monkeypatch):
+        monkeypatch.setattr("tools.checkpoint_tool.CHECKPOINT_BASE", checkpoint_base)
+        monkeypatch.setattr("shutil.which", lambda _cmd: None)
+        take_checkpoint(str(work_dir), "no git installed")  # must not raise
+
+    def test_successful_wrapper_creates_shadow_repo(self, work_dir, checkpoint_base, monkeypatch):
+        monkeypatch.setattr("tools.checkpoint_tool.CHECKPOINT_BASE", checkpoint_base)
+        take_checkpoint(str(work_dir), "via wrapper")
+        shadow_repo = _shadow_repo_path(str(work_dir))
+        assert (shadow_repo / "HEAD").exists()

--- a/tools/checkpoint_tool.py
+++ b/tools/checkpoint_tool.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+"""
+Checkpoint Tool — Shadow Git Snapshots
+
+Creates and restores filesystem snapshots of a working directory using a shadow
+git repository stored at ~/.hermes/checkpoints/{dir-hash}/. The shadow repo is
+completely separate from any git repo the user may have — their .git/ is never
+touched.
+
+GIT_DIR + GIT_WORK_TREE environment variables redirect every git command to the
+shadow repo while operating on the user's actual working tree. No git state leaks
+into the project directory.
+
+Excludes (written to shadow repo's info/exclude, not the user's .gitignore):
+  node_modules/, dist/, .env, .env.*, __pycache__/, *.pyc, .DS_Store, *.log
+
+Operations:
+  take    — git add -A && git commit -m "{reason}"
+  restore — git checkout {commit_hash} -- .   (HEAD not moved)
+  list    — git log with short hash, ISO timestamp, reason
+
+Design:
+- Single `checkpoint` tool with action parameter: take, restore, list
+- Shadow repo path is deterministic: sha256(abs_working_dir)[:16]
+- check_fn gates the tool on git being present in PATH
+- Behavioral guidance lives in the tool schema description
+"""
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CHECKPOINT_BASE = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "checkpoints"
+
+DEFAULT_EXCLUDES = [
+    "node_modules/",
+    "dist/",
+    "build/",
+    ".env",
+    ".env.*",
+    ".env.local",
+    ".env.*.local",
+    "__pycache__/",
+    "*.pyc",
+    "*.pyo",
+    ".DS_Store",
+    "*.log",
+    ".cache/",
+    ".next/",
+    ".nuxt/",
+    "coverage/",
+    ".pytest_cache/",
+]
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _shadow_repo_path(working_dir: str) -> Path:
+    """Return the shadow repo path for a given working directory.
+
+    Uses first 16 hex chars of sha256(abs_path) so the shadow directory name
+    is deterministic and collision-resistant without being too long.
+    """
+    abs_path = str(Path(working_dir).resolve())
+    dir_hash = hashlib.sha256(abs_path.encode()).hexdigest()[:16]
+    return CHECKPOINT_BASE / dir_hash
+
+
+def _git_env(shadow_repo: Path, working_dir: str) -> dict:
+    """Build an environment dict that redirects git to the shadow repo.
+
+    GIT_DIR  — points git's internal storage at the shadow directory.
+    GIT_WORK_TREE — points git's file operations at the user's working dir.
+    GIT_INDEX_FILE is cleared so we never accidentally share an index with the
+    user's own git repo.
+    """
+    env = os.environ.copy()
+    env["GIT_DIR"] = str(shadow_repo)
+    env["GIT_WORK_TREE"] = str(Path(working_dir).resolve())
+    env.pop("GIT_INDEX_FILE", None)
+    env.pop("GIT_NAMESPACE", None)
+    env.pop("GIT_ALTERNATE_OBJECT_DIRECTORIES", None)
+    return env
+
+
+def _run_git(
+    args: List[str],
+    shadow_repo: Path,
+    working_dir: str,
+    timeout: int = 30,
+) -> Tuple[bool, str, str]:
+    """Run a git subcommand with the shadow repo environment.
+
+    Returns (success: bool, stdout: str, stderr: str).
+    Never raises — all errors are returned as (False, "", error_message).
+    """
+    env = _git_env(shadow_repo, working_dir)
+    try:
+        result = subprocess.run(
+            ["git"] + args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+            cwd=str(Path(working_dir).resolve()),
+        )
+        return (
+            result.returncode == 0,
+            result.stdout.strip(),
+            result.stderr.strip(),
+        )
+    except subprocess.TimeoutExpired:
+        return False, "", f"git command timed out after {timeout}s: git {' '.join(args)}"
+    except FileNotFoundError:
+        return False, "", "git executable not found — install git to use checkpoints"
+    except Exception as exc:
+        return False, "", str(exc)
+
+
+def _init_shadow_repo(shadow_repo: Path, working_dir: str) -> Optional[str]:
+    """Initialize the shadow git repo if it doesn't already exist.
+
+    Returns an error string on failure, None on success.
+
+    Initialization steps:
+      1. mkdir -p shadow_repo
+      2. git init  (GIT_DIR points here, so git internals land in shadow_repo/)
+      3. git config user.email/name  (so commits work without global git config)
+      4. Write DEFAULT_EXCLUDES to shadow_repo/info/exclude
+    """
+    # HEAD file presence is the canonical indicator of a valid git repo
+    if (shadow_repo / "HEAD").exists():
+        return None
+
+    shadow_repo.mkdir(parents=True, exist_ok=True)
+
+    ok, _, err = _run_git(["init"], shadow_repo, working_dir)
+    if not ok:
+        return f"Failed to initialize shadow repo at {shadow_repo}: {err}"
+
+    # Set a local identity so commits never fail due to missing global config
+    _run_git(["config", "user.email", "hermes@local"], shadow_repo, working_dir)
+    _run_git(["config", "user.name", "Hermes Agent"], shadow_repo, working_dir)
+
+    # Write exclude patterns to info/exclude — this file is shadow-repo-local
+    # and never appears in the user's working directory.
+    info_dir = shadow_repo / "info"
+    info_dir.mkdir(exist_ok=True)
+    exclude_path = info_dir / "exclude"
+    exclude_path.write_text("\n".join(DEFAULT_EXCLUDES) + "\n", encoding="utf-8")
+
+    # Store the original working dir path in the shadow repo for reference
+    (shadow_repo / "HERMES_WORKDIR").write_text(
+        str(Path(working_dir).resolve()) + "\n", encoding="utf-8"
+    )
+
+    logger.debug("Initialized shadow checkpoint repo at %s for %s", shadow_repo, working_dir)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CheckpointStore class
+# ---------------------------------------------------------------------------
+
+
+class CheckpointStore:
+    """Manages shadow-git checkpoints for a single working directory.
+
+    The shadow repo lives at ~/.hermes/checkpoints/{dir-hash}/ and is
+    completely independent of any git repo the user has in their project.
+    Every git call sets GIT_DIR + GIT_WORK_TREE so no state leaks.
+
+    Methods mirror the tool actions: take, restore, list.
+    """
+
+    def __init__(self, working_dir: str):
+        self.working_dir = str(Path(working_dir).resolve())
+        self.shadow_repo = _shadow_repo_path(self.working_dir)
+
+    def _ensure_initialized(self) -> Optional[str]:
+        """Ensure the shadow repo exists. Returns error string or None."""
+        return _init_shadow_repo(self.shadow_repo, self.working_dir)
+
+    # ------------------------------------------------------------------
+    # take
+    # ------------------------------------------------------------------
+
+    def take(self, reason: str) -> Dict[str, Any]:
+        """Stage all files and commit with reason as the commit message.
+
+        Respects info/exclude (node_modules, dist, .env, etc.).
+        If nothing has changed since the last checkpoint, returns the
+        existing HEAD hash without creating a new commit.
+        """
+        err = self._ensure_initialized()
+        if err:
+            return {"success": False, "error": err}
+
+        reason = reason.strip()
+        if not reason:
+            return {"success": False, "error": "reason cannot be empty"}
+
+        # Stage all files — respects shadow repo's info/exclude
+        ok, _, err = _run_git(
+            ["add", "-A"],
+            self.shadow_repo,
+            self.working_dir,
+            timeout=60,
+        )
+        if not ok:
+            return {"success": False, "error": f"git add failed: {err}"}
+
+        # Check if anything was actually staged
+        ok, status_out, _ = _run_git(
+            ["status", "--porcelain"],
+            self.shadow_repo,
+            self.working_dir,
+        )
+        if ok and not status_out.strip():
+            # Nothing changed — return existing HEAD rather than an error
+            ok2, head, _ = _run_git(
+                ["rev-parse", "--short", "HEAD"],
+                self.shadow_repo,
+                self.working_dir,
+            )
+            if ok2 and head:
+                return {
+                    "success": True,
+                    "commit_hash": head,
+                    "files_changed": 0,
+                    "message": "No changes since last checkpoint — existing snapshot returned",
+                    "working_dir": self.working_dir,
+                }
+            return {
+                "success": False,
+                "error": (
+                    "Nothing to commit and no prior checkpoint exists. "
+                    "The working directory may be empty or all files are excluded."
+                ),
+            }
+
+        # Count staged files for the response
+        staged_files = [l for l in status_out.splitlines() if l.strip()]
+
+        ok, out, err = _run_git(
+            ["commit", "-m", reason],
+            self.shadow_repo,
+            self.working_dir,
+            timeout=60,
+        )
+        if not ok:
+            return {"success": False, "error": f"git commit failed: {err}"}
+
+        ok2, commit_hash, _ = _run_git(
+            ["rev-parse", "--short", "HEAD"],
+            self.shadow_repo,
+            self.working_dir,
+        )
+
+        return {
+            "success": True,
+            "commit_hash": commit_hash if ok2 else "unknown",
+            "files_changed": len(staged_files),
+            "message": f"Checkpoint saved: {reason}",
+            "working_dir": self.working_dir,
+            "shadow_repo": str(self.shadow_repo),
+        }
+
+    # ------------------------------------------------------------------
+    # restore
+    # ------------------------------------------------------------------
+
+    def restore(self, commit_hash: str) -> Dict[str, Any]:
+        """Restore the working tree to match a specific checkpoint.
+
+        Uses `git checkout {commit_hash} -- .` so the current HEAD is not
+        moved. Only files that were snapshotted are restored; excluded files
+        (node_modules, .env, etc.) are left untouched.
+        """
+        err = self._ensure_initialized()
+        if err:
+            return {"success": False, "error": err}
+
+        commit_hash = commit_hash.strip()
+        if not commit_hash:
+            return {"success": False, "error": "commit_hash cannot be empty"}
+
+        # Verify the commit exists before touching the working tree
+        ok, full_hash, verify_err = _run_git(
+            ["rev-parse", "--verify", f"{commit_hash}^{{commit}}"],
+            self.shadow_repo,
+            self.working_dir,
+        )
+        if not ok:
+            return {
+                "success": False,
+                "error": (
+                    f"Checkpoint '{commit_hash}' not found in shadow repo. "
+                    f"Use action='list' to see available checkpoints. ({verify_err})"
+                ),
+            }
+
+        # Retrieve commit metadata before modifying the working tree
+        ok_msg, reason, _ = _run_git(
+            ["log", "-1", "--pretty=format:%s", commit_hash],
+            self.shadow_repo,
+            self.working_dir,
+        )
+        ok_ts, timestamp, _ = _run_git(
+            ["log", "-1", "--pretty=format:%ai", commit_hash],
+            self.shadow_repo,
+            self.working_dir,
+        )
+
+        # Restore working tree contents from the commit.
+        # '--' separates the treeish from the pathspec; '.' means all paths.
+        ok, _, restore_err = _run_git(
+            ["checkout", commit_hash, "--", "."],
+            self.shadow_repo,
+            self.working_dir,
+            timeout=120,
+        )
+        if not ok:
+            return {"success": False, "error": f"git checkout failed: {restore_err}"}
+
+        return {
+            "success": True,
+            "commit_hash": commit_hash,
+            "reason": reason if ok_msg else "",
+            "timestamp": timestamp if ok_ts else "",
+            "message": f"Working directory restored to checkpoint {commit_hash}",
+            "working_dir": self.working_dir,
+            "note": (
+                "Only snapshotted files were restored. "
+                "Excluded paths (node_modules/, dist/, .env) were not modified."
+            ),
+        }
+
+    # ------------------------------------------------------------------
+    # list
+    # ------------------------------------------------------------------
+
+    def list(self, limit: int = 20) -> Dict[str, Any]:
+        """Return a list of checkpoints ordered newest-first.
+
+        Each entry contains: commit_hash, timestamp (ISO 8601), reason.
+        """
+        err = self._ensure_initialized()
+        if err:
+            return {"success": False, "error": err}
+
+        # Check whether any commits exist yet
+        ok, _, _ = _run_git(
+            ["rev-parse", "HEAD"],
+            self.shadow_repo,
+            self.working_dir,
+        )
+        if not ok:
+            return {
+                "success": True,
+                "checkpoints": [],
+                "count": 0,
+                "message": "No checkpoints yet for this directory",
+                "working_dir": self.working_dir,
+                "shadow_repo": str(self.shadow_repo),
+            }
+
+        # \x1f (unit separator) is safe to use as a field delimiter inside
+        # git's --pretty=format because it cannot appear in commit messages.
+        fmt = "%h\x1f%ai\x1f%s"
+        ok, out, err = _run_git(
+            ["log", f"--pretty=format:{fmt}", f"-{limit}"],
+            self.shadow_repo,
+            self.working_dir,
+        )
+        if not ok:
+            return {"success": False, "error": f"git log failed: {err}"}
+
+        checkpoints = []
+        for line in out.splitlines():
+            if not line.strip():
+                continue
+            parts = line.split("\x1f", 2)
+            if len(parts) == 3:
+                checkpoints.append({
+                    "commit_hash": parts[0],
+                    "timestamp": parts[1],
+                    "reason": parts[2],
+                })
+
+        return {
+            "success": True,
+            "checkpoints": checkpoints,
+            "count": len(checkpoints),
+            "working_dir": self.working_dir,
+            "shadow_repo": str(self.shadow_repo),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Dispatch function
+# ---------------------------------------------------------------------------
+
+
+def checkpoint_tool(
+    action: str,
+    working_dir: str = None,
+    reason: str = None,
+    commit_hash: str = None,
+    limit: int = 20,
+) -> str:
+    """Single entry point for the checkpoint tool. Returns JSON string."""
+    if not working_dir:
+        working_dir = os.getcwd()
+
+    try:
+        working_dir = str(Path(working_dir).expanduser().resolve())
+    except Exception as exc:
+        return json.dumps({"success": False, "error": f"Invalid working_dir: {exc}"})
+
+    if not Path(working_dir).is_dir():
+        return json.dumps({
+            "success": False,
+            "error": f"working_dir does not exist or is not a directory: {working_dir}",
+        })
+
+    store = CheckpointStore(working_dir)
+
+    if action == "take":
+        if not reason:
+            return json.dumps({
+                "success": False,
+                "error": "reason is required for 'take' action",
+            })
+        result = store.take(reason)
+
+    elif action == "restore":
+        if not commit_hash:
+            return json.dumps({
+                "success": False,
+                "error": "commit_hash is required for 'restore' action",
+            })
+        result = store.restore(commit_hash)
+
+    elif action == "list":
+        result = store.list(limit=max(1, min(int(limit), 100)))
+
+    else:
+        return json.dumps({
+            "success": False,
+            "error": f"Unknown action '{action}'. Use: take, restore, list",
+        })
+
+    return json.dumps(result, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Convenience wrapper
+# ---------------------------------------------------------------------------
+
+
+def take_checkpoint(working_dir: str, reason: str) -> None:
+    """Thin wrapper for call sites that only need to take a snapshot.
+
+    Silently swallows all errors so that callers (rm, mv, overwrite) are
+    never blocked or broken if git is unavailable or the snapshot fails.
+    The operation proceeds regardless of whether the checkpoint succeeded.
+    """
+    try:
+        checkpoint_tool(action="take", working_dir=working_dir, reason=reason)
+    except Exception as exc:
+        logger.debug("take_checkpoint silenced error: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+
+def check_checkpoint_requirements() -> bool:
+    """Return True if git is available on PATH."""
+    return shutil.which("git") is not None
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Function-Calling Schema
+# ---------------------------------------------------------------------------
+
+CHECKPOINT_SCHEMA = {
+    "name": "checkpoint",
+    "description": (
+        "Create and restore filesystem snapshots of a working directory using a shadow "
+        "git repository stored at ~/.hermes/checkpoints/. The shadow repo is completely "
+        "separate from any git repo the user has — their .git/ is never touched.\n\n"
+        "WHEN TO USE:\n"
+        "- Before large destructive edits (refactors, bulk deletions, rewrites)\n"
+        "- Before running scripts that modify many files\n"
+        "- After reaching a known-good state the user may want to return to\n"
+        "- When the user says 'save this state', 'checkpoint this', or 'I want to undo later'\n\n"
+        "ACTIONS:\n"
+        "- take: snapshot the current working directory (git add -A && git commit)\n"
+        "- restore: revert files to a prior snapshot (git checkout {hash} -- .)\n"
+        "- list: show all snapshots with hashes, timestamps, and reasons\n\n"
+        "EXCLUDED FROM SNAPSHOTS: node_modules/, dist/, build/, .env, .env.*, "
+        "__pycache__/, *.pyc, .cache/, .next/, coverage/\n\n"
+        "NOTE: restore only affects files that were snapshotted. Excluded directories "
+        "(node_modules, dist, etc.) are left untouched."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["take", "restore", "list"],
+                "description": "The action to perform.",
+            },
+            "working_dir": {
+                "type": "string",
+                "description": (
+                    "Absolute path to the directory to snapshot or restore. "
+                    "Defaults to the current working directory if omitted."
+                ),
+            },
+            "reason": {
+                "type": "string",
+                "description": (
+                    "Human-readable description of why this checkpoint was taken. "
+                    "Required for 'take'. Be specific: 'before refactoring auth module', "
+                    "'after completing user profile feature', 'pre-migration backup'."
+                ),
+            },
+            "commit_hash": {
+                "type": "string",
+                "description": (
+                    "The checkpoint hash to restore. Required for 'restore'. "
+                    "Obtain hashes from the 'list' action."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": (
+                    "Maximum number of checkpoints to return for 'list'. "
+                    "Defaults to 20, maximum 100."
+                ),
+                "default": 20,
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry
+
+registry.register(
+    name="checkpoint",
+    toolset="checkpoint",
+    schema=CHECKPOINT_SCHEMA,
+    handler=lambda args, **kw: checkpoint_tool(
+        action=args.get("action", ""),
+        working_dir=args.get("working_dir"),
+        reason=args.get("reason"),
+        commit_hash=args.get("commit_hash"),
+        limit=int(args.get("limit", 20)),
+    ),
+    check_fn=check_checkpoint_requirements,
+    requires_env=[],
+    description="Filesystem snapshot and restore via shadow git repo",
+)

--- a/tools/checkpoint_tool.py
+++ b/tools/checkpoint_tool.py
@@ -32,6 +32,7 @@ import logging
 import os
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -172,6 +173,49 @@ def _init_shadow_repo(shadow_repo: Path, working_dir: str) -> Optional[str]:
 
 
 # ---------------------------------------------------------------------------
+# Nested git detection
+# ---------------------------------------------------------------------------
+
+
+def _has_project_git(working_dir: str) -> bool:
+    """Return True if working_dir already contains a .git entry.
+
+    Both a .git directory (standard repo) and a .git file (worktree pointer)
+    mean git already owns this directory. Checkpointing is disabled in that
+    case so the shadow repo never competes with the user's own git history or
+    index, and restoring checkpoint files cannot corrupt staged changes.
+    """
+    return (Path(working_dir) / ".git").exists()
+
+
+# ---------------------------------------------------------------------------
+# Per-directory concurrency locks
+# ---------------------------------------------------------------------------
+
+_dir_locks: Dict[str, threading.Lock] = {}
+_dir_locks_meta = threading.Lock()
+
+
+def _get_dir_lock(working_dir: str) -> threading.Lock:
+    """Return the threading.Lock for a specific working directory.
+
+    Creates a new Lock on first access. The meta-lock serialises dict
+    mutations so the registry itself is never corrupted under concurrent
+    access. Callers use the returned lock as a context manager:
+
+        with _get_dir_lock(self.working_dir):
+            ...git operations...
+
+    This prevents two simultaneous take() or restore() calls on the same
+    directory from corrupting the git index or producing duplicate commits.
+    """
+    with _dir_locks_meta:
+        if working_dir not in _dir_locks:
+            _dir_locks[working_dir] = threading.Lock()
+        return _dir_locks[working_dir]
+
+
+# ---------------------------------------------------------------------------
 # CheckpointStore class
 # ---------------------------------------------------------------------------
 
@@ -201,83 +245,104 @@ class CheckpointStore:
     def take(self, reason: str) -> Dict[str, Any]:
         """Stage all files and commit with reason as the commit message.
 
+        Refuses with a warning if working_dir already contains a .git repo —
+        use git directly in that case to avoid shadow/project repo conflicts.
+
+        Acquires the per-directory lock before any git I/O so that two rapid
+        concurrent take() calls on the same directory are serialised: the
+        second call will wait, then detect no changes and return the existing
+        hash rather than producing a duplicate empty commit.
+
         Respects info/exclude (node_modules, dist, .env, etc.).
         If nothing has changed since the last checkpoint, returns the
         existing HEAD hash without creating a new commit.
         """
-        err = self._ensure_initialized()
-        if err:
-            return {"success": False, "error": err}
+        # Fast pre-lock checks — no git I/O, no lock needed
+        if _has_project_git(self.working_dir):
+            return {
+                "success": False,
+                "warning": True,
+                "error": (
+                    f"Checkpointing disabled: '{self.working_dir}' already contains a "
+                    f".git repository. Use git directly to manage snapshots in this "
+                    f"directory, or checkpoint a parent directory that is not a git repo."
+                ),
+            }
 
         reason = reason.strip()
         if not reason:
             return {"success": False, "error": "reason cannot be empty"}
 
-        # Stage all files — respects shadow repo's info/exclude
-        ok, _, err = _run_git(
-            ["add", "-A"],
-            self.shadow_repo,
-            self.working_dir,
-            timeout=60,
-        )
-        if not ok:
-            return {"success": False, "error": f"git add failed: {err}"}
+        with _get_dir_lock(self.working_dir):
+            err = self._ensure_initialized()
+            if err:
+                return {"success": False, "error": err}
 
-        # Check if anything was actually staged
-        ok, status_out, _ = _run_git(
-            ["status", "--porcelain"],
-            self.shadow_repo,
-            self.working_dir,
-        )
-        if ok and not status_out.strip():
-            # Nothing changed — return existing HEAD rather than an error
-            ok2, head, _ = _run_git(
+            # Stage all files — respects shadow repo's info/exclude
+            ok, _, err = _run_git(
+                ["add", "-A"],
+                self.shadow_repo,
+                self.working_dir,
+                timeout=60,
+            )
+            if not ok:
+                return {"success": False, "error": f"git add failed: {err}"}
+
+            # Check if anything was actually staged
+            ok, status_out, _ = _run_git(
+                ["status", "--porcelain"],
+                self.shadow_repo,
+                self.working_dir,
+            )
+            if ok and not status_out.strip():
+                # Nothing changed — return existing HEAD rather than an error
+                ok2, head, _ = _run_git(
+                    ["rev-parse", "--short", "HEAD"],
+                    self.shadow_repo,
+                    self.working_dir,
+                )
+                if ok2 and head:
+                    return {
+                        "success": True,
+                        "commit_hash": head,
+                        "files_changed": 0,
+                        "message": "No changes since last checkpoint — existing snapshot returned",
+                        "working_dir": self.working_dir,
+                    }
+                return {
+                    "success": False,
+                    "error": (
+                        "Nothing to commit and no prior checkpoint exists. "
+                        "The working directory may be empty or all files are excluded."
+                    ),
+                }
+
+            # Count staged files for the response
+            staged_files = [l for l in status_out.splitlines() if l.strip()]
+
+            ok, out, err = _run_git(
+                ["commit", "-m", reason],
+                self.shadow_repo,
+                self.working_dir,
+                timeout=60,
+            )
+            if not ok:
+                return {"success": False, "error": f"git commit failed: {err}"}
+
+            ok2, commit_hash, _ = _run_git(
                 ["rev-parse", "--short", "HEAD"],
                 self.shadow_repo,
                 self.working_dir,
             )
-            if ok2 and head:
-                return {
-                    "success": True,
-                    "commit_hash": head,
-                    "files_changed": 0,
-                    "message": "No changes since last checkpoint — existing snapshot returned",
-                    "working_dir": self.working_dir,
-                }
+
             return {
-                "success": False,
-                "error": (
-                    "Nothing to commit and no prior checkpoint exists. "
-                    "The working directory may be empty or all files are excluded."
-                ),
+                "success": True,
+                "commit_hash": commit_hash if ok2 else "unknown",
+                "files_changed": len(staged_files),
+                "message": f"Checkpoint saved: {reason}",
+                "working_dir": self.working_dir,
+                "shadow_repo": str(self.shadow_repo),
             }
-
-        # Count staged files for the response
-        staged_files = [l for l in status_out.splitlines() if l.strip()]
-
-        ok, out, err = _run_git(
-            ["commit", "-m", reason],
-            self.shadow_repo,
-            self.working_dir,
-            timeout=60,
-        )
-        if not ok:
-            return {"success": False, "error": f"git commit failed: {err}"}
-
-        ok2, commit_hash, _ = _run_git(
-            ["rev-parse", "--short", "HEAD"],
-            self.shadow_repo,
-            self.working_dir,
-        )
-
-        return {
-            "success": True,
-            "commit_hash": commit_hash if ok2 else "unknown",
-            "files_changed": len(staged_files),
-            "message": f"Checkpoint saved: {reason}",
-            "working_dir": self.working_dir,
-            "shadow_repo": str(self.shadow_repo),
-        }
 
     # ------------------------------------------------------------------
     # restore
@@ -286,68 +351,89 @@ class CheckpointStore:
     def restore(self, commit_hash: str) -> Dict[str, Any]:
         """Restore the working tree to match a specific checkpoint.
 
+        Refuses with a warning if working_dir contains a .git repo: restoring
+        checkpoint files into a git repo could corrupt staged changes or cause
+        git to lose track of modifications. Use git checkout or git stash there.
+
+        Acquires the per-directory lock for the entire operation so that a
+        concurrent take() cannot stage a half-restored working tree as a new
+        snapshot.
+
         Uses `git checkout {commit_hash} -- .` so the current HEAD is not
         moved. Only files that were snapshotted are restored; excluded files
         (node_modules, .env, etc.) are left untouched.
         """
-        err = self._ensure_initialized()
-        if err:
-            return {"success": False, "error": err}
+        # Fast pre-lock checks
+        if _has_project_git(self.working_dir):
+            return {
+                "success": False,
+                "warning": True,
+                "error": (
+                    f"Restore disabled: '{self.working_dir}' contains a .git repository. "
+                    f"Restoring checkpoint files here could conflict with git's tracked "
+                    f"state. Use git checkout or git stash instead."
+                ),
+            }
 
         commit_hash = commit_hash.strip()
         if not commit_hash:
             return {"success": False, "error": "commit_hash cannot be empty"}
 
-        # Verify the commit exists before touching the working tree
-        ok, full_hash, verify_err = _run_git(
-            ["rev-parse", "--verify", f"{commit_hash}^{{commit}}"],
-            self.shadow_repo,
-            self.working_dir,
-        )
-        if not ok:
+        with _get_dir_lock(self.working_dir):
+            err = self._ensure_initialized()
+            if err:
+                return {"success": False, "error": err}
+
+            # Verify the commit exists before touching the working tree
+            ok, full_hash, verify_err = _run_git(
+                ["rev-parse", "--verify", f"{commit_hash}^{{commit}}"],
+                self.shadow_repo,
+                self.working_dir,
+            )
+            if not ok:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Checkpoint '{commit_hash}' not found in shadow repo. "
+                        f"Use action='list' to see available checkpoints. ({verify_err})"
+                    ),
+                }
+
+            # Retrieve commit metadata before modifying the working tree
+            ok_msg, reason, _ = _run_git(
+                ["log", "-1", "--pretty=format:%s", commit_hash],
+                self.shadow_repo,
+                self.working_dir,
+            )
+            ok_ts, timestamp, _ = _run_git(
+                ["log", "-1", "--pretty=format:%ai", commit_hash],
+                self.shadow_repo,
+                self.working_dir,
+            )
+
+            # Restore working tree contents from the commit.
+            # '--' separates the treeish from the pathspec; '.' means all paths.
+            ok, _, restore_err = _run_git(
+                ["checkout", commit_hash, "--", "."],
+                self.shadow_repo,
+                self.working_dir,
+                timeout=120,
+            )
+            if not ok:
+                return {"success": False, "error": f"git checkout failed: {restore_err}"}
+
             return {
-                "success": False,
-                "error": (
-                    f"Checkpoint '{commit_hash}' not found in shadow repo. "
-                    f"Use action='list' to see available checkpoints. ({verify_err})"
+                "success": True,
+                "commit_hash": commit_hash,
+                "reason": reason if ok_msg else "",
+                "timestamp": timestamp if ok_ts else "",
+                "message": f"Working directory restored to checkpoint {commit_hash}",
+                "working_dir": self.working_dir,
+                "note": (
+                    "Only snapshotted files were restored. "
+                    "Excluded paths (node_modules/, dist/, .env) were not modified."
                 ),
             }
-
-        # Retrieve commit metadata before modifying the working tree
-        ok_msg, reason, _ = _run_git(
-            ["log", "-1", "--pretty=format:%s", commit_hash],
-            self.shadow_repo,
-            self.working_dir,
-        )
-        ok_ts, timestamp, _ = _run_git(
-            ["log", "-1", "--pretty=format:%ai", commit_hash],
-            self.shadow_repo,
-            self.working_dir,
-        )
-
-        # Restore working tree contents from the commit.
-        # '--' separates the treeish from the pathspec; '.' means all paths.
-        ok, _, restore_err = _run_git(
-            ["checkout", commit_hash, "--", "."],
-            self.shadow_repo,
-            self.working_dir,
-            timeout=120,
-        )
-        if not ok:
-            return {"success": False, "error": f"git checkout failed: {restore_err}"}
-
-        return {
-            "success": True,
-            "commit_hash": commit_hash,
-            "reason": reason if ok_msg else "",
-            "timestamp": timestamp if ok_ts else "",
-            "message": f"Working directory restored to checkpoint {commit_hash}",
-            "working_dir": self.working_dir,
-            "note": (
-                "Only snapshotted files were restored. "
-                "Excluded paths (node_modules/, dist/, .env) were not modified."
-            ),
-        }
 
     # ------------------------------------------------------------------
     # list

--- a/tools/checkpoint_tool.py
+++ b/tools/checkpoint_tool.py
@@ -65,6 +65,17 @@ DEFAULT_EXCLUDES = [
 ]
 
 # ---------------------------------------------------------------------------
+# Configurable timeout
+# ---------------------------------------------------------------------------
+
+# Base timeout (seconds) for git subprocesses. Longer operations (git add,
+# git commit, git checkout) use 2× or 4× this value respectively.
+# Override with HERMES_CHECKPOINT_TIMEOUT (clamped to 10–60 seconds).
+CHECKPOINT_TIMEOUT: int = max(
+    10, min(60, int(os.getenv("HERMES_CHECKPOINT_TIMEOUT", "30")))
+)
+
+# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
@@ -101,7 +112,7 @@ def _run_git(
     args: List[str],
     shadow_repo: Path,
     working_dir: str,
-    timeout: int = 30,
+    timeout: int = CHECKPOINT_TIMEOUT,
 ) -> Tuple[bool, str, str]:
     """Run a git subcommand with the shadow repo environment.
 
@@ -186,6 +197,41 @@ def _has_project_git(working_dir: str) -> bool:
     index, and restoring checkpoint files cannot corrupt staged changes.
     """
     return (Path(working_dir) / ".git").exists()
+
+
+def _sync_project_gitignore(shadow_repo: Path, working_dir: str) -> None:
+    """Configure the shadow repo to honour the project's .gitignore rules.
+
+    Sets core.excludesFile in the shadow repo's local git config to the
+    absolute path of working_dir/.gitignore. Called on every take() so that
+    a .gitignore added or moved after shadow repo initialisation is picked up
+    automatically without any manual reset.
+
+    Short-circuits cheaply (file read, no subprocess) when core.excludesFile
+    already points at the correct path, so the extra call on every take() has
+    negligible overhead in the steady-state case.
+
+    If no .gitignore exists in working_dir the setting is left unchanged and
+    the shadow repo continues to use only info/exclude (DEFAULT_EXCLUDES).
+    """
+    gitignore = Path(working_dir) / ".gitignore"
+    if not gitignore.exists():
+        return
+
+    abs_path = str(gitignore.resolve())
+
+    # Cheap short-circuit: read the local config file directly rather than
+    # spawning a git subprocess on every take() call.
+    config_file = shadow_repo / "config"
+    if config_file.exists() and abs_path in config_file.read_text(encoding="utf-8"):
+        return
+
+    _run_git(
+        ["config", "core.excludesFile", abs_path],
+        shadow_repo,
+        working_dir,
+    )
+    logger.debug("Shadow repo core.excludesFile set to %s", abs_path)
 
 
 # ---------------------------------------------------------------------------
@@ -278,12 +324,16 @@ class CheckpointStore:
             if err:
                 return {"success": False, "error": err}
 
-            # Stage all files — respects shadow repo's info/exclude
+            # Sync project .gitignore into shadow repo's core.excludesFile so
+            # the project's own ignore rules are applied alongside info/exclude.
+            _sync_project_gitignore(self.shadow_repo, self.working_dir)
+
+            # Stage all files — respects info/exclude and project .gitignore
             ok, _, err = _run_git(
                 ["add", "-A"],
                 self.shadow_repo,
                 self.working_dir,
-                timeout=60,
+                timeout=CHECKPOINT_TIMEOUT * 2,
             )
             if not ok:
                 return {"success": False, "error": f"git add failed: {err}"}
@@ -324,7 +374,7 @@ class CheckpointStore:
                 ["commit", "-m", reason],
                 self.shadow_repo,
                 self.working_dir,
-                timeout=60,
+                timeout=CHECKPOINT_TIMEOUT * 2,
             )
             if not ok:
                 return {"success": False, "error": f"git commit failed: {err}"}
@@ -417,7 +467,7 @@ class CheckpointStore:
                 ["checkout", commit_hash, "--", "."],
                 self.shadow_repo,
                 self.working_dir,
-                timeout=120,
+                timeout=CHECKPOINT_TIMEOUT * 4,
             )
             if not ok:
                 return {"success": False, "error": f"git checkout failed: {restore_err}"}

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -646,6 +646,8 @@ class ShellFileOperations(FileOperations):
         
         # Write via stdin pipe — content bypasses shell arg parsing entirely,
         # so there's no ARG_MAX limit regardless of file size.
+        from tools.checkpoint_tool import take_checkpoint
+        take_checkpoint(str(Path(path).parent), f"before overwrite: {path}")
         write_cmd = f"cat > {self._escape_shell_arg(path)}"
         write_result = self._exec(write_cmd, stdin_data=content)
         

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -30,6 +30,7 @@ Usage:
 
 import re
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import List, Optional, Tuple, Any
 from enum import Enum
 
@@ -324,7 +325,10 @@ def _apply_delete(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
         # File doesn't exist, nothing to delete
         return True, f"# {op.file_path} already deleted or doesn't exist"
     
-    # Delete directly via shell command using the underlying environment
+    # Delete by writing empty and then removing
+    # Use shell command via the underlying environment
+    from tools.checkpoint_tool import take_checkpoint
+    take_checkpoint(str(Path(op.file_path).parent), f"before delete: {op.file_path}")
     rm_result = file_ops._exec(f"rm -f {file_ops._escape_shell_arg(op.file_path)}")
     
     if rm_result.exit_code != 0:
@@ -337,6 +341,8 @@ def _apply_delete(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
 def _apply_move(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     """Apply a move file operation."""
     # Use shell mv command
+    from tools.checkpoint_tool import take_checkpoint
+    take_checkpoint(str(Path(op.file_path).parent), f"before move: {op.file_path}")
     mv_result = file_ops._exec(
         f"mv {file_ops._escape_shell_arg(op.file_path)} {file_ops._escape_shell_arg(op.new_path)}"
     )


### PR DESCRIPTION
Closes #452

## What changed
Added filesystem checkpointing using a shadow git repository before any destructive operation (delete, overwrite, move).

## How it works
- Shadow git repo at ~/.hermes/checkpoints/{dir-hash}/
- Automatic snapshot before rm, mv, and file overwrite
- restore and list commands via checkpoint tool
- Uses GIT_DIR env var — never conflicts with project git
- Nested git repo detection — checkpointing disabled if .git exists in working dir
- Concurrency guard — threading.Lock() per directory prevents duplicate snapshots
- Configurable timeout via HERMES_CHECKPOINT_TIMEOUT (10–60s, default 30s)
- Respects project .gitignore via shadow repo core.excludesFile

## Files changed
- tools/checkpoint_tool.py — new tool
- tools/patch_parser.py — checkpoint before delete/move
- tools/file_operations.py — checkpoint before overwrite
- model_tools.py — register new tool
- tests/tools/test_checkpoint_tool.py — 50 tests, all passing

## Tested on
macOS