### PR TITLE
fix(code-execution): close server socket in finally block to prevent fd leak

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -502,7 +502,6 @@ def execute_code(
         duration = round(time.monotonic() - exec_start, 2)
 
         # Wait for RPC thread to finish
-        server_sock.close()
         rpc_thread.join(timeout=3)
 
         # Build response
@@ -538,6 +537,10 @@ def execute_code(
 
     finally:
         # Cleanup temp dir and socket
+        try:
+            server_sock.close()
+        except Exception:
+            pass
         try:
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
## What
`server_sock` was created at the top of `execute_code()` but only closed on the success path (line 505). Any exception between socket creation and that line — e.g. a failed `Popen()` — would leak the file descriptor silently.

## Fix
Moved `server_sock.close()` into the `finally` block where temp dir and socket path cleanup already happens.