### PR TITLE
fix(doctor): detect OpenAI custom endpoint env settings

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -33,6 +33,26 @@ os.environ.setdefault("MSWEA_SILENT_STARTUP", "1")
 from hermes_cli.colors import Colors, color
 from hermes_constants import OPENROUTER_MODELS_URL
 
+
+_PROVIDER_ENV_HINTS = (
+    "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_BASE_URL",
+    "GLM_API_KEY",
+    "ZAI_API_KEY",
+    "Z_AI_API_KEY",
+    "KIMI_API_KEY",
+    "MINIMAX_API_KEY",
+    "MINIMAX_CN_API_KEY",
+)
+
+
+def _has_provider_env_config(content: str) -> bool:
+    """Return True when ~/.hermes/.env contains provider auth/base URL settings."""
+    return any(key in content for key in _PROVIDER_ENV_HINTS)
+
+
 def check_ok(text: str, detail: str = ""):
     print(f"  {color('✓', Colors.GREEN)} {text}" + (f" {color(detail, Colors.DIM)}" if detail else ""))
 
@@ -132,12 +152,8 @@ def run_doctor(args):
         
         # Check for common issues
         content = env_path.read_text()
-        if any(k in content for k in (
-            "OPENROUTER_API_KEY", "ANTHROPIC_API_KEY",
-            "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
-            "KIMI_API_KEY", "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
-        )):
-            check_ok("API key configured")
+        if _has_provider_env_config(content):
+            check_ok("API key or custom endpoint configured")
         else:
             check_warn("No API key found in ~/.hermes/.env")
             issues.append("Run 'hermes setup' to configure API keys")

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1,0 +1,17 @@
+"""Tests for hermes doctor helpers."""
+
+from hermes_cli.doctor import _has_provider_env_config
+
+
+class TestProviderEnvDetection:
+    def test_detects_openai_api_key(self):
+        content = "OPENAI_BASE_URL=http://localhost:1234/v1\nOPENAI_API_KEY=sk-test-key\n"
+        assert _has_provider_env_config(content)
+
+    def test_detects_custom_endpoint_without_openrouter_key(self):
+        content = "OPENAI_BASE_URL=http://localhost:8080/v1\n"
+        assert _has_provider_env_config(content)
+
+    def test_returns_false_when_no_provider_settings(self):
+        content = "TERMINAL_ENV=local\n"
+        assert not _has_provider_env_config(content)


### PR DESCRIPTION
## What does this PR do?
Fixes false negatives in `hermes doctor` when users configure a custom OpenAI-compatible endpoint (e.g. LM Studio / llama.cpp) with `OPENAI_BASE_URL` + `OPENAI_API_KEY`.

## Related Issue
Fixes #572

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made
- Added `_has_provider_env_config()` helper in `hermes_cli/doctor.py` to centralize provider env detection.
- Included `OPENAI_API_KEY` and `OPENAI_BASE_URL` in doctor's provider-config detection list.
- Updated doctor output text to `API key or custom endpoint configured`.
- Added regression tests in `tests/hermes_cli/test_doctor.py` for:
  - `OPENAI_API_KEY` detection
  - `OPENAI_BASE_URL`-only custom endpoint detection
  - negative case with no provider vars

## How to Test
1. Put either of these in `~/.hermes/.env`:
   - `OPENAI_BASE_URL=http://localhost:1234/v1`
   - `OPENAI_API_KEY=sk-...` (or any non-empty key for local servers)
2. Run `hermes doctor`.
3. Confirm doctor reports provider config as present instead of `No API key found`.

Also validated with:
- `python3 -m pytest -q tests/hermes_cli/test_doctor.py tests/test_runtime_provider_resolution.py`

## Checklist
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this bug fix
- [x] I've added tests for my changes
