### PR TITLE
fix(setup): prevent OpenRouter model list fallback for Nous provider

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1050,6 +1050,15 @@ def run_setup_wizard(args):
                     config['model'] = custom
                     save_env_value("LLM_MODEL", custom)
             # else: keep current
+        elif selected_provider == "nous":
+            # Nous login succeeded but model fetch failed — prompt manually
+            # instead of falling through to the OpenRouter static list.
+            print_warning("Could not fetch available models from Nous Portal.")
+            print_info("Enter a Nous model name manually (e.g., claude-opus-4-6).")
+            custom = prompt(f"  Model name (Enter to keep '{current_model}')")
+            if custom:
+                config['model'] = custom
+                save_env_value("LLM_MODEL", custom)
         elif selected_provider == "openai-codex":
             from hermes_cli.codex_models import get_codex_model_ids
             # Try to get the access token for live model discovery


### PR DESCRIPTION
## What does this PR do?

When `fetch_nous_models()` fails silently during `hermes setup`, the model selection falls through to the OpenRouter static list. Users pick a model in OpenRouter format (e.g., `anthropic/claude-opus-4.6`), but the Nous inference API expects bare model IDs (e.g., `claude-opus-4-6`) and rejects the request with a `400 missing model` error.

This PR adds an explicit `elif selected_provider == "nous"` branch that catches the case when Nous is selected but the model list is empty. Instead of falling through to the OpenRouter list, it warns the user and prompts for manual model entry with a Nous-format example.

## Related Issue

Fixes #574

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/setup.py`: Added `elif selected_provider == "nous"` branch between the successful Nous model list case and the Codex case. When Nous model fetch fails, warns the user and prompts for manual model name entry instead of falling through to the OpenRouter static list.

## How to Test

1. Run `hermes setup`, select Nous Portal, complete login
2. If model fetch succeeds: existing behavior unchanged (dynamic model list shown)
3. If model fetch fails (simulate by temporarily blocking `inference-api.nousresearch.com`):
   - **Before fix:** OpenRouter model list shown → wrong format saved → 400 error
   - **After fix:** Warning shown → manual entry prompted with correct format example

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- N/A (small fix, no docs/config/schema changes)