### PR TITLE
fix: make gateway run idempotent when already running

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -373,9 +373,17 @@ def launchd_status(deep: bool = False):
 def run_gateway(verbose: bool = False):
     """Run the gateway in foreground."""
     sys.path.insert(0, str(PROJECT_ROOT))
-    
+
     from gateway.run import start_gateway
-    
+    from gateway.status import is_gateway_running
+
+    # If gateway is already running, treat this as success to avoid restart
+    # loops for service managers with Restart=on-failure.
+    if is_gateway_running():
+        print("✓ Gateway is already running")
+        print("  Use 'hermes gateway status' to inspect the active process")
+        return
+
     print("┌─────────────────────────────────────────────────────────┐")
     print("│           ⚕ Hermes Gateway Starting...                 │")
     print("├─────────────────────────────────────────────────────────┤")
@@ -383,7 +391,7 @@ def run_gateway(verbose: bool = False):
     print("│  Press Ctrl+C to stop                                   │")
     print("└─────────────────────────────────────────────────────────┘")
     print()
-    
+
     # Exit with code 1 if gateway fails to connect any platform,
     # so systemd Restart=on-failure will retry on transient errors
     success = asyncio.run(start_gateway())

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1,0 +1,36 @@
+import sys
+import types
+
+import pytest
+
+from hermes_cli import gateway as gateway_cli
+
+
+def test_run_gateway_exits_success_when_already_running(monkeypatch, capsys):
+    start_calls = []
+
+    async def _start_gateway():
+        start_calls.append(True)
+        return True
+
+    monkeypatch.setitem(sys.modules, "gateway.run", types.SimpleNamespace(start_gateway=_start_gateway))
+    monkeypatch.setitem(sys.modules, "gateway.status", types.SimpleNamespace(is_gateway_running=lambda: True))
+
+    gateway_cli.run_gateway()
+
+    out = capsys.readouterr().out
+    assert "Gateway is already running" in out
+    assert start_calls == []
+
+
+def test_run_gateway_exits_nonzero_when_start_fails(monkeypatch):
+    async def _start_gateway():
+        return False
+
+    monkeypatch.setitem(sys.modules, "gateway.run", types.SimpleNamespace(start_gateway=_start_gateway))
+    monkeypatch.setitem(sys.modules, "gateway.status", types.SimpleNamespace(is_gateway_running=lambda: False))
+
+    with pytest.raises(SystemExit) as exc:
+        gateway_cli.run_gateway()
+
+    assert exc.value.code == 1


### PR DESCRIPTION
## Summary
- make `hermes gateway run` idempotent when a gateway process is already active
- return success instead of failing in that case, which avoids service restart loops with `Restart=on-failure`
- add focused tests for both:
  - already-running path (no new start attempted)
  - failed startup path (still exits with code 1)

## Root cause
`run_gateway()` always attempted a fresh startup and exited non-zero when startup failed. In service-managed environments this can produce repeated restarts when a gateway instance is already running.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest tests/hermes_cli/test_gateway.py`

Closes #576
