### PR TITLE
fix(gateway): make systemd startup idempotent and service-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ hermes doctor       # Diagnose any issues
 
 📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
 
+### Running Hermes under systemd (Linux)
+
+Use gateway mode for long-running services:
+
+```ini
+ExecStart=/path/to/hermes gateway run --replace
+Restart=on-failure
+```
+
+`--replace` makes startup idempotent if a previous gateway PID is still running.
+If your unit uses `ExecStart=/path/to/hermes` with no subcommand, Hermes now auto-switches to gateway mode in systemd service contexts.
+
 ---
 
 ## Documentation

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20,6 +20,7 @@ import re
 import sys
 import signal
 import threading
+import time
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from datetime import datetime
@@ -2432,10 +2433,53 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, interval: int
     logger.info("Cron ticker stopped")
 
 
-async def start_gateway(config: Optional[GatewayConfig] = None) -> bool:
+def _terminate_existing_gateway(existing_pid: int, timeout_seconds: float = 5.0) -> bool:
+    """Terminate a running gateway process for replace-on-start workflows."""
+    try:
+        os.kill(existing_pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        logger.error("Permission denied while trying to stop existing gateway PID %d", existing_pid)
+        return False
+
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        try:
+            os.kill(existing_pid, 0)
+            time.sleep(0.1)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            logger.error("Permission denied while checking gateway PID %d", existing_pid)
+            return False
+
+    try:
+        os.kill(existing_pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        logger.error("Permission denied while force-killing gateway PID %d", existing_pid)
+        return False
+
+    for _ in range(20):
+        try:
+            os.kill(existing_pid, 0)
+            time.sleep(0.05)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            logger.error("Permission denied while confirming gateway PID %d exit", existing_pid)
+            return False
+
+    logger.error("Gateway PID %d did not exit after SIGTERM/SIGKILL", existing_pid)
+    return False
+
+
+async def start_gateway(config: Optional[GatewayConfig] = None, replace_existing: bool = False) -> bool:
     """
     Start the gateway and run until interrupted.
-    
+
     This is the main entry point for running the gateway.
     Returns True if the gateway ran successfully, False if it failed to start.
     A False return causes a non-zero exit code so systemd can auto-restart.
@@ -2449,17 +2493,35 @@ async def start_gateway(config: Optional[GatewayConfig] = None) -> bool:
     existing_pid = get_running_pid()
     if existing_pid is not None and existing_pid != os.getpid():
         hermes_home = os.getenv("HERMES_HOME", "~/.hermes")
-        logger.error(
-            "Another gateway instance is already running (PID %d, HERMES_HOME=%s). "
-            "Use 'hermes gateway restart' to replace it, or 'hermes gateway stop' first.",
-            existing_pid, hermes_home,
-        )
-        print(
-            f"\n❌ Gateway already running (PID {existing_pid}).\n"
-            f"   Use 'hermes gateway restart' to replace it,\n"
-            f"   or 'hermes gateway stop' to kill it first.\n"
-        )
-        return False
+        if replace_existing:
+            logger.warning(
+                "Replacing existing gateway instance (PID %d, HERMES_HOME=%s).",
+                existing_pid,
+                hermes_home,
+            )
+            print(f"\n⚠ Existing gateway detected (PID {existing_pid}). Replacing it...\n")
+            if not _terminate_existing_gateway(existing_pid):
+                print(
+                    f"\n❌ Failed to stop existing gateway (PID {existing_pid}).\n"
+                    f"   Try 'hermes gateway stop' and retry.\n"
+                )
+                return False
+
+            from gateway.status import remove_pid_file
+            remove_pid_file()
+        else:
+            logger.error(
+                "Another gateway instance is already running (PID %d, HERMES_HOME=%s). "
+                "Use 'hermes gateway run --replace', 'hermes gateway restart', "
+                "or 'hermes gateway stop' first.",
+                existing_pid, hermes_home,
+            )
+            print(
+                f"\n❌ Gateway already running (PID {existing_pid}).\n"
+                f"   Use 'hermes gateway run --replace' to replace it,\n"
+                f"   or 'hermes gateway stop' to kill it first.\n"
+            )
+            return False
 
     # Sync bundled skills on gateway start (fast -- skips unchanged)
     try:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -163,7 +163,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart={python_path} -m hermes_cli.main gateway run
+ExecStart={python_path} -m hermes_cli.main gateway run --replace
 WorkingDirectory={working_dir}
 Restart=on-failure
 RestartSec=10
@@ -377,12 +377,17 @@ def launchd_status(deep: bool = False):
 # Gateway Runner
 # =============================================================================
 
-def run_gateway(verbose: bool = False):
+def _is_service_context() -> bool:
+    """Best-effort check for service manager context (e.g., systemd)."""
+    return any(os.getenv(key) for key in ("INVOCATION_ID", "JOURNAL_STREAM", "NOTIFY_SOCKET"))
+
+
+def run_gateway(verbose: bool = False, replace_existing: bool = False):
     """Run the gateway in foreground."""
     sys.path.insert(0, str(PROJECT_ROOT))
-    
+
     from gateway.run import start_gateway
-    
+
     print("┌─────────────────────────────────────────────────────────┐")
     print("│           ⚕ Hermes Gateway Starting...                 │")
     print("├─────────────────────────────────────────────────────────┤")
@@ -390,10 +395,10 @@ def run_gateway(verbose: bool = False):
     print("│  Press Ctrl+C to stop                                   │")
     print("└─────────────────────────────────────────────────────────┘")
     print()
-    
+
     # Exit with code 1 if gateway fails to connect any platform,
     # so systemd Restart=on-failure will retry on transient errors
-    success = asyncio.run(start_gateway())
+    success = asyncio.run(start_gateway(replace_existing=replace_existing))
     if not success:
         sys.exit(1)
 
@@ -765,7 +770,11 @@ def gateway_command(args):
     # Default to run if no subcommand
     if subcmd is None or subcmd == "run":
         verbose = getattr(args, 'verbose', False)
-        run_gateway(verbose)
+        replace_existing = getattr(args, 'replace', False)
+        # In service contexts, default to idempotent startup.
+        if _is_service_context() and not replace_existing:
+            replace_existing = True
+        run_gateway(verbose, replace_existing=replace_existing)
         return
 
     if subcmd == "setup":

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1315,6 +1315,11 @@ For more help on a command:
     # gateway run (default)
     gateway_run = gateway_subparsers.add_parser("run", help="Run gateway in foreground")
     gateway_run.add_argument("-v", "--verbose", action="store_true")
+    gateway_run.add_argument(
+        "--replace",
+        action="store_true",
+        help="If another gateway is already running, stop it and replace it"
+    )
     
     # gateway start
     gateway_start = gateway_subparsers.add_parser("start", help="Start gateway service")
@@ -1845,6 +1850,14 @@ For more help on a command:
     
     # Default to chat if no command specified
     if args.command is None:
+        # Non-interactive service contexts (systemd, etc.) should run gateway
+        # mode instead of launching interactive chat and immediately exiting.
+        if not sys.stdin.isatty() and any(os.getenv(k) for k in ("INVOCATION_ID", "JOURNAL_STREAM", "NOTIFY_SOCKET")):
+            from hermes_cli.gateway import run_gateway
+            print("Detected non-interactive service context; starting gateway mode with --replace.")
+            run_gateway(verbose=False, replace_existing=True)
+            return
+
         args.query = None
         args.model = None
         args.provider = None

--- a/tests/gateway/test_run_replace_existing.py
+++ b/tests/gateway/test_run_replace_existing.py
@@ -1,0 +1,34 @@
+import signal
+
+from gateway import run as gateway_run
+
+
+def test_terminate_existing_gateway_graceful_exit(monkeypatch):
+    calls = []
+    alive = {"value": True}
+
+    def fake_kill(pid, sig):
+        calls.append(sig)
+        if sig == signal.SIGTERM:
+            alive["value"] = False
+            return None
+        if sig == 0 and alive["value"]:
+            return None
+        if sig == 0 and not alive["value"]:
+            raise ProcessLookupError
+        return None
+
+    monkeypatch.setattr(gateway_run.os, "kill", fake_kill)
+    monkeypatch.setattr(gateway_run.time, "sleep", lambda _: None)
+
+    assert gateway_run._terminate_existing_gateway(1234, timeout_seconds=0.2) is True
+    assert calls[0] == signal.SIGTERM
+
+
+def test_terminate_existing_gateway_permission_denied(monkeypatch):
+    def fake_kill(_pid, _sig):
+        raise PermissionError
+
+    monkeypatch.setattr(gateway_run.os, "kill", fake_kill)
+
+    assert gateway_run._terminate_existing_gateway(1234, timeout_seconds=0.1) is False

--- a/tests/hermes_cli/test_gateway_service_mode.py
+++ b/tests/hermes_cli/test_gateway_service_mode.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+from hermes_cli import gateway as gateway_cli
+
+
+def test_gateway_run_enables_replace_in_service_context(monkeypatch):
+    monkeypatch.setenv("INVOCATION_ID", "unit-test")
+
+    called = {}
+
+    def fake_run_gateway(verbose=False, replace_existing=False):
+        called["verbose"] = verbose
+        called["replace_existing"] = replace_existing
+
+    monkeypatch.setattr(gateway_cli, "run_gateway", fake_run_gateway)
+
+    args = SimpleNamespace(gateway_command="run", verbose=False, replace=False)
+    gateway_cli.gateway_command(args)
+
+    assert called == {"verbose": False, "replace_existing": True}
+
+
+def test_gateway_run_respects_replace_outside_service_context(monkeypatch):
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("JOURNAL_STREAM", raising=False)
+    monkeypatch.delenv("NOTIFY_SOCKET", raising=False)
+
+    called = {}
+
+    def fake_run_gateway(verbose=False, replace_existing=False):
+        called["verbose"] = verbose
+        called["replace_existing"] = replace_existing
+
+    monkeypatch.setattr(gateway_cli, "run_gateway", fake_run_gateway)
+
+    args = SimpleNamespace(gateway_command="run", verbose=True, replace=False)
+    gateway_cli.gateway_command(args)
+
+    assert called == {"verbose": True, "replace_existing": False}


### PR DESCRIPTION
## Summary
- add `--replace` support to `hermes gateway run` so startup can replace an already-running gateway process
- default `gateway run` to replace mode in service contexts (systemd env detected)
- update generated systemd unit to use `gateway run --replace`
- when `hermes` is started in a non-interactive service context with no subcommand, auto-route to gateway mode with replace
- add README guidance for systemd `ExecStart` / `Restart` settings

## Why
Issue #576 reports restart loops under systemd in two cases:
1. `ExecStart=... hermes` launched interactive chat without a TTY and exited
2. `ExecStart=... hermes gateway run` failed with `Gateway already running` and looped

This patch makes service startup deterministic and idempotent, while preserving explicit non-replace behavior outside service contexts.

## Tests
- `python3.11 -m pytest tests/gateway/test_run_replace_existing.py tests/hermes_cli/test_gateway_service_mode.py -q`

Fixes #576
