### PR TITLE
fix(setup): warn and prompt for manual model entry when Nous model fetch fails

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1253,8 +1253,7 @@ class GatewayRunner:
         )
         
         # Let the normal message handler process it
-        await self._handle_message(retry_event)
-        return None  # Response sent through normal flow
+        return await self._handle_message(retry_event)
     
     async def _handle_undo_command(self, event: MessageEvent) -> str:
         """Handle /undo command - remove the last user/assistant exchange."""

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -930,6 +930,14 @@ def run_setup_wizard(args):
                     config['model'] = custom
                     save_env_value("LLM_MODEL", custom)
             _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
+        elif selected_provider == "nous" and not nous_models:
+            # Nous was selected but model fetch failed — warn and prompt for manual entry
+            print_warning("Could not fetch Nous Portal model list (network issue or token expiry).")
+            print_info("Please enter a Nous-format model name manually (e.g. claude-opus-4-6)")
+            custom = prompt("Enter Nous model name")
+            if custom:
+                config['model'] = custom
+                save_env_value("LLM_MODEL", custom)
         else:
             # Static list for OpenRouter / fallback (from canonical list)
             from hermes_cli.models import model_ids, menu_labels

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -172,7 +172,11 @@ class TestBuildSkillsSystemPrompt:
 
 class TestBuildContextFilesPrompt:
     def test_empty_dir_returns_empty(self, tmp_path):
-        result = build_context_files_prompt(cwd=str(tmp_path))
+        from unittest.mock import patch
+        fake_home = tmp_path / "fake_home"
+        fake_home.mkdir()
+        with patch("pathlib.Path.home", return_value=fake_home):
+            result = build_context_files_prompt(cwd=str(tmp_path))
         assert result == ""
 
     def test_loads_agents_md(self, tmp_path):

--- a/tests/gateway/test_retry_response.py
+++ b/tests/gateway/test_retry_response.py
@@ -1,0 +1,60 @@
+"""Regression test: /retry must return the agent response, not None.
+
+Before the fix in PR #441, _handle_retry_command() called
+_handle_message(retry_event) but discarded its return value with `return None`,
+so users never received the final response.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from gateway.run import GatewayRunner
+from gateway.platforms.base import MessageEvent, MessageType
+
+
+@pytest.fixture
+def gateway(tmp_path):
+    config = MagicMock()
+    config.sessions_dir = tmp_path
+    config.max_context_messages = 20
+    gw = GatewayRunner.__new__(GatewayRunner)
+    gw.config = config
+    gw.session_store = MagicMock()
+    return gw
+
+
+@pytest.mark.asyncio
+async def test_retry_returns_response_not_none(gateway):
+    """_handle_retry_command must return the inner handler response, not None."""
+    gateway.session_store.get_or_create_session.return_value = MagicMock(
+        session_id="test-session"
+    )
+    gateway.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "Hello Hermes"},
+        {"role": "assistant", "content": "Hi there!"},
+    ]
+    gateway.session_store.rewrite_transcript = MagicMock()
+    expected_response = "Hi there! (retried)"
+    gateway._handle_message = AsyncMock(return_value=expected_response)
+    event = MessageEvent(
+        text="/retry",
+        message_type=MessageType.TEXT,
+        source=MagicMock(),
+    )
+    result = await gateway._handle_retry_command(event)
+    assert result is not None, "/retry must not return None"
+    assert result == expected_response
+
+
+@pytest.mark.asyncio
+async def test_retry_no_previous_message(gateway):
+    """If there is no previous user message, return early with a message."""
+    gateway.session_store.get_or_create_session.return_value = MagicMock(
+        session_id="test-session"
+    )
+    gateway.session_store.load_transcript.return_value = []
+    event = MessageEvent(
+        text="/retry",
+        message_type=MessageType.TEXT,
+        source=MagicMock(),
+    )
+    result = await gateway._handle_retry_command(event)
+    assert result == "No previous message to retry."

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -12,8 +12,21 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 def _make_cli(**kwargs):
     """Create a HermesCLI instance with minimal mocking."""
+    import cli as _cli_mod
     from cli import HermesCLI
-    with patch("cli.get_tool_definitions", return_value=[]):
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    with patch("cli.get_tool_definitions", return_value=[]), \
+         patch.dict("os.environ", {"LLM_MODEL": ""}, clear=False), \
+         patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}):
         return HermesCLI(**kwargs)
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #574

When `hermes setup` selects Nous Portal but `fetch_nous_models()` fails silently (network timeout, DNS issue, token expiry), the wizard was falling through to the OpenRouter static model list. Users would unknowingly pick a model in OpenRouter format (e.g. `anthropic/claude-opus-4.6`) which Nous API doesn't recognize, causing `400 missing model` errors on every message.

## Fix

Added explicit `elif selected_provider == "nous" and not nous_models` branch that:
- Warns the user that model fetch failed
- Prompts for manual Nous-format model name entry (e.g. `claude-opus-4-6`)
- Does **not** fall through to the OpenRouter model list