### PR TITLE
docs: add Tensorix to supported providers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **The self-improving AI agent built by [Nous Research](https://nousresearch.com).** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.
 
-Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
+Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), [Tensorix](https://tensorix.ai) (50+ open-source models), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
 
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -68,6 +68,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
+| **Tensorix** | `OPENAI_BASE_URL=https://api.tensorix.ai/v1` + `OPENAI_API_KEY` in `~/.hermes/.env` |
 | **Custom Endpoint** | `OPENAI_BASE_URL` + `OPENAI_API_KEY` in `~/.hermes/.env` |
 
 :::info Codex Note


### PR DESCRIPTION
## Summary

Adds [Tensorix](https://tensorix.ai) to the supported providers list in the README and configuration docs.

## What is Tensorix?

Tensorix is an OpenAI-compatible API gateway providing 50+ open-source models with:
- **EU-hosted inference** (Frankfurt data center)
- **Zero data retention** — prompts and completions are never stored
- **OpenAI-compatible API** at `https://api.tensorix.ai/v1`

Popular models: `z-ai/glm-5`, `deepseek/deepseek-chat-v3.1`, `deepseek/deepseek-r1-0528`, `minimax/minimax-m2.5`, `moonshotai/kimi-k2.5`

## Changes

1. **`README.md`** — Added Tensorix to the "Use any model you want" provider list alongside z.ai, Kimi, MiniMax, etc.
2. **`website/docs/user-guide/configuration.md`** — Added Tensorix row to the Inference Providers table

## How it works

Tensorix connects via the existing custom endpoint mechanism:
```bash
OPENAI_BASE_URL=https://api.tensorix.ai/v1
OPENAI_API_KEY=<tensorix-api-key>
```

No code changes required — just documentation updates to help users discover this option.