### PR TITLE
feat(gateway): add watcher notification modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,8 @@ HERMES_MAX_ITERATIONS=60                  # Max tool-calling iterations
 MESSAGING_CWD=/home/myuser                # Terminal working directory for messaging
 
 # Tool progress is configured in config.yaml (display.tool_progress: off|new|all|verbose)
+# Background process watcher chat updates are configured separately
+# (display.background_process_notifications: off|result|error|all)
 ```
 
 ### Working Directory Behavior
@@ -339,6 +341,15 @@ When `tool_progress` is enabled in `config.yaml`, the bot sends status messages 
 Modes:
 - `new`: Only when switching to a different tool (less spam)
 - `all`: Every single tool call
+
+### Background Process Notifications
+
+Gateway watcher messages for `terminal(background=true, check_interval=...)`
+are controlled by `display.background_process_notifications`:
+- `off`: no watcher messages
+- `result`: only final completion message
+- `error`: only final message on non-zero exit
+- `all`: running updates plus final message
 
 ### Typing Indicator
 
@@ -442,6 +453,7 @@ Agent behavior (in `~/.hermes/.env`):
 - `HERMES_MAX_ITERATIONS` - Max tool-calling iterations (default: 60)
 - `MESSAGING_CWD` - Working directory for messaging platforms (default: ~)
 - `display.tool_progress` in config.yaml - Tool progress: `off`, `new`, `all`, `verbose`
+- `display.background_process_notifications` in config.yaml - Background watcher chat updates: `off`, `result`, `error`, `all`
 - `OPENAI_API_KEY` - Voice transcription (Whisper STT)
 - `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN` - Slack integration (Socket Mode)
 - `SLACK_ALLOWED_USERS` - Comma-separated Slack user IDs

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -575,3 +575,11 @@ display:
   #   verbose: Full args, results, and debug logs (same as /verbose)
   # Toggle at runtime with /verbose in the CLI
   tool_progress: all
+
+  # Background process notifications for gateway chats when using
+  # terminal(background=true, check_interval=...)
+  #   off:    Don't push watcher updates to chat
+  #   result: Only push the final completion message
+  #   error:  Only push the final message when exit_code != 0
+  #   all:    Push running output updates and the final message (default)
+  background_process_notifications: all

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -368,6 +368,40 @@ class GatewayRunner:
             pass
         return {}
 
+    @staticmethod
+    def _load_display_config() -> dict:
+        """Load display settings from config.yaml."""
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path) as _f:
+                    cfg = _y.safe_load(_f) or {}
+                return cfg.get("display", {}) or {}
+        except Exception:
+            pass
+        return {}
+
+    @classmethod
+    def _get_background_process_notifications_mode(cls) -> str:
+        """Resolve background process notification mode from config/env."""
+        raw_mode = cls._load_display_config().get("background_process_notifications")
+        if raw_mode is False:
+            mode = "off"
+        elif raw_mode not in (None, ""):
+            mode = str(raw_mode)
+        else:
+            mode = os.getenv("HERMES_BACKGROUND_PROCESS_NOTIFICATIONS") or "all"
+        mode = str(mode).strip().lower()
+        valid = {"all", "result", "off", "error"}
+        if mode not in valid:
+            logger.warning(
+                "Unknown background_process_notifications '%s', using default 'all'",
+                mode,
+            )
+            return "all"
+        return mode
+
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
@@ -1780,8 +1814,13 @@ class GatewayRunner:
         session_key = watcher.get("session_key", "")
         platform_name = watcher.get("platform", "")
         chat_id = watcher.get("chat_id", "")
+        notify_mode = self._get_background_process_notifications_mode()
 
         logger.debug("Process watcher started: %s (every %ss)", session_id, interval)
+
+        if notify_mode == "off":
+            logger.debug("Process watcher disabled for %s", session_id)
+            return
 
         last_output_len = 0
         while True:
@@ -1796,26 +1835,31 @@ class GatewayRunner:
             last_output_len = current_output_len
 
             if session.exited:
-                # Process finished -- deliver final update
-                new_output = session.output_buffer[-1000:] if session.output_buffer else ""
-                message_text = (
-                    f"[Background process {session_id} finished with exit code {session.exit_code}~ "
-                    f"Here's the final output:\n{new_output}]"
+                should_notify = (
+                    notify_mode in ("all", "result")
+                    or (notify_mode == "error" and session.exit_code not in (0, None))
                 )
-                # Try to deliver to the originating platform
-                adapter = None
-                for p, a in self.adapters.items():
-                    if p.value == platform_name:
-                        adapter = a
-                        break
-                if adapter and chat_id:
-                    try:
-                        await adapter.send(chat_id, message_text)
-                    except Exception as e:
-                        logger.error("Watcher delivery error: %s", e)
+                if should_notify:
+                    # Process finished -- deliver final update
+                    new_output = session.output_buffer[-1000:] if session.output_buffer else ""
+                    message_text = (
+                        f"[Background process {session_id} finished with exit code {session.exit_code}~ "
+                        f"Here's the final output:\n{new_output}]"
+                    )
+                    # Try to deliver to the originating platform
+                    adapter = None
+                    for p, a in self.adapters.items():
+                        if p.value == platform_name:
+                            adapter = a
+                            break
+                    if adapter and chat_id:
+                        try:
+                            await adapter.send(chat_id, message_text)
+                        except Exception as e:
+                            logger.error("Watcher delivery error: %s", e)
                 break
 
-            elif has_new_output:
+            elif has_new_output and notify_mode == "all":
                 # New output available -- deliver status update
                 new_output = session.output_buffer[-500:] if session.output_buffer else ""
                 message_text = (

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -1,0 +1,109 @@
+"""Tests for configurable background process notifications in the gateway."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+
+
+class _FakeRegistry:
+    def __init__(self, sessions):
+        self._sessions = list(sessions)
+
+    def get(self, session_id):
+        if self._sessions:
+            return self._sessions.pop(0)
+        return None
+
+
+def _write_config(tmp_path, mode: str) -> None:
+    (tmp_path / "config.yaml").write_text(
+        "display:\n"
+        f"  background_process_notifications: {mode}\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "sessions", "expected_calls", "expected_fragment"),
+    [
+        (
+            "all",
+            [SimpleNamespace(output_buffer="diff --git a\n", exited=False, exit_code=None), None],
+            1,
+            "is still running",
+        ),
+        (
+            "result",
+            [SimpleNamespace(output_buffer="done\n", exited=False, exit_code=None), None],
+            0,
+            None,
+        ),
+        (
+            "off",
+            [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)],
+            0,
+            None,
+        ),
+        (
+            "result",
+            [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)],
+            1,
+            "finished with exit code 0",
+        ),
+        (
+            "error",
+            [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)],
+            0,
+            None,
+        ),
+        (
+            "error",
+            [SimpleNamespace(output_buffer="traceback\n", exited=True, exit_code=1)],
+            1,
+            "finished with exit code 1",
+        ),
+    ],
+)
+async def test_run_process_watcher_respects_notification_mode(
+    monkeypatch, tmp_path, mode, sessions, expected_calls, expected_fragment
+):
+    _write_config(tmp_path, mode)
+
+    import gateway.run as gateway_run
+    import tools.process_registry as process_registry_module
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        process_registry_module,
+        "process_registry",
+        _FakeRegistry(sessions),
+    )
+
+    async def _no_sleep(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    runner = GatewayRunner(GatewayConfig())
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    await runner._run_process_watcher(
+        {
+            "session_id": "proc_test",
+            "check_interval": 0,
+            "platform": "telegram",
+            "chat_id": "123",
+        }
+    )
+
+    assert adapter.send.await_count == expected_calls
+    if expected_fragment is not None:
+        sent_message = adapter.send.await_args.args[1]
+        assert expected_fragment in sent_message


### PR DESCRIPTION
What changed
- add `display.background_process_notifications` for gateway watcher updates
- support `off`, `result`, `error`, and `all` modes
- add unit tests for watcher delivery behavior
- document the new config in `cli-config.yaml.example` and `AGENTS.md`

Why
- background process stdout in Telegram/Discord can be too noisy for long-running coding tasks
- this preserves the current behavior by default while allowing quieter modes

How to test
- set `display.background_process_notifications` to each mode
- run a background terminal task with `check_interval`
- verify:
  - `off`: no watcher messages
  - `result`: only final message
  - `error`: only final non-zero exit message
  - `all`: running updates plus final message
- run:
  - `pytest -q tests/gateway/test_background_process_notifications.py tests/gateway/test_config.py`

Platforms tested
- macOS local test environment

Closes #592