### PR TITLE
feat(delegation): add ACP external agent targets to delegate_task

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -546,6 +546,8 @@ code_execution:
 delegation:
   max_iterations: 50                          # Max tool-calling turns per child (default: 50)
   default_toolsets: ["terminal", "file", "web"]  # Default toolsets for subagents
+  external_timeout_seconds: 900               # Max seconds for external agents (codex/claude-code)
+  external_max_output_chars: 24000            # Truncate external agent output above this size
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/cli.py
+++ b/cli.py
@@ -205,6 +205,8 @@ def load_cli_config() -> Dict[str, Any]:
         "delegation": {
             "max_iterations": 45,  # Max tool-calling turns per child agent
             "default_toolsets": ["terminal", "file", "web"],  # Default toolsets for subagents
+            "external_timeout_seconds": 900,  # Max seconds for external ACP agents (codex/claude-code)
+            "external_max_output_chars": 24000,  # Max chars captured from external ACP agent output
         },
     }
     

--- a/run_agent.py
+++ b/run_agent.py
@@ -2574,6 +2574,7 @@ class AIAgent:
                         goal=function_args.get("goal"),
                         context=function_args.get("context"),
                         toolsets=function_args.get("toolsets"),
+                        agent=function_args.get("agent"),
                         tasks=tasks_arg,
                         model=function_args.get("model"),
                         max_iterations=function_args.get("max_iterations"),

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -19,8 +19,10 @@ from tools.delegate_tool import (
     DELEGATE_TASK_SCHEMA,
     MAX_CONCURRENT_CHILDREN,
     MAX_DEPTH,
+    SUPPORTED_AGENTS,
     check_delegate_requirements,
     delegate_task,
+    _normalize_delegate_agent,
     _build_child_system_prompt,
     _strip_blocked_tools,
 )
@@ -56,9 +58,24 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("agent", props)
         self.assertIn("model", props)
         self.assertIn("max_iterations", props)
+        self.assertIn("agent", props["tasks"]["items"]["properties"])
         self.assertEqual(props["tasks"]["maxItems"], 3)
+
+
+class TestAgentNormalization(unittest.TestCase):
+    def test_defaults_to_hermes(self):
+        self.assertEqual(_normalize_delegate_agent(None), "hermes")
+
+    def test_aliases(self):
+        self.assertEqual(_normalize_delegate_agent("claude"), "claude-code")
+        self.assertEqual(_normalize_delegate_agent("claude_code"), "claude-code")
+        self.assertEqual(_normalize_delegate_agent("codex"), "codex")
+
+    def test_invalid_returns_empty(self):
+        self.assertEqual(_normalize_delegate_agent("foo-agent"), "")
 
 
 class TestChildSystemPrompt(unittest.TestCase):
@@ -120,6 +137,21 @@ class TestDelegateTask(unittest.TestCase):
         result = json.loads(delegate_task(tasks=[{"context": "no goal here"}], parent_agent=parent))
         self.assertIn("error", result)
 
+    def test_invalid_top_level_agent(self):
+        parent = _make_mock_parent()
+        result = json.loads(delegate_task(goal="x", agent="bad-agent", parent_agent=parent))
+        self.assertIn("error", result)
+        self.assertIn("Unsupported agent", result["error"])
+
+    def test_invalid_task_agent(self):
+        parent = _make_mock_parent()
+        result = json.loads(delegate_task(
+            tasks=[{"goal": "x", "agent": "bad-agent"}],
+            parent_agent=parent,
+        ))
+        self.assertIn("error", result)
+        self.assertIn("unsupported agent", result["error"].lower())
+
     @patch("tools.delegate_tool._run_single_child")
     def test_single_task_mode(self, mock_run):
         mock_run.return_value = {
@@ -133,6 +165,30 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(result["results"][0]["status"], "completed")
         self.assertEqual(result["results"][0]["summary"], "Done!")
         mock_run.assert_called_once()
+        self.assertEqual(mock_run.call_args.kwargs["agent"], "hermes")
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_single_task_mode_with_external_agent(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "Done!", "api_calls": 0, "duration_seconds": 2.0
+        }
+        parent = _make_mock_parent()
+        result = json.loads(delegate_task(goal="Fix tests", agent="codex", parent_agent=parent))
+        self.assertIn("results", result)
+        self.assertEqual(mock_run.call_args.kwargs["agent"], "codex")
+
+    @patch("tools.delegate_tool._run_external_child")
+    def test_external_agent_dispatch(self, mock_external):
+        mock_external.return_value = {
+            "task_index": 0, "agent": "codex", "status": "completed",
+            "summary": "external done", "api_calls": 0, "duration_seconds": 1.0
+        }
+        parent = _make_mock_parent()
+        result = json.loads(delegate_task(goal="Use codex", agent="codex", parent_agent=parent))
+        self.assertEqual(result["results"][0]["agent"], "codex")
+        self.assertEqual(result["results"][0]["summary"], "external done")
+        mock_external.assert_called_once()
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode(self, mock_run):
@@ -151,6 +207,23 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(result["results"][0]["summary"], "Result A")
         self.assertEqual(result["results"][1]["summary"], "Result B")
         self.assertIn("total_duration_seconds", result)
+        self.assertEqual(mock_run.call_args_list[0].kwargs["agent"], "hermes")
+        self.assertEqual(mock_run.call_args_list[1].kwargs["agent"], "hermes")
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_batch_agent_override(self, mock_run):
+        mock_run.side_effect = [
+            {"task_index": 0, "status": "completed", "summary": "A", "api_calls": 0, "duration_seconds": 1.0},
+            {"task_index": 1, "status": "completed", "summary": "B", "api_calls": 0, "duration_seconds": 1.0},
+        ]
+        parent = _make_mock_parent()
+        tasks = [
+            {"goal": "Task A", "agent": "codex"},
+            {"goal": "Task B", "agent": "claude"},
+        ]
+        json.loads(delegate_task(tasks=tasks, agent="hermes", parent_agent=parent))
+        self.assertEqual(mock_run.call_args_list[0].kwargs["agent"], "codex")
+        self.assertEqual(mock_run.call_args_list[1].kwargs["agent"], "claude-code")
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_capped_at_3(self, mock_run):
@@ -254,6 +327,9 @@ class TestBlockedTools(unittest.TestCase):
     def test_constants(self):
         self.assertEqual(MAX_CONCURRENT_CHILDREN, 3)
         self.assertEqual(MAX_DEPTH, 2)
+        self.assertIn("hermes", SUPPORTED_AGENTS)
+        self.assertIn("codex", SUPPORTED_AGENTS)
+        self.assertIn("claude-code", SUPPORTED_AGENTS)
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """
-Delegate Tool -- Subagent Architecture
+Delegate Tool -- Subagent Architecture + ACP Delegation
 
 Spawns child AIAgent instances with isolated context, restricted toolsets,
-and their own terminal sessions. Supports single-task and batch (parallel)
-modes. The parent blocks until all children complete.
+and their own terminal sessions. Also supports ACP-style delegation to
+external coding agents (Codex / Claude Code). Supports single-task and batch
+(parallel) modes. The parent blocks until all children complete.
 
 Each child gets:
   - A fresh conversation (no parent history)
@@ -21,7 +22,10 @@ import io
 import json
 import logging
 import os
+import shutil
+import subprocess
 import sys
+import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional
@@ -40,11 +44,269 @@ MAX_CONCURRENT_CHILDREN = 3
 MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
 DEFAULT_MAX_ITERATIONS = 50
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+DEFAULT_AGENT = "hermes"
+SUPPORTED_AGENTS = frozenset(["hermes", "codex", "claude-code"])
+DEFAULT_EXTERNAL_TIMEOUT_SECONDS = 900
+DEFAULT_EXTERNAL_MAX_OUTPUT_CHARS = 24_000
+
+AGENT_ALIASES = {
+    "hermes": "hermes",
+    "codex": "codex",
+    "claude": "claude-code",
+    "claude-code": "claude-code",
+    "claude_code": "claude-code",
+}
 
 
 def check_delegate_requirements() -> bool:
     """Delegation has no external requirements -- always available."""
     return True
+
+
+def _normalize_delegate_agent(agent: Optional[str]) -> str:
+    """Normalize user-provided agent labels to canonical names."""
+    if agent is None:
+        return DEFAULT_AGENT
+    key = str(agent).strip().lower().replace("_", "-")
+    return AGENT_ALIASES.get(key, "")
+
+
+def _truncate_text(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return (
+        value[:limit]
+        + f"\n\n[Truncated: response was {len(value):,} chars, exceeding {limit:,} char limit]"
+    )
+
+
+def _build_external_child_prompt(goal: str, context: Optional[str] = None) -> str:
+    parts = [
+        "You are an ACP subagent called by Hermes Agent.",
+        "",
+        f"TASK:\n{goal}",
+    ]
+    if context and context.strip():
+        parts.append(f"\nCONTEXT:\n{context}")
+    parts.append(
+        "\nReturn only your final answer. Keep it concise and include:\n"
+        "- What you completed\n"
+        "- Files changed (if any)\n"
+        "- Any blockers or follow-ups"
+    )
+    return "\n".join(parts)
+
+
+def _run_external_child(
+    task_index: int,
+    agent: str,
+    goal: str,
+    context: Optional[str],
+    model: Optional[str],
+    max_iterations: int,
+    parent_agent,
+) -> Dict[str, Any]:
+    """Run an external coding agent (codex/claude-code) in non-interactive mode."""
+    _ = max_iterations, parent_agent
+    cfg = _load_config()
+    timeout_s = int(cfg.get("external_timeout_seconds", DEFAULT_EXTERNAL_TIMEOUT_SECONDS))
+    max_chars = int(cfg.get("external_max_output_chars", DEFAULT_EXTERNAL_MAX_OUTPUT_CHARS))
+    workdir = os.getcwd()
+    prompt = _build_external_child_prompt(goal, context)
+    start = time.monotonic()
+
+    if agent == "codex":
+        if shutil.which("codex") is None:
+            return {
+                "task_index": task_index,
+                "agent": agent,
+                "status": "error",
+                "summary": None,
+                "error": "Codex CLI not found in PATH.",
+                "api_calls": 0,
+                "duration_seconds": 0.0,
+            }
+
+        out_path = None
+        try:
+            with tempfile.NamedTemporaryFile(prefix="hermes-acp-codex-", suffix=".txt", delete=False) as tmp:
+                out_path = tmp.name
+
+            cmd = [
+                "codex",
+                "-a", "never",
+                "exec",
+                "--skip-git-repo-check",
+                "--color", "never",
+                "-C", workdir,
+                "--output-last-message", out_path,
+            ]
+            if model:
+                cmd.extend(["-m", model])
+            cmd.append("-")
+
+            completed = subprocess.run(
+                cmd,
+                input=prompt,
+                text=True,
+                capture_output=True,
+                timeout=timeout_s,
+                check=False,
+            )
+            duration = round(time.monotonic() - start, 2)
+
+            summary = ""
+            if out_path and os.path.exists(out_path):
+                with open(out_path, "r", encoding="utf-8", errors="replace") as f:
+                    summary = (f.read() or "").strip()
+            if not summary:
+                summary = (completed.stdout or "").strip()
+            if not summary and completed.stderr:
+                summary = completed.stderr.strip()
+            summary = _truncate_text(summary or "", max_chars)
+
+            if completed.returncode == 0 and summary:
+                return {
+                    "task_index": task_index,
+                    "agent": agent,
+                    "status": "completed",
+                    "summary": summary,
+                    "api_calls": 0,
+                    "duration_seconds": duration,
+                }
+            stderr_preview = _truncate_text((completed.stderr or "").strip(), 4_000)
+            return {
+                "task_index": task_index,
+                "agent": agent,
+                "status": "error",
+                "summary": summary or None,
+                "error": (
+                    f"Codex exited with code {completed.returncode}."
+                    + (f" stderr: {stderr_preview}" if stderr_preview else "")
+                ),
+                "api_calls": 0,
+                "duration_seconds": duration,
+            }
+        except subprocess.TimeoutExpired:
+            duration = round(time.monotonic() - start, 2)
+            return {
+                "task_index": task_index,
+                "agent": agent,
+                "status": "error",
+                "summary": None,
+                "error": f"Codex timed out after {timeout_s} seconds.",
+                "api_calls": 0,
+                "duration_seconds": duration,
+            }
+        except Exception as exc:
+            duration = round(time.monotonic() - start, 2)
+            return {
+                "task_index": task_index,
+                "agent": agent,
+                "status": "error",
+                "summary": None,
+                "error": f"Codex execution failed: {exc}",
+                "api_calls": 0,
+                "duration_seconds": duration,
+            }
+        finally:
+            if out_path and os.path.exists(out_path):
+                try:
+                    os.remove(out_path)
+                except OSError:
+                    pass
+
+    if agent == "claude-code":
+        binary = "claude"
+        if shutil.which(binary) is None:
+            return {
+                "task_index": task_index,
+                "agent": agent,
+                "status": "error",
+                "summary": None,
+                "error": "Claude Code CLI not found in PATH.",
+                "api_calls": 0,
+                "duration_seconds": 0.0,
+            }
+
+        cmd = [
+            binary,
+            "-p",
+            "--output-format", "text",
+            "--permission-mode", "acceptEdits",
+        ]
+        if model:
+            cmd.extend(["--model", model])
+        cmd.append(prompt)
+
+        try:
+            completed = subprocess.run(
+                cmd,
+                text=True,
+                capture_output=True,
+                timeout=timeout_s,
+                check=False,
+            )
+            duration = round(time.monotonic() - start, 2)
+            summary = (completed.stdout or "").strip()
+            if not summary and completed.stderr:
+                summary = completed.stderr.strip()
+            summary = _truncate_text(summary or "", max_chars)
+
+            if completed.returncode == 0 and summary:
+                return {
+                    "task_index": task_index,
+                    "agent": agent,
+                    "status": "completed",
+                    "summary": summary,
+                    "api_calls": 0,
+                    "duration_seconds": duration,
+                }
+            stderr_preview = _truncate_text((completed.stderr or "").strip(), 4_000)
+            return {
+                "task_index": task_index,
+                "agent": agent,
+                "status": "error",
+                "summary": summary or None,
+                "error": (
+                    f"Claude Code exited with code {completed.returncode}."
+                    + (f" stderr: {stderr_preview}" if stderr_preview else "")
+                ),
+                "api_calls": 0,
+                "duration_seconds": duration,
+            }
+        except subprocess.TimeoutExpired:
+            duration = round(time.monotonic() - start, 2)
+            return {
+                "task_index": task_index,
+                "agent": agent,
+                "status": "error",
+                "summary": None,
+                "error": f"Claude Code timed out after {timeout_s} seconds.",
+                "api_calls": 0,
+                "duration_seconds": duration,
+            }
+        except Exception as exc:
+            duration = round(time.monotonic() - start, 2)
+            return {
+                "task_index": task_index,
+                "agent": agent,
+                "status": "error",
+                "summary": None,
+                "error": f"Claude Code execution failed: {exc}",
+                "api_calls": 0,
+                "duration_seconds": duration,
+            }
+
+    return {
+        "task_index": task_index,
+        "agent": agent,
+        "status": "error",
+        "summary": None,
+        "error": f"Unsupported agent '{agent}'.",
+        "api_calls": 0,
+        "duration_seconds": round(time.monotonic() - start, 2),
+    }
 
 
 def _build_child_system_prompt(goal: str, context: Optional[str] = None) -> str:
@@ -161,6 +423,7 @@ def _run_single_child(
     goal: str,
     context: Optional[str],
     toolsets: Optional[List[str]],
+    agent: str,
     model: Optional[str],
     max_iterations: int,
     parent_agent,
@@ -173,6 +436,17 @@ def _run_single_child(
     from run_agent import AIAgent
 
     child_start = time.monotonic()
+
+    if agent != DEFAULT_AGENT:
+        return _run_external_child(
+            task_index=task_index,
+            agent=agent,
+            goal=goal,
+            context=context,
+            model=model,
+            max_iterations=max_iterations,
+            parent_agent=parent_agent,
+        )
 
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
@@ -252,6 +526,7 @@ def _run_single_child(
 
         entry: Dict[str, Any] = {
             "task_index": task_index,
+            "agent": agent,
             "status": status,
             "summary": summary,
             "api_calls": api_calls,
@@ -267,6 +542,7 @@ def _run_single_child(
         logging.exception(f"[subagent-{task_index}] failed")
         return {
             "task_index": task_index,
+            "agent": agent,
             "status": "error",
             "summary": None,
             "error": str(exc),
@@ -287,6 +563,7 @@ def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
+    agent: Optional[str] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     model: Optional[str] = None,
     max_iterations: Optional[int] = None,
@@ -298,6 +575,10 @@ def delegate_task(
     Supports two modes:
       - Single: provide goal (+ optional context, toolsets)
       - Batch:  provide tasks array [{goal, context, toolsets}, ...]
+    Supports agent targets:
+      - hermes (default in-process subagent)
+      - codex (external Codex CLI)
+      - claude-code (external Claude Code CLI)
 
     Returns JSON with results array, one entry per task.
     """
@@ -318,6 +599,14 @@ def delegate_task(
     cfg = _load_config()
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
+    default_agent = _normalize_delegate_agent(agent)
+    if not default_agent:
+        return json.dumps({
+            "error": (
+                f"Unsupported agent '{agent}'. "
+                f"Supported agents: {', '.join(sorted(SUPPORTED_AGENTS))}."
+            )
+        })
 
     # Normalize to task list
     if tasks and isinstance(tasks, list):
@@ -334,6 +623,14 @@ def delegate_task(
     for i, task in enumerate(task_list):
         if not task.get("goal", "").strip():
             return json.dumps({"error": f"Task {i} is missing a 'goal'."})
+        task_agent = _normalize_delegate_agent(task.get("agent", default_agent))
+        if not task_agent:
+            return json.dumps({
+                "error": (
+                    f"Task {i} has unsupported agent '{task.get('agent')}'. "
+                    f"Supported agents: {', '.join(sorted(SUPPORTED_AGENTS))}."
+                )
+            })
 
     overall_start = time.monotonic()
     results = []
@@ -350,6 +647,7 @@ def delegate_task(
             goal=t["goal"],
             context=t.get("context"),
             toolsets=t.get("toolsets") or toolsets,
+            agent=_normalize_delegate_agent(t.get("agent", default_agent)),
             model=model,
             max_iterations=effective_max_iter,
             parent_agent=parent_agent,
@@ -375,6 +673,7 @@ def delegate_task(
                     goal=t["goal"],
                     context=t.get("context"),
                     toolsets=t.get("toolsets") or toolsets,
+                    agent=_normalize_delegate_agent(t.get("agent", default_agent)),
                     model=model,
                     max_iterations=effective_max_iter,
                     parent_agent=parent_agent,
@@ -513,6 +812,10 @@ DELEGATE_TASK_SCHEMA = {
                     "properties": {
                         "goal": {"type": "string", "description": "Task goal"},
                         "context": {"type": "string", "description": "Task-specific context"},
+                        "agent": {
+                            "type": "string",
+                            "description": "Delegation target: hermes (default), codex, or claude-code",
+                        },
                         "toolsets": {
                             "type": "array",
                             "items": {"type": "string"},
@@ -526,6 +829,14 @@ DELEGATE_TASK_SCHEMA = {
                     "Batch mode: up to 3 tasks to run in parallel. Each gets "
                     "its own subagent with isolated context and terminal session. "
                     "When provided, top-level goal/context/toolsets are ignored."
+                ),
+            },
+            "agent": {
+                "type": "string",
+                "description": (
+                    "Delegation target agent. "
+                    "Supported: hermes (default), codex, claude-code. "
+                    "Can be overridden per item in tasks[]."
                 ),
             },
             "model": {
@@ -559,6 +870,7 @@ registry.register(
         goal=args.get("goal"),
         context=args.get("context"),
         toolsets=args.get("toolsets"),
+        agent=args.get("agent"),
         tasks=args.get("tasks"),
         model=args.get("model"),
         max_iterations=args.get("max_iterations"),

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -498,6 +498,8 @@ delegation:
     - terminal
     - file
     - web
+  external_timeout_seconds: 900  # Timeout (seconds) for codex/claude-code delegation
+  external_max_output_chars: 24000 # Truncate external agent output above this size
 ```
 
 ## Clarify

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -6,7 +6,11 @@ description: "Spawn isolated child agents for parallel workstreams with delegate
 
 # Subagent Delegation
 
-The `delegate_task` tool spawns child AIAgent instances with isolated context, restricted toolsets, and their own terminal sessions. Each child gets a fresh conversation and works independently — only its final summary enters the parent's context.
+The `delegate_task` tool can delegate to:
+- Internal Hermes subagents (default)
+- External ACP-style coding agents (`codex`, `claude-code`)
+
+Delegated agents run in isolated contexts, and only final summaries are returned to the parent.
 
 ## Single Task
 
@@ -144,6 +148,26 @@ delegate_task(
 
 If omitted, subagents use the same model as the parent.
 
+## ACP Agent Targets
+
+By default, delegation uses an internal Hermes child (`agent="hermes"`).
+You can explicitly target external coding agents:
+
+```python
+delegate_task(
+    goal="Implement the fix and run tests",
+    context="Repo root is /workspace/project. Keep patch minimal.",
+    agent="codex"
+)
+```
+
+```python
+delegate_task(tasks=[
+    {"goal": "Find regression risks", "agent": "claude-code"},
+    {"goal": "Apply patch and validate", "agent": "codex"},
+])
+```
+
 ## Toolset Selection Tips
 
 The `toolsets` parameter controls what tools the subagent has access to. Choose based on the task:
@@ -209,6 +233,8 @@ Delegation has a **depth limit of 2** — a parent (depth 0) can spawn children 
 delegation:
   max_iterations: 50                        # Max turns per child (default: 50)
   default_toolsets: ["terminal", "file", "web"]  # Default toolsets
+  external_timeout_seconds: 900             # Timeout for external agents (codex/claude-code)
+  external_max_output_chars: 24000          # Truncate external agent output above this limit
 ```
 
 :::tip


### PR DESCRIPTION
## What this PR changes
This PR adds ACP-style external agent delegation support to `delegate_task`.

### Core changes
- Add `agent` targeting support:
  - Top-level `agent` argument.
  - Per-task `tasks[].agent` override.
  - Supported targets: `hermes` (default), `codex`, `claude-code`.
- Add external delegation execution path for `codex` and `claude-code` in non-interactive mode.
- Add safety guards for external delegation:
  - `delegation.external_timeout_seconds`
  - `delegation.external_max_output_chars`
- Wire `agent` through the runtime delegation call path.
- Extend schema and tests for agent routing + validation.
- Update user docs and config docs with ACP examples and config options.

## Tests
- `tests/tools/test_delegate.py`
- `tests/test_cli_init.py`

Both pass locally.

## Notes
- No secrets or private data are included.
- This change preserves existing internal Hermes delegation behavior as default.

Closes #596