### PR TITLE
fix: strip MarkdownV2 italic markers in Telegram plaintext fallback

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -86,6 +86,9 @@ def _strip_mdv2(text: str) -> str:
     cleaned = re.sub(r'\\([_*\[\]()~`>#\+\-=|{}.!\\])', r'\1', text)
     # Remove MarkdownV2 bold markers that format_message converted from **bold**
     cleaned = re.sub(r'\*([^*]+)\*', r'\1', cleaned)
+    # Remove MarkdownV2 italic markers that format_message converted from *italic*
+    # Use word boundary (\b) to avoid breaking snake_case like my_variable_name
+    cleaned = re.sub(r'(?<!\w)_([^_]+)_(?!\w)', r'\1', cleaned)
     return cleaned
 
 

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -34,7 +34,7 @@ def _ensure_telegram_mock():
 
 _ensure_telegram_mock()
 
-from gateway.platforms.telegram import TelegramAdapter, _escape_mdv2  # noqa: E402
+from gateway.platforms.telegram import TelegramAdapter, _escape_mdv2, _strip_mdv2  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -360,3 +360,35 @@ class TestFormatMessageComplex:
         assert "Header" in result
         assert "block" in result
         assert "url.com" in result
+
+
+# =========================================================================
+# _strip_mdv2 — plaintext fallback
+# =========================================================================
+
+
+class TestStripMdv2:
+    def test_removes_escape_backslashes(self):
+        assert _strip_mdv2(r"hello\.world\!") == "hello.world!"
+
+    def test_removes_bold_markers(self):
+        assert _strip_mdv2("*bold text*") == "bold text"
+
+    def test_removes_italic_markers(self):
+        assert _strip_mdv2("_italic text_") == "italic text"
+
+    def test_removes_both_bold_and_italic(self):
+        result = _strip_mdv2("*bold* and _italic_")
+        assert result == "bold and italic"
+
+    def test_preserves_snake_case(self):
+        assert _strip_mdv2("my_variable_name") == "my_variable_name"
+
+    def test_preserves_multi_underscore_identifier(self):
+        assert _strip_mdv2("some_func_call here") == "some_func_call here"
+
+    def test_plain_text_unchanged(self):
+        assert _strip_mdv2("plain text") == "plain text"
+
+    def test_empty_string(self):
+        assert _strip_mdv2("") == ""


### PR DESCRIPTION
## Summary
When Telegram's MarkdownV2 parser rejects a message, `_strip_mdv2()` falls back to plain text. It correctly strips bold markers (`*text*` -> `text`) but misses italic markers (`_text_`), causing users to see raw underscores around italic text.

**Before:** `_italic_` visible in plaintext fallback
**After:** `italic` displayed cleanly

- Uses word boundary lookaround (`(?<!\w)` / `(?!\w)`) to preserve `snake_case` identifiers
- Adds 8 tests for `_strip_mdv2` covering italic, bold, snake_case, and edge cases