### PR TITLE
fix(security): use in-memory set for permanent allowlist save

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -295,6 +295,6 @@ def check_dangerous_command(command: str, env_type: str,
     elif choice == "always":
         approve_session(session_key, pattern_key)
         approve_permanent(pattern_key)
-        save_permanent_allowlist(load_permanent_allowlist() | {pattern_key})
+        save_permanent_allowlist(_permanent_approved)
 
     return {"approved": True, "message": None}


### PR DESCRIPTION
## What

When a user selects "always" to permanently approve a pattern, the code called:
```python
save_permanent_allowlist(load_permanent_allowlist() | {pattern_key})
```

`load_permanent_allowlist()` reads from disk, not from the in-memory `_permanent_approved` set. If patterns A and B were approved earlier in the session but not yet flushed to disk, approving C would overwrite the file with only disk contents + C — silently dropping A and B forever.

## Fix
```python
save_permanent_allowlist(_permanent_approved)
```

Use the in-memory set directly, which always contains the full approved set for the current session.

## Impact

- Data loss in permanent allowlist — previously approved patterns silently dropped
- No user-visible error, making the bug hard to detect in production