### PR TITLE
feat(cli): render assistant output as markdown

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -19,6 +19,7 @@ import sys
 import json
 import atexit
 import uuid
+from io import StringIO
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any, Optional
@@ -343,7 +344,9 @@ def load_cli_config() -> Dict[str, Any]:
 # Load configuration at module startup
 CLI_CONFIG = load_cli_config()
 
+from rich import box
 from rich.console import Console
+from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.table import Table
 
@@ -443,6 +446,38 @@ class ChatConsole:
         output = self._buffer.getvalue()
         for line in output.rstrip("\n").split("\n"):
             _cprint(line)
+
+
+def _render_plain_response_box(response: str, width: int) -> str:
+    """Render a plain-text Hermes response box as an ANSI string."""
+    label = " ⚕ Hermes "
+    fill = width - 2 - len(label)  # 2 for ╭ and ╮
+    top = f"{_GOLD}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}"
+    bot = f"{_GOLD}╰{'─' * (width - 2)}╯{_RST}"
+    return f"\n{top}\n{response}\n\n{bot}"
+
+
+def _render_markdown_response_box(response: str, width: int) -> str:
+    """Render assistant markdown inside a Rich panel and return ANSI text."""
+    buffer = StringIO()
+    console = Console(
+        file=buffer,
+        force_terminal=True,
+        color_system="truecolor",
+        highlight=False,
+        width=max(width, 20),
+    )
+    panel = Panel(
+        Markdown(str(response), code_theme="monokai", hyperlinks=False),
+        title="⚕ Hermes",
+        title_align="left",
+        border_style="#FFD700",
+        box=box.ROUNDED,
+        padding=(0, 1),
+    )
+    console.print()
+    console.print(panel)
+    return buffer.getvalue().rstrip("\n")
 
 # ASCII Art - HERMES-AGENT logo (full width, single line - requires ~95 char terminal)
 HERMES_AGENT_LOGO = """[bold #FFD700]██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗       █████╗  ██████╗ ███████╗███╗   ██╗████████╗[/]
@@ -954,6 +989,16 @@ class HermesCLI:
         if hasattr(self, "_app") and self._app and (now - self._last_invalidate) >= min_interval:
             self._last_invalidate = now
             self._app.invalidate()
+
+    def _print_assistant_response(self, response: str) -> None:
+        """Render the final assistant response with markdown support."""
+        width = shutil.get_terminal_size().columns
+        try:
+            rendered = _render_markdown_response_box(response, width)
+        except Exception:
+            logger.warning("Markdown render failed; falling back to plain text", exc_info=True)
+            rendered = _render_plain_response_box(response, width)
+        _cprint(rendered)
 
     def _ensure_runtime_credentials(self) -> bool:
         """
@@ -2360,15 +2405,7 @@ class HermesCLI:
                     response = response + "\n\n---\n_[Interrupted - processing new message]_"
             
             if response:
-                w = shutil.get_terminal_size().columns
-                label = " ⚕ Hermes "
-                fill = w - 2 - len(label)  # 2 for ╭ and ╮
-                top = f"{_GOLD}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}"
-                bot = f"{_GOLD}╰{'─' * (w - 2)}╯{_RST}"
-
-                # Render box + response as a single _cprint call so
-                # nothing can interleave between the box borders.
-                _cprint(f"\n{top}\n{response}\n\n{bot}")
+                self._print_assistant_response(response)
             
             # Combine all interrupt messages (user may have typed multiple while waiting)
             # and re-queue as one prompt for process_loop

--- a/tests/test_cli_markdown.py
+++ b/tests/test_cli_markdown.py
@@ -1,0 +1,74 @@
+import os
+import re
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return ANSI_RE.sub("", text)
+
+
+def test_render_markdown_response_box_formats_markdown():
+    from cli import _render_markdown_response_box
+
+    rendered = _render_markdown_response_box(
+        "# Plan\n\nUse `rg` and **pytest**.\n\n- first\n- second\n\n```bash\necho hi\n```",
+        width=80,
+    )
+    plain = _strip_ansi(rendered)
+
+    assert "⚕ Hermes" in plain
+    assert "Plan" in plain
+    assert "rg" in plain
+    assert "pytest" in plain
+    assert "echo hi" in plain
+    assert "# Plan" not in plain
+    assert "`rg`" not in plain
+    assert "**pytest**" not in plain
+    assert "```bash" not in plain
+
+
+def test_render_markdown_response_box_disables_hyperlink_escape_sequences():
+    from cli import _render_markdown_response_box
+
+    rendered = _render_markdown_response_box(
+        "[Google](https://google.com)\n\n![Alt text](image-url.jpg)",
+        width=80,
+    )
+
+    assert "\x1b]8;" not in rendered
+
+
+def test_chat_routes_final_response_through_markdown_renderer(monkeypatch):
+    from cli import HermesCLI
+
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.conversation_history = []
+    cli_obj.session_id = "test-session"
+    cli_obj.agent = SimpleNamespace(
+        run_conversation=lambda **kwargs: {
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "**done**"},
+            ],
+            "final_response": "**done**",
+        },
+        interrupt=MagicMock(),
+    )
+    cli_obj._ensure_runtime_credentials = lambda: True
+    cli_obj._init_agent = lambda: True
+    cli_obj._build_multimodal_content = lambda message, images: message
+    cli_obj._print_assistant_response = MagicMock()
+
+    monkeypatch.setattr("cli._cprint", lambda text: None)
+    monkeypatch.setattr("cli.shutil.get_terminal_size", lambda: os.terminal_size((80, 24)))
+    monkeypatch.setattr("cli.sys.stdout.flush", lambda: None)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    response = HermesCLI.chat(cli_obj, "hello")
+
+    assert response == "**done**"
+    cli_obj._print_assistant_response.assert_called_once_with("**done**")


### PR DESCRIPTION
## What changed
- render final Hermes CLI assistant responses with Rich Markdown inside the existing response panel
- keep a plain-text fallback if markdown rendering fails
- disable OSC 8 hyperlinks in terminal output so prompt_toolkit does not show raw escape sequences
- add focused CLI tests for markdown rendering and chat-path integration

## Why
Hermes CLI responses were displayed as plain text even when the model returned Markdown. This makes headings, emphasis, lists, and fenced code blocks much harder to read. Rich Markdown gives the CLI a clearer final-response surface without changing the agent loop.

## How to test
1. Run `source venv/bin/activate && pytest tests/test_cli_markdown.py tests/test_cli_init.py -q`
2. Start `hermes`
3. Ask for markdown with headings, italics, bold text, links, and a fenced code block
4. Verify the final response renders formatted in the CLI panel and links show readable text instead of raw OSC 8 escape codes

## Platforms tested
- Linux
- Interactive CLI
- Telegram gateway path (manual restart + live check)
