### PR TITLE
fix: return deny on approval callback timeout instead of None

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2245,6 +2245,8 @@ class HermesCLI:
         self._approval_state = None
         self._approval_deadline = 0
         self._invalidate()
+        return "deny"
+
     def chat(self, message, images: list = None) -> Optional[str]:
         """
         Send a message to the agent and get a response.


### PR DESCRIPTION
## Summary
`_approval_callback()` in `cli.py` has no `return` statement after the timeout `break`. The function returns `None` instead of `"deny"`, while callers (`tools/approval.py`) expect one of `"once"`, `"session"`, `"always"`, or `"deny"`.

**Before:** Timeout returns `None` — undefined behavior for dangerous command approval
**After:** Timeout returns `"deny"` — consistent with the existing timeout behavior in `approval.py:209`

One-line fix: added `return "deny"` after timeout cleanup.