### PR TITLE
fix(security): replace ReDoS-vulnerable regex in prompt injection scanners

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _CONTEXT_THREAT_PATTERNS = [
-    (r'ignore\s+(previous|all|above|prior)\s+instructions', "prompt_injection"),
+    (r'ignore\b.{0,50}\b(?:previous|all|above|prior)\b.{0,100}\binstructions\b', "prompt_injection"),
     (r'do\s+not\s+tell\s+the\s+user', "deception_hide"),
     (r'system\s+prompt\s+override', "sys_prompt_override"),
     (r'disregard\s+(your|all|any)\s+(instructions|rules|guidelines)', "disregard_rules"),

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -27,7 +27,7 @@ from cron.jobs import create_job, get_job, list_jobs, remove_job
 # ---------------------------------------------------------------------------
 
 _CRON_THREAT_PATTERNS = [
-    (r'ignore\s+(?:\w+\s+)*(?:previous|all|above|prior)\s+(?:\w+\s+)*instructions', "prompt_injection"),
+    (r'ignore\b.{0,50}\b(?:previous|all|above|prior)\b.{0,100}\binstructions\b', "prompt_injection"),
     (r'do\s+not\s+tell\s+the\s+user', "deception_hide"),
     (r'system\s+prompt\s+override', "sys_prompt_override"),
     (r'disregard\s+(your|all|any)\s+(instructions|rules|guidelines)', "disregard_rules"),

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -46,7 +46,7 @@ ENTRY_DELIMITER = "\n§\n"
 
 _MEMORY_THREAT_PATTERNS = [
     # Prompt injection
-    (r'ignore\s+(previous|all|above|prior)\s+instructions', "prompt_injection"),
+    (r'ignore\b.{0,50}\b(?:previous|all|above|prior)\b.{0,100}\binstructions\b', "prompt_injection"),
     (r'you\s+are\s+now\s+', "role_hijack"),
     (r'do\s+not\s+tell\s+the\s+user', "deception_hide"),
     (r'system\s+prompt\s+override', "sys_prompt_override"),


### PR DESCRIPTION
## What

`tools/cronjob_tools.py` line 30 has two adjacent `(?:\w+\s+)*` groups:
```python
r'ignore\s+(?:\w+\s+)*(?:previous|all|above|prior)\s+(?:\w+\s+)*instructions'
```

Input like `"ignore a b c d e f g h i j badword"` causes exponential backtracking — the engine tries every way to split words between the two groups.

The same pattern (simpler but inconsistent) was also in `memory_tool.py` and `prompt_builder.py`.

## Fix
```python
r'ignore\b.{0,50}\b(?:previous|all|above|prior)\b.{0,100}\binstructions\b'
```

Bounded `.{0,50}` and `.{0,100}` — no nested quantifiers, linear time.

## Files

- `tools/cronjob_tools.py` line 30
- `tools/memory_tool.py` line 49  
- `agent/prompt_builder.py` line 21