### PR TITLE
fix: reset all retry counters at start of run_conversation()

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2884,6 +2884,8 @@ class AIAgent:
         self._invalid_tool_retries = 0
         self._invalid_json_retries = 0
         self._empty_content_retries = 0
+        self._incomplete_scratchpad_retries = 0
+        self._codex_incomplete_retries = 0
         self._last_content_with_tools = None
         self._turns_since_memory = 0
         self._iters_since_skill = 0


### PR DESCRIPTION
## Summary
`_incomplete_scratchpad_retries` and `_codex_incomplete_retries` are not reset at the start of `run_conversation()`. In CLI mode, the same `AIAgent` instance is reused across conversations, so stale counters carry over.

**Impact:** After a few conversations with incomplete responses, the agent hits max retries immediately and returns partial results instead of retrying properly.

**Fix:** Add both counters to the existing reset block at the top of `run_conversation()` (line 2884), alongside the other retry counters that are already reset there.

Two-line fix — gateway is unaffected since it creates a fresh `AIAgent` per message.