### PR TITLE
fix(session): atomic write for sessions.json to prevent data loss on crash

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -342,12 +342,26 @@ class SessionStore:
     
     def _save(self) -> None:
         """Save sessions index to disk (kept for session key -> ID mapping)."""
+        import tempfile
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
         sessions_file = self.sessions_dir / "sessions.json"
-        
+
         data = {key: entry.to_dict() for key, entry in self._entries.items()}
-        with open(sessions_file, "w") as f:
-            json.dump(data, f, indent=2)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(self.sessions_dir), suffix=".tmp", prefix=".sessions_"
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, sessions_file)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
     
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""


### PR DESCRIPTION
## What

`_save()` in `gateway/session.py` was writing `sessions.json` like this:
```python
with open(sessions_file, "w") as f:
    json.dump(data, f, indent=2)
```

`open(..., "w")` truncates the file immediately. If the process crashes or gets OOM-killed mid-write, `sessions.json` ends up empty. On next startup `_ensure_loaded()` silently skips the broken file — every user gets a fresh session.

## Fix

Replaced with `tempfile.mkstemp` + `os.replace` — same pattern already used in `cron/jobs.save_jobs()`:

1. Write to a temp file in the same directory
2. `fsync` to flush to disk
3. `os.replace` — atomic rename, readers always see a complete file

## Impact

- Prevents silent session loss on crash or OOM kill
- No behaviour change under normal operation