### PR TITLE
fix(tests): remove model assertion after model param removed from delegate_task

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -56,7 +56,6 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
-        self.assertIn("model", props)
         self.assertIn("max_iterations", props)
         self.assertEqual(props["tasks"]["maxItems"], 3)
 


### PR DESCRIPTION
## Summary
The `model` parameter was removed from `delegate_task` schema in fb0f579 but `test_schema_valid` still asserts `model` is in the schema properties, breaking CI on main.

One-line fix — removes the stale assertion.