### PR TITLE
fix: avoid duplicate .env exists() check

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -67,7 +67,8 @@ def show_status(args):
     print(f"  Python:       {sys.version.split()[0]}")
     
     env_path = get_env_path()
-    print(f"  .env file:    {check_mark(env_path.exists())} {'exists' if env_path.exists() else 'not found'}")
+    env_exists = env_path.exists()
+    print(f"  .env file:    {check_mark(env_exists)} {'exists' if env_exists else 'not found'}")
     
     # =========================================================================
     # API Keys


### PR DESCRIPTION
# Why this change?
`hermes status` checked `.env` existence twice in one output line. This caused unnecessary duplicate filesystem checks and could theoretically produce inconsistent output if the file changed between calls.

# What changed?
Cached `env_path.exists()` into a local `env_exists` variable and reused it in the status line output. No behavior change beyond removing redundant work.