### PR TITLE
Improve skills tool error handling

### DIFF
--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -60,12 +60,15 @@ Usage:
 """
 
 import json
+import logging
 import os
 import re
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Tuple
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 # All skills live in ~/.hermes/skills/ (seeded from bundled skills/ on install).
@@ -226,7 +229,11 @@ def _find_all_skills() -> List[Dict[str, Any]]:
                 "category": category,
             })
             
-        except Exception:
+        except (UnicodeDecodeError, PermissionError) as e:
+            logger.warning("Failed to read skill file %s: %s", skill_md, e)
+            continue
+        except Exception as e:
+            logger.warning("Error parsing skill %s: %s", skill_md, e, exc_info=True)
             continue
     
     return skills
@@ -265,7 +272,11 @@ def _load_category_description(category_dir: Path) -> Optional[str]:
             description = description[:MAX_DESCRIPTION_LENGTH - 3] + "..."
         
         return description if description else None
-    except Exception:
+    except (UnicodeDecodeError, PermissionError) as e:
+        logger.debug("Failed to read category description %s: %s", desc_file, e)
+        return None
+    except Exception as e:
+        logger.warning("Error parsing category description %s: %s", desc_file, e, exc_info=True)
         return None
 
 


### PR DESCRIPTION
This PR improves error handling in the skills tool for better debugging and robustness. The changes add logging support and more specific exception handling for common failure scenarios when reading skill files and category descriptions. File read errors (UnicodeDecodeError, PermissionError) are now handled separately from parsing errors, and all exceptions include proper logging with exc_info=True for full stack traces. This makes it easier to diagnose issues when skills fail to load, whether due to encoding problems, permission issues, or malformed content. The improvements maintain backward compatibility while providing better visibility into failures that were previously silently ignored