### PR TITLE
fix: limit concurrent Modal sandbox creations to avoid deadlocks

### DIFF
--- a/environments/benchmarks/terminalbench_2/default.yaml
+++ b/environments/benchmarks/terminalbench_2/default.yaml
@@ -29,6 +29,10 @@ env:
   wandb_name: "terminal-bench-2"
   ensure_scores_are_not_same: false
   data_dir_to_save_evals: "environments/benchmarks/evals/terminal-bench-2"
+  # CRITICAL: Limit concurrent Modal sandbox creations to avoid deadlocks.
+  # Modal's blocking calls (App.lookup, etc.) deadlock when too many sandboxes
+  # are created simultaneously inside thread pool workers via asyncio.run().
+  max_concurrent_tasks: 8
 
 openai:
   base_url: "https://openrouter.ai/api/v1"

--- a/environments/benchmarks/terminalbench_2/terminalbench2_env.py
+++ b/environments/benchmarks/terminalbench_2/terminalbench2_env.py
@@ -118,6 +118,15 @@ class TerminalBench2EvalConfig(HermesAgentEnvConfig):
         "Tasks exceeding this are scored as FAIL. Default 30 minutes.",
     )
 
+    # --- Concurrency control ---
+    max_concurrent_tasks: int = Field(
+        default=8,
+        description="Maximum number of tasks to run concurrently. "
+        "Limits concurrent Modal sandbox creations to avoid async/threading deadlocks. "
+        "Modal has internal limits and creating too many sandboxes simultaneously "
+        "causes blocking calls to deadlock inside the thread pool.",
+    )
+
 
 # Tasks that cannot run properly on Modal and are excluded from scoring.
 MODAL_INCOMPATIBLE_TASKS = {
@@ -430,7 +439,7 @@ class TerminalBench2EvalEnv(HermesAgentBaseEnv):
                 }
 
             # --- 2. Register per-task Modal image override ---
-            register_task_env_overrides(task_id, {"modal_image": modal_image})
+            register_task_env_overrides(task_id, {"modal_image": modal_image, "cwd": "/app"})
             logger.info(
                 "Task %s: registered image override for task_id %s",
                 task_name, task_id[:8],
@@ -733,12 +742,23 @@ class TerminalBench2EvalEnv(HermesAgentBaseEnv):
         print(f"  Tool thread pool: {self.config.tool_pool_size}")
         print(f"  Terminal timeout: {self.config.terminal_timeout}s/cmd")
         print(f"  Terminal lifetime: {self.config.terminal_lifetime}s (auto: task_timeout + 120)")
+        print(f"  Max concurrent tasks: {self.config.max_concurrent_tasks}")
         print(f"{'='*60}\n")
+
+        # Semaphore to limit concurrent Modal sandbox creations.
+        # Without this, all 86 tasks fire simultaneously, each creating a Modal
+        # sandbox via asyncio.run() inside a thread pool worker. Modal's blocking
+        # calls (App.lookup, etc.) deadlock when too many are created at once.
+        semaphore = asyncio.Semaphore(self.config.max_concurrent_tasks)
+
+        async def _eval_with_semaphore(item):
+            async with semaphore:
+                return await self._eval_with_timeout(item)
 
         # Fire all tasks with wall-clock timeout, track live accuracy on the bar
         total_tasks = len(self.all_eval_items)
         eval_tasks = [
-            asyncio.ensure_future(self._eval_with_timeout(item))
+            asyncio.ensure_future(_eval_with_semaphore(item))
             for item in self.all_eval_items
         ]
 

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -137,6 +137,10 @@ class ModalEnvironment(BaseEnvironment):
 
     def cleanup(self):
         """Snapshot the filesystem (if persistent) then stop the sandbox."""
+        # Check if _inner was ever set (init may have failed)
+        if not hasattr(self, '_inner') or self._inner is None:
+            return
+
         if self._persistent:
             try:
                 sandbox = getattr(self._inner, 'deployment', None)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -424,7 +424,8 @@ def _get_env_config() -> Dict[str, Any]:
     # SSH is excluded since /home/ paths are valid on remote machines.
     cwd = os.getenv("TERMINAL_CWD", default_cwd)
     if env_type in ("modal", "docker", "singularity", "daytona") and cwd:
-        host_prefixes = ("/Users/", "C:\\", "C:/")
+        # Host paths that won't exist inside containers
+        host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
         if any(cwd.startswith(p) for p in host_prefixes) and cwd != default_cwd:
             logger.info("Ignoring TERMINAL_CWD=%r for %s backend "
                         "(host path won't exist in sandbox). Using %r instead.",


### PR DESCRIPTION
## What does this PR do?

Fixes a critical deadlock in TerminalBench2 evaluations where 86 tasks firing simultaneously would cause Modal's blocking API calls to hang inside the thread pool.

When each task creates a Modal sandbox via `asyncio.run()` inside a thread pool worker, Modal's internal blocking calls (`App.lookup`, etc.) deadlock when too many are created at once. The semaphore limits concurrent sandbox creations to 8, preventing thread pool saturation.

Also fixes CWD issues for TB2 containers by explicitly passing `cwd: "/app"` via the existing `register_task_env_overrides` mechanism, rather than changing global defaults.

## Related Issue

None filed - I worked on this fix while getting the benchmark to the point it would run

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `environments/benchmarks/terminalbench_2/default.yaml` - Add `max_concurrent_tasks: 8` config
- `environments/benchmarks/terminalbench_2/terminalbench2_env.py` - Add `max_concurrent_tasks` field, semaphore wrapping `_eval_with_timeout`, and pass `cwd: "/app"` via `register_task_env_overrides`
- `tools/environments/modal.py` - Add cleanup guard for failed initializations. This fixes a pre-existing bug: when Modal sandbox creation fails during `__init__`, `_inner` is never set, but `cleanup()` still gets called (by cleanup thread or atexit) and crashes with `AttributeError: 'ModalEnvironment' object has no attribute '_inner'`. The guard makes cleanup a no-op in this case. This bug was always present, but exposed more frequently under high concurrency when Modal API transient failures are more common.
- `tools/terminal_tool.py` - Add `/home/` to host path validation

## How to Test

1. Run TerminalBench2 eval: `python environments/benchmarks/terminalbench_2/terminalbench2_env.py evaluate --config environments/benchmarks/terminalbench_2/default.yaml`
2. Observe logs showing ~8 concurrent sandbox creations (not all 86 at once)
3. Verify no deadlock - tasks progress smoothly
4. Check that CWD is `/app` in sandboxes (via override mechanism)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) - the environments/benchmarks area does not have existing tests
- [x] I've tested on my platform: Ubuntu (Modal backend)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A - the terminal_tool change is in line with current intent and tool description

## For New Skills

N/A - not adding a skill

## Screenshots / Logs

```
21:39:15 [rex-deploy-Thread-69 (_run_loop)] INFO: Starting modal sandbox
21:39:15 [tools.terminal_tool] INFO: Creating new modal environment for task 92cd01f7...
21:39:15 [rex-deploy-Thread-70 (_run_loop)] INFO: Starting modal sandbox
21:39:15 [rex-deploy-Thread-71 (_run_loop)] INFO: Starting modal sandbox
...
```

Tasks started in batches of ~8, no deadlock, no AttributeError warnings.
