### PR TITLE
fix(cli): add model name validation with fuzzy suggestions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -362,6 +362,7 @@ from hermes_cli.banner import (
 )
 from hermes_cli.commands import COMMANDS, SlashCommandCompleter
 from hermes_cli import callbacks as _callbacks
+from hermes_cli.model_validation import validate_model_name, format_validation_result
 from toolsets import get_all_toolsets, get_toolset_info, resolve_toolset, validate_toolset
 
 # Cron job system for scheduled tasks (CRUD only — execution is handled by the gateway)
@@ -2080,7 +2081,19 @@ class HermesCLI:
             # Use original case so model names like "Anthropic/Claude-Opus-4" are preserved
             parts = cmd_original.split(maxsplit=1)
             if len(parts) > 1:
-                new_model = parts[1]
+                new_model = parts[1].strip()
+                
+                # Validate model name against known patterns
+                is_valid, warning, suggestions = validate_model_name(new_model)
+                
+                if not is_valid:
+                    # Show warning but still allow setting the model
+                    validation_msg = format_validation_result(new_model, is_valid, warning, suggestions)
+                    if validation_msg:
+                        print()
+                        print(validation_msg)
+                        print()
+                
                 self.model = new_model
                 self.agent = None  # Force re-init
                 # Save to config
@@ -2091,6 +2104,7 @@ class HermesCLI:
             else:
                 print(f"Current model: {self.model}")
                 print("  Usage: /model <model-name> to change")
+                print("  Example: /model anthropic/claude-3.5-sonnet")
         elif cmd_lower.startswith("/prompt"):
             # Use original case so prompt text isn't lowercased
             self._handle_prompt_command(cmd_original)

--- a/hermes_cli/model_validation.py
+++ b/hermes_cli/model_validation.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Model Validation Module
+
+Validates model names against known patterns and provides fuzzy matching
+suggestions for typos or invalid model names.
+
+Used by the /model command to catch invalid model names before saving them
+to config.
+"""
+
+import re
+from difflib import SequenceMatcher, get_close_matches
+from typing import Optional, Tuple, List
+
+
+# =============================================================================
+# Known Model Patterns by Provider
+# =============================================================================
+
+# Common model name patterns (provider/model-name format for OpenRouter)
+MODEL_PATTERNS = {
+    # OpenRouter format: provider/model-name or provider/model-name:variant
+    "openrouter": re.compile(
+        r"^[a-z0-9_-]+/[a-z0-9_.-]+(?::[a-z0-9_-]+)?$", re.IGNORECASE
+    ),
+    # Direct provider formats
+    "openai": re.compile(r"^(gpt-4|gpt-3\.5|o1|o3|chatgpt|text-davinci)", re.IGNORECASE),
+    "anthropic": re.compile(r"^claude-", re.IGNORECASE),
+    "google": re.compile(r"^(gemini|palm)", re.IGNORECASE),
+    "meta": re.compile(r"^(llama|codellama)", re.IGNORECASE),
+    "mistral": re.compile(r"^(mistral|mixtral|codestral)", re.IGNORECASE),
+    "nous": re.compile(r"^(hermes|nous)", re.IGNORECASE),
+    "deepseek": re.compile(r"^deepseek", re.IGNORECASE),
+    "qwen": re.compile(r"^qwen", re.IGNORECASE),
+    "cohere": re.compile(r"^(command|c4ai)", re.IGNORECASE),
+}
+
+# Well-known model names for fuzzy matching suggestions
+KNOWN_MODELS = [
+    # OpenAI (via OpenRouter or direct)
+    "openai/gpt-4o",
+    "openai/gpt-4o-mini",
+    "openai/gpt-4-turbo",
+    "openai/o1",
+    "openai/o1-mini",
+    "openai/o3-mini",
+    # Anthropic
+    "anthropic/claude-3.5-sonnet",
+    "anthropic/claude-3.5-sonnet:beta",
+    "anthropic/claude-3-opus",
+    "anthropic/claude-3-sonnet",
+    "anthropic/claude-3-haiku",
+    "anthropic/claude-opus-4",
+    "anthropic/claude-sonnet-4",
+    # Google
+    "google/gemini-2.0-flash-001",
+    "google/gemini-2.0-flash-thinking-exp",
+    "google/gemini-pro",
+    "google/gemini-3-flash-preview",
+    # Meta
+    "meta-llama/llama-3.3-70b-instruct",
+    "meta-llama/llama-3.2-90b-vision-instruct",
+    "meta-llama/llama-3.1-405b-instruct",
+    "meta-llama/llama-4-scout",
+    "meta-llama/llama-4-maverick",
+    # Mistral
+    "mistralai/mistral-large",
+    "mistralai/mistral-medium",
+    "mistralai/codestral-latest",
+    "mistralai/mixtral-8x22b-instruct",
+    # DeepSeek
+    "deepseek/deepseek-chat",
+    "deepseek/deepseek-r1",
+    "deepseek/deepseek-coder",
+    # Nous
+    "nousresearch/hermes-3-llama-3.1-405b",
+    "nousresearch/hermes-3-llama-3.1-70b",
+    # Qwen
+    "qwen/qwen-2.5-72b-instruct",
+    "qwen/qwen-2.5-coder-32b-instruct",
+    "qwen/qwq-32b",
+    # Cohere
+    "cohere/command-r-plus",
+    "cohere/command-r",
+    # xAI
+    "x-ai/grok-2",
+    "x-ai/grok-beta",
+]
+
+
+def validate_model_name(model: str) -> Tuple[bool, Optional[str], List[str]]:
+    """
+    Validate a model name against known patterns.
+    
+    Args:
+        model: The model name to validate
+    
+    Returns:
+        Tuple of:
+        - is_valid: True if model matches any known pattern
+        - warning: Warning message if model is unusual (or None)
+        - suggestions: List of similar model names if validation fails
+    """
+    if not model or not model.strip():
+        return False, "Model name cannot be empty", []
+    
+    model = model.strip()
+    
+    # Check against known patterns
+    for provider, pattern in MODEL_PATTERNS.items():
+        if pattern.match(model):
+            return True, None, []
+    
+    # Model doesn't match known patterns - generate suggestions
+    suggestions = get_close_matches(
+        model.lower(),
+        [m.lower() for m in KNOWN_MODELS],
+        n=3,
+        cutoff=0.4
+    )
+    
+    # Map back to original case
+    model_map = {m.lower(): m for m in KNOWN_MODELS}
+    suggestions = [model_map.get(s, s) for s in suggestions]
+    
+    # Generate warning message
+    warning = (
+        f"'{model}' doesn't match any known model pattern. "
+        "Model names typically use 'provider/model-name' format (e.g., 'anthropic/claude-3.5-sonnet')."
+    )
+    
+    return False, warning, suggestions
+
+
+def format_validation_result(model: str, is_valid: bool, warning: Optional[str], 
+                             suggestions: List[str]) -> Optional[str]:
+    """
+    Format validation results for display.
+    
+    Returns None if model is valid, otherwise returns a warning message.
+    """
+    if is_valid:
+        return None
+    
+    lines = [f"⚠️  {warning}"]
+    
+    if suggestions:
+        lines.append("")
+        lines.append("Did you mean one of these?")
+        for s in suggestions:
+            lines.append(f"  • {s}")
+    
+    lines.append("")
+    lines.append("The model will be saved, but API calls may fail if the name is invalid.")
+    
+    return "\n".join(lines)
+
+
+def interactive_model_validation(model: str) -> Tuple[bool, str]:
+    """
+    Validate model and return whether to proceed.
+    
+    Returns:
+        Tuple of (should_proceed, display_message)
+    """
+    is_valid, warning, suggestions = validate_model_name(model)
+    
+    if is_valid:
+        return True, ""
+    
+    message = format_validation_result(model, is_valid, warning, suggestions)
+    return True, message  # Still allow saving, but show warning

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Tests for model validation module."""
+
+import pytest
+from hermes_cli.model_validation import (
+    validate_model_name,
+    format_validation_result,
+    interactive_model_validation,
+    KNOWN_MODELS,
+    MODEL_PATTERNS,
+)
+
+
+class TestValidateModelName:
+    """Tests for validate_model_name function."""
+    
+    def test_valid_openrouter_format(self):
+        """OpenRouter provider/model format should be valid."""
+        valid_models = [
+            "anthropic/claude-3.5-sonnet",
+            "openai/gpt-4o",
+            "meta-llama/llama-3.3-70b-instruct",
+            "google/gemini-2.0-flash-001",
+            "mistralai/mistral-large",
+            "deepseek/deepseek-r1",
+        ]
+        for model in valid_models:
+            is_valid, warning, suggestions = validate_model_name(model)
+            assert is_valid, f"Model {model} should be valid"
+            assert warning is None
+            assert suggestions == []
+    
+    def test_valid_with_variant(self):
+        """Models with :variant suffix should be valid."""
+        is_valid, warning, _ = validate_model_name("anthropic/claude-3.5-sonnet:beta")
+        assert is_valid
+        assert warning is None
+    
+    def test_valid_direct_provider_models(self):
+        """Direct provider model names should be valid."""
+        valid_models = [
+            "gpt-4o",
+            "claude-3.5-sonnet",
+            "gemini-pro",
+            "llama-3.3-70b",
+            "mistral-large",
+            "deepseek-chat",
+        ]
+        for model in valid_models:
+            is_valid, warning, _ = validate_model_name(model)
+            assert is_valid, f"Model {model} should be valid"
+    
+    def test_invalid_empty_model(self):
+        """Empty model name should be invalid."""
+        is_valid, warning, _ = validate_model_name("")
+        assert not is_valid
+        assert "cannot be empty" in warning
+        
+        is_valid, warning, _ = validate_model_name("   ")
+        assert not is_valid
+        assert "cannot be empty" in warning
+    
+    def test_invalid_random_string(self):
+        """Random strings should be invalid with suggestions."""
+        is_valid, warning, suggestions = validate_model_name("asdf1234")
+        assert not is_valid
+        assert "doesn't match any known model pattern" in warning
+    
+    def test_invalid_model_gets_suggestions(self):
+        """Invalid model similar to known models should get suggestions."""
+        # Typo of "anthropic/claude-3.5-sonnet"
+        is_valid, warning, suggestions = validate_model_name("anthropic/claude-3.5-sonet")
+        assert not is_valid
+        # Should suggest the correct model
+        assert any("claude" in s.lower() for s in suggestions)
+    
+    def test_case_insensitive_validation(self):
+        """Validation should be case-insensitive for patterns."""
+        is_valid, _, _ = validate_model_name("OpenAI/GPT-4o")
+        assert is_valid
+        
+        is_valid, _, _ = validate_model_name("ANTHROPIC/CLAUDE-3.5-SONNET")
+        assert is_valid
+
+
+class TestFormatValidationResult:
+    """Tests for format_validation_result function."""
+    
+    def test_valid_returns_none(self):
+        """Valid model should return None."""
+        result = format_validation_result("anthropic/claude-3.5-sonnet", True, None, [])
+        assert result is None
+    
+    def test_invalid_returns_message(self):
+        """Invalid model should return warning message."""
+        result = format_validation_result(
+            "invalid-model",
+            False,
+            "Model doesn't match patterns",
+            ["anthropic/claude-3.5-sonnet"]
+        )
+        assert result is not None
+        assert "⚠️" in result
+        assert "Model doesn't match patterns" in result
+        assert "anthropic/claude-3.5-sonnet" in result
+    
+    def test_includes_did_you_mean(self):
+        """Should include 'Did you mean' when suggestions exist."""
+        result = format_validation_result(
+            "invalid",
+            False,
+            "Invalid",
+            ["suggestion1", "suggestion2"]
+        )
+        assert "Did you mean" in result
+        assert "suggestion1" in result
+        assert "suggestion2" in result
+
+
+class TestInteractiveModelValidation:
+    """Tests for interactive_model_validation function."""
+    
+    def test_valid_model_proceeds(self):
+        """Valid model should return proceed=True with empty message."""
+        proceed, message = interactive_model_validation("anthropic/claude-3.5-sonnet")
+        assert proceed is True
+        assert message == ""
+    
+    def test_invalid_model_still_proceeds_with_warning(self):
+        """Invalid model should still proceed but with warning."""
+        proceed, message = interactive_model_validation("invalid-model")
+        assert proceed is True  # Still allow setting
+        assert len(message) > 0  # But show warning
+
+
+class TestKnownModels:
+    """Tests for KNOWN_MODELS list."""
+    
+    def test_known_models_all_valid(self):
+        """All models in KNOWN_MODELS should pass validation."""
+        for model in KNOWN_MODELS:
+            is_valid, warning, _ = validate_model_name(model)
+            assert is_valid, f"Known model {model} should be valid but got warning: {warning}"
+
+
+class TestModelPatterns:
+    """Tests for MODEL_PATTERNS regex patterns."""
+    
+    def test_openrouter_pattern_basic(self):
+        """OpenRouter pattern should match provider/model format."""
+        pattern = MODEL_PATTERNS["openrouter"]
+        assert pattern.match("provider/model")
+        assert pattern.match("anthropic/claude-3.5-sonnet")
+        assert pattern.match("meta-llama/llama-3.3-70b-instruct")
+        assert pattern.match("openai/gpt-4o:variant")
+        assert not pattern.match("just-a-model")
+        assert not pattern.match("/model")
+        assert not pattern.match("provider/")
+    
+    def test_openai_pattern(self):
+        """OpenAI pattern should match GPT models."""
+        pattern = MODEL_PATTERNS["openai"]
+        assert pattern.match("gpt-4o")
+        assert pattern.match("gpt-3.5-turbo")
+        assert pattern.match("o1-mini")
+        assert not pattern.match("claude-3.5")
+    
+    def test_anthropic_pattern(self):
+        """Anthropic pattern should match Claude models."""
+        pattern = MODEL_PATTERNS["anthropic"]
+        assert pattern.match("claude-3.5-sonnet")
+        assert pattern.match("claude-opus-4")
+        assert not pattern.match("gpt-4o")


### PR DESCRIPTION
## Summary

Adds validation to the `/model` command to catch invalid model names before saving them to config, addressing #632.

## Changes

### New Module: `hermes_cli/model_validation.py`
- Pattern-based validation for known providers:
  - OpenRouter format (`provider/model-name`)
  - Direct provider models (OpenAI, Anthropic, Google, Meta, Mistral, DeepSeek, Qwen, etc.)
- Fuzzy matching using `difflib.get_close_matches` to suggest similar valid model names
- Non-blocking warnings (still allows setting unknown models for flexibility)

### Updated `/model` Handler in `cli.py`
- Validates model names against known patterns before saving
- Shows warning with suggestions for unrecognized models
- Added example in usage help (`/model anthropic/claude-3.5-sonnet`)

### Tests
- Comprehensive test suite in `tests/hermes_cli/test_model_validation.py`
- Tests for valid patterns, invalid inputs, suggestions, and edge cases

## Example Output

```
/model gpt4o

⚠️  'gpt4o' doesn't match any known model pattern. Model names typically use 'provider/model-name' format (e.g., 'anthropic/claude-3.5-sonnet').

Did you mean one of these?
  • openai/gpt-4o
  • openai/gpt-4o-mini

The model will be saved, but API calls may fail if the name is invalid.

(^_^)b Model changed to: gpt4o (saved to config)
```

## Design Decisions

1. **Non-blocking**: Warnings don't prevent saving - users might use custom endpoints with non-standard model names
2. **Pattern-based**: Uses regex patterns for each known provider format, easy to extend
3. **Fuzzy matching**: Helps users who make typos find the correct model name

Fixes #632