### PR TITLE
fix(code_execution): web_extract always available in execute_code

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -393,9 +393,8 @@ def execute_code(
 
     try:
         # Write the auto-generated hermes_tools module
-        tools_src = generate_hermes_tools_module(
-            list(sandbox_tools) if enabled_tools else list(SANDBOX_ALLOWED_TOOLS)
-        )
+        # sandbox_tools already contains the correct intersection (or fallback to SANDBOX_ALLOWED_TOOLS)
+        tools_src = generate_hermes_tools_module(list(sandbox_tools))
         with open(os.path.join(tmpdir, "hermes_tools.py"), "w") as f:
             f.write(tools_src)
 


### PR DESCRIPTION
Fixes #662

## Problem
The `generate_hermes_tools_module` function had called with:
```python
list(sandbox_tools) if enabled_tools else list(sandbox_tools)
```

When `enabled_tools=None`, this correctly evaluates to `list(enabled_tools)` (falsy), but generating tools for *all* SANDBOX_ALLOWED_TOOLS.

But when `enabled_tools` is *provided*, the was using `enabled_tools` directly (which is None), instead of `sandbox_tools` (which contains the correct intersection).

## Fix
Always use `sandbox_tools` (already computed correctly on line 356):\n```python
sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)

if not sandbox_tools:
    sandbox_tools = SANDBOX_ALLOWED_TOOLS
```

This ensures `web_extract` is always included when it session has web tools enabled.

## Testing
- Without fix: web_extract missing when enabled_tools is None
- With fix: web_extract correctly included via sandbox_tools