### PR TITLE
fix(tools): empty tool selection persists instead of resetting to default

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -308,7 +308,9 @@ def _get_platform_tools(config: dict, platform: str) -> Set[str]:
     platform_toolsets = config.get("platform_toolsets", {})
     toolset_names = platform_toolsets.get(platform)
 
-    if not toolset_names or not isinstance(toolset_names, list):
+    # Note: Empty list [] is a valid selection (user disabled all tools)
+    # Only fallback to default if key is missing or not a list
+    if toolset_names is None or not isinstance(toolset_names, list):
         default_ts = PLATFORMS[platform]["default_toolset"]
         toolset_names = [default_ts]
 


### PR DESCRIPTION
Fixes #637

## Problem
When user disables all tools (0/18 enabled), the empty list `[]` triggers fallback to platform default on next load.

## Root Cause
`if not toolset_names` treats empty list `[]` as falsy, triggering fallback.

## Fix
Use `if toolset_names is None` instead:
- `None` (key missing) → use default
- `[]` (user selected none) → keep empty
- `["tool1", "tool2"]` → use selection

## Testing
- Before: Disable all tools → restart → tools reset to default
- After: Disable all tools → restart → stays empty