### PR TITLE
fix(cli): remove duplicate COMMANDS dict, consolidate to hermes_cli/commands.py

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -909,28 +909,6 @@ def build_welcome_banner(console: Console, model: str, cwd: str, tools: List[dic
 # CLI Commands
 # ============================================================================
 
-COMMANDS = {
-    "/help": "Show this help message",
-    "/tools": "List available tools",
-    "/toolsets": "List available toolsets",
-    "/model": "Show or change the current model",
-    "/prompt": "View/set custom system prompt",
-    "/personality": "Set a predefined personality",
-    "/clear": "Clear screen and reset conversation (fresh start)",
-    "/history": "Show conversation history",
-    "/new": "Start a new conversation (reset history)",
-    "/reset": "Reset conversation only (keep screen)",
-    "/retry": "Retry the last message (resend to agent)",
-    "/undo": "Remove the last user/assistant exchange",
-    "/save": "Save the current conversation",
-    "/config": "Show current configuration",
-    "/cron": "Manage scheduled tasks (list, add, remove)",
-    "/skills": "Search, install, inspect, or manage skills from online registries",
-    "/platforms": "Show gateway/messaging platform status",
-    "/paste": "Check clipboard for an image and attach it",
-    "/reload-mcp": "Reload MCP servers from config.yaml",
-    "/quit": "Exit the CLI (also: /exit, /q)",
-}
 
 
 # ============================================================================


### PR DESCRIPTION
Fixes #631

## Problem
Two `COMMANDS` dicts exist:
- `hermes_cli/commands.py` (22 commands)
- `cli.py` (20 commands, shadows import)

This causes:
- `/verbose`, `/compress`, `/usage`, `/insights` missing from autocomplete
- `/paste`, `/reload-mcp` only in cli.py version

## Fix
1. Added `/paste` and `/reload-mcp` to `hermes_cli/commands.py`
2. Removed duplicate `COMMANDS` definition from `cli.py`
3. Now single source of truth: `hermes_cli/commands.py`

## Impact
All 24 slash commands now appear in autocomplete correctly.