### PR TITLE
fix(cli): add model name validation with suggestions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2081,6 +2081,29 @@ class HermesCLI:
             parts = cmd_original.split(maxsplit=1)
             if len(parts) > 1:
                 new_model = parts[1]
+                
+                # Validate model name
+                try:
+                    from hermes_cli.models import model_ids
+                    known_models = model_ids()
+                    
+                    # Check if model is known (case-insensitive partial match)
+                    model_lower = new_model.lower()
+                    is_known = any(model_lower == m.lower() for m in known_models)
+                    
+                    if not is_known:
+                        # Try to find similar models for suggestion
+                        from difflib import get_close_matches
+                        suggestions = get_close_matches(model_lower, [m.lower() for m in known_models], n=3, cutoff=0.6)
+                        
+                        print(f"[yellow]⚠️  Model '{new_model}' not found in known models list.[/]")
+                        if suggestions:
+                            print(f"[dim]   Did you mean: {', '.join(suggestions[:3])}?[/]")
+                        print(f"[dim]   Saving anyway - API will validate on next call.[/]")
+                        print()
+                except Exception:
+                    pass  # Don't block model change if validation fails
+                
                 self.model = new_model
                 self.agent = None  # Force re-init
                 # Save to config


### PR DESCRIPTION
Fixes #632

## Problem
`/model` command accepts any string without validation. Invalid model names are silently saved and only fail on API call.

## Fix
1. Check model against known models from `hermes_cli/models.model_ids()`
2. Show warning if model not found
3. Provide fuzzy-match suggestions using `difflib.get_close_matches`
4. Still allow saving (API will validate on call)

## Example
```
/model gpt-5
⚠️  Model 'gpt-5' not found in known models list.
   Did you mean: gpt-4o, gpt-4o-mini, gpt-4-turbo?
   Saving anyway - API will validate on next call.
```

## Impact
Users get immediate feedback on typos and suggestions for correct model names.