### PR TITLE
feat: add Nous Portal API key provider (#644)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -11,6 +11,7 @@ model:
   
   # Inference provider selection:
   #   "auto"       - Use Nous Portal if logged in, otherwise OpenRouter/env vars (default)
+  #   "nous-api"   - Use Nous Portal via API key (requires: NOUS_API_KEY)
   #   "openrouter" - Always use OpenRouter API key from OPENROUTER_API_KEY
   #   "nous"       - Always use Nous Portal (requires: hermes login)
   #   "zai"        - Use z.ai / ZhipuAI GLM models (requires: GLM_API_KEY)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -103,6 +103,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="oauth_external",
         inference_base_url=DEFAULT_CODEX_BASE_URL,
     ),
+    "nous-api": ProviderConfig(
+        id="nous-api",
+        name="Nous Portal (API Key)",
+        auth_type="api_key",
+        inference_base_url="https://inference-api.nousresearch.com/v1",
+        api_key_env_vars=("NOUS_API_KEY",),
+        base_url_env_var="NOUS_BASE_URL",
+    ),
     "zai": ProviderConfig(
         id="zai",
         name="Z.AI / GLM",
@@ -475,6 +483,7 @@ def resolve_provider(
 
     # Normalize provider aliases
     _PROVIDER_ALIASES = {
+        "nous_api": "nous-api", "nousapi": "nous-api", "nous-portal-api": "nous-api",
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "kimi": "kimi-coding", "moonshot": "kimi-coding",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -165,6 +165,22 @@ REQUIRED_ENV_VARS = {}
 # Optional environment variables that enhance functionality
 OPTIONAL_ENV_VARS = {
     # ── Provider (handled in provider selection, not shown in checklists) ──
+    "NOUS_API_KEY": {
+        "description": "Nous Portal API key (direct API key access to Nous inference)",
+        "prompt": "Nous Portal API key",
+        "url": "https://portal.nousresearch.com",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "NOUS_BASE_URL": {
+        "description": "Nous Portal base URL override",
+        "prompt": "Nous Portal base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
     "OPENROUTER_API_KEY": {
         "description": "OpenRouter API key (for vision, web scraping helpers, and MoA)",
         "prompt": "OpenRouter API key",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -516,7 +516,8 @@ def setup_model_provider(config: dict):
         keep_label = None  # No provider configured — don't show "Keep current"
 
     provider_choices = [
-        "Login with Nous Portal (Nous Research subscription)",
+        "Nous Portal API key (direct API key access)",
+        "Login with Nous Portal (Nous Research subscription — OAuth)",
         "Login with OpenAI Codex",
         "OpenRouter API key (100+ models, pay-per-use)",
         "Custom OpenAI-compatible endpoint (self-hosted / VLLM / etc.)",
@@ -529,7 +530,7 @@ def setup_model_provider(config: dict):
         provider_choices.append(keep_label)
     
     # Default to "Keep current" if a provider exists, otherwise OpenRouter (most common)
-    default_provider = len(provider_choices) - 1 if has_any_provider else 2
+    default_provider = len(provider_choices) - 1 if has_any_provider else 3
     
     if not has_any_provider:
         print_warning("An inference provider is required for Hermes to work.")
@@ -541,7 +542,37 @@ def setup_model_provider(config: dict):
     selected_provider = None  # "nous", "openai-codex", "openrouter", "custom", or None (keep)
     nous_models = []  # populated if Nous login succeeds
 
-    if provider_idx == 0:  # Nous Portal
+    if provider_idx == 0:  # Nous Portal API Key (direct)
+        selected_provider = "nous-api"
+        print()
+        print_header("Nous Portal API Key")
+        print_info("Use a Nous Portal API key for direct access to Nous inference.")
+        print_info("Get your API key at: https://portal.nousresearch.com")
+        print()
+
+        existing_key = get_env_value("NOUS_API_KEY")
+        if existing_key:
+            print_info(f"Current: {existing_key[:8]}... (configured)")
+            if prompt_yes_no("Update Nous API key?", False):
+                api_key = prompt("  Nous API key", password=True)
+                if api_key:
+                    save_env_value("NOUS_API_KEY", api_key)
+                    print_success("Nous API key updated")
+        else:
+            api_key = prompt("  Nous API key", password=True)
+            if api_key:
+                save_env_value("NOUS_API_KEY", api_key)
+                print_success("Nous API key saved")
+            else:
+                print_warning("Skipped - agent won't work without an API key")
+
+        # Clear custom endpoint vars if switching
+        if existing_custom:
+            save_env_value("OPENAI_BASE_URL", "")
+            save_env_value("OPENAI_API_KEY", "")
+        _update_config_for_provider("nous-api", "https://inference-api.nousresearch.com/v1")
+
+    elif provider_idx == 1:  # Nous Portal
         selected_provider = "nous"
         print()
         print_header("Nous Portal Login")
@@ -581,7 +612,7 @@ def setup_model_provider(config: dict):
             print_info("You can try again later with: hermes model")
             selected_provider = None
 
-    elif provider_idx == 1:  # OpenAI Codex
+    elif provider_idx == 2:  # OpenAI Codex
         selected_provider = "openai-codex"
         print()
         print_header("OpenAI Codex Login")
@@ -605,7 +636,7 @@ def setup_model_provider(config: dict):
             print_info("You can try again later with: hermes model")
             selected_provider = None
 
-    elif provider_idx == 2:  # OpenRouter
+    elif provider_idx == 3:  # OpenRouter
         selected_provider = "openrouter"
         print()
         print_header("OpenRouter API Key")
@@ -632,7 +663,7 @@ def setup_model_provider(config: dict):
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
 
-    elif provider_idx == 3:  # Custom endpoint
+    elif provider_idx == 4:  # Custom endpoint
         selected_provider = "custom"
         print()
         print_header("Custom OpenAI-Compatible Endpoint")
@@ -661,7 +692,7 @@ def setup_model_provider(config: dict):
             save_env_value("LLM_MODEL", model_name)
         print_success("Custom endpoint configured")
 
-    elif provider_idx == 4:  # Z.AI / GLM
+    elif provider_idx == 5:  # Z.AI / GLM
         selected_provider = "zai"
         print()
         print_header("Z.AI / GLM API Key")
@@ -715,7 +746,7 @@ def setup_model_provider(config: dict):
             save_env_value("OPENAI_API_KEY", "")
         _update_config_for_provider("zai", zai_base_url)
 
-    elif provider_idx == 5:  # Kimi / Moonshot
+    elif provider_idx == 6:  # Kimi / Moonshot
         selected_provider = "kimi-coding"
         print()
         print_header("Kimi / Moonshot API Key")
@@ -747,7 +778,7 @@ def setup_model_provider(config: dict):
             save_env_value("OPENAI_API_KEY", "")
         _update_config_for_provider("kimi-coding", pconfig.inference_base_url)
 
-    elif provider_idx == 6:  # MiniMax
+    elif provider_idx == 7:  # MiniMax
         selected_provider = "minimax"
         print()
         print_header("MiniMax API Key")
@@ -779,7 +810,7 @@ def setup_model_provider(config: dict):
             save_env_value("OPENAI_API_KEY", "")
         _update_config_for_provider("minimax", pconfig.inference_base_url)
 
-    elif provider_idx == 7:  # MiniMax China
+    elif provider_idx == 8:  # MiniMax China
         selected_provider = "minimax-cn"
         print()
         print_header("MiniMax China API Key")
@@ -811,12 +842,12 @@ def setup_model_provider(config: dict):
             save_env_value("OPENAI_API_KEY", "")
         _update_config_for_provider("minimax-cn", pconfig.inference_base_url)
 
-    # else: provider_idx == 8 (Keep current) — only shown when a provider already exists
+    # else: provider_idx == 9 (Keep current) — only shown when a provider already exists
 
     # ── OpenRouter API Key for tools (if not already set) ──
     # Tools (vision, web, MoA) use OpenRouter independently of the main provider.
     # Prompt for OpenRouter key if not set and a non-OpenRouter provider was chosen.
-    if selected_provider in ("nous", "openai-codex", "custom", "zai", "kimi-coding", "minimax", "minimax-cn") and not get_env_value("OPENROUTER_API_KEY"):
+    if selected_provider in ("nous", "nous-api", "openai-codex", "custom", "zai", "kimi-coding", "minimax", "minimax-cn") and not get_env_value("OPENROUTER_API_KEY"):
         print()
         print_header("OpenRouter API Key (for tools)")
         print_info("Tools like vision analysis, web search, and MoA use OpenRouter")
@@ -865,6 +896,14 @@ def setup_model_provider(config: dict):
             # instead of falling through to the OpenRouter static list.
             print_warning("Could not fetch available models from Nous Portal.")
             print_info("Enter a Nous model name manually (e.g., claude-opus-4-6).")
+            custom = prompt(f"  Model name (Enter to keep '{current_model}')")
+            if custom:
+                config['model'] = custom
+                save_env_value("LLM_MODEL", custom)
+        elif selected_provider == "nous-api":
+            # Nous API key provider — prompt for model manually
+            print_info("Enter a model name available on Nous inference API.")
+            print_info("Examples: anthropic/claude-opus-4.6, deepseek/deepseek-r1")
             custom = prompt(f"  Model name (Enter to keep '{current_model}')")
             if custom:
                 config['model'] = custom

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -7,3 +7,6 @@ without risk of circular imports.
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 OPENROUTER_MODELS_URL = f"{OPENROUTER_BASE_URL}/models"
 OPENROUTER_CHAT_URL = f"{OPENROUTER_BASE_URL}/chat/completions"
+
+NOUS_API_BASE_URL = "https://inference-api.nousresearch.com/v1"
+NOUS_API_CHAT_URL = f"{NOUS_API_BASE_URL}/chat/completions"

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -158,6 +158,29 @@ def test_custom_endpoint_auto_provider_prefers_openai_key(monkeypatch):
     assert resolved["api_key"] == "sk-vllm-key"
 
 
+def test_resolve_runtime_provider_nous_api(monkeypatch):
+    """Nous Portal API key provider resolves via the api_key path."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "nous-api")
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda pid: {
+            "provider": "nous-api",
+            "api_key": "nous-test-key",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "source": "NOUS_API_KEY",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="nous-api")
+
+    assert resolved["provider"] == "nous-api"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://inference-api.nousresearch.com/v1"
+    assert resolved["api_key"] == "nous-test-key"
+    assert resolved["requested_provider"] == "nous-api"
+
+
 def test_resolve_requested_provider_precedence(monkeypatch):
     monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "nous")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openai-codex"})


### PR DESCRIPTION
Add support for using Nous Portal via a direct API key, mirroring how OpenRouter and other API-key providers work. This gives users a simpler alternative to the OAuth device-code flow when they already have a Nous API key.

Changes:
- Add 'nous-api' to PROVIDER_REGISTRY as an api_key provider pointing to https://inference-api.nousresearch.com/v1
- Add NOUS_API_KEY and NOUS_BASE_URL to OPTIONAL_ENV_VARS
- Add NOUS_API_BASE_URL / NOUS_API_CHAT_URL to hermes_constants
- Add 'Nous Portal API key' as first option in setup wizard
- Add provider aliases (nous_api, nousapi, nous-portal-api)
- Add test for nous-api runtime provider resolution

Closes #644

## What does this PR do?                                                                          
                                                                                                     
   Adds support for using Nous Portal via a direct API key (`NOUS_API_KEY`), mirroring how           
 OpenRouter and other API-key providers (Z.AI, Kimi, MiniMax) already work. This gives users a       
 simpler alternative to the OAuth device-code flow when they already have a Nous API key.            
                                                                                                     
   ## Related Issue                                                                                  
                                                                                                     
   Fixes #644                                                                                        
                                                                                                     
   ## Type of Change                                                                                 
                                                                                                     
   - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)                                        
   - [x] ✨ New feature (non-breaking change that adds functionality)                                
   - [ ] 🔒 Security fix                                                                             
   - [ ] 📝 Documentation update                                                                     
   - [ ] ✅ Tests (adding or improving test coverage)                                                
   - [ ] ♻️ Refactor (no behavior change)                                                            
   - [ ] 🎯 New skill (bundled or hub)                                                               
                                                                                                     
   ## Changes Made                                                                                   
                                                                                                     
   - `hermes_constants.py` — Add `NOUS_API_BASE_URL` and `NOUS_API_CHAT_URL` constants               
   - `hermes_cli/auth.py` — Add `nous-api` to `PROVIDER_REGISTRY` as an `api_key` provider with      
 `NOUS_API_KEY` env var, optional `NOUS_BASE_URL` override, and aliases (`nous_api`, `nousapi`,      
 `nous-portal-api`)                                                                                  
   - `hermes_cli/config.py` — Add `NOUS_API_KEY` and `NOUS_BASE_URL` to `OPTIONAL_ENV_VARS`          
   - `hermes_cli/setup.py` — Add "Nous Portal API key" as first option in provider selection wizard, 
 with model prompt and proper index updates                                                          
   - `cli-config.yaml.example` — Add `nous-api` to provider comments                                 
   - `tests/test_runtime_provider_resolution.py` — Add `test_resolve_runtime_provider_nous_api`      
                                                                                                     
   ## How to Test                                                                                    
                                                                                                     
   1. Set `NOUS_API_KEY` via `hermes config set NOUS_API_KEY <key>` or `export NOUS_API_KEY=<key>`   
   2. Run `hermes setup` — "Nous Portal API key (direct API key access)" should appear as the first  
 provider option                                                                                     
   3. Select it, confirm it resolves to `https://inference-api.nousresearch.com/v1`                  
   4. Run `pytest tests/test_runtime_provider_resolution.py -v` — all 10 tests pass                  
                                                                                                     
   ## Checklist                                                                                      
                                                                                                     
   ### Code                                                                                          
                                                                                                     
   - [x] I've read the [Contributing                                                                 
 Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)                      
   - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)      
 (`fix(scope):`, `feat(scope):`, etc.)                                                               
   - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make   
 sure this isn't a duplicate                                                                         
   - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)          
   - [x] I've run `pytest tests/ -q` and all tests pass                                              
   - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)  
   - [x] I've tested on my platform: macOS (Apple Silicon)                                           
                                                                                                     
   ### Documentation & Housekeeping                                                                  
                                                                                                     
   - [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A                              
   - [x] I've updated `cli-config.yaml.example` if I added/changed config keys                                
   - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A           
   - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility                        
 guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)  
 — N/A                                                                                                        
   - [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A   
   - [ ] 
   ## Screenshots / Logs                                                                             
                                                                                                     
   N/A — no UI changes, configuration-only feature.