### PR TITLE
fix(file_tools): pass docker_volumes to sandbox container config

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -91,6 +91,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "container_memory": config.get("container_memory", 5120),
                     "container_disk": config.get("container_disk", 51200),
                     "container_persistent": config.get("container_persistent", True),
+                    "docker_volumes": config.get("docker_volumes", []),
                 }
             terminal_env = _create_environment(
                 env_type=env_type,


### PR DESCRIPTION
## Summary

`file_tools.py` creates its own Docker sandbox environment when `read_file`/`search_files`/`write_file`/`patch` runs before any terminal command. The `container_config` dict was missing `docker_volumes`, so the sandbox was created without any user volume mounts.

This means if a bot's first tool call in a session is a file operation (common — bots often read config files before running commands), the sandbox has no access to mounted data like heartbeat state, cron output, credentials, etc. All subsequent tools in that session reuse the same broken sandbox.

## Root cause

PR #158 (`feat: add docker_volumes config for custom volume mounts`) added `container_config` passing to `file_tools.py` but forgot to include the `docker_volumes` key. `terminal_tool.py` has it correctly at line 872.

## Changes

- Add `"docker_volumes": config.get("docker_volumes", [])` to `container_config` in `file_tools.py:_get_file_ops()`, matching `terminal_tool.py`

## How to reproduce

1. Configure `docker_volumes` in `config.yaml`
2. Start a session where the agent's **first** tool call is `read_file` (not `terminal`)
3. The sandbox container has no user volume mounts → file not found
4. If `terminal` runs first instead, sandbox is created correctly (with volumes) and file tools reuse it — masking the bug

## Test plan

- [x] Before fix: `read_file /home/pn/heartbeat-state/state.json` → error (file not found)
- [x] After fix: `read_file` successfully reads the file through mounted volume


🤖 Generated with [Claude Code](https://claude.com/claude-code)