### PR TITLE
fix(cli): auto-select Codex model when provider resolves to openai-codex

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1012,6 +1012,11 @@ class HermesCLI:
         # Configuration - priority: CLI args > env vars > config file
         # Model can come from: CLI arg, LLM_MODEL env, OPENAI_MODEL env (custom endpoint), or config
         self.model = model or os.getenv("LLM_MODEL") or os.getenv("OPENAI_MODEL") or CLI_CONFIG["model"]["default"]
+        # Track whether model was explicitly chosen by the user or fell back to the
+        # global default. Provider-specific normalisation may override the default
+        # at credential-resolution time but must never silently override an explicit
+        # user choice.
+        self._model_is_default = not (model or os.getenv("LLM_MODEL") or os.getenv("OPENAI_MODEL"))
 
         self._explicit_api_key = api_key
         self._explicit_base_url = base_url
@@ -1161,8 +1166,35 @@ class HermesCLI:
         self.api_key = api_key
         self.base_url = base_url
 
-        # AIAgent/OpenAI client holds auth at init time, so rebuild if key rotated
-        if (credentials_changed or routing_changed) and self.agent is not None:
+        # If the resolved provider is Codex, ensure the active model is
+        # Codex-compatible.  The Codex Responses API rejects non-Codex models
+        # (e.g. anthropic/claude-opus-4.6) with a 400 error — the root cause
+        # of issue #651.  We always normalise here regardless of whether the
+        # model came from a CLI arg, env-var, or the global config default.
+        if resolved_provider == "openai-codex":
+            current_model = (self.model or "").strip()
+            current_slug = current_model.split("/")[-1]
+            is_codex_model = "codex" in current_slug.lower()
+            if not is_codex_model:
+                try:
+                    from hermes_cli.codex_models import get_codex_model_ids
+                    codex_models = get_codex_model_ids(access_token=api_key)
+                    codex_default = codex_models[0] if codex_models else None
+                except Exception:
+                    codex_default = None
+                if codex_default:
+                    if not getattr(self, "_model_is_default", True):
+                        self.console.print(
+                            f"[yellow]⚠️  Model '{current_model}' is not supported with "
+                            f"OpenAI Codex; switching to '{codex_default}'.[/]"
+                        )
+                    self.model = codex_default
+
+        # AIAgent/OpenAI client holds auth at init time, so rebuild if key,
+        # routing, or effective model changed.
+        model_changed = getattr(self, "_last_agent_model", None) != self.model
+        self._last_agent_model = self.model
+        if (credentials_changed or routing_changed or model_changed) and self.agent is not None:
             self.agent = None
 
         return True

--- a/tests/gateway/test_retry_response.py
+++ b/tests/gateway/test_retry_response.py
@@ -1,0 +1,60 @@
+"""Regression test: /retry must return the agent response, not None.
+
+Before the fix in PR #441, _handle_retry_command() called
+_handle_message(retry_event) but discarded its return value with `return None`,
+so users never received the final response.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from gateway.run import GatewayRunner
+from gateway.platforms.base import MessageEvent, MessageType
+
+
+@pytest.fixture
+def gateway(tmp_path):
+    config = MagicMock()
+    config.sessions_dir = tmp_path
+    config.max_context_messages = 20
+    gw = GatewayRunner.__new__(GatewayRunner)
+    gw.config = config
+    gw.session_store = MagicMock()
+    return gw
+
+
+@pytest.mark.asyncio
+async def test_retry_returns_response_not_none(gateway):
+    """_handle_retry_command must return the inner handler response, not None."""
+    gateway.session_store.get_or_create_session.return_value = MagicMock(
+        session_id="test-session"
+    )
+    gateway.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "Hello Hermes"},
+        {"role": "assistant", "content": "Hi there!"},
+    ]
+    gateway.session_store.rewrite_transcript = MagicMock()
+    expected_response = "Hi there! (retried)"
+    gateway._handle_message = AsyncMock(return_value=expected_response)
+    event = MessageEvent(
+        text="/retry",
+        message_type=MessageType.TEXT,
+        source=MagicMock(),
+    )
+    result = await gateway._handle_retry_command(event)
+    assert result is not None, "/retry must not return None"
+    assert result == expected_response
+
+
+@pytest.mark.asyncio
+async def test_retry_no_previous_message(gateway):
+    """If there is no previous user message, return early with a message."""
+    gateway.session_store.get_or_create_session.return_value = MagicMock(
+        session_id="test-session"
+    )
+    gateway.session_store.load_transcript.return_value = []
+    event = MessageEvent(
+        text="/retry",
+        message_type=MessageType.TEXT,
+        source=MagicMock(),
+    )
+    result = await gateway._handle_retry_command(event)
+    assert result == "No previous message to retry."

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -185,3 +185,105 @@ def test_cmd_model_falls_back_to_auto_on_invalid_provider(monkeypatch, capsys):
     assert "Warning:" in output
     assert "falling back to auto provider detection" in output.lower()
     assert "No change." in output
+
+
+def test_incompatible_model_replaced_with_codex_model_from_config_default(monkeypatch):
+    """Root cause fix for #651 (config default path): when provider resolves to
+    openai-codex and no model was explicitly chosen, the global default
+    (anthropic/claude-opus-4.6) must be replaced with a Codex-compatible model."""
+    cli = _import_cli()
+
+    # Clear env-var model overrides so HermesCLI falls back to the config default
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "codex-token",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.2-codex", "gpt-5.1-codex-mini"],
+    )
+
+    shell = cli.HermesCLI(compact=True, max_turns=1)
+
+    assert shell._model_is_default is True
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.provider == "openai-codex"
+    assert "anthropic" not in shell.model
+    assert "claude" not in shell.model
+    assert shell.model == "gpt-5.2-codex"
+
+
+def test_incompatible_model_replaced_with_codex_model_from_env_var(monkeypatch):
+    """Root cause fix for #651 (env-var path): when LLM_MODEL is set to a
+    non-Codex model and provider resolves to openai-codex, the model must
+    still be replaced — this is the exact user scenario reported in #651."""
+    cli = _import_cli()
+
+    # Simulate the exact #651 scenario: LLM_MODEL set to an Anthropic model
+    monkeypatch.setenv("LLM_MODEL", "claude-opus-4-6")
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "codex-token",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.2-codex", "gpt-5.1-codex-mini"],
+    )
+
+    shell = cli.HermesCLI(compact=True, max_turns=1)
+
+    assert shell._model_is_default is False  # came from env var
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.provider == "openai-codex"
+    assert "claude" not in shell.model
+    assert shell.model == "gpt-5.2-codex"
+
+
+def test_explicit_codex_model_not_overridden(monkeypatch):
+    """If the user explicitly passes a Codex-compatible model, it must be
+    preserved even when the provider resolves to openai-codex."""
+    cli = _import_cli()
+
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "codex-token",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.2-codex"],
+    )
+
+    shell = cli.HermesCLI(model="gpt-5.1-codex-mini", compact=True, max_turns=1)
+
+    assert shell._model_is_default is False
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.model == "gpt-5.1-codex-mini"


### PR DESCRIPTION
## Problem

Fixes #651

When a user sets up Hermes with OpenAI Codex, any non-Codex model in `LLM_MODEL`, `OPENAI_MODEL`, or the config default (e.g. `anthropic/claude-opus-4.6`) causes an immediate 400 BadRequestError on every request:

```
Error code: 400 - {'detail': "The 'anthropic/claude-opus-4.6' model is not supported when using Codex with a ChatGPT account."}
```

## Root Cause

`HermesCLI.__init__` sets `self.model` from `LLM_MODEL` / `OPENAI_MODEL` env-vars or the config default before the provider is resolved. When `_ensure_runtime_credentials()` later resolves the provider to `openai-codex`, the incompatible model was never corrected.

PR #661 addressed only the config-default path and used a hardcoded fallback model (`gpt-5.3-codex`). This PR fixes the root cause for all model sources including env-vars, which is the exact scenario reported in #651.

## Fix

In `_ensure_runtime_credentials()`, after the provider resolves to `openai-codex`, check whether the active model is Codex-compatible. If not, replace it with the first model returned by `get_codex_model_ids()` and warn the user if they had explicitly set the model.

## Changes

- **cli.py**: Add `_model_is_default` flag to track explicit vs default model selection
- **cli.py**: In `_ensure_runtime_credentials()`, normalise incompatible models when provider is `openai-codex` — covers CLI arg, env-var, and config default paths
- **cli.py**: Trigger agent rebuild when effective model changes
- **tests/test_cli_provider_resolution.py**: Add 3 tests covering config-default path, env-var path (exact #651 scenario), and explicit Codex model preservation

## Testing

```
pytest tests/test_cli_provider_resolution.py tests/test_codex_models.py -q
9 passed in 2.92s
```

Full suite: 2063 passed, 0 failed.