### PR TITLE
fix(config): atomic write for config.yaml to prevent data loss on crash

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -622,11 +622,11 @@ def load_config() -> Dict[str, Any]:
 
 def save_config(config: Dict[str, Any]):
     """Save configuration to ~/.hermes/config.yaml."""
+    from utils import atomic_yaml_write
+
     ensure_hermes_home()
     config_path = get_config_path()
-    
-    with open(config_path, 'w') as f:
-        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+    atomic_yaml_write(config_path, config)
 
 
 def load_env() -> Dict[str, str]:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -2,7 +2,9 @@
 
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+
+import yaml
 
 from hermes_cli.config import (
     DEFAULT_CONFIG,
@@ -66,3 +68,62 @@ class TestSaveAndLoadRoundtrip:
 
             reloaded = load_config()
             assert reloaded["terminal"]["timeout"] == 999
+
+
+class TestSaveConfigAtomicity:
+    """Verify save_config uses atomic writes (tempfile + os.replace)."""
+
+    def test_no_partial_write_on_crash(self, tmp_path):
+        """If save_config crashes mid-write, the previous file stays intact."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            # Write an initial config
+            config = load_config()
+            config["model"] = "original-model"
+            save_config(config)
+
+            config_path = tmp_path / "config.yaml"
+            assert config_path.exists()
+
+            # Simulate a crash during yaml.dump by making atomic_yaml_write's
+            # yaml.dump raise after the temp file is created but before replace.
+            with patch("utils.yaml.dump", side_effect=OSError("disk full")):
+                try:
+                    config["model"] = "should-not-persist"
+                    save_config(config)
+                except OSError:
+                    pass
+
+            # Original file must still be intact
+            reloaded = load_config()
+            assert reloaded["model"] == "original-model"
+
+    def test_no_leftover_temp_files(self, tmp_path):
+        """Failed writes must clean up their temp files."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            save_config(config)
+
+            with patch("utils.yaml.dump", side_effect=OSError("disk full")):
+                try:
+                    save_config(config)
+                except OSError:
+                    pass
+
+            # No .tmp files should remain
+            tmp_files = list(tmp_path.glob(".*config*.tmp"))
+            assert tmp_files == []
+
+    def test_atomic_write_creates_valid_yaml(self, tmp_path):
+        """The written file must be valid YAML matching the input."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            config["model"] = "test/atomic-model"
+            config["max_turns"] = 77
+            save_config(config)
+
+            # Read raw YAML to verify it's valid and correct
+            config_path = tmp_path / "config.yaml"
+            with open(config_path) as f:
+                raw = yaml.safe_load(f)
+            assert raw["model"] == "test/atomic-model"
+            assert raw["max_turns"] == 77

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,8 @@ import tempfile
 from pathlib import Path
 from typing import Any, Union
 
+import yaml
+
 
 def atomic_json_write(path: Union[str, Path], data: Any, *, indent: int = 2) -> None:
     """Write JSON data to a file atomically.
@@ -30,6 +32,47 @@ def atomic_json_write(path: Union[str, Path], data: Any, *, indent: int = 2) -> 
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=indent, ensure_ascii=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_yaml_write(
+    path: Union[str, Path],
+    data: Any,
+    *,
+    default_flow_style: bool = False,
+    sort_keys: bool = False,
+) -> None:
+    """Write YAML data to a file atomically.
+
+    Uses temp file + fsync + os.replace to ensure the target file is never
+    left in a partially-written state.  If the process crashes mid-write,
+    the previous version of the file remains intact.
+
+    Args:
+        path: Target file path (will be created or overwritten).
+        data: YAML-serializable data to write.
+        default_flow_style: YAML flow style (default False).
+        sort_keys: Whether to sort dict keys (default False).
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.stem}_",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, default_flow_style=default_flow_style, sort_keys=sort_keys)
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp_path, path)


### PR DESCRIPTION
save_config() was using open("w") which truncates the file immediately.
A crash mid-write leaves config.yaml empty — on next start, load_config()
catches the parse error and silently returns defaults. The user's model,
personality, and tool settings all reset with no warning.

Same tempfile.mkstemp + os.replace pattern already used in
gateway/session.py and cron/jobs.py.

Added 3 tests covering the crash simulation, temp file cleanup, and
valid YAML output.