### PR TITLE
fix(ui): improve command formatting across CLI and gateway

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -343,9 +343,10 @@ def load_cli_config() -> Dict[str, Any]:
 # Load configuration at module startup
 CLI_CONFIG = load_cli_config()
 
-from rich.console import Console
+from rich.console import Console, Group
 from rich.panel import Panel
 from rich.table import Table
+from rich import box
 
 import fire
 
@@ -949,6 +950,31 @@ def _cli_render_section(title: str, entries: list[tuple[str, str]], *, command_w
     for command, description in entries:
         lines.append(f"    {_GOLD}{command:<{width}}{_RST} {_DIM}-{_RST} {description}")
     return "\n".join(lines)
+
+
+def _cli_render_value_section(title: str, entries: list[tuple[str, str]], *, key_width: int | None = None) -> str:
+    """Render aligned key/value rows as a single ANSI string."""
+    width = key_width or (max(len(key) for key, _ in entries) + 2)
+    lines = [f"", f"  {_BOLD}{title}{_RST}"]
+    for key, value in entries:
+        lines.append(f"    {_GOLD}{key:<{width}}{_RST} {_DIM}:{_RST} {value}")
+    return "\n".join(lines)
+
+
+def _render_rich(*renderables) -> str:
+    """Render Rich objects to a single ANSI string for prompt_toolkit output."""
+    from io import StringIO
+
+    buffer = StringIO()
+    console = Console(
+        file=buffer,
+        force_terminal=True,
+        highlight=False,
+        width=_terminal_columns(),
+    )
+    for renderable in renderables:
+        console.print(renderable)
+    return buffer.getvalue().rstrip("\n")
 
 
 def save_config_value(key_path: str, value: any) -> bool:
@@ -1569,40 +1595,47 @@ class HermesCLI:
         if not tools:
             print("(;_;) No tools available")
             return
-        
-        # Header
-        print()
-        title = "(^_^)/ Available Tools"
-        width = 78
-        pad = width - len(title)
-        print("+" + "-" * width + "+")
-        print("|" + " " * (pad // 2) + title + " " * (pad - pad // 2) + "|")
-        print("+" + "-" * width + "+")
-        print()
-        
-        # Group tools by toolset
-        toolsets = {}
+
+        rows = []
+        tool_preview_length = _dynamic_preview_length(
+            command_width=28,
+            indent=16,
+            minimum=52,
+            maximum=120,
+        )
         for tool in sorted(tools, key=lambda t: t["function"]["name"]):
             name = tool["function"]["name"]
             toolset = get_toolset_for_tool(name) or "unknown"
-            if toolset not in toolsets:
-                toolsets[toolset] = []
             desc = tool["function"].get("description", "")
             # First sentence: split on ". " (period+space) to avoid breaking on "e.g." or "v2.0"
             desc = desc.split("\n")[0]
             if ". " in desc:
                 desc = desc[:desc.index(". ") + 1]
-            toolsets[toolset].append((name, desc))
-        
-        # Display by toolset
-        for toolset in sorted(toolsets.keys()):
-            print(f"  [{toolset}]")
-            for name, desc in toolsets[toolset]:
-                print(f"    * {name:<20} - {desc}")
-            print()
-        
-        print(f"  Total: {len(tools)} tools  ヽ(^o^)ノ")
-        print()
+            rows.append((toolset, name, _preview_text(desc, tool_preview_length)))
+
+        table = Table(
+            show_header=True,
+            header_style="bold",
+            box=box.SIMPLE_HEAVY,
+            expand=True,
+        )
+        table.add_column("Toolset", style="bold cyan", no_wrap=True)
+        table.add_column("Tool", style="bold yellow", no_wrap=True)
+        table.add_column("Description", style="white")
+
+        for toolset, name, desc in rows:
+            table.add_row(toolset, name, desc)
+
+        panel = Panel(
+            Group(
+                table,
+                f"[dim]Total: {len(tools)} tools  ヽ(^o^)ノ[/]",
+            ),
+            title="(^_^)/ Available Tools",
+            border_style="bright_black",
+            padding=(0, 1),
+        )
+        _cprint(_render_rich("", panel, ""))
     
     def show_toolsets(self):
         """Display available toolsets with kawaii ASCII art."""
@@ -1651,39 +1684,52 @@ class HermesCLI:
         config_status = "(loaded)" if config_path.exists() else "(not found)"
         
         api_key_display = '********' + self.api_key[-4:] if self.api_key and len(self.api_key) > 4 else 'Not set!'
-        
-        print()
-        title = "(^_^) Configuration"
-        width = 50
-        pad = width - len(title)
-        print("+" + "-" * width + "+")
-        print("|" + " " * (pad // 2) + title + " " * (pad - pad // 2) + "|")
-        print("+" + "-" * width + "+")
-        print()
-        print("  -- Model --")
-        print(f"  Model:     {self.model}")
-        print(f"  Base URL:  {self.base_url}")
-        print(f"  API Key:   {api_key_display}")
-        print()
-        print("  -- Terminal --")
-        print(f"  Environment:  {terminal_env}")
+
+        terminal_entries = [
+            ("Environment", terminal_env),
+            ("Working Dir", terminal_cwd),
+            ("Timeout", f"{terminal_timeout}s"),
+        ]
         if terminal_env == "ssh":
             ssh_host = os.getenv("TERMINAL_SSH_HOST", "not set")
             ssh_user = os.getenv("TERMINAL_SSH_USER", "not set")
             ssh_port = os.getenv("TERMINAL_SSH_PORT", "22")
-            print(f"  SSH Target:   {ssh_user}@{ssh_host}:{ssh_port}")
-        print(f"  Working Dir:  {terminal_cwd}")
-        print(f"  Timeout:      {terminal_timeout}s")
-        print()
-        print("  -- Agent --")
-        print(f"  Max Turns:  {self.max_turns}")
-        print(f"  Toolsets:   {', '.join(self.enabled_toolsets) if self.enabled_toolsets else 'all'}")
-        print(f"  Verbose:    {self.verbose}")
-        print()
-        print("  -- Session --")
-        print(f"  Started:     {self.session_start.strftime('%Y-%m-%d %H:%M:%S')}")
-        print(f"  Config File: {config_path} {config_status}")
-        print()
+            terminal_entries.append(("SSH Target", f"{ssh_user}@{ssh_host}:{ssh_port}"))
+
+        def _config_table(title: str, entries: list[tuple[str, str]]) -> Group:
+            table = Table.grid(padding=(0, 2), expand=False)
+            table.add_column(style="bold yellow", no_wrap=True, width=12)
+            table.add_column(style="white")
+            for key, value in entries:
+                table.add_row(key, value)
+            return Group(f"[bold]{title}[/]", table)
+
+        panel = Panel.fit(
+            Group(
+                _config_table("Model", [
+                    ("Model", self.model),
+                    ("Base URL", self.base_url),
+                    ("API Key", api_key_display),
+                ]),
+                "",
+                _config_table("Terminal", terminal_entries),
+                "",
+                _config_table("Agent", [
+                    ("Max Turns", str(self.max_turns)),
+                    ("Toolsets", ", ".join(self.enabled_toolsets) if self.enabled_toolsets else "all"),
+                    ("Verbose", str(self.verbose)),
+                ]),
+                "",
+                _config_table("Session", [
+                    ("Started", self.session_start.strftime('%Y-%m-%d %H:%M:%S')),
+                    ("Config File", f"{config_path} {config_status}"),
+                ]),
+            ),
+            title="(^_^) Configuration",
+            border_style="bright_black",
+            padding=(0, 1),
+        )
+        _cprint(_render_rich("", panel, ""))
     
     def show_history(self):
         """Display conversation history."""
@@ -1917,26 +1963,35 @@ class HermesCLI:
                 print(f"  Available: {', '.join(self.personalities.keys())}")
         else:
             # Show available personalities
-            print()
-            print("+" + "-" * 50 + "+")
-            print("|" + " " * 12 + "(^o^)/ Personalities" + " " * 15 + "|")
-            print("+" + "-" * 50 + "+")
-            print()
             names = sorted(self.personalities)
             personality_preview_length = _dynamic_preview_length(
-                indent=8,
+                command_width=16,
+                indent=18,
                 minimum=48,
                 maximum=100,
             )
-            for index, name in enumerate(names):
+            table = Table(
+                show_header=True,
+                header_style="bold",
+                box=box.SIMPLE_HEAVY,
+                expand=True,
+            )
+            table.add_column("Name", style="bold cyan", no_wrap=True, width=16)
+            table.add_column("Preview", style="white")
+            for name in names:
                 preview = _preview_text(self.personalities[name], max_length=personality_preview_length)
-                print(f"  {name}")
-                print(f"    {preview}")
-                if index != len(names) - 1:
-                    print("    " + "-" * 42)
-            print()
-            print("  Usage: /personality <name>")
-            print()
+                table.add_row(name, preview)
+
+            panel = Panel(
+                Group(
+                    table,
+                    "[dim]Usage: /personality <name>[/]",
+                ),
+                title="(^o^)/ Personalities",
+                border_style="bright_black",
+                padding=(0, 1),
+            )
+            _cprint(_render_rich("", panel, ""))
     
     def _handle_cron_command(self, cmd: str):
         """Handle the /cron command to manage scheduled tasks."""
@@ -2335,17 +2390,35 @@ class HermesCLI:
             else:
                 current = raw_provider
             current_label = _PROVIDER_LABELS.get(current, current)
-            print(f"\n  Current provider: {current_label} ({current})\n")
             providers = list_available_providers()
-            print("  Available providers:")
+            table = Table(
+                show_header=True,
+                header_style="bold",
+                box=box.SIMPLE_HEAVY,
+                expand=True,
+            )
+            table.add_column("Status", style="bold", no_wrap=True, width=6)
+            table.add_column("Provider", style="bold cyan", no_wrap=True, width=14)
+            table.add_column("Label", style="white")
             for p in providers:
                 marker = " ← active" if p["id"] == current else ""
                 auth = "✓" if p["authenticated"] else "✗"
-                aliases = f"  (also: {', '.join(p['aliases'])})" if p["aliases"] else ""
-                print(f"    [{auth}] {p['id']:<14} {p['label']}{aliases}{marker}")
-            print()
-            print("  Switch: /model provider:model-name")
-            print("  Setup:  hermes setup")
+                aliases = f" (also: {', '.join(p['aliases'])})" if p["aliases"] else ""
+                table.add_row(f"[{auth}]", p["id"], f"{p['label']}{aliases}{marker}")
+            panel = Panel.fit(
+                Group(
+                    f"[bold]Current provider:[/] {current_label} ({current})",
+                    "",
+                    table,
+                    "",
+                    "[dim]Switch: /model provider:model-name[/]",
+                    "[dim]Setup:  hermes setup[/]",
+                ),
+                title="(^_^)/ Providers",
+                border_style="bright_black",
+                padding=(0, 1),
+            )
+            _cprint(_render_rich("", panel, ""))
         elif cmd_lower.startswith("/prompt"):
             # Use original case so prompt text isn't lowercased
             self._handle_prompt_command(cmd_original)

--- a/cli.py
+++ b/cli.py
@@ -914,6 +914,22 @@ from agent.skill_commands import scan_skill_commands, get_skill_commands, build_
 _skill_commands = scan_skill_commands()
 
 
+def _preview_text(text: str, max_length: int = 96) -> str:
+    """Collapse whitespace so long descriptions stay readable."""
+    preview = " ".join(str(text).split())
+    if len(preview) <= max_length:
+        return preview
+    return preview[: max_length - 3].rstrip() + "..."
+
+
+def _cli_print_section(title: str, entries: list[tuple[str, str]], *, command_width: int | None = None) -> None:
+    """Render an aligned command section in the interactive CLI."""
+    width = command_width or (max(len(command) for command, _ in entries) + 2)
+    _cprint(f"\n  {_BOLD}{title}{_RST}")
+    for command, description in entries:
+        _cprint(f"    {_GOLD}{command:<{width}}{_RST} {_DIM}-{_RST} {description}")
+
+
 def save_config_value(key_path: str, value: any) -> bool:
     """
     Save a value to the active config file at the specified key path.
@@ -1441,14 +1457,66 @@ class HermesCLI:
         _cprint(f"\n{_BOLD}+{'-' * 50}+{_RST}")
         _cprint(f"{_BOLD}|{' ' * 14}(^_^)? Available Commands{' ' * 10}|{_RST}")
         _cprint(f"{_BOLD}+{'-' * 50}+{_RST}\n")
-        
-        for cmd, desc in COMMANDS.items():
-            _cprint(f"  {_GOLD}{cmd:<15}{_RST} {_DIM}-{_RST} {desc}")
-        
+
+        sections = [
+            (
+                "Session",
+                [
+                    ("/new", "Start a new session with a fresh conversation"),
+                    ("/reset", "Clear the current session's conversation history"),
+                    ("/clear", "Clear the screen and reset the conversation"),
+                    ("/history", "Show conversation history"),
+                    ("/retry", "Retry the last message"),
+                    ("/undo", "Remove the last exchange"),
+                    ("/save", "Save the current conversation"),
+                    ("/quit", "Exit the CLI"),
+                ],
+            ),
+            (
+                "Configuration",
+                [
+                    ("/model", "Show or change the current model"),
+                    ("/provider", "Show available providers and current provider"),
+                    ("/prompt", "View or set a custom system prompt"),
+                    ("/personality", "List or switch predefined personalities"),
+                    ("/config", "Show current configuration"),
+                    ("/verbose", "Cycle tool progress display modes"),
+                ],
+            ),
+            (
+                "Tools & Platform",
+                [
+                    ("/tools", "List available tools"),
+                    ("/toolsets", "List available toolsets"),
+                    ("/skills", "Search, install, inspect, or manage skills"),
+                    ("/platforms", "Show gateway and messaging platform status"),
+                    ("/reload-mcp", "Reload MCP servers from config.yaml"),
+                    ("/paste", "Attach an image from the clipboard"),
+                ],
+            ),
+            (
+                "Context & Automation",
+                [
+                    ("/compress", "Manually compress conversation context"),
+                    ("/usage", "Show token usage for the current session"),
+                    ("/insights", "Show usage insights and analytics"),
+                    ("/cron", "Manage scheduled tasks"),
+                    ("/help", "Show this message"),
+                ],
+            ),
+        ]
+
+        for title, entries in sections:
+            _cli_print_section(title, entries)
+
         if _skill_commands:
-            _cprint(f"\n  ⚡ {_BOLD}Skill Commands{_RST} ({len(_skill_commands)} installed):")
-            for cmd, info in sorted(_skill_commands.items()):
-                _cprint(f"  {_GOLD}{cmd:<22}{_RST} {_DIM}-{_RST} {info['description']}")
+            skill_entries = [
+                (cmd, _preview_text(info.get("description", "Skill command")))
+                for cmd, info in sorted(_skill_commands.items())
+            ]
+            _cprint(f"\n  ⚡ {_BOLD}Skill Commands{_RST} ({len(_skill_commands)} installed)")
+            _cprint(f"    {_DIM}Use a skill command directly to run it.{_RST}")
+            _cli_print_section("Installed Skills", skill_entries, command_width=24)
 
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
         _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
@@ -1814,8 +1882,13 @@ class HermesCLI:
             print("|" + " " * 12 + "(^o^)/ Personalities" + " " * 15 + "|")
             print("+" + "-" * 50 + "+")
             print()
-            for name, prompt in self.personalities.items():
-                print(f"  {name:<12} - \"{prompt}\"")
+            names = sorted(self.personalities)
+            for index, name in enumerate(names):
+                preview = _preview_text(self.personalities[name], max_length=76)
+                print(f"  {name}")
+                print(f"    {preview}")
+                if index != len(names) - 1:
+                    print("    " + "-" * 42)
             print()
             print("  Usage: /personality <name>")
             print()

--- a/cli.py
+++ b/cli.py
@@ -922,12 +922,33 @@ def _preview_text(text: str, max_length: int = 96) -> str:
     return preview[: max_length - 3].rstrip() + "..."
 
 
+def _terminal_columns(default: int = 100) -> int:
+    """Return terminal width with a sane fallback for tests and non-TTY runs."""
+    try:
+        return shutil.get_terminal_size(fallback=(default, 24)).columns
+    except Exception:
+        return default
+
+
+def _dynamic_preview_length(*, command_width: int = 0, indent: int = 0,
+                            minimum: int = 36, maximum: int = 120) -> int:
+    """Choose a preview width based on the current terminal size."""
+    available = _terminal_columns() - command_width - indent
+    return max(minimum, min(maximum, available))
+
+
 def _cli_print_section(title: str, entries: list[tuple[str, str]], *, command_width: int | None = None) -> None:
     """Render an aligned command section in the interactive CLI."""
+    _cprint(_cli_render_section(title, entries, command_width=command_width))
+
+
+def _cli_render_section(title: str, entries: list[tuple[str, str]], *, command_width: int | None = None) -> str:
+    """Render an aligned command section as a single ANSI string."""
     width = command_width or (max(len(command) for command, _ in entries) + 2)
-    _cprint(f"\n  {_BOLD}{title}{_RST}")
+    lines = [f"", f"  {_BOLD}{title}{_RST}"]
     for command, description in entries:
-        _cprint(f"    {_GOLD}{command:<{width}}{_RST} {_DIM}-{_RST} {description}")
+        lines.append(f"    {_GOLD}{command:<{width}}{_RST} {_DIM}-{_RST} {description}")
+    return "\n".join(lines)
 
 
 def save_config_value(key_path: str, value: any) -> bool:
@@ -1454,9 +1475,13 @@ class HermesCLI:
     
     def show_help(self):
         """Display help information."""
-        _cprint(f"\n{_BOLD}+{'-' * 50}+{_RST}")
-        _cprint(f"{_BOLD}|{' ' * 14}(^_^)? Available Commands{' ' * 10}|{_RST}")
-        _cprint(f"{_BOLD}+{'-' * 50}+{_RST}\n")
+        lines = [
+            "",
+            f"{_BOLD}+{'-' * 50}+{_RST}",
+            f"{_BOLD}|{' ' * 14}(^_^)? Available Commands{' ' * 10}|{_RST}",
+            f"{_BOLD}+{'-' * 50}+{_RST}",
+            "",
+        ]
 
         sections = [
             (
@@ -1507,20 +1532,35 @@ class HermesCLI:
         ]
 
         for title, entries in sections:
-            _cli_print_section(title, entries)
+            lines.append(_cli_render_section(title, entries))
 
         if _skill_commands:
+            skill_width = 24
+            skill_preview_length = _dynamic_preview_length(
+                command_width=skill_width,
+                indent=12,
+                minimum=48,
+                maximum=120,
+            )
             skill_entries = [
-                (cmd, _preview_text(info.get("description", "Skill command")))
+                (cmd, _preview_text(info.get("description", "Skill command"), skill_preview_length))
                 for cmd, info in sorted(_skill_commands.items())
             ]
-            _cprint(f"\n  ⚡ {_BOLD}Skill Commands{_RST} ({len(_skill_commands)} installed)")
-            _cprint(f"    {_DIM}Use a skill command directly to run it.{_RST}")
-            _cli_print_section("Installed Skills", skill_entries, command_width=24)
+            lines.extend([
+                "",
+                f"  ⚡ {_BOLD}Skill Commands{_RST} ({len(_skill_commands)} installed)",
+                f"    {_DIM}Use a skill command directly to run it.{_RST}",
+                _cli_render_section("Installed Skills", skill_entries, command_width=skill_width),
+            ])
 
-        _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
-        _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
-        _cprint(f"  {_DIM}Paste image: Alt+V (or /paste){_RST}\n")
+        lines.extend([
+            "",
+            f"  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}",
+            f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}",
+            f"  {_DIM}Paste image: Alt+V (or /paste){_RST}",
+            "",
+        ])
+        _cprint("\n".join(lines))
     
     def show_tools(self):
         """Display available tools with kawaii ASCII art."""
@@ -1883,8 +1923,13 @@ class HermesCLI:
             print("+" + "-" * 50 + "+")
             print()
             names = sorted(self.personalities)
+            personality_preview_length = _dynamic_preview_length(
+                indent=8,
+                minimum=48,
+                maximum=100,
+            )
             for index, name in enumerate(names):
-                preview = _preview_text(self.personalities[name], max_length=76)
+                preview = _preview_text(self.personalities[name], max_length=personality_preview_length)
                 print(f"  {name}")
                 print(f"    {preview}")
                 if index != len(names) - 1:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -158,10 +158,17 @@ def _resolve_runtime_agent_kwargs() -> dict:
 
 
 def _format_gateway_section(title: str, entries: list[tuple[str, str]]) -> list[str]:
-    """Render a titled markdown section with one command per line."""
-    lines = [f"**{title}**"]
+    """Render a titled markdown section with aligned command rows."""
+    return [f"**{title}**", *_format_gateway_rows(entries)]
+
+
+def _format_gateway_rows(entries: list[tuple[str, str]]) -> list[str]:
+    """Render aligned rows inside a fenced code block."""
+    command_width = max(len(command) for command, _ in entries) + 2
+    lines = ["```text"]
     for command, description in entries:
-        lines.append(f"`{command}` — {description}")
+        lines.append(f"{command:<{command_width}}{description}")
+    lines.append("```")
     return lines
 
 
@@ -171,6 +178,11 @@ def _format_personality_preview(prompt: str, max_length: int = 72) -> str:
     if len(preview) <= max_length:
         return preview
     return preview[: max_length - 3].rstrip() + "..."
+
+
+def _format_skill_command_preview(description: str, max_length: int = 96) -> str:
+    """Keep skill command descriptions compact in /help output."""
+    return _format_personality_preview(description, max_length=max_length)
 
 
 class GatewayRunner:
@@ -1353,8 +1365,13 @@ class GatewayRunner:
             if skill_cmds:
                 lines.append("")
                 lines.append(f"⚡ **Skill Commands** ({len(skill_cmds)} installed)")
+                lines.append("Use a skill command directly to run it.")
+                skill_entries = []
                 for cmd in sorted(skill_cmds):
-                    lines.append(f"`{cmd}` — {skill_cmds[cmd]['description']}")
+                    description = str(skill_cmds[cmd].get("description", "Skill command"))
+                    preview = _format_skill_command_preview(description)
+                    skill_entries.append((cmd, preview))
+                lines.extend(_format_gateway_rows(skill_entries))
         except Exception:
             pass
         return "\n".join(lines)
@@ -1570,7 +1587,7 @@ class GatewayRunner:
             lines = ["🎭 **Available Personalities**"]
             for name in sorted(personalities):
                 lines.append("")
-                lines.append(f"`{name}`")
+                lines.append(f"**{name}**")
                 lines.append(_format_personality_preview(str(personalities[name])))
             lines.append("")
             lines.append("Use `/personality <name>` to switch.")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1546,16 +1546,18 @@ class GatewayRunner:
         lines = [
             f"🔌 **Current provider:** {current_label} (`{current_provider}`)",
             "",
-            "**Available providers:**",
+            "**Available providers**",
+            "```text",
         ]
 
         providers = list_available_providers()
         for p in providers:
             marker = " ← active" if p["id"] == current_provider else ""
             auth = "✅" if p["authenticated"] else "❌"
-            aliases = f"  _(also: {', '.join(p['aliases'])})_" if p["aliases"] else ""
-            lines.append(f"{auth} `{p['id']}` — {p['label']}{aliases}{marker}")
+            aliases = f" ({', '.join(p['aliases'])})" if p["aliases"] else ""
+            lines.append(f"{auth} {p['id']:<12} {p['label']}{aliases}{marker}")
 
+        lines.append("```")
         lines.append("")
         lines.append("Switch: `/model provider:model-name`")
         lines.append("Setup: `hermes setup`")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -157,6 +157,22 @@ def _resolve_runtime_agent_kwargs() -> dict:
     }
 
 
+def _format_gateway_section(title: str, entries: list[tuple[str, str]]) -> list[str]:
+    """Render a titled markdown section with one command per line."""
+    lines = [f"**{title}**"]
+    for command, description in entries:
+        lines.append(f"`{command}` — {description}")
+    return lines
+
+
+def _format_personality_preview(prompt: str, max_length: int = 72) -> str:
+    """Collapse whitespace so personality previews stay readable in chat."""
+    preview = " ".join(prompt.split())
+    if len(preview) <= max_length:
+        return preview
+    return preview[: max_length - 3].rstrip() + "..."
+
+
 class GatewayRunner:
     """
     Main gateway controller.
@@ -1288,30 +1304,55 @@ class GatewayRunner:
     
     async def _handle_help_command(self, event: MessageEvent) -> str:
         """Handle /help command - list available commands."""
-        lines = [
-            "📖 **Hermes Commands**\n",
-            "`/new` — Start a new conversation",
-            "`/reset` — Reset conversation history",
-            "`/status` — Show session info",
-            "`/stop` — Interrupt the running agent",
-            "`/model [provider:model]` — Show/change model (or switch provider)",
-            "`/provider` — Show available providers and auth status",
-            "`/personality [name]` — Set a personality",
-            "`/retry` — Retry your last message",
-            "`/undo` — Remove the last exchange",
-            "`/sethome` — Set this chat as the home channel",
-            "`/compress` — Compress conversation context",
-            "`/usage` — Show token usage for this session",
-            "`/insights [days]` — Show usage insights and analytics",
-            "`/reload-mcp` — Reload MCP servers from config",
-            "`/update` — Update Hermes Agent to the latest version",
-            "`/help` — Show this message",
+        sections = [
+            (
+                "Session",
+                [
+                    ("/new", "Start a new session with a fresh conversation"),
+                    ("/reset", "Clear the current session's conversation history"),
+                    ("/status", "Show session info"),
+                    ("/stop", "Interrupt the running agent"),
+                    ("/retry", "Retry your last message"),
+                    ("/undo", "Remove the last exchange"),
+                ],
+            ),
+            (
+                "Configuration",
+                [
+                    ("/model [provider:model]", "Show or change the current model"),
+                    ("/provider", "Show available providers and auth status"),
+                    ("/personality [name]", "List or switch personalities"),
+                    ("/sethome", "Set this chat as the home channel"),
+                    ("/reload-mcp", "Reload MCP servers from config"),
+                ],
+            ),
+            (
+                "Context",
+                [
+                    ("/compress", "Compress conversation context"),
+                    ("/usage", "Show token usage for this session"),
+                    ("/insights [days]", "Show usage insights and analytics"),
+                ],
+            ),
+            (
+                "Maintenance",
+                [
+                    ("/update", "Update Hermes Agent to the latest version"),
+                    ("/help", "Show this message"),
+                ],
+            ),
         ]
+
+        lines = ["📖 **Hermes Commands**"]
+        for title, entries in sections:
+            lines.append("")
+            lines.extend(_format_gateway_section(title, entries))
         try:
             from agent.skill_commands import get_skill_commands
             skill_cmds = get_skill_commands()
             if skill_cmds:
-                lines.append(f"\n⚡ **Skill Commands** ({len(skill_cmds)} installed):")
+                lines.append("")
+                lines.append(f"⚡ **Skill Commands** ({len(skill_cmds)} installed)")
                 for cmd in sorted(skill_cmds):
                     lines.append(f"`{cmd}` — {skill_cmds[cmd]['description']}")
         except Exception:
@@ -1526,11 +1567,13 @@ class GatewayRunner:
             return "No personalities configured in `~/.hermes/config.yaml`"
 
         if not args:
-            lines = ["🎭 **Available Personalities**\n"]
-            for name, prompt in personalities.items():
-                preview = prompt[:50] + "..." if len(prompt) > 50 else prompt
-                lines.append(f"• `{name}` — {preview}")
-            lines.append(f"\nUsage: `/personality <name>`")
+            lines = ["🎭 **Available Personalities**"]
+            for name in sorted(personalities):
+                lines.append("")
+                lines.append(f"`{name}`")
+                lines.append(_format_personality_preview(str(personalities[name])))
+            lines.append("")
+            lines.append("Use `/personality <name>` to switch.")
             return "\n".join(lines)
 
         if args in personalities:

--- a/tests/gateway/test_help_personality_formatting.py
+++ b/tests/gateway/test_help_personality_formatting.py
@@ -1,0 +1,106 @@
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/help", platform=Platform.TELEGRAM,
+                user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    return runner
+
+
+class TestHelpFormatting:
+    @pytest.mark.asyncio
+    async def test_help_output_groups_commands_into_sections(self):
+        runner = _make_runner()
+
+        result = await runner._handle_help_command(_make_event(text="/help"))
+
+        assert "📖 **Hermes Commands**" in result
+        assert "**Session**" in result
+        assert "**Configuration**" in result
+        assert "**Context**" in result
+        assert "**Maintenance**" in result
+        assert "`/new` — Start a new session with a fresh conversation" in result
+        assert "`/personality [name]` — List or switch personalities" in result
+        assert "`/update` — Update Hermes Agent to the latest version" in result
+
+    @pytest.mark.asyncio
+    async def test_help_output_separates_skill_commands_section(self):
+        runner = _make_runner()
+
+        with patch("agent.skill_commands.get_skill_commands", return_value={
+            "/gif-search": {"description": "Search for GIFs across providers"},
+        }):
+            result = await runner._handle_help_command(_make_event(text="/help"))
+
+        assert "⚡ **Skill Commands** (1 installed)" in result
+        assert "\n\n⚡ **Skill Commands** (1 installed)\n`/gif-search` — Search for GIFs across providers" in result
+
+
+class TestPersonalityFormatting:
+    @pytest.mark.asyncio
+    async def test_personality_list_is_sorted_and_separated(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "agent:\n"
+            "  personalities:\n"
+            "    zebra: |\n"
+            "      A personality with extra spacing\n"
+            "      for tests.\n"
+            "    alpha: 'Short and direct.'\n"
+        )
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            result = await runner._handle_personality_command(
+                _make_event(text="/personality")
+            )
+
+        assert result.startswith("🎭 **Available Personalities**")
+        assert "\n\n`alpha`\nShort and direct." in result
+        assert "\n\n`zebra`\nA personality with extra spacing for tests." in result
+        assert result.index("`alpha`") < result.index("`zebra`")
+        assert result.endswith("Use `/personality <name>` to switch.")
+
+    @pytest.mark.asyncio
+    async def test_personality_preview_truncates_long_prompt(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "agent:\n"
+            "  personalities:\n"
+            "    builder: '"
+            + ("very long prompt " * 10)
+            + "'\n"
+        )
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            result = await runner._handle_personality_command(
+                _make_event(text="/personality")
+            )
+
+        assert "`builder`" in result
+        assert "..." in result
+        assert "very long prompt very long prompt" in result

--- a/tests/gateway/test_help_personality_formatting.py
+++ b/tests/gateway/test_help_personality_formatting.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import patch
 
 import pytest
@@ -38,9 +39,9 @@ class TestHelpFormatting:
         assert "**Configuration**" in result
         assert "**Context**" in result
         assert "**Maintenance**" in result
-        assert "`/new` — Start a new session with a fresh conversation" in result
-        assert "`/personality [name]` — List or switch personalities" in result
-        assert "`/update` — Update Hermes Agent to the latest version" in result
+        assert "```text\n/new" in result
+        assert re.search(r"/personality \[name\]\s+List or switch personalities", result)
+        assert re.search(r"/update\s+Update Hermes Agent to the latest version", result)
 
     @pytest.mark.asyncio
     async def test_help_output_separates_skill_commands_section(self):
@@ -52,7 +53,23 @@ class TestHelpFormatting:
             result = await runner._handle_help_command(_make_event(text="/help"))
 
         assert "⚡ **Skill Commands** (1 installed)" in result
-        assert "\n\n⚡ **Skill Commands** (1 installed)\n`/gif-search` — Search for GIFs across providers" in result
+        assert "Use a skill command directly to run it." in result
+        assert "```text\n/gif-search" in result
+        assert "Search for GIFs across providers" in result
+
+    @pytest.mark.asyncio
+    async def test_help_output_truncates_long_skill_descriptions(self):
+        runner = _make_runner()
+        long_description = " ".join(["Search across providers with extra detail"] * 6)
+
+        with patch("agent.skill_commands.get_skill_commands", return_value={
+            "/gif-search": {"description": long_description},
+        }):
+            result = await runner._handle_help_command(_make_event(text="/help"))
+
+        assert "/gif-search" in result
+        assert "..." in result
+        assert long_description not in result
 
 
 class TestPersonalityFormatting:
@@ -77,9 +94,9 @@ class TestPersonalityFormatting:
             )
 
         assert result.startswith("🎭 **Available Personalities**")
-        assert "\n\n`alpha`\nShort and direct." in result
-        assert "\n\n`zebra`\nA personality with extra spacing for tests." in result
-        assert result.index("`alpha`") < result.index("`zebra`")
+        assert "\n\n**alpha**\nShort and direct." in result
+        assert "\n\n**zebra**\nA personality with extra spacing for tests." in result
+        assert result.index("**alpha**") < result.index("**zebra**")
         assert result.endswith("Use `/personality <name>` to switch.")
 
     @pytest.mark.asyncio
@@ -101,6 +118,6 @@ class TestPersonalityFormatting:
                 _make_event(text="/personality")
             )
 
-        assert "`builder`" in result
+        assert "**builder**" in result
         assert "..." in result
         assert "very long prompt very long prompt" in result

--- a/tests/gateway/test_provider_command_formatting.py
+++ b/tests/gateway/test_provider_command_formatting.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/provider", platform=Platform.TELEGRAM,
+                user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    return runner
+
+
+class TestGatewayProviderFormatting:
+    @pytest.mark.asyncio
+    async def test_provider_output_uses_aligned_block(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  provider: openrouter\n"
+        )
+
+        providers = [
+            {"id": "openrouter", "label": "OpenRouter", "authenticated": True, "aliases": ["or"]},
+            {"id": "anthropic", "label": "Anthropic", "authenticated": False, "aliases": []},
+        ]
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("hermes_cli.models.list_available_providers", return_value=providers):
+            result = await runner._handle_provider_command(_make_event())
+
+        assert "🔌 **Current provider:** OpenRouter (`openrouter`)" in result
+        assert "**Available providers**" in result
+        assert "```text" in result
+        assert "✅ openrouter" in result
+        assert "OpenRouter (or) ← active" in result
+        assert "❌ anthropic" in result
+        assert "Switch: `/model provider:model-name`" in result

--- a/tests/test_cli_command_formatting.py
+++ b/tests/test_cli_command_formatting.py
@@ -1,0 +1,107 @@
+import os
+import re
+import sys
+from datetime import datetime
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _make_cli():
+    from cli import HermesCLI
+
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.model = "anthropic/claude-opus-4.6"
+    cli_obj.base_url = "https://openrouter.ai/api/v1"
+    cli_obj.api_key = "sk-test-1234"
+    cli_obj.provider = "openrouter"
+    cli_obj.requested_provider = None
+    cli_obj._explicit_api_key = None
+    cli_obj._explicit_base_url = None
+    cli_obj.max_turns = 90
+    cli_obj.enabled_toolsets = ["file", "web"]
+    cli_obj.verbose = False
+    cli_obj.session_start = datetime(2026, 3, 8, 20, 0, 0)
+    cli_obj.personalities = {}
+    cli_obj.system_prompt = ""
+    cli_obj.agent = None
+    return cli_obj
+
+
+class TestCLIToolsFormatting:
+    def test_show_tools_uses_rich_panel_and_table(self, capsys):
+        cli_obj = _make_cli()
+        tools = [
+            {"function": {"name": "read_file", "description": "Read file contents from disk. Supports text files."}},
+            {"function": {"name": "search_files", "description": "Search files by pattern across the repository. Supports regex."}},
+            {"function": {"name": "web_search", "description": "Search the web for relevant information and sources."}},
+        ]
+        toolsets = {"read_file": "file", "search_files": "file", "web_search": "web"}
+
+        with patch("cli.get_tool_definitions", return_value=tools), \
+             patch("cli.get_toolset_for_tool", side_effect=lambda name: toolsets[name]), \
+             patch("cli._cprint", lambda text: print(text)), \
+             patch("cli.shutil.get_terminal_size", return_value=os.terminal_size((100, 24))):
+            cli_obj.show_tools()
+
+        output = _strip_ansi(capsys.readouterr().out)
+        assert "Available Tools" in output
+        assert "Toolset" in output
+        assert "Tool" in output
+        assert "Description" in output
+        assert "file" in output
+        assert "web" in output
+        assert "read_file" in output
+        assert "web_search" in output
+        assert "Total: 3 tools" in output
+
+
+class TestCLIConfigFormatting:
+    def test_show_config_uses_panel_sections(self, capsys):
+        cli_obj = _make_cli()
+
+        with patch("cli._cprint", lambda text: print(text)):
+            cli_obj.show_config()
+
+        output = _strip_ansi(capsys.readouterr().out)
+        assert "Configuration" in output
+        assert "Model" in output
+        assert "Terminal" in output
+        assert "Agent" in output
+        assert "Session" in output
+        assert "anthropic/claude-opus-4.6" in output
+        assert "file, web" in output
+
+
+class TestCLIProviderFormatting:
+    def test_provider_command_uses_rich_panel_and_table(self, capsys):
+        from cli import HermesCLI
+
+        cli_obj = _make_cli()
+        providers = [
+            {"id": "openrouter", "label": "OpenRouter", "authenticated": True, "aliases": ["or"]},
+            {"id": "anthropic", "label": "Anthropic", "authenticated": False, "aliases": []},
+        ]
+
+        with patch("hermes_cli.models.list_available_providers", return_value=providers), \
+             patch("cli._cprint", lambda text: print(text)):
+            HermesCLI.process_command(cli_obj, "/provider")
+
+        output = _strip_ansi(capsys.readouterr().out)
+        assert "Providers" in output
+        assert "Current provider:" in output
+        assert "OpenRouter (openrouter)" in output
+        assert "Status" in output
+        assert "Provider" in output
+        assert "Label" in output
+        assert "[✓]" in output
+        assert "[✗]" in output
+        assert "openrouter" in output
+        assert "OpenRouter (also: or) ← active" in output
+        assert "anthropic" in output
+        assert "Switch: /model provider:model-name" in output
+        assert "Setup:  hermes setup" in output

--- a/tests/test_cli_help_personality_formatting.py
+++ b/tests/test_cli_help_personality_formatting.py
@@ -50,19 +50,34 @@ class TestCLIHelpFormatting:
 
         with patch("cli._skill_commands", {
             "/gif-search": {"description": long_description},
-        }), patch("cli._cprint", lambda text: print(text)):
+        }), patch("cli._cprint", lambda text: print(text)), \
+             patch("cli.shutil.get_terminal_size", return_value=os.terminal_size((80, 24))):
             cli_obj.show_help()
 
         output = _strip_ansi(capsys.readouterr().out)
         assert "..." in output
         assert long_description not in output
 
+    def test_show_help_uses_more_space_on_wider_terminals(self, capsys):
+        cli_obj = _make_cli()
+        description = "Search and download GIFs from Tenor using curl. No dependencies beyond curl and jq."
+
+        with patch("cli._skill_commands", {
+            "/gif-search": {"description": description},
+        }), patch("cli._cprint", lambda text: print(text)), \
+             patch("cli.shutil.get_terminal_size", return_value=os.terminal_size((140, 24))):
+            cli_obj.show_help()
+
+        output = _strip_ansi(capsys.readouterr().out)
+        assert description in output
+
 
 class TestCLIPersonalityFormatting:
     def test_personality_list_is_sorted_and_separated(self, capsys):
         cli_obj = _make_cli()
 
-        cli_obj._handle_personality_command("/personality")
+        with patch("cli.shutil.get_terminal_size", return_value=os.terminal_size((80, 24))):
+            cli_obj._handle_personality_command("/personality")
 
         output = capsys.readouterr().out
 
@@ -72,3 +87,15 @@ class TestCLIPersonalityFormatting:
         assert output.index("  alpha") < output.index("  zebra")
         assert "-" * 42 in output
         assert "Usage: /personality <name>" in output
+
+    def test_personality_preview_expands_on_wider_terminals(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj.personalities = {
+            "builder": "very long prompt " * 10,
+        }
+
+        with patch("cli.shutil.get_terminal_size", return_value=os.terminal_size((140, 24))):
+            cli_obj._handle_personality_command("/personality")
+
+        output = capsys.readouterr().out
+        assert "very long prompt very long prompt very long prompt" in output

--- a/tests/test_cli_help_personality_formatting.py
+++ b/tests/test_cli_help_personality_formatting.py
@@ -73,19 +73,23 @@ class TestCLIHelpFormatting:
 
 
 class TestCLIPersonalityFormatting:
-    def test_personality_list_is_sorted_and_separated(self, capsys):
+    def test_personality_list_uses_rich_table(self, capsys):
         cli_obj = _make_cli()
 
-        with patch("cli.shutil.get_terminal_size", return_value=os.terminal_size((80, 24))):
+        with patch("cli.shutil.get_terminal_size", return_value=os.terminal_size((80, 24))), \
+             patch("cli._cprint", lambda text: print(text)):
             cli_obj._handle_personality_command("/personality")
 
-        output = capsys.readouterr().out
+        output = _strip_ansi(capsys.readouterr().out)
 
         assert "Personalities" in output
-        assert "  alpha\n    Short and direct." in output
-        assert "  zebra\n    A personality with extra spacing for tests." in output
-        assert output.index("  alpha") < output.index("  zebra")
-        assert "-" * 42 in output
+        assert "Name" in output
+        assert "Preview" in output
+        assert "alpha" in output
+        assert "Short and direct." in output
+        assert "zebra" in output
+        assert "A personality with extra spacing for tests." in output
+        assert output.index("alpha") < output.index("zebra")
         assert "Usage: /personality <name>" in output
 
     def test_personality_preview_expands_on_wider_terminals(self, capsys):
@@ -94,8 +98,9 @@ class TestCLIPersonalityFormatting:
             "builder": "very long prompt " * 10,
         }
 
-        with patch("cli.shutil.get_terminal_size", return_value=os.terminal_size((140, 24))):
+        with patch("cli.shutil.get_terminal_size", return_value=os.terminal_size((140, 24))), \
+             patch("cli._cprint", lambda text: print(text)):
             cli_obj._handle_personality_command("/personality")
 
-        output = capsys.readouterr().out
+        output = _strip_ansi(capsys.readouterr().out)
         assert "very long prompt very long prompt very long prompt" in output

--- a/tests/test_cli_help_personality_formatting.py
+++ b/tests/test_cli_help_personality_formatting.py
@@ -1,0 +1,74 @@
+import os
+import re
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _make_cli():
+    from cli import HermesCLI
+
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.personalities = {
+        "zebra": "A personality with extra spacing\nfor tests.",
+        "alpha": "Short and direct.",
+    }
+    cli_obj.system_prompt = ""
+    cli_obj.agent = None
+    return cli_obj
+
+
+class TestCLIHelpFormatting:
+    def test_show_help_groups_and_aligns_commands(self, capsys):
+        cli_obj = _make_cli()
+
+        with patch("cli._skill_commands", {
+            "/gif-search": {"description": "Search for GIFs across providers"},
+        }), patch("cli._cprint", lambda text: print(text)):
+            cli_obj.show_help()
+
+        output = _strip_ansi(capsys.readouterr().out)
+
+        assert "Session" in output
+        assert "Configuration" in output
+        assert "Tools & Platform" in output
+        assert "Context & Automation" in output
+        assert re.search(r"/new\s+- Start a new session with a fresh conversation", output)
+        assert re.search(r"/personality\s+- List or switch predefined personalities", output)
+        assert "Skill Commands (1 installed)" in output
+        assert "Use a skill command directly to run it." in output
+        assert re.search(r"/gif-search\s+- Search for GIFs across providers", output)
+
+    def test_show_help_truncates_long_skill_descriptions(self, capsys):
+        cli_obj = _make_cli()
+        long_description = " ".join(["Search across providers with extra detail"] * 6)
+
+        with patch("cli._skill_commands", {
+            "/gif-search": {"description": long_description},
+        }), patch("cli._cprint", lambda text: print(text)):
+            cli_obj.show_help()
+
+        output = _strip_ansi(capsys.readouterr().out)
+        assert "..." in output
+        assert long_description not in output
+
+
+class TestCLIPersonalityFormatting:
+    def test_personality_list_is_sorted_and_separated(self, capsys):
+        cli_obj = _make_cli()
+
+        cli_obj._handle_personality_command("/personality")
+
+        output = capsys.readouterr().out
+
+        assert "Personalities" in output
+        assert "  alpha\n    Short and direct." in output
+        assert "  zebra\n    A personality with extra spacing for tests." in output
+        assert output.index("  alpha") < output.index("  zebra")
+        assert "-" * 42 in output
+        assert "Usage: /personality <name>" in output


### PR DESCRIPTION
## Summary
- improve `/help` formatting in the gateway with clearer grouping, spacing, and aligned command output
- improve `/personality` formatting in both the gateway and CLI with cleaner previews and stronger separation between entries
- polish CLI command views for `/tools`, `/config`, and `/provider` so they match the richer formatting style already used elsewhere
- clean up gateway `/provider` output and add regression coverage for the new command layouts

Fixes #640

## Testing
- `.venv/bin/python -m pytest tests/test_cli_command_formatting.py tests/test_cli_help_personality_formatting.py tests/gateway/test_provider_command_formatting.py -q`
- `.venv/bin/python -m pytest tests/gateway/test_help_personality_formatting.py tests/gateway/test_update_command.py tests/hermes_cli/test_commands.py -q`
