### PR TITLE
feat(skills): add NeuroSkill BCI integration skill

### DIFF
--- a/skills/health/neuroskill-bci/SKILL.md
+++ b/skills/health/neuroskill-bci/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: neuroskill-bci
+description: Connect to a running NeuroSkill instance and incorporate the user's real-time cognitive and emotional state (focus, relaxation, stress, cognitive load, drowsiness, heart rate, HRV, sleep staging) into responses. Requires a BCI wearable (Muse, OpenBCI, AttentivU) and NeuroSkill desktop app running locally.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [BCI, Neurofeedback, Health, Focus, EEG, Cognitive-State, Biometrics]
+    related_skills: []
+---
+
+# NeuroSkill BCI Integration
+
+Connect Hermes to a running NeuroSkill instance to read real-time brain and body metrics from a BCI wearable. Use this to give cognitively-aware responses, suggest interventions, and track mental performance over time.
+
+See `references/metrics.md` for metric definitions and `references/protocols.md` for intervention protocols.
+
+## Prerequisites
+
+- Node.js 20+ installed
+- NeuroSkill desktop app running with a connected BCI device
+- `npx neuroskill status` returns data without errors
+
+### Verify Setup
+```bash
+# Check Node.js version
+node --version  # Must be 20+
+
+# Check NeuroSkill is running and device is connected
+npx neuroskill status
+```
+
+If `npx neuroskill status` returns an error, tell the user:
+- Make sure the NeuroSkill desktop app is open
+- Ensure BCI device is powered on and connected via Bluetooth
+- Check that electrode contact is good (green indicators in NeuroSkill)
+
+---
+
+## 1. Checking Current State
+
+### Get Live Metrics
+```bash
+npx neuroskill status
+```
+
+**Example output:**
+```json
+{
+  "device": "Muse 2",
+  "connected": true,
+  "session_duration": "00:23:14",
+  "metrics": {
+    "focus": 72,
+    "relaxation": 58,
+    "engagement": 65,
+    "cognitive_load": 48,
+    "drowsiness": 18,
+    "heart_rate": 68,
+    "hrv_rmssd": 42,
+    "sleep_stage": null
+  },
+  "band_powers": {
+    "delta": 0.12,
+    "theta": 0.18,
+    "alpha": 0.31,
+    "beta": 0.28,
+    "gamma": 0.11
+  }
+}
+```
+
+### Interpreting the Output
+
+Parse the JSON and translate metrics into natural language. Never report raw numbers alone — always give them meaning:
+
+**DO:**
+> "Your focus is solid right now at 72 — you've been in a good flow state. Heart rate is steady at 68 bpm and HRV looks healthy. Good time to tackle something complex."
+
+**DON'T:**
+> "Focus: 72, Relaxation: 58, HR: 68"
+
+Use `references/metrics.md` to interpret values. Key thresholds:
+- Focus > 70 → flow state territory, protect it
+- Focus < 40 → suggest a break or protocol
+- Drowsiness > 60 → fatigue warning
+- Relaxation < 30 → stress intervention
+- Cognitive Load > 80 sustained → mind dump or break
+
+---
+
+## 2. Historical Search
+
+### Find Past Brain States
+```bash
+npx neuroskill search --label "focus"
+npx neuroskill search --label "stress"
+npx neuroskill search --label "flow"
+npx neuroskill search --query "high beta low theta morning"
+```
+
+Use this when the user asks:
+- "When was I last in a flow state?"
+- "Find my best focus sessions"
+- "When do I usually crash in the afternoon?"
+
+---
+
+## 3. Session Comparison
+```bash
+npx neuroskill compare
+npx neuroskill compare --sessions "today,yesterday"
+npx neuroskill compare --sessions "this-week,last-week"
+```
+
+Use this when the user asks:
+- "How does today compare to yesterday?"
+- "Is my focus improving over time?"
+- "Compare my morning vs afternoon sessions"
+
+Interpret comparisons with context — mention trends, not just deltas:
+> "Yesterday you had two strong focus blocks at 10am and 2pm. Today you've had one starting around 11am that's still going. Your overall engagement is higher today but there have been more stress spikes — likely related to whatever was stressful this morning."
+
+---
+
+## 4. Sleep Data
+```bash
+npx neuroskill sleep
+npx neuroskill sleep --date "2026-03-07"
+```
+
+Returns hypnogram with Wake/N1/N2/N3/REM staging and sleep quality score.
+
+Use this when the user mentions sleep, tiredness, or asks about recovery. See `references/metrics.md` for sleep stage interpretations.
+
+---
+
+## 5. Session List
+```bash
+npx neuroskill sessions
+npx neuroskill sessions --limit 10
+```
+
+Use this to find available sessions for comparison or trend analysis.
+
+---
+
+## 6. Labeling Moments
+```bash
+npx neuroskill label "breakthrough"
+npx neuroskill label "studying algorithms"
+npx neuroskill label "post-meditation"
+```
+
+Auto-label moments when:
+- User reports a breakthrough or insight
+- User starts a new task type
+- User completes a significant protocol
+- User asks you to mark the current moment
+
+---
+
+## 7. Proactive State Awareness
+
+### Session Start Check
+At the beginning of a session, optionally run a status check if the user mentions they're wearing their device or asks about their state:
+```bash
+npx neuroskill status
+```
+
+Inject a brief state summary into context:
+> "Quick check-in: your focus is building (62), relaxation is good. Looks like a solid start."
+
+### When to Proactively Mention State
+
+Mention cognitive state **only** when:
+- User explicitly asks ("How am I doing?", "Check my focus")
+- User reports difficulty concentrating, stress, or fatigue
+- A critical threshold is crossed (Drowsiness > 70, Focus < 30 for > 10 min)
+- User is about to do something cognitively demanding and asks for readiness
+
+**Do NOT** interrupt flow state to report metrics. If focus > 75, protect the session.
+
+---
+
+## 8. Suggesting Protocols
+
+When metrics indicate a need, suggest a protocol from `references/protocols.md`. Always ask before starting:
+
+> "Your focus has been declining for the past 15 minutes and theta is rising — signs of mental fatigue. Want me to guide you through a 2-minute box breathing reset? It usually helps."
+
+Key triggers:
+- Focus < 40 → Box Breathing or Pomodoro Break
+- Relaxation < 30 → 4-7-8 Breathing or Progressive Relaxation
+- Cognitive Load > 80 sustained → Mind Dump
+- Drowsiness > 70 → NASA Nap Protocol
+- Flow State (Focus > 75, Engagement > 70) → Do NOT interrupt
+
+---
+
+## 9. WebSocket API (Advanced)
+
+NeuroSkill also exposes a local WebSocket on `localhost` (discoverable via `lsof -i -n -P | grep neuroskill`).
+```bash
+# Discover port
+NEURO_PORT=$(lsof -i -n -P | grep neuroskill | grep LISTEN | awk '{print $9}' | cut -d: -f2 | head -1)
+echo "NeuroSkill WebSocket on port: $NEURO_PORT"
+```
+
+For real-time streaming, the WebSocket accepts the same commands as the CLI (`status`, `search`, `compare`, `sleep`, `sessions`, `label`). Use CLI for one-off queries; WebSocket for continuous monitoring.
+
+---
+
+## Error Handling
+
+| Error | Likely Cause | Fix |
+|-------|-------------|-----|
+| `npx neuroskill status` hangs | NeuroSkill app not running | Open NeuroSkill desktop app |
+| `device: null` or `connected: false` | BCI device not connected | Check Bluetooth, device battery, electrode contact |
+| All metrics return 0 | Poor electrode contact | Reposition headband, ensure electrodes are moist |
+| `command not found: npx` | Node.js not installed | Install Node.js 20+ |
+| Metrics seem wrong | Movement artifacts | Minimize head movement during readings |
+
+---
+
+## Example Interactions
+
+**"How am I doing right now?"**
+```bash
+npx neuroskill status
+```
+→ Interpret and respond naturally based on metrics.
+
+**"I can't concentrate"**
+```bash
+npx neuroskill status
+```
+→ Check if metrics confirm it (high theta, low beta, high drowsiness).
+→ If confirmed, suggest appropriate protocol from `references/protocols.md`.
+
+**"Compare my focus today vs yesterday"**
+```bash
+npx neuroskill compare --sessions "today,yesterday"
+```
+→ Interpret trends, not just numbers.
+
+**"When was I last in a flow state?"**
+```bash
+npx neuroskill search --label "flow"
+```
+→ Report session timestamps and what was happening.
+
+**"Mark this moment — I just had a breakthrough"**
+```bash
+npx neuroskill label "breakthrough"
+```
+→ Confirm label saved.

--- a/skills/health/neuroskill-bci/references/metrics.md
+++ b/skills/health/neuroskill-bci/references/metrics.md
@@ -1,0 +1,67 @@
+# NeuroSkill Metric Definitions & Interpretation Guide
+
+## EEG Band Powers
+| Band | Hz Range | High Means | Low Means |
+|------|----------|------------|-----------|
+| Delta (δ) | 0.5–4 Hz | Deep sleep, unconscious processing | Awake, alert |
+| Theta (θ) | 4–8 Hz | Mental fatigue, drowsiness, creative daydreaming | Alert, focused |
+| Alpha (α) | 8–13 Hz | Relaxed alertness, calm focus, eyes-closed rest | Active thinking, anxiety |
+| Beta (β) | 13–30 Hz | Active concentration, problem-solving, alertness | Relaxed, unfocused |
+| Gamma (γ) | 30–100 Hz | High-level cognition, binding, peak performance | Baseline |
+
+## Derived Cognitive Metrics (0–100 scale unless noted)
+
+### Focus
+- **High (70–100):** Deep concentration, flow state, task absorption
+- **Medium (40–69):** Moderate attention, some mind-wandering
+- **Low (0–39):** Distracted, fatigued, difficulty concentrating
+- **Key ratio:** Beta/Theta — higher = more focused
+
+### Relaxation
+- **High (70–100):** Calm, stress-free, parasympathetic dominant
+- **Medium (40–69):** Mild tension present
+- **Low (0–39):** Stressed, anxious, sympathetic dominant
+- **Key ratio:** Alpha/Beta — higher = more relaxed
+
+### Engagement
+- **High (70–100):** Mentally invested, motivated, active processing
+- **Medium (40–69):** Passive participation
+- **Low (0–39):** Bored, disengaged, autopilot mode
+- **Key ratio:** Beta/(Alpha+Theta)
+
+### Cognitive Load
+- **High (70–100):** Working memory near capacity, complex processing
+- **Medium (40–69):** Moderate mental effort
+- **Low (0–39):** Task is easy or automatic
+- **Interpretation:** High load + high focus = productive struggle. High load + low focus = overwhelmed.
+
+### Drowsiness
+- **High (70–100):** Sleep pressure building, microsleep risk
+- **Medium (40–69):** Mild fatigue
+- **Low (0–39):** Alert
+- **Key ratio:** Theta+Alpha/Beta — rising drowsiness means this ratio climbs
+
+## Cardiac Metrics
+| Metric | Normal Range | Interpretation |
+|--------|-------------|----------------|
+| Heart Rate (HR) | 60–100 bpm | Elevated = stress/exertion; Low = calm/fitness |
+| HRV (RMSSD) | 20–100 ms | Higher = better stress resilience, recovery |
+| HRV Trend | Rising/Falling | Rising = recovering; Falling = accumulating stress |
+
+## Sleep Staging
+| Stage | EEG Signature | Function |
+|-------|--------------|----------|
+| Wake | Beta dominant | Conscious awareness |
+| N1 | Alpha→Theta transition | Light sleep onset |
+| N2 | Sleep spindles, K-complexes | Memory consolidation |
+| N3 | Delta dominant | Deep restorative sleep |
+| REM | Mixed, low amplitude | Emotional processing, dreaming |
+
+## Composite State Patterns
+| Pattern | Metrics | Interpretation |
+|---------|---------|----------------|
+| Flow State | Focus >75, Cognitive Load 50–70, HR steady | Optimal performance zone |
+| Mental Fatigue | Focus <40, Drowsiness >60, Theta elevated | Rest or break needed |
+| Anxiety | Relaxation <30, HR elevated, Beta >Alpha | Calming intervention helpful |
+| Peak Alert | Focus >80, Engagement >70, Drowsiness <20 | Best time for hard tasks |
+| Recovery | Relaxation >70, HRV rising, Alpha dominant | Integration, light tasks only |

--- a/skills/health/neuroskill-bci/references/protocols.md
+++ b/skills/health/neuroskill-bci/references/protocols.md
@@ -1,0 +1,105 @@
+# NeuroSkill Guided Protocols
+
+## When to Suggest Protocols
+
+| User State | Recommended Protocol |
+|------------|---------------------|
+| Focus < 40, Drowsiness > 50 | Box Breathing or Cold Water Reset |
+| Relaxation < 30, HR elevated | 4-7-8 Breathing or Progressive Relaxation |
+| Cognitive Load > 80 sustained | Mind Dump or Pomodoro Break |
+| Engagement < 30 > 20 min | Environment Change or Body Doubling |
+| Flow State detected | Do NOT interrupt — protect the session |
+| Pre-sleep HRV low | Sleep Wind-Down Protocol |
+
+## Focus Restoration Protocols
+
+### Box Breathing (4-4-4-4)
+**Duration:** 2–4 minutes
+**When:** Focus dropping, mild stress, pre-task preparation
+**Instructions:**
+1. Inhale for 4 counts
+2. Hold for 4 counts
+3. Exhale for 4 counts
+4. Hold for 4 counts
+5. Repeat 4–8 cycles
+**Expected effect:** Focus typically improves within 5–10 minutes post-protocol
+
+### 4-7-8 Breathing
+**Duration:** 3–5 minutes
+**When:** High anxiety, relaxation < 30, racing thoughts
+**Instructions:**
+1. Exhale completely through mouth
+2. Inhale through nose for 4 counts
+3. Hold for 7 counts
+4. Exhale through mouth for 8 counts
+5. Repeat 4 cycles
+**Expected effect:** Activates parasympathetic nervous system, reduces beta activity
+
+### Pomodoro Break
+**Duration:** 5 minutes
+**When:** Cognitive load > 75 sustained for > 30 minutes
+**Instructions:**
+1. Stop current task completely
+2. Stand up, move away from screen
+3. Light physical movement (walk, stretch)
+4. No phone/screens during break
+**Expected effect:** Cognitive load reduction, theta clearance
+
+## Focus Enhancement Protocols
+
+### Pre-Task Priming
+**Duration:** 3 minutes
+**When:** Low engagement at session start, Drowsiness < 50
+**Instructions:**
+1. Set a clear intention for the next work block
+2. Write down the single most important task
+3. Do 10 jumping jacks or 20 deep breaths
+4. Start with the easiest sub-task to build momentum
+
+### Ultradian Rhythm Alignment
+**When:** Recurring afternoon slumps (90-min cycles)
+**Instructions:**
+- Track your peak focus windows over 3 days
+- Schedule deep work during your personal peak windows
+- Use low-engagement tasks during natural troughs
+
+## Stress & Recovery Protocols
+
+### Progressive Muscle Relaxation
+**Duration:** 10 minutes
+**When:** Relaxation < 25, HRV declining over session
+**Instructions:**
+1. Start with feet — tense for 5 seconds, release
+2. Move upward through calves, thighs, abdomen, hands, arms, shoulders, face
+3. Hold each tension 5 seconds, release 10 seconds
+4. End with 3 deep breaths
+
+### Mind Dump
+**Duration:** 5 minutes
+**When:** Cognitive load > 80, racing thoughts, high beta
+**Instructions:**
+1. Open a blank document
+2. Write everything on your mind without filtering
+3. Brain-dump worries, tasks, ideas — anything occupying working memory
+4. Close the document (you can review later)
+**Expected effect:** Externalizing working memory reduces cognitive load by 20–40%
+
+## Sleep Protocols
+
+### Sleep Wind-Down (60 min before bed)
+**When:** Evening session, HRV low, Drowsiness rising
+**Instructions:**
+1. Dim all screens to night mode
+2. Stop new learning/complex tasks
+3. Do a mind dump of tomorrow's tasks
+4. 10 minutes of progressive relaxation or 4-7-8 breathing
+5. Keep room cool (65–68°F / 18–20°C)
+
+### Nap Protocol (NASA Nap)
+**Duration:** 20 minutes max
+**When:** Drowsiness > 70, post-lunch slump, Theta dominant
+**Instructions:**
+1. Set alarm for 20 minutes (avoids N3 sleep inertia)
+2. Lie down or recline
+3. Even if you don't fully sleep, rest with eyes closed
+**Expected effect:** Restores focus and alertness for 2–3 hours


### PR DESCRIPTION
## Summary

Closes #694

Adds a new skill under `skills/health/neuroskill-bci/` that connects Hermes to a running NeuroSkill instance for real-time cognitive state awareness via BCI wearables (Muse, OpenBCI, AttentivU).

## Files Added

- `skills/health/neuroskill-bci/SKILL.md` — main skill: connection, all CLI commands (status/search/compare/sleep/sessions/label), metric interpretation guidance, protocol triggers, WebSocket discovery, error handling, example interactions
- `skills/health/neuroskill-bci/references/metrics.md` — EEG band power definitions, derived cognitive metrics, cardiac metrics, sleep staging, composite state patterns
- `skills/health/neuroskill-bci/references/protocols.md` — 8 guided protocols with trigger conditions, durations, and step-by-step instructions

## No Core Code Changes

Pure skill addition — zero changes to any Python files or core codebase.