### PR TITLE
fix: close log file handles to prevent resource leaks

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1523,7 +1523,7 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
                 pid_file = os.path.join(socket_dir, f"{session_name}.pid")
                 if os.path.isfile(pid_file):
                     try:
-                        daemon_pid = int(open(pid_file).read().strip())
+                        daemon_pid = int(Path(pid_file).read_text().strip())
                         os.kill(daemon_pid, signal.SIGTERM)
                         logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
                     except (ProcessLookupError, ValueError, PermissionError, OSError):

--- a/tools/rl_training_tool.py
+++ b/tools/rl_training_tool.py
@@ -323,7 +323,10 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         # Step 1: Start the Atropos API server (run-api)
         print(f"[{run_id}] Starting Atropos API server (run-api)...")
         
-        api_log_file = open(api_log, "w")
+        # File must stay open while the subprocess runs; we store the handle
+        # on run_state so _stop_training_run() can close it when done.
+        api_log_file = open(api_log, "w")  # closed by _stop_training_run
+        run_state.api_log_file = api_log_file
         run_state.api_process = subprocess.Popen(
             ["run-api"],
             stdout=api_log_file,
@@ -344,7 +347,8 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         # Step 2: Start the Tinker trainer
         print(f"[{run_id}] Starting Tinker trainer: launch_training.py --config {config_path}")
         
-        trainer_log_file = open(trainer_log, "w")
+        trainer_log_file = open(trainer_log, "w")  # closed by _stop_training_run
+        run_state.trainer_log_file = trainer_log_file
         run_state.trainer_process = subprocess.Popen(
             [sys.executable, "launch_training.py", "--config", str(config_path)],
             stdout=trainer_log_file,
@@ -384,7 +388,8 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         
         print(f"[{run_id}] Starting environment: {env_info.file_path} serve")
         
-        env_log_file = open(env_log, "w")
+        env_log_file = open(env_log, "w")  # closed by _stop_training_run
+        run_state.env_log_file = env_log_file
         run_state.env_process = subprocess.Popen(
             [sys.executable, str(env_info.file_path), "serve", "--config", str(config_path)],
             stdout=env_log_file,
@@ -479,6 +484,16 @@ def _stop_training_run(run_state: RunState):
     
     if run_state.status == "running":
         run_state.status = "stopped"
+
+    # Close log file handles that were opened for subprocess stdout.
+    for attr in ("env_log_file", "trainer_log_file", "api_log_file"):
+        fh = getattr(run_state, attr, None)
+        if fh is not None:
+            try:
+                fh.close()
+            except Exception:
+                pass
+            setattr(run_state, attr, None)
 
 
 # ============================================================================


### PR DESCRIPTION
## Problem

`_start_training_run()` inside `tools/rl_training_tool.py` opened three
log files (api_log, trainer_log, env_log) for subprocess stdout but never
closed them. If a process exited early, the file handles were leaked for
the lifetime of the program.

Similarly, `tools/browser_tool.py` used a bare `open()` call to read a
PID file without closing it.

## Fix

- `rl_training_tool.py`: Store each file handle as an attribute on
  `run_state` (`api_log_file`, `trainer_log_file`, `env_log_file`).
  `_stop_training_run()` now iterates over these attributes and closes
  any that are still open.

- `browser_tool.py`: Replace `open(pid_file).read()` with
  `Path(pid_file).read_text()` which opens, reads, and closes
  automatically.

## Files Changed
- `tools/rl_training_tool.py`
- `tools/browser_tool.py`