### PR TITLE
feat: native Anthropic Messages API provider

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -58,6 +58,7 @@ def convert_messages_to_anthropic(
 
     Returns (system_prompt, anthropic_messages).
     System messages are extracted since Anthropic takes them as a separate param.
+    system_prompt is a string or list of content blocks (when cache_control present).
     """
     system = None
     result = []
@@ -68,9 +69,14 @@ def convert_messages_to_anthropic(
 
         if role == "system":
             if isinstance(content, list):
-                system = "\n".join(
-                    p["text"] for p in content if p.get("type") == "text"
-                )
+                # Preserve cache_control markers on content blocks
+                has_cache = any(p.get("cache_control") for p in content if isinstance(p, dict))
+                if has_cache:
+                    system = [p for p in content if isinstance(p, dict)]
+                else:
+                    system = "\n".join(
+                        p["text"] for p in content if p.get("type") == "text"
+                    )
             else:
                 system = content
             continue

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import anthropic
 from httpx import Timeout
 
+THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
+
 
 def build_anthropic_client(api_key: str, base_url: str = None) -> anthropic.Anthropic:
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys."""
@@ -161,12 +163,7 @@ def build_anthropic_kwargs(
     if reasoning_config and isinstance(reasoning_config, dict):
         if reasoning_config.get("enabled") is not False:
             effort = reasoning_config.get("effort", "medium")
-            budget = {
-                "xhigh": 32000,
-                "high": 16000,
-                "medium": 8000,
-                "low": 4000,
-            }.get(effort, 8000)
+            budget = THINKING_BUDGET.get(effort, 8000)
             kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
             kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1,0 +1,223 @@
+"""Anthropic Messages API adapter for Hermes Agent.
+
+Translates between Hermes's internal OpenAI-style message format and
+Anthropic's Messages API. Follows the same pattern as the codex_responses
+adapter — all provider-specific logic is isolated here.
+
+Auth supports both regular API keys (sk-ant-api*) and Claude setup-tokens
+(sk-ant-oat01-*). Setup-tokens require bearer auth + beta header.
+"""
+
+import json
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+
+import anthropic
+from httpx import Timeout
+
+
+def build_anthropic_client(api_key: str, base_url: str = None) -> anthropic.Anthropic:
+    """Create an Anthropic client, auto-detecting setup-tokens vs API keys."""
+    kwargs = {
+        "timeout": Timeout(timeout=900.0, connect=10.0),
+    }
+    if base_url:
+        kwargs["base_url"] = base_url
+
+    if api_key.startswith("sk-ant-oat"):
+        # Setup-token (OAuth access token from `claude setup-token`)
+        kwargs["auth_token"] = api_key
+        kwargs["default_headers"] = {"anthropic-beta": "oauth-2025-04-20"}
+    else:
+        kwargs["api_key"] = api_key
+
+    return anthropic.Anthropic(**kwargs)
+
+
+def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
+    """Convert OpenAI tool definitions to Anthropic format."""
+    if not tools:
+        return []
+    result = []
+    for t in tools:
+        fn = t.get("function", {})
+        result.append({
+            "name": fn.get("name", ""),
+            "description": fn.get("description", ""),
+            "input_schema": fn.get("parameters", {"type": "object", "properties": {}}),
+        })
+    return result
+
+
+def convert_messages_to_anthropic(
+    messages: List[Dict],
+) -> Tuple[Optional[str], List[Dict]]:
+    """Convert OpenAI-format messages to Anthropic format.
+
+    Returns (system_prompt, anthropic_messages).
+    System messages are extracted since Anthropic takes them as a separate param.
+    """
+    system = None
+    result = []
+
+    for m in messages:
+        role = m.get("role", "user")
+        content = m.get("content", "")
+
+        if role == "system":
+            if isinstance(content, list):
+                system = "\n".join(
+                    p["text"] for p in content if p.get("type") == "text"
+                )
+            else:
+                system = content
+            continue
+
+        if role == "assistant":
+            blocks = []
+            if content:
+                text = content if isinstance(content, str) else json.dumps(content)
+                blocks.append({"type": "text", "text": text})
+            for tc in m.get("tool_calls", []):
+                fn = tc.get("function", {})
+                args = fn.get("arguments", "{}")
+                blocks.append({
+                    "type": "tool_use",
+                    "id": tc.get("id", ""),
+                    "name": fn.get("name", ""),
+                    "input": json.loads(args) if isinstance(args, str) else args,
+                })
+            result.append({"role": "assistant", "content": blocks or content})
+            continue
+
+        if role == "tool":
+            tool_result = {
+                "type": "tool_result",
+                "tool_use_id": m.get("tool_call_id", ""),
+                "content": content if isinstance(content, str) else json.dumps(content),
+            }
+            # Merge consecutive tool results into one user message
+            if (
+                result
+                and result[-1]["role"] == "user"
+                and isinstance(result[-1]["content"], list)
+                and result[-1]["content"]
+                and result[-1]["content"][0].get("type") == "tool_result"
+            ):
+                result[-1]["content"].append(tool_result)
+            else:
+                result.append({"role": "user", "content": [tool_result]})
+            continue
+
+        # Regular user message
+        result.append({"role": "user", "content": content})
+
+    # Strip orphaned tool_use blocks (no matching tool_result)
+    tool_result_ids = set()
+    for m in result:
+        if m["role"] == "user" and isinstance(m["content"], list):
+            for block in m["content"]:
+                if block.get("type") == "tool_result":
+                    tool_result_ids.add(block.get("tool_use_id"))
+    for m in result:
+        if m["role"] == "assistant" and isinstance(m["content"], list):
+            m["content"] = [
+                b
+                for b in m["content"]
+                if b.get("type") != "tool_use" or b.get("id") in tool_result_ids
+            ]
+            if not m["content"]:
+                m["content"] = [{"type": "text", "text": "(tool call removed)"}]
+
+    return system, result
+
+
+def build_anthropic_kwargs(
+    model: str,
+    messages: List[Dict],
+    tools: Optional[List[Dict]],
+    max_tokens: Optional[int],
+    reasoning_config: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build kwargs for anthropic.messages.create()."""
+    system, anthropic_messages = convert_messages_to_anthropic(messages)
+    anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
+
+    effective_max_tokens = max_tokens or 16384
+
+    kwargs: Dict[str, Any] = {
+        "model": model,
+        "messages": anthropic_messages,
+        "max_tokens": effective_max_tokens,
+    }
+
+    if system:
+        kwargs["system"] = system
+
+    if anthropic_tools:
+        kwargs["tools"] = anthropic_tools
+
+    # Map reasoning_config to Anthropic's thinking parameter
+    if reasoning_config and isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is not False:
+            effort = reasoning_config.get("effort", "medium")
+            budget = {
+                "xhigh": 32000,
+                "high": 16000,
+                "medium": 8000,
+                "low": 4000,
+            }.get(effort, 8000)
+            kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
+            kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
+
+    return kwargs
+
+
+def normalize_anthropic_response(
+    response,
+) -> Tuple[SimpleNamespace, str]:
+    """Normalize Anthropic response to match the shape expected by AIAgent.
+
+    Returns (assistant_message, finish_reason) where assistant_message has
+    .content, .tool_calls, and .reasoning attributes.
+    """
+    text_parts = []
+    reasoning_parts = []
+    tool_calls = []
+
+    for block in response.content:
+        if block.type == "text":
+            text_parts.append(block.text)
+        elif block.type == "thinking":
+            reasoning_parts.append(block.thinking)
+        elif block.type == "tool_use":
+            tool_calls.append(
+                SimpleNamespace(
+                    id=block.id,
+                    type="function",
+                    function=SimpleNamespace(
+                        name=block.name,
+                        arguments=json.dumps(block.input),
+                    ),
+                )
+            )
+
+    # Map Anthropic stop_reason to OpenAI finish_reason
+    stop_reason_map = {
+        "end_turn": "stop",
+        "tool_use": "tool_calls",
+        "max_tokens": "length",
+        "stop_sequence": "stop",
+    }
+    finish_reason = stop_reason_map.get(response.stop_reason, "stop")
+
+    return (
+        SimpleNamespace(
+            content="\n".join(text_parts) if text_parts else None,
+            tool_calls=tool_calls or None,
+            reasoning="\n\n".join(reasoning_parts) if reasoning_parts else None,
+            reasoning_content=None,
+            reasoning_details=None,
+        ),
+        finish_reason,
+    )

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -10,14 +10,17 @@ Resolution order for text tasks:
   3. Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY)
   4. Codex OAuth (Responses API via chatgpt.com with gpt-5.3-codex,
      wrapped to look like a chat.completions client)
-  5. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
+  5. Anthropic (ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, wrapped to look
+     like a chat.completions client)
+  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
      — checked via PROVIDER_REGISTRY entries with auth_type='api_key'
-  6. None
+  7. None
 
 Resolution order for vision/multimodal tasks:
   1. OpenRouter
   2. Nous Portal
-  3. None  (custom endpoints can't substitute for Gemini multimodal)
+  3. Anthropic (Claude supports vision natively)
+  4. None
 """
 
 import json
@@ -245,6 +248,130 @@ class AsyncCodexAuxiliaryClient:
         self.base_url = sync_wrapper.base_url
 
 
+_ANTHROPIC_AUX_MODEL = "claude-haiku-4-5-20251001"
+
+
+def _read_anthropic_token() -> Optional[str]:
+    """Return an Anthropic API key or OAuth token if available."""
+    for var in ("ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY"):
+        val = os.getenv(var, "").strip()
+        if val:
+            return val
+    return None
+
+
+class _AnthropicCompletionsAdapter:
+    """Shim that accepts chat.completions.create() kwargs and routes
+    them through the Anthropic Messages API."""
+
+    def __init__(self, client, model: str):
+        self._client = client
+        self._model = model
+
+    def create(self, **kwargs) -> Any:
+        from agent.anthropic_adapter import (
+            convert_messages_to_anthropic,
+            convert_tools_to_anthropic,
+        )
+
+        messages = kwargs.get("messages", [])
+        model = kwargs.get("model", self._model)
+        system, ant_messages = convert_messages_to_anthropic(messages)
+        tools = convert_tools_to_anthropic(kwargs.get("tools") or [])
+        max_tokens = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens") or 4096
+
+        api_kwargs: Dict[str, Any] = {
+            "model": model,
+            "messages": ant_messages,
+            "max_tokens": max_tokens,
+        }
+        if system:
+            api_kwargs["system"] = system
+        if tools:
+            api_kwargs["tools"] = tools
+
+        resp = self._client.messages.create(**api_kwargs)
+
+        # Build OpenAI-shaped response
+        text_parts = []
+        tool_calls_raw = []
+        for block in resp.content:
+            if block.type == "text":
+                text_parts.append(block.text)
+            elif block.type == "tool_use":
+                tool_calls_raw.append(SimpleNamespace(
+                    id=block.id,
+                    type="function",
+                    function=SimpleNamespace(
+                        name=block.name,
+                        arguments=json.dumps(block.input),
+                    ),
+                ))
+
+        content = "\n".join(text_parts).strip() or None
+        message = SimpleNamespace(
+            role="assistant",
+            content=content,
+            tool_calls=tool_calls_raw or None,
+        )
+        choice = SimpleNamespace(
+            index=0,
+            message=message,
+            finish_reason="tool_calls" if tool_calls_raw else "stop",
+        )
+        usage = SimpleNamespace(
+            prompt_tokens=resp.usage.input_tokens,
+            completion_tokens=resp.usage.output_tokens,
+            total_tokens=resp.usage.input_tokens + resp.usage.output_tokens,
+        )
+        return SimpleNamespace(choices=[choice], model=model, usage=usage)
+
+
+class _AnthropicChatShim:
+    def __init__(self, adapter: _AnthropicCompletionsAdapter):
+        self.completions = adapter
+
+
+class AnthropicAuxiliaryClient:
+    """OpenAI-client-compatible wrapper for Anthropic Messages API.
+
+    Consumers call client.chat.completions.create(**kwargs) as normal.
+    """
+
+    def __init__(self, client, model: str):
+        self._client = client
+        adapter = _AnthropicCompletionsAdapter(client, model)
+        self.chat = _AnthropicChatShim(adapter)
+        self.api_key = "anthropic"
+        self.base_url = "https://api.anthropic.com"
+
+    def close(self):
+        self._client.close()
+
+
+class _AsyncAnthropicCompletionsAdapter:
+    def __init__(self, sync_adapter: _AnthropicCompletionsAdapter):
+        self._sync = sync_adapter
+
+    async def create(self, **kwargs) -> Any:
+        import asyncio
+        return await asyncio.to_thread(self._sync.create, **kwargs)
+
+
+class _AsyncAnthropicChatShim:
+    def __init__(self, adapter: _AsyncAnthropicCompletionsAdapter):
+        self.completions = adapter
+
+
+class AsyncAnthropicAuxiliaryClient:
+    def __init__(self, sync_wrapper: AnthropicAuxiliaryClient):
+        sync_adapter = sync_wrapper.chat.completions
+        async_adapter = _AsyncAnthropicCompletionsAdapter(sync_adapter)
+        self.chat = _AsyncAnthropicChatShim(async_adapter)
+        self.api_key = sync_wrapper.api_key
+        self.base_url = sync_wrapper.base_url
+
+
 def _read_nous_auth() -> Optional[dict]:
     """Read and validate ~/.hermes/auth.json for an active Nous provider.
 
@@ -379,12 +506,20 @@ def get_text_auxiliary_client() -> Tuple[Optional[OpenAI], Optional[str]]:
         real_client = OpenAI(api_key=codex_token, base_url=_CODEX_AUX_BASE_URL)
         return CodexAuxiliaryClient(real_client, _CODEX_AUX_MODEL), _CODEX_AUX_MODEL
 
-    # 5. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, etc.)
+    # 5. Anthropic (ANTHROPIC_TOKEN or ANTHROPIC_API_KEY)
+    ant_token = _read_anthropic_token()
+    if ant_token:
+        from agent.anthropic_adapter import build_anthropic_client
+        logger.debug("Auxiliary text client: Anthropic (%s)", _ANTHROPIC_AUX_MODEL)
+        client = build_anthropic_client(ant_token)
+        return AnthropicAuxiliaryClient(client, _ANTHROPIC_AUX_MODEL), _ANTHROPIC_AUX_MODEL
+
+    # 6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, etc.)
     api_client, api_model = _resolve_api_key_provider()
     if api_client is not None:
         return api_client, api_model
 
-    # 6. Nothing available
+    # 7. Nothing available
     logger.debug("Auxiliary text client: none available")
     return None, None
 
@@ -404,6 +539,9 @@ def get_async_text_auxiliary_client():
 
     if isinstance(sync_client, CodexAuxiliaryClient):
         return AsyncCodexAuxiliaryClient(sync_client), model
+
+    if isinstance(sync_client, AnthropicAuxiliaryClient):
+        return AsyncAnthropicAuxiliaryClient(sync_client), model
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -438,7 +576,15 @@ def get_vision_auxiliary_client() -> Tuple[Optional[OpenAI], Optional[str]]:
             _NOUS_MODEL,
         )
 
-    # 3. Nothing suitable
+    # 3. Anthropic (Claude supports vision natively)
+    ant_token = _read_anthropic_token()
+    if ant_token:
+        from agent.anthropic_adapter import build_anthropic_client
+        logger.debug("Auxiliary vision client: Anthropic (%s)", _ANTHROPIC_AUX_MODEL)
+        client = build_anthropic_client(ant_token)
+        return AnthropicAuxiliaryClient(client, _ANTHROPIC_AUX_MODEL), _ANTHROPIC_AUX_MODEL
+
+    # 4. Nothing suitable
     logger.debug("Auxiliary vision client: none available")
     return None, None
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -41,7 +41,6 @@ DEFAULT_CONTEXT_LENGTHS = {
     "anthropic/claude-sonnet-4": 200000,
     "anthropic/claude-sonnet-4-20250514": 200000,
     "anthropic/claude-haiku-4.5": 200000,
-    # Bare Anthropic model names (native provider)
     "claude-opus-4-20250514": 200000,
     "claude-sonnet-4-20250514": 200000,
     "claude-haiku-4-5-20251001": 200000,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -41,6 +41,10 @@ DEFAULT_CONTEXT_LENGTHS = {
     "anthropic/claude-sonnet-4": 200000,
     "anthropic/claude-sonnet-4-20250514": 200000,
     "anthropic/claude-haiku-4.5": 200000,
+    # Bare Anthropic model names (native provider)
+    "claude-opus-4-20250514": 200000,
+    "claude-sonnet-4-20250514": 200000,
+    "claude-haiku-4-5-20251001": 200000,
     "openai/gpt-4o": 128000,
     "openai/gpt-4-turbo": 128000,
     "openai/gpt-4o-mini": 128000,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -135,6 +135,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
     ),
+    "anthropic": ProviderConfig(
+        id="anthropic",
+        name="Anthropic",
+        auth_type="api_key",
+        inference_base_url="https://api.anthropic.com",
+        api_key_env_vars=("ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY"),
+    ),
 }
 
 
@@ -478,6 +485,7 @@ def resolve_provider(
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "kimi": "kimi-coding", "moonshot": "kimi-coding",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
+        "claude": "anthropic",
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1277,7 +1277,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "zai", "kimi-coding", "minimax", "minimax-cn"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "anthropic", "zai", "kimi-coding", "minimax", "minimax-cn"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -53,6 +53,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
     ],
+    "anthropic": [
+        "claude-opus-4-20250514",
+        "claude-sonnet-4-20250514",
+        "claude-haiku-4-5-20251001",
+    ],
 }
 
 _PROVIDER_LABELS = {
@@ -63,6 +68,7 @@ _PROVIDER_LABELS = {
     "kimi-coding": "Kimi / Moonshot",
     "minimax": "MiniMax",
     "minimax-cn": "MiniMax (China)",
+    "anthropic": "Anthropic",
     "custom": "custom endpoint",
 }
 
@@ -75,6 +81,7 @@ _PROVIDER_ALIASES = {
     "moonshot": "kimi-coding",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
+    "claude": "anthropic",
 }
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -148,6 +148,18 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    # Anthropic (native Messages API)
+    if provider == "anthropic":
+        creds = resolve_api_key_provider_credentials(provider)
+        return {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": creds.get("base_url", "").rstrip("/"),
+            "api_key": creds.get("api_key", ""),
+            "source": creds.get("source", "env"),
+            "requested_provider": requested_provider,
+        }
+
     # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -524,6 +524,7 @@ def setup_model_provider(config: dict):
         "Kimi / Moonshot (Kimi coding models)",
         "MiniMax (global endpoint)",
         "MiniMax China (mainland China endpoint)",
+        "Anthropic (Claude models, API key or setup-token)",
     ]
     if keep_label:
         provider_choices.append(keep_label)
@@ -811,12 +812,45 @@ def setup_model_provider(config: dict):
             save_env_value("OPENAI_API_KEY", "")
         _update_config_for_provider("minimax-cn", pconfig.inference_base_url)
 
-    # else: provider_idx == 8 (Keep current) — only shown when a provider already exists
+    elif provider_idx == 8:  # Anthropic
+        selected_provider = "anthropic"
+        print()
+        print_header("Anthropic API Key or Setup-Token")
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["anthropic"]
+        print_info(f"Provider: {pconfig.name}")
+        print_info("Accepts API keys (sk-ant-api-*) or setup-tokens (sk-ant-oat01-*)")
+        print_info("Get an API key at: https://console.anthropic.com/")
+        print_info("Or run 'claude setup-token' to get a setup-token")
+        print()
+
+        existing_key = get_env_value("ANTHROPIC_TOKEN") or get_env_value("ANTHROPIC_API_KEY")
+        if existing_key:
+            print_info(f"Current: {existing_key[:12]}... (configured)")
+            if prompt_yes_no("Update key?", False):
+                api_key = prompt("  Anthropic API key or setup-token", password=True)
+                if api_key:
+                    save_env_value("ANTHROPIC_TOKEN", api_key)
+                    print_success("Anthropic key saved")
+        else:
+            api_key = prompt("  Anthropic API key or setup-token", password=True)
+            if api_key:
+                save_env_value("ANTHROPIC_TOKEN", api_key)
+                print_success("Anthropic key saved")
+            else:
+                print_warning("Skipped - agent won't work without an API key")
+
+        if existing_custom:
+            save_env_value("OPENAI_BASE_URL", "")
+            save_env_value("OPENAI_API_KEY", "")
+        _update_config_for_provider("anthropic", pconfig.inference_base_url)
+
+    # else: provider_idx == 9 (Keep current) — only shown when a provider already exists
 
     # ── OpenRouter API Key for tools (if not already set) ──
     # Tools (vision, web, MoA) use OpenRouter independently of the main provider.
     # Prompt for OpenRouter key if not set and a non-OpenRouter provider was chosen.
-    if selected_provider in ("nous", "openai-codex", "custom", "zai", "kimi-coding", "minimax", "minimax-cn") and not get_env_value("OPENROUTER_API_KEY"):
+    if selected_provider in ("nous", "openai-codex", "custom", "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic") and not get_env_value("OPENROUTER_API_KEY"):
         print()
         print_header("OpenRouter API Key (for tools)")
         print_info("Tools like vision analysis, web search, and MoA use OpenRouter")
@@ -944,6 +978,28 @@ def setup_model_provider(config: dict):
                 save_env_value("LLM_MODEL", minimax_models[model_idx])
             elif model_idx == len(minimax_models):
                 custom = prompt("Enter model name")
+                if custom:
+                    config['model'] = custom
+                    save_env_value("LLM_MODEL", custom)
+            # else: keep current
+        elif selected_provider == "anthropic":
+            anthropic_models = [
+                "claude-sonnet-4-20250514",
+                "claude-opus-4-20250514",
+                "claude-haiku-4-5-20251001",
+            ]
+            model_choices = list(anthropic_models)
+            model_choices.append("Custom model")
+            model_choices.append(f"Keep current ({current_model})")
+
+            keep_idx = len(model_choices) - 1
+            model_idx = prompt_choice("Select default model:", model_choices, keep_idx)
+
+            if model_idx < len(anthropic_models):
+                config['model'] = anthropic_models[model_idx]
+                save_env_value("LLM_MODEL", anthropic_models[model_idx])
+            elif model_idx == len(anthropic_models):
+                custom = prompt("Enter model name (e.g., claude-sonnet-4-20250514)")
                 if custom:
                     config['model'] = custom
                     save_env_value("LLM_MODEL", custom)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license = { text = "MIT" }
 dependencies = [
   # Core
   "openai",
+  "anthropic>=0.39.0",
   "python-dotenv",
   "fire",
   "httpx",

--- a/run_agent.py
+++ b/run_agent.py
@@ -287,12 +287,10 @@ class AIAgent:
         self.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         
-        # Anthropic prompt caching: auto-enabled for Claude models via OpenRouter.
-        # Reduces input costs by ~75% on multi-turn conversations by caching the
-        # conversation prefix. Uses system_and_3 strategy (4 breakpoints).
         is_openrouter = "openrouter" in self.base_url.lower()
         is_claude = "claude" in self.model.lower()
-        self._use_prompt_caching = is_openrouter and is_claude
+        is_native_anthropic = self.api_mode == "anthropic_messages"
+        self._use_prompt_caching = (is_openrouter and is_claude) or is_native_anthropic
         self._cache_ttl = "5m"  # Default 5-minute TTL (1.25x write cost)
         
         # Persistent error log -- always writes WARNING+ to ~/.hermes/logs/errors.log
@@ -465,7 +463,8 @@ class AIAgent:
         
         # Show prompt caching status
         if self._use_prompt_caching and not self.quiet_mode:
-            print(f"💾 Prompt caching: ENABLED (Claude via OpenRouter, {self._cache_ttl} TTL)")
+            source = "native Anthropic" if is_native_anthropic else "Claude via OpenRouter"
+            print(f"💾 Prompt caching: ENABLED ({source}, {self._cache_ttl} TTL)")
         
         # Session logging setup - auto-save conversation trajectories for debugging
         self.session_start = datetime.now()

--- a/run_agent.py
+++ b/run_agent.py
@@ -244,13 +244,16 @@ class AIAgent:
         self.base_url = base_url or OPENROUTER_BASE_URL
         provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
         self.provider = provider_name or "openrouter"
-        if api_mode in {"chat_completions", "codex_responses"}:
+        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
         elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self.base_url.lower():
             self.api_mode = "codex_responses"
             self.provider = "openai-codex"
+        elif self.provider == "anthropic" or (provider_name is None and "api.anthropic.com" in self.base_url.lower()):
+            self.api_mode = "anthropic_messages"
+            self.provider = "anthropic"
         else:
             self.api_mode = "chat_completions"
 
@@ -359,52 +362,67 @@ class AIAgent:
                 ]:
                     logging.getLogger(quiet_logger).setLevel(logging.ERROR)
         
-        # Initialize OpenAI client - defaults to OpenRouter
-        client_kwargs = {}
-        
-        # Default to OpenRouter if no base_url provided
-        if base_url:
-            client_kwargs["base_url"] = base_url
-        else:
-            client_kwargs["base_url"] = OPENROUTER_BASE_URL
-        
-        # Handle API key - OpenRouter is the primary provider
-        if api_key:
-            client_kwargs["api_key"] = api_key
-        else:
-            # Primary: OPENROUTER_API_KEY, fallback to direct provider keys
-            client_kwargs["api_key"] = os.getenv("OPENROUTER_API_KEY", "")
-        
-        # OpenRouter app attribution — shows hermes-agent in rankings/analytics
-        effective_base = client_kwargs.get("base_url", "")
-        if "openrouter" in effective_base.lower():
-            client_kwargs["default_headers"] = {
-                "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
-                "X-OpenRouter-Title": "Hermes Agent",
-                "X-OpenRouter-Categories": "productivity,cli-agent",
-            }
-        elif "api.kimi.com" in effective_base.lower():
-            # Kimi Code API requires a recognized coding-agent User-Agent
-            # (see https://github.com/MoonshotAI/kimi-cli)
-            client_kwargs["default_headers"] = {
-                "User-Agent": "KimiCLI/1.0",
-            }
-        
-        self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
-        try:
-            self.client = OpenAI(**client_kwargs)
+        # Initialize LLM client
+        self._anthropic_client = None
+
+        if self.api_mode == "anthropic_messages":
+            from agent.anthropic_adapter import build_anthropic_client
+            effective_key = api_key or os.getenv("ANTHROPIC_TOKEN", "") or os.getenv("ANTHROPIC_API_KEY", "")
+            self._anthropic_api_key = effective_key
+            self._anthropic_client = build_anthropic_client(effective_key, base_url if base_url and "anthropic" in base_url else None)
+            # Still create a dummy OpenAI client for code paths that reference self.client
+            self.client = None
+            self._client_kwargs = {}
             if not self.quiet_mode:
-                print(f"🤖 AI Agent initialized with model: {self.model}")
-                if base_url:
-                    print(f"🔗 Using custom base URL: {base_url}")
-                # Always show API key info (masked) for debugging auth issues
-                key_used = client_kwargs.get("api_key", "none")
-                if key_used and key_used != "dummy-key" and len(key_used) > 12:
-                    print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
-                else:
-                    print(f"⚠️  Warning: API key appears invalid or missing (got: '{key_used[:20] if key_used else 'none'}...')")
-        except Exception as e:
-            raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
+                print(f"🤖 AI Agent initialized with model: {self.model} (Anthropic native)")
+                if effective_key and len(effective_key) > 12:
+                    print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
+        else:
+            client_kwargs = {}
+
+            # Default to OpenRouter if no base_url provided
+            if base_url:
+                client_kwargs["base_url"] = base_url
+            else:
+                client_kwargs["base_url"] = OPENROUTER_BASE_URL
+
+            # Handle API key - OpenRouter is the primary provider
+            if api_key:
+                client_kwargs["api_key"] = api_key
+            else:
+                # Primary: OPENROUTER_API_KEY, fallback to direct provider keys
+                client_kwargs["api_key"] = os.getenv("OPENROUTER_API_KEY", "")
+
+            # OpenRouter app attribution — shows hermes-agent in rankings/analytics
+            effective_base = client_kwargs.get("base_url", "")
+            if "openrouter" in effective_base.lower():
+                client_kwargs["default_headers"] = {
+                    "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
+                    "X-OpenRouter-Title": "Hermes Agent",
+                    "X-OpenRouter-Categories": "productivity,cli-agent",
+                }
+            elif "api.kimi.com" in effective_base.lower():
+                # Kimi Code API requires a recognized coding-agent User-Agent
+                # (see https://github.com/MoonshotAI/kimi-cli)
+                client_kwargs["default_headers"] = {
+                    "User-Agent": "KimiCLI/1.0",
+                }
+
+            self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
+            try:
+                self.client = OpenAI(**client_kwargs)
+                if not self.quiet_mode:
+                    print(f"🤖 AI Agent initialized with model: {self.model}")
+                    if base_url:
+                        print(f"🔗 Using custom base URL: {base_url}")
+                    # Always show API key info (masked) for debugging auth issues
+                    key_used = client_kwargs.get("api_key", "none")
+                    if key_used and key_used != "dummy-key" and len(key_used) > 12:
+                        print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
+                    else:
+                        print(f"⚠️  Warning: API key appears invalid or missing (got: '{key_used[:20] if key_used else 'none'}...')")
+            except Exception as e:
+                raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
         
         # Get available tools with filtering
         self.tools = get_tool_definitions(
@@ -2121,6 +2139,8 @@ class AIAgent:
             try:
                 if self.api_mode == "codex_responses":
                     result["response"] = self._run_codex_stream(api_kwargs)
+                elif self.api_mode == "anthropic_messages":
+                    result["response"] = self._anthropic_client.messages.create(**api_kwargs)
                 else:
                     result["response"] = self.client.chat.completions.create(**api_kwargs)
             except Exception as e:
@@ -2133,12 +2153,19 @@ class AIAgent:
             if self._interrupt_requested:
                 # Force-close the HTTP connection to stop token generation
                 try:
-                    self.client.close()
+                    if self.api_mode == "anthropic_messages":
+                        self._anthropic_client.close()
+                    else:
+                        self.client.close()
                 except Exception:
                     pass
                 # Rebuild the client for future calls (cheap, no network)
                 try:
-                    self.client = OpenAI(**self._client_kwargs)
+                    if self.api_mode == "anthropic_messages":
+                        from agent.anthropic_adapter import build_anthropic_client
+                        self._anthropic_client = build_anthropic_client(self._anthropic_api_key)
+                    else:
+                        self.client = OpenAI(**self._client_kwargs)
                 except Exception:
                     pass
                 raise InterruptedError("Agent interrupted during API call")
@@ -2148,6 +2175,16 @@ class AIAgent:
 
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
+        if self.api_mode == "anthropic_messages":
+            from agent.anthropic_adapter import build_anthropic_kwargs
+            return build_anthropic_kwargs(
+                model=self.model,
+                messages=api_messages,
+                tools=self.tools,
+                max_tokens=self.max_tokens,
+                reasoning_config=self.reasoning_config,
+            )
+
         if self.api_mode == "codex_responses":
             instructions = ""
             payload_messages = api_messages
@@ -3192,6 +3229,17 @@ class AIAgent:
                         elif len(output_items) == 0:
                             response_invalid = True
                             error_details.append("response.output is empty")
+                    elif self.api_mode == "anthropic_messages":
+                        content_blocks = getattr(response, "content", None) if response is not None else None
+                        if response is None:
+                            response_invalid = True
+                            error_details.append("response is None")
+                        elif not isinstance(content_blocks, list):
+                            response_invalid = True
+                            error_details.append("response.content is not a list")
+                        elif len(content_blocks) == 0:
+                            response_invalid = True
+                            error_details.append("response.content is empty")
                     else:
                         if response is None or not hasattr(response, 'choices') or response.choices is None or len(response.choices) == 0:
                             response_invalid = True
@@ -3287,6 +3335,9 @@ class AIAgent:
                             finish_reason = "length"
                         else:
                             finish_reason = "stop"
+                    elif self.api_mode == "anthropic_messages":
+                        stop_reason_map = {"end_turn": "stop", "tool_use": "tool_calls", "max_tokens": "length", "stop_sequence": "stop"}
+                        finish_reason = stop_reason_map.get(response.stop_reason, "stop")
                     else:
                         finish_reason = response.choices[0].finish_reason
                     
@@ -3325,7 +3376,7 @@ class AIAgent:
                     
                     # Track actual token usage from response for context management
                     if hasattr(response, 'usage') and response.usage:
-                        if self.api_mode == "codex_responses":
+                        if self.api_mode in ("codex_responses", "anthropic_messages"):
                             prompt_tokens = getattr(response.usage, 'input_tokens', 0) or 0
                             completion_tokens = getattr(response.usage, 'output_tokens', 0) or 0
                             total_tokens = (
@@ -3624,6 +3675,9 @@ class AIAgent:
             try:
                 if self.api_mode == "codex_responses":
                     assistant_message, finish_reason = self._normalize_codex_response(response)
+                elif self.api_mode == "anthropic_messages":
+                    from agent.anthropic_adapter import normalize_anthropic_response
+                    assistant_message, finish_reason = normalize_anthropic_response(response)
                 else:
                     assistant_message = response.choices[0].message
                 

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -1,0 +1,209 @@
+"""Tests for agent/anthropic_adapter.py — Anthropic Messages API adapter."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent.anthropic_adapter import (
+    build_anthropic_client,
+    build_anthropic_kwargs,
+    convert_messages_to_anthropic,
+    convert_tools_to_anthropic,
+    normalize_anthropic_response,
+)
+
+
+class TestBuildAnthropicClient:
+    def test_setup_token_uses_auth_token(self):
+        with patch("agent.anthropic_adapter.anthropic.Anthropic") as mock_cls:
+            build_anthropic_client("sk-ant-oat01-abcdefghijklmnop" + "x" * 60)
+            kwargs = mock_cls.call_args[1]
+            assert "auth_token" in kwargs
+            assert kwargs["default_headers"]["anthropic-beta"] == "oauth-2025-04-20"
+            assert "api_key" not in kwargs
+
+    def test_api_key_uses_api_key(self):
+        with patch("agent.anthropic_adapter.anthropic.Anthropic") as mock_cls:
+            build_anthropic_client("sk-ant-api03-something")
+            kwargs = mock_cls.call_args[1]
+            assert kwargs["api_key"] == "sk-ant-api03-something"
+            assert "auth_token" not in kwargs
+
+
+class TestConvertTools:
+    def test_converts_openai_to_anthropic_format(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search the web",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                },
+            }
+        ]
+        result = convert_tools_to_anthropic(tools)
+        assert len(result) == 1
+        assert result[0]["name"] == "search"
+        assert result[0]["description"] == "Search the web"
+        assert result[0]["input_schema"]["properties"]["query"]["type"] == "string"
+
+    def test_empty_tools(self):
+        assert convert_tools_to_anthropic([]) == []
+        assert convert_tools_to_anthropic(None) == []
+
+
+class TestConvertMessages:
+    def test_extracts_system_prompt(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ]
+        system, result = convert_messages_to_anthropic(messages)
+        assert system == "You are helpful."
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+
+    def test_converts_tool_calls(self):
+        messages = [
+            {"role": "assistant", "content": "Let me search.", "tool_calls": [
+                {"id": "tc_1", "function": {"name": "search", "arguments": '{"query": "test"}'}}
+            ]},
+            {"role": "tool", "tool_call_id": "tc_1", "content": "search results"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        blocks = result[0]["content"]
+        assert blocks[0] == {"type": "text", "text": "Let me search."}
+        assert blocks[1]["type"] == "tool_use"
+        assert blocks[1]["id"] == "tc_1"
+        assert blocks[1]["input"] == {"query": "test"}
+
+    def test_converts_tool_results(self):
+        messages = [
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result data"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assert result[0]["role"] == "user"
+        assert result[0]["content"][0]["type"] == "tool_result"
+        assert result[0]["content"][0]["tool_use_id"] == "tc_1"
+
+    def test_merges_consecutive_tool_results(self):
+        messages = [
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result 1"},
+            {"role": "tool", "tool_call_id": "tc_2", "content": "result 2"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assert len(result) == 1
+        assert len(result[0]["content"]) == 2
+
+    def test_strips_orphaned_tool_use(self):
+        messages = [
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "tc_orphan", "function": {"name": "x", "arguments": "{}"}}
+            ]},
+            {"role": "user", "content": "never mind"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        # tc_orphan has no matching tool_result, should be stripped
+        assistant_blocks = result[0]["content"]
+        assert all(b.get("type") != "tool_use" for b in assistant_blocks)
+
+
+class TestBuildAnthropicKwargs:
+    def test_basic_kwargs(self):
+        messages = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "Hi"},
+        ]
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=messages,
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+        )
+        assert kwargs["model"] == "claude-sonnet-4-20250514"
+        assert kwargs["system"] == "Be helpful."
+        assert kwargs["max_tokens"] == 4096
+        assert "tools" not in kwargs
+
+    def test_reasoning_config_maps_to_thinking(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "think hard"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kwargs["thinking"]["type"] == "enabled"
+        assert kwargs["thinking"]["budget_tokens"] == 16000
+        assert kwargs["max_tokens"] >= 16000 + 4096
+
+    def test_reasoning_disabled(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "quick"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+        )
+        assert "thinking" not in kwargs
+
+
+class TestNormalizeResponse:
+    def _make_response(self, content_blocks, stop_reason="end_turn"):
+        resp = SimpleNamespace()
+        resp.content = content_blocks
+        resp.stop_reason = stop_reason
+        resp.usage = SimpleNamespace(input_tokens=100, output_tokens=50)
+        return resp
+
+    def test_text_response(self):
+        block = SimpleNamespace(type="text", text="Hello world")
+        msg, reason = normalize_anthropic_response(self._make_response([block]))
+        assert msg.content == "Hello world"
+        assert reason == "stop"
+        assert msg.tool_calls is None
+
+    def test_tool_use_response(self):
+        blocks = [
+            SimpleNamespace(type="text", text="Searching..."),
+            SimpleNamespace(
+                type="tool_use",
+                id="tc_1",
+                name="search",
+                input={"query": "test"},
+            ),
+        ]
+        msg, reason = normalize_anthropic_response(
+            self._make_response(blocks, "tool_use")
+        )
+        assert msg.content == "Searching..."
+        assert reason == "tool_calls"
+        assert len(msg.tool_calls) == 1
+        assert msg.tool_calls[0].function.name == "search"
+        assert json.loads(msg.tool_calls[0].function.arguments) == {"query": "test"}
+
+    def test_thinking_response(self):
+        blocks = [
+            SimpleNamespace(type="thinking", thinking="Let me reason about this..."),
+            SimpleNamespace(type="text", text="The answer is 42."),
+        ]
+        msg, reason = normalize_anthropic_response(self._make_response(blocks))
+        assert msg.content == "The answer is 42."
+        assert msg.reasoning == "Let me reason about this..."
+
+    def test_stop_reason_mapping(self):
+        block = SimpleNamespace(type="text", text="x")
+        _, r1 = normalize_anthropic_response(self._make_response([block], "end_turn"))
+        _, r2 = normalize_anthropic_response(self._make_response([block], "tool_use"))
+        _, r3 = normalize_anthropic_response(self._make_response([block], "max_tokens"))
+        assert r1 == "stop"
+        assert r2 == "tool_calls"
+        assert r3 == "length"

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -281,20 +281,21 @@ class TestMaskApiKey:
 
 class TestInit:
     def test_anthropic_base_url_accepted(self):
-        """Anthropic base URLs should be accepted (OpenAI-compatible endpoint)."""
+        """Anthropic base URLs should route to native Anthropic client."""
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
             patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI") as mock_openai,
+            patch("agent.anthropic_adapter.anthropic.Anthropic") as mock_anthropic,
         ):
-            AIAgent(
+            agent = AIAgent(
                 api_key="test-key-1234567890",
                 base_url="https://api.anthropic.com/v1/",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
             )
-            mock_openai.assert_called_once()
+            assert agent.api_mode == "anthropic_messages"
+            mock_anthropic.assert_called_once()
 
     def test_prompt_caching_claude_openrouter(self):
         """Claude model via OpenRouter should enable prompt caching."""

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -346,6 +346,23 @@ class TestInit:
             )
             assert a._use_prompt_caching is False
 
+    def test_prompt_caching_native_anthropic(self):
+        """Native Anthropic provider should enable prompt caching."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter.anthropic.Anthropic"),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://api.anthropic.com/v1/",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a.api_mode == "anthropic_messages"
+            assert a._use_prompt_caching is True
+
     def test_valid_tool_names_populated(self):
         """valid_tool_names should contain names from loaded tools."""
         tools = _make_tool_defs("web_search", "terminal")


### PR DESCRIPTION
## Summary
- Adds direct Anthropic SDK integration so hermes can call Claude models natively without an OpenAI-compatible proxy
- Supports both OAuth setup-tokens (`sk-ant-oat01-*`) and regular API keys (`sk-ant-api-*`)
- Adds `AnthropicAuxiliaryClient` shim so subtask calls (compression, vision, search) also work natively with Anthropic
- 16 tests covering adapter conversion logic, all 2274 existing tests still pass

## Changes
- `agent/anthropic_adapter.py` — message/tool/response conversion between OpenAI and Anthropic formats
- `agent/auxiliary_client.py` — Anthropic added to text + vision auxiliary client resolution chains
- `run_agent.py` — `anthropic_messages` api_mode branches (follows existing `codex_responses` pattern)
- `hermes_cli/` — provider registration, model catalog, runtime resolution, CLI arg
- `agent/model_metadata.py` — bare Anthropic model context lengths
- `pyproject.toml` — `anthropic>=0.39.0` dependency

## Auth
- Setup-token: uses `auth_token=` + `anthropic-beta: oauth-2025-04-20` header
- API key: uses standard `api_key=`
- Env vars: `ANTHROPIC_TOKEN` (preferred), `ANTHROPIC_API_KEY`

## Test plan
- [x] 16 new adapter tests pass
- [x] Full test suite (2274 tests) passes with no regressions
- [x] E2E: `hermes chat --provider anthropic --model claude-sonnet-4-20250514 --query "Say hello in exactly 5 words"` → works

🤖 Generated with [Claude Code](https://claude.com/claude-code)