### PR TITLE
fix(setup): correct import of get_codex_model_ids in setup wizard

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -870,8 +870,8 @@ def setup_model_provider(config: dict):
                 config['model'] = custom
                 save_env_value("LLM_MODEL", custom)
         elif selected_provider == "openai-codex":
-            from hermes_cli.codex_models import get_codex_models
-            codex_models = get_codex_models()
+            from hermes_cli.codex_models import get_codex_model_ids
+            codex_models = get_codex_model_ids()
             model_choices = codex_models + [f"Keep current ({current_model})"]
             default_codex = 0
             if current_model in codex_models:


### PR DESCRIPTION
## Summary
- Fixes a runtime `ImportError` when selecting the `openai-codex` provider during `hermes setup`
- The setup wizard imported `get_codex_models` from `hermes_cli.codex_models`, but the actual function is `get_codex_model_ids`
- This was introduced in commit 50ee4aa during a large setup wizard refactor that renamed the import incorrectly

## Test plan
- [x] Run `hermes setup` and select `openai-codex` as the provider — should no longer crash with `ImportError`
- [x] Verify existing tests pass (`pytest tests/test_codex_models.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)