### PR TITLE
docs: clarify Telegram token regex constraint

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -47,7 +47,8 @@ _AUTH_HEADER_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Telegram bot tokens: bot<digits>:<token> or <digits>:<alphanum>
+# Telegram bot tokens: bot<digits>:<token> or <digits>:<token>,
+# where token part is restricted to [-A-Za-z0-9_] and length >= 30
 _TELEGRAM_RE = re.compile(
     r"(bot)?(\d{8,}):([-A-Za-z0-9_]{30,})",
 )


### PR DESCRIPTION
## Why
The comment above `_TELEGRAM_RE` implied it matches any `<digits>:<alphanum>` token format, but the actual regex requires a restricted charset and a minimum token length of 30 characters. This mismatch could mislead future maintenance and reviews.

## What changed
Updated the Telegram token comment in agent/redact.py to accurately describe the real regex constraints (`[-A-Za-z0-9_]`, length `>= 30`). No runtime logic was changed.