### PR TITLE
fix(cli): add loading state for slow slash commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -19,6 +19,7 @@ import sys
 import json
 import atexit
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any, Optional
@@ -47,6 +48,8 @@ from prompt_toolkit import print_formatted_text as _pt_print
 from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
 import threading
 import queue
+
+_COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
 
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback
@@ -1107,6 +1110,8 @@ class HermesCLI:
         # History file for persistent input recall across sessions
         self._history_file = Path.home() / ".hermes_history"
         self._last_invalidate: float = 0.0  # throttle UI repaints
+        self._command_running = False
+        self._command_status = ""
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
@@ -1115,6 +1120,44 @@ class HermesCLI:
         if hasattr(self, "_app") and self._app and (now - self._last_invalidate) >= min_interval:
             self._last_invalidate = now
             self._app.invalidate()
+
+    def _slow_command_status(self, command: str) -> str:
+        """Return a user-facing status message for slower slash commands."""
+        cmd_lower = command.lower().strip()
+        if cmd_lower.startswith("/skills search"):
+            return "Searching skills..."
+        if cmd_lower.startswith("/skills browse"):
+            return "Loading skills..."
+        if cmd_lower.startswith("/skills inspect"):
+            return "Inspecting skill..."
+        if cmd_lower.startswith("/skills install"):
+            return "Installing skill..."
+        if cmd_lower.startswith("/skills"):
+            return "Processing skills command..."
+        if cmd_lower == "/reload-mcp":
+            return "Reloading MCP servers..."
+        return "Processing command..."
+
+    def _command_spinner_frame(self) -> str:
+        """Return the current spinner frame for slow slash commands."""
+        import time as _time
+
+        frame_idx = int(_time.monotonic() * 10) % len(_COMMAND_SPINNER_FRAMES)
+        return _COMMAND_SPINNER_FRAMES[frame_idx]
+
+    @contextmanager
+    def _busy_command(self, status: str):
+        """Expose a temporary busy state in the TUI while a slash command runs."""
+        self._command_running = True
+        self._command_status = status
+        self._invalidate(min_interval=0.0)
+        try:
+            print(f"⏳ {status}")
+            yield
+        finally:
+            self._command_running = False
+            self._command_status = ""
+            self._invalidate(min_interval=0.0)
 
     def _ensure_runtime_credentials(self) -> bool:
         """
@@ -2246,7 +2289,8 @@ class HermesCLI:
         elif cmd_lower.startswith("/cron"):
             self._handle_cron_command(cmd_original)
         elif cmd_lower.startswith("/skills"):
-            self._handle_skills_command(cmd_original)
+            with self._busy_command(self._slow_command_status(cmd_original)):
+                self._handle_skills_command(cmd_original)
         elif cmd_lower == "/platforms" or cmd_lower == "/gateway":
             self._show_gateway_status()
         elif cmd_lower == "/verbose":
@@ -2260,7 +2304,8 @@ class HermesCLI:
         elif cmd_lower == "/paste":
             self._handle_paste_command()
         elif cmd_lower == "/reload-mcp":
-            self._reload_mcp()
+            with self._busy_command(self._slow_command_status(cmd_original)):
+                self._reload_mcp()
         else:
             # Check for skill slash commands (/gif-search, /axolotl, etc.)
             base_cmd = cmd_lower.split()[0]
@@ -2428,7 +2473,8 @@ class HermesCLI:
             with _lock:
                 old_servers = set(_servers.keys())
 
-            print("🔄 Reloading MCP servers...")
+            if not self._command_running:
+                print("🔄 Reloading MCP servers...")
 
             # Shutdown existing connections
             shutdown_mcp_servers()
@@ -2835,6 +2881,10 @@ class HermesCLI:
         self._approval_state = None     # dict with command, description, choices, selected, response_queue
         self._approval_deadline = 0
 
+        # Slash command loading state
+        self._command_running = False
+        self._command_status = ""
+
         # Clipboard image attachments (paste images into the CLI)
         self._attached_images: list[Path] = []
         self._image_counter = 0
@@ -3107,6 +3157,8 @@ class HermesCLI:
                 return [('class:clarify-selected', '✎ ❯ ')]
             if cli_ref._clarify_state:
                 return [('class:prompt-working', '? ❯ ')]
+            if cli_ref._command_running:
+                return [('class:prompt-working', f"{cli_ref._command_spinner_frame()} ❯ ")]
             if cli_ref._agent_running:
                 return [('class:prompt-working', '⚕ ❯ ')]
             return [('class:prompt', '❯ ')]
@@ -3118,6 +3170,7 @@ class HermesCLI:
             style='class:input-area',
             multiline=True,
             wrap_lines=True,
+            read_only=Condition(lambda: bool(cli_ref._command_running)),
             history=FileHistory(str(self._history_file)),
             completer=SlashCommandCompleter(skill_commands_provider=lambda: _skill_commands),
             complete_while_typing=True,
@@ -3200,6 +3253,10 @@ class HermesCLI:
                 return ""
             if cli_ref._clarify_state:
                 return ""
+            if cli_ref._command_running:
+                frame = cli_ref._command_spinner_frame()
+                status = cli_ref._command_status or "Processing command..."
+                return f"{frame} {status}"
             if cli_ref._agent_running:
                 return "type a message + Enter to interrupt, Ctrl+C to cancel"
             return ""
@@ -3234,15 +3291,21 @@ class HermesCLI:
                         ('class:hint', '  type your answer and press Enter'),
                         ('class:clarify-countdown', countdown),
                     ]
+                    return [
+                        ('class:hint', '  ↑/↓ to select, Enter to confirm'),
+                        ('class:clarify-countdown', countdown),
+                    ]
+
+            if cli_ref._command_running:
+                frame = cli_ref._command_spinner_frame()
                 return [
-                    ('class:hint', '  ↑/↓ to select, Enter to confirm'),
-                    ('class:clarify-countdown', countdown),
+                    ('class:hint', f'  {frame} command in progress · input temporarily disabled'),
                 ]
 
             return []
 
         def get_hint_height():
-            if cli_ref._sudo_state or cli_ref._approval_state or cli_ref._clarify_state:
+            if cli_ref._sudo_state or cli_ref._approval_state or cli_ref._clarify_state or cli_ref._command_running:
                 return 1
             # Keep a 1-line spacer while agent runs so output doesn't push
             # right up against the top rule of the input area
@@ -3486,6 +3549,19 @@ class HermesCLI:
             mouse_support=False,
         )
         self._app = app  # Store reference for clarify_callback
+
+        def spinner_loop():
+            import time as _time
+
+            while not self._should_exit:
+                if self._command_running and self._app:
+                    self._invalidate(min_interval=0.1)
+                    _time.sleep(0.1)
+                else:
+                    _time.sleep(0.05)
+
+        spinner_thread = threading.Thread(target=spinner_loop, daemon=True)
+        spinner_thread.start()
         
         # Background thread to process inputs and run agent
         def process_loop():

--- a/tests/test_cli_loading_indicator.py
+++ b/tests/test_cli_loading_indicator.py
@@ -1,0 +1,65 @@
+"""Regression tests for loading feedback on slow slash commands."""
+
+from unittest.mock import patch
+
+from cli import HermesCLI
+
+
+class TestCLILoadingIndicator:
+    def _make_cli(self):
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        cli_obj._app = None
+        cli_obj._last_invalidate = 0.0
+        cli_obj._command_running = False
+        cli_obj._command_status = ""
+        return cli_obj
+
+    def test_skills_command_sets_busy_state_and_prints_status(self, capsys):
+        cli_obj = self._make_cli()
+        seen = {}
+
+        def fake_handle(cmd: str):
+            seen["cmd"] = cmd
+            seen["running"] = cli_obj._command_running
+            seen["status"] = cli_obj._command_status
+            print("skills done")
+
+        with patch.object(cli_obj, "_handle_skills_command", side_effect=fake_handle), \
+             patch.object(cli_obj, "_invalidate") as invalidate_mock:
+            assert cli_obj.process_command("/skills search kubernetes")
+
+        output = capsys.readouterr().out
+        assert "⏳ Searching skills..." in output
+        assert "skills done" in output
+        assert seen == {
+            "cmd": "/skills search kubernetes",
+            "running": True,
+            "status": "Searching skills...",
+        }
+        assert cli_obj._command_running is False
+        assert cli_obj._command_status == ""
+        assert invalidate_mock.call_count == 2
+
+    def test_reload_mcp_sets_busy_state_and_prints_status(self, capsys):
+        cli_obj = self._make_cli()
+        seen = {}
+
+        def fake_reload():
+            seen["running"] = cli_obj._command_running
+            seen["status"] = cli_obj._command_status
+            print("reload done")
+
+        with patch.object(cli_obj, "_reload_mcp", side_effect=fake_reload), \
+             patch.object(cli_obj, "_invalidate") as invalidate_mock:
+            assert cli_obj.process_command("/reload-mcp")
+
+        output = capsys.readouterr().out
+        assert "⏳ Reloading MCP servers..." in output
+        assert "reload done" in output
+        assert seen == {
+            "running": True,
+            "status": "Reloading MCP servers...",
+        }
+        assert cli_obj._command_running is False
+        assert cli_obj._command_status == ""
+        assert invalidate_mock.call_count == 2


### PR DESCRIPTION
## What changed
- show an immediate loading message for slower slash commands like `/skills ...` and `/reload-mcp`
- add a small spinner in the prompt while the command is running
- make the input temporarily read-only so it doesn't feel like the CLI froze

## Why
Right now these commands can sit there for a bit with no feedback, which makes it look like nothing is happening. This keeps the fix pretty small, but it gives the user immediate confirmation that Hermes is still working.

## Testing
- `.venv/bin/python -m pytest tests/test_cli_loading_indicator.py tests/test_cli_model_command.py tests/hermes_cli/test_commands.py -q`

Fixes #636
