### PR TITLE
fix: close leaked file handles in rl_training_tool

### DIFF
--- a/tests/tools/test_rl_training_tool.py
+++ b/tests/tools/test_rl_training_tool.py
@@ -1,0 +1,125 @@
+"""Tests for rl_training_tool.py - file handle lifecycle and cleanup."""
+
+import subprocess
+from dataclasses import dataclass
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.rl_training_tool import RunState, _stop_training_run
+
+
+def _make_run_state(**overrides) -> RunState:
+    """Create a minimal RunState for testing."""
+    defaults = {
+        "run_id": "test-run-001",
+        "environment": "test_env",
+        "config": {},
+    }
+    defaults.update(overrides)
+    return RunState(**defaults)
+
+
+class TestRunStateLogFiles:
+    """Verify that RunState tracks log file handles."""
+
+    def test_log_files_default_empty(self):
+        state = _make_run_state()
+        assert state._log_files == []
+
+    def test_log_files_accumulates(self):
+        state = _make_run_state()
+        fh1 = StringIO()
+        fh2 = StringIO()
+        state._log_files.append(fh1)
+        state._log_files.append(fh2)
+        assert len(state._log_files) == 2
+
+    def test_separate_instances_have_separate_lists(self):
+        s1 = _make_run_state(run_id="a")
+        s2 = _make_run_state(run_id="b")
+        s1._log_files.append(StringIO())
+        assert len(s2._log_files) == 0
+
+
+class TestStopTrainingRun:
+    """Verify that _stop_training_run closes file handles and terminates processes."""
+
+    def test_closes_all_log_files(self):
+        state = _make_run_state()
+        files = [MagicMock() for _ in range(3)]
+        state._log_files = files
+
+        _stop_training_run(state)
+
+        for fh in files:
+            fh.close.assert_called_once()
+        assert state._log_files == []
+
+    def test_clears_log_files_list(self):
+        state = _make_run_state()
+        state._log_files = [MagicMock()]
+
+        _stop_training_run(state)
+
+        assert state._log_files == []
+
+    def test_close_exception_does_not_propagate(self):
+        """If a file handle .close() raises, it should not crash."""
+        state = _make_run_state()
+        bad_fh = MagicMock()
+        bad_fh.close.side_effect = OSError("already closed")
+        good_fh = MagicMock()
+        state._log_files = [bad_fh, good_fh]
+
+        _stop_training_run(state)
+
+        # Both should be attempted, second should succeed
+        bad_fh.close.assert_called_once()
+        good_fh.close.assert_called_once()
+        assert state._log_files == []
+
+    def test_terminates_processes(self):
+        state = _make_run_state()
+        for attr in ("api_process", "trainer_process", "env_process"):
+            proc = MagicMock()
+            proc.poll.return_value = None  # still running
+            setattr(state, attr, proc)
+
+        _stop_training_run(state)
+
+        for attr in ("api_process", "trainer_process", "env_process"):
+            getattr(state, attr).terminate.assert_called_once()
+
+    def test_no_crash_with_no_processes_and_no_files(self):
+        state = _make_run_state()
+        _stop_training_run(state)  # should not raise
+
+    def test_sets_status_to_stopped_when_running(self):
+        state = _make_run_state(status="running")
+        _stop_training_run(state)
+        assert state.status == "stopped"
+
+    def test_does_not_change_status_when_failed(self):
+        state = _make_run_state(status="failed")
+        _stop_training_run(state)
+        assert state.status == "failed"
+
+    def test_handles_mixed_running_and_exited_processes(self):
+        state = _make_run_state()
+        # api still running
+        api = MagicMock()
+        api.poll.return_value = None
+        state.api_process = api
+        # trainer already exited
+        trainer = MagicMock()
+        trainer.poll.return_value = 0
+        state.trainer_process = trainer
+        # env is None
+        state.env_process = None
+
+        _stop_training_run(state)
+
+        api.terminate.assert_called_once()
+        trainer.terminate.assert_not_called()

--- a/tools/rl_training_tool.py
+++ b/tools/rl_training_tool.py
@@ -131,6 +131,8 @@ class RunState:
     api_process: Optional[subprocess.Popen] = None
     trainer_process: Optional[subprocess.Popen] = None
     env_process: Optional[subprocess.Popen] = None
+    # Log file handles (must be closed when stopping)
+    _log_files: List = field(default_factory=list)
 
 
 # Global state
@@ -324,6 +326,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         print(f"[{run_id}] Starting Atropos API server (run-api)...")
         
         api_log_file = open(api_log, "w")
+        run_state._log_files.append(api_log_file)
         run_state.api_process = subprocess.Popen(
             ["run-api"],
             stdout=api_log_file,
@@ -337,6 +340,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         if run_state.api_process.poll() is not None:
             run_state.status = "failed"
             run_state.error_message = f"API server exited with code {run_state.api_process.returncode}. Check {api_log}"
+            _stop_training_run(run_state)
             return
         
         print(f"[{run_id}] Atropos API server started")
@@ -345,6 +349,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         print(f"[{run_id}] Starting Tinker trainer: launch_training.py --config {config_path}")
         
         trainer_log_file = open(trainer_log, "w")
+        run_state._log_files.append(trainer_log_file)
         run_state.trainer_process = subprocess.Popen(
             [sys.executable, "launch_training.py", "--config", str(config_path)],
             stdout=trainer_log_file,
@@ -360,8 +365,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         if run_state.trainer_process.poll() is not None:
             run_state.status = "failed"
             run_state.error_message = f"Trainer exited with code {run_state.trainer_process.returncode}. Check {trainer_log}"
-            if run_state.api_process:
-                run_state.api_process.terminate()
+            _stop_training_run(run_state)
             return
         
         print(f"[{run_id}] Trainer started, inference server on port 8001")
@@ -380,11 +384,13 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         if not env_info:
             run_state.status = "failed"
             run_state.error_message = f"Environment '{run_state.environment}' not found"
+            _stop_training_run(run_state)
             return
         
         print(f"[{run_id}] Starting environment: {env_info.file_path} serve")
         
         env_log_file = open(env_log, "w")
+        run_state._log_files.append(env_log_file)
         run_state.env_process = subprocess.Popen(
             [sys.executable, str(env_info.file_path), "serve", "--config", str(config_path)],
             stdout=env_log_file,
@@ -398,10 +404,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         if run_state.env_process.poll() is not None:
             run_state.status = "failed"
             run_state.error_message = f"Environment exited with code {run_state.env_process.returncode}. Check {env_log}"
-            if run_state.trainer_process:
-                run_state.trainer_process.terminate()
-            if run_state.api_process:
-                run_state.api_process.terminate()
+            _stop_training_run(run_state)
             return
         
         run_state.status = "running"
@@ -477,6 +480,14 @@ def _stop_training_run(run_state: RunState):
         except subprocess.TimeoutExpired:
             run_state.api_process.kill()
     
+    # Close leaked log file handles
+    for fh in run_state._log_files:
+        try:
+            fh.close()
+        except Exception:
+            pass
+    run_state._log_files.clear()
+
     if run_state.status == "running":
         run_state.status = "stopped"
 


### PR DESCRIPTION
## Summary
- `_spawn_training_run` opens 3 log files (`api_log_file`, `trainer_log_file`, `env_log_file`) for subprocess stdout redirection but never closes them
- `_stop_training_run` only terminates processes — no `.close()` call exists anywhere in the file
- Each training run leaks 3 file descriptors; repeated runs eventually cause `OSError: [Errno 24] Too many open files`
- Early return paths (process exit, env not found) also leak handles since cleanup was never called

## Changes
- Add `_log_files` list to `RunState` dataclass to track open file handles
- Append each opened log file to `run_state._log_files` immediately after `open()`
- Close all tracked file handles in `_stop_training_run` (with exception safety)
- Call `_stop_training_run` on all early-return failure paths instead of manual `terminate()` calls

## Test plan
- [x] 11 new tests in `tests/tools/test_rl_training_tool.py`
- [x] Verifies `_log_files` default empty, accumulates, instance isolation
- [x] Verifies `_stop_training_run` closes all handles, clears list, handles `.close()` exceptions
- [x] Verifies process termination, status transitions, mixed running/exited processes