### PR TITLE
feat(agent): implicit signal detection & behavioral nudges

### DIFF
--- a/agent/signal_detector.py
+++ b/agent/signal_detector.py
@@ -1,0 +1,146 @@
+"""Implicit signal detection & behavioral nudges.
+
+Scans user messages for implicit emotional/cognitive signals (frustration,
+confusion, fatigue, etc.) using lightweight regex patterns and prepends
+a behavioral nudge to the message before the LLM sees it.
+
+The nudge steers the model toward more context-appropriate responses without
+modifying the system prompt or conversation history (cache-safe).
+
+Inspired by NeuroSkill (MIT Media Lab, arXiv:2603.03212).
+See: https://github.com/NousResearch/hermes-agent/issues/692
+"""
+
+import re
+from typing import Dict, List
+
+# ---------------------------------------------------------------------------
+# Signal patterns — each key maps to a list of regex patterns that indicate
+# a particular user state. Patterns use word boundaries and are matched
+# case-insensitively against the full message text.
+# ---------------------------------------------------------------------------
+
+SIGNALS: Dict[str, List[str]] = {
+    "frustration": [
+        r"\b(stupid|annoying|ugh|wtf|damn|hate this|sick of)\b",
+        r"\b(still (not|won't|doesn't|can't))\b",
+        r"\b(for hours|all day|keeps? (failing|breaking|crashing))\b",
+        r"\b(tried everything|nothing works|give up)\b",
+    ],
+    "confusion": [
+        r"\b(confused|don't (understand|get it)|makes? no sense)\b",
+        r"\b(lost|stuck|no idea|bewildered)\b",
+    ],
+    "urgency": [
+        r"\b(asap|urgent|deadline|due (today|tomorrow|soon))\b",
+        r"\b(quickly|fast|hurry|right now|immediately)\b",
+    ],
+    "fatigue": [
+        r"\b(exhausted|tired|burned? out|drained|sleepy)\b",
+        r"\b(been (at|doing|working on) this .{0,15}(hours|all day))\b",
+        r"\b(can't think|brain.{0,5}(fried|dead|mush))\b",
+    ],
+    "learning": [
+        r"\b(learning|studying|new to|beginner|first time)\b",
+        r"\b(explain|teach|walk me through|eli5)\b",
+    ],
+    "exploration": [
+        r"\b(curious|wondering|what if|explore|experiment)\b",
+        r"\b(brainstorm|ideas?|possibilities)\b",
+    ],
+    "celebration": [
+        r"\b(it works|finally|hell yeah|awesome|nailed it)\b",
+        r"\b(fixed|solved|figured (it )?out|got it)\b",
+    ],
+    "anxiety": [
+        r"\b(worried|nervous|anxious|scared|afraid)\b",
+        r"\b(might (break|fail|crash)|what if .{0,20}(goes wrong|breaks))\b",
+    ],
+    "overwhelm": [
+        r"\b(overwhelm|too (much|many)|where do I (start|begin))\b",
+        r"\b(information overload|drowning in)\b",
+    ],
+    "deep_work": [
+        r"\b(deep (dive|work)|focus|concentrate|in the zone)\b",
+        r"\b(don't (interrupt|distract)|flow state)\b",
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Nudge strings — short behavioral guidance the LLM receives when a signal
+# fires.  Kept concise to minimise token overhead (~20-40 tokens total).
+# ---------------------------------------------------------------------------
+
+NUDGES: Dict[str, str] = {
+    "frustration": (
+        "User sounds frustrated. Acknowledge briefly, pivot to a concrete "
+        "alternative. Don't repeat what they've tried."
+    ),
+    "confusion": (
+        "User seems confused. Use simpler language, break into clear steps, "
+        "lead with a concrete example."
+    ),
+    "urgency": (
+        "User is in a hurry. Lead with the answer, skip preamble, most "
+        "direct solution first."
+    ),
+    "fatigue": (
+        "User sounds tired/burned out. Keep response focused, avoid "
+        "overload. Offer to handle more autonomously."
+    ),
+    "learning": (
+        "User is learning. Be patient, explain concepts before "
+        "implementation, point out beginner pitfalls."
+    ),
+    "exploration": (
+        "User is exploring. Be creative, suggest multiple approaches, "
+        "encourage experimentation."
+    ),
+    "celebration": (
+        "User just succeeded. Match their energy briefly, then suggest "
+        "next steps."
+    ),
+    "anxiety": (
+        "User is anxious about risk. Reassure with specifics, suggest "
+        "reversible approaches, offer dry runs."
+    ),
+    "overwhelm": (
+        "User is overwhelmed. Give ONE clear next step, offer to break "
+        "the problem down."
+    ),
+    "deep_work": (
+        "User is in deep focus. Be precise and efficient, no small talk."
+    ),
+}
+
+
+def detect_signals(message: str) -> Dict[str, bool]:
+    """Scan *message* for implicit user-state signals.
+
+    Returns a dict mapping each signal name to ``True`` if any of its
+    patterns matched, ``False`` otherwise.  Matching is case-insensitive.
+    """
+    if not message:
+        return {name: False for name in SIGNALS}
+
+    lowered = message.lower()
+    return {
+        name: any(re.search(p, lowered) for p in patterns)
+        for name, patterns in SIGNALS.items()
+    }
+
+
+def build_nudge_prefix(message: str) -> str:
+    """Return a ``[Context: …]`` prefix for *message*, or ``""`` if no
+    signals were detected.
+
+    The prefix is meant to be **prepended** to the user message before
+    the API call so the LLM receives behavioural guidance without any
+    change to the system prompt or conversation history.
+    """
+    signals = detect_signals(message)
+    active = [NUDGES[name] for name, fired in signals.items() if fired]
+    if not active:
+        return ""
+    nudge_text = " ".join(active)
+    return f"[Context: {nudge_text}]\n\n"

--- a/run_agent.py
+++ b/run_agent.py
@@ -39,6 +39,8 @@ import fire
 from datetime import datetime
 from pathlib import Path
 
+from agent.signal_detector import build_nudge_prefix
+
 # Load .env from ~/.hermes/.env first, then project root as dev fallback
 from dotenv import load_dotenv
 
@@ -2805,6 +2807,14 @@ class AIAgent:
         # Preserve the original user message before nudge injection.
         # Honcho should receive the actual user input, not system nudges.
         original_user_message = user_message
+
+        # Implicit signal detection: scan the user message for emotional/
+        # cognitive signals (frustration, confusion, fatigue, …) and prepend
+        # a behavioural nudge so the LLM responds more appropriately.
+        # Cache-safe: only the new user message is modified.  See #692.
+        signal_nudge = build_nudge_prefix(user_message)
+        if signal_nudge:
+            user_message = signal_nudge + user_message
 
         # Periodic memory nudge: remind the model to consider saving memories.
         # Counter resets whenever the memory tool is actually used.

--- a/tests/agent/test_signal_detector.py
+++ b/tests/agent/test_signal_detector.py
@@ -1,0 +1,237 @@
+"""Tests for agent.signal_detector — implicit signal detection & nudges."""
+
+import pytest
+
+from agent.signal_detector import (
+    SIGNALS,
+    NUDGES,
+    detect_signals,
+    build_nudge_prefix,
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_signals() — individual signal categories
+# ---------------------------------------------------------------------------
+
+
+class TestFrustration:
+    def test_explicit_frustration(self):
+        result = detect_signals("ugh this is so stupid, nothing works")
+        assert result["frustration"] is True
+
+    def test_still_not_working(self):
+        result = detect_signals("it still won't compile after all my changes")
+        assert result["frustration"] is True
+
+    def test_keeping_failing(self):
+        result = detect_signals("the tests keep failing for hours")
+        assert result["frustration"] is True
+
+
+class TestConfusion:
+    def test_dont_understand(self):
+        result = detect_signals("I don't understand what this function does")
+        assert result["confusion"] is True
+
+    def test_makes_no_sense(self):
+        result = detect_signals("this error makes no sense to me")
+        assert result["confusion"] is True
+
+    def test_stuck(self):
+        result = detect_signals("I'm completely stuck on this problem")
+        assert result["confusion"] is True
+
+
+class TestUrgency:
+    def test_asap(self):
+        result = detect_signals("I need this fixed asap")
+        assert result["urgency"] is True
+
+    def test_deadline(self):
+        result = detect_signals("the deadline is due tomorrow")
+        assert result["urgency"] is True
+
+    def test_immediately(self):
+        result = detect_signals("please do this immediately")
+        assert result["urgency"] is True
+
+
+class TestFatigue:
+    def test_exhausted(self):
+        result = detect_signals("I'm exhausted, been debugging all day")
+        assert result["fatigue"] is True
+
+    def test_brain_fried(self):
+        result = detect_signals("my brain is fried, can't think straight")
+        assert result["fatigue"] is True
+
+    def test_burned_out(self):
+        result = detect_signals("I'm completely burned out on this")
+        assert result["fatigue"] is True
+
+
+class TestLearning:
+    def test_new_to(self):
+        result = detect_signals("I'm new to Python, can you help?")
+        assert result["learning"] is True
+
+    def test_explain(self):
+        result = detect_signals("can you explain how async works?")
+        assert result["learning"] is True
+
+    def test_eli5(self):
+        result = detect_signals("eli5 what is a closure?")
+        assert result["learning"] is True
+
+
+class TestExploration:
+    def test_what_if(self):
+        result = detect_signals("what if we used a different algorithm?")
+        assert result["exploration"] is True
+
+    def test_brainstorm(self):
+        result = detect_signals("let's brainstorm some ideas for the API")
+        assert result["exploration"] is True
+
+
+class TestCelebration:
+    def test_it_works(self):
+        result = detect_signals("it works! the tests are all passing!")
+        assert result["celebration"] is True
+
+    def test_figured_it_out(self):
+        result = detect_signals("I figured it out, the bug was in the parser")
+        assert result["celebration"] is True
+
+
+class TestAnxiety:
+    def test_worried(self):
+        result = detect_signals("I'm worried this change might break production")
+        assert result["anxiety"] is True
+
+    def test_what_if_goes_wrong(self):
+        result = detect_signals("what if the migration goes wrong?")
+        assert result["anxiety"] is True
+
+
+class TestOverwhelm:
+    def test_too_much(self):
+        result = detect_signals("there's too much to do, where do I start?")
+        assert result["overwhelm"] is True
+
+    def test_information_overload(self):
+        result = detect_signals("information overload, I can't process this")
+        assert result["overwhelm"] is True
+
+
+class TestDeepWork:
+    def test_focus(self):
+        result = detect_signals("I need to focus, just give me the code")
+        assert result["deep_work"] is True
+
+    def test_dont_interrupt(self):
+        result = detect_signals("don't interrupt, I'm in flow state")
+        assert result["deep_work"] is True
+
+
+# ---------------------------------------------------------------------------
+# detect_signals() — edge cases & cross-cutting
+# ---------------------------------------------------------------------------
+
+
+class TestNeutralMessages:
+    """Neutral/casual messages should not trigger any signals."""
+
+    def test_simple_greeting(self):
+        result = detect_signals("hello, how are you?")
+        assert not any(result.values())
+
+    def test_normal_request(self):
+        result = detect_signals("please create a function that sorts a list")
+        assert not any(result.values())
+
+    def test_technical_discussion(self):
+        result = detect_signals("the API returns JSON with a status field")
+        assert not any(result.values())
+
+
+class TestMultipleSignals:
+    """A single message can trigger multiple signals simultaneously."""
+
+    def test_frustration_and_fatigue(self):
+        result = detect_signals(
+            "this stupid thing still won't compile, I've been at this for hours"
+        )
+        assert result["frustration"] is True
+        assert result["fatigue"] is True
+
+    def test_confusion_and_learning(self):
+        result = detect_signals(
+            "I'm new to React and I don't understand hooks at all"
+        )
+        assert result["learning"] is True
+        assert result["confusion"] is True
+
+    def test_urgency_and_anxiety(self):
+        result = detect_signals(
+            "deadline is due tomorrow and I'm worried it might break"
+        )
+        assert result["urgency"] is True
+        assert result["anxiety"] is True
+
+
+class TestEmptyAndEdgeCases:
+    def test_empty_string(self):
+        result = detect_signals("")
+        assert not any(result.values())
+
+    def test_case_insensitive(self):
+        result = detect_signals("UGH THIS IS SO STUPID")
+        assert result["frustration"] is True
+
+    def test_all_signal_names_have_nudges(self):
+        """Every signal category must have a corresponding nudge string."""
+        for name in SIGNALS:
+            assert name in NUDGES, f"Signal '{name}' missing from NUDGES"
+
+    def test_returns_all_signal_keys(self):
+        """detect_signals always returns a key for every signal category."""
+        result = detect_signals("hello")
+        assert set(result.keys()) == set(SIGNALS.keys())
+
+
+# ---------------------------------------------------------------------------
+# build_nudge_prefix()
+# ---------------------------------------------------------------------------
+
+
+class TestBuildNudgePrefix:
+    def test_no_signals_returns_empty(self):
+        prefix = build_nudge_prefix("hello, how are you?")
+        assert prefix == ""
+
+    def test_single_signal_format(self):
+        prefix = build_nudge_prefix("ugh this is so stupid")
+        assert prefix.startswith("[Context: ")
+        assert prefix.endswith("]\n\n")
+        assert "frustrated" in prefix.lower() or "frustrat" in prefix.lower()
+
+    def test_multiple_signals_combined(self):
+        prefix = build_nudge_prefix(
+            "I'm exhausted and nothing works, tried everything"
+        )
+        assert prefix.startswith("[Context: ")
+        assert prefix.endswith("]\n\n")
+        # Should contain both frustration and fatigue nudges
+        assert "frustrat" in prefix.lower()
+        assert "tired" in prefix.lower() or "fatigue" in prefix.lower()
+
+    def test_empty_message(self):
+        assert build_nudge_prefix("") == ""
+
+    def test_prefix_does_not_modify_message(self):
+        """build_nudge_prefix returns only the prefix, not the message."""
+        msg = "ugh this is broken"
+        prefix = build_nudge_prefix(msg)
+        assert msg not in prefix


### PR DESCRIPTION
## Summary

Implements **implicit signal detection** that scans user messages for emotional/cognitive signals and prepends behavioral nudges to guide the LLM's response — without modifying the system prompt or conversation history.

Inspired by [NeuroSkill](https://arxiv.org/abs/2603.03212) (MIT Media Lab, March 2026). Cache-safe, zero dependencies, ~20-40 token overhead per message when signals fire.

**10 signal categories** detected via regex:

| Signal | Example Trigger | Nudge Effect |
|--------|----------------|--------------|
| Frustration | "ugh nothing works" | Acknowledge, pivot to alternative |
| Confusion | "I don't understand" | Simpler language, concrete examples |
| Urgency | "deadline tomorrow" | Lead with answer, skip preamble |
| Fatigue | "been at this for hours" | Keep brief, offer autonomy |
| Learning | "I'm new to this" | Patient, explain before implement |
| Exploration | "what if we tried..." | Creative, suggest alternatives |
| Celebration | "it works finally!" | Match energy, suggest next steps |
| Anxiety | "worried it might break" | Reassure, suggest reversible approaches |
| Overwhelm | "too much, where do I start" | ONE clear next step |
| Deep Work | "just do it, don't explain" | Precise and efficient |

## Changes

- **New:** `agent/signal_detector.py` (~120 lines) — `SIGNALS` patterns, `NUDGES` mapping, `detect_signals()`, `build_nudge_prefix()`
- **New:** `tests/agent/test_signal_detector.py` — 40 tests (all passing)
- **Modified:** `run_agent.py` — 1 import + 6-line integration at the nudge injection point (after `original_user_message` preservation, before memory/skill nudges)

## How it works

```
User message: "this stupid thing still won't compile, been at this for hours"
                              ↓
detect_signals() → frustration: True, fatigue: True
                              ↓
build_nudge_prefix() → "[Context: User sounds frustrated. Acknowledge briefly...
                         User sounds tired. Keep response focused...]\n\n"
                              ↓
LLM receives: "[Context: ...]\n\nthis stupid thing still won't compile..."
```

The user never sees the prefix. The system prompt and conversation history are untouched (cache-safe).

## Design decisions

- **Prepend to user message** (not system prompt) — system prompt is frozen at session start for cache efficiency
- **Regex-based** — microsecond detection, no external API calls, no ML model
- **Placed before memory/skill nudges** in `run_agent.py` — signal nudge is behavioral context, memory/skill nudges are operational reminders
- **All 10 categories from issue spec** — patterns and nudge strings follow #692 exactly

## Test plan

- [x] 40 unit tests covering all 10 signal categories
- [x] Neutral message tests (no false positives on "hello", "create a function", etc.)
- [x] Multi-signal tests (frustration + fatigue, confusion + learning, urgency + anxiety)
- [x] Edge cases: empty string, case insensitivity, all signals have nudges
- [x] `build_nudge_prefix` format validation (`[Context: ...]` wrapper)
- [ ] Manual: `hermes chat` → "ugh this is broken" → verify empathetic response
- [ ] Manual: "hello" → verify no nudge injected

Closes #692