### PR TITLE
feat: Claude Code credential auto-discovery + Anthropic -> OpenRouter fallback

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -145,6 +145,13 @@ def build_anthropic_kwargs(
     system, anthropic_messages = convert_messages_to_anthropic(messages)
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
 
+    # Normalize OpenRouter-style model names for Anthropic API
+    # "anthropic/claude-opus-4.6" -> "claude-opus-4-6"
+    if model.startswith("anthropic/"):
+        model = model[len("anthropic/"):]
+    # Anthropic uses hyphens not dots (claude-opus-4.6 -> claude-opus-4-6)
+    model = model.replace(".", "-")
+
     effective_max_tokens = max_tokens or 16384
 
     kwargs: Dict[str, Any] = {
@@ -164,7 +171,7 @@ def build_anthropic_kwargs(
         if reasoning_config.get("enabled") is not False:
             effort = reasoning_config.get("effort", "medium")
             budget = THINKING_BUDGET.get(effort, 8000)
-            kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
+            kwargs["thinking"] = {"type": "adaptive", "budget_tokens": budget}
             kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
 
     return kwargs

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -171,7 +171,8 @@ def build_anthropic_kwargs(
         if reasoning_config.get("enabled") is not False:
             effort = reasoning_config.get("effort", "medium")
             budget = THINKING_BUDGET.get(effort, 8000)
-            kwargs["thinking"] = {"type": "adaptive", "budget_tokens": budget}
+            kwargs["thinking"] = {"type": "adaptive"}
+            # adaptive thinking still needs max_tokens headroom for thinking output
             kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
 
     return kwargs

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import anthropic
 from httpx import Timeout
 
+THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
+
 
 def build_anthropic_client(api_key: str, base_url: str = None) -> anthropic.Anthropic:
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys."""
@@ -161,12 +163,7 @@ def build_anthropic_kwargs(
     if reasoning_config and isinstance(reasoning_config, dict):
         if reasoning_config.get("enabled") is not False:
             effort = reasoning_config.get("effort", "medium")
-            budget = {
-                "xhigh": 32000,
-                "high": 16000,
-                "medium": 8000,
-                "low": 4000,
-            }.get(effort, 8000)
+            budget = THINKING_BUDGET.get(effort, 8000)
             kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
             kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1,0 +1,223 @@
+"""Anthropic Messages API adapter for Hermes Agent.
+
+Translates between Hermes's internal OpenAI-style message format and
+Anthropic's Messages API. Follows the same pattern as the codex_responses
+adapter — all provider-specific logic is isolated here.
+
+Auth supports both regular API keys (sk-ant-api*) and Claude setup-tokens
+(sk-ant-oat01-*). Setup-tokens require bearer auth + beta header.
+"""
+
+import json
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+
+import anthropic
+from httpx import Timeout
+
+
+def build_anthropic_client(api_key: str, base_url: str = None) -> anthropic.Anthropic:
+    """Create an Anthropic client, auto-detecting setup-tokens vs API keys."""
+    kwargs = {
+        "timeout": Timeout(timeout=900.0, connect=10.0),
+    }
+    if base_url:
+        kwargs["base_url"] = base_url
+
+    if api_key.startswith("sk-ant-oat"):
+        # Setup-token (OAuth access token from `claude setup-token`)
+        kwargs["auth_token"] = api_key
+        kwargs["default_headers"] = {"anthropic-beta": "oauth-2025-04-20"}
+    else:
+        kwargs["api_key"] = api_key
+
+    return anthropic.Anthropic(**kwargs)
+
+
+def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
+    """Convert OpenAI tool definitions to Anthropic format."""
+    if not tools:
+        return []
+    result = []
+    for t in tools:
+        fn = t.get("function", {})
+        result.append({
+            "name": fn.get("name", ""),
+            "description": fn.get("description", ""),
+            "input_schema": fn.get("parameters", {"type": "object", "properties": {}}),
+        })
+    return result
+
+
+def convert_messages_to_anthropic(
+    messages: List[Dict],
+) -> Tuple[Optional[str], List[Dict]]:
+    """Convert OpenAI-format messages to Anthropic format.
+
+    Returns (system_prompt, anthropic_messages).
+    System messages are extracted since Anthropic takes them as a separate param.
+    """
+    system = None
+    result = []
+
+    for m in messages:
+        role = m.get("role", "user")
+        content = m.get("content", "")
+
+        if role == "system":
+            if isinstance(content, list):
+                system = "\n".join(
+                    p["text"] for p in content if p.get("type") == "text"
+                )
+            else:
+                system = content
+            continue
+
+        if role == "assistant":
+            blocks = []
+            if content:
+                text = content if isinstance(content, str) else json.dumps(content)
+                blocks.append({"type": "text", "text": text})
+            for tc in m.get("tool_calls", []):
+                fn = tc.get("function", {})
+                args = fn.get("arguments", "{}")
+                blocks.append({
+                    "type": "tool_use",
+                    "id": tc.get("id", ""),
+                    "name": fn.get("name", ""),
+                    "input": json.loads(args) if isinstance(args, str) else args,
+                })
+            result.append({"role": "assistant", "content": blocks or content})
+            continue
+
+        if role == "tool":
+            tool_result = {
+                "type": "tool_result",
+                "tool_use_id": m.get("tool_call_id", ""),
+                "content": content if isinstance(content, str) else json.dumps(content),
+            }
+            # Merge consecutive tool results into one user message
+            if (
+                result
+                and result[-1]["role"] == "user"
+                and isinstance(result[-1]["content"], list)
+                and result[-1]["content"]
+                and result[-1]["content"][0].get("type") == "tool_result"
+            ):
+                result[-1]["content"].append(tool_result)
+            else:
+                result.append({"role": "user", "content": [tool_result]})
+            continue
+
+        # Regular user message
+        result.append({"role": "user", "content": content})
+
+    # Strip orphaned tool_use blocks (no matching tool_result)
+    tool_result_ids = set()
+    for m in result:
+        if m["role"] == "user" and isinstance(m["content"], list):
+            for block in m["content"]:
+                if block.get("type") == "tool_result":
+                    tool_result_ids.add(block.get("tool_use_id"))
+    for m in result:
+        if m["role"] == "assistant" and isinstance(m["content"], list):
+            m["content"] = [
+                b
+                for b in m["content"]
+                if b.get("type") != "tool_use" or b.get("id") in tool_result_ids
+            ]
+            if not m["content"]:
+                m["content"] = [{"type": "text", "text": "(tool call removed)"}]
+
+    return system, result
+
+
+def build_anthropic_kwargs(
+    model: str,
+    messages: List[Dict],
+    tools: Optional[List[Dict]],
+    max_tokens: Optional[int],
+    reasoning_config: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build kwargs for anthropic.messages.create()."""
+    system, anthropic_messages = convert_messages_to_anthropic(messages)
+    anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
+
+    effective_max_tokens = max_tokens or 16384
+
+    kwargs: Dict[str, Any] = {
+        "model": model,
+        "messages": anthropic_messages,
+        "max_tokens": effective_max_tokens,
+    }
+
+    if system:
+        kwargs["system"] = system
+
+    if anthropic_tools:
+        kwargs["tools"] = anthropic_tools
+
+    # Map reasoning_config to Anthropic's thinking parameter
+    if reasoning_config and isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is not False:
+            effort = reasoning_config.get("effort", "medium")
+            budget = {
+                "xhigh": 32000,
+                "high": 16000,
+                "medium": 8000,
+                "low": 4000,
+            }.get(effort, 8000)
+            kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
+            kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
+
+    return kwargs
+
+
+def normalize_anthropic_response(
+    response,
+) -> Tuple[SimpleNamespace, str]:
+    """Normalize Anthropic response to match the shape expected by AIAgent.
+
+    Returns (assistant_message, finish_reason) where assistant_message has
+    .content, .tool_calls, and .reasoning attributes.
+    """
+    text_parts = []
+    reasoning_parts = []
+    tool_calls = []
+
+    for block in response.content:
+        if block.type == "text":
+            text_parts.append(block.text)
+        elif block.type == "thinking":
+            reasoning_parts.append(block.thinking)
+        elif block.type == "tool_use":
+            tool_calls.append(
+                SimpleNamespace(
+                    id=block.id,
+                    type="function",
+                    function=SimpleNamespace(
+                        name=block.name,
+                        arguments=json.dumps(block.input),
+                    ),
+                )
+            )
+
+    # Map Anthropic stop_reason to OpenAI finish_reason
+    stop_reason_map = {
+        "end_turn": "stop",
+        "tool_use": "tool_calls",
+        "max_tokens": "length",
+        "stop_sequence": "stop",
+    }
+    finish_reason = stop_reason_map.get(response.stop_reason, "stop")
+
+    return (
+        SimpleNamespace(
+            content="\n".join(text_parts) if text_parts else None,
+            tool_calls=tool_calls or None,
+            reasoning="\n\n".join(reasoning_parts) if reasoning_parts else None,
+            reasoning_content=None,
+            reasoning_details=None,
+        ),
+        finish_reason,
+    )

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -10,14 +10,17 @@ Resolution order for text tasks:
   3. Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY)
   4. Codex OAuth (Responses API via chatgpt.com with gpt-5.3-codex,
      wrapped to look like a chat.completions client)
-  5. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
+  5. Anthropic (ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, wrapped to look
+     like a chat.completions client)
+  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
      — checked via PROVIDER_REGISTRY entries with auth_type='api_key'
-  6. None
+  7. None
 
 Resolution order for vision/multimodal tasks:
   1. OpenRouter
   2. Nous Portal
-  3. None  (custom endpoints can't substitute for Gemini multimodal)
+  3. Anthropic (Claude supports vision natively)
+  4. None
 """
 
 import json
@@ -245,6 +248,130 @@ class AsyncCodexAuxiliaryClient:
         self.base_url = sync_wrapper.base_url
 
 
+_ANTHROPIC_AUX_MODEL = "claude-haiku-4-5-20251001"
+
+
+def _read_anthropic_token() -> Optional[str]:
+    """Return an Anthropic API key or OAuth token if available."""
+    for var in ("ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY"):
+        val = os.getenv(var, "").strip()
+        if val:
+            return val
+    return None
+
+
+class _AnthropicCompletionsAdapter:
+    """Shim that accepts chat.completions.create() kwargs and routes
+    them through the Anthropic Messages API."""
+
+    def __init__(self, client, model: str):
+        self._client = client
+        self._model = model
+
+    def create(self, **kwargs) -> Any:
+        from agent.anthropic_adapter import (
+            convert_messages_to_anthropic,
+            convert_tools_to_anthropic,
+        )
+
+        messages = kwargs.get("messages", [])
+        model = kwargs.get("model", self._model)
+        system, ant_messages = convert_messages_to_anthropic(messages)
+        tools = convert_tools_to_anthropic(kwargs.get("tools") or [])
+        max_tokens = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens") or 4096
+
+        api_kwargs: Dict[str, Any] = {
+            "model": model,
+            "messages": ant_messages,
+            "max_tokens": max_tokens,
+        }
+        if system:
+            api_kwargs["system"] = system
+        if tools:
+            api_kwargs["tools"] = tools
+
+        resp = self._client.messages.create(**api_kwargs)
+
+        # Build OpenAI-shaped response
+        text_parts = []
+        tool_calls_raw = []
+        for block in resp.content:
+            if block.type == "text":
+                text_parts.append(block.text)
+            elif block.type == "tool_use":
+                tool_calls_raw.append(SimpleNamespace(
+                    id=block.id,
+                    type="function",
+                    function=SimpleNamespace(
+                        name=block.name,
+                        arguments=json.dumps(block.input),
+                    ),
+                ))
+
+        content = "\n".join(text_parts).strip() or None
+        message = SimpleNamespace(
+            role="assistant",
+            content=content,
+            tool_calls=tool_calls_raw or None,
+        )
+        choice = SimpleNamespace(
+            index=0,
+            message=message,
+            finish_reason="tool_calls" if tool_calls_raw else "stop",
+        )
+        usage = SimpleNamespace(
+            prompt_tokens=resp.usage.input_tokens,
+            completion_tokens=resp.usage.output_tokens,
+            total_tokens=resp.usage.input_tokens + resp.usage.output_tokens,
+        )
+        return SimpleNamespace(choices=[choice], model=model, usage=usage)
+
+
+class _AnthropicChatShim:
+    def __init__(self, adapter: _AnthropicCompletionsAdapter):
+        self.completions = adapter
+
+
+class AnthropicAuxiliaryClient:
+    """OpenAI-client-compatible wrapper for Anthropic Messages API.
+
+    Consumers call client.chat.completions.create(**kwargs) as normal.
+    """
+
+    def __init__(self, client, model: str):
+        self._client = client
+        adapter = _AnthropicCompletionsAdapter(client, model)
+        self.chat = _AnthropicChatShim(adapter)
+        self.api_key = "anthropic"
+        self.base_url = "https://api.anthropic.com"
+
+    def close(self):
+        self._client.close()
+
+
+class _AsyncAnthropicCompletionsAdapter:
+    def __init__(self, sync_adapter: _AnthropicCompletionsAdapter):
+        self._sync = sync_adapter
+
+    async def create(self, **kwargs) -> Any:
+        import asyncio
+        return await asyncio.to_thread(self._sync.create, **kwargs)
+
+
+class _AsyncAnthropicChatShim:
+    def __init__(self, adapter: _AsyncAnthropicCompletionsAdapter):
+        self.completions = adapter
+
+
+class AsyncAnthropicAuxiliaryClient:
+    def __init__(self, sync_wrapper: AnthropicAuxiliaryClient):
+        sync_adapter = sync_wrapper.chat.completions
+        async_adapter = _AsyncAnthropicCompletionsAdapter(sync_adapter)
+        self.chat = _AsyncAnthropicChatShim(async_adapter)
+        self.api_key = sync_wrapper.api_key
+        self.base_url = sync_wrapper.base_url
+
+
 def _read_nous_auth() -> Optional[dict]:
     """Read and validate ~/.hermes/auth.json for an active Nous provider.
 
@@ -379,12 +506,20 @@ def get_text_auxiliary_client() -> Tuple[Optional[OpenAI], Optional[str]]:
         real_client = OpenAI(api_key=codex_token, base_url=_CODEX_AUX_BASE_URL)
         return CodexAuxiliaryClient(real_client, _CODEX_AUX_MODEL), _CODEX_AUX_MODEL
 
-    # 5. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, etc.)
+    # 5. Anthropic (ANTHROPIC_TOKEN or ANTHROPIC_API_KEY)
+    ant_token = _read_anthropic_token()
+    if ant_token:
+        from agent.anthropic_adapter import build_anthropic_client
+        logger.debug("Auxiliary text client: Anthropic (%s)", _ANTHROPIC_AUX_MODEL)
+        client = build_anthropic_client(ant_token)
+        return AnthropicAuxiliaryClient(client, _ANTHROPIC_AUX_MODEL), _ANTHROPIC_AUX_MODEL
+
+    # 6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, etc.)
     api_client, api_model = _resolve_api_key_provider()
     if api_client is not None:
         return api_client, api_model
 
-    # 6. Nothing available
+    # 7. Nothing available
     logger.debug("Auxiliary text client: none available")
     return None, None
 
@@ -404,6 +539,9 @@ def get_async_text_auxiliary_client():
 
     if isinstance(sync_client, CodexAuxiliaryClient):
         return AsyncCodexAuxiliaryClient(sync_client), model
+
+    if isinstance(sync_client, AnthropicAuxiliaryClient):
+        return AsyncAnthropicAuxiliaryClient(sync_client), model
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -438,7 +576,15 @@ def get_vision_auxiliary_client() -> Tuple[Optional[OpenAI], Optional[str]]:
             _NOUS_MODEL,
         )
 
-    # 3. Nothing suitable
+    # 3. Anthropic (Claude supports vision natively)
+    ant_token = _read_anthropic_token()
+    if ant_token:
+        from agent.anthropic_adapter import build_anthropic_client
+        logger.debug("Auxiliary vision client: Anthropic (%s)", _ANTHROPIC_AUX_MODEL)
+        client = build_anthropic_client(ant_token)
+        return AnthropicAuxiliaryClient(client, _ANTHROPIC_AUX_MODEL), _ANTHROPIC_AUX_MODEL
+
+    # 4. Nothing suitable
     logger.debug("Auxiliary vision client: none available")
     return None, None
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -41,7 +41,6 @@ DEFAULT_CONTEXT_LENGTHS = {
     "anthropic/claude-sonnet-4": 200000,
     "anthropic/claude-sonnet-4-20250514": 200000,
     "anthropic/claude-haiku-4.5": 200000,
-    # Bare Anthropic model names (native provider)
     "claude-opus-4-20250514": 200000,
     "claude-sonnet-4-20250514": 200000,
     "claude-haiku-4-5-20251001": 200000,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -41,6 +41,10 @@ DEFAULT_CONTEXT_LENGTHS = {
     "anthropic/claude-sonnet-4": 200000,
     "anthropic/claude-sonnet-4-20250514": 200000,
     "anthropic/claude-haiku-4.5": 200000,
+    # Bare Anthropic model names (native provider)
+    "claude-opus-4-20250514": 200000,
+    "claude-sonnet-4-20250514": 200000,
+    "claude-haiku-4-5-20251001": 200000,
     "openai/gpt-4o": 128000,
     "openai/gpt-4-turbo": 128000,
     "openai/gpt-4o-mini": 128000,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -65,6 +65,10 @@ CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 
+# Anthropic Claude Code OAuth credentials
+DEFAULT_CLAUDE_CREDENTIALS_PATH = Path.home() / ".claude" / ".credentials.json"
+ANTHROPIC_API_BASE_URL = "https://api.anthropic.com"
+
 
 # =============================================================================
 # Provider Registry
@@ -485,7 +489,7 @@ def resolve_provider(
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "kimi": "kimi-coding", "moonshot": "kimi-coding",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
-        "claude": "anthropic",
+        "claude": "anthropic", "claude-code": "anthropic",
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 
@@ -513,6 +517,17 @@ def resolve_provider(
                 return active
     except Exception as e:
         logger.debug("Could not detect active auth provider: %s", e)
+
+    # Check for Claude Code credentials (auto-detect Anthropic via Claude Code)
+    try:
+        claude_creds = _read_claude_code_credentials()
+        if claude_creds:
+            expires_at_ms = claude_creds.get("expiresAt")
+            if isinstance(expires_at_ms, (int, float)) and expires_at_ms > 0:
+                if (expires_at_ms / 1000.0) > time.time():
+                    return "anthropic"
+    except Exception as e:
+        logger.debug("Could not detect Claude Code credentials: %s", e)
 
     if os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY"):
         return "openrouter"
@@ -1368,6 +1383,108 @@ def get_codex_auth_status() -> Dict[str, Any]:
         }
 
 
+# =============================================================================
+# Claude Code OAuth Credentials
+# =============================================================================
+
+def _read_claude_code_credentials() -> Optional[Dict[str, Any]]:
+    """Read Claude Code's OAuth credentials from ~/.claude/.credentials.json.
+
+    Returns the claudeAiOauth dict if present and contains an access token,
+    or None if the file doesn't exist or is malformed.
+    """
+    creds_path = DEFAULT_CLAUDE_CREDENTIALS_PATH
+    if not creds_path.is_file():
+        return None
+    try:
+        raw = json.loads(creds_path.read_text())
+        oauth = raw.get("claudeAiOauth")
+        if not isinstance(oauth, dict):
+            return None
+        access_token = oauth.get("accessToken")
+        if not isinstance(access_token, str) or not access_token.strip():
+            return None
+        return oauth
+    except Exception as exc:
+        logger.debug("Failed to read Claude Code credentials: %s", exc)
+        return None
+
+
+def resolve_anthropic_claude_code_credentials() -> Dict[str, Any]:
+    """Resolve runtime credentials from Claude Code's OAuth token store.
+
+    Reads ~/.claude/.credentials.json written by Claude Code.
+    The token works as a standard Anthropic API key (sk-ant-oat* format
+    requires bearer auth, handled by the anthropic_adapter).
+
+    Returns dict with: provider, base_url, api_key, source, expires_at.
+    """
+    oauth = _read_claude_code_credentials()
+    if not oauth:
+        raise AuthError(
+            "No Claude Code credentials found. Install and authenticate "
+            "Claude Code first, or set ANTHROPIC_TOKEN / ANTHROPIC_API_KEY.",
+            provider="anthropic",
+            code="claude_code_auth_missing",
+            relogin_required=True,
+        )
+
+    access_token = oauth["accessToken"].strip()
+    expires_at_ms = oauth.get("expiresAt")
+
+    # Check expiry (expiresAt is milliseconds timestamp)
+    if isinstance(expires_at_ms, (int, float)) and expires_at_ms > 0:
+        expires_at_s = expires_at_ms / 1000.0
+        if expires_at_s <= time.time():
+            raise AuthError(
+                "Claude Code OAuth token has expired. Run `claude` to refresh it.",
+                provider="anthropic",
+                code="claude_code_token_expired",
+                relogin_required=True,
+            )
+
+    base_url = (
+        os.getenv("ANTHROPIC_BASE_URL", "").strip().rstrip("/")
+        or ANTHROPIC_API_BASE_URL
+    )
+
+    return {
+        "provider": "anthropic",
+        "api_mode": "anthropic_messages",
+        "base_url": base_url,
+        "api_key": access_token,
+        "source": "claude-code",
+        "subscription_type": oauth.get("subscriptionType", "unknown"),
+        "expires_at": expires_at_ms,
+    }
+
+
+def get_claude_code_auth_status() -> Dict[str, Any]:
+    """Status snapshot for Claude Code credentials."""
+    oauth = _read_claude_code_credentials()
+    if not oauth:
+        return {
+            "logged_in": False,
+            "credentials_path": str(DEFAULT_CLAUDE_CREDENTIALS_PATH),
+            "source": "claude-code",
+        }
+
+    expires_at_ms = oauth.get("expiresAt")
+    is_expired = False
+    if isinstance(expires_at_ms, (int, float)) and expires_at_ms > 0:
+        is_expired = (expires_at_ms / 1000.0) <= time.time()
+
+    return {
+        "logged_in": not is_expired,
+        "credentials_path": str(DEFAULT_CLAUDE_CREDENTIALS_PATH),
+        "source": "claude-code",
+        "subscription_type": oauth.get("subscriptionType"),
+        "expires_at": expires_at_ms,
+        "scopes": oauth.get("scopes"),
+        "is_expired": is_expired,
+    }
+
+
 def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for API-key providers (z.ai, Kimi, MiniMax)."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
@@ -1411,6 +1528,12 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_nous_auth_status()
     if target == "openai-codex":
         return get_codex_auth_status()
+    if target == "anthropic":
+        # Check Claude Code credentials first, then fall back to env-var status
+        claude_status = get_claude_code_auth_status()
+        if claude_status.get("logged_in"):
+            return claude_status
+        return get_api_key_provider_status(target)
     # API-key providers
     pconfig = PROVIDER_REGISTRY.get(target)
     if pconfig and pconfig.auth_type == "api_key":

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -135,6 +135,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
     ),
+    "anthropic": ProviderConfig(
+        id="anthropic",
+        name="Anthropic",
+        auth_type="api_key",
+        inference_base_url="https://api.anthropic.com",
+        api_key_env_vars=("ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY"),
+    ),
 }
 
 
@@ -478,6 +485,7 @@ def resolve_provider(
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "kimi": "kimi-coding", "moonshot": "kimi-coding",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
+        "claude": "anthropic",
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1277,7 +1277,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "zai", "kimi-coding", "minimax", "minimax-cn"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "anthropic", "zai", "kimi-coding", "minimax", "minimax-cn"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -53,6 +53,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
     ],
+    "anthropic": [
+        "claude-opus-4-20250514",
+        "claude-sonnet-4-20250514",
+        "claude-haiku-4-5-20251001",
+    ],
 }
 
 _PROVIDER_LABELS = {
@@ -63,6 +68,7 @@ _PROVIDER_LABELS = {
     "kimi-coding": "Kimi / Moonshot",
     "minimax": "MiniMax",
     "minimax-cn": "MiniMax (China)",
+    "anthropic": "Anthropic",
     "custom": "custom endpoint",
 }
 
@@ -75,6 +81,7 @@ _PROVIDER_ALIASES = {
     "moonshot": "kimi-coding",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
+    "claude": "anthropic",
 }
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -13,6 +13,7 @@ from hermes_cli.auth import (
     resolve_nous_runtime_credentials,
     resolve_codex_runtime_credentials,
     resolve_api_key_provider_credentials,
+    resolve_anthropic_claude_code_credentials,
 )
 from hermes_cli.config import load_config
 from hermes_constants import OPENROUTER_BASE_URL
@@ -149,7 +150,20 @@ def resolve_runtime_provider(
         }
 
     # Anthropic (native Messages API)
+    # Try Claude Code OAuth credentials first, then fall back to env vars
     if provider == "anthropic":
+        try:
+            creds = resolve_anthropic_claude_code_credentials()
+            return {
+                "provider": "anthropic",
+                "api_mode": "anthropic_messages",
+                "base_url": creds.get("base_url", "").rstrip("/"),
+                "api_key": creds.get("api_key", ""),
+                "source": creds.get("source", "claude-code"),
+                "requested_provider": requested_provider,
+            }
+        except AuthError:
+            pass  # Fall through to env-var resolution
         creds = resolve_api_key_provider_credentials(provider)
         return {
             "provider": "anthropic",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -148,6 +148,18 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    # Anthropic (native Messages API)
+    if provider == "anthropic":
+        creds = resolve_api_key_provider_credentials(provider)
+        return {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": creds.get("base_url", "").rstrip("/"),
+            "api_key": creds.get("api_key", ""),
+            "source": creds.get("source", "env"),
+            "requested_provider": requested_provider,
+        }
+
     # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license = { text = "MIT" }
 dependencies = [
   # Core
   "openai",
+  "anthropic>=0.39.0",
   "python-dotenv",
   "fire",
   "httpx",

--- a/run_agent.py
+++ b/run_agent.py
@@ -365,6 +365,11 @@ class AIAgent:
         # Initialize LLM client
         self._anthropic_client = None
 
+        # Fallback provider support: when primary is Anthropic, prepare an
+        # OpenRouter client to switch to on rate-limit or auth failures.
+        self._fallback_available = False
+        self._fallback_activated = False
+
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
             effective_key = api_key or os.getenv("ANTHROPIC_TOKEN", "") or os.getenv("ANTHROPIC_API_KEY", "")
@@ -377,6 +382,22 @@ class AIAgent:
                 print(f"🤖 AI Agent initialized with model: {self.model} (Anthropic native)")
                 if effective_key and len(effective_key) > 12:
                     print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
+
+            # Prepare OpenRouter fallback if key is available
+            fallback_key = os.getenv("OPENROUTER_API_KEY", "").strip()
+            if fallback_key:
+                self._fallback_available = True
+                self._fallback_client_kwargs = {
+                    "base_url": OPENROUTER_BASE_URL,
+                    "api_key": fallback_key,
+                    "default_headers": {
+                        "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
+                        "X-OpenRouter-Title": "Hermes Agent",
+                        "X-OpenRouter-Categories": "productivity,cli-agent",
+                    },
+                }
+                if not self.quiet_mode:
+                    print(f"🔄 Fallback provider: OpenRouter (ready)")
         else:
             client_kwargs = {}
 
@@ -2173,6 +2194,38 @@ class AIAgent:
             raise result["error"]
         return result["response"]
 
+    def _switch_to_fallback_provider(self) -> bool:
+        """Switch from Anthropic to OpenRouter fallback.
+
+        Returns True if switch succeeded, False if no fallback available.
+        Called when the primary Anthropic provider fails with rate-limit,
+        auth, or overload errors.
+        """
+        if not self._fallback_available or self._fallback_activated:
+            return False
+
+        try:
+            self.client = OpenAI(**self._fallback_client_kwargs)
+            self._client_kwargs = self._fallback_client_kwargs
+            self.api_mode = "chat_completions"
+            self.provider = "openrouter"
+            self.base_url = OPENROUTER_BASE_URL
+            self._fallback_activated = True
+
+            # Re-map bare model names to OpenRouter format if needed
+            if not self.model.startswith("anthropic/") and "claude" in self.model.lower():
+                self.model = f"anthropic/{self.model}"
+
+            # Enable prompt caching for Claude via OpenRouter
+            self._use_prompt_caching = True
+
+            print(f"{self.log_prefix}🔄 Switched to fallback provider: OpenRouter ({self.model})")
+            logging.info("Fallback activated: Anthropic -> OpenRouter (%s)", self.model)
+            return True
+        except Exception as e:
+            logging.error("Failed to initialize fallback OpenRouter client: %s", e)
+            return False
+
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
         if self.api_mode == "anthropic_messages":
@@ -3457,6 +3510,19 @@ class AIAgent:
                         nous_auth_retry_attempted = True
                         if self._try_refresh_nous_client_credentials(force=True):
                             print(f"{self.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request...")
+                            continue
+
+                    # Anthropic fallback: on rate-limit (429), auth (401), or
+                    # overload (529) errors, switch to OpenRouter if available.
+                    if (
+                        self.api_mode == "anthropic_messages"
+                        and self.provider == "anthropic"
+                        and status_code in {401, 429, 529}
+                        and not self._fallback_activated
+                    ):
+                        print(f"{self.log_prefix}⚠️  Anthropic API error ({status_code}): {str(api_error)[:150]}")
+                        if self._switch_to_fallback_provider():
+                            print(f"{self.log_prefix}   🔄 Retrying with OpenRouter fallback...")
                             continue
 
                     retry_count += 1

--- a/run_agent.py
+++ b/run_agent.py
@@ -244,13 +244,16 @@ class AIAgent:
         self.base_url = base_url or OPENROUTER_BASE_URL
         provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
         self.provider = provider_name or "openrouter"
-        if api_mode in {"chat_completions", "codex_responses"}:
+        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
         elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self.base_url.lower():
             self.api_mode = "codex_responses"
             self.provider = "openai-codex"
+        elif self.provider == "anthropic" or (provider_name is None and "api.anthropic.com" in self.base_url.lower()):
+            self.api_mode = "anthropic_messages"
+            self.provider = "anthropic"
         else:
             self.api_mode = "chat_completions"
 
@@ -359,52 +362,67 @@ class AIAgent:
                 ]:
                     logging.getLogger(quiet_logger).setLevel(logging.ERROR)
         
-        # Initialize OpenAI client - defaults to OpenRouter
-        client_kwargs = {}
-        
-        # Default to OpenRouter if no base_url provided
-        if base_url:
-            client_kwargs["base_url"] = base_url
-        else:
-            client_kwargs["base_url"] = OPENROUTER_BASE_URL
-        
-        # Handle API key - OpenRouter is the primary provider
-        if api_key:
-            client_kwargs["api_key"] = api_key
-        else:
-            # Primary: OPENROUTER_API_KEY, fallback to direct provider keys
-            client_kwargs["api_key"] = os.getenv("OPENROUTER_API_KEY", "")
-        
-        # OpenRouter app attribution — shows hermes-agent in rankings/analytics
-        effective_base = client_kwargs.get("base_url", "")
-        if "openrouter" in effective_base.lower():
-            client_kwargs["default_headers"] = {
-                "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
-                "X-OpenRouter-Title": "Hermes Agent",
-                "X-OpenRouter-Categories": "productivity,cli-agent",
-            }
-        elif "api.kimi.com" in effective_base.lower():
-            # Kimi Code API requires a recognized coding-agent User-Agent
-            # (see https://github.com/MoonshotAI/kimi-cli)
-            client_kwargs["default_headers"] = {
-                "User-Agent": "KimiCLI/1.0",
-            }
-        
-        self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
-        try:
-            self.client = OpenAI(**client_kwargs)
+        # Initialize LLM client
+        self._anthropic_client = None
+
+        if self.api_mode == "anthropic_messages":
+            from agent.anthropic_adapter import build_anthropic_client
+            effective_key = api_key or os.getenv("ANTHROPIC_TOKEN", "") or os.getenv("ANTHROPIC_API_KEY", "")
+            self._anthropic_api_key = effective_key
+            self._anthropic_client = build_anthropic_client(effective_key, base_url if base_url and "anthropic" in base_url else None)
+            # Still create a dummy OpenAI client for code paths that reference self.client
+            self.client = None
+            self._client_kwargs = {}
             if not self.quiet_mode:
-                print(f"🤖 AI Agent initialized with model: {self.model}")
-                if base_url:
-                    print(f"🔗 Using custom base URL: {base_url}")
-                # Always show API key info (masked) for debugging auth issues
-                key_used = client_kwargs.get("api_key", "none")
-                if key_used and key_used != "dummy-key" and len(key_used) > 12:
-                    print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
-                else:
-                    print(f"⚠️  Warning: API key appears invalid or missing (got: '{key_used[:20] if key_used else 'none'}...')")
-        except Exception as e:
-            raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
+                print(f"🤖 AI Agent initialized with model: {self.model} (Anthropic native)")
+                if effective_key and len(effective_key) > 12:
+                    print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
+        else:
+            client_kwargs = {}
+
+            # Default to OpenRouter if no base_url provided
+            if base_url:
+                client_kwargs["base_url"] = base_url
+            else:
+                client_kwargs["base_url"] = OPENROUTER_BASE_URL
+
+            # Handle API key - OpenRouter is the primary provider
+            if api_key:
+                client_kwargs["api_key"] = api_key
+            else:
+                # Primary: OPENROUTER_API_KEY, fallback to direct provider keys
+                client_kwargs["api_key"] = os.getenv("OPENROUTER_API_KEY", "")
+
+            # OpenRouter app attribution — shows hermes-agent in rankings/analytics
+            effective_base = client_kwargs.get("base_url", "")
+            if "openrouter" in effective_base.lower():
+                client_kwargs["default_headers"] = {
+                    "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
+                    "X-OpenRouter-Title": "Hermes Agent",
+                    "X-OpenRouter-Categories": "productivity,cli-agent",
+                }
+            elif "api.kimi.com" in effective_base.lower():
+                # Kimi Code API requires a recognized coding-agent User-Agent
+                # (see https://github.com/MoonshotAI/kimi-cli)
+                client_kwargs["default_headers"] = {
+                    "User-Agent": "KimiCLI/1.0",
+                }
+
+            self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
+            try:
+                self.client = OpenAI(**client_kwargs)
+                if not self.quiet_mode:
+                    print(f"🤖 AI Agent initialized with model: {self.model}")
+                    if base_url:
+                        print(f"🔗 Using custom base URL: {base_url}")
+                    # Always show API key info (masked) for debugging auth issues
+                    key_used = client_kwargs.get("api_key", "none")
+                    if key_used and key_used != "dummy-key" and len(key_used) > 12:
+                        print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
+                    else:
+                        print(f"⚠️  Warning: API key appears invalid or missing (got: '{key_used[:20] if key_used else 'none'}...')")
+            except Exception as e:
+                raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
         
         # Get available tools with filtering
         self.tools = get_tool_definitions(
@@ -2121,6 +2139,8 @@ class AIAgent:
             try:
                 if self.api_mode == "codex_responses":
                     result["response"] = self._run_codex_stream(api_kwargs)
+                elif self.api_mode == "anthropic_messages":
+                    result["response"] = self._anthropic_client.messages.create(**api_kwargs)
                 else:
                     result["response"] = self.client.chat.completions.create(**api_kwargs)
             except Exception as e:
@@ -2133,12 +2153,19 @@ class AIAgent:
             if self._interrupt_requested:
                 # Force-close the HTTP connection to stop token generation
                 try:
-                    self.client.close()
+                    if self.api_mode == "anthropic_messages":
+                        self._anthropic_client.close()
+                    else:
+                        self.client.close()
                 except Exception:
                     pass
                 # Rebuild the client for future calls (cheap, no network)
                 try:
-                    self.client = OpenAI(**self._client_kwargs)
+                    if self.api_mode == "anthropic_messages":
+                        from agent.anthropic_adapter import build_anthropic_client
+                        self._anthropic_client = build_anthropic_client(self._anthropic_api_key)
+                    else:
+                        self.client = OpenAI(**self._client_kwargs)
                 except Exception:
                     pass
                 raise InterruptedError("Agent interrupted during API call")
@@ -2148,6 +2175,16 @@ class AIAgent:
 
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
+        if self.api_mode == "anthropic_messages":
+            from agent.anthropic_adapter import build_anthropic_kwargs
+            return build_anthropic_kwargs(
+                model=self.model,
+                messages=api_messages,
+                tools=self.tools,
+                max_tokens=self.max_tokens,
+                reasoning_config=self.reasoning_config,
+            )
+
         if self.api_mode == "codex_responses":
             instructions = ""
             payload_messages = api_messages
@@ -3192,6 +3229,17 @@ class AIAgent:
                         elif len(output_items) == 0:
                             response_invalid = True
                             error_details.append("response.output is empty")
+                    elif self.api_mode == "anthropic_messages":
+                        content_blocks = getattr(response, "content", None) if response is not None else None
+                        if response is None:
+                            response_invalid = True
+                            error_details.append("response is None")
+                        elif not isinstance(content_blocks, list):
+                            response_invalid = True
+                            error_details.append("response.content is not a list")
+                        elif len(content_blocks) == 0:
+                            response_invalid = True
+                            error_details.append("response.content is empty")
                     else:
                         if response is None or not hasattr(response, 'choices') or response.choices is None or len(response.choices) == 0:
                             response_invalid = True
@@ -3287,6 +3335,9 @@ class AIAgent:
                             finish_reason = "length"
                         else:
                             finish_reason = "stop"
+                    elif self.api_mode == "anthropic_messages":
+                        stop_reason_map = {"end_turn": "stop", "tool_use": "tool_calls", "max_tokens": "length", "stop_sequence": "stop"}
+                        finish_reason = stop_reason_map.get(response.stop_reason, "stop")
                     else:
                         finish_reason = response.choices[0].finish_reason
                     
@@ -3325,7 +3376,7 @@ class AIAgent:
                     
                     # Track actual token usage from response for context management
                     if hasattr(response, 'usage') and response.usage:
-                        if self.api_mode == "codex_responses":
+                        if self.api_mode in ("codex_responses", "anthropic_messages"):
                             prompt_tokens = getattr(response.usage, 'input_tokens', 0) or 0
                             completion_tokens = getattr(response.usage, 'output_tokens', 0) or 0
                             total_tokens = (
@@ -3624,6 +3675,9 @@ class AIAgent:
             try:
                 if self.api_mode == "codex_responses":
                     assistant_message, finish_reason = self._normalize_codex_response(response)
+                elif self.api_mode == "anthropic_messages":
+                    from agent.anthropic_adapter import normalize_anthropic_response
+                    assistant_message, finish_reason = normalize_anthropic_response(response)
                 else:
                     assistant_message = response.choices[0].message
                 

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -142,7 +142,7 @@ class TestBuildAnthropicKwargs:
             reasoning_config={"enabled": True, "effort": "high"},
         )
         assert kwargs["thinking"]["type"] == "adaptive"
-        assert kwargs["thinking"]["budget_tokens"] == 16000
+        assert "budget_tokens" not in kwargs["thinking"]
         assert kwargs["max_tokens"] >= 16000 + 4096
 
     def test_reasoning_disabled(self):

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -141,7 +141,7 @@ class TestBuildAnthropicKwargs:
             max_tokens=4096,
             reasoning_config={"enabled": True, "effort": "high"},
         )
-        assert kwargs["thinking"]["type"] == "enabled"
+        assert kwargs["thinking"]["type"] == "adaptive"
         assert kwargs["thinking"]["budget_tokens"] == 16000
         assert kwargs["max_tokens"] >= 16000 + 4096
 

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -1,0 +1,209 @@
+"""Tests for agent/anthropic_adapter.py — Anthropic Messages API adapter."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent.anthropic_adapter import (
+    build_anthropic_client,
+    build_anthropic_kwargs,
+    convert_messages_to_anthropic,
+    convert_tools_to_anthropic,
+    normalize_anthropic_response,
+)
+
+
+class TestBuildAnthropicClient:
+    def test_setup_token_uses_auth_token(self):
+        with patch("agent.anthropic_adapter.anthropic.Anthropic") as mock_cls:
+            build_anthropic_client("sk-ant-oat01-abcdefghijklmnop" + "x" * 60)
+            kwargs = mock_cls.call_args[1]
+            assert "auth_token" in kwargs
+            assert kwargs["default_headers"]["anthropic-beta"] == "oauth-2025-04-20"
+            assert "api_key" not in kwargs
+
+    def test_api_key_uses_api_key(self):
+        with patch("agent.anthropic_adapter.anthropic.Anthropic") as mock_cls:
+            build_anthropic_client("sk-ant-api03-something")
+            kwargs = mock_cls.call_args[1]
+            assert kwargs["api_key"] == "sk-ant-api03-something"
+            assert "auth_token" not in kwargs
+
+
+class TestConvertTools:
+    def test_converts_openai_to_anthropic_format(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search the web",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                },
+            }
+        ]
+        result = convert_tools_to_anthropic(tools)
+        assert len(result) == 1
+        assert result[0]["name"] == "search"
+        assert result[0]["description"] == "Search the web"
+        assert result[0]["input_schema"]["properties"]["query"]["type"] == "string"
+
+    def test_empty_tools(self):
+        assert convert_tools_to_anthropic([]) == []
+        assert convert_tools_to_anthropic(None) == []
+
+
+class TestConvertMessages:
+    def test_extracts_system_prompt(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ]
+        system, result = convert_messages_to_anthropic(messages)
+        assert system == "You are helpful."
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+
+    def test_converts_tool_calls(self):
+        messages = [
+            {"role": "assistant", "content": "Let me search.", "tool_calls": [
+                {"id": "tc_1", "function": {"name": "search", "arguments": '{"query": "test"}'}}
+            ]},
+            {"role": "tool", "tool_call_id": "tc_1", "content": "search results"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        blocks = result[0]["content"]
+        assert blocks[0] == {"type": "text", "text": "Let me search."}
+        assert blocks[1]["type"] == "tool_use"
+        assert blocks[1]["id"] == "tc_1"
+        assert blocks[1]["input"] == {"query": "test"}
+
+    def test_converts_tool_results(self):
+        messages = [
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result data"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assert result[0]["role"] == "user"
+        assert result[0]["content"][0]["type"] == "tool_result"
+        assert result[0]["content"][0]["tool_use_id"] == "tc_1"
+
+    def test_merges_consecutive_tool_results(self):
+        messages = [
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result 1"},
+            {"role": "tool", "tool_call_id": "tc_2", "content": "result 2"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assert len(result) == 1
+        assert len(result[0]["content"]) == 2
+
+    def test_strips_orphaned_tool_use(self):
+        messages = [
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "tc_orphan", "function": {"name": "x", "arguments": "{}"}}
+            ]},
+            {"role": "user", "content": "never mind"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        # tc_orphan has no matching tool_result, should be stripped
+        assistant_blocks = result[0]["content"]
+        assert all(b.get("type") != "tool_use" for b in assistant_blocks)
+
+
+class TestBuildAnthropicKwargs:
+    def test_basic_kwargs(self):
+        messages = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "Hi"},
+        ]
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=messages,
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+        )
+        assert kwargs["model"] == "claude-sonnet-4-20250514"
+        assert kwargs["system"] == "Be helpful."
+        assert kwargs["max_tokens"] == 4096
+        assert "tools" not in kwargs
+
+    def test_reasoning_config_maps_to_thinking(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "think hard"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kwargs["thinking"]["type"] == "enabled"
+        assert kwargs["thinking"]["budget_tokens"] == 16000
+        assert kwargs["max_tokens"] >= 16000 + 4096
+
+    def test_reasoning_disabled(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "quick"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+        )
+        assert "thinking" not in kwargs
+
+
+class TestNormalizeResponse:
+    def _make_response(self, content_blocks, stop_reason="end_turn"):
+        resp = SimpleNamespace()
+        resp.content = content_blocks
+        resp.stop_reason = stop_reason
+        resp.usage = SimpleNamespace(input_tokens=100, output_tokens=50)
+        return resp
+
+    def test_text_response(self):
+        block = SimpleNamespace(type="text", text="Hello world")
+        msg, reason = normalize_anthropic_response(self._make_response([block]))
+        assert msg.content == "Hello world"
+        assert reason == "stop"
+        assert msg.tool_calls is None
+
+    def test_tool_use_response(self):
+        blocks = [
+            SimpleNamespace(type="text", text="Searching..."),
+            SimpleNamespace(
+                type="tool_use",
+                id="tc_1",
+                name="search",
+                input={"query": "test"},
+            ),
+        ]
+        msg, reason = normalize_anthropic_response(
+            self._make_response(blocks, "tool_use")
+        )
+        assert msg.content == "Searching..."
+        assert reason == "tool_calls"
+        assert len(msg.tool_calls) == 1
+        assert msg.tool_calls[0].function.name == "search"
+        assert json.loads(msg.tool_calls[0].function.arguments) == {"query": "test"}
+
+    def test_thinking_response(self):
+        blocks = [
+            SimpleNamespace(type="thinking", thinking="Let me reason about this..."),
+            SimpleNamespace(type="text", text="The answer is 42."),
+        ]
+        msg, reason = normalize_anthropic_response(self._make_response(blocks))
+        assert msg.content == "The answer is 42."
+        assert msg.reasoning == "Let me reason about this..."
+
+    def test_stop_reason_mapping(self):
+        block = SimpleNamespace(type="text", text="x")
+        _, r1 = normalize_anthropic_response(self._make_response([block], "end_turn"))
+        _, r2 = normalize_anthropic_response(self._make_response([block], "tool_use"))
+        _, r3 = normalize_anthropic_response(self._make_response([block], "max_tokens"))
+        assert r1 == "stop"
+        assert r2 == "tool_calls"
+        assert r3 == "length"

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -95,6 +95,10 @@ PROVIDER_ENV_VARS = (
 def _clear_provider_env(monkeypatch):
     for key in PROVIDER_ENV_VARS:
         monkeypatch.delenv(key, raising=False)
+    # Prevent Claude Code credential auto-detection from interfering
+    monkeypatch.setattr(
+        "hermes_cli.auth._read_claude_code_credentials", lambda: None
+    )
 
 
 class TestResolveProvider:

--- a/tests/test_claude_code_auth.py
+++ b/tests/test_claude_code_auth.py
@@ -1,0 +1,395 @@
+"""Tests for Claude Code OAuth credential discovery and fallback provider.
+
+Tests the auto-detection of Claude Code's ~/.claude/.credentials.json
+for the Anthropic provider, and the Anthropic -> OpenRouter fallback chain.
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock, PropertyMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+VALID_CREDENTIALS = {
+    "claudeAiOauth": {
+        "accessToken": "sk-ant-oat01-test-token-value",
+        "refreshToken": "sk-ant-rt01-test-refresh",
+        "expiresAt": int((time.time() + 86400) * 1000),  # 24h from now
+        "scopes": ["user:inference", "user:profile"],
+        "subscriptionType": "pro",
+        "rateLimitTier": "default_claude_ai",
+    }
+}
+
+EXPIRED_CREDENTIALS = {
+    "claudeAiOauth": {
+        "accessToken": "sk-ant-oat01-expired-token",
+        "refreshToken": "sk-ant-rt01-expired-refresh",
+        "expiresAt": int((time.time() - 3600) * 1000),  # 1h ago
+        "scopes": ["user:inference"],
+        "subscriptionType": "pro",
+    }
+}
+
+
+@pytest.fixture
+def mock_creds_file(tmp_path):
+    """Create a temporary credentials file."""
+    creds_path = tmp_path / ".claude" / ".credentials.json"
+    creds_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _write(data):
+        creds_path.write_text(json.dumps(data))
+        return creds_path
+
+    return _write
+
+
+# ---------------------------------------------------------------------------
+# _read_claude_code_credentials
+# ---------------------------------------------------------------------------
+
+class TestReadClaudeCodeCredentials:
+    def test_valid_credentials(self, mock_creds_file):
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import _read_claude_code_credentials
+            result = _read_claude_code_credentials()
+            assert result is not None
+            assert result["accessToken"] == "sk-ant-oat01-test-token-value"
+            assert result["subscriptionType"] == "pro"
+
+    def test_missing_file(self, tmp_path):
+        missing = tmp_path / ".claude" / ".credentials.json"
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", missing):
+            from hermes_cli.auth import _read_claude_code_credentials
+            assert _read_claude_code_credentials() is None
+
+    def test_malformed_json(self, mock_creds_file, tmp_path):
+        creds_path = tmp_path / ".claude" / ".credentials.json"
+        creds_path.parent.mkdir(parents=True, exist_ok=True)
+        creds_path.write_text("not json{{{")
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import _read_claude_code_credentials
+            assert _read_claude_code_credentials() is None
+
+    def test_missing_oauth_key(self, mock_creds_file):
+        creds_path = mock_creds_file({"someOtherKey": {}})
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import _read_claude_code_credentials
+            assert _read_claude_code_credentials() is None
+
+    def test_empty_access_token(self, mock_creds_file):
+        data = {"claudeAiOauth": {"accessToken": "", "expiresAt": 9999999999999}}
+        creds_path = mock_creds_file(data)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import _read_claude_code_credentials
+            assert _read_claude_code_credentials() is None
+
+    def test_oauth_not_dict(self, mock_creds_file):
+        data = {"claudeAiOauth": "not-a-dict"}
+        creds_path = mock_creds_file(data)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import _read_claude_code_credentials
+            assert _read_claude_code_credentials() is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_anthropic_claude_code_credentials
+# ---------------------------------------------------------------------------
+
+class TestResolveClaudeCodeCredentials:
+    def test_valid_returns_creds(self, mock_creds_file):
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import resolve_anthropic_claude_code_credentials
+            result = resolve_anthropic_claude_code_credentials()
+            assert result["provider"] == "anthropic"
+            assert result["api_mode"] == "anthropic_messages"
+            assert result["api_key"] == "sk-ant-oat01-test-token-value"
+            assert result["source"] == "claude-code"
+            assert result["subscription_type"] == "pro"
+            assert result["base_url"] == "https://api.anthropic.com"
+
+    def test_expired_raises(self, mock_creds_file):
+        creds_path = mock_creds_file(EXPIRED_CREDENTIALS)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import resolve_anthropic_claude_code_credentials, AuthError
+            with pytest.raises(AuthError, match="expired"):
+                resolve_anthropic_claude_code_credentials()
+
+    def test_missing_raises(self, tmp_path):
+        missing = tmp_path / ".claude" / ".credentials.json"
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", missing):
+            from hermes_cli.auth import resolve_anthropic_claude_code_credentials, AuthError
+            with pytest.raises(AuthError, match="No Claude Code credentials"):
+                resolve_anthropic_claude_code_credentials()
+
+    def test_custom_base_url_from_env(self, mock_creds_file):
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path),
+            patch.dict("os.environ", {"ANTHROPIC_BASE_URL": "https://custom.example.com/v1/"}),
+        ):
+            from hermes_cli.auth import resolve_anthropic_claude_code_credentials
+            result = resolve_anthropic_claude_code_credentials()
+            assert result["base_url"] == "https://custom.example.com/v1"
+
+
+# ---------------------------------------------------------------------------
+# get_claude_code_auth_status
+# ---------------------------------------------------------------------------
+
+class TestClaudeCodeAuthStatus:
+    def test_logged_in(self, mock_creds_file):
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import get_claude_code_auth_status
+            status = get_claude_code_auth_status()
+            assert status["logged_in"] is True
+            assert status["source"] == "claude-code"
+            assert status["subscription_type"] == "pro"
+            assert status["is_expired"] is False
+
+    def test_expired(self, mock_creds_file):
+        creds_path = mock_creds_file(EXPIRED_CREDENTIALS)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import get_claude_code_auth_status
+            status = get_claude_code_auth_status()
+            assert status["logged_in"] is False
+            assert status["is_expired"] is True
+
+    def test_no_credentials(self, tmp_path):
+        missing = tmp_path / ".claude" / ".credentials.json"
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", missing):
+            from hermes_cli.auth import get_claude_code_auth_status
+            status = get_claude_code_auth_status()
+            assert status["logged_in"] is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_provider auto-detection
+# ---------------------------------------------------------------------------
+
+class TestResolveProviderClaudeCode:
+    def test_auto_detects_claude_code(self, mock_creds_file):
+        """When Claude Code creds are present and valid, auto-resolve to anthropic."""
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path),
+            patch("hermes_cli.auth._load_auth_store", return_value={}),
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            # Remove any env vars that would cause earlier resolution
+            import os
+            env_backup = {}
+            for k in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY"):
+                if k in os.environ:
+                    env_backup[k] = os.environ.pop(k)
+            try:
+                from hermes_cli.auth import resolve_provider
+                result = resolve_provider()
+                assert result == "anthropic"
+            finally:
+                os.environ.update(env_backup)
+
+    def test_expired_creds_not_detected(self, mock_creds_file):
+        """Expired Claude Code creds should not auto-resolve."""
+        creds_path = mock_creds_file(EXPIRED_CREDENTIALS)
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path),
+            patch("hermes_cli.auth._load_auth_store", return_value={}),
+        ):
+            import os
+            env_backup = {}
+            for k in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY"):
+                if k in os.environ:
+                    env_backup[k] = os.environ.pop(k)
+            try:
+                from hermes_cli.auth import resolve_provider
+                result = resolve_provider()
+                # Should fall through to openrouter (default)
+                assert result == "openrouter"
+            finally:
+                os.environ.update(env_backup)
+
+    def test_claude_alias(self):
+        """'claude' and 'claude-code' should resolve to 'anthropic'."""
+        from hermes_cli.auth import resolve_provider
+        assert resolve_provider("claude") == "anthropic"
+        assert resolve_provider("claude-code") == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# runtime_provider resolution
+# ---------------------------------------------------------------------------
+
+class TestRuntimeProviderClaudeCode:
+    def test_claude_code_creds_used(self, mock_creds_file):
+        """runtime_provider should use Claude Code creds when available."""
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path),
+            patch("hermes_cli.runtime_provider.resolve_provider", return_value="anthropic"),
+        ):
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+            result = resolve_runtime_provider(requested="anthropic")
+            assert result["provider"] == "anthropic"
+            assert result["api_mode"] == "anthropic_messages"
+            assert result["source"] == "claude-code"
+            assert result["api_key"] == "sk-ant-oat01-test-token-value"
+
+    def test_falls_back_to_env_var(self, tmp_path):
+        """When no Claude Code creds, fall back to env var."""
+        missing = tmp_path / ".claude" / ".credentials.json"
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", missing),
+            patch("hermes_cli.runtime_provider.resolve_provider", return_value="anthropic"),
+            patch.dict("os.environ", {"ANTHROPIC_TOKEN": "sk-ant-api-test-key"}),
+        ):
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+            result = resolve_runtime_provider(requested="anthropic")
+            assert result["provider"] == "anthropic"
+            assert result["api_mode"] == "anthropic_messages"
+            assert result["source"] == "ANTHROPIC_TOKEN"
+
+
+# ---------------------------------------------------------------------------
+# get_auth_status dispatcher
+# ---------------------------------------------------------------------------
+
+class TestAuthStatusDispatcher:
+    def test_anthropic_prefers_claude_code(self, mock_creds_file):
+        """get_auth_status('anthropic') should return Claude Code status if available."""
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path),
+            patch("hermes_cli.auth.get_active_provider", return_value="anthropic"),
+        ):
+            from hermes_cli.auth import get_auth_status
+            status = get_auth_status("anthropic")
+            assert status["logged_in"] is True
+            assert status["source"] == "claude-code"
+
+    def test_anthropic_falls_back_to_env(self, tmp_path):
+        """get_auth_status('anthropic') falls back to api_key status."""
+        missing = tmp_path / ".claude" / ".credentials.json"
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", missing),
+            patch("hermes_cli.auth.get_active_provider", return_value="anthropic"),
+            patch.dict("os.environ", {"ANTHROPIC_TOKEN": "sk-test"}),
+        ):
+            from hermes_cli.auth import get_auth_status
+            status = get_auth_status("anthropic")
+            assert status.get("configured") is True
+            assert status.get("provider") == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# Fallback provider: Anthropic -> OpenRouter
+# ---------------------------------------------------------------------------
+
+class TestFallbackProvider:
+    """Test the Anthropic -> OpenRouter fallback mechanism in AIAgent."""
+
+    def _make_agent(self, **extra_env):
+        """Create an AIAgent in anthropic_messages mode with mocked clients."""
+        import sys
+
+        env = {
+            "ANTHROPIC_TOKEN": "sk-ant-oat01-test-token",
+            "OPENROUTER_API_KEY": "sk-or-test-key",
+        }
+        env.update(extra_env)
+
+        # Mock the anthropic SDK if not installed
+        mock_anthropic_mod = MagicMock()
+        mock_anthropic_mod.Anthropic.return_value = MagicMock()
+        needs_mock = "anthropic" not in sys.modules
+        if needs_mock:
+            sys.modules["anthropic"] = mock_anthropic_mod
+
+        # Also mock httpx.Timeout if needed
+        mock_httpx = MagicMock()
+        needs_httpx_mock = "httpx" not in sys.modules
+        if needs_httpx_mock:
+            sys.modules["httpx"] = mock_httpx
+
+        try:
+            # Force re-import of adapter to pick up mocked anthropic
+            if "agent.anthropic_adapter" in sys.modules:
+                del sys.modules["agent.anthropic_adapter"]
+
+            with (
+                patch("run_agent.get_tool_definitions", return_value=[]),
+                patch("run_agent.check_toolset_requirements", return_value={}),
+                patch.dict("os.environ", env),
+            ):
+                from run_agent import AIAgent
+                agent = AIAgent(
+                    api_key="sk-ant-oat01-test-token",
+                    model="claude-opus-4-20250514",
+                    provider="anthropic",
+                    api_mode="anthropic_messages",
+                    quiet_mode=True,
+                    skip_context_files=True,
+                    skip_memory=True,
+                )
+                return agent
+        finally:
+            if needs_mock:
+                sys.modules.pop("anthropic", None)
+            if needs_httpx_mock:
+                sys.modules.pop("httpx", None)
+
+    def test_fallback_available_with_openrouter_key(self):
+        agent = self._make_agent()
+        assert agent._fallback_available is True
+        assert agent._fallback_activated is False
+        assert agent.api_mode == "anthropic_messages"
+
+    def test_fallback_not_available_without_key(self):
+        agent = self._make_agent(OPENROUTER_API_KEY="")
+        assert agent._fallback_available is False
+
+    def test_switch_to_fallback(self):
+        agent = self._make_agent()
+        with patch("run_agent.OpenAI") as mock_openai:
+            result = agent._switch_to_fallback_provider()
+            assert result is True
+            assert agent._fallback_activated is True
+            assert agent.api_mode == "chat_completions"
+            assert agent.provider == "openrouter"
+            assert agent.model == "anthropic/claude-opus-4-20250514"
+            mock_openai.assert_called_once()
+
+    def test_switch_idempotent(self):
+        """Calling switch twice should return False the second time."""
+        agent = self._make_agent()
+        with patch("run_agent.OpenAI"):
+            assert agent._switch_to_fallback_provider() is True
+            assert agent._switch_to_fallback_provider() is False
+
+    def test_model_remapping(self):
+        """Bare model names should get anthropic/ prefix for OpenRouter."""
+        agent = self._make_agent()
+        agent.model = "claude-sonnet-4-20250514"
+        with patch("run_agent.OpenAI"):
+            agent._switch_to_fallback_provider()
+            assert agent.model == "anthropic/claude-sonnet-4-20250514"
+
+    def test_already_prefixed_model_not_doubled(self):
+        """Models already prefixed shouldn't get double-prefixed."""
+        agent = self._make_agent()
+        agent.model = "anthropic/claude-opus-4-20250514"
+        with patch("run_agent.OpenAI"):
+            agent._switch_to_fallback_provider()
+            assert agent.model == "anthropic/claude-opus-4-20250514"

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -281,20 +281,21 @@ class TestMaskApiKey:
 
 class TestInit:
     def test_anthropic_base_url_accepted(self):
-        """Anthropic base URLs should be accepted (OpenAI-compatible endpoint)."""
+        """Anthropic base URLs should route to native Anthropic client."""
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
             patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI") as mock_openai,
+            patch("agent.anthropic_adapter.anthropic.Anthropic") as mock_anthropic,
         ):
-            AIAgent(
+            agent = AIAgent(
                 api_key="test-key-1234567890",
                 base_url="https://api.anthropic.com/v1/",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
             )
-            mock_openai.assert_called_once()
+            assert agent.api_mode == "anthropic_messages"
+            mock_anthropic.assert_called_once()
 
     def test_prompt_caching_claude_openrouter(self):
         """Claude model via OpenRouter should enable prompt caching."""


### PR DESCRIPTION
## Summary

Builds on #710 (native Anthropic Messages API provider) with two user-facing features. **This PR includes #710's commits as its base — merge #710 first, then this.**

### 1. Claude Code Credential Auto-Discovery

If you have [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated, Hermes will automatically detect and use your existing credentials — no extra configuration needed.

- Reads `~/.claude/.credentials.json` written by Claude Code
- Auto-detects `anthropic` provider when valid credentials are present
- Token expiry checking with helpful error messages (`Run claude to refresh it`)
- Falls back to `ANTHROPIC_TOKEN` / `ANTHROPIC_API_KEY` env vars if no Claude Code creds
- `claude-code` added as a provider alias

### 2. Fallback Provider Chain (Anthropic → OpenRouter)

When the Anthropic API returns rate-limit (429), auth (401), or overload (529) errors, Hermes transparently switches to OpenRouter if `OPENROUTER_API_KEY` is set.

- One-shot switch (won't ping-pong back to Anthropic)
- Remaps bare model names to OpenRouter format (`claude-opus-4` → `anthropic/claude-opus-4`)
- Enables prompt caching for Claude via OpenRouter
- Fallback readiness shown at startup: `🔄 Fallback provider: OpenRouter (ready)`

### 3. Model Name Normalization

OpenRouter-format model names are automatically normalized for the Anthropic API:

- Strips `anthropic/` prefix (`anthropic/claude-opus-4.6` → `claude-opus-4.6`)
- Converts dots to hyphens (`claude-opus-4.6` → `claude-opus-4-6`)
- Users can keep one `LLM_MODEL` value in `.env` that works with both providers

## Changes

| File | What |
|------|------|
| `hermes_cli/auth.py` | Claude Code credential reader, resolver, auth status, auto-detect in `resolve_provider()` |
| `hermes_cli/runtime_provider.py` | Try Claude Code creds before env vars for anthropic provider |
| `agent/anthropic_adapter.py` | Model name normalization (strip prefix, dots→hyphens) |
| `run_agent.py` | Fallback provider init, `_switch_to_fallback_provider()`, error handler hook |
| `tests/test_claude_code_auth.py` | 26 tests covering all new functionality |
| `tests/test_api_key_providers.py` | Mock Claude Code creds in autouse fixture to prevent interference |

## Testing

```
$ pytest tests/test_claude_code_auth.py tests/test_anthropic_adapter.py tests/test_api_key_providers.py -v
113 passed in 2.5s
```

**Dog-fooded live**: Set `HERMES_INFERENCE_PROVIDER=anthropic` with Claude Code creds maxed out → hit 429 → seamlessly fell over to OpenRouter → responded normally. The full chain works.

## Depends On

- #710 — this PR is branched off `feat/anthropic-provider`. Merge #710 first to avoid conflicts.
