### PR TITLE
feat: include session ID in system prompt

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -203,6 +203,10 @@ def cmd_chat(args):
     except Exception:
         pass
 
+    # --pass-session-id: include session ID in the agent's system prompt
+    if getattr(args, "pass_session_id", False):
+        os.environ["HERMES_PASS_SESSION_ID"] = "1"
+
     # Import and run the CLI
     from cli import main as cli_main
     
@@ -1303,6 +1307,12 @@ For more help on a command:
         default=False,
         help="Run in an isolated git worktree (for parallel agents)"
     )
+    parser.add_argument(
+        "--pass-session-id",
+        action="store_true",
+        default=False,
+        help="Include the session ID in the agent's system prompt"
+    )
     
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
     
@@ -1356,6 +1366,12 @@ For more help on a command:
         action="store_true",
         default=False,
         help="Run in an isolated git worktree (for parallel agents on the same repo)"
+    )
+    chat_parser.add_argument(
+        "--pass-session-id",
+        action="store_true",
+        default=False,
+        help="Include the session ID in the agent's system prompt"
     )
     chat_parser.set_defaults(func=cmd_chat)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1409,9 +1409,10 @@ class AIAgent:
 
         from hermes_time import now as _hermes_now
         now = _hermes_now()
-        prompt_parts.append(
-            f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
-        )
+        timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
+        if self.session_id:
+            timestamp_line += f"\nSession ID: {self.session_id}"
+        prompt_parts.append(timestamp_line)
 
         platform_key = (self.platform or "").lower().strip()
         if platform_key in PLATFORM_HINTS:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1410,7 +1410,7 @@ class AIAgent:
         from hermes_time import now as _hermes_now
         now = _hermes_now()
         timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
-        if self.session_id:
+        if self.session_id and os.getenv("HERMES_PASS_SESSION_ID"):
             timestamp_line += f"\nSession ID: {self.session_id}"
         prompt_parts.append(timestamp_line)
 


### PR DESCRIPTION
## What

Adds `--pass-session-id` CLI flag. When set, the agent's system prompt includes the session ID:

```
Conversation started: Sunday, March 08, 2026 06:32 PM
Session ID: 20260308_183200_abc123
```

Usage:
```bash
hermes --pass-session-id
hermes chat --pass-session-id
```

## Changes

- `hermes_cli/main.py`: adds `--pass-session-id` flag (both top-level and chat subparser), sets `HERMES_PASS_SESSION_ID=1` env var
- `run_agent.py`: `_build_system_prompt()` appends session ID when env var is set