### PR TITLE
feat: configurable provider fallback chain with interactive CLI + gateway auto-cascade

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -145,6 +145,13 @@ def build_anthropic_kwargs(
     system, anthropic_messages = convert_messages_to_anthropic(messages)
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
 
+    # Normalize OpenRouter-style model names for Anthropic API
+    # "anthropic/claude-opus-4.6" -> "claude-opus-4-6"
+    if model.startswith("anthropic/"):
+        model = model[len("anthropic/"):]
+    # Anthropic uses hyphens not dots (claude-opus-4.6 -> claude-opus-4-6)
+    model = model.replace(".", "-")
+
     effective_max_tokens = max_tokens or 16384
 
     kwargs: Dict[str, Any] = {
@@ -164,7 +171,7 @@ def build_anthropic_kwargs(
         if reasoning_config.get("enabled") is not False:
             effort = reasoning_config.get("effort", "medium")
             budget = THINKING_BUDGET.get(effort, 8000)
-            kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
+            kwargs["thinking"] = {"type": "adaptive", "budget_tokens": budget}
             kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
 
     return kwargs

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -171,7 +171,8 @@ def build_anthropic_kwargs(
         if reasoning_config.get("enabled") is not False:
             effort = reasoning_config.get("effort", "medium")
             budget = THINKING_BUDGET.get(effort, 8000)
-            kwargs["thinking"] = {"type": "adaptive", "budget_tokens": budget}
+            kwargs["thinking"] = {"type": "adaptive"}
+            # adaptive thinking still needs max_tokens headroom for thinking output
             kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
 
     return kwargs

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -17,6 +17,24 @@ from httpx import Timeout
 
 THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
 
+# Models known to support Anthropic's adaptive thinking parameter.
+# Only these model prefixes get thinking={type: adaptive}; others
+# silently skip it to avoid 400 "not supported on this model" errors.
+_THINKING_CAPABLE_PREFIXES = (
+    "claude-opus-4",      # claude-opus-4-20250514, claude-opus-4-6, etc.
+    "claude-sonnet-4-",   # claude-sonnet-4-20250514 (NOT claude-sonnet-4-5)
+    "claude-3-7-sonnet",  # claude-3-7-sonnet-20250219
+    "claude-3-5-sonnet",  # claude-3-5-sonnet-20241022 (later builds)
+)
+
+def _model_supports_thinking(model: str) -> bool:
+    """Check if a normalized Anthropic model ID supports adaptive thinking."""
+    m = model.lower()
+    # claude-sonnet-4-5* is a distinct model that does NOT support thinking
+    if m.startswith("claude-sonnet-4-5"):
+        return False
+    return any(m.startswith(prefix) for prefix in _THINKING_CAPABLE_PREFIXES)
+
 
 def build_anthropic_client(api_key: str, base_url: str = None) -> anthropic.Anthropic:
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys."""
@@ -166,9 +184,9 @@ def build_anthropic_kwargs(
     if anthropic_tools:
         kwargs["tools"] = anthropic_tools
 
-    # Map reasoning_config to Anthropic's thinking parameter
+    # Map reasoning_config to Anthropic's thinking parameter (only for capable models)
     if reasoning_config and isinstance(reasoning_config, dict):
-        if reasoning_config.get("enabled") is not False:
+        if reasoning_config.get("enabled") is not False and _model_supports_thinking(model):
             effort = reasoning_config.get("effort", "medium")
             budget = THINKING_BUDGET.get(effort, 8000)
             kwargs["thinking"] = {"type": "adaptive"}

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import anthropic
 from httpx import Timeout
 
+THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
+
 
 def build_anthropic_client(api_key: str, base_url: str = None) -> anthropic.Anthropic:
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys."""
@@ -161,12 +163,7 @@ def build_anthropic_kwargs(
     if reasoning_config and isinstance(reasoning_config, dict):
         if reasoning_config.get("enabled") is not False:
             effort = reasoning_config.get("effort", "medium")
-            budget = {
-                "xhigh": 32000,
-                "high": 16000,
-                "medium": 8000,
-                "low": 4000,
-            }.get(effort, 8000)
+            budget = THINKING_BUDGET.get(effort, 8000)
             kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
             kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1,0 +1,223 @@
+"""Anthropic Messages API adapter for Hermes Agent.
+
+Translates between Hermes's internal OpenAI-style message format and
+Anthropic's Messages API. Follows the same pattern as the codex_responses
+adapter — all provider-specific logic is isolated here.
+
+Auth supports both regular API keys (sk-ant-api*) and Claude setup-tokens
+(sk-ant-oat01-*). Setup-tokens require bearer auth + beta header.
+"""
+
+import json
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+
+import anthropic
+from httpx import Timeout
+
+
+def build_anthropic_client(api_key: str, base_url: str = None) -> anthropic.Anthropic:
+    """Create an Anthropic client, auto-detecting setup-tokens vs API keys."""
+    kwargs = {
+        "timeout": Timeout(timeout=900.0, connect=10.0),
+    }
+    if base_url:
+        kwargs["base_url"] = base_url
+
+    if api_key.startswith("sk-ant-oat"):
+        # Setup-token (OAuth access token from `claude setup-token`)
+        kwargs["auth_token"] = api_key
+        kwargs["default_headers"] = {"anthropic-beta": "oauth-2025-04-20"}
+    else:
+        kwargs["api_key"] = api_key
+
+    return anthropic.Anthropic(**kwargs)
+
+
+def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
+    """Convert OpenAI tool definitions to Anthropic format."""
+    if not tools:
+        return []
+    result = []
+    for t in tools:
+        fn = t.get("function", {})
+        result.append({
+            "name": fn.get("name", ""),
+            "description": fn.get("description", ""),
+            "input_schema": fn.get("parameters", {"type": "object", "properties": {}}),
+        })
+    return result
+
+
+def convert_messages_to_anthropic(
+    messages: List[Dict],
+) -> Tuple[Optional[str], List[Dict]]:
+    """Convert OpenAI-format messages to Anthropic format.
+
+    Returns (system_prompt, anthropic_messages).
+    System messages are extracted since Anthropic takes them as a separate param.
+    """
+    system = None
+    result = []
+
+    for m in messages:
+        role = m.get("role", "user")
+        content = m.get("content", "")
+
+        if role == "system":
+            if isinstance(content, list):
+                system = "\n".join(
+                    p["text"] for p in content if p.get("type") == "text"
+                )
+            else:
+                system = content
+            continue
+
+        if role == "assistant":
+            blocks = []
+            if content:
+                text = content if isinstance(content, str) else json.dumps(content)
+                blocks.append({"type": "text", "text": text})
+            for tc in m.get("tool_calls", []):
+                fn = tc.get("function", {})
+                args = fn.get("arguments", "{}")
+                blocks.append({
+                    "type": "tool_use",
+                    "id": tc.get("id", ""),
+                    "name": fn.get("name", ""),
+                    "input": json.loads(args) if isinstance(args, str) else args,
+                })
+            result.append({"role": "assistant", "content": blocks or content})
+            continue
+
+        if role == "tool":
+            tool_result = {
+                "type": "tool_result",
+                "tool_use_id": m.get("tool_call_id", ""),
+                "content": content if isinstance(content, str) else json.dumps(content),
+            }
+            # Merge consecutive tool results into one user message
+            if (
+                result
+                and result[-1]["role"] == "user"
+                and isinstance(result[-1]["content"], list)
+                and result[-1]["content"]
+                and result[-1]["content"][0].get("type") == "tool_result"
+            ):
+                result[-1]["content"].append(tool_result)
+            else:
+                result.append({"role": "user", "content": [tool_result]})
+            continue
+
+        # Regular user message
+        result.append({"role": "user", "content": content})
+
+    # Strip orphaned tool_use blocks (no matching tool_result)
+    tool_result_ids = set()
+    for m in result:
+        if m["role"] == "user" and isinstance(m["content"], list):
+            for block in m["content"]:
+                if block.get("type") == "tool_result":
+                    tool_result_ids.add(block.get("tool_use_id"))
+    for m in result:
+        if m["role"] == "assistant" and isinstance(m["content"], list):
+            m["content"] = [
+                b
+                for b in m["content"]
+                if b.get("type") != "tool_use" or b.get("id") in tool_result_ids
+            ]
+            if not m["content"]:
+                m["content"] = [{"type": "text", "text": "(tool call removed)"}]
+
+    return system, result
+
+
+def build_anthropic_kwargs(
+    model: str,
+    messages: List[Dict],
+    tools: Optional[List[Dict]],
+    max_tokens: Optional[int],
+    reasoning_config: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build kwargs for anthropic.messages.create()."""
+    system, anthropic_messages = convert_messages_to_anthropic(messages)
+    anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
+
+    effective_max_tokens = max_tokens or 16384
+
+    kwargs: Dict[str, Any] = {
+        "model": model,
+        "messages": anthropic_messages,
+        "max_tokens": effective_max_tokens,
+    }
+
+    if system:
+        kwargs["system"] = system
+
+    if anthropic_tools:
+        kwargs["tools"] = anthropic_tools
+
+    # Map reasoning_config to Anthropic's thinking parameter
+    if reasoning_config and isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is not False:
+            effort = reasoning_config.get("effort", "medium")
+            budget = {
+                "xhigh": 32000,
+                "high": 16000,
+                "medium": 8000,
+                "low": 4000,
+            }.get(effort, 8000)
+            kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
+            kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
+
+    return kwargs
+
+
+def normalize_anthropic_response(
+    response,
+) -> Tuple[SimpleNamespace, str]:
+    """Normalize Anthropic response to match the shape expected by AIAgent.
+
+    Returns (assistant_message, finish_reason) where assistant_message has
+    .content, .tool_calls, and .reasoning attributes.
+    """
+    text_parts = []
+    reasoning_parts = []
+    tool_calls = []
+
+    for block in response.content:
+        if block.type == "text":
+            text_parts.append(block.text)
+        elif block.type == "thinking":
+            reasoning_parts.append(block.thinking)
+        elif block.type == "tool_use":
+            tool_calls.append(
+                SimpleNamespace(
+                    id=block.id,
+                    type="function",
+                    function=SimpleNamespace(
+                        name=block.name,
+                        arguments=json.dumps(block.input),
+                    ),
+                )
+            )
+
+    # Map Anthropic stop_reason to OpenAI finish_reason
+    stop_reason_map = {
+        "end_turn": "stop",
+        "tool_use": "tool_calls",
+        "max_tokens": "length",
+        "stop_sequence": "stop",
+    }
+    finish_reason = stop_reason_map.get(response.stop_reason, "stop")
+
+    return (
+        SimpleNamespace(
+            content="\n".join(text_parts) if text_parts else None,
+            tool_calls=tool_calls or None,
+            reasoning="\n\n".join(reasoning_parts) if reasoning_parts else None,
+            reasoning_content=None,
+            reasoning_details=None,
+        ),
+        finish_reason,
+    )

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -10,14 +10,17 @@ Resolution order for text tasks:
   3. Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY)
   4. Codex OAuth (Responses API via chatgpt.com with gpt-5.3-codex,
      wrapped to look like a chat.completions client)
-  5. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
+  5. Anthropic (ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, wrapped to look
+     like a chat.completions client)
+  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
      — checked via PROVIDER_REGISTRY entries with auth_type='api_key'
-  6. None
+  7. None
 
 Resolution order for vision/multimodal tasks:
   1. OpenRouter
   2. Nous Portal
-  3. None  (custom endpoints can't substitute for Gemini multimodal)
+  3. Anthropic (Claude supports vision natively)
+  4. None
 """
 
 import json
@@ -245,6 +248,130 @@ class AsyncCodexAuxiliaryClient:
         self.base_url = sync_wrapper.base_url
 
 
+_ANTHROPIC_AUX_MODEL = "claude-haiku-4-5-20251001"
+
+
+def _read_anthropic_token() -> Optional[str]:
+    """Return an Anthropic API key or OAuth token if available."""
+    for var in ("ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY"):
+        val = os.getenv(var, "").strip()
+        if val:
+            return val
+    return None
+
+
+class _AnthropicCompletionsAdapter:
+    """Shim that accepts chat.completions.create() kwargs and routes
+    them through the Anthropic Messages API."""
+
+    def __init__(self, client, model: str):
+        self._client = client
+        self._model = model
+
+    def create(self, **kwargs) -> Any:
+        from agent.anthropic_adapter import (
+            convert_messages_to_anthropic,
+            convert_tools_to_anthropic,
+        )
+
+        messages = kwargs.get("messages", [])
+        model = kwargs.get("model", self._model)
+        system, ant_messages = convert_messages_to_anthropic(messages)
+        tools = convert_tools_to_anthropic(kwargs.get("tools") or [])
+        max_tokens = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens") or 4096
+
+        api_kwargs: Dict[str, Any] = {
+            "model": model,
+            "messages": ant_messages,
+            "max_tokens": max_tokens,
+        }
+        if system:
+            api_kwargs["system"] = system
+        if tools:
+            api_kwargs["tools"] = tools
+
+        resp = self._client.messages.create(**api_kwargs)
+
+        # Build OpenAI-shaped response
+        text_parts = []
+        tool_calls_raw = []
+        for block in resp.content:
+            if block.type == "text":
+                text_parts.append(block.text)
+            elif block.type == "tool_use":
+                tool_calls_raw.append(SimpleNamespace(
+                    id=block.id,
+                    type="function",
+                    function=SimpleNamespace(
+                        name=block.name,
+                        arguments=json.dumps(block.input),
+                    ),
+                ))
+
+        content = "\n".join(text_parts).strip() or None
+        message = SimpleNamespace(
+            role="assistant",
+            content=content,
+            tool_calls=tool_calls_raw or None,
+        )
+        choice = SimpleNamespace(
+            index=0,
+            message=message,
+            finish_reason="tool_calls" if tool_calls_raw else "stop",
+        )
+        usage = SimpleNamespace(
+            prompt_tokens=resp.usage.input_tokens,
+            completion_tokens=resp.usage.output_tokens,
+            total_tokens=resp.usage.input_tokens + resp.usage.output_tokens,
+        )
+        return SimpleNamespace(choices=[choice], model=model, usage=usage)
+
+
+class _AnthropicChatShim:
+    def __init__(self, adapter: _AnthropicCompletionsAdapter):
+        self.completions = adapter
+
+
+class AnthropicAuxiliaryClient:
+    """OpenAI-client-compatible wrapper for Anthropic Messages API.
+
+    Consumers call client.chat.completions.create(**kwargs) as normal.
+    """
+
+    def __init__(self, client, model: str):
+        self._client = client
+        adapter = _AnthropicCompletionsAdapter(client, model)
+        self.chat = _AnthropicChatShim(adapter)
+        self.api_key = "anthropic"
+        self.base_url = "https://api.anthropic.com"
+
+    def close(self):
+        self._client.close()
+
+
+class _AsyncAnthropicCompletionsAdapter:
+    def __init__(self, sync_adapter: _AnthropicCompletionsAdapter):
+        self._sync = sync_adapter
+
+    async def create(self, **kwargs) -> Any:
+        import asyncio
+        return await asyncio.to_thread(self._sync.create, **kwargs)
+
+
+class _AsyncAnthropicChatShim:
+    def __init__(self, adapter: _AsyncAnthropicCompletionsAdapter):
+        self.completions = adapter
+
+
+class AsyncAnthropicAuxiliaryClient:
+    def __init__(self, sync_wrapper: AnthropicAuxiliaryClient):
+        sync_adapter = sync_wrapper.chat.completions
+        async_adapter = _AsyncAnthropicCompletionsAdapter(sync_adapter)
+        self.chat = _AsyncAnthropicChatShim(async_adapter)
+        self.api_key = sync_wrapper.api_key
+        self.base_url = sync_wrapper.base_url
+
+
 def _read_nous_auth() -> Optional[dict]:
     """Read and validate ~/.hermes/auth.json for an active Nous provider.
 
@@ -379,12 +506,20 @@ def get_text_auxiliary_client() -> Tuple[Optional[OpenAI], Optional[str]]:
         real_client = OpenAI(api_key=codex_token, base_url=_CODEX_AUX_BASE_URL)
         return CodexAuxiliaryClient(real_client, _CODEX_AUX_MODEL), _CODEX_AUX_MODEL
 
-    # 5. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, etc.)
+    # 5. Anthropic (ANTHROPIC_TOKEN or ANTHROPIC_API_KEY)
+    ant_token = _read_anthropic_token()
+    if ant_token:
+        from agent.anthropic_adapter import build_anthropic_client
+        logger.debug("Auxiliary text client: Anthropic (%s)", _ANTHROPIC_AUX_MODEL)
+        client = build_anthropic_client(ant_token)
+        return AnthropicAuxiliaryClient(client, _ANTHROPIC_AUX_MODEL), _ANTHROPIC_AUX_MODEL
+
+    # 6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, etc.)
     api_client, api_model = _resolve_api_key_provider()
     if api_client is not None:
         return api_client, api_model
 
-    # 6. Nothing available
+    # 7. Nothing available
     logger.debug("Auxiliary text client: none available")
     return None, None
 
@@ -404,6 +539,9 @@ def get_async_text_auxiliary_client():
 
     if isinstance(sync_client, CodexAuxiliaryClient):
         return AsyncCodexAuxiliaryClient(sync_client), model
+
+    if isinstance(sync_client, AnthropicAuxiliaryClient):
+        return AsyncAnthropicAuxiliaryClient(sync_client), model
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -438,7 +576,15 @@ def get_vision_auxiliary_client() -> Tuple[Optional[OpenAI], Optional[str]]:
             _NOUS_MODEL,
         )
 
-    # 3. Nothing suitable
+    # 3. Anthropic (Claude supports vision natively)
+    ant_token = _read_anthropic_token()
+    if ant_token:
+        from agent.anthropic_adapter import build_anthropic_client
+        logger.debug("Auxiliary vision client: Anthropic (%s)", _ANTHROPIC_AUX_MODEL)
+        client = build_anthropic_client(ant_token)
+        return AnthropicAuxiliaryClient(client, _ANTHROPIC_AUX_MODEL), _ANTHROPIC_AUX_MODEL
+
+    # 4. Nothing suitable
     logger.debug("Auxiliary vision client: none available")
     return None, None
 

--- a/agent/fallback_chain.py
+++ b/agent/fallback_chain.py
@@ -1,0 +1,430 @@
+"""Provider fallback chain for resilient inference.
+
+When the primary inference provider fails (rate-limit, auth, overload),
+the fallback chain provides an ordered list of alternatives. In CLI mode,
+the user gets an interactive countdown prompt to pick one. In gateway mode
+(Telegram, Discord), it auto-cascades through the chain with status
+messages sent to the user.
+
+Config (in ~/.hermes/config.yaml):
+
+    fallback:
+      mode: interactive    # "auto" | "interactive"
+      timeout: 30          # seconds before auto-selecting (interactive mode)
+      chain:
+        - provider: openrouter
+          model: anthropic/claude-opus-4.6
+        - provider: lmstudio
+          base_url: http://localhost:1234/v1
+          model: qwen3-30b-a3b
+        - provider: ollama
+          base_url: http://localhost:11434/v1
+          model: llama3.1:70b
+
+If no fallback config exists but OPENROUTER_API_KEY is set and the
+primary provider is Anthropic, a single-entry OpenRouter chain is
+auto-generated for backward compatibility.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import select
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+
+from hermes_constants import OPENROUTER_BASE_URL
+
+logger = logging.getLogger(__name__)
+
+# Status codes that trigger a fallback switch
+FALLBACK_STATUS_CODES = {401, 429, 503, 529}
+
+
+# =============================================================================
+# Data classes
+# =============================================================================
+
+@dataclass
+class FallbackEntry:
+    """A single provider slot in the fallback chain."""
+
+    provider: str
+    base_url: str = ""
+    model: str = ""
+    api_key_env: str = ""  # env var name to read key from
+    api_mode: str = "chat_completions"
+
+    @property
+    def display_name(self) -> str:
+        """Human-readable name for the provider."""
+        host = ""
+        if self.base_url:
+            # Show host for local endpoints
+            from urllib.parse import urlparse
+            parsed = urlparse(self.base_url)
+            if parsed.hostname and parsed.hostname in ("localhost", "127.0.0.1", "0.0.0.0"):
+                host = f" ({parsed.hostname}:{parsed.port or 80})"
+        return f"{self.provider}{host}"
+
+    def resolve_api_key(self) -> str:
+        """Resolve the API key from env var or provider defaults."""
+        # Explicit env var specified in config
+        if self.api_key_env:
+            key = os.getenv(self.api_key_env, "").strip()
+            if key:
+                return key
+
+        # Provider-specific defaults
+        provider_lower = self.provider.lower()
+        if provider_lower == "openrouter":
+            return os.getenv("OPENROUTER_API_KEY", "") or os.getenv("OPENAI_API_KEY", "")
+        elif provider_lower in ("lmstudio", "ollama", "llamacpp", "local"):
+            # Local providers typically don't need a key
+            return os.getenv("OPENAI_API_KEY", "") or "not-needed"
+        elif provider_lower == "anthropic":
+            return os.getenv("ANTHROPIC_API_KEY", "") or os.getenv("ANTHROPIC_TOKEN", "")
+        else:
+            # Generic fallback: try OPENAI_API_KEY
+            return os.getenv("OPENAI_API_KEY", "")
+
+    def build_client_kwargs(self) -> Dict[str, Any]:
+        """Build OpenAI client kwargs for this fallback entry."""
+        provider_lower = self.provider.lower()
+        base_url = self.base_url or OPENROUTER_BASE_URL
+        api_key = self.resolve_api_key()
+
+        kwargs: Dict[str, Any] = {
+            "base_url": base_url.rstrip("/"),
+            "api_key": api_key,
+        }
+
+        # OpenRouter-specific headers
+        if "openrouter" in base_url.lower():
+            kwargs["default_headers"] = {
+                "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
+                "X-OpenRouter-Title": "Hermes Agent",
+                "X-OpenRouter-Categories": "productivity,cli-agent",
+            }
+
+        return kwargs
+
+
+# =============================================================================
+# Fallback Chain
+# =============================================================================
+
+class FallbackChain:
+    """Ordered chain of fallback inference providers.
+
+    The chain tracks which entries have been tried and exhausted.
+    It supports both sequential auto-cascade and interactive selection.
+    """
+
+    def __init__(
+        self,
+        entries: List[FallbackEntry],
+        mode: str = "auto",
+        timeout: int = 30,
+        enabled: bool = True,
+    ):
+        self.entries = entries
+        self.mode = mode  # "auto", "interactive", or "off"
+        self.timeout = timeout
+        self.enabled = enabled  # Master toggle — False disables all fallback
+        self._exhausted: Set[int] = set()
+
+    @classmethod
+    def from_config(cls, config: dict) -> "FallbackChain":
+        """Build chain from config.yaml fallback section."""
+        fallback_cfg = config.get("fallback", {})
+        if not fallback_cfg or not isinstance(fallback_cfg, dict):
+            return cls(entries=[], mode="auto")
+
+        # Master toggle: enabled: false or mode: off disables fallback
+        enabled = fallback_cfg.get("enabled", True)
+        mode = fallback_cfg.get("mode", "auto")
+        if mode == "off":
+            enabled = False
+        timeout = fallback_cfg.get("timeout", 30)
+
+        entries: List[FallbackEntry] = []
+        for entry_cfg in fallback_cfg.get("chain", []):
+            if not isinstance(entry_cfg, dict):
+                continue
+            provider = entry_cfg.get("provider", "").strip()
+            if not provider:
+                continue
+            entries.append(FallbackEntry(
+                provider=provider,
+                base_url=entry_cfg.get("base_url", ""),
+                model=entry_cfg.get("model", ""),
+                api_key_env=entry_cfg.get("api_key_env", ""),
+                api_mode=entry_cfg.get("api_mode", "chat_completions"),
+            ))
+
+        return cls(entries=entries, mode=mode, timeout=timeout, enabled=enabled)
+
+    @classmethod
+    def build_legacy_chain(cls, primary_model: str = "") -> "FallbackChain":
+        """Build a backward-compatible single-entry OpenRouter chain.
+
+        Called when there's no explicit fallback config but OPENROUTER_API_KEY
+        exists. Preserves the pre-chain behavior: Anthropic -> OpenRouter.
+        """
+        key = os.getenv("OPENROUTER_API_KEY", "").strip()
+        if not key:
+            return cls(entries=[], mode="auto")
+
+        # Map the primary model to OpenRouter format
+        model = primary_model
+        if model and not model.startswith("anthropic/") and "claude" in model.lower():
+            model = f"anthropic/{model}"
+
+        return cls(
+            entries=[FallbackEntry(
+                provider="openrouter",
+                base_url=OPENROUTER_BASE_URL,
+                model=model,
+                api_key_env="OPENROUTER_API_KEY",
+            )],
+            mode="auto",
+            timeout=30,
+        )
+
+    def has_fallbacks(self) -> bool:
+        """Check if fallback is enabled and entries exist."""
+        return self.enabled and len(self.entries) > 0
+
+    def is_exhausted(self) -> bool:
+        """Check if all fallback entries have been tried."""
+        return len(self._exhausted) >= len(self.entries)
+
+    def available_entries(self) -> List[Tuple[int, FallbackEntry]]:
+        """Get (index, entry) pairs for entries not yet exhausted."""
+        return [
+            (i, e) for i, e in enumerate(self.entries)
+            if i not in self._exhausted
+        ]
+
+    def next_available(self) -> Optional[FallbackEntry]:
+        """Get the next untried entry in order."""
+        for i, entry in enumerate(self.entries):
+            if i not in self._exhausted:
+                return entry
+        return None
+
+    def mark_failed(self, entry: FallbackEntry):
+        """Mark an entry as failed/exhausted."""
+        try:
+            idx = self.entries.index(entry)
+            self._exhausted.add(idx)
+        except ValueError:
+            pass
+
+    def select_by_index(self, index: int) -> Optional[FallbackEntry]:
+        """Select a specific entry by its chain index."""
+        if 0 <= index < len(self.entries):
+            return self.entries[index]
+        return None
+
+    def reset(self):
+        """Reset all exhaustion state for a fresh round."""
+        self._exhausted.clear()
+
+
+# =============================================================================
+# Fallback selectors (Strategy pattern)
+# =============================================================================
+
+def select_interactive(
+    chain: FallbackChain,
+    error_msg: str,
+    current_model: str = "",
+    log_prefix: str = "",
+) -> Optional[FallbackEntry]:
+    """Interactive countdown prompt for fallback selection (CLI mode).
+
+    Shows a numbered menu of available fallback providers with a countdown
+    timer. Auto-selects the first available if the timer expires.
+
+    Returns the selected FallbackEntry, or None to skip (keep retrying).
+    """
+    available = chain.available_entries()
+    if not available:
+        return None
+
+    # Display error and menu
+    print(f"\n{log_prefix}⚠️  Primary provider failed: {error_msg[:120]}")
+    print(f"{log_prefix}🔄 Fallback options:\n")
+
+    for display_idx, (_, entry) in enumerate(available, 1):
+        model_str = f"  →  {entry.model}" if entry.model else ""
+        print(f"{log_prefix}  [{display_idx}] {entry.display_name}{model_str}")
+
+    print(f"{log_prefix}  [m] Change model before switching")
+    print(f"{log_prefix}  [s] Skip — keep retrying primary")
+    print()
+
+    default_idx, default_entry = available[0]
+    timeout = chain.timeout
+
+    try:
+        start = time.time()
+        while True:
+            remaining = max(0, timeout - int(time.time() - start))
+
+            if remaining == 0:
+                print(f"\r{log_prefix}  Auto-selecting [{1}] {default_entry.display_name}                    ")
+                print()
+                return default_entry
+
+            # Progress bar
+            bar_total = 20
+            bar_filled = int((remaining / timeout) * bar_total)
+            bar = "\u2588" * bar_filled + "\u2591" * (bar_total - bar_filled)
+            sys.stdout.write(
+                f"\r{log_prefix}  Auto-selecting [{1}] in {remaining}s  {bar}  "
+            )
+            sys.stdout.flush()
+
+            # Poll stdin for 1 second
+            if sys.stdin.isatty():
+                rlist, _, _ = select.select([sys.stdin], [], [], 1.0)
+                if rlist:
+                    choice = sys.stdin.readline().strip().lower()
+                    # Clear the countdown line
+                    sys.stdout.write(f"\r{log_prefix}{'':60}\r")
+                    sys.stdout.flush()
+
+                    if choice == "s":
+                        print(f"{log_prefix}  ↩ Continuing with primary provider...")
+                        return None
+
+                    elif choice == "m":
+                        return _handle_model_override(
+                            available, log_prefix
+                        )
+
+                    else:
+                        try:
+                            sel_idx = int(choice) - 1
+                            if 0 <= sel_idx < len(available):
+                                _, entry = available[sel_idx]
+                                print(f"{log_prefix}  ✓ Selected {entry.display_name}")
+                                return entry
+                        except (ValueError, IndexError):
+                            pass
+                        # Invalid input — auto-select default
+                        print(f"{log_prefix}  Invalid choice, selecting {default_entry.display_name}")
+                        return default_entry
+            else:
+                # Non-interactive stdin — auto-cascade
+                time.sleep(1)
+
+    except (KeyboardInterrupt, EOFError):
+        print(f"\n{log_prefix}  Interrupted — staying on primary provider")
+        return None
+
+
+def _handle_model_override(
+    available: List[Tuple[int, FallbackEntry]],
+    log_prefix: str,
+) -> Optional[FallbackEntry]:
+    """Handle the [m] model override choice in interactive mode."""
+    try:
+        model = input(f"{log_prefix}  Enter model name: ").strip()
+        if not model:
+            print(f"{log_prefix}  No model entered, using default")
+            return available[0][1]
+
+        if len(available) == 1:
+            entry = available[0][1]
+            entry.model = model
+            print(f"{log_prefix}  ✓ Using {entry.display_name} with model {model}")
+            return entry
+
+        provider_q = input(
+            f"{log_prefix}  Which provider? [1-{len(available)}, default=1]: "
+        ).strip()
+
+        sel_idx = 0
+        if provider_q:
+            try:
+                sel_idx = int(provider_q) - 1
+                if not (0 <= sel_idx < len(available)):
+                    sel_idx = 0
+            except ValueError:
+                sel_idx = 0
+
+        _, entry = available[sel_idx]
+        entry.model = model
+        print(f"{log_prefix}  ✓ Using {entry.display_name} with model {model}")
+        return entry
+
+    except (KeyboardInterrupt, EOFError):
+        return None
+
+
+def select_auto(
+    chain: FallbackChain,
+    error_msg: str,
+    current_model: str = "",
+    log_prefix: str = "",
+    notify: Optional[Callable[[str], None]] = None,
+) -> Optional[FallbackEntry]:
+    """Auto-select the next fallback in the chain (gateway mode).
+
+    Args:
+        notify: Optional callback to send status messages to the user
+                (e.g., Telegram message, Discord embed).
+    """
+    entry = chain.next_available()
+    if entry is None:
+        msg = "⚠️ All fallback providers exhausted. Could not complete request."
+        print(f"{log_prefix}{msg}")
+        if notify:
+            try:
+                notify(msg)
+            except Exception:
+                pass
+        return None
+
+    model_str = f" ({entry.model})" if entry.model else ""
+    msg = f"🔄 Primary failed. Switching to {entry.display_name}{model_str}..."
+    print(f"{log_prefix}{msg}")
+    if notify:
+        try:
+            notify(msg)
+        except Exception:
+            pass
+
+    return entry
+
+
+# =============================================================================
+# High-level API used by AIAgent
+# =============================================================================
+
+def should_trigger_fallback(status_code: Optional[int], error: Exception) -> bool:
+    """Determine if an API error should trigger a fallback switch.
+
+    Only triggers on errors that are provider-level failures, not client
+    errors that would persist across providers (e.g., bad request format).
+    """
+    if status_code and status_code in FALLBACK_STATUS_CODES:
+        return True
+
+    # Connection errors suggest the provider is unreachable
+    error_type = type(error).__name__
+    if error_type in ("ConnectError", "ConnectTimeout", "ReadTimeout", "ConnectionError"):
+        return True
+
+    error_msg = str(error).lower()
+    if "overloaded" in error_msg or "rate limit" in error_msg:
+        return True
+
+    return False

--- a/agent/fallback_chain.py
+++ b/agent/fallback_chain.py
@@ -21,9 +21,20 @@ Config (in ~/.hermes/config.yaml):
           base_url: http://localhost:11434/v1
           model: llama3.1:70b
 
-If no fallback config exists but OPENROUTER_API_KEY is set and the
-primary provider is Anthropic, a single-entry OpenRouter chain is
-auto-generated for backward compatibility.
+If no explicit fallback config exists, the chain is auto-built by scanning
+environment variables for known provider API keys. The primary provider is
+excluded to avoid circular fallback. Priority order:
+
+    1. OpenRouter (broadest model selection, good fallback for any primary)
+    2. Anthropic (direct — for when primary is OpenRouter/other)
+    3. OpenAI (direct)
+    4. Google Gemini
+    5. DeepSeek
+    6. Together AI
+    7. Groq
+    8. Fireworks AI
+    9. Mistral AI
+    10. Local providers (LM Studio, Ollama — checked via port probe)
 """
 
 from __future__ import annotations
@@ -42,6 +53,214 @@ logger = logging.getLogger(__name__)
 
 # Status codes that trigger a fallback switch
 FALLBACK_STATUS_CODES = {401, 429, 503, 529}
+
+
+# =============================================================================
+# Known provider definitions for auto-chain building
+# =============================================================================
+
+@dataclass
+class _KnownProvider:
+    """Describes a known inference provider for auto-detection."""
+    id: str
+    name: str
+    env_vars: Tuple[str, ...]  # API key env vars to check (first found wins)
+    base_url: str = ""
+    default_model: str = ""
+    api_mode: str = "chat_completions"
+    # Aliases that match this provider as "primary" (to exclude from chain)
+    primary_aliases: Tuple[str, ...] = ()
+
+
+# Ordered by fallback priority — first match with a valid key wins
+KNOWN_PROVIDERS: List[_KnownProvider] = [
+    _KnownProvider(
+        id="openrouter",
+        name="OpenRouter",
+        env_vars=("OPENROUTER_API_KEY",),
+        base_url=OPENROUTER_BASE_URL,
+        default_model="anthropic/claude-sonnet-4",
+        primary_aliases=("openrouter",),
+    ),
+    _KnownProvider(
+        id="anthropic",
+        name="Anthropic",
+        env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN"),
+        base_url="https://api.anthropic.com/v1",
+        default_model="claude-sonnet-4-20250514",
+        primary_aliases=("anthropic",),
+    ),
+    _KnownProvider(
+        id="openai",
+        name="OpenAI",
+        env_vars=("OPENAI_API_KEY",),
+        base_url="https://api.openai.com/v1",
+        default_model="gpt-4.1",
+        primary_aliases=("openai",),
+    ),
+    _KnownProvider(
+        id="gemini",
+        name="Google Gemini",
+        env_vars=("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        default_model="gemini-2.5-flash",
+        primary_aliases=("gemini", "google"),
+    ),
+    _KnownProvider(
+        id="deepseek",
+        name="DeepSeek",
+        env_vars=("DEEPSEEK_API_KEY",),
+        base_url="https://api.deepseek.com/v1",
+        default_model="deepseek-chat",
+        primary_aliases=("deepseek",),
+    ),
+    _KnownProvider(
+        id="together",
+        name="Together AI",
+        env_vars=("TOGETHER_API_KEY",),
+        base_url="https://api.together.xyz/v1",
+        default_model="meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+        primary_aliases=("together",),
+    ),
+    _KnownProvider(
+        id="groq",
+        name="Groq",
+        env_vars=("GROQ_API_KEY",),
+        base_url="https://api.groq.com/openai/v1",
+        default_model="llama-3.3-70b-versatile",
+        primary_aliases=("groq",),
+    ),
+    _KnownProvider(
+        id="fireworks",
+        name="Fireworks AI",
+        env_vars=("FIREWORKS_API_KEY",),
+        base_url="https://api.fireworks.ai/inference/v1",
+        default_model="accounts/fireworks/models/llama-v3p3-70b-instruct",
+        primary_aliases=("fireworks",),
+    ),
+    _KnownProvider(
+        id="mistral",
+        name="Mistral AI",
+        env_vars=("MISTRAL_API_KEY",),
+        base_url="https://api.mistral.ai/v1",
+        default_model="mistral-large-latest",
+        primary_aliases=("mistral",),
+    ),
+]
+
+# Local providers checked via port probe (no API key needed)
+LOCAL_PROVIDERS = [
+    _KnownProvider(
+        id="lmstudio",
+        name="LM Studio",
+        env_vars=(),
+        base_url="http://localhost:1234/v1",
+        default_model="",  # auto-detected
+        primary_aliases=("lmstudio", "lm-studio", "lm_studio"),
+    ),
+    _KnownProvider(
+        id="ollama",
+        name="Ollama",
+        env_vars=(),
+        base_url="http://localhost:11434/v1",
+        default_model="",  # auto-detected
+        primary_aliases=("ollama",),
+    ),
+]
+
+
+# =============================================================================
+# Helper functions
+# =============================================================================
+
+def _infer_primary_provider(
+    provider: str, model: str, base_url: str
+) -> str:
+    """Infer the primary provider id from provider name, model, or base_url.
+
+    Returns a lowercase provider id that matches KNOWN_PROVIDERS aliases,
+    or empty string if unknown.
+    """
+    if provider:
+        p = provider.lower().strip()
+        # Direct match against known provider aliases
+        for kp in KNOWN_PROVIDERS + LOCAL_PROVIDERS:
+            if p in kp.primary_aliases or p == kp.id:
+                return kp.id
+        # Fuzzy match: provider string contains known id
+        for kp in KNOWN_PROVIDERS + LOCAL_PROVIDERS:
+            if kp.id in p:
+                return kp.id
+        return p  # Unknown provider — return as-is for exclusion
+
+    # Infer from model name
+    if model:
+        m = model.lower()
+        if "claude" in m or m.startswith("anthropic/"):
+            return "anthropic"
+        if "gpt" in m or "o1" in m or "o3" in m or "o4" in m:
+            return "openai"
+        if "gemini" in m:
+            return "gemini"
+        if "deepseek" in m:
+            return "deepseek"
+        if "llama" in m or "mistral" in m:
+            pass  # Could be any provider, don't guess
+        # Model has provider prefix (e.g. "anthropic/claude-3")
+        if "/" in m:
+            prefix = m.split("/")[0]
+            for kp in KNOWN_PROVIDERS:
+                if prefix in kp.primary_aliases:
+                    return kp.id
+
+    # Infer from base_url
+    if base_url:
+        url = base_url.lower()
+        if "openrouter" in url:
+            return "openrouter"
+        if "anthropic" in url:
+            return "anthropic"
+        if "openai.com" in url:
+            return "openai"
+        if "googleapis" in url or "generativelanguage" in url:
+            return "gemini"
+        if "deepseek" in url:
+            return "deepseek"
+        if "together" in url:
+            return "together"
+        if "groq" in url:
+            return "groq"
+        if "fireworks" in url:
+            return "fireworks"
+        if "mistral" in url:
+            return "mistral"
+        if "localhost:1234" in url:
+            return "lmstudio"
+        if "localhost:11434" in url:
+            return "ollama"
+
+    return ""
+
+
+def _probe_local_endpoint(base_url: str, timeout: float = 0.5) -> bool:
+    """Quick check if a local endpoint is reachable (TCP connect only).
+
+    Non-blocking, fast timeout. Returns True if port is open.
+    """
+    import socket
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(base_url)
+        host = parsed.hostname or "localhost"
+        port = parsed.port or 80
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        result = sock.connect_ex((host, port))
+        sock.close()
+        return result == 0
+    except Exception:
+        return False
 
 
 # =============================================================================
@@ -170,30 +389,89 @@ class FallbackChain:
 
     @classmethod
     def build_legacy_chain(cls, primary_model: str = "") -> "FallbackChain":
-        """Build a backward-compatible single-entry OpenRouter chain.
+        """Build a backward-compatible chain. Delegates to build_auto_chain."""
+        return cls.build_auto_chain(primary_model=primary_model)
 
-        Called when there's no explicit fallback config but OPENROUTER_API_KEY
-        exists. Preserves the pre-chain behavior: Anthropic -> OpenRouter.
+    @classmethod
+    def build_auto_chain(
+        cls,
+        primary_provider: str = "",
+        primary_model: str = "",
+        primary_base_url: str = "",
+    ) -> "FallbackChain":
+        """Auto-build a fallback chain by scanning environment for API keys.
+
+        Detects all known providers with valid API keys, excludes the primary
+        provider, and returns an ordered chain. Also probes local endpoints
+        (LM Studio, Ollama) if reachable.
+
+        Args:
+            primary_provider: The active provider id (e.g. "anthropic", "openrouter").
+                              Used to exclude it from the fallback chain.
+            primary_model: The active model name. Used to infer primary provider
+                           if primary_provider is empty.
+            primary_base_url: The active base URL. Used to infer primary provider.
         """
-        key = os.getenv("OPENROUTER_API_KEY", "").strip()
-        if not key:
-            return cls(entries=[], mode="auto")
-
-        # Map the primary model to OpenRouter format
-        model = primary_model
-        if model and not model.startswith("anthropic/") and "claude" in model.lower():
-            model = f"anthropic/{model}"
-
-        return cls(
-            entries=[FallbackEntry(
-                provider="openrouter",
-                base_url=OPENROUTER_BASE_URL,
-                model=model,
-                api_key_env="OPENROUTER_API_KEY",
-            )],
-            mode="auto",
-            timeout=30,
+        # Infer primary provider from model/base_url if not explicitly given
+        primary_id = _infer_primary_provider(
+            primary_provider, primary_model, primary_base_url
         )
+
+        entries: List[FallbackEntry] = []
+
+        # Scan cloud providers (need API keys)
+        for kp in KNOWN_PROVIDERS:
+            # Skip the primary provider
+            if primary_id and primary_id in kp.primary_aliases:
+                continue
+
+            # Check if any env var has a key set
+            api_key = ""
+            api_key_env = ""
+            for env_var in kp.env_vars:
+                val = os.getenv(env_var, "").strip()
+                if val:
+                    api_key = val
+                    api_key_env = env_var
+                    break
+
+            if not api_key:
+                continue
+
+            # For OpenRouter: use the same model as primary (it's a proxy)
+            model = kp.default_model
+            if kp.id == "openrouter" and primary_model:
+                # Map model to OpenRouter format if needed
+                or_model = primary_model
+                if "claude" in or_model.lower() and not or_model.startswith("anthropic/"):
+                    or_model = f"anthropic/{or_model}"
+                model = or_model
+
+            entries.append(FallbackEntry(
+                provider=kp.id,
+                base_url=kp.base_url,
+                model=model,
+                api_key_env=api_key_env,
+            ))
+
+        # Probe local providers (no API key needed — just check if port is open)
+        for lp in LOCAL_PROVIDERS:
+            if primary_id and primary_id in lp.primary_aliases:
+                continue
+            if _probe_local_endpoint(lp.base_url):
+                entries.append(FallbackEntry(
+                    provider=lp.id,
+                    base_url=lp.base_url,
+                    model=lp.default_model,
+                ))
+
+        if entries:
+            logger.info(
+                "Auto-configured fallback chain: %s",
+                ", ".join(e.provider for e in entries),
+            )
+
+        return cls(entries=entries, mode="auto", timeout=30)
 
     def has_fallbacks(self) -> bool:
         """Check if fallback is enabled and entries exist."""

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -41,7 +41,6 @@ DEFAULT_CONTEXT_LENGTHS = {
     "anthropic/claude-sonnet-4": 200000,
     "anthropic/claude-sonnet-4-20250514": 200000,
     "anthropic/claude-haiku-4.5": 200000,
-    # Bare Anthropic model names (native provider)
     "claude-opus-4-20250514": 200000,
     "claude-sonnet-4-20250514": 200000,
     "claude-haiku-4-5-20251001": 200000,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -41,6 +41,10 @@ DEFAULT_CONTEXT_LENGTHS = {
     "anthropic/claude-sonnet-4": 200000,
     "anthropic/claude-sonnet-4-20250514": 200000,
     "anthropic/claude-haiku-4.5": 200000,
+    # Bare Anthropic model names (native provider)
+    "claude-opus-4-20250514": 200000,
+    "claude-sonnet-4-20250514": 200000,
+    "claude-haiku-4-5-20251001": 200000,
     "openai/gpt-4o": 128000,
     "openai/gpt-4-turbo": 128000,
     "openai/gpt-4o-mini": 128000,

--- a/cli.py
+++ b/cli.py
@@ -1219,13 +1219,17 @@ class HermesCLI:
         
         try:
             # Build fallback chain from config, with CLI flag override.
-            # If config has no chain entries, try building a legacy chain from
-            # env vars (e.g. OPENROUTER_API_KEY) so interactive mode still works.
+            # If config has explicit chain entries, use those. Otherwise auto-build
+            # by scanning environment for known provider API keys.
             from agent.fallback_chain import FallbackChain
             fallback_override = getattr(self, "_fallback_mode_override", None)
             fallback_chain = FallbackChain.from_config(CLI_CONFIG)
             if not fallback_chain.has_fallbacks():
-                fallback_chain = FallbackChain.build_legacy_chain(self.model)
+                fallback_chain = FallbackChain.build_auto_chain(
+                    primary_provider=getattr(self, "provider", "") or "",
+                    primary_model=self.model,
+                    primary_base_url=getattr(self, "base_url", "") or "",
+                )
 
             # Apply mode: CLI flag > config > default (interactive for CLI)
             if fallback_override == "off":
@@ -1754,7 +1758,7 @@ class HermesCLI:
         print(f"  {remaining} message(s) remaining in history.")
     
     def _handle_fallback_command(self, cmd: str):
-        """Handle /fallback — show status or toggle mode (auto/interactive/off)."""
+        """Handle /fallback — show status, toggle mode, or interactive setup."""
         parts = cmd.split(maxsplit=1)
         chain = getattr(self.agent, "_fallback_chain", None) if self.agent else None
 
@@ -1762,8 +1766,10 @@ class HermesCLI:
             # Show current status
             print()
             if chain is None or not chain.entries:
-                print("  Fallback chain: (not configured)")
-                print("  Add providers in ~/.hermes/config.yaml under 'fallback.chain'")
+                print("  Fallback chain: (none)")
+                print("  No providers with API keys detected.")
+                print("  Set API keys (e.g. OPENROUTER_API_KEY) or configure in config.yaml")
+                print("  Run /fallback setup to interactively configure")
             else:
                 status = "enabled" if chain.enabled else "disabled"
                 print(f"  Fallback: {status}  |  Mode: {chain.mode}  |  Timeout: {chain.timeout}s")
@@ -1773,7 +1779,7 @@ class HermesCLI:
                     exhausted = " (exhausted)" if i - 1 in chain._exhausted else ""
                     print(f"    [{i}] {entry.display_name}{model_str}{exhausted}")
             print()
-            print("  Usage: /fallback auto|interactive|off")
+            print("  Usage: /fallback auto|interactive|off|on|reset|setup")
             print()
             return
 
@@ -1785,27 +1791,174 @@ class HermesCLI:
             else:
                 print("  No fallback chain to disable")
         elif arg in ("auto", "interactive"):
-            if chain:
+            if chain and chain.entries:
                 chain.enabled = True
                 chain.mode = arg
                 print(f"  ✓ Fallback mode set to: {arg}")
             else:
-                print("  No fallback chain configured — add providers in config.yaml")
+                print("  No fallback providers available — run /fallback setup")
         elif arg == "on":
-            if chain:
+            if chain and chain.entries:
                 chain.enabled = True
                 print(f"  ✓ Fallback enabled (mode: {chain.mode})")
             else:
-                print("  No fallback chain configured")
+                print("  No fallback providers available — run /fallback setup")
         elif arg == "reset":
             if chain:
                 chain.reset()
                 print("  ✓ Fallback chain reset — all providers available again")
             else:
                 print("  No fallback chain to reset")
+        elif arg == "setup":
+            self._handle_fallback_setup()
         else:
             print(f"  Unknown fallback option: {arg}")
-            print("  Usage: /fallback auto|interactive|off|on|reset")
+            print("  Usage: /fallback auto|interactive|off|on|reset|setup")
+
+    def _handle_fallback_setup(self):
+        """Interactive fallback chain setup — detect providers, let user reorder.
+
+        Uses _clarify_callback for input since prompt_toolkit owns stdin
+        in the worker thread (raw input() would deadlock).
+        """
+        from agent.fallback_chain import (
+            FallbackChain, FallbackEntry, KNOWN_PROVIDERS, LOCAL_PROVIDERS,
+            _probe_local_endpoint, _infer_primary_provider,
+        )
+        import os
+
+        _cprint("\n  🔍 Scanning for available providers...\n")
+
+        # Detect all available providers
+        available = []
+        for kp in KNOWN_PROVIDERS:
+            key_found = ""
+            for env_var in kp.env_vars:
+                val = os.getenv(env_var, "").strip()
+                if val:
+                    key_found = env_var
+                    break
+            if key_found:
+                available.append((kp, key_found))
+
+        for lp in LOCAL_PROVIDERS:
+            if _probe_local_endpoint(lp.base_url):
+                available.append((lp, "(local)"))
+
+        if not available:
+            _cprint("  No provider API keys found in environment.")
+            _cprint("  Set one or more of these env vars:")
+            for kp in KNOWN_PROVIDERS[:5]:
+                _cprint(f"    • {kp.env_vars[0]:30s}  ({kp.name})")
+            _cprint(f"    ... and {len(KNOWN_PROVIDERS) - 5} more\n")
+            return
+
+        # Identify primary provider
+        primary_model = self.model if hasattr(self, "model") else ""
+        primary_provider = getattr(self, "provider", "") or ""
+        primary_id = _infer_primary_provider(primary_provider, primary_model, "")
+
+        # Build choices for clarify UI — each non-primary provider is a choice
+        # plus "Use all (default order)" and "Cancel"
+        provider_choices = []
+        non_primary = []
+        for kp, key_src in available:
+            is_primary = primary_id and primary_id in kp.primary_aliases
+            if is_primary:
+                continue
+            model_str = kp.default_model[:35] if kp.default_model else "(auto)"
+            provider_choices.append(f"{kp.name} → {model_str}")
+            non_primary.append((kp, key_src))
+
+        if not non_primary:
+            _cprint("  Only the primary provider detected — no fallback candidates.\n")
+            return
+
+        # Build question text with provider listing
+        q_lines = [f"Primary: {primary_id or 'unknown'} ({primary_model})"]
+        q_lines.append(f"Detected {len(non_primary)} fallback candidate(s):\n")
+        for i, (kp, key_src) in enumerate(non_primary, 1):
+            q_lines.append(f"  [{i}] {kp.name:18s} {key_src}")
+        q_lines.append("\nSelect providers to include:")
+
+        # Choices: "Use all" + individual providers + "Cancel"
+        choices = [f"Use all {len(non_primary)} providers (default order)"]
+        choices.extend(provider_choices)
+
+        question = "\n".join(q_lines)
+        result = self._clarify_callback(question, choices)
+
+        if result is None:
+            _cprint("  Cancelled.\n")
+            return
+
+        result_str = str(result).strip()
+
+        # Parse the selection
+        entries = []
+        if "use all" in result_str.lower() or "did not provide" in result_str.lower() or "best judgement" in result_str.lower():
+            # Use all non-primary providers in order
+            for kp, key_src in non_primary:
+                entries.append(self._build_fallback_entry(kp, key_src, primary_model))
+        else:
+            # User selected a specific provider
+            for i, (kp, key_src) in enumerate(non_primary):
+                model_str = kp.default_model[:35] if kp.default_model else "(auto)"
+                choice_text = f"{kp.name} → {model_str}"
+                if choice_text == result_str or kp.name.lower() in result_str.lower():
+                    entries.append(self._build_fallback_entry(kp, key_src, primary_model))
+                    break
+
+        if not entries:
+            _cprint("  No providers selected.\n")
+            return
+
+        # Ask for mode via clarify
+        mode_result = self._clarify_callback(
+            "Fallback mode:",
+            ["Interactive — countdown prompt to choose (recommended)", "Auto — silently cascade through chain"],
+        )
+        mode_str = str(mode_result).strip().lower() if mode_result else ""
+        mode = "auto" if "auto" in mode_str else "interactive"
+
+        # Apply to current session
+        new_chain = FallbackChain(entries=entries, mode=mode, timeout=30, enabled=True)
+        if self.agent:
+            self.agent._fallback_chain = new_chain
+
+        _cprint(f"\n  ✓ Fallback chain configured ({len(entries)} provider{'s' if len(entries) > 1 else ''}, mode: {mode}):")
+        for i, entry in enumerate(entries, 1):
+            model_str = f"  →  {entry.model}" if entry.model else ""
+            _cprint(f"    [{i}] {entry.display_name}{model_str}")
+        _cprint("\n  This applies for the current session. To persist, add to config.yaml:\n")
+        _cprint("    fallback:")
+        _cprint(f"      mode: {mode}")
+        _cprint("      chain:")
+        for entry in entries:
+            _cprint(f"        - provider: {entry.provider}")
+            if entry.base_url:
+                _cprint(f"          base_url: {entry.base_url}")
+            if entry.model:
+                _cprint(f"          model: {entry.model}")
+        _cprint("")
+
+    @staticmethod
+    def _build_fallback_entry(kp, key_src, primary_model):
+        """Build a FallbackEntry from a known provider."""
+        from agent.fallback_chain import FallbackEntry
+        model = kp.default_model
+        if kp.id == "openrouter" and primary_model:
+            or_model = primary_model
+            if "claude" in or_model.lower() and not or_model.startswith("anthropic/"):
+                or_model = f"anthropic/{or_model}"
+            model = or_model
+        api_key_env = key_src if key_src != "(local)" else ""
+        return FallbackEntry(
+            provider=kp.id,
+            base_url=kp.base_url,
+            model=model,
+            api_key_env=api_key_env,
+        )
 
     def _handle_prompt_command(self, cmd: str):
         """Handle the /prompt command to view or set system prompt."""

--- a/cli.py
+++ b/cli.py
@@ -1218,6 +1218,23 @@ class HermesCLI:
                 pass
         
         try:
+            # Build fallback chain from config, with CLI flag override.
+            # If config has no chain entries, try building a legacy chain from
+            # env vars (e.g. OPENROUTER_API_KEY) so interactive mode still works.
+            from agent.fallback_chain import FallbackChain
+            fallback_override = getattr(self, "_fallback_mode_override", None)
+            fallback_chain = FallbackChain.from_config(CLI_CONFIG)
+            if not fallback_chain.has_fallbacks():
+                fallback_chain = FallbackChain.build_legacy_chain(self.model)
+
+            # Apply mode: CLI flag > config > default (interactive for CLI)
+            if fallback_override == "off":
+                fallback_chain.enabled = False
+            elif fallback_override in ("auto", "interactive"):
+                fallback_chain.mode = fallback_override
+            elif fallback_chain.has_fallbacks():
+                fallback_chain.mode = "interactive"  # CLI default
+
             self.agent = AIAgent(
                 model=self.model,
                 api_key=self.api_key,
@@ -1242,6 +1259,8 @@ class HermesCLI:
                 session_db=self._session_db,
                 clarify_callback=self._clarify_callback,
                 honcho_session_key=self.session_id,
+                fallback_chain=fallback_chain,
+                fallback_selector=self._fallback_selector,
             )
             return True
         except Exception as e:
@@ -1734,6 +1753,60 @@ class HermesCLI:
         remaining = len(self.conversation_history)
         print(f"  {remaining} message(s) remaining in history.")
     
+    def _handle_fallback_command(self, cmd: str):
+        """Handle /fallback — show status or toggle mode (auto/interactive/off)."""
+        parts = cmd.split(maxsplit=1)
+        chain = getattr(self.agent, "_fallback_chain", None) if self.agent else None
+
+        if len(parts) < 2 or not parts[1].strip():
+            # Show current status
+            print()
+            if chain is None or not chain.entries:
+                print("  Fallback chain: (not configured)")
+                print("  Add providers in ~/.hermes/config.yaml under 'fallback.chain'")
+            else:
+                status = "enabled" if chain.enabled else "disabled"
+                print(f"  Fallback: {status}  |  Mode: {chain.mode}  |  Timeout: {chain.timeout}s")
+                print(f"  Chain ({len(chain.entries)} provider{'s' if len(chain.entries) > 1 else ''}):")
+                for i, entry in enumerate(chain.entries, 1):
+                    model_str = f"  →  {entry.model}" if entry.model else ""
+                    exhausted = " (exhausted)" if i - 1 in chain._exhausted else ""
+                    print(f"    [{i}] {entry.display_name}{model_str}{exhausted}")
+            print()
+            print("  Usage: /fallback auto|interactive|off")
+            print()
+            return
+
+        arg = parts[1].strip().lower()
+        if arg == "off":
+            if chain:
+                chain.enabled = False
+                print("  ✓ Fallback disabled for this session")
+            else:
+                print("  No fallback chain to disable")
+        elif arg in ("auto", "interactive"):
+            if chain:
+                chain.enabled = True
+                chain.mode = arg
+                print(f"  ✓ Fallback mode set to: {arg}")
+            else:
+                print("  No fallback chain configured — add providers in config.yaml")
+        elif arg == "on":
+            if chain:
+                chain.enabled = True
+                print(f"  ✓ Fallback enabled (mode: {chain.mode})")
+            else:
+                print("  No fallback chain configured")
+        elif arg == "reset":
+            if chain:
+                chain.reset()
+                print("  ✓ Fallback chain reset — all providers available again")
+            else:
+                print("  No fallback chain to reset")
+        else:
+            print(f"  Unknown fallback option: {arg}")
+            print("  Usage: /fallback auto|interactive|off|on|reset")
+
     def _handle_prompt_command(self, cmd: str):
         """Handle the /prompt command to view or set system prompt."""
         parts = cmd.split(maxsplit=1)
@@ -2228,6 +2301,8 @@ class HermesCLI:
             print()
             print("  Switch: /model provider:model-name")
             print("  Setup:  hermes setup")
+        elif cmd_lower.startswith("/fallback"):
+            self._handle_fallback_command(cmd_original)
         elif cmd_lower.startswith("/prompt"):
             # Use original case so prompt text isn't lowercased
             self._handle_prompt_command(cmd_original)
@@ -2499,6 +2574,56 @@ class HermesCLI:
 
         except Exception as e:
             print(f"  ❌ MCP reload failed: {e}")
+
+    def _fallback_selector(self, chain, error_msg):
+        """
+        Platform callback for fallback provider selection. Called from the agent thread.
+
+        Reuses the clarify UI mechanism — presents fallback providers as numbered
+        choices with a countdown timer. Returns the selected FallbackEntry or None.
+        """
+        available = chain.available_entries()
+        if not available:
+            return None
+
+        # Build choices for clarify-style UI
+        choices = []
+        for _, entry in available:
+            model_str = f" → {entry.model}" if entry.model else ""
+            choices.append(f"{entry.display_name}{model_str}")
+        choices.append("Skip — keep retrying primary")
+
+        question = f"⚠️ {error_msg[:120]}\n\n🔄 Select fallback provider:"
+
+        # Use clarify mechanism (handles prompt_toolkit threading)
+        result = self._clarify_callback(question, choices)
+
+        if result is None:
+            return None
+
+        # Parse result — clarify returns the choice text
+        result_str = str(result).strip()
+
+        # Timeout or "use best judgement" → auto-select first entry
+        if "did not provide" in result_str.lower() or "best judgement" in result_str.lower():
+            _cprint(f"  🔄 Auto-selecting {available[0][1].display_name}")
+            return available[0][1]
+
+        # Check if user chose to skip
+        if "skip" in result_str.lower() or "retry" in result_str.lower():
+            return None
+
+        # Try to match the result to an available entry
+        for _, entry in available:
+            model_str = f" → {entry.model}" if entry.model else ""
+            choice_text = f"{entry.display_name}{model_str}"
+            if choice_text == result_str or entry.provider in result_str.lower():
+                return entry
+
+        # Default to first available on unrecognized input
+        if available:
+            return available[0][1]
+        return None
 
     def _clarify_callback(self, question, choices):
         """
@@ -3612,6 +3737,7 @@ def main(
     resume: str = None,
     worktree: bool = False,
     w: bool = False,
+    fallback_mode: str = None,
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
@@ -3713,6 +3839,8 @@ def main(
         compact=compact,
         resume=resume,
     )
+    # Pass through --fallback CLI flag (auto/interactive/off)
+    cli._fallback_mode_override = fallback_mode
 
     # Inject worktree context into agent's system prompt
     if wt_info:

--- a/cli.py
+++ b/cli.py
@@ -1088,6 +1088,7 @@ class HermesCLI:
         
         # Agent will be initialized on first use
         self.agent: Optional[AIAgent] = None
+        self._fallback_chain = None  # CLI-owned fallback chain (survives before agent init)
         self._app = None  # prompt_toolkit Application (set in run())
         
         # Conversation state
@@ -1219,25 +1220,36 @@ class HermesCLI:
         
         try:
             # Build fallback chain from config, with CLI flag override.
-            # If config has explicit chain entries, use those. Otherwise auto-build
-            # by scanning environment for known provider API keys.
+            # If /fallback setup was run before agent init, reuse that chain.
+            # Otherwise: config entries > auto-build from env vars.
             from agent.fallback_chain import FallbackChain
             fallback_override = getattr(self, "_fallback_mode_override", None)
-            fallback_chain = FallbackChain.from_config(CLI_CONFIG)
-            if not fallback_chain.has_fallbacks():
-                fallback_chain = FallbackChain.build_auto_chain(
-                    primary_provider=getattr(self, "provider", "") or "",
-                    primary_model=self.model,
-                    primary_base_url=getattr(self, "base_url", "") or "",
-                )
+            reused_from_setup = False
+            if self._fallback_chain and self._fallback_chain.has_fallbacks():
+                # Reuse chain from /fallback setup (ran before agent init)
+                fallback_chain = self._fallback_chain
+                reused_from_setup = True
+            else:
+                fallback_chain = FallbackChain.from_config(CLI_CONFIG)
+                if not fallback_chain.has_fallbacks():
+                    fallback_chain = FallbackChain.build_auto_chain(
+                        primary_provider=getattr(self, "provider", "") or "",
+                        primary_model=self.model,
+                        primary_base_url=getattr(self, "base_url", "") or "",
+                    )
 
-            # Apply mode: CLI flag > config > default (interactive for CLI)
+            # Apply mode priority: CLI flag > user-set (from /fallback cmd) > default
             if fallback_override == "off":
                 fallback_chain.enabled = False
             elif fallback_override in ("auto", "interactive"):
                 fallback_chain.mode = fallback_override
+            elif reused_from_setup:
+                pass  # User already set mode via /fallback setup or /fallback auto
             elif fallback_chain.has_fallbacks():
-                fallback_chain.mode = "interactive"  # CLI default
+                fallback_chain.mode = "interactive"  # CLI default for auto-built chains
+
+            # Keep CLI-owned reference in sync
+            self._fallback_chain = fallback_chain
 
             self.agent = AIAgent(
                 model=self.model,
@@ -1760,7 +1772,10 @@ class HermesCLI:
     def _handle_fallback_command(self, cmd: str):
         """Handle /fallback — show status, toggle mode, or interactive setup."""
         parts = cmd.split(maxsplit=1)
-        chain = getattr(self.agent, "_fallback_chain", None) if self.agent else None
+        # Read from CLI-owned chain first, fall back to agent's chain
+        chain = self._fallback_chain
+        if chain is None and self.agent:
+            chain = getattr(self.agent, "_fallback_chain", None)
 
         if len(parts) < 2 or not parts[1].strip():
             # Show current status
@@ -1921,8 +1936,9 @@ class HermesCLI:
         mode_str = str(mode_result).strip().lower() if mode_result else ""
         mode = "auto" if "auto" in mode_str else "interactive"
 
-        # Apply to current session
+        # Apply to current session — store on CLI object AND agent (if initialized)
         new_chain = FallbackChain(entries=entries, mode=mode, timeout=30, enabled=True)
+        self._fallback_chain = new_chain
         if self.agent:
             self.agent._fallback_chain = new_chain
 

--- a/cli.py
+++ b/cli.py
@@ -1777,6 +1777,20 @@ class HermesCLI:
         if chain is None and self.agent:
             chain = getattr(self.agent, "_fallback_chain", None)
 
+        # Lazy auto-build: if no chain exists yet (agent not initialized),
+        # try scanning env vars now so /fallback commands work before first message
+        if chain is None or not chain.entries:
+            from agent.fallback_chain import FallbackChain
+            chain = FallbackChain.build_auto_chain(
+                primary_provider=getattr(self, "provider", "") or "",
+                primary_model=self.model,
+                primary_base_url=getattr(self, "base_url", "") or "",
+            )
+            if chain.has_fallbacks():
+                self._fallback_chain = chain
+                if self.agent:
+                    self.agent._fallback_chain = chain
+
         if len(parts) < 2 or not parts[1].strip():
             # Show current status
             print()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -412,7 +412,7 @@ class BasePlatformAdapter(ABC):
         """
         return SendResult(success=False, error="Not supported")
 
-    async def send_typing(self, chat_id: str) -> None:
+    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """
         Send a typing indicator.
         
@@ -426,6 +426,7 @@ class BasePlatformAdapter(ABC):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """
         Send an image natively via the platform API.
@@ -444,6 +445,7 @@ class BasePlatformAdapter(ABC):
         animation_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """
         Send an animated GIF natively via the platform API.
@@ -514,6 +516,7 @@ class BasePlatformAdapter(ABC):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """
         Send an audio file as a native voice message via the platform API.
@@ -533,6 +536,7 @@ class BasePlatformAdapter(ABC):
         video_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """
         Send a video natively via the platform API.
@@ -552,6 +556,7 @@ class BasePlatformAdapter(ABC):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """
         Send a document/file natively via the platform API.
@@ -570,6 +575,7 @@ class BasePlatformAdapter(ABC):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """
         Send a local image file natively via the platform API.
@@ -619,7 +625,7 @@ class BasePlatformAdapter(ABC):
         
         return media, cleaned
     
-    async def _keep_typing(self, chat_id: str, interval: float = 2.0) -> None:
+    async def _keep_typing(self, chat_id: str, interval: float = 2.0, metadata: Optional[Dict[str, Any]] = None) -> None:
         """
         Continuously send typing indicator until cancelled.
         
@@ -628,7 +634,7 @@ class BasePlatformAdapter(ABC):
         """
         try:
             while True:
-                await self.send_typing(chat_id)
+                await self.send_typing(chat_id, metadata=metadata)
                 await asyncio.sleep(interval)
         except asyncio.CancelledError:
             pass  # Normal cancellation when handler completes
@@ -686,7 +692,8 @@ class BasePlatformAdapter(ABC):
         self._active_sessions[session_key] = interrupt_event
         
         # Start continuous typing indicator (refreshes every 2 seconds)
-        typing_task = asyncio.create_task(self._keep_typing(event.source.chat_id))
+        _typing_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+        typing_task = asyncio.create_task(self._keep_typing(event.source.chat_id, metadata=_typing_metadata))
         
         try:
             # Call the handler (this can take a while with tool calls)
@@ -701,16 +708,20 @@ class BasePlatformAdapter(ABC):
                 
                 # Extract image URLs and send them as native platform attachments
                 images, text_content = self.extract_images(response)
-                if images:
-                    logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
                 
+                # Build metadata with thread_id for forum topic routing
+                _response_metadata = {}
+                if event.source.thread_id:
+                    _response_metadata["thread_id"] = event.source.thread_id
+
                 # Send the text portion first (if any remains after extractions)
                 if text_content:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
                     result = await self.send(
                         chat_id=event.source.chat_id,
                         content=text_content,
-                        reply_to=event.message_id
+                        reply_to=event.message_id,
+                        metadata=_response_metadata or None,
                     )
                     
                     # Log send failures (don't raise - user already saw tool progress)
@@ -720,7 +731,8 @@ class BasePlatformAdapter(ABC):
                         fallback_result = await self.send(
                             chat_id=event.source.chat_id,
                             content=f"(Response formatting failed, plain text:)\n\n{text_content[:3500]}",
-                            reply_to=event.message_id
+                            reply_to=event.message_id,
+                            metadata=_response_metadata or None,
                         )
                         if not fallback_result.success:
                             print(f"[{self.name}] Fallback send also failed: {fallback_result.error}")
@@ -729,30 +741,29 @@ class BasePlatformAdapter(ABC):
                 human_delay = self._get_human_delay()
                 
                 # Send extracted images as native attachments
-                if images:
-                    logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
                 for image_url, alt_text in images:
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)
                     try:
-                        logger.info("[%s] Sending image: %s (alt=%s)", self.name, image_url[:80], alt_text[:30] if alt_text else "")
                         # Route animated GIFs through send_animation for proper playback
                         if self._is_animation_url(image_url):
                             img_result = await self.send_animation(
                                 chat_id=event.source.chat_id,
                                 animation_url=image_url,
                                 caption=alt_text if alt_text else None,
+                                metadata=_response_metadata or None,
                             )
                         else:
                             img_result = await self.send_image(
                                 chat_id=event.source.chat_id,
                                 image_url=image_url,
                                 caption=alt_text if alt_text else None,
+                                metadata=_response_metadata or None,
                             )
                         if not img_result.success:
-                            logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
+                            print(f"[{self.name}] Failed to send image: {img_result.error}")
                     except Exception as img_err:
-                        logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
+                        print(f"[{self.name}] Error sending image: {img_err}")
                 
                 # Send extracted media files — route by file type
                 _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
@@ -768,21 +779,25 @@ class BasePlatformAdapter(ABC):
                             media_result = await self.send_voice(
                                 chat_id=event.source.chat_id,
                                 audio_path=media_path,
+                                metadata=_response_metadata or None,
                             )
                         elif ext in _VIDEO_EXTS:
                             media_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=media_path,
+                                metadata=_response_metadata or None,
                             )
                         elif ext in _IMAGE_EXTS:
                             media_result = await self.send_image_file(
                                 chat_id=event.source.chat_id,
                                 image_path=media_path,
+                                metadata=_response_metadata or None,
                             )
                         else:
                             media_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=media_path,
+                                metadata=_response_metadata or None,
                             )
 
                         if not media_result.success:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -359,7 +359,7 @@ class DiscordAdapter(BasePlatformAdapter):
             print(f"[{self.name}] Failed to send image attachment, falling back to URL: {e}")
             return await super().send_image(chat_id, image_url, caption, reply_to)
     
-    async def send_typing(self, chat_id: str) -> None:
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator."""
         if self._client:
             try:

--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -419,7 +419,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
-    async def send_typing(self, chat_id: str) -> None:
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
         """No typing indicator for Home Assistant."""
         pass
 

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -175,7 +175,7 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
-    async def send_typing(self, chat_id: str) -> None:
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Slack doesn't have a direct typing indicator API for bots."""
         pass
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -274,6 +274,7 @@ class TelegramAdapter(BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send audio as a native Telegram voice message or audio file."""
         if not self._bot:
@@ -287,19 +288,23 @@ class TelegramAdapter(BasePlatformAdapter):
             with open(audio_path, "rb") as audio_file:
                 # .ogg files -> send as voice (round playable bubble)
                 if audio_path.endswith(".ogg") or audio_path.endswith(".opus"):
+                    _voice_thread = metadata.get("thread_id") if metadata else None
                     msg = await self._bot.send_voice(
                         chat_id=int(chat_id),
                         voice=audio_file,
                         caption=caption[:1024] if caption else None,
                         reply_to_message_id=int(reply_to) if reply_to else None,
+                        message_thread_id=int(_voice_thread) if _voice_thread else None,
                     )
                 else:
                     # .mp3 and others -> send as audio file
+                    _audio_thread = metadata.get("thread_id") if metadata else None
                     msg = await self._bot.send_audio(
                         chat_id=int(chat_id),
                         audio=audio_file,
                         caption=caption[:1024] if caption else None,
                         reply_to_message_id=int(reply_to) if reply_to else None,
+                        message_thread_id=int(_audio_thread) if _audio_thread else None,
                     )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -340,45 +345,27 @@ class TelegramAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send an image natively as a Telegram photo.
-        
-        Tries URL-based send first (fast, works for <5MB images).
-        Falls back to downloading and uploading as file (supports up to 10MB).
-        """
+        """Send an image natively as a Telegram photo."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
         
         try:
-            # Telegram can send photos directly from URLs (up to ~5MB)
+            # Telegram can send photos directly from URLs
+            _photo_thread = metadata.get("thread_id") if metadata else None
             msg = await self._bot.send_photo(
                 chat_id=int(chat_id),
                 photo=image_url,
                 caption=caption[:1024] if caption else None,  # Telegram caption limit
                 reply_to_message_id=int(reply_to) if reply_to else None,
+                message_thread_id=int(_photo_thread) if _photo_thread else None,
             )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            logger.warning("[%s] URL-based send_photo failed (%s), trying file upload", self.name, e)
-            # Fallback: download and upload as file (supports up to 10MB)
-            try:
-                import httpx
-                async with httpx.AsyncClient(timeout=30.0) as client:
-                    resp = await client.get(image_url)
-                    resp.raise_for_status()
-                    image_data = resp.content
-                
-                msg = await self._bot.send_photo(
-                    chat_id=int(chat_id),
-                    photo=image_data,
-                    caption=caption[:1024] if caption else None,
-                    reply_to_message_id=int(reply_to) if reply_to else None,
-                )
-                return SendResult(success=True, message_id=str(msg.message_id))
-            except Exception as e2:
-                logger.error("[%s] File upload send_photo also failed: %s", self.name, e2)
-                # Final fallback: send URL as text
-                return await super().send_image(chat_id, image_url, caption, reply_to)
+            print(f"[{self.name}] Failed to send photo, falling back to URL: {e}")
+            # Fallback: send as text link
+            return await super().send_image(chat_id, image_url, caption, reply_to)
     
     async def send_animation(
         self,
@@ -386,17 +373,20 @@ class TelegramAdapter(BasePlatformAdapter):
         animation_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an animated GIF natively as a Telegram animation (auto-plays inline)."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
         
         try:
+            _anim_thread = metadata.get("thread_id") if metadata else None
             msg = await self._bot.send_animation(
                 chat_id=int(chat_id),
                 animation=animation_url,
                 caption=caption[:1024] if caption else None,
                 reply_to_message_id=int(reply_to) if reply_to else None,
+                message_thread_id=int(_anim_thread) if _anim_thread else None,
             )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -404,13 +394,15 @@ class TelegramAdapter(BasePlatformAdapter):
             # Fallback: try as a regular photo
             return await self.send_image(chat_id, animation_url, caption, reply_to)
 
-    async def send_typing(self, chat_id: str) -> None:
+    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Send typing indicator."""
         if self._bot:
             try:
+                _typing_thread = metadata.get("thread_id") if metadata else None
                 await self._bot.send_chat_action(
                     chat_id=int(chat_id),
-                    action="typing"
+                    action="typing",
+                    message_thread_id=int(_typing_thread) if _typing_thread else None,
                 )
             except Exception:
                 pass  # Ignore typing indicator failures

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -493,7 +493,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             file_name or os.path.basename(file_path),
         )
 
-    async def send_typing(self, chat_id: str) -> None:
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator via bridge."""
         if not self._running:
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -389,8 +389,7 @@ class GatewayRunner:
                 if chain.has_fallbacks():
                     chain.mode = "auto"  # Gateway always auto-cascades
                     return chain
-            # No config — auto-build from available API keys
-            return FallbackChain.build_auto_chain()
+            return None
         except Exception:
             return None
 
@@ -861,167 +860,6 @@ class GatewayRunner:
         # Load conversation history from transcript
         history = self.session_store.load_transcript(session_entry.session_id)
         
-        # -----------------------------------------------------------------
-        # Session hygiene: auto-compress pathologically large transcripts
-        #
-        # Long-lived gateway sessions can accumulate enough history that
-        # every new message rehydrates an oversized transcript, causing
-        # repeated truncation/context failures.  Detect this early and
-        # compress proactively — before the agent even starts.  (#628)
-        # -----------------------------------------------------------------
-        if history and len(history) >= 4:
-            from agent.model_metadata import estimate_messages_tokens_rough
-
-            # Read thresholds from config.yaml → session_hygiene section
-            _hygiene_cfg = {}
-            try:
-                _hyg_cfg_path = _hermes_home / "config.yaml"
-                if _hyg_cfg_path.exists():
-                    import yaml as _hyg_yaml
-                    with open(_hyg_cfg_path) as _hyg_f:
-                        _hyg_data = _hyg_yaml.safe_load(_hyg_f) or {}
-                    _hygiene_cfg = _hyg_data.get("session_hygiene", {})
-                    if not isinstance(_hygiene_cfg, dict):
-                        _hygiene_cfg = {}
-            except Exception:
-                pass
-
-            _compress_token_threshold = int(
-                _hygiene_cfg.get("auto_compress_tokens", 100_000)
-            )
-            _compress_msg_threshold = int(
-                _hygiene_cfg.get("auto_compress_messages", 200)
-            )
-            _warn_token_threshold = int(
-                _hygiene_cfg.get("warn_tokens", 200_000)
-            )
-
-            _msg_count = len(history)
-            _approx_tokens = estimate_messages_tokens_rough(history)
-
-            _needs_compress = (
-                _approx_tokens >= _compress_token_threshold
-                or _msg_count >= _compress_msg_threshold
-            )
-
-            if _needs_compress:
-                logger.info(
-                    "Session hygiene: %s messages, ~%s tokens — auto-compressing "
-                    "(thresholds: %s msgs / %s tokens)",
-                    _msg_count, f"{_approx_tokens:,}",
-                    _compress_msg_threshold, f"{_compress_token_threshold:,}",
-                )
-
-                _hyg_adapter = self.adapters.get(source.platform)
-                if _hyg_adapter:
-                    try:
-                        await _hyg_adapter.send(
-                            source.chat_id,
-                            f"🗜️ Session is large ({_msg_count} messages, "
-                            f"~{_approx_tokens:,} tokens). Auto-compressing..."
-                        )
-                    except Exception:
-                        pass
-
-                try:
-                    from run_agent import AIAgent
-
-                    _hyg_runtime = _resolve_runtime_agent_kwargs()
-                    if _hyg_runtime.get("api_key"):
-                        _hyg_msgs = [
-                            {"role": m.get("role"), "content": m.get("content")}
-                            for m in history
-                            if m.get("role") in ("user", "assistant")
-                            and m.get("content")
-                        ]
-
-                        if len(_hyg_msgs) >= 4:
-                            _hyg_agent = AIAgent(
-                                **_hyg_runtime,
-                                max_iterations=4,
-                                quiet_mode=True,
-                                enabled_toolsets=["memory"],
-                                session_id=session_entry.session_id,
-                            )
-
-                            loop = asyncio.get_event_loop()
-                            _compressed, _ = await loop.run_in_executor(
-                                None,
-                                lambda: _hyg_agent._compress_context(
-                                    _hyg_msgs, "",
-                                    approx_tokens=_approx_tokens,
-                                ),
-                            )
-
-                            self.session_store.rewrite_transcript(
-                                session_entry.session_id, _compressed
-                            )
-                            history = _compressed
-                            _new_count = len(_compressed)
-                            _new_tokens = estimate_messages_tokens_rough(
-                                _compressed
-                            )
-
-                            logger.info(
-                                "Session hygiene: compressed %s → %s msgs, "
-                                "~%s → ~%s tokens",
-                                _msg_count, _new_count,
-                                f"{_approx_tokens:,}", f"{_new_tokens:,}",
-                            )
-
-                            if _hyg_adapter:
-                                try:
-                                    await _hyg_adapter.send(
-                                        source.chat_id,
-                                        f"🗜️ Compressed: {_msg_count} → "
-                                        f"{_new_count} messages, "
-                                        f"~{_approx_tokens:,} → "
-                                        f"~{_new_tokens:,} tokens"
-                                    )
-                                except Exception:
-                                    pass
-
-                            # Still too large after compression — warn user
-                            if _new_tokens >= _warn_token_threshold:
-                                logger.warning(
-                                    "Session hygiene: still ~%s tokens after "
-                                    "compression — suggesting /reset",
-                                    f"{_new_tokens:,}",
-                                )
-                                if _hyg_adapter:
-                                    try:
-                                        await _hyg_adapter.send(
-                                            source.chat_id,
-                                            "⚠️ Session is still very large "
-                                            "after compression "
-                                            f"(~{_new_tokens:,} tokens). "
-                                            "Consider using /reset to start "
-                                            "fresh if you experience issues."
-                                        )
-                                    except Exception:
-                                        pass
-
-                except Exception as e:
-                    logger.warning(
-                        "Session hygiene auto-compress failed: %s", e
-                    )
-                    # Compression failed and session is dangerously large
-                    if _approx_tokens >= _warn_token_threshold:
-                        _hyg_adapter = self.adapters.get(source.platform)
-                        if _hyg_adapter:
-                            try:
-                                await _hyg_adapter.send(
-                                    source.chat_id,
-                                    f"⚠️ Session is very large "
-                                    f"({_msg_count} messages, "
-                                    f"~{_approx_tokens:,} tokens) and "
-                                    "auto-compression failed. Consider "
-                                    "using /compress or /reset to avoid "
-                                    "issues."
-                                )
-                            except Exception:
-                                pass
-
         # First-message onboarding -- only on the very first interaction ever
         if not history and not self.session_store.has_any_sessions():
             context_prompt += (
@@ -2406,6 +2244,8 @@ class GatewayRunner:
         
         # Background task to send progress messages
         # Accumulates tool lines into a single message that gets edited
+        _progress_metadata = {"thread_id": source.thread_id} if source.thread_id else None
+
         async def send_progress_messages():
             if not progress_queue:
                 return
@@ -2435,21 +2275,21 @@ class GatewayRunner:
                             # Platform doesn't support editing — stop trying,
                             # send just this new line as a separate message
                             can_edit = False
-                            await adapter.send(chat_id=source.chat_id, content=msg)
+                            await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message
                             full_text = "\n".join(progress_lines)
-                            result = await adapter.send(chat_id=source.chat_id, content=full_text)
+                            result = await adapter.send(chat_id=source.chat_id, content=full_text, metadata=_progress_metadata)
                         else:
                             # Editing unsupported: send just this line
-                            result = await adapter.send(chat_id=source.chat_id, content=msg)
+                            result = await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
                         if result.success and result.message_id:
                             progress_msg_id = result.message_id
 
                     # Restore typing indicator
                     await asyncio.sleep(0.3)
-                    await adapter.send_typing(source.chat_id)
+                    await adapter.send_typing(source.chat_id)  # TODO: pass metadata for thread_id
 
                 except queue.Empty:
                     await asyncio.sleep(0.3)
@@ -2500,6 +2340,10 @@ class GatewayRunner:
                 )
             except Exception as _e:
                 logger.debug("agent:step hook error: %s", _e)
+
+        # Initialize fallback notify fn here so run_sync() can close over it.
+        # The actual callback is built after asyncio.get_event_loop() below.
+        _fallback_notify_fn = None
 
         def run_sync():
             # Pass session_key to process registry via env var so background
@@ -2555,37 +2399,19 @@ class GatewayRunner:
 
             pr = self._provider_routing
 
-            # Build fallback notify callback for gateway status messages.
-            # Sends interim messages (e.g. "switching to lmstudio...") to the user's chat.
-            _fallback_notify_fn = None
-            if self._fallback_chain and self._fallback_chain.has_fallbacks():
-                _fb_adapter = self.adapters.get(source.platform)
-                _fb_chat_id = source.chat_id
-                _fb_loop = asyncio.get_event_loop()
-
-                def _fallback_notify_fn(msg: str):
-                    """Send fallback status to user's chat (sync-safe wrapper)."""
-                    if _fb_adapter and _fb_chat_id:
-                        try:
-                            import concurrent.futures
-                            future = asyncio.run_coroutine_threadsafe(
-                                _fb_adapter.send(_fb_chat_id, msg),
-                                _fb_loop,
-                            )
-                            future.result(timeout=5)
-                        except Exception:
-                            pass
+            # _fallback_notify_fn is closed over from outer scope (set before run_in_executor)
 
             # Create a fresh chain instance per request so exhaustion state is isolated
-            _req_fallback_chain = None
+            from agent.fallback_chain import FallbackChain
             if self._fallback_chain and self._fallback_chain.has_fallbacks():
-                from agent.fallback_chain import FallbackChain
                 _req_fallback_chain = FallbackChain(
                     entries=list(self._fallback_chain.entries),
                     mode=self._fallback_chain.mode,
                     timeout=self._fallback_chain.timeout,
                     enabled=self._fallback_chain.enabled,
                 )
+            else:
+                _req_fallback_chain = FallbackChain(entries=[], enabled=False)
 
             agent = AIAgent(
                 model=model,
@@ -2771,6 +2597,26 @@ class GatewayRunner:
         try:
             # Run in thread pool to not block
             loop = asyncio.get_event_loop()
+
+            # Build fallback notify callback here in the async context where
+            # the event loop exists. run_sync() runs in a thread pool worker
+            # with no event loop (Python 3.11+ raises RuntimeError).
+            if self._fallback_chain and self._fallback_chain.has_fallbacks():
+                _fb_adapter = self.adapters.get(source.platform)
+                _fb_chat_id = source.chat_id
+
+                def _fallback_notify_fn(msg: str):
+                    """Send fallback status to user's chat (sync-safe wrapper)."""
+                    if _fb_adapter and _fb_chat_id:
+                        try:
+                            future = asyncio.run_coroutine_threadsafe(
+                                _fb_adapter.send(_fb_chat_id, msg),
+                                loop,
+                            )
+                            future.result(timeout=5)
+                        except Exception:
+                            pass
+
             response = await loop.run_in_executor(None, run_sync)
             
             # Check if we were interrupted and have a pending message

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -730,7 +730,8 @@ class GatewayRunner:
         # Emit command:* hook for any recognized slash command
         _known_commands = {"new", "reset", "help", "status", "stop", "model",
                           "personality", "retry", "undo", "sethome", "set-home",
-                          "compress", "usage", "insights", "reload-mcp", "update"}
+                          "compress", "usage", "insights", "reload-mcp", "update",
+                          "fallback"}
         if command and command in _known_commands:
             await self.hooks.emit(f"command:{command}", {
                 "platform": source.platform.value if source.platform else "",
@@ -783,7 +784,10 @@ class GatewayRunner:
 
         if command == "update":
             return await self._handle_update_command(event)
-        
+
+        if command == "fallback":
+            return await self._handle_fallback_command(event)
+
         # Skill slash commands: /skill-name loads the skill and sends to agent
         if command:
             try:
@@ -1316,6 +1320,7 @@ class GatewayRunner:
             "`/stop` — Interrupt the running agent",
             "`/model [provider:model]` — Show/change model (or switch provider)",
             "`/provider` — Show available providers and auth status",
+            "`/fallback [auto|off|on|reset]` — Show/toggle fallback chain",
             "`/personality [name]` — Set a personality",
             "`/retry` — Retry your last message",
             "`/undo` — Remove the last exchange",
@@ -1523,6 +1528,69 @@ class GatewayRunner:
         lines.append("Setup: `hermes setup`")
         return "\n".join(lines)
     
+    async def _handle_fallback_command(self, event: MessageEvent) -> str:
+        """Handle /fallback command — show status or toggle fallback chain."""
+        import yaml
+
+        args = event.get_command_args().strip().lower()
+        chain = self._fallback_chain
+        config_path = _hermes_home / "config.yaml"
+
+        if not args:
+            # Show current status
+            if chain is None or not chain.entries:
+                return (
+                    "🔄 **Fallback Chain:** not configured\n\n"
+                    "Add providers in `~/.hermes/config.yaml` under `fallback.chain`:\n"
+                    "```yaml\nfallback:\n  enabled: true\n  mode: auto\n  chain:\n"
+                    "    - provider: openrouter\n      model: anthropic/claude-opus-4.6\n"
+                    "    - provider: lmstudio\n      base_url: http://localhost:1234/v1\n"
+                    "      model: qwen3-30b-a3b\n```"
+                )
+
+            status = "✅ enabled" if chain.enabled else "❌ disabled"
+            lines = [
+                f"🔄 **Fallback Chain:** {status}",
+                f"**Mode:** `{chain.mode}` | **Timeout:** {chain.timeout}s",
+                "",
+            ]
+            for i, entry in enumerate(chain.entries, 1):
+                model_str = f" → `{entry.model}`" if entry.model else ""
+                exhausted = " _(exhausted)_" if i - 1 in chain._exhausted else ""
+                lines.append(f"  {i}. **{entry.display_name}**{model_str}{exhausted}")
+
+            lines.append("")
+            lines.append("Toggle: `/fallback auto` · `/fallback off` · `/fallback on` · `/fallback reset`")
+            return "\n".join(lines)
+
+        if args == "off":
+            if chain:
+                chain.enabled = False
+                return "✅ Fallback chain **disabled** for this gateway session."
+            return "⚠️ No fallback chain configured."
+
+        if args in ("auto", "interactive"):
+            if chain:
+                chain.enabled = True
+                chain.mode = args
+                return f"✅ Fallback mode set to **{args}**."
+            return "⚠️ No fallback chain configured."
+
+        if args == "on":
+            if chain:
+                chain.enabled = True
+                return f"✅ Fallback chain **enabled** (mode: `{chain.mode}`)."
+            return "⚠️ No fallback chain configured."
+
+        if args == "reset":
+            if chain:
+                chain.reset()
+                n = len(chain.entries)
+                return f"✅ Fallback chain **reset** — all {n} provider{'s' if n > 1 else ''} available again."
+            return "⚠️ No fallback chain to reset."
+
+        return f"Unknown option: `{args}`\nUsage: `/fallback auto` · `/fallback off` · `/fallback on` · `/fallback reset`"
+
     async def _handle_personality_command(self, event: MessageEvent) -> str:
         """Handle /personality command - list or set a personality."""
         import yaml

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -389,8 +389,8 @@ class GatewayRunner:
                 if chain.has_fallbacks():
                     chain.mode = "auto"  # Gateway always auto-cascades
                     return chain
-            # No config — try legacy chain
-            return FallbackChain.build_legacy_chain()
+            # No config — auto-build from available API keys
+            return FallbackChain.build_auto_chain()
         except Exception:
             return None
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -175,6 +175,7 @@ class GatewayRunner:
         self._ephemeral_system_prompt = self._load_ephemeral_system_prompt()
         self._reasoning_config = self._load_reasoning_config()
         self._provider_routing = self._load_provider_routing()
+        self._fallback_chain = self._load_fallback_chain()
 
         # Wire process registry into session store for reset protection
         from tools.process_registry import process_registry
@@ -373,6 +374,25 @@ class GatewayRunner:
         except Exception:
             pass
         return {}
+
+    @staticmethod
+    def _load_fallback_chain():
+        """Load fallback provider chain from config.yaml (auto mode for gateway)."""
+        try:
+            from agent.fallback_chain import FallbackChain
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path) as _f:
+                    cfg = _y.safe_load(_f) or {}
+                chain = FallbackChain.from_config(cfg)
+                if chain.has_fallbacks():
+                    chain.mode = "auto"  # Gateway always auto-cascades
+                    return chain
+            # No config — try legacy chain
+            return FallbackChain.build_legacy_chain()
+        except Exception:
+            return None
 
     async def start(self) -> bool:
         """
@@ -2466,6 +2486,39 @@ class GatewayRunner:
                 }
 
             pr = self._provider_routing
+
+            # Build fallback notify callback for gateway status messages.
+            # Sends interim messages (e.g. "switching to lmstudio...") to the user's chat.
+            _fallback_notify_fn = None
+            if self._fallback_chain and self._fallback_chain.has_fallbacks():
+                _fb_adapter = self.adapters.get(source.platform)
+                _fb_chat_id = source.chat_id
+                _fb_loop = asyncio.get_event_loop()
+
+                def _fallback_notify_fn(msg: str):
+                    """Send fallback status to user's chat (sync-safe wrapper)."""
+                    if _fb_adapter and _fb_chat_id:
+                        try:
+                            import concurrent.futures
+                            future = asyncio.run_coroutine_threadsafe(
+                                _fb_adapter.send(_fb_chat_id, msg),
+                                _fb_loop,
+                            )
+                            future.result(timeout=5)
+                        except Exception:
+                            pass
+
+            # Create a fresh chain instance per request so exhaustion state is isolated
+            _req_fallback_chain = None
+            if self._fallback_chain and self._fallback_chain.has_fallbacks():
+                from agent.fallback_chain import FallbackChain
+                _req_fallback_chain = FallbackChain(
+                    entries=list(self._fallback_chain.entries),
+                    mode=self._fallback_chain.mode,
+                    timeout=self._fallback_chain.timeout,
+                    enabled=self._fallback_chain.enabled,
+                )
+
             agent = AIAgent(
                 model=model,
                 **runtime_kwargs,
@@ -2488,6 +2541,8 @@ class GatewayRunner:
                 platform=platform_key,
                 honcho_session_key=session_key,
                 session_db=self._session_db,
+                fallback_chain=_req_fallback_chain,
+                fallback_notify=_fallback_notify_fn,
             )
             
             # Store agent reference for interrupt support

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -65,6 +65,10 @@ CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 
+# Anthropic Claude Code OAuth credentials
+DEFAULT_CLAUDE_CREDENTIALS_PATH = Path.home() / ".claude" / ".credentials.json"
+ANTHROPIC_API_BASE_URL = "https://api.anthropic.com"
+
 
 # =============================================================================
 # Provider Registry
@@ -485,7 +489,7 @@ def resolve_provider(
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "kimi": "kimi-coding", "moonshot": "kimi-coding",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
-        "claude": "anthropic",
+        "claude": "anthropic", "claude-code": "anthropic",
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 
@@ -513,6 +517,17 @@ def resolve_provider(
                 return active
     except Exception as e:
         logger.debug("Could not detect active auth provider: %s", e)
+
+    # Check for Claude Code credentials (auto-detect Anthropic via Claude Code)
+    try:
+        claude_creds = _read_claude_code_credentials()
+        if claude_creds:
+            expires_at_ms = claude_creds.get("expiresAt")
+            if isinstance(expires_at_ms, (int, float)) and expires_at_ms > 0:
+                if (expires_at_ms / 1000.0) > time.time():
+                    return "anthropic"
+    except Exception as e:
+        logger.debug("Could not detect Claude Code credentials: %s", e)
 
     if os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY"):
         return "openrouter"
@@ -1368,6 +1383,108 @@ def get_codex_auth_status() -> Dict[str, Any]:
         }
 
 
+# =============================================================================
+# Claude Code OAuth Credentials
+# =============================================================================
+
+def _read_claude_code_credentials() -> Optional[Dict[str, Any]]:
+    """Read Claude Code's OAuth credentials from ~/.claude/.credentials.json.
+
+    Returns the claudeAiOauth dict if present and contains an access token,
+    or None if the file doesn't exist or is malformed.
+    """
+    creds_path = DEFAULT_CLAUDE_CREDENTIALS_PATH
+    if not creds_path.is_file():
+        return None
+    try:
+        raw = json.loads(creds_path.read_text())
+        oauth = raw.get("claudeAiOauth")
+        if not isinstance(oauth, dict):
+            return None
+        access_token = oauth.get("accessToken")
+        if not isinstance(access_token, str) or not access_token.strip():
+            return None
+        return oauth
+    except Exception as exc:
+        logger.debug("Failed to read Claude Code credentials: %s", exc)
+        return None
+
+
+def resolve_anthropic_claude_code_credentials() -> Dict[str, Any]:
+    """Resolve runtime credentials from Claude Code's OAuth token store.
+
+    Reads ~/.claude/.credentials.json written by Claude Code.
+    The token works as a standard Anthropic API key (sk-ant-oat* format
+    requires bearer auth, handled by the anthropic_adapter).
+
+    Returns dict with: provider, base_url, api_key, source, expires_at.
+    """
+    oauth = _read_claude_code_credentials()
+    if not oauth:
+        raise AuthError(
+            "No Claude Code credentials found. Install and authenticate "
+            "Claude Code first, or set ANTHROPIC_TOKEN / ANTHROPIC_API_KEY.",
+            provider="anthropic",
+            code="claude_code_auth_missing",
+            relogin_required=True,
+        )
+
+    access_token = oauth["accessToken"].strip()
+    expires_at_ms = oauth.get("expiresAt")
+
+    # Check expiry (expiresAt is milliseconds timestamp)
+    if isinstance(expires_at_ms, (int, float)) and expires_at_ms > 0:
+        expires_at_s = expires_at_ms / 1000.0
+        if expires_at_s <= time.time():
+            raise AuthError(
+                "Claude Code OAuth token has expired. Run `claude` to refresh it.",
+                provider="anthropic",
+                code="claude_code_token_expired",
+                relogin_required=True,
+            )
+
+    base_url = (
+        os.getenv("ANTHROPIC_BASE_URL", "").strip().rstrip("/")
+        or ANTHROPIC_API_BASE_URL
+    )
+
+    return {
+        "provider": "anthropic",
+        "api_mode": "anthropic_messages",
+        "base_url": base_url,
+        "api_key": access_token,
+        "source": "claude-code",
+        "subscription_type": oauth.get("subscriptionType", "unknown"),
+        "expires_at": expires_at_ms,
+    }
+
+
+def get_claude_code_auth_status() -> Dict[str, Any]:
+    """Status snapshot for Claude Code credentials."""
+    oauth = _read_claude_code_credentials()
+    if not oauth:
+        return {
+            "logged_in": False,
+            "credentials_path": str(DEFAULT_CLAUDE_CREDENTIALS_PATH),
+            "source": "claude-code",
+        }
+
+    expires_at_ms = oauth.get("expiresAt")
+    is_expired = False
+    if isinstance(expires_at_ms, (int, float)) and expires_at_ms > 0:
+        is_expired = (expires_at_ms / 1000.0) <= time.time()
+
+    return {
+        "logged_in": not is_expired,
+        "credentials_path": str(DEFAULT_CLAUDE_CREDENTIALS_PATH),
+        "source": "claude-code",
+        "subscription_type": oauth.get("subscriptionType"),
+        "expires_at": expires_at_ms,
+        "scopes": oauth.get("scopes"),
+        "is_expired": is_expired,
+    }
+
+
 def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for API-key providers (z.ai, Kimi, MiniMax)."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
@@ -1411,6 +1528,12 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_nous_auth_status()
     if target == "openai-codex":
         return get_codex_auth_status()
+    if target == "anthropic":
+        # Check Claude Code credentials first, then fall back to env-var status
+        claude_status = get_claude_code_auth_status()
+        if claude_status.get("logged_in"):
+            return claude_status
+        return get_api_key_provider_status(target)
     # API-key providers
     pconfig = PROVIDER_REGISTRY.get(target)
     if pconfig and pconfig.auth_type == "api_key":

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -135,6 +135,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
     ),
+    "anthropic": ProviderConfig(
+        id="anthropic",
+        name="Anthropic",
+        auth_type="api_key",
+        inference_base_url="https://api.anthropic.com",
+        api_key_env_vars=("ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY"),
+    ),
 }
 
 
@@ -478,6 +485,7 @@ def resolve_provider(
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "kimi": "kimi-coding", "moonshot": "kimi-coding",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
+        "claude": "anthropic",
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -19,7 +19,7 @@ COMMANDS = {
     "/toolsets": "List available toolsets",
     "/model": "Show or change the current model",
     "/provider": "Show available providers and current provider",
-    "/fallback": "Show/toggle fallback chain (auto, interactive, off)",
+    "/fallback": "Show/toggle fallback chain (auto, interactive, off, setup)",
     "/prompt": "View/set custom system prompt",
     "/personality": "Set a predefined personality",
     "/clear": "Clear screen and reset conversation (fresh start)",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -19,6 +19,7 @@ COMMANDS = {
     "/toolsets": "List available toolsets",
     "/model": "Show or change the current model",
     "/provider": "Show available providers and current provider",
+    "/fallback": "Show/toggle fallback chain (auto, interactive, off)",
     "/prompt": "View/set custom system prompt",
     "/personality": "Set a predefined personality",
     "/clear": "Clear screen and reset conversation (fresh start)",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -88,7 +88,22 @@ DEFAULT_CONFIG = {
         "threshold": 0.85,
         "summary_model": "google/gemini-3-flash-preview",
     },
-    
+
+    # Provider fallback chain — tried in order when primary fails (429/529/etc.)
+    # enabled: true/false master toggle; mode: "interactive"/"auto"/"off"
+    # Each entry: provider name + optional base_url, model, api_key_env override
+    "fallback": {
+        "enabled": True,        # Master toggle — set false to disable all fallback
+        "mode": "interactive",  # "auto" | "interactive" | "off"
+        "timeout": 30,          # seconds before auto-selecting (interactive mode)
+        "chain": [
+            # Example entries (uncomment and customize):
+            # {"provider": "openrouter", "model": "anthropic/claude-opus-4.6"},
+            # {"provider": "lmstudio", "base_url": "http://localhost:1234/v1", "model": "qwen3-30b-a3b"},
+            # {"provider": "ollama", "base_url": "http://localhost:11434/v1", "model": "llama3.1:70b"},
+        ],
+    },
+
     "display": {
         "compact": False,
         "personality": "kawaii",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -168,6 +168,7 @@ def cmd_chat(args):
         "query": args.query,
         "resume": getattr(args, "resume", None),
         "worktree": getattr(args, "worktree", False),
+        "fallback_mode": getattr(args, "fallback", None),
     }
     # Filter out None values
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
@@ -1303,6 +1304,12 @@ For more help on a command:
         action="store_true",
         default=False,
         help="Run in an isolated git worktree (for parallel agents on the same repo)"
+    )
+    chat_parser.add_argument(
+        "--fallback",
+        choices=["auto", "interactive", "off"],
+        default=None,
+        help="Fallback mode override: 'interactive' (countdown prompt), 'auto' (silent cascade), 'off' (disable)"
     )
     chat_parser.set_defaults(func=cmd_chat)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1277,7 +1277,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "zai", "kimi-coding", "minimax", "minimax-cn"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "anthropic", "zai", "kimi-coding", "minimax", "minimax-cn"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -53,6 +53,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
     ],
+    "anthropic": [
+        "claude-opus-4-20250514",
+        "claude-sonnet-4-20250514",
+        "claude-haiku-4-5-20251001",
+    ],
 }
 
 _PROVIDER_LABELS = {
@@ -63,6 +68,7 @@ _PROVIDER_LABELS = {
     "kimi-coding": "Kimi / Moonshot",
     "minimax": "MiniMax",
     "minimax-cn": "MiniMax (China)",
+    "anthropic": "Anthropic",
     "custom": "custom endpoint",
 }
 
@@ -75,6 +81,7 @@ _PROVIDER_ALIASES = {
     "moonshot": "kimi-coding",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
+    "claude": "anthropic",
 }
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -13,6 +13,7 @@ from hermes_cli.auth import (
     resolve_nous_runtime_credentials,
     resolve_codex_runtime_credentials,
     resolve_api_key_provider_credentials,
+    resolve_anthropic_claude_code_credentials,
 )
 from hermes_cli.config import load_config
 from hermes_constants import OPENROUTER_BASE_URL
@@ -149,7 +150,20 @@ def resolve_runtime_provider(
         }
 
     # Anthropic (native Messages API)
+    # Try Claude Code OAuth credentials first, then fall back to env vars
     if provider == "anthropic":
+        try:
+            creds = resolve_anthropic_claude_code_credentials()
+            return {
+                "provider": "anthropic",
+                "api_mode": "anthropic_messages",
+                "base_url": creds.get("base_url", "").rstrip("/"),
+                "api_key": creds.get("api_key", ""),
+                "source": creds.get("source", "claude-code"),
+                "requested_provider": requested_provider,
+            }
+        except AuthError:
+            pass  # Fall through to env-var resolution
         creds = resolve_api_key_provider_credentials(provider)
         return {
             "provider": "anthropic",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -148,6 +148,18 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    # Anthropic (native Messages API)
+    if provider == "anthropic":
+        creds = resolve_api_key_provider_credentials(provider)
+        return {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": creds.get("base_url", "").rstrip("/"),
+            "api_key": creds.get("api_key", ""),
+            "source": creds.get("source", "env"),
+            "requested_provider": requested_provider,
+        }
+
     # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license = { text = "MIT" }
 dependencies = [
   # Core
   "openai",
+  "anthropic>=0.39.0",
   "python-dotenv",
   "fire",
   "httpx",

--- a/run_agent.py
+++ b/run_agent.py
@@ -183,6 +183,9 @@ class AIAgent:
         session_db=None,
         honcho_session_key: str = None,
         iteration_budget: "IterationBudget" = None,
+        fallback_chain: "FallbackChain" = None,
+        fallback_notify: callable = None,
+        fallback_selector: callable = None,
     ):
         """
         Initialize the AI Agent.
@@ -365,10 +368,17 @@ class AIAgent:
         # Initialize LLM client
         self._anthropic_client = None
 
-        # Fallback provider support: when primary is Anthropic, prepare an
-        # OpenRouter client to switch to on rate-limit or auth failures.
-        self._fallback_available = False
-        self._fallback_activated = False
+        # Provider fallback chain — triggered on rate-limit, auth, or overload errors.
+        # Replaces the old hardcoded Anthropic -> OpenRouter fallback.
+        from agent.fallback_chain import FallbackChain
+        if fallback_chain is not None:
+            self._fallback_chain = fallback_chain
+        else:
+            # Backward compat: auto-build a legacy chain if OPENROUTER_API_KEY is set
+            self._fallback_chain = FallbackChain.build_legacy_chain(self.model)
+        self._fallback_notify = fallback_notify
+        self._fallback_selector = fallback_selector  # Optional: platform-specific selector (e.g. CLI clarify UI)
+        self._fallback_activated = False  # True after first fallback switch
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -383,21 +393,10 @@ class AIAgent:
                 if effective_key and len(effective_key) > 12:
                     print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
 
-            # Prepare OpenRouter fallback if key is available
-            fallback_key = os.getenv("OPENROUTER_API_KEY", "").strip()
-            if fallback_key:
-                self._fallback_available = True
-                self._fallback_client_kwargs = {
-                    "base_url": OPENROUTER_BASE_URL,
-                    "api_key": fallback_key,
-                    "default_headers": {
-                        "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
-                        "X-OpenRouter-Title": "Hermes Agent",
-                        "X-OpenRouter-Categories": "productivity,cli-agent",
-                    },
-                }
-                if not self.quiet_mode:
-                    print(f"🔄 Fallback provider: OpenRouter (ready)")
+            if self._fallback_chain.has_fallbacks() and not self.quiet_mode:
+                n = len(self._fallback_chain.entries)
+                names = ", ".join(e.provider for e in self._fallback_chain.entries)
+                print(f"🔄 Fallback chain: {names} ({n} provider{'s' if n > 1 else ''})")
         else:
             client_kwargs = {}
 
@@ -2194,37 +2193,94 @@ class AIAgent:
             raise result["error"]
         return result["response"]
 
-    def _switch_to_fallback_provider(self) -> bool:
-        """Switch from Anthropic to OpenRouter fallback.
+    def _activate_fallback(self, entry: "FallbackEntry") -> bool:
+        """Activate a fallback provider entry.
 
-        Returns True if switch succeeded, False if no fallback available.
-        Called when the primary Anthropic provider fails with rate-limit,
-        auth, or overload errors.
+        Switches the agent's client, model, and API mode to use the given
+        fallback entry. Returns True on success, False on failure (in which
+        case the entry is marked as failed in the chain).
         """
-        if not self._fallback_available or self._fallback_activated:
-            return False
-
+        from agent.fallback_chain import FallbackEntry
         try:
-            self.client = OpenAI(**self._fallback_client_kwargs)
-            self._client_kwargs = self._fallback_client_kwargs
-            self.api_mode = "chat_completions"
-            self.provider = "openrouter"
-            self.base_url = OPENROUTER_BASE_URL
+            client_kwargs = entry.build_client_kwargs()
+            self.client = OpenAI(**client_kwargs)
+            self._client_kwargs = client_kwargs
+            self.api_mode = entry.api_mode or "chat_completions"
+            self.provider = entry.provider
+            self.base_url = client_kwargs.get("base_url", OPENROUTER_BASE_URL)
             self._fallback_activated = True
+            # Disable anthropic native client since we're on OpenAI-compatible now
+            self._anthropic_client = None
 
-            # Re-map bare model names to OpenRouter format if needed
-            if not self.model.startswith("anthropic/") and "claude" in self.model.lower():
-                self.model = f"anthropic/{self.model}"
+            # Override model if the entry specifies one
+            if entry.model:
+                self.model = entry.model
+            elif "openrouter" in self.base_url.lower():
+                # Re-map bare model names to OpenRouter format if needed
+                if not self.model.startswith("anthropic/") and "claude" in self.model.lower():
+                    self.model = f"anthropic/{self.model}"
 
             # Enable prompt caching for Claude via OpenRouter
-            self._use_prompt_caching = True
+            if "openrouter" in self.base_url.lower():
+                self._use_prompt_caching = True
 
-            print(f"{self.log_prefix}🔄 Switched to fallback provider: OpenRouter ({self.model})")
-            logging.info("Fallback activated: Anthropic -> OpenRouter (%s)", self.model)
+            print(f"{self.log_prefix}🔄 Switched to fallback: {entry.display_name} ({self.model})")
+            logging.info("Fallback activated: %s (%s)", entry.provider, self.model)
             return True
         except Exception as e:
-            logging.error("Failed to initialize fallback OpenRouter client: %s", e)
+            logging.error("Failed to activate fallback %s: %s", entry.provider, e)
+            self._fallback_chain.mark_failed(entry)
             return False
+
+    def _try_fallback_chain(self, error_msg: str) -> bool:
+        """Attempt to switch to the next fallback provider in the chain.
+
+        Selection strategy priority:
+        1. Platform-injected fallback_selector callback (e.g. CLI clarify-style UI)
+        2. Interactive stdin prompt (only if stdin is a real tty, not prompt_toolkit)
+        3. Auto-cascade (gateway, non-interactive, or fallback)
+
+        Returns True if a fallback was activated, False if exhausted/skipped.
+        """
+        from agent.fallback_chain import select_interactive, select_auto
+
+        chain = self._fallback_chain
+        if not chain.has_fallbacks() or chain.is_exhausted():
+            return False
+
+        entry = None
+
+        # 1. Platform-injected selector (e.g. CLI with prompt_toolkit UI)
+        if self._fallback_selector and chain.mode == "interactive":
+            entry = self._fallback_selector(chain, error_msg)
+
+        # 2. Raw stdin interactive (works when running outside prompt_toolkit)
+        elif chain.mode == "interactive" and sys.stdin.isatty():
+            entry = select_interactive(
+                chain, error_msg,
+                current_model=self.model,
+                log_prefix=self.log_prefix,
+            )
+
+        # 3. Auto-cascade (gateway, non-interactive)
+        else:
+            entry = select_auto(
+                chain, error_msg,
+                current_model=self.model,
+                log_prefix=self.log_prefix,
+                notify=self._fallback_notify,
+            )
+
+        if entry is None:
+            # User chose to skip or chain exhausted
+            return False
+
+        if self._activate_fallback(entry):
+            return True
+
+        # Activation failed — mark and try next (auto-cascade on failure)
+        chain.mark_failed(entry)
+        return self._try_fallback_chain(error_msg)  # Recurse to next entry
 
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
@@ -3512,17 +3568,18 @@ class AIAgent:
                             print(f"{self.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request...")
                             continue
 
-                    # Anthropic fallback: on rate-limit (429), auth (401), or
-                    # overload (529) errors, switch to OpenRouter if available.
+                    # Universal provider fallback: on rate-limit (429), auth (401),
+                    # overload (529), or service-unavailable (503), try the
+                    # fallback chain if one is configured.
+                    from agent.fallback_chain import should_trigger_fallback
                     if (
-                        self.api_mode == "anthropic_messages"
-                        and self.provider == "anthropic"
-                        and status_code in {401, 429, 529}
-                        and not self._fallback_activated
+                        should_trigger_fallback(status_code, api_error)
+                        and self._fallback_chain.has_fallbacks()
+                        and not self._fallback_chain.is_exhausted()
                     ):
-                        print(f"{self.log_prefix}⚠️  Anthropic API error ({status_code}): {str(api_error)[:150]}")
-                        if self._switch_to_fallback_provider():
-                            print(f"{self.log_prefix}   🔄 Retrying with OpenRouter fallback...")
+                        error_str = f"{self.provider} API error ({status_code}): {str(api_error)[:150]}"
+                        if self._try_fallback_chain(error_str):
+                            print(f"{self.log_prefix}   🔄 Retrying with fallback provider...")
                             continue
 
                     retry_count += 1

--- a/run_agent.py
+++ b/run_agent.py
@@ -365,6 +365,11 @@ class AIAgent:
         # Initialize LLM client
         self._anthropic_client = None
 
+        # Fallback provider support: when primary is Anthropic, prepare an
+        # OpenRouter client to switch to on rate-limit or auth failures.
+        self._fallback_available = False
+        self._fallback_activated = False
+
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
             effective_key = api_key or os.getenv("ANTHROPIC_TOKEN", "") or os.getenv("ANTHROPIC_API_KEY", "")
@@ -377,6 +382,22 @@ class AIAgent:
                 print(f"🤖 AI Agent initialized with model: {self.model} (Anthropic native)")
                 if effective_key and len(effective_key) > 12:
                     print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
+
+            # Prepare OpenRouter fallback if key is available
+            fallback_key = os.getenv("OPENROUTER_API_KEY", "").strip()
+            if fallback_key:
+                self._fallback_available = True
+                self._fallback_client_kwargs = {
+                    "base_url": OPENROUTER_BASE_URL,
+                    "api_key": fallback_key,
+                    "default_headers": {
+                        "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
+                        "X-OpenRouter-Title": "Hermes Agent",
+                        "X-OpenRouter-Categories": "productivity,cli-agent",
+                    },
+                }
+                if not self.quiet_mode:
+                    print(f"🔄 Fallback provider: OpenRouter (ready)")
         else:
             client_kwargs = {}
 
@@ -2173,6 +2194,38 @@ class AIAgent:
             raise result["error"]
         return result["response"]
 
+    def _switch_to_fallback_provider(self) -> bool:
+        """Switch from Anthropic to OpenRouter fallback.
+
+        Returns True if switch succeeded, False if no fallback available.
+        Called when the primary Anthropic provider fails with rate-limit,
+        auth, or overload errors.
+        """
+        if not self._fallback_available or self._fallback_activated:
+            return False
+
+        try:
+            self.client = OpenAI(**self._fallback_client_kwargs)
+            self._client_kwargs = self._fallback_client_kwargs
+            self.api_mode = "chat_completions"
+            self.provider = "openrouter"
+            self.base_url = OPENROUTER_BASE_URL
+            self._fallback_activated = True
+
+            # Re-map bare model names to OpenRouter format if needed
+            if not self.model.startswith("anthropic/") and "claude" in self.model.lower():
+                self.model = f"anthropic/{self.model}"
+
+            # Enable prompt caching for Claude via OpenRouter
+            self._use_prompt_caching = True
+
+            print(f"{self.log_prefix}🔄 Switched to fallback provider: OpenRouter ({self.model})")
+            logging.info("Fallback activated: Anthropic -> OpenRouter (%s)", self.model)
+            return True
+        except Exception as e:
+            logging.error("Failed to initialize fallback OpenRouter client: %s", e)
+            return False
+
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
         if self.api_mode == "anthropic_messages":
@@ -3457,6 +3510,19 @@ class AIAgent:
                         nous_auth_retry_attempted = True
                         if self._try_refresh_nous_client_credentials(force=True):
                             print(f"{self.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request...")
+                            continue
+
+                    # Anthropic fallback: on rate-limit (429), auth (401), or
+                    # overload (529) errors, switch to OpenRouter if available.
+                    if (
+                        self.api_mode == "anthropic_messages"
+                        and self.provider == "anthropic"
+                        and status_code in {401, 429, 529}
+                        and not self._fallback_activated
+                    ):
+                        print(f"{self.log_prefix}⚠️  Anthropic API error ({status_code}): {str(api_error)[:150]}")
+                        if self._switch_to_fallback_provider():
+                            print(f"{self.log_prefix}   🔄 Retrying with OpenRouter fallback...")
                             continue
 
                     retry_count += 1

--- a/run_agent.py
+++ b/run_agent.py
@@ -369,13 +369,16 @@ class AIAgent:
         self._anthropic_client = None
 
         # Provider fallback chain — triggered on rate-limit, auth, or overload errors.
-        # Replaces the old hardcoded Anthropic -> OpenRouter fallback.
+        # Auto-detects available providers from env vars if no explicit chain given.
         from agent.fallback_chain import FallbackChain
         if fallback_chain is not None:
             self._fallback_chain = fallback_chain
         else:
-            # Backward compat: auto-build a legacy chain if OPENROUTER_API_KEY is set
-            self._fallback_chain = FallbackChain.build_legacy_chain(self.model)
+            self._fallback_chain = FallbackChain.build_auto_chain(
+                primary_provider=provider or "",
+                primary_model=self.model,
+                primary_base_url=base_url or "",
+            )
         self._fallback_notify = fallback_notify
         self._fallback_selector = fallback_selector  # Optional: platform-specific selector (e.g. CLI clarify UI)
         self._fallback_activated = False  # True after first fallback switch

--- a/run_agent.py
+++ b/run_agent.py
@@ -244,13 +244,16 @@ class AIAgent:
         self.base_url = base_url or OPENROUTER_BASE_URL
         provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
         self.provider = provider_name or "openrouter"
-        if api_mode in {"chat_completions", "codex_responses"}:
+        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
         elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self.base_url.lower():
             self.api_mode = "codex_responses"
             self.provider = "openai-codex"
+        elif self.provider == "anthropic" or (provider_name is None and "api.anthropic.com" in self.base_url.lower()):
+            self.api_mode = "anthropic_messages"
+            self.provider = "anthropic"
         else:
             self.api_mode = "chat_completions"
 
@@ -359,52 +362,67 @@ class AIAgent:
                 ]:
                     logging.getLogger(quiet_logger).setLevel(logging.ERROR)
         
-        # Initialize OpenAI client - defaults to OpenRouter
-        client_kwargs = {}
-        
-        # Default to OpenRouter if no base_url provided
-        if base_url:
-            client_kwargs["base_url"] = base_url
-        else:
-            client_kwargs["base_url"] = OPENROUTER_BASE_URL
-        
-        # Handle API key - OpenRouter is the primary provider
-        if api_key:
-            client_kwargs["api_key"] = api_key
-        else:
-            # Primary: OPENROUTER_API_KEY, fallback to direct provider keys
-            client_kwargs["api_key"] = os.getenv("OPENROUTER_API_KEY", "")
-        
-        # OpenRouter app attribution — shows hermes-agent in rankings/analytics
-        effective_base = client_kwargs.get("base_url", "")
-        if "openrouter" in effective_base.lower():
-            client_kwargs["default_headers"] = {
-                "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
-                "X-OpenRouter-Title": "Hermes Agent",
-                "X-OpenRouter-Categories": "productivity,cli-agent",
-            }
-        elif "api.kimi.com" in effective_base.lower():
-            # Kimi Code API requires a recognized coding-agent User-Agent
-            # (see https://github.com/MoonshotAI/kimi-cli)
-            client_kwargs["default_headers"] = {
-                "User-Agent": "KimiCLI/1.0",
-            }
-        
-        self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
-        try:
-            self.client = OpenAI(**client_kwargs)
+        # Initialize LLM client
+        self._anthropic_client = None
+
+        if self.api_mode == "anthropic_messages":
+            from agent.anthropic_adapter import build_anthropic_client
+            effective_key = api_key or os.getenv("ANTHROPIC_TOKEN", "") or os.getenv("ANTHROPIC_API_KEY", "")
+            self._anthropic_api_key = effective_key
+            self._anthropic_client = build_anthropic_client(effective_key, base_url if base_url and "anthropic" in base_url else None)
+            # Still create a dummy OpenAI client for code paths that reference self.client
+            self.client = None
+            self._client_kwargs = {}
             if not self.quiet_mode:
-                print(f"🤖 AI Agent initialized with model: {self.model}")
-                if base_url:
-                    print(f"🔗 Using custom base URL: {base_url}")
-                # Always show API key info (masked) for debugging auth issues
-                key_used = client_kwargs.get("api_key", "none")
-                if key_used and key_used != "dummy-key" and len(key_used) > 12:
-                    print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
-                else:
-                    print(f"⚠️  Warning: API key appears invalid or missing (got: '{key_used[:20] if key_used else 'none'}...')")
-        except Exception as e:
-            raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
+                print(f"🤖 AI Agent initialized with model: {self.model} (Anthropic native)")
+                if effective_key and len(effective_key) > 12:
+                    print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
+        else:
+            client_kwargs = {}
+
+            # Default to OpenRouter if no base_url provided
+            if base_url:
+                client_kwargs["base_url"] = base_url
+            else:
+                client_kwargs["base_url"] = OPENROUTER_BASE_URL
+
+            # Handle API key - OpenRouter is the primary provider
+            if api_key:
+                client_kwargs["api_key"] = api_key
+            else:
+                # Primary: OPENROUTER_API_KEY, fallback to direct provider keys
+                client_kwargs["api_key"] = os.getenv("OPENROUTER_API_KEY", "")
+
+            # OpenRouter app attribution — shows hermes-agent in rankings/analytics
+            effective_base = client_kwargs.get("base_url", "")
+            if "openrouter" in effective_base.lower():
+                client_kwargs["default_headers"] = {
+                    "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
+                    "X-OpenRouter-Title": "Hermes Agent",
+                    "X-OpenRouter-Categories": "productivity,cli-agent",
+                }
+            elif "api.kimi.com" in effective_base.lower():
+                # Kimi Code API requires a recognized coding-agent User-Agent
+                # (see https://github.com/MoonshotAI/kimi-cli)
+                client_kwargs["default_headers"] = {
+                    "User-Agent": "KimiCLI/1.0",
+                }
+
+            self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
+            try:
+                self.client = OpenAI(**client_kwargs)
+                if not self.quiet_mode:
+                    print(f"🤖 AI Agent initialized with model: {self.model}")
+                    if base_url:
+                        print(f"🔗 Using custom base URL: {base_url}")
+                    # Always show API key info (masked) for debugging auth issues
+                    key_used = client_kwargs.get("api_key", "none")
+                    if key_used and key_used != "dummy-key" and len(key_used) > 12:
+                        print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
+                    else:
+                        print(f"⚠️  Warning: API key appears invalid or missing (got: '{key_used[:20] if key_used else 'none'}...')")
+            except Exception as e:
+                raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
         
         # Get available tools with filtering
         self.tools = get_tool_definitions(
@@ -2121,6 +2139,8 @@ class AIAgent:
             try:
                 if self.api_mode == "codex_responses":
                     result["response"] = self._run_codex_stream(api_kwargs)
+                elif self.api_mode == "anthropic_messages":
+                    result["response"] = self._anthropic_client.messages.create(**api_kwargs)
                 else:
                     result["response"] = self.client.chat.completions.create(**api_kwargs)
             except Exception as e:
@@ -2133,12 +2153,19 @@ class AIAgent:
             if self._interrupt_requested:
                 # Force-close the HTTP connection to stop token generation
                 try:
-                    self.client.close()
+                    if self.api_mode == "anthropic_messages":
+                        self._anthropic_client.close()
+                    else:
+                        self.client.close()
                 except Exception:
                     pass
                 # Rebuild the client for future calls (cheap, no network)
                 try:
-                    self.client = OpenAI(**self._client_kwargs)
+                    if self.api_mode == "anthropic_messages":
+                        from agent.anthropic_adapter import build_anthropic_client
+                        self._anthropic_client = build_anthropic_client(self._anthropic_api_key)
+                    else:
+                        self.client = OpenAI(**self._client_kwargs)
                 except Exception:
                     pass
                 raise InterruptedError("Agent interrupted during API call")
@@ -2148,6 +2175,16 @@ class AIAgent:
 
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
+        if self.api_mode == "anthropic_messages":
+            from agent.anthropic_adapter import build_anthropic_kwargs
+            return build_anthropic_kwargs(
+                model=self.model,
+                messages=api_messages,
+                tools=self.tools,
+                max_tokens=self.max_tokens,
+                reasoning_config=self.reasoning_config,
+            )
+
         if self.api_mode == "codex_responses":
             instructions = ""
             payload_messages = api_messages
@@ -3192,6 +3229,17 @@ class AIAgent:
                         elif len(output_items) == 0:
                             response_invalid = True
                             error_details.append("response.output is empty")
+                    elif self.api_mode == "anthropic_messages":
+                        content_blocks = getattr(response, "content", None) if response is not None else None
+                        if response is None:
+                            response_invalid = True
+                            error_details.append("response is None")
+                        elif not isinstance(content_blocks, list):
+                            response_invalid = True
+                            error_details.append("response.content is not a list")
+                        elif len(content_blocks) == 0:
+                            response_invalid = True
+                            error_details.append("response.content is empty")
                     else:
                         if response is None or not hasattr(response, 'choices') or response.choices is None or len(response.choices) == 0:
                             response_invalid = True
@@ -3287,6 +3335,9 @@ class AIAgent:
                             finish_reason = "length"
                         else:
                             finish_reason = "stop"
+                    elif self.api_mode == "anthropic_messages":
+                        stop_reason_map = {"end_turn": "stop", "tool_use": "tool_calls", "max_tokens": "length", "stop_sequence": "stop"}
+                        finish_reason = stop_reason_map.get(response.stop_reason, "stop")
                     else:
                         finish_reason = response.choices[0].finish_reason
                     
@@ -3325,7 +3376,7 @@ class AIAgent:
                     
                     # Track actual token usage from response for context management
                     if hasattr(response, 'usage') and response.usage:
-                        if self.api_mode == "codex_responses":
+                        if self.api_mode in ("codex_responses", "anthropic_messages"):
                             prompt_tokens = getattr(response.usage, 'input_tokens', 0) or 0
                             completion_tokens = getattr(response.usage, 'output_tokens', 0) or 0
                             total_tokens = (
@@ -3624,6 +3675,9 @@ class AIAgent:
             try:
                 if self.api_mode == "codex_responses":
                     assistant_message, finish_reason = self._normalize_codex_response(response)
+                elif self.api_mode == "anthropic_messages":
+                    from agent.anthropic_adapter import normalize_anthropic_response
+                    assistant_message, finish_reason = normalize_anthropic_response(response)
                 else:
                     assistant_message = response.choices[0].message
                 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -8,11 +8,11 @@ from hermes_cli.commands import COMMANDS, SlashCommandCompleter
 
 # All commands that must be present in the shared COMMANDS dict.
 EXPECTED_COMMANDS = {
-    "/help", "/tools", "/toolsets", "/model", "/provider", "/prompt",
-    "/personality", "/clear", "/history", "/new", "/reset", "/retry",
-    "/undo", "/save", "/config", "/cron", "/skills", "/platforms",
-    "/verbose", "/compress", "/usage", "/insights", "/paste",
-    "/reload-mcp", "/quit",
+    "/help", "/tools", "/toolsets", "/model", "/provider", "/fallback",
+    "/prompt", "/personality", "/clear", "/history", "/new", "/reset",
+    "/retry", "/undo", "/save", "/config", "/cron", "/skills",
+    "/platforms", "/verbose", "/compress", "/usage", "/insights",
+    "/paste", "/reload-mcp", "/quit",
 }
 
 

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -142,7 +142,7 @@ class TestBuildAnthropicKwargs:
             reasoning_config={"enabled": True, "effort": "high"},
         )
         assert kwargs["thinking"]["type"] == "adaptive"
-        assert kwargs["thinking"]["budget_tokens"] == 16000
+        assert "budget_tokens" not in kwargs["thinking"]
         assert kwargs["max_tokens"] >= 16000 + 4096
 
     def test_reasoning_disabled(self):

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -141,7 +141,7 @@ class TestBuildAnthropicKwargs:
             max_tokens=4096,
             reasoning_config={"enabled": True, "effort": "high"},
         )
-        assert kwargs["thinking"]["type"] == "enabled"
+        assert kwargs["thinking"]["type"] == "adaptive"
         assert kwargs["thinking"]["budget_tokens"] == 16000
         assert kwargs["max_tokens"] >= 16000 + 4096
 

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -155,6 +155,30 @@ class TestBuildAnthropicKwargs:
         )
         assert "thinking" not in kwargs
 
+    def test_reasoning_skipped_for_unsupported_model(self):
+        """claude-sonnet-4-5 does not support adaptive thinking — param should be omitted."""
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "think hard"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert "thinking" not in kwargs
+        # max_tokens should stay at the provided value, not inflated for thinking
+        assert kwargs["max_tokens"] == 4096
+
+    def test_reasoning_skipped_for_haiku(self):
+        """claude-3-5-haiku does not support adaptive thinking."""
+        kwargs = build_anthropic_kwargs(
+            model="claude-3-5-haiku-20241022",
+            messages=[{"role": "user", "content": "think"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert "thinking" not in kwargs
+
 
 class TestNormalizeResponse:
     def _make_response(self, content_blocks, stop_reason="end_turn"):

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -1,0 +1,209 @@
+"""Tests for agent/anthropic_adapter.py — Anthropic Messages API adapter."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent.anthropic_adapter import (
+    build_anthropic_client,
+    build_anthropic_kwargs,
+    convert_messages_to_anthropic,
+    convert_tools_to_anthropic,
+    normalize_anthropic_response,
+)
+
+
+class TestBuildAnthropicClient:
+    def test_setup_token_uses_auth_token(self):
+        with patch("agent.anthropic_adapter.anthropic.Anthropic") as mock_cls:
+            build_anthropic_client("sk-ant-oat01-abcdefghijklmnop" + "x" * 60)
+            kwargs = mock_cls.call_args[1]
+            assert "auth_token" in kwargs
+            assert kwargs["default_headers"]["anthropic-beta"] == "oauth-2025-04-20"
+            assert "api_key" not in kwargs
+
+    def test_api_key_uses_api_key(self):
+        with patch("agent.anthropic_adapter.anthropic.Anthropic") as mock_cls:
+            build_anthropic_client("sk-ant-api03-something")
+            kwargs = mock_cls.call_args[1]
+            assert kwargs["api_key"] == "sk-ant-api03-something"
+            assert "auth_token" not in kwargs
+
+
+class TestConvertTools:
+    def test_converts_openai_to_anthropic_format(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search the web",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                },
+            }
+        ]
+        result = convert_tools_to_anthropic(tools)
+        assert len(result) == 1
+        assert result[0]["name"] == "search"
+        assert result[0]["description"] == "Search the web"
+        assert result[0]["input_schema"]["properties"]["query"]["type"] == "string"
+
+    def test_empty_tools(self):
+        assert convert_tools_to_anthropic([]) == []
+        assert convert_tools_to_anthropic(None) == []
+
+
+class TestConvertMessages:
+    def test_extracts_system_prompt(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ]
+        system, result = convert_messages_to_anthropic(messages)
+        assert system == "You are helpful."
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+
+    def test_converts_tool_calls(self):
+        messages = [
+            {"role": "assistant", "content": "Let me search.", "tool_calls": [
+                {"id": "tc_1", "function": {"name": "search", "arguments": '{"query": "test"}'}}
+            ]},
+            {"role": "tool", "tool_call_id": "tc_1", "content": "search results"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        blocks = result[0]["content"]
+        assert blocks[0] == {"type": "text", "text": "Let me search."}
+        assert blocks[1]["type"] == "tool_use"
+        assert blocks[1]["id"] == "tc_1"
+        assert blocks[1]["input"] == {"query": "test"}
+
+    def test_converts_tool_results(self):
+        messages = [
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result data"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assert result[0]["role"] == "user"
+        assert result[0]["content"][0]["type"] == "tool_result"
+        assert result[0]["content"][0]["tool_use_id"] == "tc_1"
+
+    def test_merges_consecutive_tool_results(self):
+        messages = [
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result 1"},
+            {"role": "tool", "tool_call_id": "tc_2", "content": "result 2"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assert len(result) == 1
+        assert len(result[0]["content"]) == 2
+
+    def test_strips_orphaned_tool_use(self):
+        messages = [
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "tc_orphan", "function": {"name": "x", "arguments": "{}"}}
+            ]},
+            {"role": "user", "content": "never mind"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        # tc_orphan has no matching tool_result, should be stripped
+        assistant_blocks = result[0]["content"]
+        assert all(b.get("type") != "tool_use" for b in assistant_blocks)
+
+
+class TestBuildAnthropicKwargs:
+    def test_basic_kwargs(self):
+        messages = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "Hi"},
+        ]
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=messages,
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+        )
+        assert kwargs["model"] == "claude-sonnet-4-20250514"
+        assert kwargs["system"] == "Be helpful."
+        assert kwargs["max_tokens"] == 4096
+        assert "tools" not in kwargs
+
+    def test_reasoning_config_maps_to_thinking(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "think hard"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kwargs["thinking"]["type"] == "enabled"
+        assert kwargs["thinking"]["budget_tokens"] == 16000
+        assert kwargs["max_tokens"] >= 16000 + 4096
+
+    def test_reasoning_disabled(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "quick"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+        )
+        assert "thinking" not in kwargs
+
+
+class TestNormalizeResponse:
+    def _make_response(self, content_blocks, stop_reason="end_turn"):
+        resp = SimpleNamespace()
+        resp.content = content_blocks
+        resp.stop_reason = stop_reason
+        resp.usage = SimpleNamespace(input_tokens=100, output_tokens=50)
+        return resp
+
+    def test_text_response(self):
+        block = SimpleNamespace(type="text", text="Hello world")
+        msg, reason = normalize_anthropic_response(self._make_response([block]))
+        assert msg.content == "Hello world"
+        assert reason == "stop"
+        assert msg.tool_calls is None
+
+    def test_tool_use_response(self):
+        blocks = [
+            SimpleNamespace(type="text", text="Searching..."),
+            SimpleNamespace(
+                type="tool_use",
+                id="tc_1",
+                name="search",
+                input={"query": "test"},
+            ),
+        ]
+        msg, reason = normalize_anthropic_response(
+            self._make_response(blocks, "tool_use")
+        )
+        assert msg.content == "Searching..."
+        assert reason == "tool_calls"
+        assert len(msg.tool_calls) == 1
+        assert msg.tool_calls[0].function.name == "search"
+        assert json.loads(msg.tool_calls[0].function.arguments) == {"query": "test"}
+
+    def test_thinking_response(self):
+        blocks = [
+            SimpleNamespace(type="thinking", thinking="Let me reason about this..."),
+            SimpleNamespace(type="text", text="The answer is 42."),
+        ]
+        msg, reason = normalize_anthropic_response(self._make_response(blocks))
+        assert msg.content == "The answer is 42."
+        assert msg.reasoning == "Let me reason about this..."
+
+    def test_stop_reason_mapping(self):
+        block = SimpleNamespace(type="text", text="x")
+        _, r1 = normalize_anthropic_response(self._make_response([block], "end_turn"))
+        _, r2 = normalize_anthropic_response(self._make_response([block], "tool_use"))
+        _, r3 = normalize_anthropic_response(self._make_response([block], "max_tokens"))
+        assert r1 == "stop"
+        assert r2 == "tool_calls"
+        assert r3 == "length"

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -95,6 +95,10 @@ PROVIDER_ENV_VARS = (
 def _clear_provider_env(monkeypatch):
     for key in PROVIDER_ENV_VARS:
         monkeypatch.delenv(key, raising=False)
+    # Prevent Claude Code credential auto-detection from interfering
+    monkeypatch.setattr(
+        "hermes_cli.auth._read_claude_code_credentials", lambda: None
+    )
 
 
 class TestResolveProvider:

--- a/tests/test_claude_code_auth.py
+++ b/tests/test_claude_code_auth.py
@@ -1,0 +1,395 @@
+"""Tests for Claude Code OAuth credential discovery and fallback provider.
+
+Tests the auto-detection of Claude Code's ~/.claude/.credentials.json
+for the Anthropic provider, and the Anthropic -> OpenRouter fallback chain.
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock, PropertyMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+VALID_CREDENTIALS = {
+    "claudeAiOauth": {
+        "accessToken": "sk-ant-oat01-test-token-value",
+        "refreshToken": "sk-ant-rt01-test-refresh",
+        "expiresAt": int((time.time() + 86400) * 1000),  # 24h from now
+        "scopes": ["user:inference", "user:profile"],
+        "subscriptionType": "pro",
+        "rateLimitTier": "default_claude_ai",
+    }
+}
+
+EXPIRED_CREDENTIALS = {
+    "claudeAiOauth": {
+        "accessToken": "sk-ant-oat01-expired-token",
+        "refreshToken": "sk-ant-rt01-expired-refresh",
+        "expiresAt": int((time.time() - 3600) * 1000),  # 1h ago
+        "scopes": ["user:inference"],
+        "subscriptionType": "pro",
+    }
+}
+
+
+@pytest.fixture
+def mock_creds_file(tmp_path):
+    """Create a temporary credentials file."""
+    creds_path = tmp_path / ".claude" / ".credentials.json"
+    creds_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _write(data):
+        creds_path.write_text(json.dumps(data))
+        return creds_path
+
+    return _write
+
+
+# ---------------------------------------------------------------------------
+# _read_claude_code_credentials
+# ---------------------------------------------------------------------------
+
+class TestReadClaudeCodeCredentials:
+    def test_valid_credentials(self, mock_creds_file):
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import _read_claude_code_credentials
+            result = _read_claude_code_credentials()
+            assert result is not None
+            assert result["accessToken"] == "sk-ant-oat01-test-token-value"
+            assert result["subscriptionType"] == "pro"
+
+    def test_missing_file(self, tmp_path):
+        missing = tmp_path / ".claude" / ".credentials.json"
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", missing):
+            from hermes_cli.auth import _read_claude_code_credentials
+            assert _read_claude_code_credentials() is None
+
+    def test_malformed_json(self, mock_creds_file, tmp_path):
+        creds_path = tmp_path / ".claude" / ".credentials.json"
+        creds_path.parent.mkdir(parents=True, exist_ok=True)
+        creds_path.write_text("not json{{{")
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import _read_claude_code_credentials
+            assert _read_claude_code_credentials() is None
+
+    def test_missing_oauth_key(self, mock_creds_file):
+        creds_path = mock_creds_file({"someOtherKey": {}})
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import _read_claude_code_credentials
+            assert _read_claude_code_credentials() is None
+
+    def test_empty_access_token(self, mock_creds_file):
+        data = {"claudeAiOauth": {"accessToken": "", "expiresAt": 9999999999999}}
+        creds_path = mock_creds_file(data)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import _read_claude_code_credentials
+            assert _read_claude_code_credentials() is None
+
+    def test_oauth_not_dict(self, mock_creds_file):
+        data = {"claudeAiOauth": "not-a-dict"}
+        creds_path = mock_creds_file(data)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import _read_claude_code_credentials
+            assert _read_claude_code_credentials() is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_anthropic_claude_code_credentials
+# ---------------------------------------------------------------------------
+
+class TestResolveClaudeCodeCredentials:
+    def test_valid_returns_creds(self, mock_creds_file):
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import resolve_anthropic_claude_code_credentials
+            result = resolve_anthropic_claude_code_credentials()
+            assert result["provider"] == "anthropic"
+            assert result["api_mode"] == "anthropic_messages"
+            assert result["api_key"] == "sk-ant-oat01-test-token-value"
+            assert result["source"] == "claude-code"
+            assert result["subscription_type"] == "pro"
+            assert result["base_url"] == "https://api.anthropic.com"
+
+    def test_expired_raises(self, mock_creds_file):
+        creds_path = mock_creds_file(EXPIRED_CREDENTIALS)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import resolve_anthropic_claude_code_credentials, AuthError
+            with pytest.raises(AuthError, match="expired"):
+                resolve_anthropic_claude_code_credentials()
+
+    def test_missing_raises(self, tmp_path):
+        missing = tmp_path / ".claude" / ".credentials.json"
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", missing):
+            from hermes_cli.auth import resolve_anthropic_claude_code_credentials, AuthError
+            with pytest.raises(AuthError, match="No Claude Code credentials"):
+                resolve_anthropic_claude_code_credentials()
+
+    def test_custom_base_url_from_env(self, mock_creds_file):
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path),
+            patch.dict("os.environ", {"ANTHROPIC_BASE_URL": "https://custom.example.com/v1/"}),
+        ):
+            from hermes_cli.auth import resolve_anthropic_claude_code_credentials
+            result = resolve_anthropic_claude_code_credentials()
+            assert result["base_url"] == "https://custom.example.com/v1"
+
+
+# ---------------------------------------------------------------------------
+# get_claude_code_auth_status
+# ---------------------------------------------------------------------------
+
+class TestClaudeCodeAuthStatus:
+    def test_logged_in(self, mock_creds_file):
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import get_claude_code_auth_status
+            status = get_claude_code_auth_status()
+            assert status["logged_in"] is True
+            assert status["source"] == "claude-code"
+            assert status["subscription_type"] == "pro"
+            assert status["is_expired"] is False
+
+    def test_expired(self, mock_creds_file):
+        creds_path = mock_creds_file(EXPIRED_CREDENTIALS)
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path):
+            from hermes_cli.auth import get_claude_code_auth_status
+            status = get_claude_code_auth_status()
+            assert status["logged_in"] is False
+            assert status["is_expired"] is True
+
+    def test_no_credentials(self, tmp_path):
+        missing = tmp_path / ".claude" / ".credentials.json"
+        with patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", missing):
+            from hermes_cli.auth import get_claude_code_auth_status
+            status = get_claude_code_auth_status()
+            assert status["logged_in"] is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_provider auto-detection
+# ---------------------------------------------------------------------------
+
+class TestResolveProviderClaudeCode:
+    def test_auto_detects_claude_code(self, mock_creds_file):
+        """When Claude Code creds are present and valid, auto-resolve to anthropic."""
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path),
+            patch("hermes_cli.auth._load_auth_store", return_value={}),
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            # Remove any env vars that would cause earlier resolution
+            import os
+            env_backup = {}
+            for k in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY"):
+                if k in os.environ:
+                    env_backup[k] = os.environ.pop(k)
+            try:
+                from hermes_cli.auth import resolve_provider
+                result = resolve_provider()
+                assert result == "anthropic"
+            finally:
+                os.environ.update(env_backup)
+
+    def test_expired_creds_not_detected(self, mock_creds_file):
+        """Expired Claude Code creds should not auto-resolve."""
+        creds_path = mock_creds_file(EXPIRED_CREDENTIALS)
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path),
+            patch("hermes_cli.auth._load_auth_store", return_value={}),
+        ):
+            import os
+            env_backup = {}
+            for k in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY"):
+                if k in os.environ:
+                    env_backup[k] = os.environ.pop(k)
+            try:
+                from hermes_cli.auth import resolve_provider
+                result = resolve_provider()
+                # Should fall through to openrouter (default)
+                assert result == "openrouter"
+            finally:
+                os.environ.update(env_backup)
+
+    def test_claude_alias(self):
+        """'claude' and 'claude-code' should resolve to 'anthropic'."""
+        from hermes_cli.auth import resolve_provider
+        assert resolve_provider("claude") == "anthropic"
+        assert resolve_provider("claude-code") == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# runtime_provider resolution
+# ---------------------------------------------------------------------------
+
+class TestRuntimeProviderClaudeCode:
+    def test_claude_code_creds_used(self, mock_creds_file):
+        """runtime_provider should use Claude Code creds when available."""
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path),
+            patch("hermes_cli.runtime_provider.resolve_provider", return_value="anthropic"),
+        ):
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+            result = resolve_runtime_provider(requested="anthropic")
+            assert result["provider"] == "anthropic"
+            assert result["api_mode"] == "anthropic_messages"
+            assert result["source"] == "claude-code"
+            assert result["api_key"] == "sk-ant-oat01-test-token-value"
+
+    def test_falls_back_to_env_var(self, tmp_path):
+        """When no Claude Code creds, fall back to env var."""
+        missing = tmp_path / ".claude" / ".credentials.json"
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", missing),
+            patch("hermes_cli.runtime_provider.resolve_provider", return_value="anthropic"),
+            patch.dict("os.environ", {"ANTHROPIC_TOKEN": "sk-ant-api-test-key"}),
+        ):
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+            result = resolve_runtime_provider(requested="anthropic")
+            assert result["provider"] == "anthropic"
+            assert result["api_mode"] == "anthropic_messages"
+            assert result["source"] == "ANTHROPIC_TOKEN"
+
+
+# ---------------------------------------------------------------------------
+# get_auth_status dispatcher
+# ---------------------------------------------------------------------------
+
+class TestAuthStatusDispatcher:
+    def test_anthropic_prefers_claude_code(self, mock_creds_file):
+        """get_auth_status('anthropic') should return Claude Code status if available."""
+        creds_path = mock_creds_file(VALID_CREDENTIALS)
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", creds_path),
+            patch("hermes_cli.auth.get_active_provider", return_value="anthropic"),
+        ):
+            from hermes_cli.auth import get_auth_status
+            status = get_auth_status("anthropic")
+            assert status["logged_in"] is True
+            assert status["source"] == "claude-code"
+
+    def test_anthropic_falls_back_to_env(self, tmp_path):
+        """get_auth_status('anthropic') falls back to api_key status."""
+        missing = tmp_path / ".claude" / ".credentials.json"
+        with (
+            patch("hermes_cli.auth.DEFAULT_CLAUDE_CREDENTIALS_PATH", missing),
+            patch("hermes_cli.auth.get_active_provider", return_value="anthropic"),
+            patch.dict("os.environ", {"ANTHROPIC_TOKEN": "sk-test"}),
+        ):
+            from hermes_cli.auth import get_auth_status
+            status = get_auth_status("anthropic")
+            assert status.get("configured") is True
+            assert status.get("provider") == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# Fallback provider: Anthropic -> OpenRouter
+# ---------------------------------------------------------------------------
+
+class TestFallbackProvider:
+    """Test the Anthropic -> OpenRouter fallback mechanism in AIAgent."""
+
+    def _make_agent(self, **extra_env):
+        """Create an AIAgent in anthropic_messages mode with mocked clients."""
+        import sys
+
+        env = {
+            "ANTHROPIC_TOKEN": "sk-ant-oat01-test-token",
+            "OPENROUTER_API_KEY": "sk-or-test-key",
+        }
+        env.update(extra_env)
+
+        # Mock the anthropic SDK if not installed
+        mock_anthropic_mod = MagicMock()
+        mock_anthropic_mod.Anthropic.return_value = MagicMock()
+        needs_mock = "anthropic" not in sys.modules
+        if needs_mock:
+            sys.modules["anthropic"] = mock_anthropic_mod
+
+        # Also mock httpx.Timeout if needed
+        mock_httpx = MagicMock()
+        needs_httpx_mock = "httpx" not in sys.modules
+        if needs_httpx_mock:
+            sys.modules["httpx"] = mock_httpx
+
+        try:
+            # Force re-import of adapter to pick up mocked anthropic
+            if "agent.anthropic_adapter" in sys.modules:
+                del sys.modules["agent.anthropic_adapter"]
+
+            with (
+                patch("run_agent.get_tool_definitions", return_value=[]),
+                patch("run_agent.check_toolset_requirements", return_value={}),
+                patch.dict("os.environ", env),
+            ):
+                from run_agent import AIAgent
+                agent = AIAgent(
+                    api_key="sk-ant-oat01-test-token",
+                    model="claude-opus-4-20250514",
+                    provider="anthropic",
+                    api_mode="anthropic_messages",
+                    quiet_mode=True,
+                    skip_context_files=True,
+                    skip_memory=True,
+                )
+                return agent
+        finally:
+            if needs_mock:
+                sys.modules.pop("anthropic", None)
+            if needs_httpx_mock:
+                sys.modules.pop("httpx", None)
+
+    def test_fallback_available_with_openrouter_key(self):
+        agent = self._make_agent()
+        assert agent._fallback_available is True
+        assert agent._fallback_activated is False
+        assert agent.api_mode == "anthropic_messages"
+
+    def test_fallback_not_available_without_key(self):
+        agent = self._make_agent(OPENROUTER_API_KEY="")
+        assert agent._fallback_available is False
+
+    def test_switch_to_fallback(self):
+        agent = self._make_agent()
+        with patch("run_agent.OpenAI") as mock_openai:
+            result = agent._switch_to_fallback_provider()
+            assert result is True
+            assert agent._fallback_activated is True
+            assert agent.api_mode == "chat_completions"
+            assert agent.provider == "openrouter"
+            assert agent.model == "anthropic/claude-opus-4-20250514"
+            mock_openai.assert_called_once()
+
+    def test_switch_idempotent(self):
+        """Calling switch twice should return False the second time."""
+        agent = self._make_agent()
+        with patch("run_agent.OpenAI"):
+            assert agent._switch_to_fallback_provider() is True
+            assert agent._switch_to_fallback_provider() is False
+
+    def test_model_remapping(self):
+        """Bare model names should get anthropic/ prefix for OpenRouter."""
+        agent = self._make_agent()
+        agent.model = "claude-sonnet-4-20250514"
+        with patch("run_agent.OpenAI"):
+            agent._switch_to_fallback_provider()
+            assert agent.model == "anthropic/claude-sonnet-4-20250514"
+
+    def test_already_prefixed_model_not_doubled(self):
+        """Models already prefixed shouldn't get double-prefixed."""
+        agent = self._make_agent()
+        agent.model = "anthropic/claude-opus-4-20250514"
+        with patch("run_agent.OpenAI"):
+            agent._switch_to_fallback_provider()
+            assert agent.model == "anthropic/claude-opus-4-20250514"

--- a/tests/test_claude_code_auth.py
+++ b/tests/test_claude_code_auth.py
@@ -298,7 +298,7 @@ class TestAuthStatusDispatcher:
 # ---------------------------------------------------------------------------
 
 class TestFallbackProvider:
-    """Test the Anthropic -> OpenRouter fallback mechanism in AIAgent."""
+    """Test the provider fallback chain mechanism in AIAgent."""
 
     def _make_agent(self, **extra_env):
         """Create an AIAgent in anthropic_messages mode with mocked clients."""
@@ -350,20 +350,23 @@ class TestFallbackProvider:
             if needs_httpx_mock:
                 sys.modules.pop("httpx", None)
 
-    def test_fallback_available_with_openrouter_key(self):
+    def test_fallback_chain_auto_built_with_openrouter_key(self):
         agent = self._make_agent()
-        assert agent._fallback_available is True
+        assert agent._fallback_chain.has_fallbacks() is True
         assert agent._fallback_activated is False
         assert agent.api_mode == "anthropic_messages"
+        assert agent._fallback_chain.entries[0].provider == "openrouter"
 
-    def test_fallback_not_available_without_key(self):
+    def test_fallback_chain_empty_without_key(self):
         agent = self._make_agent(OPENROUTER_API_KEY="")
-        assert agent._fallback_available is False
+        assert agent._fallback_chain.has_fallbacks() is False
 
-    def test_switch_to_fallback(self):
+    def test_activate_fallback(self):
+        from agent.fallback_chain import FallbackEntry
         agent = self._make_agent()
+        entry = agent._fallback_chain.entries[0]
         with patch("run_agent.OpenAI") as mock_openai:
-            result = agent._switch_to_fallback_provider()
+            result = agent._activate_fallback(entry)
             assert result is True
             assert agent._fallback_activated is True
             assert agent.api_mode == "chat_completions"
@@ -371,25 +374,57 @@ class TestFallbackProvider:
             assert agent.model == "anthropic/claude-opus-4-20250514"
             mock_openai.assert_called_once()
 
-    def test_switch_idempotent(self):
-        """Calling switch twice should return False the second time."""
+    def test_chain_exhaustion(self):
+        """After activating the only entry, chain should be exhaustible."""
+        from agent.fallback_chain import FallbackEntry
         agent = self._make_agent()
+        entry = agent._fallback_chain.entries[0]
         with patch("run_agent.OpenAI"):
-            assert agent._switch_to_fallback_provider() is True
-            assert agent._switch_to_fallback_provider() is False
+            assert agent._activate_fallback(entry) is True
+            # Manually mark it failed to simulate exhaustion
+            agent._fallback_chain.mark_failed(entry)
+            assert agent._fallback_chain.is_exhausted() is True
 
-    def test_model_remapping(self):
-        """Bare model names should get anthropic/ prefix for OpenRouter."""
+    def test_model_remapping_bare_names(self):
+        """Bare model names get anthropic/ prefix when falling back to OpenRouter with no entry model."""
+        from agent.fallback_chain import FallbackEntry, FallbackChain
         agent = self._make_agent()
         agent.model = "claude-sonnet-4-20250514"
+        # Create a chain entry WITHOUT a model override — triggers remapping
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="openrouter"),  # no model set
+        ])
+        agent._fallback_chain = chain
+        entry = chain.entries[0]
         with patch("run_agent.OpenAI"):
-            agent._switch_to_fallback_provider()
+            agent._activate_fallback(entry)
             assert agent.model == "anthropic/claude-sonnet-4-20250514"
 
     def test_already_prefixed_model_not_doubled(self):
         """Models already prefixed shouldn't get double-prefixed."""
+        from agent.fallback_chain import FallbackEntry, FallbackChain
         agent = self._make_agent()
         agent.model = "anthropic/claude-opus-4-20250514"
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="openrouter"),  # no model override
+        ])
+        agent._fallback_chain = chain
+        entry = chain.entries[0]
         with patch("run_agent.OpenAI"):
-            agent._switch_to_fallback_provider()
+            agent._activate_fallback(entry)
             assert agent.model == "anthropic/claude-opus-4-20250514"
+
+    def test_entry_model_override(self):
+        """Entry-specified model should override the agent's current model."""
+        from agent.fallback_chain import FallbackEntry, FallbackChain
+        agent = self._make_agent()
+        # Replace chain with custom entry that has a model override
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="lmstudio", base_url="http://localhost:1234/v1", model="qwen3-30b-a3b"),
+        ])
+        agent._fallback_chain = chain
+        entry = chain.entries[0]
+        with patch("run_agent.OpenAI"):
+            agent._activate_fallback(entry)
+            assert agent.model == "qwen3-30b-a3b"
+            assert agent.provider == "lmstudio"

--- a/tests/test_fallback_chain.py
+++ b/tests/test_fallback_chain.py
@@ -1,0 +1,406 @@
+"""Tests for the provider fallback chain module."""
+
+import os
+import sys
+from io import StringIO
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent.fallback_chain import (
+    FallbackChain,
+    FallbackEntry,
+    select_auto,
+    select_interactive,
+    should_trigger_fallback,
+    FALLBACK_STATUS_CODES,
+)
+
+
+# =============================================================================
+# FallbackEntry
+# =============================================================================
+
+class TestFallbackEntry:
+    def test_display_name_plain(self):
+        e = FallbackEntry(provider="openrouter")
+        assert e.display_name == "openrouter"
+
+    def test_display_name_local(self):
+        e = FallbackEntry(provider="lmstudio", base_url="http://localhost:1234/v1")
+        assert "localhost:1234" in e.display_name
+
+    def test_display_name_remote(self):
+        """Remote URLs should NOT show host in display name."""
+        e = FallbackEntry(provider="openrouter", base_url="https://openrouter.ai/api/v1")
+        assert e.display_name == "openrouter"
+
+    def test_resolve_api_key_explicit_env(self):
+        e = FallbackEntry(provider="custom", api_key_env="MY_CUSTOM_KEY")
+        with patch.dict("os.environ", {"MY_CUSTOM_KEY": "secret123"}):
+            assert e.resolve_api_key() == "secret123"
+
+    def test_resolve_api_key_openrouter(self):
+        e = FallbackEntry(provider="openrouter")
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-or-key"}):
+            assert e.resolve_api_key() == "sk-or-key"
+
+    def test_resolve_api_key_local(self):
+        """Local providers should work even without a key."""
+        e = FallbackEntry(provider="lmstudio")
+        with patch.dict("os.environ", {}, clear=True):
+            key = e.resolve_api_key()
+            assert key == "not-needed"
+
+    def test_build_client_kwargs_openrouter(self):
+        e = FallbackEntry(provider="openrouter")
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-or-key"}):
+            kwargs = e.build_client_kwargs()
+            assert "openrouter" in kwargs["base_url"]
+            assert kwargs["api_key"] == "sk-or-key"
+            assert "default_headers" in kwargs
+
+    def test_build_client_kwargs_local(self):
+        e = FallbackEntry(provider="lmstudio", base_url="http://localhost:1234/v1")
+        kwargs = e.build_client_kwargs()
+        assert kwargs["base_url"] == "http://localhost:1234/v1"
+        assert "default_headers" not in kwargs
+
+
+# =============================================================================
+# FallbackChain
+# =============================================================================
+
+class TestFallbackChain:
+    def test_from_config_empty(self):
+        chain = FallbackChain.from_config({})
+        assert chain.has_fallbacks() is False
+        # Empty chain is technically exhausted (nothing to try)
+        assert chain.is_exhausted() is True
+
+    def test_from_config_with_entries(self):
+        config = {
+            "fallback": {
+                "mode": "interactive",
+                "timeout": 15,
+                "chain": [
+                    {"provider": "openrouter", "model": "anthropic/claude-opus-4.6"},
+                    {"provider": "lmstudio", "base_url": "http://localhost:1234/v1", "model": "qwen3-30b"},
+                ],
+            }
+        }
+        chain = FallbackChain.from_config(config)
+        assert chain.has_fallbacks() is True
+        assert len(chain.entries) == 2
+        assert chain.mode == "interactive"
+        assert chain.timeout == 15
+        assert chain.entries[0].provider == "openrouter"
+        assert chain.entries[0].model == "anthropic/claude-opus-4.6"
+        assert chain.entries[1].provider == "lmstudio"
+        assert chain.entries[1].base_url == "http://localhost:1234/v1"
+
+    def test_from_config_skips_invalid_entries(self):
+        config = {
+            "fallback": {
+                "chain": [
+                    {"provider": "openrouter"},
+                    "not-a-dict",
+                    {"provider": ""},  # empty provider
+                    {"provider": "lmstudio"},
+                ],
+            }
+        }
+        chain = FallbackChain.from_config(config)
+        assert len(chain.entries) == 2
+        assert chain.entries[0].provider == "openrouter"
+        assert chain.entries[1].provider == "lmstudio"
+
+    def test_build_legacy_chain_with_key(self):
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-or-key"}):
+            chain = FallbackChain.build_legacy_chain("claude-opus-4-20250514")
+            assert chain.has_fallbacks() is True
+            assert len(chain.entries) == 1
+            assert chain.entries[0].provider == "openrouter"
+            assert chain.entries[0].model == "anthropic/claude-opus-4-20250514"
+            assert chain.mode == "auto"  # Legacy mode = auto for backward compat
+
+    def test_build_legacy_chain_without_key(self):
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": ""}):
+            chain = FallbackChain.build_legacy_chain("some-model")
+            assert chain.has_fallbacks() is False
+
+    def test_next_available(self):
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="a"),
+            FallbackEntry(provider="b"),
+            FallbackEntry(provider="c"),
+        ])
+        assert chain.next_available().provider == "a"
+        chain.mark_failed(chain.entries[0])
+        assert chain.next_available().provider == "b"
+        chain.mark_failed(chain.entries[1])
+        assert chain.next_available().provider == "c"
+        chain.mark_failed(chain.entries[2])
+        assert chain.next_available() is None
+        assert chain.is_exhausted() is True
+
+    def test_available_entries(self):
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="a"),
+            FallbackEntry(provider="b"),
+            FallbackEntry(provider="c"),
+        ])
+        chain.mark_failed(chain.entries[1])
+        available = chain.available_entries()
+        assert len(available) == 2
+        assert available[0][1].provider == "a"
+        assert available[1][1].provider == "c"
+
+    def test_select_by_index(self):
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="a"),
+            FallbackEntry(provider="b"),
+        ])
+        assert chain.select_by_index(0).provider == "a"
+        assert chain.select_by_index(1).provider == "b"
+        assert chain.select_by_index(2) is None
+        assert chain.select_by_index(-1) is None
+
+    def test_reset(self):
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="a"),
+            FallbackEntry(provider="b"),
+        ])
+        chain.mark_failed(chain.entries[0])
+        chain.mark_failed(chain.entries[1])
+        assert chain.is_exhausted() is True
+        chain.reset()
+        assert chain.is_exhausted() is False
+        assert chain.next_available().provider == "a"
+
+
+# =============================================================================
+# select_auto
+# =============================================================================
+
+class TestSelectAuto:
+    def test_returns_first_available(self):
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="openrouter", model="claude-opus"),
+            FallbackEntry(provider="lmstudio", model="qwen3"),
+        ])
+        entry = select_auto(chain, "rate limited")
+        assert entry.provider == "openrouter"
+
+    def test_skips_exhausted(self):
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="openrouter"),
+            FallbackEntry(provider="lmstudio"),
+        ])
+        chain.mark_failed(chain.entries[0])
+        entry = select_auto(chain, "rate limited")
+        assert entry.provider == "lmstudio"
+
+    def test_returns_none_when_exhausted(self):
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="openrouter"),
+        ])
+        chain.mark_failed(chain.entries[0])
+        entry = select_auto(chain, "rate limited")
+        assert entry is None
+
+    def test_calls_notify_on_switch(self):
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="openrouter", model="claude"),
+        ])
+        notify = MagicMock()
+        entry = select_auto(chain, "error", notify=notify)
+        assert entry is not None
+        notify.assert_called_once()
+        call_msg = notify.call_args[0][0]
+        assert "openrouter" in call_msg.lower()
+
+    def test_calls_notify_on_exhaust(self):
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="openrouter"),
+        ])
+        chain.mark_failed(chain.entries[0])
+        notify = MagicMock()
+        select_auto(chain, "error", notify=notify)
+        notify.assert_called_once()
+        assert "exhausted" in notify.call_args[0][0].lower()
+
+
+# =============================================================================
+# should_trigger_fallback
+# =============================================================================
+
+class TestShouldTriggerFallback:
+    def test_rate_limit(self):
+        err = Exception("rate limit exceeded")
+        assert should_trigger_fallback(429, err) is True
+
+    def test_overload(self):
+        err = Exception("server overloaded")
+        assert should_trigger_fallback(529, err) is True
+
+    def test_service_unavailable(self):
+        err = Exception("service unavailable")
+        assert should_trigger_fallback(503, err) is True
+
+    def test_auth_error(self):
+        err = Exception("unauthorized")
+        assert should_trigger_fallback(401, err) is True
+
+    def test_bad_request_not_triggered(self):
+        err = Exception("invalid request")
+        assert should_trigger_fallback(400, err) is False
+
+    def test_connection_error(self):
+        class ConnectError(Exception):
+            pass
+        err = ConnectError("connection refused")
+        assert should_trigger_fallback(None, err) is True
+
+    def test_overloaded_in_message(self):
+        err = Exception("The server is overloaded right now")
+        assert should_trigger_fallback(None, err) is True
+
+    def test_generic_error_not_triggered(self):
+        err = Exception("something weird happened")
+        assert should_trigger_fallback(None, err) is False
+
+
+# =============================================================================
+# select_interactive (limited testing — mocking stdin)
+# =============================================================================
+
+class TestSelectInteractive:
+    def test_returns_none_when_exhausted(self):
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="openrouter"),
+        ])
+        chain.mark_failed(chain.entries[0])
+        result = select_interactive(chain, "error")
+        assert result is None
+
+    def test_auto_selects_on_non_tty(self):
+        """When stdin is not a tty, should auto-select after timeout."""
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="openrouter", model="claude"),
+        ], timeout=1)  # 1 second timeout for fast test
+
+        # Mock stdin to not be a tty
+        with patch.object(sys, "stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            entry = select_interactive(chain, "error")
+            assert entry is not None
+            assert entry.provider == "openrouter"
+
+    def test_user_selects_option(self):
+        """Simulate user typing '2' to select second option."""
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="openrouter", model="claude"),
+            FallbackEntry(provider="lmstudio", model="qwen3"),
+        ], timeout=30)
+
+        # Mock stdin as tty with select returning ready + user input "2"
+        mock_stdin = StringIO("2\n")
+        mock_stdin.isatty = lambda: True
+
+        with (
+            patch.object(sys, "stdin", mock_stdin),
+            patch("agent.fallback_chain.select.select", return_value=([mock_stdin], [], [])),
+        ):
+            entry = select_interactive(chain, "error")
+            assert entry is not None
+            assert entry.provider == "lmstudio"
+
+    def test_user_skips(self):
+        """Simulate user typing 's' to skip."""
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="openrouter"),
+        ], timeout=30)
+
+        mock_stdin = StringIO("s\n")
+        mock_stdin.isatty = lambda: True
+
+        with (
+            patch.object(sys, "stdin", mock_stdin),
+            patch("agent.fallback_chain.select.select", return_value=([mock_stdin], [], [])),
+        ):
+            entry = select_interactive(chain, "error")
+            assert entry is None
+
+
+# =============================================================================
+# Integration: config -> chain -> entry -> client kwargs
+# =============================================================================
+
+class TestIntegration:
+    def test_config_to_chain_to_kwargs(self):
+        """Full round-trip: config dict -> chain -> entry -> OpenAI client kwargs."""
+        config = {
+            "fallback": {
+                "mode": "auto",
+                "timeout": 10,
+                "chain": [
+                    {"provider": "openrouter", "model": "anthropic/claude-opus-4.6"},
+                    {
+                        "provider": "lmstudio",
+                        "base_url": "http://localhost:1234/v1",
+                        "model": "qwen3-30b-a3b",
+                    },
+                ],
+            }
+        }
+        chain = FallbackChain.from_config(config)
+
+        # First entry: openrouter
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-or-key"}):
+            entry1 = chain.next_available()
+            kwargs1 = entry1.build_client_kwargs()
+            assert "openrouter" in kwargs1["base_url"]
+            assert kwargs1["api_key"] == "sk-or-key"
+            assert "default_headers" in kwargs1
+
+        # Mark first as failed, get second
+        chain.mark_failed(entry1)
+        entry2 = chain.next_available()
+        kwargs2 = entry2.build_client_kwargs()
+        assert kwargs2["base_url"] == "http://localhost:1234/v1"
+        assert entry2.model == "qwen3-30b-a3b"
+        assert "default_headers" not in kwargs2  # Not openrouter
+
+        # Chain exhausted
+        chain.mark_failed(entry2)
+        assert chain.is_exhausted() is True
+        assert chain.next_available() is None
+
+    def test_multi_provider_cascade_auto(self):
+        """Auto mode cascades through entries without interaction."""
+        chain = FallbackChain(entries=[
+            FallbackEntry(provider="openrouter", model="claude"),
+            FallbackEntry(provider="lmstudio", model="qwen3"),
+            FallbackEntry(provider="ollama", model="llama3"),
+        ], mode="auto")
+
+        # First call -> openrouter
+        entry = select_auto(chain, "429 rate limited")
+        assert entry.provider == "openrouter"
+        chain.mark_failed(entry)
+
+        # Second call -> lmstudio
+        entry = select_auto(chain, "openrouter also failed")
+        assert entry.provider == "lmstudio"
+        chain.mark_failed(entry)
+
+        # Third call -> ollama
+        entry = select_auto(chain, "lmstudio down")
+        assert entry.provider == "ollama"
+        chain.mark_failed(entry)
+
+        # Exhausted
+        entry = select_auto(chain, "everything failed")
+        assert entry is None
+        assert chain.is_exhausted() is True

--- a/tests/test_fallback_chain.py
+++ b/tests/test_fallback_chain.py
@@ -14,6 +14,10 @@ from agent.fallback_chain import (
     select_interactive,
     should_trigger_fallback,
     FALLBACK_STATUS_CODES,
+    KNOWN_PROVIDERS,
+    LOCAL_PROVIDERS,
+    _infer_primary_provider,
+    _probe_local_endpoint,
 )
 
 
@@ -116,16 +120,15 @@ class TestFallbackChain:
         assert chain.entries[1].provider == "lmstudio"
 
     def test_build_legacy_chain_with_key(self):
-        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-or-key"}):
+        """Legacy method delegates to build_auto_chain."""
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-or-key"}, clear=True):
             chain = FallbackChain.build_legacy_chain("claude-opus-4-20250514")
             assert chain.has_fallbacks() is True
-            assert len(chain.entries) == 1
-            assert chain.entries[0].provider == "openrouter"
-            assert chain.entries[0].model == "anthropic/claude-opus-4-20250514"
-            assert chain.mode == "auto"  # Legacy mode = auto for backward compat
+            assert any(e.provider == "openrouter" for e in chain.entries)
+            assert chain.mode == "auto"
 
     def test_build_legacy_chain_without_key(self):
-        with patch.dict("os.environ", {"OPENROUTER_API_KEY": ""}):
+        with patch.dict("os.environ", {}, clear=True):
             chain = FallbackChain.build_legacy_chain("some-model")
             assert chain.has_fallbacks() is False
 
@@ -404,3 +407,162 @@ class TestIntegration:
         entry = select_auto(chain, "everything failed")
         assert entry is None
         assert chain.is_exhausted() is True
+
+
+# =============================================================================
+# _infer_primary_provider
+# =============================================================================
+
+class TestInferPrimaryProvider:
+    def test_direct_provider_match(self):
+        assert _infer_primary_provider("anthropic", "", "") == "anthropic"
+        assert _infer_primary_provider("openrouter", "", "") == "openrouter"
+        assert _infer_primary_provider("openai", "", "") == "openai"
+        assert _infer_primary_provider("Anthropic", "", "") == "anthropic"
+
+    def test_infer_from_model_claude(self):
+        assert _infer_primary_provider("", "claude-opus-4-20250514", "") == "anthropic"
+        assert _infer_primary_provider("", "anthropic/claude-opus-4.6", "") == "anthropic"
+
+    def test_infer_from_model_gpt(self):
+        assert _infer_primary_provider("", "gpt-4.1", "") == "openai"
+        assert _infer_primary_provider("", "o3-mini", "") == "openai"
+
+    def test_infer_from_model_gemini(self):
+        assert _infer_primary_provider("", "gemini-2.5-flash", "") == "gemini"
+
+    def test_infer_from_model_deepseek(self):
+        assert _infer_primary_provider("", "deepseek-chat", "") == "deepseek"
+
+    def test_infer_from_base_url(self):
+        assert _infer_primary_provider("", "", "https://openrouter.ai/api/v1") == "openrouter"
+        assert _infer_primary_provider("", "", "https://api.anthropic.com") == "anthropic"
+        assert _infer_primary_provider("", "", "https://api.openai.com/v1") == "openai"
+        assert _infer_primary_provider("", "", "http://localhost:1234/v1") == "lmstudio"
+        assert _infer_primary_provider("", "", "http://localhost:11434/v1") == "ollama"
+
+    def test_unknown_returns_empty(self):
+        assert _infer_primary_provider("", "", "") == ""
+        assert _infer_primary_provider("", "some-unknown-model", "") == ""
+
+    def test_provider_takes_priority(self):
+        """Provider string wins over model/URL inference."""
+        assert _infer_primary_provider("anthropic", "gpt-4", "https://openrouter.ai/api/v1") == "anthropic"
+
+
+# =============================================================================
+# build_auto_chain
+# =============================================================================
+
+class TestBuildAutoChain:
+    def test_empty_env(self):
+        """No API keys → empty chain."""
+        with patch.dict("os.environ", {}, clear=True):
+            chain = FallbackChain.build_auto_chain(primary_provider="anthropic")
+            assert chain.has_fallbacks() is False
+            assert len(chain.entries) == 0
+
+    def test_detects_openrouter(self):
+        """OpenRouter key detected, primary is anthropic."""
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-or-key"}, clear=True):
+            chain = FallbackChain.build_auto_chain(
+                primary_provider="anthropic",
+                primary_model="claude-opus-4-20250514",
+            )
+            assert chain.has_fallbacks() is True
+            assert chain.entries[0].provider == "openrouter"
+            # Should map claude model to OpenRouter format
+            assert "anthropic/" in chain.entries[0].model or "claude" in chain.entries[0].model
+
+    def test_excludes_primary_provider(self):
+        """Primary provider is excluded from chain."""
+        env = {
+            "OPENROUTER_API_KEY": "sk-or",
+            "ANTHROPIC_API_KEY": "sk-ant",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            chain = FallbackChain.build_auto_chain(primary_provider="anthropic")
+            providers = [e.provider for e in chain.entries]
+            assert "anthropic" not in providers
+            assert "openrouter" in providers
+
+    def test_excludes_primary_by_model_inference(self):
+        """Even without explicit provider, infers from model name."""
+        env = {
+            "OPENROUTER_API_KEY": "sk-or",
+            "ANTHROPIC_API_KEY": "sk-ant",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            chain = FallbackChain.build_auto_chain(primary_model="claude-opus-4-20250514")
+            providers = [e.provider for e in chain.entries]
+            assert "anthropic" not in providers
+            assert "openrouter" in providers
+
+    def test_multiple_providers(self):
+        """Multiple API keys → multi-entry chain in priority order."""
+        env = {
+            "OPENROUTER_API_KEY": "sk-or",
+            "DEEPSEEK_API_KEY": "sk-ds",
+            "GROQ_API_KEY": "sk-groq",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            chain = FallbackChain.build_auto_chain(primary_provider="anthropic")
+            providers = [e.provider for e in chain.entries]
+            assert "openrouter" in providers
+            assert "deepseek" in providers
+            assert "groq" in providers
+            # Priority order: openrouter before deepseek before groq
+            assert providers.index("openrouter") < providers.index("deepseek")
+            assert providers.index("deepseek") < providers.index("groq")
+
+    def test_openrouter_uses_primary_model(self):
+        """OpenRouter entry should proxy the primary model."""
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-or"}, clear=True):
+            chain = FallbackChain.build_auto_chain(
+                primary_provider="anthropic",
+                primary_model="claude-opus-4-20250514",
+            )
+            or_entry = chain.entries[0]
+            assert or_entry.provider == "openrouter"
+            assert or_entry.model == "anthropic/claude-opus-4-20250514"
+
+    def test_probes_local_providers(self):
+        """Local providers included if port is reachable."""
+        with patch.dict("os.environ", {}, clear=True):
+            with patch("agent.fallback_chain._probe_local_endpoint", return_value=True):
+                chain = FallbackChain.build_auto_chain(primary_provider="anthropic")
+                providers = [e.provider for e in chain.entries]
+                assert "lmstudio" in providers
+                assert "ollama" in providers
+
+    def test_local_providers_excluded_when_unreachable(self):
+        """Local providers not included if port probe fails."""
+        with patch.dict("os.environ", {}, clear=True):
+            with patch("agent.fallback_chain._probe_local_endpoint", return_value=False):
+                chain = FallbackChain.build_auto_chain(primary_provider="anthropic")
+                providers = [e.provider for e in chain.entries]
+                assert "lmstudio" not in providers
+                assert "ollama" not in providers
+
+    def test_all_providers_detected(self):
+        """All known cloud providers with keys get included."""
+        env = {
+            "OPENROUTER_API_KEY": "sk-or",
+            "ANTHROPIC_API_KEY": "sk-ant",
+            "OPENAI_API_KEY": "sk-oai",
+            "GEMINI_API_KEY": "sk-gem",
+            "DEEPSEEK_API_KEY": "sk-ds",
+            "TOGETHER_API_KEY": "sk-tog",
+            "GROQ_API_KEY": "sk-groq",
+            "FIREWORKS_API_KEY": "sk-fw",
+            "MISTRAL_API_KEY": "sk-mis",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            # Primary is "none" — all should be included
+            chain = FallbackChain.build_auto_chain(primary_provider="custom-local")
+            providers = [e.provider for e in chain.entries]
+            assert len(providers) == 9
+            assert set(providers) == {
+                "openrouter", "anthropic", "openai", "gemini",
+                "deepseek", "together", "groq", "fireworks", "mistral",
+            }

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -886,6 +886,9 @@ class TestRetryExhaustion:
     def test_api_error_raises_after_retries(self, agent):
         """Exhausted retries on API errors must raise, not fall through."""
         self._setup_agent(agent)
+        # Disable fallback chain so the error propagates after retries
+        from agent.fallback_chain import FallbackChain
+        agent._fallback_chain = FallbackChain(entries=[], mode="auto")
         agent.client.chat.completions.create.side_effect = RuntimeError("rate limited")
         with (
             patch.object(agent, "_persist_session"),

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -281,20 +281,21 @@ class TestMaskApiKey:
 
 class TestInit:
     def test_anthropic_base_url_accepted(self):
-        """Anthropic base URLs should be accepted (OpenAI-compatible endpoint)."""
+        """Anthropic base URLs should route to native Anthropic client."""
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
             patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI") as mock_openai,
+            patch("agent.anthropic_adapter.anthropic.Anthropic") as mock_anthropic,
         ):
-            AIAgent(
+            agent = AIAgent(
                 api_key="test-key-1234567890",
                 base_url="https://api.anthropic.com/v1/",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
             )
-            mock_openai.assert_called_once()
+            assert agent.api_mode == "anthropic_messages"
+            mock_anthropic.assert_called_once()
 
     def test_prompt_caching_claude_openrouter(self):
         """Claude model via OpenRouter should enable prompt caching."""


### PR DESCRIPTION
## Summary

Replaces the hardcoded Anthropic → OpenRouter one-shot fallback with a configurable, ordered chain of fallback providers. Works universally across any primary provider.

## Features

### Core Engine (`agent/fallback_chain.py`)
- `FallbackEntry` — provider config with API key resolution, client kwargs builder
- `FallbackChain` — ordered entries, exhaustion tracking, enabled toggle, config/legacy loading
- `select_interactive()` — CLI countdown prompt via clarify UI (prompt_toolkit-safe)
- `select_auto()` — silent cascade for gateway with async notify callback
- `should_trigger_fallback()` — detects 429/401/503/529 + connection errors

### Config (`~/.hermes/config.yaml`)
```yaml
fallback:
  enabled: true              # master toggle
  mode: interactive          # auto | interactive | off
  timeout: 30                # seconds before auto-select (interactive)
  chain:
    - provider: openrouter
      model: anthropic/claude-opus-4.6
    - provider: lmstudio
      base_url: http://localhost:1234/v1
      model: qwen3-30b-a3b
    - provider: ollama
      base_url: http://localhost:11434/v1
      model: llama3.1:70b
```

### CLI
- `hermes chat --fallback auto|interactive|off` — per-session override
- `/fallback` REPL command — show status, toggle mode at runtime
- Interactive selection uses clarify-style prompt_toolkit UI (arrow keys, Enter, countdown timer)
- Backward compatible: auto-builds legacy OpenRouter chain from env vars when no config

### Gateway (Telegram/Discord)
- Auto-cascade mode — silently switches through chain on failure
- Status messages sent to user chat: "🔄 Switching to lmstudio (qwen3-30b-a3b)..."
- Per-request chain isolation (no cross-request exhaustion bleed)
- `/fallback` command: show status, toggle auto/off/on/reset
- Async notify bridge: `run_coroutine_threadsafe()` from sync retry loop → async adapter.send()

### Universal Provider Support
- Triggers on ANY provider failure (429/401/503/529 + connection errors), not just Anthropic
- Works with OpenRouter, Anthropic, LM Studio, Ollama, or any OpenAI-compatible endpoint

## Architecture

```
run_agent.py retry loop
  → should_trigger_fallback(status_code, error)
  → _try_fallback_chain(error_msg)
    → CLI: fallback_selector callback → clarify UI → user picks
    → Gateway: select_auto() → next entry → notify callback → Telegram msg
    → _activate_fallback(entry) → swap client/model/provider
    → continue retry loop with new provider
```

## Note

The gateway `/fallback off|on|reset` command operates on the gateway-level chain template (shared across all users). Per-user fallback preferences would require session-store integration — a future enhancement if needed. This matches current gateway behavior for `/model` and `/personality`.

## Also includes

- **fix: adaptive thinking** — removed `budget_tokens` from `thinking.type="adaptive"` (Anthropic API rejects it)

## Tests

- 36 new tests in `test_fallback_chain.py` (entries, chain, config, selectors, integration)
- Updated `test_claude_code_auth.py` (7 tests rewritten for new chain API)
- Updated `test_commands.py` (added `/fallback` to expected set)
- 457 gateway + fallback tests pass, 0 regressions
