### PR TITLE
feat: bell_on_complete — terminal bell when agent finishes

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -635,3 +635,8 @@ display:
   #   verbose: Full args, results, and debug logs (same as /verbose)
   # Toggle at runtime with /verbose in the CLI
   tool_progress: all
+
+  # Play terminal bell when agent finishes a response.
+  # Useful for long-running tasks — your terminal will ding when the agent is done.
+  # Works over SSH. Most terminals can be configured to flash the taskbar or play a sound.
+  bell_on_complete: false

--- a/cli.py
+++ b/cli.py
@@ -1035,6 +1035,8 @@ class HermesCLI:
         self.tool_progress_mode = CLI_CONFIG["display"].get("tool_progress", "all")
         # resume_display: "full" (show history) | "minimal" (one-liner only)
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
+        # bell_on_complete: play terminal bell (\a) when agent finishes a response
+        self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         self.verbose = verbose if verbose is not None else (self.tool_progress_mode == "verbose")
         
         # Configuration - priority: CLI args > env vars > config file
@@ -3119,6 +3121,12 @@ class HermesCLI:
                 # Render box + response as a single _cprint call so
                 # nothing can interleave between the box borders.
                 _cprint(f"\n{top}\n{response}\n\n{bot}")
+            
+            # Play terminal bell when agent finishes (if enabled).
+            # Works over SSH — the bell propagates to the user's terminal.
+            if self.bell_on_complete:
+                sys.stdout.write("\a")
+                sys.stdout.flush()
             
             # Combine all interrupt messages (user may have typed multiple while waiting)
             # and re-queue as one prompt for process_loop

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -107,6 +107,7 @@ DEFAULT_CONFIG = {
         "compact": False,
         "personality": "kawaii",
         "resume_display": "full",  # "full" (show previous messages) | "minimal" (one-liner only)
+        "bell_on_complete": False,  # Play terminal bell (\a) when agent finishes a response
     },
     
     # Text-to-speech configuration

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -581,6 +581,7 @@ display:
   personality: "kawaii"  # Default personality for the CLI
   compact: false         # Compact output mode (less whitespace)
   resume_display: full   # full (show previous messages on resume) | minimal (one-liner only)
+  bell_on_complete: false  # Play terminal bell when agent finishes (great for long tasks)
 ```
 
 | Mode | What you see |


### PR DESCRIPTION
## Summary

Plays the terminal bell (`\a`) when the agent finishes a response. Useful for long-running tasks — switch to another window and your terminal dings when done.

**Default: off.** Enable with:

```yaml
# ~/.hermes/config.yaml
display:
  bell_on_complete: true
```

Or: `hermes config set display.bell_on_complete true`

## Why not a tool?

Replaces the approach in PR #320 (notification tool the agent calls). A config-driven bell is better because:
- **Always fires** — no relying on the agent to remember to call `notify`
- **Zero overhead** — no tool call, no token cost
- **Works over SSH** — bell propagates through the connection
- **Universal** — every terminal supports `\a` (audio bell, visual flash, taskbar highlight)

## Changes

- `cli.py`: Read `bell_on_complete` from config, fire `\a` after response box
- `hermes_cli/config.py`: Added to `DEFAULT_CONFIG`
- `cli-config.yaml.example`: Documented
- `website/docs/user-guide/configuration.md`: Added to Display Settings

## Test plan

1. `hermes config set display.bell_on_complete true`
2. Ask the agent something (e.g. `hermes chat -q 'hello'`)
3. Verify terminal bell fires after the response
4. Test over SSH to confirm bell propagates

Closes #318