### PR TITLE
fix: first-time setup skips API key prompts + install.sh sudo on WSL

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -882,7 +882,10 @@ def tools_command(args=None):
         # Show checklist
         new_enabled = _prompt_toolset_checklist(pinfo["label"], current_enabled)
 
-        if new_enabled != current_enabled:
+        # Detect first-time configuration (no saved toolsets for this platform yet)
+        is_first_config = pkey not in config.get("platform_toolsets", {})
+
+        if new_enabled != current_enabled or is_first_config:
             added = new_enabled - current_enabled
             removed = current_enabled - new_enabled
 
@@ -895,12 +898,28 @@ def tools_command(args=None):
                     label = next((l for k, l, _ in CONFIGURABLE_TOOLSETS if k == ts), ts)
                     print(color(f"  - {label}", Colors.RED))
 
-            # Configure newly enabled toolsets that need API keys
-            if added:
-                for ts_key in sorted(added):
-                    if TOOL_CATEGORIES.get(ts_key) or TOOLSET_ENV_REQUIREMENTS.get(ts_key):
-                        if not _toolset_has_keys(ts_key):
-                            _configure_toolset(ts_key, config)
+            # Determine which tools need API key configuration.
+            # On first-time setup, check ALL enabled tools (the defaults
+            # include everything, so "added" would be empty and no API key
+            # prompts would ever appear).  For returning users, only
+            # prompt for newly added tools.
+            tools_to_configure = new_enabled if is_first_config else added
+
+            unconfigured = [
+                ts_key for ts_key in sorted(tools_to_configure)
+                if (TOOL_CATEGORIES.get(ts_key) or TOOLSET_ENV_REQUIREMENTS.get(ts_key))
+                and not _toolset_has_keys(ts_key)
+            ]
+
+            if unconfigured:
+                print()
+                print(color(f"  {len(unconfigured)} tool(s) need API keys to be configured:", Colors.YELLOW))
+                for ts_key in unconfigured:
+                    label = next((l for k, l, _ in CONFIGURABLE_TOOLSETS if k == ts_key), ts_key)
+                    print(color(f"    • {label}", Colors.DIM))
+                print()
+                for ts_key in unconfigured:
+                    _configure_toolset(ts_key, config)
 
             _save_platform_tools(config, pkey, new_enabled)
             save_config(config)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -492,9 +492,23 @@ install_system_packages() {
                         return 0
                     fi
                 fi
+            elif [ -e /dev/tty ]; then
+                # Non-interactive (e.g. curl | bash) but a terminal is available.
+                # Read the prompt from /dev/tty (same approach the setup wizard uses).
+                echo ""
+                log_info "Installing ${description} requires sudo."
+                read -p "Install? [Y/n] " -n 1 -r < /dev/tty
+                echo
+                if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+                    if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a $install_cmd < /dev/tty; then
+                        [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
+                        [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+                        return 0
+                    fi
+                fi
             else
-                log_warn "Non-interactive mode: cannot prompt for sudo password"
-                log_info "Install missing packages manually: sudo $install_cmd"
+                log_warn "Non-interactive mode and no terminal available — cannot install system packages"
+                log_info "Install manually after setup completes: sudo $install_cmd"
             fi
         fi
     fi


### PR DESCRIPTION
## Summary

Two setup/install issues reported by a new user on WSL2/Ubuntu.

### Issue 1 (Critical): First-time tool setup never prompts for API keys

**Problem:** When running `hermes setup` or `hermes tools` for the first time (no existing `.env` or `config.yaml`), the tool checklist appears with almost all tools pre-selected (from the default `hermes-cli` toolset). After the user confirms the selection, setup finishes immediately without ever prompting for any API keys.

**Root cause:** `tools_command()` only configured API keys for *newly added* tools (`added = new_enabled - current_enabled`). But on first setup, `current_enabled` comes from the default toolset which already includes everything. So `added` is always empty → no prompts.

**Fix:** Detect first-time configuration (no `platform_toolsets` entry exists in config) and check ALL enabled tools for missing API keys. For returning users, only prompt for newly added tools (preserving the skip behavior).

### Issue 2: install.sh can't install ripgrep/ffmpeg on WSL via curl|bash

**Problem:** When running `curl -fsSL ... | bash`, the installer detects non-interactive mode and silently skips the ripgrep/ffmpeg install with a confusing message: 'Non-interactive mode: cannot prompt for sudo password'.

**Root cause:** The script already uses `< /dev/tty` for the setup wizard and build-tools prompts, but the system package section skipped this fallback entirely.

**Fix:** Try reading from `/dev/tty` when available (same pattern as the setup wizard). Only truly skip when no terminal exists at all (Docker build, CI).

## Test plan
- `python -m pytest tests/ -q` — all 2548 tests pass
- First-time setup now shows: '5 tool(s) need API keys to be configured' and walks through each one
- Returning users only see prompts for newly added tools