### PR TITLE
fix(config): unify max_turns config location (#634)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4005,7 +4005,7 @@ def main(
         provider: Inference provider ("auto", "openrouter", "nous", "openai-codex", "zai", "kimi-coding", "minimax", "minimax-cn")
         api_key: API key for authentication
         base_url: Base URL for the API
-        max_turns: Maximum tool-calling iterations (default: 60)
+        max_turns: Maximum tool-calling iterations (default: 90)
         verbose: Enable verbose logging
         compact: Use compact display mode
         list_tools: List available tools and exit

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -62,7 +62,11 @@ def ensure_hermes_home():
 DEFAULT_CONFIG = {
     "model": "anthropic/claude-opus-4.6",
     "toolsets": ["hermes-cli"],
-    "max_turns": 100,
+    
+    # Agent behavior settings
+    "agent": {
+        "max_turns": 90,  # Maximum tool-calling iterations per conversation
+    },
     
     "terminal": {
         "backend": "local",
@@ -166,7 +170,7 @@ DEFAULT_CONFIG = {
     "command_allowlist": [],
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 5,
+    "_config_version": 6,
 }
 
 # =============================================================================
@@ -611,6 +615,33 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 tz_display = config["timezone"] or "(server-local)"
                 print(f"  ✓ Added timezone to config.yaml: {tz_display}")
 
+    # ── Version 5 → 6: migrate root-level max_turns to agent.max_turns ──
+    if current_ver < 6:
+        config = load_config()
+        # Check if root-level max_turns exists and agent.max_turns doesn't
+        root_max_turns = config.get("max_turns")
+        agent_section = config.get("agent", {})
+        if not isinstance(agent_section, dict):
+            agent_section = {}
+        
+        if root_max_turns is not None and "max_turns" not in agent_section:
+            # Migrate root-level max_turns to agent.max_turns
+            if "agent" not in config:
+                config["agent"] = {}
+            config["agent"]["max_turns"] = root_max_turns
+            # Remove the root-level key
+            del config["max_turns"]
+            results["config_added"].append(f"agent.max_turns={root_max_turns} (migrated from root)")
+            save_config(config)
+            if not quiet:
+                print(f"  ✓ Migrated max_turns to agent.max_turns: {root_max_turns}")
+        elif root_max_turns is not None:
+            # Both exist, just remove root-level to avoid confusion
+            del config["max_turns"]
+            save_config(config)
+            if not quiet:
+                print(f"  ✓ Removed deprecated root-level max_turns (agent.max_turns already set)")
+
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")
     
@@ -908,7 +939,9 @@ def show_config():
     print()
     print(color("◆ Model", Colors.CYAN, Colors.BOLD))
     print(f"  Model:        {config.get('model', 'not set')}")
-    print(f"  Max turns:    {config.get('max_turns', 100)}")
+    agent_config = config.get('agent', {})
+    max_turns = agent_config.get('max_turns') or config.get('max_turns', 90)  # backwards compat
+    print(f"  Max turns:    {max_turns}")
     print(f"  Toolsets:     {', '.join(config.get('toolsets', ['all']))}")
     
     # Terminal

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1274,7 +1274,10 @@ def setup_agent_settings(config: dict):
         max_iter = int(max_iter_str)
         if max_iter > 0:
             save_env_value("HERMES_MAX_ITERATIONS", str(max_iter))
-            config['max_turns'] = max_iter
+            # Write to agent.max_turns (the canonical location)
+            if 'agent' not in config:
+                config['agent'] = {}
+            config['agent']['max_turns'] = max_iter
             print_success(f"Max iterations set to {max_iter}")
     except ValueError:
         print_warning("Invalid number, keeping current value")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -321,9 +321,27 @@ def delegate_task(
             )
         })
 
-    # Load config
+    # Load config — check delegation config first, then agent.max_turns, then env var
     cfg = _load_config()
-    default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
+    default_max_iter = cfg.get("max_iterations")
+    if default_max_iter is None:
+        # Try agent.max_turns from main config
+        try:
+            from cli import CLI_CONFIG
+            agent_cfg = CLI_CONFIG.get("agent", {})
+            default_max_iter = agent_cfg.get("max_turns")
+        except Exception:
+            pass
+    if default_max_iter is None:
+        # Check environment variable
+        env_max = os.getenv("HERMES_MAX_ITERATIONS")
+        if env_max:
+            try:
+                default_max_iter = int(env_max)
+            except ValueError:
+                pass
+    if default_max_iter is None:
+        default_max_iter = DEFAULT_MAX_ITERATIONS
     effective_max_iter = max_iterations or default_max_iter
 
     # Normalize to task list


### PR DESCRIPTION
## Summary

Fixes #634 — max_turns config has inconsistent defaults across modules.

## Changes

1. **Move max_turns to agent.max_turns** in DEFAULT_CONFIG (canonical location)
2. **Add migration v5→v6** to auto-migrate existing configs:
   - Copies root-level max_turns to agent.max_turns
   - Removes deprecated root-level key
3. **Update show_config()** to read from agent.max_turns with backwards compat
4. **Update setup.py** to write to agent.max_turns
5. **Update delegate_tool.py** to check agent.max_turns as fallback (priority: delegation config > agent.max_turns > env var > default)
6. **Fix cli.py docstring** (was 60, now 90)

## Config Structure

Before:
```yaml
max_turns: 100  # root level
```

After:
```yaml
agent:
  max_turns: 90  # canonical location
```

## Migration

Existing users with root-level max_turns will have it automatically migrated on next startup via the config version migration system.

## Testing

- [x] All modified files compile (py_compile)
- [x] Backwards compatibility maintained (reads root-level as fallback)
- [x] Migration preserves user's existing max_turns value