### PR TITLE
feat(subagent): add configurable subagent model/provider (#609)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -80,6 +80,18 @@ DEFAULT_CONFIG = {
         "summary_model": "google/gemini-3-flash-preview",
     },
     
+    # Subagent configuration — model/provider for tasks spawned via delegate_task
+    # By default subagents inherit the parent agent's model. Set these to use
+    # a different (potentially cheaper/faster) model for delegated tasks.
+    "subagent": {
+        # Provider for subagent model (optional — defaults to parent's provider)
+        # "provider": "openrouter",
+        
+        # Model to use for subagents (optional — defaults to parent's model)
+        # A fast/cheap model is recommended since subtasks are narrowly scoped
+        # "model": "google/gemini-3-flash-preview",
+    },
+    
     "display": {
         "compact": False,
         "personality": "kawaii",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -77,6 +77,15 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     return [t for t in toolsets if t not in blocked_toolset_names]
 
 
+def _get_subagent_config() -> Dict[str, Any]:
+    """Load subagent config from CLI_CONFIG if available."""
+    try:
+        from cli import CLI_CONFIG
+        return CLI_CONFIG.get("subagent", {})
+    except Exception:
+        return {}
+
+
 def _run_single_child(
     task_index: int,
     goal: str,
@@ -104,10 +113,21 @@ def _run_single_child(
         if hasattr(parent_agent, '_client_kwargs'):
             parent_api_key = parent_agent._client_kwargs.get("api_key")
 
+        # Load subagent config for model/provider overrides
+        # Precedence: explicit model arg > config.subagent.model > parent model
+        subagent_cfg = _get_subagent_config()
+        configured_model = subagent_cfg.get("model")
+        configured_provider = subagent_cfg.get("provider")
+        
+        # Determine effective model and provider
+        effective_model = model or configured_model or parent_agent.model
+        effective_provider = configured_provider or getattr(parent_agent, "provider", None)
+
         child = AIAgent(
             base_url=parent_agent.base_url,
             api_key=parent_api_key,
-            model=model or parent_agent.model,
+            model=effective_model,
+            provider=effective_provider,
             max_iterations=max_iterations,
             enabled_toolsets=child_toolsets,
             quiet_mode=True,


### PR DESCRIPTION
## Summary

Implements #609 — Allow configurable subagent model in config.yaml

## Changes

1. **Add `subagent` section to DEFAULT_CONFIG** with optional model/provider fields
2. **Update delegate_tool.py** to read from subagent config when spawning child agents

## Config Structure

```yaml
# config.yaml
subagent:
  # Provider for subagent model (optional — defaults to parent's provider)
  # provider: openrouter
  
  # Model to use for subagents spawned by delegate_task
  # A fast/cheap model is recommended since subtasks are narrowly scoped
  # model: google/gemini-3-flash-preview
```

## Precedence

1. Explicit model passed via tool call (highest)
2. `config.subagent.model`
3. Parent agent's model (inherit - current behavior)

This matches the existing pattern used by `compression.summary_model`.

## Use Cases

- **Cost savings**: Run main agent on Opus, delegate subtasks to Gemini Flash
- **Speed**: Use faster models for narrowly scoped subagent tasks
- **Provider flexibility**: Use different provider for subagents (e.g. main on Nous Portal, subagents on OpenRouter)

## Testing

- [x] All modified files compile (py_compile)
- [x] Backwards compatible (defaults to parent's model if not configured)