### PR TITLE
feat: add display.fullscreen config option for alternate screen mode (#639)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -655,3 +655,8 @@ display:
   # Useful for long-running tasks — your terminal will ding when the agent is done.
   # Works over SSH. Most terminals can be configured to flash the taskbar or play a sound.
   bell_on_complete: false
+
+  # Enter alternate screen buffer on launch, like vim or htop.
+  # Keeps the Hermes session visually separate from prior terminal history.
+  # On exit, the original terminal content is restored.
+  fullscreen: false

--- a/cli.py
+++ b/cli.py
@@ -195,6 +195,7 @@ def load_cli_config() -> Dict[str, Any]:
         "display": {
             "compact": False,
             "resume_display": "full",
+            "fullscreen": False,  # Enter alternate screen buffer on launch (like vim/htop)
         },
         "clarify": {
             "timeout": 120,  # Seconds to wait for a clarify answer before auto-proceeding
@@ -3866,11 +3867,12 @@ class HermesCLI:
         })
         
         # Create the application
+        _fullscreen = CLI_CONFIG.get("display", {}).get("fullscreen", False)
         app = Application(
             layout=layout,
             key_bindings=kb,
             style=style,
-            full_screen=False,
+            full_screen=_fullscreen,
             mouse_support=False,
         )
         self._app = app  # Store reference for clarify_callback

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -109,6 +109,7 @@ DEFAULT_CONFIG = {
         "personality": "kawaii",
         "resume_display": "full",  # "full" (show previous messages) | "minimal" (one-liner only)
         "bell_on_complete": False,  # Play terminal bell (\a) when agent finishes a response
+        "fullscreen": False,  # Enter alternate screen buffer on launch (like vim/htop)
     },
     
     # Text-to-speech configuration

--- a/tests/test_fullscreen_config.py
+++ b/tests/test_fullscreen_config.py
@@ -1,0 +1,34 @@
+"""Tests for display.fullscreen config option (issue #639)."""
+import pytest
+from unittest.mock import patch
+import cli as _cli_mod
+
+
+# ─── load_cli_config defaults ─────────────────────────────────────────────────
+
+class TestFullscreenDefault:
+    def test_default_is_false(self):
+        """fullscreen must default to False so existing behaviour is unchanged."""
+        from cli import load_cli_config
+        config = load_cli_config()
+        assert config.get("display", {}).get("fullscreen") is False
+
+    def test_default_config_has_fullscreen_key(self):
+        """The display section must contain a fullscreen key."""
+        from cli import load_cli_config
+        config = load_cli_config()
+        assert "fullscreen" in config.get("display", {})
+
+
+# ─── hermes_cli/config.py DEFAULT_CONFIG ──────────────────────────────────────
+
+class TestHermesConfigDefault:
+    def test_hermes_default_config_has_fullscreen(self):
+        from hermes_cli.config import load_config
+        config = load_config()
+        assert "fullscreen" in config.get("display", {})
+
+    def test_hermes_default_fullscreen_is_false(self):
+        from hermes_cli.config import load_config
+        config = load_config()
+        assert config["display"]["fullscreen"] is False


### PR DESCRIPTION
## Summary

Adds `display.fullscreen` config option that enters the terminal's alternate screen buffer on launch, keeping the Hermes session visually separate from prior terminal history. On exit, the original terminal content is restored automatically by prompt_toolkit.

## What Changed

### cli.py
- Read `display.fullscreen` from `CLI_CONFIG` at `Application()` creation
- Pass as `full_screen` parameter — prompt_toolkit handles enter/restore natively via the alternate screen sequence

### hermes_cli/config.py
- Add `display.fullscreen: False` to `DEFAULT_CONFIG`

### cli-config.yaml.example
- Document the new option under the `display` section

## Config

```yaml
display:
  fullscreen: true   # Enter alternate screen on launch (like vim/htop)
```

Defaults to `false` — no behaviour change for existing users.

## Implementation

prompt_toolkit's `Application(full_screen=True)` natively handles the alternate screen sequence. No new dependencies, ~3 lines of core logic.

## Test Results
- 4 new unit tests
- 2610 passed, 0 failed, 5 skipped

Closes #639