### PR TITLE
 Add tools summary flag to Hermes CLI

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2244,6 +2244,11 @@ For more help on a command:
         help="Configure which tools are enabled per platform",
         description="Interactive tool configuration — enable/disable tools for CLI, Telegram, Discord, etc."
     )
+    tools_parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print a summary of enabled tools per platform and exit"
+    )
 
     def cmd_tools(args):
         from hermes_cli.tools_config import tools_command

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -308,6 +308,22 @@ def _get_enabled_platforms() -> List[str]:
     return enabled
 
 
+def _platform_toolset_summary(config: dict, platforms: List[str] | None = None) -> Dict[str, Set[str]]:
+    """Return a summary of enabled toolsets per platform.
+
+    When ``platforms`` is None, this uses ``_get_enabled_platforms`` to
+    auto-detect platforms. Tests can pass an explicit list to avoid relying
+    on environment variables.
+    """
+    if platforms is None:
+        platforms = _get_enabled_platforms()
+
+    summary: Dict[str, Set[str]] = {}
+    for pkey in platforms:
+        summary[pkey] = _get_platform_tools(config, pkey)
+    return summary
+
+
 def _get_platform_tools(config: dict, platform: str) -> Set[str]:
     """Resolve which individual toolset names are enabled for a platform."""
     from toolsets import resolve_toolset, TOOLSETS
@@ -874,6 +890,24 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
     enabled_platforms = _get_enabled_platforms()
 
     print()
+
+    # Non-interactive summary mode for CLI usage
+    if getattr(args, "summary", False):
+        summary = _platform_toolset_summary(config, enabled_platforms)
+        for pkey in enabled_platforms:
+            pinfo = PLATFORMS[pkey]
+            enabled = summary.get(pkey, set())
+            if not enabled:
+                enabled_label = "none"
+            else:
+                labels = []
+                for ts_key in sorted(enabled):
+                    label = next((l for k, l, _ in CONFIGURABLE_TOOLSETS if k == ts_key), ts_key)
+                    labels.append(label)
+                enabled_label = ", ".join(labels)
+            print(color(f"- {pinfo['label']}: {enabled_label}", Colors.DIM))
+        print()
+        return
     print(color("⚕ Hermes Tool Configuration", Colors.CYAN, Colors.BOLD))
     print(color("  Enable or disable tools per platform.", Colors.DIM))
     print(color("  Tools that need API keys will be configured when enabled.", Colors.DIM))

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1,6 +1,6 @@
 """Tests for hermes_cli.tools_config platform tool persistence."""
 
-from hermes_cli.tools_config import _get_platform_tools
+from hermes_cli.tools_config import _get_platform_tools, _platform_toolset_summary
 
 
 def test_get_platform_tools_uses_default_when_platform_not_configured():
@@ -17,3 +17,12 @@ def test_get_platform_tools_preserves_explicit_empty_selection():
     enabled = _get_platform_tools(config, "cli")
 
     assert enabled == set()
+
+
+def test_platform_toolset_summary_uses_explicit_platform_list():
+    config = {}
+
+    summary = _platform_toolset_summary(config, platforms=["cli"])
+
+    assert set(summary.keys()) == {"cli"}
+    assert summary["cli"] == _get_platform_tools(config, "cli")


### PR DESCRIPTION
This PR adds a --summary flag to the hermes tools command, allowing users to quickly view which toolsets are enabled per platform without entering the interactive configurator