### PR TITLE
fix: unify visibility filter in codex model discovery

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -47,7 +47,7 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
         if item.get("supported_in_api") is False:
             continue
         visibility = item.get("visibility", "")
-        if isinstance(visibility, str) and visibility.strip().lower() == "hidden":
+        if isinstance(visibility, str) and visibility.strip().lower() in ("hide", "hidden"):
             continue
         priority = item.get("priority")
         rank = int(priority) if isinstance(priority, (int, float)) else 10_000
@@ -97,7 +97,7 @@ def _read_cache_models(codex_home: Path) -> List[str]:
             if item.get("supported_in_api") is False:
                 continue
             visibility = item.get("visibility")
-            if isinstance(visibility, str) and visibility.strip().lower() == "hidden":
+            if isinstance(visibility, str) and visibility.strip().lower() in ("hide", "hidden"):
                 continue
             priority = item.get("priority")
             rank = int(priority) if isinstance(priority, (int, float)) else 10_000


### PR DESCRIPTION
## Summary
- `_fetch_models_from_api()` filtered models with `visibility == "hide"` while `_read_cache_models()` filtered with `visibility == "hidden"`
- This mismatch means a model hidden by the API response could still appear when loaded from the local cache
- Both functions now accept either `"hide"` or `"hidden"` to ensure consistent behavior

## Test plan
- [x] Existing `tests/test_codex_models.py` passes (11/11)