### PR TITLE
fix: off-by-one in setup toggle selection error message

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -243,7 +243,7 @@ def prompt_checklist(title: str, items: list, pre_selected: list = None) -> list
                     else:
                         selected.add(idx)
                 else:
-                    print_error(f"Enter a number between 1 and {len(items) + 1}")
+                    print_error(f"Enter a number between 1 and {len(items)}")
             except ValueError:
                 print_error("Enter a number")
             except (KeyboardInterrupt, EOFError):


### PR DESCRIPTION
## Summary
- `_toggle_selection()` in setup.py displayed "Enter a number between 1 and N+1" for N items
- Entering the max displayed value (N+1) would be rejected since valid range is 1..N
- Fixed to show the correct max value: `len(items)` instead of `len(items) + 1`

## Test plan
- [x] Manual verification: 5 items now shows "between 1 and 5"