### PR TITLE
fix: replace blocking time.sleep with await asyncio.sleep in WhatsApp connect

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -181,8 +181,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
             
             # Kill any orphaned bridge from a previous gateway run
             _kill_port_process(self._bridge_port)
-            import time
-            time.sleep(1)
+            import asyncio
+            await asyncio.sleep(1)
             
             # Start the bridge process in its own process group.
             # Route output to a log file so QR codes, errors, and reconnection


### PR DESCRIPTION
## Summary
- `time.sleep(1)` inside `async def connect()` blocks the entire event loop for 1 second
- Replaced with `await asyncio.sleep(1)` to properly yield control back to the event loop
- The sleep waits for a killed port process to release, so non-blocking wait is sufficient

## Test plan
- [x] `tests/gateway/test_whatsapp_connect.py` passes (13/13)