### PR TITLE
fix: clean up empty file after failed wl-paste clipboard extraction

### DIFF
--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -254,6 +254,7 @@ def _wayland_save(dest: Path) -> bool:
             )
 
         if not dest.exists() or dest.stat().st_size == 0:
+            dest.unlink(missing_ok=True)
             return False
 
         # BMP needs conversion to PNG (common in WSLg where only BMP


### PR DESCRIPTION
## Summary
- When `wl-paste` produces empty output, the destination file was left on disk as a 0-byte orphan
- Added `dest.unlink(missing_ok=True)` before returning `False` to clean up the empty file

## Test plan
- [x] Code review: single-line addition, clean up path matches existing pattern at line 270