### PR TITLE
feat: telegram streaming with dual-transport (draft + edit fallback)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -344,6 +344,7 @@ class BasePlatformAdapter(ABC):
         # Key: session_key (e.g., chat_id), Value: (event, asyncio.Event for interrupt)
         self._active_sessions: Dict[str, asyncio.Event] = {}
         self._pending_messages: Dict[str, MessageEvent] = {}
+        self._stream_msg_ids: Dict[str, str] = {}  # chat_id -> msg_id of streamed response
     
     @property
     def name(self) -> str:
@@ -412,6 +413,32 @@ class BasePlatformAdapter(ABC):
         sending a new message.
         """
         return SendResult(success=False, error="Not supported")
+
+    @property
+    def supports_streaming(self) -> bool:
+        """Whether this platform supports response streaming via message edits.
+
+        Platforms that return True must also implement edit_message() and
+        delete_message().  The gateway will stream LLM text chunks by
+        sending an initial message and progressively editing it.
+        """
+        return False
+
+    async def delete_message(self, chat_id: str, message_id: str) -> SendResult:
+        """Delete a previously sent message.
+
+        Used to clean up transient progress messages when streaming starts.
+        Override in subclasses if the platform supports message deletion.
+        """
+        return SendResult(success=False, error="Not supported")
+
+    async def send_raw(self, chat_id: str, content: str) -> "SendResult":
+        """Send without formatting (default: delegates to send)."""
+        return await self.send(chat_id=chat_id, content=content)
+
+    async def edit_message_raw(self, chat_id: str, message_id: str, content: str) -> "SendResult":
+        """Edit without formatting (default: delegates to edit_message)."""
+        return await self.edit_message(chat_id=chat_id, message_id=message_id, content=content)
 
     async def send_typing(self, chat_id: str) -> None:
         """
@@ -707,25 +734,39 @@ class BasePlatformAdapter(ABC):
                 
                 # Send the text portion first (if any remains after extractions)
                 if text_content:
-                    logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
-                    result = await self.send(
-                        chat_id=event.source.chat_id,
-                        content=text_content,
-                        reply_to=event.message_id
-                    )
-                    
-                    # Log send failures (don't raise - user already saw tool progress)
-                    if not result.success:
-                        print(f"[{self.name}] Failed to send response: {result.error}")
-                        # Try sending without markdown as fallback
-                        fallback_result = await self.send(
+                    # Check if streaming already delivered the text via edits.
+                    # If so, do a final formatted edit instead of a duplicate send.
+                    _stream_mid = self._stream_msg_ids.pop(event.source.chat_id, None)
+                    if _stream_mid:
+                        logger.info("[%s] Streaming delivered response, final edit on msg %s", self.name, _stream_mid)
+                        try:
+                            await self.edit_message(
+                                chat_id=event.source.chat_id,
+                                message_id=_stream_mid,
+                                content=text_content,
+                            )
+                        except Exception as _e:
+                            logger.debug("[%s] Final stream edit failed: %s", self.name, _e)
+                    else:
+                        logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
+                        result = await self.send(
                             chat_id=event.source.chat_id,
-                            content=f"(Response formatting failed, plain text:)\n\n{text_content[:3500]}",
+                            content=text_content,
                             reply_to=event.message_id
                         )
-                        if not fallback_result.success:
-                            print(f"[{self.name}] Fallback send also failed: {fallback_result.error}")
-                
+                        
+                        # Log send failures (don't raise - user already saw tool progress)
+                        if not result.success:
+                            print(f"[{self.name}] Failed to send response: {result.error}")
+                            # Try sending without markdown as fallback
+                            fallback_result = await self.send(
+                                chat_id=event.source.chat_id,
+                                content=f"(Response formatting failed, plain text:)\n\n{text_content[:3500]}",
+                                reply_to=event.message_id
+                            )
+                            if not fallback_result.success:
+                                print(f"[{self.name}] Fallback send also failed: {fallback_result.error}")
+
                 # Human-like pacing delay between text and media
                 human_delay = self._get_human_delay()
                 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -424,6 +424,25 @@ class BasePlatformAdapter(ABC):
         """
         return False
 
+
+    @property
+    def supports_draft_streaming(self) -> bool:
+        """Whether this platform supports native draft streaming (Bot API 9.3+).
+
+        Platforms that return True must implement send_draft() and
+        finalize_draft().  The gateway tries draft transport first and
+        falls back to edit-based streaming on failure.
+        """
+        return False
+
+    async def send_draft(self, chat_id: str, draft_id: int, text: str) -> bool:
+        """Push a draft text update.  Override in subclasses."""
+        return False
+
+    async def finalize_draft(self, chat_id: str, content: str) -> "SendResult":
+        """Finalize a draft stream with the completed message."""
+        return SendResult(success=False, error="Not supported")
+
     async def delete_message(self, chat_id: str, message_id: str) -> SendResult:
         """Delete a previously sent message.
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -329,6 +329,75 @@ class TelegramAdapter(BasePlatformAdapter):
     def supports_streaming(self) -> bool:
         return True
 
+
+    @property
+    def supports_draft_streaming(self) -> bool:
+        """Whether this adapter supports Telegram Bot API sendMessageDraft.
+
+        Draft streaming (Bot API 9.3+) pushes partial text to the client
+        natively without message edits.  The client animates incremental
+        updates for the same ``draft_id``, producing a smoother experience
+        than edit-based streaming and avoiding edit rate limits entirely.
+        """
+        return True
+
+    async def send_draft(
+        self,
+        chat_id: str,
+        draft_id: int,
+        text: str,
+    ) -> bool:
+        """Push a draft update via sendMessageDraft (Bot API 9.3+).
+
+        Each call with the same ``draft_id`` animates the growing text on
+        the client.  Returns True on success, False on failure (caller
+        should fall back to edit-based streaming).
+        """
+        if not self._bot:
+            return False
+        try:
+            return await self._bot.send_message_draft(
+                chat_id=int(chat_id),
+                draft_id=draft_id,
+                text=text,
+                parse_mode=None,  # raw text during streaming, same as edit path
+            )
+        except Exception as e:
+            logger.warning("[%s] send_message_draft failed: %s", self.name, e)
+            return False
+
+    async def finalize_draft(
+        self,
+        chat_id: str,
+        content: str,
+    ) -> SendResult:
+        """Finalize a draft stream by sending the completed message.
+
+        After the last ``send_draft`` call, this sends a persistent
+        ``sendMessage`` with full MarkdownV2 formatting.  The draft
+        bubble is automatically replaced by the final message on the client.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            formatted = self.format_message(content)
+            try:
+                msg = await self._bot.send_message(
+                    chat_id=int(chat_id),
+                    text=formatted,
+                    parse_mode=ParseMode.MARKDOWN_V2,
+                )
+            except Exception as fmt_err:
+                logger.debug("[%s] finalize_draft markdown failed, using plain text: %s", self.name, fmt_err)
+                msg = await self._bot.send_message(
+                    chat_id=int(chat_id),
+                    text=content,
+                    parse_mode=None,
+                )
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
     async def delete_message(self, chat_id: str, message_id: str) -> SendResult:
         """Delete a Telegram message (used to remove progress indicators)."""
         if not self._bot:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -280,6 +280,68 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
+    async def send_raw(
+        self,
+        chat_id: str,
+        content: str,
+    ) -> SendResult:
+        """Send a plain-text message without MarkdownV2 formatting.
+
+        Used for streaming intermediate updates where the content is
+        incomplete markdown that would fail MarkdownV2 parsing.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            msg = await self._bot.send_message(
+                chat_id=int(chat_id),
+                text=content,
+                parse_mode=None,
+            )
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def edit_message_raw(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+    ) -> SendResult:
+        """Edit a message with plain text (no MarkdownV2 formatting).
+
+        Used for streaming intermediate updates.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            await self._bot.edit_message_text(
+                chat_id=int(chat_id),
+                message_id=int(message_id),
+                text=content,
+                parse_mode=None,
+            )
+            return SendResult(success=True, message_id=message_id)
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    @property
+    def supports_streaming(self) -> bool:
+        return True
+
+    async def delete_message(self, chat_id: str, message_id: str) -> SendResult:
+        """Delete a Telegram message (used to remove progress indicators)."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            await self._bot.delete_message(
+                chat_id=int(chat_id), message_id=int(message_id),
+            )
+            return SendResult(success=True, message_id=message_id)
+        except Exception as e:
+            logger.debug("Failed to delete message %s in %s: %s", message_id, chat_id, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_voice(
         self,
         chat_id: str,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2478,6 +2478,7 @@ class GatewayRunner:
         _stream_edit_interval = float(_streaming_cfg.get("edit_interval", 1.5))
         _stream_buffer_threshold = int(_streaming_cfg.get("buffer_threshold", 300))
         _stream_cursor = str(_streaming_cfg.get("cursor", " ▉"))
+        _stream_transport = str(_streaming_cfg.get("transport", "auto"))  # "auto", "draft", "edit"
 
         # Queue for streaming text chunks (thread-safe, sync -> async bridge)
         stream_queue = queue.Queue() if streaming_enabled else None
@@ -2645,7 +2646,20 @@ class GatewayRunner:
         # and progressively edits a Telegram message.
 
         async def send_stream_messages():
-            """Consume LLM text chunks and display them via progressive edits."""
+            """Consume LLM text chunks and display them via progressive edits.
+
+            Supports two transport modes controlled by ``streaming.transport``:
+
+            - **draft** (Bot API 9.3+): calls ``sendMessageDraft`` with a
+              stable ``draft_id`` for each chunk.  The Telegram client
+              animates the growing text natively -- no message edits, no
+              edit rate-limit pressure.  Finalized with a regular
+              ``sendMessage`` once the response is complete.
+            - **edit**: the original approach -- sends an initial plain-text
+              message, then progressively ``editMessageText`` on a timer.
+            - **auto** (default): tries draft first; on any failure falls
+              back to edit for the remainder of the stream.
+            """
             if not stream_queue:
                 return
 
@@ -2665,7 +2679,22 @@ class GatewayRunner:
             chunk_count = 0
             edit_count = 0
 
-            logger.debug("[stream] consumer started, interval=%ss, threshold=%s", _stream_edit_interval, _stream_buffer_threshold)
+            # -- Transport negotiation --
+            # Decide whether to attempt draft streaming.  "auto" tries
+            # draft first and falls back to edit on failure.  "draft"
+            # forces draft-only (no fallback).  "edit" skips draft
+            # entirely (original behaviour).
+            use_draft = (
+                _stream_transport in ("auto", "draft")
+                and getattr(adapter, "supports_draft_streaming", False)
+            )
+            draft_failed = False  # set True on first draft error -> fall back to edit
+            _draft_id = int.from_bytes(os.urandom(4), "big") >> 1 | 1 if use_draft else 0
+
+            logger.debug(
+                "[stream] consumer started, transport=%s, use_draft=%s, draft_id=%s, interval=%ss, threshold=%s",
+                _stream_transport, use_draft, _draft_id, _stream_edit_interval, _stream_buffer_threshold,
+            )
 
             while not is_complete:
                 # Drain ALL available chunks from queue at once
@@ -2692,9 +2721,83 @@ class GatewayRunner:
                 now = time.time()
                 elapsed = now - last_edit_time
 
-                # Decide whether to edit now
+                # -- Draft transport path --
+                if use_draft and not draft_failed:
+                    # Draft updates can be pushed at higher frequency than
+                    # edits because they bypass the editMessageText rate
+                    # limit.  Throttle slightly to avoid flooding the wire.
+                    should_push = (
+                        is_complete
+                        or elapsed >= 0.15  # ~6-7 pushes/sec max
+                        or len(stream_buffer) >= _stream_buffer_threshold
+                    )
+                    if not should_push:
+                        continue
+
+                    try:
+                        # Delete tool progress message on first push
+                        if edit_count == 0:
+                            pmid = progress_msg_id_holder[0]
+                            if pmid:
+                                try:
+                                    await adapter.delete_message(source.chat_id, pmid)
+                                except Exception:
+                                    pass
+                                progress_msg_id_holder[0] = None
+
+                        if is_complete:
+                            # Final push: send the finished message with formatting
+                            result = await adapter.finalize_draft(
+                                chat_id=source.chat_id,
+                                content=stream_buffer,
+                            )
+                            if result.success and result.message_id:
+                                stream_msg_id = result.message_id
+                                edit_count += 1
+                                logger.debug("[stream/draft] finalized: id=%s", stream_msg_id)
+                            else:
+                                logger.warning("[stream/draft] finalize failed: %s", result.error)
+                                draft_failed = True
+                        else:
+                            display = stream_buffer + _stream_cursor
+                            ok = await adapter.send_draft(
+                                chat_id=source.chat_id,
+                                draft_id=_draft_id,
+                                text=display,
+                            )
+                            if ok:
+                                edit_count += 1
+                                last_edit_time = time.time()
+                            else:
+                                logger.warning("[stream/draft] send_draft returned False, falling back to edit")
+                                draft_failed = True
+
+                    except asyncio.CancelledError:
+                        try:
+                            await adapter.finalize_draft(
+                                chat_id=source.chat_id,
+                                content=stream_buffer,
+                            )
+                        except Exception as _cancel_err:
+                            logger.debug("[stream/draft] finalize on cancel failed: %s", _cancel_err)
+                        stream_msg_holder[0] = stream_msg_id
+                        logger.debug("[stream/draft] cancelled. %d chars, %d pushes", len(stream_buffer), edit_count)
+                        return
+                    except Exception as e:
+                        logger.warning("[stream/draft] unexpected error, falling back to edit: %s", e)
+                        draft_failed = True
+
+                    if not draft_failed:
+                        continue  # draft push succeeded, loop for next chunk
+
+                    # Draft failed -- fall through to edit path.
+                    logger.info("[stream] draft->edit fallback at %d chars, %d chunks", len(stream_buffer), chunk_count)
+                    # Reset edit timer so the edit path fires immediately on
+                    # this iteration instead of waiting for the next interval.
+                    last_edit_time = 0
+
+                # -- Edit transport path (original) --
                 if stream_msg_id is None:
-                    # First message: send as soon as we have any text
                     should_edit = len(stream_buffer.strip()) >= 5 or is_complete
                 else:
                     should_edit = (
@@ -2708,7 +2811,6 @@ class GatewayRunner:
 
                 try:
                     if stream_msg_id is None:
-                        # Delete tool progress message
                         pmid = progress_msg_id_holder[0]
                         if pmid:
                             try:
@@ -2718,7 +2820,7 @@ class GatewayRunner:
                             progress_msg_id_holder[0] = None
 
                         display = stream_buffer if is_complete else stream_buffer + _stream_cursor
-                        logger.debug("[stream] sending first msg (%d chars, %d chunks)", len(stream_buffer), chunk_count)
+                        logger.debug("[stream/edit] sending first msg (%d chars, %d chunks)", len(stream_buffer), chunk_count)
                         result = await adapter.send_raw(
                             chat_id=source.chat_id,
                             content=display,
@@ -2726,9 +2828,9 @@ class GatewayRunner:
                         if result.success and result.message_id:
                             stream_msg_id = result.message_id
                             edit_count += 1
-                            logger.debug("[stream] first msg sent: id=%s", stream_msg_id)
+                            logger.debug("[stream/edit] first msg sent: id=%s", stream_msg_id)
                         else:
-                            logger.warning("[stream] first msg failed: %s", result.error)
+                            logger.warning("[stream/edit] first msg failed: %s", result.error)
                     else:
                         display = stream_buffer if is_complete else stream_buffer + _stream_cursor
                         try:
@@ -2739,7 +2841,7 @@ class GatewayRunner:
                             )
                             edit_count += 1
                         except Exception as e:
-                            logger.debug("[stream] edit failed (non-fatal): %s", e)
+                            logger.debug("[stream/edit] edit failed (non-fatal): %s", e)
 
                     last_edit_time = time.time()
 
@@ -2754,10 +2856,11 @@ class GatewayRunner:
                         except Exception:
                             pass
                     stream_msg_holder[0] = stream_msg_id
-                    logger.debug("[stream] cancelled. %d chars, %d edits", len(stream_buffer), edit_count)
+                    logger.debug("[stream/edit] cancelled. %d chars, %d edits", len(stream_buffer), edit_count)
                     return
 
-            logger.debug("[stream] done. %d chars, %d chunks, %d edits", len(stream_buffer), chunk_count, edit_count)
+            transport_used = "draft" if (use_draft and not draft_failed) else "edit"
+            logger.debug("[stream] done. transport=%s, %d chars, %d chunks, %d updates", transport_used, len(stream_buffer), chunk_count, edit_count)
             stream_msg_holder[0] = stream_msg_id
 
         # We need to share the agent instance for interrupt support

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20,6 +20,7 @@ import re
 import sys
 import signal
 import threading
+import time
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from datetime import datetime
@@ -1213,6 +1214,15 @@ class GatewayRunner:
             
             response = agent_result.get("final_response", "")
             agent_messages = agent_result.get("messages", [])
+
+            # If streaming delivered the response, store the message ID on the
+            # adapter so _process_message_background can do a final formatted
+            # edit instead of sending a duplicate message.
+            _smid = agent_result.get("stream_msg_id")
+            if _smid:
+                adapter = self.adapters.get(source.platform)
+                if adapter and hasattr(adapter, '_stream_msg_ids'):
+                    adapter._stream_msg_ids[source.chat_id] = _smid
             
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
@@ -2450,6 +2460,34 @@ class GatewayRunner:
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if tool_progress_enabled else None
         last_tool = [None]  # Mutable container for tracking in closure
+
+        # ── Streaming config ──────────────────────────────────────────
+        # Read from config.yaml: streaming.enabled (default false)
+        _streaming_cfg = {}
+        try:
+            _s_cfg_path = _hermes_home / "config.yaml"
+            if _s_cfg_path.exists():
+                import yaml as _s_yaml
+                with open(_s_cfg_path) as _s_f:
+                    _s_data = _s_yaml.safe_load(_s_f) or {}
+                _streaming_cfg = _s_data.get("streaming", {})
+        except Exception:
+            pass
+
+        streaming_enabled = bool(_streaming_cfg.get("enabled", False))
+        _stream_edit_interval = float(_streaming_cfg.get("edit_interval", 1.5))
+        _stream_buffer_threshold = int(_streaming_cfg.get("buffer_threshold", 300))
+        _stream_cursor = str(_streaming_cfg.get("cursor", " ▉"))
+
+        # Queue for streaming text chunks (thread-safe, sync -> async bridge)
+        stream_queue = queue.Queue() if streaming_enabled else None
+        stream_msg_holder = [None]  # Holds the Telegram message ID of the stream
+
+        def stream_callback_sync(chunk: str, is_done: bool):
+            """Called from the agent thread with LLM text chunks."""
+            if stream_queue is not None:
+                stream_queue.put((chunk, is_done))
+
         
         def progress_callback(tool_name: str, preview: str = None, args: dict = None):
             """Callback invoked by agent when a tool is called."""
@@ -2524,6 +2562,10 @@ class GatewayRunner:
             
             progress_queue.put(msg)
         
+        # Shared between progress and stream consumers so that the
+        # stream consumer can delete the progress message when streaming starts.
+        progress_msg_id_holder = [None]
+
         # Background task to send progress messages
         # Accumulates tool lines into a single message that gets edited
         async def send_progress_messages():
@@ -2566,6 +2608,7 @@ class GatewayRunner:
                             result = await adapter.send(chat_id=source.chat_id, content=msg)
                         if result.success and result.message_id:
                             progress_msg_id = result.message_id
+                            progress_msg_id_holder[0] = progress_msg_id
 
                     # Restore typing indicator
                     await asyncio.sleep(0.3)
@@ -2597,6 +2640,126 @@ class GatewayRunner:
                     logger.error("Progress message error: %s", e)
                     await asyncio.sleep(1)
         
+        # ── Streaming consumer ─────────────────────────────────────
+        # Reads text chunks from stream_queue (fed by the agent thread)
+        # and progressively edits a Telegram message.
+
+        async def send_stream_messages():
+            """Consume LLM text chunks and display them via progressive edits."""
+            if not stream_queue:
+                return
+
+            adapter = self.adapters.get(source.platform)
+            if not adapter or not adapter.supports_streaming:
+                while True:
+                    try:
+                        stream_queue.get_nowait()
+                    except Exception:
+                        break
+                return
+
+            stream_buffer = ""
+            stream_msg_id = None
+            last_edit_time = time.time()
+            is_complete = False
+            chunk_count = 0
+            edit_count = 0
+
+            logger.debug("[stream] consumer started, interval=%ss, threshold=%s", _stream_edit_interval, _stream_buffer_threshold)
+
+            while not is_complete:
+                # Drain ALL available chunks from queue at once
+                got_any = False
+                while True:
+                    try:
+                        chunk, is_done = stream_queue.get_nowait()
+                        stream_buffer += chunk
+                        chunk_count += 1
+                        got_any = True
+                        if is_done:
+                            is_complete = True
+                            break
+                    except queue.Empty:
+                        break
+
+                if not got_any:
+                    await asyncio.sleep(0.05)
+                    continue
+
+                if not stream_buffer.strip():
+                    continue
+
+                now = time.time()
+                elapsed = now - last_edit_time
+
+                # Decide whether to edit now
+                if stream_msg_id is None:
+                    # First message: send as soon as we have any text
+                    should_edit = len(stream_buffer.strip()) >= 5 or is_complete
+                else:
+                    should_edit = (
+                        is_complete
+                        or len(stream_buffer) >= _stream_buffer_threshold
+                        or elapsed >= _stream_edit_interval
+                    )
+
+                if not should_edit:
+                    continue
+
+                try:
+                    if stream_msg_id is None:
+                        # Delete tool progress message
+                        pmid = progress_msg_id_holder[0]
+                        if pmid:
+                            try:
+                                await adapter.delete_message(source.chat_id, pmid)
+                            except Exception:
+                                pass
+                            progress_msg_id_holder[0] = None
+
+                        display = stream_buffer if is_complete else stream_buffer + _stream_cursor
+                        logger.debug("[stream] sending first msg (%d chars, %d chunks)", len(stream_buffer), chunk_count)
+                        result = await adapter.send_raw(
+                            chat_id=source.chat_id,
+                            content=display,
+                        )
+                        if result.success and result.message_id:
+                            stream_msg_id = result.message_id
+                            edit_count += 1
+                            logger.debug("[stream] first msg sent: id=%s", stream_msg_id)
+                        else:
+                            logger.warning("[stream] first msg failed: %s", result.error)
+                    else:
+                        display = stream_buffer if is_complete else stream_buffer + _stream_cursor
+                        try:
+                            await adapter.edit_message_raw(
+                                chat_id=source.chat_id,
+                                message_id=stream_msg_id,
+                                content=display,
+                            )
+                            edit_count += 1
+                        except Exception as e:
+                            logger.debug("[stream] edit failed (non-fatal): %s", e)
+
+                    last_edit_time = time.time()
+
+                except asyncio.CancelledError:
+                    if stream_msg_id and stream_buffer.strip():
+                        try:
+                            await adapter.edit_message_raw(
+                                chat_id=source.chat_id,
+                                message_id=stream_msg_id,
+                                content=stream_buffer,
+                            )
+                        except Exception:
+                            pass
+                    stream_msg_holder[0] = stream_msg_id
+                    logger.debug("[stream] cancelled. %d chars, %d edits", len(stream_buffer), edit_count)
+                    return
+
+            logger.debug("[stream] done. %d chars, %d chunks, %d edits", len(stream_buffer), chunk_count, edit_count)
+            stream_msg_holder[0] = stream_msg_id
+
         # We need to share the agent instance for interrupt support
         agent_holder = [None]  # Mutable container for the agent instance
         result_holder = [None]  # Mutable container for the result
@@ -2759,7 +2922,7 @@ class GatewayRunner:
                             if _p:
                                 _history_media_paths.add(_p)
             
-            result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+            result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id, stream_callback=stream_callback_sync if stream_queue else None)
             result_holder[0] = result
             
             # Return final response, or a message if something went wrong
@@ -2821,6 +2984,11 @@ class GatewayRunner:
         progress_task = None
         if tool_progress_enabled:
             progress_task = asyncio.create_task(send_progress_messages())
+
+        # Start streaming consumer if enabled
+        stream_task = None
+        if streaming_enabled:
+            stream_task = asyncio.create_task(send_stream_messages())
         
         # Track this agent as running for this session (for interrupt support)
         # We do this in a callback after the agent is created
@@ -2858,6 +3026,18 @@ class GatewayRunner:
             # Run in thread pool to not block
             loop = asyncio.get_event_loop()
             response = await loop.run_in_executor(None, run_sync)
+
+            # Give the stream consumer a moment to process the final chunk
+            # (the is_done=True signal) before we proceed.
+            if stream_task and not stream_task.done():
+                try:
+                    await asyncio.wait_for(stream_task, timeout=3.0)
+                except (asyncio.TimeoutError, asyncio.CancelledError):
+                    pass
+
+            # Attach streaming message ID so base.py can skip duplicate send
+            if stream_msg_holder[0] and response:
+                response["stream_msg_id"] = stream_msg_holder[0]
             
             # Check if we were interrupted and have a pending message
             result = result_holder[0]
@@ -2896,9 +3076,11 @@ class GatewayRunner:
                     session_key=session_key
                 )
         finally:
-            # Stop progress sender and interrupt monitor
+            # Stop progress sender, stream consumer, and interrupt monitor
             if progress_task:
                 progress_task.cancel()
+            if stream_task:
+                stream_task.cancel()
             interrupt_monitor.cancel()
             
             # Clean up tracking
@@ -2907,7 +3089,7 @@ class GatewayRunner:
                 del self._running_agents[session_key]
             
             # Wait for cancelled tasks
-            for task in [progress_task, interrupt_monitor, tracking_task]:
+            for task in [progress_task, stream_task, interrupt_monitor, tracking_task]:
                 if task:
                     try:
                         await task

--- a/run_agent.py
+++ b/run_agent.py
@@ -33,7 +33,7 @@ import time
 import threading
 from types import SimpleNamespace
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import Callable, List, Dict, Any, Optional
 from openai import OpenAI
 import fire
 from datetime import datetime
@@ -1973,15 +1973,40 @@ class AIAgent:
             finish_reason = "stop"
         return assistant_message, finish_reason
 
-    def _run_codex_stream(self, api_kwargs: dict):
-        """Execute one streaming Responses API request and return the final response."""
+    def _run_codex_stream(self, api_kwargs: dict, stream_callback=None):
+        """Execute one streaming Responses API request and return the final response.
+        
+        If stream_callback is provided, text delta events are forwarded to the
+        caller in real time.  The callback is suppressed when the response
+        contains tool calls (intermediate turn, not the final answer).
+        """
         max_stream_retries = 1
         for attempt in range(max_stream_retries + 1):
             try:
                 with self.client.responses.stream(**api_kwargs) as stream:
-                    for _ in stream:
-                        pass
-                    return stream.get_final_response()
+                    _has_tool_calls = False
+                    for event in stream:
+                        if not stream_callback:
+                            continue
+                        etype = getattr(event, "type", None)
+                        if etype == "response.output_text.delta":
+                            delta = getattr(event, "delta", "")
+                            if delta and not _has_tool_calls:
+                                try:
+                                    stream_callback(delta, False)
+                                except Exception:
+                                    pass
+                        elif etype == "response.output_item.added":
+                            item = getattr(event, "item", None)
+                            if getattr(item, "type", None) == "function_call":
+                                _has_tool_calls = True
+                    final_resp = stream.get_final_response()
+                    if stream_callback and not _has_tool_calls:
+                        try:
+                            stream_callback("", True)
+                        except Exception:
+                            pass
+                    return final_resp
             except RuntimeError as exc:
                 err_text = str(exc)
                 missing_completed = "response.completed" in err_text
@@ -2037,6 +2062,118 @@ class AIAgent:
         if terminal_response is not None:
             return terminal_response
         raise RuntimeError("Responses create(stream=True) fallback did not emit a terminal response.")
+
+    def _run_chat_completions_stream(self, api_kwargs: dict, stream_callback=None):
+        """Execute a chat completions request with streaming, forwarding text
+        chunks via stream_callback.  Returns a reconstructed response object
+        compatible with the non-streaming path.
+
+        Tool-call responses are detected early and the callback is suppressed
+        so only the final text answer is streamed to the user.
+        """
+        stream_kwargs = dict(api_kwargs)
+        stream_kwargs["stream"] = True
+        # Request usage stats in the final chunk (OpenAI stream_options)
+        stream_kwargs.setdefault("stream_options", {"include_usage": True})
+
+        accumulated_content = ""
+        accumulated_tool_calls = {}  # index -> {id, type, function: {name, arguments}}
+        finish_reason = None
+        model = None
+        usage = None
+        has_tool_calls = False
+
+        stream_resp = self.client.chat.completions.create(**stream_kwargs)
+        try:
+            for chunk in stream_resp:
+                if not chunk.choices and hasattr(chunk, "usage") and chunk.usage:
+                    usage = chunk.usage
+                    continue
+                if not chunk.choices:
+                    continue
+                delta = chunk.choices[0].delta
+                model = model or getattr(chunk, "model", None)
+                if chunk.choices[0].finish_reason:
+                    finish_reason = chunk.choices[0].finish_reason
+
+                # Accumulate text content
+                if delta and delta.content:
+                    accumulated_content += delta.content
+                    if stream_callback and not has_tool_calls:
+                        try:
+                            stream_callback(delta.content, False)
+                        except Exception:
+                            pass
+
+                # Detect and accumulate tool calls
+                if delta and delta.tool_calls:
+                    has_tool_calls = True
+                    for tc_delta in delta.tool_calls:
+                        idx = tc_delta.index
+                        if idx not in accumulated_tool_calls:
+                            accumulated_tool_calls[idx] = {
+                                "id": tc_delta.id or "",
+                                "type": "function",
+                                "function": {"name": "", "arguments": ""},
+                            }
+                        entry = accumulated_tool_calls[idx]
+                        if tc_delta.id:
+                            entry["id"] = tc_delta.id
+                        if tc_delta.function:
+                            if tc_delta.function.name:
+                                entry["function"]["name"] += tc_delta.function.name
+                            if tc_delta.function.arguments:
+                                entry["function"]["arguments"] += tc_delta.function.arguments
+        finally:
+            close_fn = getattr(stream_resp, "close", None)
+            if callable(close_fn):
+                try:
+                    close_fn()
+                except Exception:
+                    pass
+
+        # Signal completion for text-only responses
+        if stream_callback and not has_tool_calls:
+            try:
+                stream_callback("", True)
+            except Exception:
+                pass
+
+        # Reconstruct a response object that matches the non-streaming shape.
+        # We build a lightweight namespace so downstream code (.choices[0].message,
+        # .usage, .model) works without changes.
+        from types import SimpleNamespace
+
+        tool_calls_list = None
+        if accumulated_tool_calls:
+            tool_calls_list = [
+                SimpleNamespace(**{
+                    "id": v["id"],
+                    "type": v["type"],
+                    "function": SimpleNamespace(
+                        name=v["function"]["name"],
+                        arguments=v["function"]["arguments"],
+                    ),
+                })
+                for _, v in sorted(accumulated_tool_calls.items())
+            ]
+
+        message = SimpleNamespace(
+            role="assistant",
+            content=accumulated_content or None,
+            tool_calls=tool_calls_list,
+        )
+        choice = SimpleNamespace(
+            index=0,
+            message=message,
+            finish_reason=finish_reason or "stop",
+        )
+        response = SimpleNamespace(
+            choices=[choice],
+            model=model,
+            usage=usage,
+        )
+        return response
 
     def _try_refresh_codex_client_credentials(self, *, force: bool = True) -> bool:
         if self.api_mode != "codex_responses" or self.provider != "openai-codex":
@@ -2118,7 +2255,7 @@ class AIAgent:
 
         return True
 
-    def _interruptible_api_call(self, api_kwargs: dict):
+    def _interruptible_api_call(self, api_kwargs: dict, stream_callback=None):
         """
         Run the API call in a background thread so the main conversation loop
         can detect interrupts without waiting for the full HTTP round-trip.
@@ -2126,15 +2263,24 @@ class AIAgent:
         On interrupt, closes the HTTP client to cancel the in-flight request
         (stops token generation and avoids wasting money), then rebuilds the
         client for future calls.
+
+        If stream_callback is provided, text chunks are forwarded in real time
+        for streaming display.  The callback is automatically suppressed for
+        responses that contain tool calls (intermediate agent turns).
         """
         result = {"response": None, "error": None}
 
         def _call():
             try:
                 if self.api_mode == "codex_responses":
-                    result["response"] = self._run_codex_stream(api_kwargs)
+                    result["response"] = self._run_codex_stream(api_kwargs, stream_callback=stream_callback)
                 else:
-                    result["response"] = self.client.chat.completions.create(**api_kwargs)
+                    if stream_callback:
+                        result["response"] = self._run_chat_completions_stream(
+                            api_kwargs, stream_callback=stream_callback,
+                        )
+                    else:
+                        result["response"] = self.client.chat.completions.create(**api_kwargs)
             except Exception as e:
                 result["error"] = e
 
@@ -3020,7 +3166,8 @@ class AIAgent:
         user_message: str,
         system_message: str = None,
         conversation_history: List[Dict[str, Any]] = None,
-        task_id: str = None
+        task_id: str = None,
+        stream_callback: "Optional[Callable[[str, bool], None]]" = None,
     ) -> Dict[str, Any]:
         """
         Run a complete conversation with tool calling until completion.
@@ -3030,12 +3177,20 @@ class AIAgent:
             system_message (str): Custom system message (optional, overrides ephemeral_system_prompt if provided)
             conversation_history (List[Dict]): Previous conversation messages (optional)
             task_id (str): Unique identifier for this task to isolate VMs between concurrent tasks (optional, auto-generated if not provided)
+            stream_callback: Optional callback for streaming text chunks to the caller.
+                Signature: (chunk: str, is_done: bool) -> None.
+                Called with partial text as it arrives from the LLM. is_done=True
+                signals the final chunk of the response (no more text coming).
+                Only fires for text-only responses (tool-call responses are skipped).
 
         Returns:
             Dict: Complete conversation result with final response and message history
         """
         # Generate unique task_id if not provided to isolate VMs between concurrent tasks
         effective_task_id = task_id or str(uuid.uuid4())
+
+        # Store streaming callback for use in API calls
+        self._stream_callback = stream_callback
         
         # Reset retry counters and iteration budget at the start of each turn
         # so subagent usage from a previous turn doesn't eat into the next one.
@@ -3353,7 +3508,7 @@ class AIAgent:
                     if os.getenv("HERMES_DUMP_REQUESTS", "").strip().lower() in {"1", "true", "yes", "on"}:
                         self._dump_api_request_debug(api_kwargs, reason="preflight")
 
-                    response = self._interruptible_api_call(api_kwargs)
+                    response = self._interruptible_api_call(api_kwargs, stream_callback=self._stream_callback)
                     
                     api_duration = time.time() - api_start_time
                     


### PR DESCRIPTION
## summary

add real-time response streaming for the telegram gateway with a dual-transport architecture. text chunks are streamed to the user as they arrive from the llm, using bot api 9.3+ sendmessagedraft as the primary transport with progressive message edits as the fallback.

## transports

### draft (primary, bot api 9.3+)
calls sendmessagedraft with a stable draft_id for each chunk. the telegram client animates the growing text natively without message edits, avoiding edit rate-limit pressure entirely. finalized with a regular sendmessage once the response is complete.

### edit (fallback)
the original approach: sends an initial plain-text message, then progressively calls editmessagetext on a configurable interval.

### auto (default)
tries draft first. on any failure (unsupported client, api error, finalize failure), falls back to edit for the remainder of the stream. the fallback is seamless -- the edit path fires immediately on the same iteration via a last_edit_time reset.

## how it works

- **run_agent.py**: threads an optional stream_callback(chunk, is_done) through run_conversation -> _interruptible_api_call -> streaming methods. supports both codex_responses and chat_completions api modes. callback is automatically suppressed during tool-call turns.

- **gateway/platforms/base.py**: adds supports_streaming and supports_draft_streaming properties, send_raw()/edit_message_raw() for edit transport, send_draft()/finalize_draft() for draft transport, and delete_message().

- **gateway/platforms/telegram.py**: implements both transports. draft uses send_message_draft (ptb 22.6+). finalize_draft sends the final formatted message with markdownv2, falling back to plain text with debug logging on parse failure.

- **gateway/run.py**: async stream consumer with transport negotiation. reads streaming.transport config, negotiates draft availability via adapter property, maintains draft_failed flag for mid-stream fallback. queue-based sync-to-async bridge matches the existing tool progress pattern.

## config
```yaml
streaming:
  enabled: true
  edit_interval: 0.5
  buffer_threshold: 50
  cursor: " ▉"
  transport: auto  # auto, draft, or edit
```

## design decisions

- **draft-first with edit fallback**: draft is smoother and avoids rate limits, but requires bot api 9.3+ support on the client. auto mode provides graceful degradation.
- **os.urandom for draft id**: avoids collision risk from random.randint. generates a positive 31-bit integer from 4 random bytes.
- **immediate fallback on draft failure**: when draft fails, last_edit_time is reset to 0 so the edit path fires on the same loop iteration. prevents message loss on the final chunk (critical fix for the case where draft fails on is_complete=true).
- **raw text for intermediate updates**: both transports use raw text during streaming to avoid markdownv2 parse failures on incomplete text. only the final message gets full formatting.
- **debug-level lifecycle logs**: consumer started/done logs are debug level to reduce noise in production. errors and fallbacks remain at warning/info.
- **tool call suppression**: streaming callback is suppressed when the response contains tool calls, so only the final text answer is streamed.