### PR TITLE
fix(terminal): validate env var types with clear error messages

### DIFF
--- a/tests/tools/test_parse_env_var.py
+++ b/tests/tools/test_parse_env_var.py
@@ -1,0 +1,64 @@
+"""Tests for _parse_env_var and _get_env_config env-var validation."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+import sys
+import tools.terminal_tool  # noqa: F401 -- ensure module is loaded
+_tt_mod = sys.modules["tools.terminal_tool"]
+from tools.terminal_tool import _parse_env_var
+
+
+class TestParseEnvVar:
+    """Unit tests for _parse_env_var."""
+
+    # -- valid values work normally --
+
+    def test_valid_int(self):
+        with patch.dict("os.environ", {"TERMINAL_TIMEOUT": "300"}):
+            assert _parse_env_var("TERMINAL_TIMEOUT", "180") == 300
+
+    def test_valid_float(self):
+        with patch.dict("os.environ", {"TERMINAL_CONTAINER_CPU": "2.5"}):
+            assert _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number") == 2.5
+
+    def test_valid_json(self):
+        volumes = '["/host:/container"]'
+        with patch.dict("os.environ", {"TERMINAL_DOCKER_VOLUMES": volumes}):
+            result = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
+            assert result == ["/host:/container"]
+
+    def test_falls_back_to_default(self):
+        with patch.dict("os.environ", {}, clear=False):
+            # Remove the var if it exists, rely on default
+            import os
+            env = os.environ.copy()
+            env.pop("TERMINAL_TIMEOUT", None)
+            with patch.dict("os.environ", env, clear=True):
+                assert _parse_env_var("TERMINAL_TIMEOUT", "180") == 180
+
+    # -- invalid int raises ValueError with env var name --
+
+    def test_invalid_int_raises_with_var_name(self):
+        with patch.dict("os.environ", {"TERMINAL_TIMEOUT": "5m"}):
+            with pytest.raises(ValueError, match="TERMINAL_TIMEOUT"):
+                _parse_env_var("TERMINAL_TIMEOUT", "180")
+
+    def test_invalid_int_includes_bad_value(self):
+        with patch.dict("os.environ", {"TERMINAL_SSH_PORT": "ssh"}):
+            with pytest.raises(ValueError, match="ssh"):
+                _parse_env_var("TERMINAL_SSH_PORT", "22")
+
+    # -- invalid JSON raises ValueError with env var name --
+
+    def test_invalid_json_raises_with_var_name(self):
+        with patch.dict("os.environ", {"TERMINAL_DOCKER_VOLUMES": "/host:/container"}):
+            with pytest.raises(ValueError, match="TERMINAL_DOCKER_VOLUMES"):
+                _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
+
+    def test_invalid_json_includes_type_label(self):
+        with patch.dict("os.environ", {"TERMINAL_DOCKER_VOLUMES": "not json"}):
+            with pytest.raises(ValueError, match="valid JSON"):
+                _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -403,6 +403,23 @@ def clear_task_env_overrides(task_id: str):
     _task_env_overrides.pop(task_id, None)
 
 # Configuration from environment variables
+
+def _parse_env_var(name: str, default: str, converter=int, type_label: str = "integer"):
+    """Parse an environment variable with *converter*, raising a clear error on bad values.
+
+    Without this wrapper, a single malformed env var (e.g. TERMINAL_TIMEOUT=5m)
+    causes an unhandled ValueError that kills every terminal command.
+    """
+    raw = os.getenv(name, default)
+    try:
+        return converter(raw)
+    except (ValueError, json.JSONDecodeError):
+        raise ValueError(
+            f"Invalid value for {name}: {raw!r} (expected {type_label}). "
+            f"Check ~/.hermes/.env or environment variables."
+        )
+
+
 def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
@@ -438,19 +455,19 @@ def _get_env_config() -> Dict[str, Any]:
         "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
         "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
         "cwd": cwd,
-        "timeout": int(os.getenv("TERMINAL_TIMEOUT", "180")),
-        "lifetime_seconds": int(os.getenv("TERMINAL_LIFETIME_SECONDS", "300")),
+        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
+        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
         # SSH-specific config
         "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
         "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
-        "ssh_port": int(os.getenv("TERMINAL_SSH_PORT", "22")),
+        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
         "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
         # Container resource config (applies to docker, singularity, modal, daytona -- ignored for local/ssh)
-        "container_cpu": float(os.getenv("TERMINAL_CONTAINER_CPU", "1")),
-        "container_memory": int(os.getenv("TERMINAL_CONTAINER_MEMORY", "5120")),     # MB (default 5GB)
-        "container_disk": int(os.getenv("TERMINAL_CONTAINER_DISK", "51200")),        # MB (default 50GB)
+        "container_cpu": _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number"),
+        "container_memory": _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120"),     # MB (default 5GB)
+        "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
         "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in ("true", "1", "yes"),
-        "docker_volumes": json.loads(os.getenv("TERMINAL_DOCKER_VOLUMES", "[]")),
+        "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
     }
 
 


### PR DESCRIPTION
**The problem**

If you set `TERMINAL_TIMEOUT=5m` or `TERMINAL_DOCKER_VOLUMES=/host:/container` in your `.env`, every terminal command silently dies with a cryptic `ValueError`. There's no indication of which variable is wrong or what format it expects — you just get a traceback.

**The fix**

Added `_parse_env_var()` that wraps each conversion and raises a clear message:
Invalid value for TERMINAL_TIMEOUT: '5m' (expected integer).
Check ~/.hermes/.env or environment variables.

**Tests**

`tests/tools/test_parse_env_var.py` — 8 new tests covering valid values, defaults, bad ints, and bad JSON. All 10 tests pass (8 new + 2 existing).