### PR TITLE
fix: replace debug print() with logger.error() in file_tools

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -140,7 +140,7 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
         result = file_ops.write_file(path, content)
         return json.dumps(result.to_dict(), ensure_ascii=False)
     except Exception as e:
-        print(f"[FileTools] write_file error: {type(e).__name__}: {e}", flush=True)  
+        logger.error("write_file error: %s: %s", type(e).__name__, e)
         return json.dumps({"error": str(e)}, ensure_ascii=False)
 
 


### PR DESCRIPTION
## Problem

`tools/file_tools.py` içindeki `write_file_tool()` fonksiyonu hata
durumunda `print()` ile doğrudan stdout'a yazıyordu. Bu üretim
ortamında istenmeyen bir davranış — hatalar logging sistemi üzerinden
yönetilmeli.

## Fix

`print(f"[FileTools] write_file error: ...")` satırı kaldırıldı,
yerine `logger.error("write_file error: %s: %s", ...)` kullanıldı.
`logger` zaten dosyanın üstünde tanımlı.

## Files Changed
- `tools/file_tools.py`