### PR TITLE
fix(prompt): reinforce terminal tool implies shell access

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -88,6 +88,12 @@ SKILLS_GUIDANCE = (
     "skill with skill_manage so you can reuse it next time."
 )
 
+TERMINAL_GUIDANCE = (
+    "When the terminal tool is available, you already have shell access in this "
+    "environment. Use the terminal tool directly instead of asking the user to "
+    "run commands for you."
+)
+
 PLATFORM_HINTS = {
     "whatsapp": (
         "You are on a text messaging communication platform, WhatsApp. "

--- a/run_agent.py
+++ b/run_agent.py
@@ -77,7 +77,7 @@ from hermes_constants import OPENROUTER_BASE_URL, OPENROUTER_MODELS_URL
 # Agent internals extracted to agent/ package for modularity
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
-    MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
+    MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE, TERMINAL_GUIDANCE,
 )
 from agent.model_metadata import (
     fetch_model_metadata, get_model_context_length,
@@ -1390,6 +1390,8 @@ class AIAgent:
             tool_guidance.append(SESSION_SEARCH_GUIDANCE)
         if "skill_manage" in self.valid_tool_names:
             tool_guidance.append(SKILLS_GUIDANCE)
+        if "terminal" in self.valid_tool_names:
+            tool_guidance.append(TERMINAL_GUIDANCE)
         if tool_guidance:
             prompt_parts.append(" ".join(tool_guidance))
 

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -45,7 +45,7 @@ def agent():
         patch("run_agent.OpenAI"),
     ):
         a = AIAgent(
-            api_key="test-key-1234567890",
+            api_key="test-k...7890",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -63,7 +63,25 @@ def agent_with_memory_tool():
         patch("run_agent.OpenAI"),
     ):
         a = AIAgent(
-            api_key="test-key-1234567890",
+            api_key="test-k...7890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        return a
+
+
+@pytest.fixture()
+def agent_with_terminal_tool():
+    """Agent whose valid_tool_names includes 'terminal'."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search", "terminal")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-k...7890",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -354,7 +372,7 @@ class TestInit:
             patch("run_agent.OpenAI"),
         ):
             a = AIAgent(
-                api_key="test-key-1234567890",
+                api_key="test-k...7890",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -369,7 +387,7 @@ class TestInit:
             patch("run_agent.OpenAI"),
         ):
             a = AIAgent(
-                api_key="test-key-1234567890",
+                api_key="test-k...7890",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -461,6 +479,16 @@ class TestBuildSystemPrompt:
         from agent.prompt_builder import MEMORY_GUIDANCE
         prompt = agent._build_system_prompt()
         assert MEMORY_GUIDANCE not in prompt
+
+    def test_terminal_guidance_when_terminal_tool_loaded(self, agent_with_terminal_tool):
+        from agent.prompt_builder import TERMINAL_GUIDANCE
+        prompt = agent_with_terminal_tool._build_system_prompt()
+        assert TERMINAL_GUIDANCE in prompt
+
+    def test_no_terminal_guidance_without_tool(self, agent):
+        from agent.prompt_builder import TERMINAL_GUIDANCE
+        prompt = agent._build_system_prompt()
+        assert TERMINAL_GUIDANCE not in prompt
 
     def test_includes_datetime(self, agent):
         prompt = agent._build_system_prompt()


### PR DESCRIPTION
## Summary
- add TERMINAL_GUIDANCE to system prompt guidance in agent/prompt_builder.py
- inject this guidance only when the terminal tool is actually loaded (run_agent.py)
- add regression tests in tests/test_run_agent.py to verify guidance appears only with terminal tool

## Why
Issue #747 reports cases (especially Codex/ChatGPT paths) where the agent replies as if it lacks shell access.
This PR adds a minimal, tool-aware reminder in the cached system prompt so the model is explicitly told it already has shell access when terminal is available.

## Scope
- narrow follow-up for #747
- no tool execution semantics changed
- no prompt-caching lifecycle changes (prompt still built once per session)

## Test plan
- python -m pytest tests/test_run_agent.py tests/test_provider_parity.py -q
  - Result: 141 passed
- full suite run: one unrelated pre-existing failure observed in tests/test_timezone.py::TestCronTimezone::test_get_due_jobs_handles_naive_timestamps

Refs #747