### PR TITLE
fix: support max_tokens config for custom providers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -149,6 +149,7 @@ def load_cli_config() -> Dict[str, Any]:
             "default": "anthropic/claude-opus-4.6",
             "base_url": OPENROUTER_BASE_URL,
             "provider": "auto",
+            "max_tokens": None,
         },
         "terminal": {
             "env_type": "local",
@@ -1086,6 +1087,7 @@ class HermesCLI:
         self._provider_source: Optional[str] = None
         self.provider = self.requested_provider
         self.api_mode = "chat_completions"
+        self.max_tokens: Optional[int] = None
         self.base_url = (
             base_url
             or os.getenv("OPENAI_BASE_URL")
@@ -1203,6 +1205,7 @@ class HermesCLI:
         base_url = runtime.get("base_url")
         resolved_provider = runtime.get("provider", "openrouter")
         resolved_api_mode = runtime.get("api_mode", self.api_mode)
+        resolved_max_tokens = runtime.get("max_tokens")
         if not isinstance(api_key, str) or not api_key:
             self.console.print("[bold red]Provider resolver returned an empty API key.[/]")
             return False
@@ -1215,14 +1218,16 @@ class HermesCLI:
             resolved_provider != self.provider
             or resolved_api_mode != self.api_mode
         )
+        max_tokens_changed = resolved_max_tokens != self.max_tokens
         self.provider = resolved_provider
         self.api_mode = resolved_api_mode
         self._provider_source = runtime.get("source")
         self.api_key = api_key
         self.base_url = base_url
+        self.max_tokens = resolved_max_tokens
 
         # AIAgent/OpenAI client holds auth at init time, so rebuild if key rotated
-        if (credentials_changed or routing_changed) and self.agent is not None:
+        if (credentials_changed or routing_changed or max_tokens_changed) and self.agent is not None:
             self.agent = None
 
         return True
@@ -1285,6 +1290,7 @@ class HermesCLI:
                 provider=self.provider,
                 api_mode=self.api_mode,
                 max_iterations=self.max_turns,
+                max_tokens=self.max_tokens,
                 enabled_toolsets=self.enabled_toolsets,
                 verbose_logging=self.verbose,
                 quiet_mode=True,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -245,6 +245,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             base_url=runtime.get("base_url"),
             provider=runtime.get("provider"),
             api_mode=runtime.get("api_mode"),
+            max_tokens=runtime.get("max_tokens"),
             max_iterations=max_iterations,
             reasoning_config=reasoning_config,
             prefill_messages=prefill_messages,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any, Dict, Optional
 
@@ -18,6 +19,9 @@ from hermes_cli.config import load_config
 from hermes_constants import OPENROUTER_BASE_URL
 
 
+logger = logging.getLogger(__name__)
+
+
 def _get_model_config() -> Dict[str, Any]:
     config = load_config()
     model_cfg = config.get("model")
@@ -26,6 +30,50 @@ def _get_model_config() -> Dict[str, Any]:
     if isinstance(model_cfg, str) and model_cfg.strip():
         return {"default": model_cfg.strip()}
     return {}
+
+
+def _coerce_max_tokens(raw_value: Any, source: str) -> Optional[int]:
+    if raw_value is None:
+        return None
+
+    if isinstance(raw_value, bool):
+        logger.warning(f"Ignoring invalid {source} value for max_tokens: {raw_value!r}")
+        return None
+
+    if isinstance(raw_value, int):
+        if raw_value > 0:
+            return raw_value
+        logger.warning(
+            f"Ignoring non-positive {source} value for max_tokens: {raw_value!r}"
+        )
+        return None
+
+    raw_text = str(raw_value).strip()
+    if not raw_text:
+        return None
+
+    try:
+        parsed = int(raw_text)
+    except (TypeError, ValueError):
+        logger.warning(f"Ignoring invalid {source} value for max_tokens: {raw_value!r}")
+        return None
+
+    if parsed <= 0:
+        logger.warning(
+            f"Ignoring non-positive {source} value for max_tokens: {raw_value!r}"
+        )
+        return None
+
+    return parsed
+
+
+def resolve_runtime_max_tokens() -> Optional[int]:
+    env_value = _coerce_max_tokens(os.getenv("HERMES_MAX_TOKENS"), "HERMES_MAX_TOKENS")
+    if env_value is not None:
+        return env_value
+
+    model_cfg = _get_model_config()
+    return _coerce_max_tokens(model_cfg.get("max_tokens"), "config model.max_tokens")
 
 
 def resolve_requested_provider(requested: Optional[str] = None) -> str:
@@ -52,8 +100,12 @@ def _resolve_openrouter_runtime(
     explicit_base_url: Optional[str] = None,
 ) -> Dict[str, Any]:
     model_cfg = _get_model_config()
-    cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
-    cfg_provider = model_cfg.get("provider") if isinstance(model_cfg.get("provider"), str) else ""
+    cfg_base_url = (
+        model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
+    )
+    cfg_provider = (
+        model_cfg.get("provider") if isinstance(model_cfg.get("provider"), str) else ""
+    )
     requested_norm = (requested_provider or "").strip().lower()
     cfg_provider = cfg_provider.strip().lower()
 
@@ -114,6 +166,7 @@ def resolve_runtime_provider(
 ) -> Dict[str, Any]:
     """Resolve runtime provider credentials for agent execution."""
     requested_provider = resolve_requested_provider(requested)
+    max_tokens = resolve_runtime_max_tokens()
 
     provider = resolve_provider(
         requested_provider,
@@ -123,7 +176,9 @@ def resolve_runtime_provider(
 
     if provider == "nous":
         creds = resolve_nous_runtime_credentials(
-            min_key_ttl_seconds=max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),
+            min_key_ttl_seconds=max(
+                60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))
+            ),
             timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
         )
         return {
@@ -131,6 +186,7 @@ def resolve_runtime_provider(
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
+            "max_tokens": max_tokens,
             "source": creds.get("source", "portal"),
             "expires_at": creds.get("expires_at"),
             "requested_provider": requested_provider,
@@ -143,6 +199,7 @@ def resolve_runtime_provider(
             "api_mode": "codex_responses",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
+            "max_tokens": max_tokens,
             "source": creds.get("source", "hermes-auth-store"),
             "last_refresh": creds.get("last_refresh"),
             "requested_provider": requested_provider,
@@ -157,6 +214,7 @@ def resolve_runtime_provider(
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
+            "max_tokens": max_tokens,
             "source": creds.get("source", "env"),
             "requested_provider": requested_provider,
         }
@@ -166,6 +224,7 @@ def resolve_runtime_provider(
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
     )
+    runtime["max_tokens"] = max_tokens
     runtime["requested_provider"] = requested_provider
     return runtime
 

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -91,10 +91,18 @@ def test_hermes_cli_init_does_not_eagerly_resolve_runtime_provider(monkeypatch):
 
     def _unexpected_runtime_resolve(**kwargs):
         calls["count"] += 1
-        raise AssertionError("resolve_runtime_provider should not be called in HermesCLI.__init__")
+        raise AssertionError(
+            "resolve_runtime_provider should not be called in HermesCLI.__init__"
+        )
 
-    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _unexpected_runtime_resolve)
-    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _unexpected_runtime_resolve,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error",
+        lambda exc: str(exc),
+    )
 
     shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
 
@@ -122,8 +130,13 @@ def test_runtime_resolution_failure_is_not_sticky(monkeypatch):
         def __init__(self, *args, **kwargs):
             self.kwargs = kwargs
 
-    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
-    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error",
+        lambda exc: str(exc),
+    )
     monkeypatch.setattr(cli, "AIAgent", _DummyAgent)
 
     shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
@@ -146,8 +159,13 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
             "source": "env/config",
         }
 
-    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
-    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error",
+        lambda exc: str(exc),
+    )
 
     shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
     shell.provider = "openrouter"
@@ -162,6 +180,71 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     assert shell.api_mode == "codex_responses"
 
 
+def test_init_agent_passes_runtime_max_tokens(monkeypatch):
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "test-key",
+            "max_tokens": 32768,
+            "source": "env/config",
+        }
+
+    class _DummyAgent:
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error",
+        lambda exc: str(exc),
+    )
+    monkeypatch.setattr(cli, "AIAgent", _DummyAgent)
+
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+
+    assert shell._init_agent() is True
+    assert shell.max_tokens == 32768
+    assert shell.agent.kwargs["max_tokens"] == 32768
+
+
+def test_runtime_resolution_rebuilds_agent_on_max_tokens_change(monkeypatch):
+    cli = _import_cli()
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://same-endpoint.example/v1",
+            "api_key": "same-key",
+            "max_tokens": 32768,
+            "source": "env/config",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error",
+        lambda exc: str(exc),
+    )
+
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell.provider = "openrouter"
+    shell.api_mode = "chat_completions"
+    shell.base_url = "https://same-endpoint.example/v1"
+    shell.api_key = "same-key"
+    shell.max_tokens = 1024
+    shell.agent = object()
+
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.agent is None
+    assert shell.max_tokens == 32768
+
+
 def test_cmd_model_falls_back_to_auto_on_invalid_provider(monkeypatch, capsys):
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
@@ -173,11 +256,15 @@ def test_cmd_model_falls_back_to_auto_on_invalid_provider(monkeypatch, capsys):
 
     def _resolve_provider(requested, **kwargs):
         if requested == "invalid-provider":
-            raise AuthError("Unknown provider 'invalid-provider'.", code="invalid_provider")
+            raise AuthError(
+                "Unknown provider 'invalid-provider'.", code="invalid_provider"
+            )
         return "openrouter"
 
     monkeypatch.setattr("hermes_cli.auth.resolve_provider", _resolve_provider)
-    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", lambda choices: len(choices) - 1)
+    monkeypatch.setattr(
+        hermes_main, "_prompt_provider_choice", lambda choices: len(choices) - 1
+    )
 
     hermes_main.cmd_model(SimpleNamespace())
     output = capsys.readouterr().out

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -162,3 +162,47 @@ def test_resolve_requested_provider_precedence(monkeypatch):
     monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "nous")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openai-codex"})
     assert rp.resolve_requested_provider("openrouter") == "openrouter"
+
+
+def test_resolve_runtime_provider_uses_env_max_tokens(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"max_tokens": 1024})
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("HERMES_MAX_TOKENS", "32768")
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["max_tokens"] == 32768
+
+
+def test_resolve_runtime_provider_uses_config_max_tokens(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"max_tokens": "8192"})
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("HERMES_MAX_TOKENS", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["max_tokens"] == 8192
+
+
+def test_resolve_runtime_provider_invalid_env_max_tokens_falls_back_to_config(
+    monkeypatch,
+):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"max_tokens": 4096})
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("HERMES_MAX_TOKENS", "not-a-number")
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["max_tokens"] == 4096

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -116,6 +116,7 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | Variable | Description |
 |----------|-------------|
 | `HERMES_MAX_ITERATIONS` | Max tool-calling iterations per conversation (default: 60) |
+| `HERMES_MAX_TOKENS` | Force the `max_tokens` request parameter for model responses |
 | `HERMES_TOOL_PROGRESS` | Send progress messages when using tools (`true`/`false`) |
 | `HERMES_TOOL_PROGRESS_MODE` | `all` (every call, default) or `new` (only when tool changes) |
 | `HERMES_HUMAN_DELAY_MODE` | Response pacing: `off`/`natural`/`custom` |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -105,6 +105,7 @@ Or set the provider permanently in `config.yaml`:
 model:
   provider: "zai"       # or: kimi-coding, minimax, minimax-cn
   default: "glm-4-plus"
+  # max_tokens: 32768     # Optional: force output budget for custom providers
 ```
 
 Base URLs can be overridden with `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, or `MINIMAX_CN_BASE_URL` environment variables.
@@ -133,6 +134,22 @@ LLM_MODEL=your-model-name
 ```
 
 Everything below follows this same pattern — just change the URL, key, and model name.
+
+You can also pin an output token budget in `config.yaml` when your provider's default is too small for reasoning models:
+
+```yaml
+model:
+  default: moonshotai/kimi-k2.5
+  provider: custom
+  base_url: https://integrate.api.nvidia.com/v1
+  max_tokens: 32768
+```
+
+Or override it per environment:
+
+```bash
+HERMES_MAX_TOKENS=32768
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- thread `HERMES_MAX_TOKENS` and `model.max_tokens` through runtime provider resolution so CLI, gateway, and cron-created agents pass `max_tokens` to custom providers
- rebuild the CLI agent when the resolved `max_tokens` changes and add regression coverage for env/config precedence and fallback behavior
- document the new config and environment variable for custom reasoning-model providers like NVIDIA NIM + Kimi

## Testing
- `source .venv/bin/activate && pytest tests/test_runtime_provider_resolution.py tests/test_cli_provider_resolution.py tests/test_cli_init.py tests/test_run_agent.py tests/hermes_cli/test_set_config_value.py tests/cron/test_scheduler.py tests/test_codex_execution_paths.py && python -m compileall cli.py cron/scheduler.py hermes_cli/runtime_provider.py gateway/run.py`
- `source .venv/bin/activate && pytest -q`

Fixes #782