### PR TITLE
fix: support max_tokens config for custom providers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -148,6 +148,7 @@ def load_cli_config() -> Dict[str, Any]:
             "default": "anthropic/claude-opus-4.6",
             "base_url": OPENROUTER_BASE_URL,
             "provider": "auto",
+            "max_tokens": None,
         },
         "terminal": {
             "env_type": "local",
@@ -1091,6 +1092,7 @@ class HermesCLI:
         self._provider_source: Optional[str] = None
         self.provider = self.requested_provider
         self.api_mode = "chat_completions"
+        self.max_tokens: Optional[int] = None
         self.base_url = (
             base_url
             or os.getenv("OPENAI_BASE_URL")
@@ -1276,6 +1278,7 @@ class HermesCLI:
         base_url = runtime.get("base_url")
         resolved_provider = runtime.get("provider", "openrouter")
         resolved_api_mode = runtime.get("api_mode", self.api_mode)
+        resolved_max_tokens = runtime.get("max_tokens")
         if not isinstance(api_key, str) or not api_key:
             self.console.print("[bold red]Provider resolver returned an empty API key.[/]")
             return False
@@ -1288,11 +1291,13 @@ class HermesCLI:
             resolved_provider != self.provider
             or resolved_api_mode != self.api_mode
         )
+        max_tokens_changed = resolved_max_tokens != self.max_tokens
         self.provider = resolved_provider
         self.api_mode = resolved_api_mode
         self._provider_source = runtime.get("source")
         self.api_key = api_key
         self.base_url = base_url
+        self.max_tokens = resolved_max_tokens
 
         # Normalize model for the resolved provider (e.g. swap non-Codex
         # models when provider is openai-codex).  Fixes #651.
@@ -1300,7 +1305,7 @@ class HermesCLI:
 
         # AIAgent/OpenAI client holds auth at init time, so rebuild if key,
         # routing, or the effective model changed.
-        if (credentials_changed or routing_changed or model_changed) and self.agent is not None:
+        if (credentials_changed or routing_changed or model_changed or max_tokens_changed) and self.agent is not None:
             self.agent = None
 
         return True
@@ -1369,6 +1374,7 @@ class HermesCLI:
                 provider=self.provider,
                 api_mode=self.api_mode,
                 max_iterations=self.max_turns,
+                max_tokens=self.max_tokens,
                 enabled_toolsets=self.enabled_toolsets,
                 verbose_logging=self.verbose,
                 quiet_mode=True,

--- a/cli.py
+++ b/cli.py
@@ -1007,8 +1007,12 @@ def save_config_value(key_path: str, value: any) -> bool:
         keys = key_path.split('.')
         current = config
         for key in keys[:-1]:
-            if key not in current or not isinstance(current[key], dict):
-                current[key] = {}
+            existing = current.get(key)
+            if not isinstance(existing, dict):
+                if key == "model" and isinstance(existing, str) and existing.strip():
+                    current[key] = {"default": existing.strip()}
+                else:
+                    current[key] = {}
             current = current[key]
         current[keys[-1]] = value
         

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -246,6 +246,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             base_url=runtime.get("base_url"),
             provider=runtime.get("provider"),
             api_mode=runtime.get("api_mode"),
+            max_tokens=runtime.get("max_tokens"),
             max_iterations=max_iterations,
             reasoning_config=reasoning_config,
             prefill_messages=prefill_messages,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -179,6 +179,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
         "api_mode": runtime.get("api_mode"),
+        "max_tokens": runtime.get("max_tokens"),
     }
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -510,8 +510,12 @@ def _set_nested(config: dict, dotted_key: str, value):
     parts = dotted_key.split(".")
     current = config
     for part in parts[:-1]:
-        if part not in current or not isinstance(current.get(part), dict):
-            current[part] = {}
+        existing = current.get(part)
+        if not isinstance(existing, dict):
+            if part == "model" and isinstance(existing, str) and existing.strip():
+                current[part] = {"default": existing.strip()}
+            else:
+                current[part] = {}
         current = current[part]
     current[parts[-1]] = value
 
@@ -1079,8 +1083,12 @@ def set_config_value(key: str, value: str):
     current = user_config
     
     for part in parts[:-1]:
-        if part not in current or not isinstance(current.get(part), dict):
-            current[part] = {}
+        existing = current.get(part)
+        if not isinstance(existing, dict):
+            if part == "model" and isinstance(existing, str) and existing.strip():
+                current[part] = {"default": existing.strip()}
+            else:
+                current[part] = {}
         current = current[part]
     
     # Convert value to appropriate type

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any, Dict, Optional
 
@@ -18,6 +19,9 @@ from hermes_cli.config import load_config
 from hermes_constants import OPENROUTER_BASE_URL
 
 
+logger = logging.getLogger(__name__)
+
+
 def _get_model_config() -> Dict[str, Any]:
     config = load_config()
     model_cfg = config.get("model")
@@ -26,6 +30,50 @@ def _get_model_config() -> Dict[str, Any]:
     if isinstance(model_cfg, str) and model_cfg.strip():
         return {"default": model_cfg.strip()}
     return {}
+
+
+def _coerce_max_tokens(raw_value: Any, source: str) -> Optional[int]:
+    if raw_value is None:
+        return None
+
+    if isinstance(raw_value, bool):
+        logger.warning(f"Ignoring invalid {source} value for max_tokens: {raw_value!r}")
+        return None
+
+    if isinstance(raw_value, int):
+        if raw_value > 0:
+            return raw_value
+        logger.warning(
+            f"Ignoring non-positive {source} value for max_tokens: {raw_value!r}"
+        )
+        return None
+
+    raw_text = str(raw_value).strip()
+    if not raw_text:
+        return None
+
+    try:
+        parsed = int(raw_text)
+    except (TypeError, ValueError):
+        logger.warning(f"Ignoring invalid {source} value for max_tokens: {raw_value!r}")
+        return None
+
+    if parsed <= 0:
+        logger.warning(
+            f"Ignoring non-positive {source} value for max_tokens: {raw_value!r}"
+        )
+        return None
+
+    return parsed
+
+
+def resolve_runtime_max_tokens() -> Optional[int]:
+    env_value = _coerce_max_tokens(os.getenv("HERMES_MAX_TOKENS"), "HERMES_MAX_TOKENS")
+    if env_value is not None:
+        return env_value
+
+    model_cfg = _get_model_config()
+    return _coerce_max_tokens(model_cfg.get("max_tokens"), "config model.max_tokens")
 
 
 def resolve_requested_provider(requested: Optional[str] = None) -> str:
@@ -52,8 +100,12 @@ def _resolve_openrouter_runtime(
     explicit_base_url: Optional[str] = None,
 ) -> Dict[str, Any]:
     model_cfg = _get_model_config()
-    cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
-    cfg_provider = model_cfg.get("provider") if isinstance(model_cfg.get("provider"), str) else ""
+    cfg_base_url = (
+        model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
+    )
+    cfg_provider = (
+        model_cfg.get("provider") if isinstance(model_cfg.get("provider"), str) else ""
+    )
     requested_norm = (requested_provider or "").strip().lower()
     cfg_provider = cfg_provider.strip().lower()
 
@@ -114,6 +166,7 @@ def resolve_runtime_provider(
 ) -> Dict[str, Any]:
     """Resolve runtime provider credentials for agent execution."""
     requested_provider = resolve_requested_provider(requested)
+    max_tokens = resolve_runtime_max_tokens()
 
     provider = resolve_provider(
         requested_provider,
@@ -123,7 +176,9 @@ def resolve_runtime_provider(
 
     if provider == "nous":
         creds = resolve_nous_runtime_credentials(
-            min_key_ttl_seconds=max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),
+            min_key_ttl_seconds=max(
+                60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))
+            ),
             timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
         )
         return {
@@ -131,6 +186,7 @@ def resolve_runtime_provider(
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
+            "max_tokens": max_tokens,
             "source": creds.get("source", "portal"),
             "expires_at": creds.get("expires_at"),
             "requested_provider": requested_provider,
@@ -143,6 +199,7 @@ def resolve_runtime_provider(
             "api_mode": "codex_responses",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
+            "max_tokens": max_tokens,
             "source": creds.get("source", "hermes-auth-store"),
             "last_refresh": creds.get("last_refresh"),
             "requested_provider": requested_provider,
@@ -157,6 +214,7 @@ def resolve_runtime_provider(
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
+            "max_tokens": max_tokens,
             "source": creds.get("source", "env"),
             "requested_provider": requested_provider,
         }
@@ -166,6 +224,7 @@ def resolve_runtime_provider(
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
     )
+    runtime["max_tokens"] = max_tokens
     runtime["requested_provider"] = requested_provider
     return runtime
 

--- a/tests/gateway/test_runtime_provider_kwargs.py
+++ b/tests/gateway/test_runtime_provider_kwargs.py
@@ -1,0 +1,40 @@
+import pytest
+
+
+def test_resolve_runtime_agent_kwargs_includes_max_tokens(monkeypatch):
+    from gateway import run as gateway_run
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "test-key",
+            "base_url": "https://example.com/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "max_tokens": 32768,
+        },
+    )
+
+    kwargs = gateway_run._resolve_runtime_agent_kwargs()
+
+    assert kwargs["api_key"] == "test-key"
+    assert kwargs["base_url"] == "https://example.com/v1"
+    assert kwargs["provider"] == "openrouter"
+    assert kwargs["api_mode"] == "chat_completions"
+    assert kwargs["max_tokens"] == 32768
+
+
+def test_resolve_runtime_agent_kwargs_wraps_errors(monkeypatch):
+    from gateway import run as gateway_run
+
+    def _raise(**kwargs):
+        raise RuntimeError("raw")
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _raise)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error",
+        lambda exc: "formatted-runtime-provider-error",
+    )
+
+    with pytest.raises(RuntimeError, match="formatted-runtime-provider-error"):
+        gateway_run._resolve_runtime_agent_kwargs()

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch, call
 
 import pytest
+import yaml
 
 from hermes_cli.config import set_config_value
 
@@ -115,3 +116,11 @@ class TestConfigYamlRouting:
         set_config_value("terminal.docker_image", "python:3.12")
         config = _read_config(_isolated_hermes_home)
         assert "python:3.12" in config
+
+    def test_model_nested_key_preserves_scalar_default(self, _isolated_hermes_home):
+        set_config_value("model", "anthropic/claude-opus-4.6")
+        set_config_value("model.max_tokens", "32768")
+
+        config = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert config["model"]["default"] == "anthropic/claude-opus-4.6"
+        assert config["model"]["max_tokens"] == 32768

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -4,6 +4,8 @@ import types
 from contextlib import nullcontext
 from types import SimpleNamespace
 
+import yaml
+
 from hermes_cli.auth import AuthError
 from hermes_cli import main as hermes_main
 
@@ -360,3 +362,20 @@ def test_cmd_model_falls_back_to_auto_on_invalid_provider(monkeypatch, capsys):
     assert "Warning:" in output
     assert "falling back to auto provider detection" in output.lower()
     assert "No change." in output
+
+def test_save_config_value_preserves_scalar_model_default(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    config_dir = home / ".hermes"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.yaml"
+    config_path.write_text("model: anthropic/claude-opus-4.6\n")
+
+    monkeypatch.setenv("HOME", str(home))
+    cli = _import_cli()
+
+    assert cli.save_config_value("model.max_tokens", 32768) is True
+
+    config = yaml.safe_load(config_path.read_text())
+    assert config["model"]["default"] == "anthropic/claude-opus-4.6"
+    assert config["model"]["max_tokens"] == 32768
+

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -162,6 +162,63 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     assert shell.api_mode == "codex_responses"
 
 
+def test_init_agent_passes_runtime_max_tokens(monkeypatch):
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "test-key",
+            "max_tokens": 32768,
+            "source": "env/config",
+        }
+
+    class _DummyAgent:
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr(cli, "AIAgent", _DummyAgent)
+
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+
+    assert shell._init_agent() is True
+    assert shell.max_tokens == 32768
+    assert shell.agent.kwargs["max_tokens"] == 32768
+
+
+def test_runtime_resolution_rebuilds_agent_on_max_tokens_change(monkeypatch):
+    cli = _import_cli()
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://same-endpoint.example/v1",
+            "api_key": "same-key",
+            "max_tokens": 32768,
+            "source": "env/config",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell.provider = "openrouter"
+    shell.api_mode = "chat_completions"
+    shell.base_url = "https://same-endpoint.example/v1"
+    shell.api_key = "same-key"
+    shell.max_tokens = 1024
+    shell.agent = object()
+
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.agent is None
+    assert shell.max_tokens == 32768
+
+
 def test_codex_provider_replaces_incompatible_default_model(monkeypatch):
     """When provider resolves to openai-codex and no model was explicitly
     chosen, the global config default (e.g. anthropic/claude-opus-4.6) must

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -162,3 +162,47 @@ def test_resolve_requested_provider_precedence(monkeypatch):
     monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "nous")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openai-codex"})
     assert rp.resolve_requested_provider("openrouter") == "openrouter"
+
+
+def test_resolve_runtime_provider_uses_env_max_tokens(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"max_tokens": 1024})
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("HERMES_MAX_TOKENS", "32768")
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["max_tokens"] == 32768
+
+
+def test_resolve_runtime_provider_uses_config_max_tokens(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"max_tokens": "8192"})
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("HERMES_MAX_TOKENS", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["max_tokens"] == 8192
+
+
+def test_resolve_runtime_provider_invalid_env_max_tokens_falls_back_to_config(
+    monkeypatch,
+):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"max_tokens": 4096})
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("HERMES_MAX_TOKENS", "not-a-number")
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["max_tokens"] == 4096

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -120,6 +120,7 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | Variable | Description |
 |----------|-------------|
 | `HERMES_MAX_ITERATIONS` | Max tool-calling iterations per conversation (default: 60) |
+| `HERMES_MAX_TOKENS` | Force the `max_tokens` request parameter for model responses |
 | `HERMES_TOOL_PROGRESS` | Send progress messages when using tools (`true`/`false`) |
 | `HERMES_TOOL_PROGRESS_MODE` | `all` (every call, default) or `new` (only when tool changes) |
 | `HERMES_HUMAN_DELAY_MODE` | Response pacing: `off`/`natural`/`custom` |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -105,6 +105,7 @@ Or set the provider permanently in `config.yaml`:
 model:
   provider: "zai"       # or: kimi-coding, minimax, minimax-cn
   default: "glm-4-plus"
+  # max_tokens: 32768     # Optional output budget override
 ```
 
 Base URLs can be overridden with `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, or `MINIMAX_CN_BASE_URL` environment variables.
@@ -130,6 +131,22 @@ hermes model
 OPENAI_BASE_URL=http://localhost:8000/v1
 OPENAI_API_KEY=your-key-or-dummy
 LLM_MODEL=your-model-name
+```
+
+If your provider has a low default output budget, you can explicitly set `max_tokens`:
+
+```yaml
+model:
+  default: moonshotai/kimi-k2.5
+  provider: custom
+  base_url: https://integrate.api.nvidia.com/v1
+  max_tokens: 32768
+```
+
+Or override per environment:
+
+```bash
+HERMES_MAX_TOKENS=32768
 ```
 
 Everything below follows this same pattern — just change the URL, key, and model name.


### PR DESCRIPTION
## Summary
- thread `HERMES_MAX_TOKENS` and `model.max_tokens` through runtime provider resolution so CLI, gateway, and cron-created agents pass `max_tokens` to custom providers
- rebuild the CLI agent when the resolved `max_tokens` changes and add regression coverage for env/config precedence and fallback behavior
- document the new config and environment variable for custom reasoning-model providers like NVIDIA NIM + Kimi

## Testing
- `source .venv/bin/activate && pytest tests/test_runtime_provider_resolution.py tests/test_cli_provider_resolution.py tests/test_cli_init.py tests/test_run_agent.py tests/hermes_cli/test_set_config_value.py tests/cron/test_scheduler.py tests/test_codex_execution_paths.py && python -m compileall cli.py cron/scheduler.py hermes_cli/runtime_provider.py gateway/run.py`
- `source .venv/bin/activate && pytest -q`

Fixes #782