### PR TITLE
feat(cli): add /reasoning slash command to manage reasoning effort

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2174,6 +2174,37 @@ class HermesCLI:
             print("  Usage: /personality <name>")
             print()
     
+    def _handle_reasoning_command(self, cmd: str):
+        """Handle the /reasoning command to view or set reasoning effort."""
+        parts = cmd.split(maxsplit=1)
+        valid_efforts = ("low", "medium", "high", "xhigh", "minimal", "none")
+
+        if len(parts) == 1:
+            if self.reasoning_config is None:
+                current = "default (provider default)"
+            elif self.reasoning_config.get("enabled") is False:
+                current = "none"
+            else:
+                current = self.reasoning_config.get("effort", "medium")
+
+            print(f"Current reasoning effort: {current}")
+            print("  Usage: /reasoning <low|medium|high|xhigh>")
+            return
+
+        effort = parts[1].strip().lower()
+        if effort not in valid_efforts:
+            print(f"(._.) Invalid reasoning level: {effort}")
+            print("  Valid levels: low, medium, high, xhigh")
+            return
+
+        self.reasoning_config = _parse_reasoning_config(effort)
+        self.agent = None  # Force re-init with new reasoning config
+
+        if save_config_value("agent.reasoning_effort", effort):
+            print(f"(^_^)b Reasoning effort set to: {effort} (saved to config)")
+        else:
+            print(f"(^_^) Reasoning effort set to: {effort} (session only)")
+
     def _handle_cron_command(self, cmd: str):
         """Handle the /cron command to manage scheduled tasks."""
         parts = cmd.split(maxsplit=2)
@@ -2638,6 +2669,8 @@ class HermesCLI:
         elif cmd_lower.startswith("/personality"):
             # Use original case (handler lowercases the personality name itself)
             self._handle_personality_command(cmd_original)
+        elif cmd_lower.startswith("/reasoning"):
+            self._handle_reasoning_command(cmd_original)
         elif cmd_lower == "/retry":
             retry_msg = self.retry_last()
             if retry_msg and hasattr(self, '_pending_input'):

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -21,6 +21,7 @@ COMMANDS = {
     "/provider": "Show available providers and current provider",
     "/prompt": "View/set custom system prompt",
     "/personality": "Set a predefined personality",
+    "/reasoning": "Show or change reasoning effort (low|medium|high|xhigh)",
     "/clear": "Clear screen and reset conversation (fresh start)",
     "/history": "Show conversation history",
     "/new": "Start a new conversation (reset history)",

--- a/tests/test_cli_reasoning_command.py
+++ b/tests/test_cli_reasoning_command.py
@@ -1,0 +1,67 @@
+"""Tests for /reasoning slash command in HermesCLI."""
+
+from unittest.mock import patch
+
+
+def _make_cli(**kwargs):
+    """Create a HermesCLI instance with minimal mocking."""
+    import cli as _cli_mod
+    from cli import HermesCLI
+
+    clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {"reasoning_effort": "medium"},
+        "terminal": {"env_type": "local"},
+    }
+
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+
+    with (
+        patch("cli.get_tool_definitions", return_value=[]),
+        patch.dict("os.environ", clean_env, clear=False),
+        patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": clean_config}),
+    ):
+        return HermesCLI(**kwargs)
+
+
+def test_reasoning_command_sets_high_and_persists():
+    cli_obj = _make_cli()
+    cli_obj.agent = object()  # ensure command forces re-init
+
+    with patch("cli.save_config_value", return_value=True) as mock_save:
+        keep_running = cli_obj.process_command("/reasoning high")
+
+    assert keep_running is True
+    assert cli_obj.reasoning_config == {"enabled": True, "effort": "high"}
+    assert cli_obj.agent is None
+    mock_save.assert_called_once_with("agent.reasoning_effort", "high")
+
+
+def test_reasoning_command_rejects_invalid_level(capsys):
+    cli_obj = _make_cli()
+    before = cli_obj.reasoning_config
+
+    with patch("cli.save_config_value", return_value=True) as mock_save:
+        keep_running = cli_obj.process_command("/reasoning ultra")
+
+    out = capsys.readouterr().out
+    assert keep_running is True
+    assert "Invalid reasoning level" in out
+    assert cli_obj.reasoning_config == before
+    mock_save.assert_not_called()
+
+
+def test_reasoning_command_without_args_shows_current(capsys):
+    cli_obj = _make_cli()
+    cli_obj.reasoning_config = {"enabled": True, "effort": "medium"}
+
+    keep_running = cli_obj.process_command("/reasoning")
+
+    out = capsys.readouterr().out
+    assert keep_running is True
+    assert "Current reasoning effort: medium" in out


### PR DESCRIPTION
## What Changed and Why

This PR adds a new `/reasoning` slash command to the Hermes CLI that allows users to view and change the reasoning effort level without manually editing the configuration file.

Previously, users had to:
1. Find the config file at `~/.hermes/config.yaml`
2. Manually edit the `agent.reasoning_effort` value
3. Restart Hermes for changes to take effect

Now users can simply run:
- `/reasoning` - Shows current reasoning effort level
- `/reasoning high` - Sets reasoning effort to high
- `/reasoning low` - Sets reasoning effort to low

Supported levels: `low`, `medium`, `high`, `xhigh` (also accepts `minimal` and `none` for low)

Changes persist to the config file and force an agent re-initialization to apply immediately.

## Files Changed

- `cli.py` - Added `/reasoning` command handler in `process_command()`
- `hermes_cli/commands.py` - Added command definition and autocomplete
- `tests/test_cli_reasoning_command.py` - New test file with 3 unit tests

## How to Test

1. Start Hermes: `hermes`
2. Run `/reasoning` to see current level (should show `medium` by default)
3. Run `/reasoning high` to change to high
4. Run `/reasoning` again to verify it shows `high`
5. Run `/reasoning ultra` to verify invalid input is rejected with error message

## Platforms Tested

- macOS (Darwin) - Python 3.11

## Tests

```bash
python -m pytest tests/test_cli_reasoning_command.py -v
# 3 passed
```

## Related

Addresses user request for a convenient way to change reasoning effort level from within the CLI.