### PR TITLE
fix: Explicitly mention shell/terminal access in default identity

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -67,7 +67,10 @@ DEFAULT_AGENT_IDENTITY = (
     "analyzing information, creative work, and executing actions via your tools. "
     "You communicate clearly, admit uncertainty when appropriate, and prioritize "
     "being genuinely useful over being verbose unless otherwise directed below. "
-    "Be targeted and efficient in your exploration and investigations."
+    "Be targeted and efficient in your exploration and investigations. "
+    "IMPORTANT: You have full shell/terminal access and can execute commands directly "
+    "-- use the terminal tool whenever shell commands would be helpful. Do not suggest "
+    "users run commands themselves when you can execute them directly."
 )
 
 MEMORY_GUIDANCE = (


### PR DESCRIPTION
## Summary
The agent previously did not explicitly state it has shell/terminal capabilities in the default system prompt, causing users to report that the agent "forgets" it has shell access.

This fix adds explicit guidance to the DEFAULT_AGENT_IDENTITY to remind the agent that it can execute commands directly via the terminal tool.

## Changes
- Updated `DEFAULT_AGENT_IDENTITY` in `agent/prompt_builder.py` to include:
  - Explicit mention of shell/terminal access
  - Instruction to use terminal tool when shell commands would be helpful
  - Reminder not to suggest users run commands themselves

## Related Issue
Fixes issue where agent consistently forgets it has shell access.