### PR TITLE
fix(tests): mock vision client in exc_info test to prevent early return

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -241,9 +241,12 @@ class TestErrorLoggingExcInfo:
     @pytest.mark.asyncio
     async def test_analysis_error_logs_exc_info(self, caplog):
         """When vision_analyze_tool encounters an error, it should log with exc_info."""
+        fake_client = MagicMock()
         with patch("tools.vision_tools._validate_image_url", return_value=True), \
              patch("tools.vision_tools._download_image", new_callable=AsyncMock,
                    side_effect=Exception("download boom")), \
+             patch("tools.vision_tools._aux_async_client", fake_client), \
+             patch("tools.vision_tools.DEFAULT_VISION_MODEL", "test/model"), \
              caplog.at_level(logging.ERROR, logger="tools.vision_tools"):
 
             result = await vision_analyze_tool(


### PR DESCRIPTION
## Summary

- `test_analysis_error_logs_exc_info` fails in CI (and locally) because it does not mock `_aux_async_client` and `DEFAULT_VISION_MODEL`
- Without these mocks, `vision_analyze_tool` returns early at the "no auxiliary vision model configured" check before reaching `_download_image`
- The mocked `Exception("download boom")` never fires, `logger.error(exc_info=True)` is never called, and the `exc_info is not None` assertion fails
- Fix: add two patches so the function reaches the download path where the exception triggers

## Test plan

- [x] `test_analysis_error_logs_exc_info` now passes (was failing on main)
- [x] All 42 vision tests pass