### PR TITLE
test: parallelize test suite with pytest-xdist

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          python -m pytest tests/ -q --ignore=tests/integration --tb=short
+          python -m pytest tests/ -q --ignore=tests/integration --tb=short -n auto
         env:
           # Ensure tests don't accidentally call real APIs
           OPENROUTER_API_KEY: ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 [project.optional-dependencies]
 modal = ["swe-rex[modal]>=1.4.0"]
 daytona = ["daytona>=0.148.0"]
-dev = ["pytest", "pytest-asyncio", "mcp>=1.2.0"]
+dev = ["pytest", "pytest-asyncio", "pytest-xdist", "mcp>=1.2.0"]
 messaging = ["python-telegram-bot>=20.0", "discord.py>=2.0", "aiohttp>=3.9.0", "slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]
 cron = ["croniter"]
 slack = ["slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]
@@ -81,4 +81,4 @@ testpaths = ["tests"]
 markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
 ]
-addopts = "-m 'not integration'"
+addopts = "-m 'not integration' -n auto"


### PR DESCRIPTION
## What does this PR do?

Adds pytest-xdist to run the test suite in parallel across all CPU cores. Cuts wall-clock time from ~2min to ~30s locally.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `pyproject.toml`: added `pytest-xdist` to `[dev]` deps, added `-n auto` to default `addopts`
- `.github/workflows/tests.yml`: added `-n auto` to CI pytest invocation

## How to Test

1. `uv pip install -e ".[all,dev]"`
2. `pytest tests/ -q --ignore=tests/integration --tb=short`
3. Confirm tests run across multiple workers and pass (2677 passed, 1 skipped)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: Ubuntu (WSL2)

### Documentation & Housekeeping

- [x] N/A — no docs, config, or architecture changes