### PR TITLE
chore: fix vision test by mocking aux client

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -245,6 +245,7 @@ class TestErrorLoggingExcInfo:
              patch("tools.vision_tools._download_image", new_callable=AsyncMock,
                    side_effect=Exception("download boom")), \
              patch("tools.vision_tools._aux_async_client", new="fake"), \
+             patch("tools.vision_tools.DEFAULT_VISION_MODEL", new="test/model"), \
              caplog.at_level(logging.ERROR, logger="tools.vision_tools"):
 
             result = await vision_analyze_tool(

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -244,17 +244,17 @@ class TestErrorLoggingExcInfo:
         with patch("tools.vision_tools._validate_image_url", return_value=True), \
              patch("tools.vision_tools._download_image", new_callable=AsyncMock,
                    side_effect=Exception("download boom")), \
+             patch("tools.vision_tools._aux_async_client", new="fake"), \
              caplog.at_level(logging.ERROR, logger="tools.vision_tools"):
 
             result = await vision_analyze_tool(
                 "https://example.com/img.jpg", "describe this", "test/model"
             )
             result_data = json.loads(result)
-            # Error response uses "success": False, not an "error" key
             assert result_data["success"] is False
 
             error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
-            assert any(r.exc_info is not None for r in error_records)
+            assert any(r.exc_info and r.exc_info[0] is not None for r in error_records)
 
     @pytest.mark.asyncio
     async def test_cleanup_error_logs_exc_info(self, tmp_path, caplog):


### PR DESCRIPTION
## What does this PR do?

`test_analysis_error_logs_exc_info` fails in CI but passes locally. The test doesn't mock `_aux_async_client`, so when another test leaves that global as `None`, the function early-returns before reaching the `except` block — no error is ever logged, assertion fails.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/tools/test_vision_tools.py`: mock `_aux_async_client` to a truthy value so the code reaches the download/exception path
- Tightened assertion from `r.exc_info is not None` to `r.exc_info and r.exc_info[0] is not None` (the former passes even when there's no real exception)

## How to Test

1. `python -m pytest tests/tools/test_vision_tools.py::TestErrorLoggingExcInfo -xvs`
2. Run the full suite a few times to confirm no ordering-dependent flake

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `make check` (lint + test) and all checks pass
- [x] I've added tests for my changes — N/A (this fixes an existing test)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [x] N/A — no docs, config, or schema changes