### PR TITLE
fix: mock vision client in exc_info test to fix CI failure

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -242,7 +242,10 @@ class TestErrorLoggingExcInfo:
     async def test_analysis_error_logs_exc_info(self):
         """When vision_analyze_tool encounters an error, it should log with exc_info."""
         import tools.vision_tools as _vt
-        with patch.object(_vt.logger, "error") as mock_error, \
+        mock_async_client = MagicMock()
+        with patch.object(_vt, "_aux_async_client", mock_async_client), \
+             patch.object(_vt, "DEFAULT_VISION_MODEL", "test/model"), \
+             patch.object(_vt.logger, "error") as mock_error, \
              patch("tools.vision_tools._validate_image_url", return_value=True), \
              patch("tools.vision_tools._download_image", new_callable=AsyncMock,
                    side_effect=Exception("download boom")):

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -239,10 +239,10 @@ class TestErrorLoggingExcInfo:
             assert error_records[0].exc_info is not None
 
     @pytest.mark.asyncio
-    async def test_analysis_error_logs_exc_info(self, caplog):
+    async def test_analysis_error_logs_exc_info(self):
         """When vision_analyze_tool encounters an error, it should log with exc_info."""
-        caplog.handler.setLevel(logging.ERROR)
-        with caplog.at_level(logging.ERROR, logger="tools.vision_tools"), \
+        import tools.vision_tools as _vt
+        with patch.object(_vt.logger, "error") as mock_error, \
              patch("tools.vision_tools._validate_image_url", return_value=True), \
              patch("tools.vision_tools._download_image", new_callable=AsyncMock,
                    side_effect=Exception("download boom")):
@@ -250,10 +250,10 @@ class TestErrorLoggingExcInfo:
                 "https://example.com/img.jpg", "describe this", "test/model"
             )
         result_data = json.loads(result)
-        # Error response uses "success": False, not an "error" key
         assert result_data["success"] is False
-        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
-        assert any(r.exc_info is not None for r in error_records)
+        assert mock_error.called
+        _, kwargs = mock_error.call_args
+        assert kwargs.get("exc_info") is True
 
     @pytest.mark.asyncio
     async def test_cleanup_error_logs_exc_info(self, tmp_path, caplog):

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -241,20 +241,19 @@ class TestErrorLoggingExcInfo:
     @pytest.mark.asyncio
     async def test_analysis_error_logs_exc_info(self, caplog):
         """When vision_analyze_tool encounters an error, it should log with exc_info."""
-        with patch("tools.vision_tools._validate_image_url", return_value=True), \
+        caplog.handler.setLevel(logging.ERROR)
+        with caplog.at_level(logging.ERROR, logger="tools.vision_tools"), \
+             patch("tools.vision_tools._validate_image_url", return_value=True), \
              patch("tools.vision_tools._download_image", new_callable=AsyncMock,
-                   side_effect=Exception("download boom")), \
-             caplog.at_level(logging.ERROR, logger="tools.vision_tools"):
-
+                   side_effect=Exception("download boom")):
             result = await vision_analyze_tool(
                 "https://example.com/img.jpg", "describe this", "test/model"
             )
-            result_data = json.loads(result)
-            # Error response uses "success": False, not an "error" key
-            assert result_data["success"] is False
-
-            error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
-            assert any(r.exc_info is not None for r in error_records)
+        result_data = json.loads(result)
+        # Error response uses "success": False, not an "error" key
+        assert result_data["success"] is False
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any(r.exc_info is not None for r in error_records)
 
     @pytest.mark.asyncio
     async def test_cleanup_error_logs_exc_info(self, tmp_path, caplog):


### PR DESCRIPTION
## Problem
`test_analysis_error_logs_exc_info` was failing in CI with:
assert mock_error.called
AssertionError: assert False

## Root Cause
In CI environments where no vision API key is configured, `_aux_async_client` is `None` and `DEFAULT_VISION_MODEL` is `None`. The function returns early before reaching the download/error path, so `logger.error` is never called and the assertion fails.

## Fix
Mock `_aux_async_client` and `DEFAULT_VISION_MODEL` in the test so the function proceeds past the early-return guard and actually reaches the error handling path.

## Testing
All 42 vision tool tests pass locally.