### PR TITLE
fix(execute_code): avoid global toolset cross-talk across subagents

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -123,8 +123,13 @@ TOOL_TO_TOOLSET_MAP: Dict[str, str] = registry.get_tool_to_toolset_map()
 TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
 
 # Resolved tool names from the last get_tool_definitions() call.
-# Used by code_execution_tool to know which tools are available in this session.
+# Used as a fallback for execute_code when per-call tool context is unavailable.
 _last_resolved_tool_names: List[str] = []
+
+# Internal argument key injected by the agent loop when dispatching execute_code.
+# This avoids process-global cross-talk when multiple agents/subagents run in
+# the same process and resolve different toolsets.
+_INTERNAL_ENABLED_TOOLS_ARG = "__hermes_enabled_tools"
 
 
 # =============================================================================
@@ -284,10 +289,17 @@ def handle_function_call(
             return json.dumps({"error": f"{function_name} must be handled by the agent loop"})
 
         if function_name == "execute_code":
+            call_args = dict(function_args or {})
+            explicit_enabled_tools = call_args.pop(_INTERNAL_ENABLED_TOOLS_ARG, None)
+            enabled_tools = (
+                explicit_enabled_tools
+                if isinstance(explicit_enabled_tools, list)
+                else _last_resolved_tool_names
+            )
             return registry.dispatch(
-                function_name, function_args,
+                function_name, call_args,
                 task_id=task_id,
-                enabled_tools=_last_resolved_tool_names,
+                enabled_tools=enabled_tools,
             )
 
         return registry.dispatch(

--- a/run_agent.py
+++ b/run_agent.py
@@ -2814,7 +2814,11 @@ class AIAgent:
                 spinner.start()
                 _spinner_result = None
                 try:
-                    function_result = handle_function_call(function_name, function_args, effective_task_id)
+                    dispatch_args = function_args
+                    if function_name == "execute_code":
+                        dispatch_args = dict(function_args)
+                        dispatch_args["__hermes_enabled_tools"] = sorted(self.valid_tool_names)
+                    function_result = handle_function_call(function_name, dispatch_args, effective_task_id)
                     _spinner_result = function_result
                 except Exception as tool_error:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"
@@ -2825,7 +2829,11 @@ class AIAgent:
                     spinner.stop(cute_msg)
             else:
                 try:
-                    function_result = handle_function_call(function_name, function_args, effective_task_id)
+                    dispatch_args = function_args
+                    if function_name == "execute_code":
+                        dispatch_args = dict(function_args)
+                        dispatch_args["__hermes_enabled_tools"] = sorted(self.valid_tool_names)
+                    function_result = handle_function_call(function_name, dispatch_args, effective_task_id)
                 except Exception as tool_error:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"
                     logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -2,6 +2,7 @@
 
 import json
 import pytest
+import model_tools
 
 from model_tools import (
     handle_function_call,
@@ -37,6 +38,48 @@ class TestHandleFunctionCall:
         assert "error" in parsed
         assert len(parsed["error"]) > 0
         assert "error" in parsed["error"].lower() or "failed" in parsed["error"].lower()
+
+    def test_execute_code_uses_explicit_enabled_tools_when_provided(self, monkeypatch):
+        captured = {}
+
+        def _fake_dispatch(name, args, **kwargs):
+            captured["name"] = name
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr(model_tools.registry, "dispatch", _fake_dispatch)
+        monkeypatch.setattr(model_tools, "_last_resolved_tool_names", ["web_search"])
+
+        result = handle_function_call(
+            "execute_code",
+            {
+                "code": "print('hi')",
+                "__hermes_enabled_tools": ["terminal", "read_file"],
+            },
+            task_id="task-1",
+        )
+
+        assert json.loads(result)["ok"] is True
+        assert captured["name"] == "execute_code"
+        assert captured["args"] == {"code": "print('hi')"}
+        assert captured["kwargs"]["enabled_tools"] == ["terminal", "read_file"]
+        assert captured["kwargs"]["task_id"] == "task-1"
+
+    def test_execute_code_falls_back_to_last_resolved_tools(self, monkeypatch):
+        captured = {}
+
+        def _fake_dispatch(name, args, **kwargs):
+            captured["kwargs"] = kwargs
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr(model_tools.registry, "dispatch", _fake_dispatch)
+        monkeypatch.setattr(model_tools, "_last_resolved_tool_names", ["search_files", "read_file"])
+
+        result = handle_function_call("execute_code", {"code": "print(1)"}, task_id="task-2")
+
+        assert json.loads(result)["ok"] is True
+        assert captured["kwargs"]["enabled_tools"] == ["search_files", "read_file"]
 
 
 # =========================================================================

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -643,6 +643,21 @@ class TestExecuteToolCalls:
         assert len(messages[0]["content"]) < 150_000
         assert "Truncated" in messages[0]["content"]
 
+    def test_execute_code_injects_enabled_tools_context(self, agent):
+        tc = _mock_tool_call(name="execute_code", arguments='{"code":"print(1)"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        agent.valid_tool_names = {"execute_code", "read_file", "terminal"}
+
+        with patch("run_agent.handle_function_call", return_value="ok") as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        called_name, called_args, called_task_id = mock_hfc.call_args.args
+        assert called_name == "execute_code"
+        assert called_task_id == "task-1"
+        assert called_args["code"] == "print(1)"
+        assert called_args["__hermes_enabled_tools"] == sorted(agent.valid_tool_names)
+
 
 class TestHandleMaxIterations:
     def test_returns_summary(self, agent):


### PR DESCRIPTION
## Summary
- remove execute_code reliance on process-global tool context when per-call context is available
- inject enabled tool names from AIAgent into execute_code dispatch payload
- keep backward-compatible fallback to last resolved tool list when per-call context is absent
- add regression tests in model_tools and run_agent

## Problem
model_tools._last_resolved_tool_names is process-global. In multi-agent/subagent flows, one agent can overwrite this value, causing later execute_code calls in another agent to receive the wrong enabled tool list.

## Fix
- run_agent now injects an internal arg (__hermes_enabled_tools) only for execute_code calls.
- model_tools.handle_function_call(execute_code, ...) consumes this internal arg, strips it from tool args, and passes it to registry dispatch as enabled_tools.
- if the internal arg is missing, behavior falls back to _last_resolved_tool_names for compatibility with non-agent-loop callers.

## Tests
- python -m pytest tests/test_model_tools.py tests/test_run_agent.py -q (104 passed)
- python -m pytest tests/tools/test_code_execution.py -q (28 passed)
- full suite run still has one unrelated pre-existing failure:
  - tests/test_timezone.py::TestCronTimezone::test_get_due_jobs_handles_naive_timestamps

## Notes
This targets the known pitfall documented in AGENTS.md about _last_resolved_tool_names global overwrite during delegation.