### PR TITLE
fix(telegram): enable document sending for PDFs and other files

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -430,6 +430,34 @@ class TelegramAdapter(BasePlatformAdapter):
             # Fallback: try as a regular photo
             return await self.send_image(chat_id, animation_url, caption, reply_to)
 
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+    ) -> SendResult:
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            import os
+            if not os.path.exists(file_path):
+                return SendResult(success=False, error=f"File not found: {file_path}")
+
+            with open(file_path, "rb") as doc_file:
+                msg = await self._bot.send_document(
+                    chat_id=int(chat_id),
+                    document=doc_file,
+                    caption=caption[:1024] if caption else None,
+                    reply_to_message_id=int(reply_to) if reply_to else None,
+                )
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.error(f"[{self.name}] Failed to send document: {e}")
+            return await super().send_document(chat_id, file_path, caption, file_name, reply_to)
+
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Send typing indicator."""
         if self._bot:


### PR DESCRIPTION
## Problem
Telegram bot couldn't send PDFs or other documents. When a user asked for a PDF, they'd only get text like:
```
File: /tmp/document.pdf
```
Instead of the actual file.

Images, audio, and video worked fine because those methods existed. Documents didn't because `send_document()` was missing.

## Fix
Added the missing `send_document()` method to `TelegramAdapter` using the same pattern as `send_image_file()` and `send_voice()`. Uses Telegram Bot API's `send_document` endpoint.

## What works now
- PDFs, DOCX, XLSX, PPTX, TXT, MD, and any other file type
- Files are sent as actual downloadable documents
- Caption support included

## Testing
Tested method override - TelegramAdapter now properly sends documents instead of falling back to text.

## Files changed
gateway/platforms/telegram.py - Added send_document() method
