### PR TITLE
fix(context): detect Anthropic 'prompt is too long' as context length error

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3703,6 +3703,7 @@ class AIAgent:
                         'token limit', 'too many tokens', 'reduce the length',
                         'exceeds the limit', 'context window',
                         'request entity too large',  # OpenRouter/Nous 413 safety net
+                        'prompt is too long',  # Anthropic native format: "prompt is too long: N tokens > M maximum"
                     ])
                     
                     if is_context_length_error:

--- a/tests/test_413_compression.py
+++ b/tests/test_413_compression.py
@@ -234,6 +234,45 @@ class TestHTTP413Compression:
         mock_compress.assert_called_once()
         assert result["completed"] is True
 
+    def test_400_anthropic_prompt_too_long_triggers_compression(self, agent):
+        """A 400 with Anthropic's 'prompt is too long' should trigger compression.
+
+        Anthropic's native API returns errors in the format:
+        "prompt is too long: 233153 tokens > 200000 maximum"
+        This must trigger compression, not abort as a generic 4xx error.
+        See: https://github.com/NousResearch/hermes-agent/issues/813
+        """
+        err_400 = Exception(
+            "Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', "
+            "'message': 'prompt is too long: 233153 tokens > 200000 maximum'}}"
+        )
+        err_400.status_code = 400
+        ok_resp = _mock_response(content="Recovered after compression", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_400, ok_resp]
+
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "hello"}],
+                "compressed prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        # Must NOT have "failed": True (which would mean the generic 4xx handler caught it)
+        assert result.get("failed") is not True
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered after compression"
+
     def test_413_cannot_compress_further(self, agent):
         """When compression can't reduce messages, return partial result."""
         err_413 = _make_413_error()


### PR DESCRIPTION
## Summary

Fixes #813 — Anthropic's native API returns context overflow errors in a unique format that wasn't being detected:

```
prompt is too long: 233153 tokens > 200000 maximum
```

This format wasn't matched by the existing `is_context_length_error` phrases, causing the agent to abort immediately as a "non-retryable client error" instead of triggering context compression.

## Changes

1. **run_agent.py**: Added `'prompt is too long'` to the context length error detection phrases
2. **tests/test_413_compression.py**: Added test case for Anthropic's error format

## Testing

- All 10 tests in `test_413_compression.py` pass
- New test specifically verifies Anthropic format triggers compression instead of abort

## Impact

Users on Anthropic models (direct API or via OpenRouter) will now get proper context compression when hitting the 200k token limit, instead of an immediate failure.