### PR TITLE
fix: stop repeated identical tool doom loops

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2705,6 +2705,8 @@ class AIAgent:
 
     def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute tool calls from the assistant message and append results to messages."""
+        blocked_doom_loop_signature: Optional[tuple[str, str]] = None
+        deferred_doom_loop_recovery_msg: Optional[str] = None
         for i, tool_call in enumerate(assistant_message.tool_calls, 1):
             # SAFETY: check interrupt BEFORE starting each tool.
             # If the user sent "stop" during a previous tool's execution,
@@ -2740,14 +2742,66 @@ class AIAgent:
                 function_args = {}
 
             doom_loop_signature = self._make_doom_loop_signature(function_name, function_args)
+            if blocked_doom_loop_signature is not None and doom_loop_signature == blocked_doom_loop_signature:
+                skip_content = (
+                    f"[Tool execution skipped - doom loop detected: '{function_name}' "
+                    "was requested again with the same arguments in this turn]"
+                )
+                messages.append(
+                    {
+                        "role": "tool",
+                        "content": skip_content,
+                        "tool_call_id": tool_call.id,
+                    }
+                )
+                continue
+
             if self._should_trigger_doom_loop(doom_loop_signature):
-                if self._handle_doom_loop(
-                    assistant_message=assistant_message,
-                    messages=messages,
-                    tool_call_index=i - 1,
-                    tool_name=function_name,
-                ):
+                decision = self._handle_doom_loop(tool_name=function_name)
+                if decision == "continue":
+                    pass
+                elif decision == "stop":
+                    skip_content = (
+                        f"[Tool execution skipped - doom loop detected: '{function_name}' was about to be called "
+                        f"{DOOM_LOOP_THRESHOLD} times in a row with the same arguments]"
+                    )
+                    for skipped_tc in assistant_message.tool_calls[i - 1:]:
+                        messages.append(
+                            {
+                                "role": "tool",
+                                "content": skip_content,
+                                "tool_call_id": skipped_tc.id,
+                            }
+                        )
+                    deferred_doom_loop_recovery_msg = (
+                        f"A doom loop was detected on the '{function_name}' tool, and the user chose to stop. "
+                        "Do not call more tools. Provide a final response summarizing what you found so far."
+                    )
+                    self._doom_loop_signature = None
+                    self._doom_loop_count = 0
                     break
+                else:
+                    skip_content = (
+                        f"[Tool execution skipped - doom loop detected: '{function_name}' was about to be called "
+                        f"{DOOM_LOOP_THRESHOLD} times in a row with the same arguments]"
+                    )
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "content": skip_content,
+                            "tool_call_id": tool_call.id,
+                        }
+                    )
+                    blocked_doom_loop_signature = doom_loop_signature
+                    deferred_doom_loop_recovery_msg = (
+                        f"A doom loop was detected on the '{function_name}' tool: you attempted the same call "
+                        f"with the same arguments {DOOM_LOOP_THRESHOLD} times in a row. "
+                        "Do NOT repeat that exact tool call again. Try a different approach, use different "
+                        "arguments, use another tool, or provide a final response if you are blocked."
+                    )
+                    self._doom_loop_signature = None
+                    self._doom_loop_count = 0
+                    continue
 
             if not self.quiet_mode:
                 args_str = json.dumps(function_args, ensure_ascii=False)
@@ -2961,6 +3015,9 @@ class AIAgent:
             if self.tool_delay > 0 and i < len(assistant_message.tool_calls):
                 time.sleep(self.tool_delay)
 
+        if deferred_doom_loop_recovery_msg:
+            messages.append({"role": "user", "content": deferred_doom_loop_recovery_msg})
+
         # ── Budget pressure injection ─────────────────────────────────
         # After all tool calls in this turn are processed, check if we're
         # approaching max_iterations. If so, inject a warning into the LAST
@@ -3051,13 +3108,7 @@ class AIAgent:
         self._doom_loop_signature = signature
         self._doom_loop_count = 1
 
-    def _handle_doom_loop(
-        self,
-        assistant_message,
-        messages: list,
-        tool_call_index: int,
-        tool_name: str,
-    ) -> bool:
+    def _handle_doom_loop(self, tool_name: str) -> str:
         logger.warning(
             "Doom loop detected for %s after %s identical calls",
             tool_name,
@@ -3083,38 +3134,10 @@ class AIAgent:
 
         normalized_response = response.lower()
         if "continue" in normalized_response:
-            return False
-
-        skip_content = (
-            f"[Tool execution skipped - doom loop detected: '{tool_name}' was about to be called "
-            f"{DOOM_LOOP_THRESHOLD} times in a row with the same arguments]"
-        )
-        for skipped_tc in assistant_message.tool_calls[tool_call_index:]:
-            skip_msg = {
-                "role": "tool",
-                "content": skip_content,
-                "tool_call_id": skipped_tc.id,
-            }
-            messages.append(skip_msg)
-
+            return "continue"
         if "stop" in normalized_response:
-            recovery_msg = (
-                f"A doom loop was detected on the '{tool_name}' tool, and the user chose to stop. "
-                "Do not call more tools. Provide a final response summarizing what you found so far."
-            )
-        else:
-            recovery_msg = (
-                f"A doom loop was detected on the '{tool_name}' tool: you attempted the same call "
-                f"with the same arguments {DOOM_LOOP_THRESHOLD} times in a row. "
-                "Do NOT repeat that exact tool call again. Try a different approach, use different "
-                "arguments, use another tool, or provide a final response if you are blocked."
-            )
-
-        recovery_dict = {"role": "user", "content": recovery_msg}
-        messages.append(recovery_dict)
-        self._doom_loop_signature = None
-        self._doom_loop_count = 0
-        return True
+            return "stop"
+        return "reroute"
 
     def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
         """Request a summary when max iterations are reached. Returns the final response text."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -15,7 +15,7 @@ Features:
 
 Usage:
     from run_agent import AIAgent
-    
+
     agent = AIAgent(base_url="http://localhost:30000/v1", model="claude-opus-4-20250514")
     response = agent.run_conversation("Tell me about the latest Python updates")
 """
@@ -24,6 +24,7 @@ import copy
 import hashlib
 import json
 import logging
+
 logger = logging.getLogger(__name__)
 import os
 import random
@@ -44,7 +45,7 @@ from dotenv import load_dotenv
 
 _hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
 _user_env = _hermes_home / ".env"
-_project_env = Path(__file__).parent / '.env'
+_project_env = Path(__file__).parent / ".env"
 if _user_env.exists():
     try:
         load_dotenv(dotenv_path=_user_env, encoding="utf-8")
@@ -65,7 +66,11 @@ os.environ.setdefault("MSWEA_GLOBAL_CONFIG_DIR", str(_hermes_home))
 os.environ.setdefault("MSWEA_SILENT_STARTUP", "1")
 
 # Import our tool system
-from model_tools import get_tool_definitions, handle_function_call, check_toolset_requirements
+from model_tools import (
+    get_tool_definitions,
+    handle_function_call,
+    check_toolset_requirements,
+)
 from tools.terminal_tool import cleanup_vm
 from tools.interrupt import set_interrupt as _set_interrupt
 from tools.browser_tool import cleanup_browser
@@ -76,25 +81,33 @@ from hermes_constants import OPENROUTER_BASE_URL, OPENROUTER_MODELS_URL
 
 # Agent internals extracted to agent/ package for modularity
 from agent.prompt_builder import (
-    DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
-    MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
+    DEFAULT_AGENT_IDENTITY,
+    PLATFORM_HINTS,
+    MEMORY_GUIDANCE,
+    SESSION_SEARCH_GUIDANCE,
+    SKILLS_GUIDANCE,
 )
 from agent.model_metadata import (
-    fetch_model_metadata, get_model_context_length,
-    estimate_tokens_rough, estimate_messages_tokens_rough,
-    get_next_probe_tier, parse_context_limit_from_error,
+    fetch_model_metadata,
+    get_model_context_length,
+    estimate_tokens_rough,
+    estimate_messages_tokens_rough,
+    get_next_probe_tier,
+    parse_context_limit_from_error,
     save_context_length,
 )
 from agent.context_compressor import ContextCompressor
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt
 from agent.display import (
-    KawaiiSpinner, build_tool_preview as _build_tool_preview,
+    KawaiiSpinner,
+    build_tool_preview as _build_tool_preview,
     get_cute_tool_message as _get_cute_tool_message_impl,
     _detect_tool_failure,
 )
 from agent.trajectory import (
-    convert_scratchpad_to_think, has_incomplete_scratchpad,
+    convert_scratchpad_to_think,
+    has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
 )
 
@@ -144,11 +157,11 @@ class IterationBudget:
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
-    
+
     This class manages the conversation flow, tool execution, and response handling
     for AI models that support function calling.
     """
-    
+
     def __init__(
         self,
         base_url: str = None,
@@ -248,13 +261,19 @@ class AIAgent:
         # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
         # When no base_url is provided, the client defaults to OpenRouter, so reflect that here.
         self.base_url = base_url or OPENROUTER_BASE_URL
-        provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
+        provider_name = (
+            provider.strip().lower()
+            if isinstance(provider, str) and provider.strip()
+            else None
+        )
         self.provider = provider_name or "openrouter"
         if api_mode in {"chat_completions", "codex_responses"}:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
-        elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self.base_url.lower():
+        elif (
+            provider_name is None
+        ) and "chatgpt.com/backend-api/codex" in self.base_url.lower():
             self.api_mode = "codex_responses"
             self.provider = "openai-codex"
         else:
@@ -267,15 +286,15 @@ class AIAgent:
         self._last_reported_tool = None  # Track for "new tool" mode
         self._doom_loop_signature = None
         self._doom_loop_count = 0
-        
+
         # Interrupt mechanism for breaking out of tool loops
         self._interrupt_requested = False
         self._interrupt_message = None  # Optional message that triggered interrupt
-        
+
         # Subagent delegation state
-        self._delegate_depth = 0        # 0 = top-level agent, incremented for children
-        self._active_children = []      # Running child AIAgents (for interrupt propagation)
-        
+        self._delegate_depth = 0  # 0 = top-level agent, incremented for children
+        self._active_children = []  # Running child AIAgents (for interrupt propagation)
+
         # Store OpenRouter provider preferences
         self.providers_allowed = providers_allowed
         self.providers_ignored = providers_ignored
@@ -287,12 +306,14 @@ class AIAgent:
         # Store toolset filtering options
         self.enabled_toolsets = enabled_toolsets
         self.disabled_toolsets = disabled_toolsets
-        
+
         # Model response configuration
         self.max_tokens = max_tokens  # None = use model default
-        self.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
+        self.reasoning_config = (
+            reasoning_config  # None = use default (medium for OpenRouter)
+        )
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
-        
+
         # Anthropic prompt caching: auto-enabled for Claude models via OpenRouter.
         # Reduces input costs by ~75% on multi-turn conversations by caching the
         # conversation prefix. Uses system_and_3 strategy (4 breakpoints).
@@ -300,97 +321,107 @@ class AIAgent:
         is_claude = "claude" in self.model.lower()
         self._use_prompt_caching = is_openrouter and is_claude
         self._cache_ttl = "5m"  # Default 5-minute TTL (1.25x write cost)
-        
+
         # Iteration budget pressure: warn the LLM as it approaches max_iterations.
         # Warnings are injected into the last tool result JSON (not as separate
         # messages) so they don't break message structure or invalidate caching.
-        self._budget_caution_threshold = 0.7   # 70% — nudge to start wrapping up
-        self._budget_warning_threshold = 0.9   # 90% — urgent, respond now
+        self._budget_caution_threshold = 0.7  # 70% — nudge to start wrapping up
+        self._budget_warning_threshold = 0.9  # 90% — urgent, respond now
         self._budget_pressure_enabled = True
 
         # Persistent error log -- always writes WARNING+ to ~/.hermes/logs/errors.log
         # so tool failures, API errors, etc. are inspectable after the fact.
         from agent.redact import RedactingFormatter
+
         _error_log_dir = Path.home() / ".hermes" / "logs"
         _error_log_dir.mkdir(parents=True, exist_ok=True)
         _error_log_path = _error_log_dir / "errors.log"
         from logging.handlers import RotatingFileHandler
+
         _error_file_handler = RotatingFileHandler(
-            _error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,
+            _error_log_path,
+            maxBytes=2 * 1024 * 1024,
+            backupCount=2,
         )
         _error_file_handler.setLevel(logging.WARNING)
-        _error_file_handler.setFormatter(RedactingFormatter(
-            '%(asctime)s %(levelname)s %(name)s: %(message)s',
-        ))
+        _error_file_handler.setFormatter(
+            RedactingFormatter(
+                "%(asctime)s %(levelname)s %(name)s: %(message)s",
+            )
+        )
         logging.getLogger().addHandler(_error_file_handler)
 
         if self.verbose_logging:
             logging.basicConfig(
                 level=logging.DEBUG,
-                format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-                datefmt='%H:%M:%S'
+                format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                datefmt="%H:%M:%S",
             )
             for handler in logging.getLogger().handlers:
-                handler.setFormatter(RedactingFormatter(
-                    '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-                    datefmt='%H:%M:%S',
-                ))
+                handler.setFormatter(
+                    RedactingFormatter(
+                        "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                        datefmt="%H:%M:%S",
+                    )
+                )
             # Keep third-party libraries at WARNING level to reduce noise
             # We have our own retry and error logging that's more informative
-            logging.getLogger('openai').setLevel(logging.WARNING)
-            logging.getLogger('openai._base_client').setLevel(logging.WARNING)
-            logging.getLogger('httpx').setLevel(logging.WARNING)
-            logging.getLogger('httpcore').setLevel(logging.WARNING)
-            logging.getLogger('asyncio').setLevel(logging.WARNING)
+            logging.getLogger("openai").setLevel(logging.WARNING)
+            logging.getLogger("openai._base_client").setLevel(logging.WARNING)
+            logging.getLogger("httpx").setLevel(logging.WARNING)
+            logging.getLogger("httpcore").setLevel(logging.WARNING)
+            logging.getLogger("asyncio").setLevel(logging.WARNING)
             # Suppress Modal/gRPC related debug spam
-            logging.getLogger('hpack').setLevel(logging.WARNING)
-            logging.getLogger('hpack.hpack').setLevel(logging.WARNING)
-            logging.getLogger('grpc').setLevel(logging.WARNING)
-            logging.getLogger('modal').setLevel(logging.WARNING)
-            logging.getLogger('rex-deploy').setLevel(logging.INFO)  # Keep INFO for sandbox status
+            logging.getLogger("hpack").setLevel(logging.WARNING)
+            logging.getLogger("hpack.hpack").setLevel(logging.WARNING)
+            logging.getLogger("grpc").setLevel(logging.WARNING)
+            logging.getLogger("modal").setLevel(logging.WARNING)
+            logging.getLogger("rex-deploy").setLevel(
+                logging.INFO
+            )  # Keep INFO for sandbox status
             logger.info("Verbose logging enabled (third-party library logs suppressed)")
         else:
             # Set logging to INFO level for important messages only
             logging.basicConfig(
                 level=logging.INFO,
-                format='%(asctime)s - %(levelname)s - %(message)s',
-                datefmt='%H:%M:%S'
+                format="%(asctime)s - %(levelname)s - %(message)s",
+                datefmt="%H:%M:%S",
             )
             # Suppress noisy library logging
-            logging.getLogger('openai').setLevel(logging.ERROR)
-            logging.getLogger('openai._base_client').setLevel(logging.ERROR)
-            logging.getLogger('httpx').setLevel(logging.ERROR)
-            logging.getLogger('httpcore').setLevel(logging.ERROR)
+            logging.getLogger("openai").setLevel(logging.ERROR)
+            logging.getLogger("openai._base_client").setLevel(logging.ERROR)
+            logging.getLogger("httpx").setLevel(logging.ERROR)
+            logging.getLogger("httpcore").setLevel(logging.ERROR)
             if self.quiet_mode:
                 # In quiet mode (CLI default), suppress all tool/infra log
                 # noise. The TUI has its own rich display for status; logger
                 # INFO/WARNING messages just clutter it.
                 for quiet_logger in [
-                    'tools',               # all tools.* (terminal, browser, web, file, etc.)
-                    'minisweagent',         # mini-swe-agent execution backend
-                    'run_agent',            # agent runner internals
-                    'trajectory_compressor',
-                    'cron',                 # scheduler (only relevant in daemon mode)
-                    'hermes_cli',           # CLI helpers
+                    "tools",  # all tools.* (terminal, browser, web, file, etc.)
+                    "minisweagent",  # mini-swe-agent execution backend
+                    "run_agent",  # agent runner internals
+                    "trajectory_compressor",
+                    "cron",  # scheduler (only relevant in daemon mode)
+                    "hermes_cli",  # CLI helpers
                 ]:
                     logging.getLogger(quiet_logger).setLevel(logging.ERROR)
-        
+
         # Initialize OpenAI client - defaults to OpenRouter
         client_kwargs = {}
-        
+
         # Default to OpenRouter if no base_url provided
         if base_url:
             client_kwargs["base_url"] = base_url
         else:
             client_kwargs["base_url"] = OPENROUTER_BASE_URL
-        
+
         # Handle API key - OpenRouter is the primary provider
         if api_key:
             client_kwargs["api_key"] = api_key
         else:
             # Primary: OPENROUTER_API_KEY, fallback to direct provider keys
             client_kwargs["api_key"] = os.getenv("OPENROUTER_API_KEY", "")
-        
+
         # OpenRouter app attribution — shows hermes-agent in rankings/analytics
         effective_base = client_kwargs.get("base_url", "")
         if "openrouter" in effective_base.lower():
@@ -405,7 +436,7 @@ class AIAgent:
             client_kwargs["default_headers"] = {
                 "User-Agent": "KimiCLI/1.0",
             }
-        
+
         self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
         try:
             self.client = OpenAI(**client_kwargs)
@@ -418,14 +449,18 @@ class AIAgent:
                 if key_used and key_used != "dummy-key" and len(key_used) > 12:
                     print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
                 else:
-                    print(f"⚠️  Warning: API key appears invalid or missing (got: '{key_used[:20] if key_used else 'none'}...')")
+                    print(
+                        f"⚠️  Warning: API key appears invalid or missing (got: '{key_used[:20] if key_used else 'none'}...')"
+                    )
         except Exception as e:
             raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
-        
+
         # Provider fallback — a single backup model/provider tried when the
         # primary is exhausted (rate-limit, overload, connection failure).
         # Config shape: {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}
-        self._fallback_model = fallback_model if isinstance(fallback_model, dict) else None
+        self._fallback_model = (
+            fallback_model if isinstance(fallback_model, dict) else None
+        )
         self._fallback_activated = False
         if self._fallback_model:
             fb_p = self._fallback_model.get("provider", "")
@@ -439,7 +474,7 @@ class AIAgent:
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
         )
-        
+
         # Show tool configuration and store valid tool names for validation
         self.valid_tool_names = set()
         if self.tools:
@@ -447,7 +482,7 @@ class AIAgent:
             tool_names = sorted(self.valid_tool_names)
             if not self.quiet_mode:
                 print(f"🛠️  Loaded {len(self.tools)} tools: {', '.join(tool_names)}")
-                
+
                 # Show filtering info if applied
                 if enabled_toolsets:
                     print(f"   ✅ Enabled toolsets: {', '.join(enabled_toolsets)}")
@@ -455,27 +490,39 @@ class AIAgent:
                     print(f"   ❌ Disabled toolsets: {', '.join(disabled_toolsets)}")
         elif not self.quiet_mode:
             print("🛠️  No tools loaded (all tools filtered out or unavailable)")
-        
+
         # Check tool requirements
         if self.tools and not self.quiet_mode:
             requirements = check_toolset_requirements()
-            missing_reqs = [name for name, available in requirements.items() if not available]
+            missing_reqs = [
+                name for name, available in requirements.items() if not available
+            ]
             if missing_reqs:
-                print(f"⚠️  Some tools may not work due to missing requirements: {missing_reqs}")
-        
+                print(
+                    f"⚠️  Some tools may not work due to missing requirements: {missing_reqs}"
+                )
+
         # Show trajectory saving status
         if self.save_trajectories and not self.quiet_mode:
             print("📝 Trajectory saving enabled")
-        
+
         # Show ephemeral system prompt status
         if self.ephemeral_system_prompt and not self.quiet_mode:
-            prompt_preview = self.ephemeral_system_prompt[:60] + "..." if len(self.ephemeral_system_prompt) > 60 else self.ephemeral_system_prompt
-            print(f"🔒 Ephemeral system prompt: '{prompt_preview}' (not saved to trajectories)")
-        
+            prompt_preview = (
+                self.ephemeral_system_prompt[:60] + "..."
+                if len(self.ephemeral_system_prompt) > 60
+                else self.ephemeral_system_prompt
+            )
+            print(
+                f"🔒 Ephemeral system prompt: '{prompt_preview}' (not saved to trajectories)"
+            )
+
         # Show prompt caching status
         if self._use_prompt_caching and not self.quiet_mode:
-            print(f"💾 Prompt caching: ENABLED (Claude via OpenRouter, {self._cache_ttl} TTL)")
-        
+            print(
+                f"💾 Prompt caching: ENABLED (Claude via OpenRouter, {self._cache_ttl} TTL)"
+            )
+
         # Session logging setup - auto-save conversation trajectories for debugging
         self.session_start = datetime.now()
         if session_id:
@@ -486,29 +533,32 @@ class AIAgent:
             timestamp_str = self.session_start.strftime("%Y%m%d_%H%M%S")
             short_uuid = uuid.uuid4().hex[:6]
             self.session_id = f"{timestamp_str}_{short_uuid}"
-        
+
         # Session logs go into ~/.hermes/sessions/ alongside gateway sessions
         hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
         self.logs_dir = hermes_home / "sessions"
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
-        
+
         # Track conversation messages for session logging
         self._session_messages: List[Dict[str, Any]] = []
-        
+
         # Cached system prompt -- built once per session, only rebuilt on compression
         self._cached_system_prompt: Optional[str] = None
-        
+
         # Filesystem checkpoint manager (transparent — not a tool)
         from tools.checkpoint_manager import CheckpointManager
+
         self._checkpoint_mgr = CheckpointManager(
             enabled=checkpoints_enabled,
             max_snapshots=checkpoint_max_snapshots,
         )
-        
+
         # SQLite session store (optional -- provided by CLI or gateway)
         self._session_db = session_db
-        self._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
+        self._last_flushed_db_idx = (
+            0  # tracks DB-write cursor to prevent duplicate writes
+        )
         if self._session_db:
             try:
                 self._session_db.create_session(
@@ -524,11 +574,12 @@ class AIAgent:
                 )
             except Exception as e:
                 logger.debug("Session DB create_session failed: %s", e)
-        
+
         # In-memory todo list for task planning (one per agent/session)
         from tools.todo_tool import TodoStore
+
         self._todo_store = TodoStore()
-        
+
         # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
         self._memory_store = None
         self._memory_enabled = False
@@ -538,13 +589,17 @@ class AIAgent:
         if not skip_memory:
             try:
                 from hermes_cli.config import load_config as _load_mem_config
+
                 mem_config = _load_mem_config().get("memory", {})
                 self._memory_enabled = mem_config.get("memory_enabled", False)
-                self._user_profile_enabled = mem_config.get("user_profile_enabled", False)
+                self._user_profile_enabled = mem_config.get(
+                    "user_profile_enabled", False
+                )
                 self._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
                 self._memory_flush_min_turns = int(mem_config.get("flush_min_turns", 6))
                 if self._memory_enabled or self._user_profile_enabled:
                     from tools.memory_tool import MemoryStore
+
                     self._memory_store = MemoryStore(
                         memory_char_limit=mem_config.get("memory_char_limit", 2200),
                         user_char_limit=mem_config.get("user_char_limit", 1375),
@@ -552,17 +607,22 @@ class AIAgent:
                     self._memory_store.load_from_disk()
             except Exception:
                 pass  # Memory is optional -- don't break agent init
-        
+
         # Honcho AI-native memory (cross-session user modeling)
         # Reads ~/.honcho/config.json as the single source of truth.
         self._honcho = None  # HonchoSessionManager | None
         self._honcho_session_key = honcho_session_key
         if not skip_memory:
             try:
-                from honcho_integration.client import HonchoClientConfig, get_honcho_client
+                from honcho_integration.client import (
+                    HonchoClientConfig,
+                    get_honcho_client,
+                )
+
                 hcfg = HonchoClientConfig.from_global_config()
                 if hcfg.enabled and hcfg.api_key:
                     from honcho_integration.session import HonchoSessionManager
+
                     client = get_honcho_client(hcfg)
                     self._honcho = HonchoSessionManager(
                         honcho=client,
@@ -572,17 +632,19 @@ class AIAgent:
                     # Resolve session key: explicit arg > global sessions map > fallback
                     if not self._honcho_session_key:
                         self._honcho_session_key = (
-                            hcfg.resolve_session_name()
-                            or "hermes-default"
+                            hcfg.resolve_session_name() or "hermes-default"
                         )
                     # Ensure session exists in Honcho
                     self._honcho.get_or_create(self._honcho_session_key)
                     # Inject session context into the honcho tool module
                     from tools.honcho_tools import set_session_context
+
                     set_session_context(self._honcho, self._honcho_session_key)
                     logger.info(
                         "Honcho active (session: %s, user: %s, workspace: %s)",
-                        self._honcho_session_key, hcfg.peer_name, hcfg.workspace_id,
+                        self._honcho_session_key,
+                        hcfg.peer_name,
+                        hcfg.workspace_id,
                     )
                 else:
                     if not hcfg.enabled:
@@ -597,18 +659,25 @@ class AIAgent:
         self._skill_nudge_interval = 15
         try:
             from hermes_cli.config import load_config as _load_skills_config
+
             skills_config = _load_skills_config().get("skills", {})
-            self._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 15))
+            self._skill_nudge_interval = int(
+                skills_config.get("creation_nudge_interval", 15)
+            )
         except Exception:
             pass
-        
+
         # Initialize context compressor for automatic context management
         # Compresses conversation when approaching model's context limit
         # Configuration via config.yaml (compression section) or environment variables
-        compression_threshold = float(os.getenv("CONTEXT_COMPRESSION_THRESHOLD", "0.85"))
-        compression_enabled = os.getenv("CONTEXT_COMPRESSION_ENABLED", "true").lower() in ("true", "1", "yes")
+        compression_threshold = float(
+            os.getenv("CONTEXT_COMPRESSION_THRESHOLD", "0.85")
+        )
+        compression_enabled = os.getenv(
+            "CONTEXT_COMPRESSION_ENABLED", "true"
+        ).lower() in ("true", "1", "yes")
         compression_summary_model = os.getenv("CONTEXT_COMPRESSION_MODEL") or None
-        
+
         self.context_compressor = ContextCompressor(
             model=self.model,
             threshold_percent=compression_threshold,
@@ -627,16 +696,20 @@ class AIAgent:
         self.session_completion_tokens = 0
         self.session_total_tokens = 0
         self.session_api_calls = 0
-        
+
         if not self.quiet_mode:
             if compression_enabled:
-                print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {self.context_compressor.threshold_tokens:,})")
+                print(
+                    f"📊 Context limit: {self.context_compressor.context_length:,} tokens (compress at {int(compression_threshold * 100)}% = {self.context_compressor.threshold_tokens:,})"
+                )
             else:
-                print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)")
-    
+                print(
+                    f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)"
+                )
+
     def _max_tokens_param(self, value: int) -> dict:
         """Return the correct max tokens kwarg for the current provider.
-        
+
         OpenAI's newer models (gpt-4o, o-series, gpt-5+) require
         'max_completion_tokens'. OpenRouter, local models, and older
         OpenAI models use 'max_tokens'.
@@ -652,30 +725,30 @@ class AIAgent:
     def _has_content_after_think_block(self, content: str) -> bool:
         """
         Check if content has actual text after any <think></think> blocks.
-        
+
         This detects cases where the model only outputs reasoning but no actual
         response, which indicates an incomplete generation that should be retried.
-        
+
         Args:
             content: The assistant message content to check
-            
+
         Returns:
             True if there's meaningful content after think blocks, False otherwise
         """
         if not content:
             return False
-        
+
         # Remove all <think>...</think> blocks (including nested ones, non-greedy)
-        cleaned = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL)
-        
+        cleaned = re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL)
+
         # Check if there's any non-whitespace content remaining
         return bool(cleaned.strip())
-    
+
     def _strip_think_blocks(self, content: str) -> str:
         """Remove <think>...</think> blocks from content, returning only visible text."""
         if not content:
             return ""
-        return re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL)
+        return re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL)
 
     def _looks_like_codex_intermediate_ack(
         self,
@@ -687,14 +760,19 @@ class AIAgent:
         if any(isinstance(msg, dict) and msg.get("role") == "tool" for msg in messages):
             return False
 
-        assistant_text = self._strip_think_blocks(assistant_content or "").strip().lower()
+        assistant_text = (
+            self._strip_think_blocks(assistant_content or "").strip().lower()
+        )
         if not assistant_text:
             return False
         if len(assistant_text) > 1200:
             return False
 
         has_future_ack = bool(
-            re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
+            re.search(
+                r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b",
+                assistant_text,
+            )
         )
         if not has_future_ack:
             return False
@@ -742,56 +820,69 @@ class AIAgent:
             or "~/" in user_text
             or "/" in user_text
         )
-        assistant_mentions_action = any(marker in assistant_text for marker in action_markers)
+        assistant_mentions_action = any(
+            marker in assistant_text for marker in action_markers
+        )
         assistant_targets_workspace = any(
             marker in assistant_text for marker in workspace_markers
         )
-        return (user_targets_workspace or assistant_targets_workspace) and assistant_mentions_action
-    
-    
+        return (
+            user_targets_workspace or assistant_targets_workspace
+        ) and assistant_mentions_action
+
     def _extract_reasoning(self, assistant_message) -> Optional[str]:
         """
         Extract reasoning/thinking content from an assistant message.
-        
+
         OpenRouter and various providers can return reasoning in multiple formats:
         1. message.reasoning - Direct reasoning field (DeepSeek, Qwen, etc.)
         2. message.reasoning_content - Alternative field (Moonshot AI, Novita, etc.)
         3. message.reasoning_details - Array of {type, summary, ...} objects (OpenRouter unified)
-        
+
         Args:
             assistant_message: The assistant message object from the API response
-            
+
         Returns:
             Combined reasoning text, or None if no reasoning found
         """
         reasoning_parts = []
-        
+
         # Check direct reasoning field
-        if hasattr(assistant_message, 'reasoning') and assistant_message.reasoning:
+        if hasattr(assistant_message, "reasoning") and assistant_message.reasoning:
             reasoning_parts.append(assistant_message.reasoning)
-        
+
         # Check reasoning_content field (alternative name used by some providers)
-        if hasattr(assistant_message, 'reasoning_content') and assistant_message.reasoning_content:
+        if (
+            hasattr(assistant_message, "reasoning_content")
+            and assistant_message.reasoning_content
+        ):
             # Don't duplicate if same as reasoning
             if assistant_message.reasoning_content not in reasoning_parts:
                 reasoning_parts.append(assistant_message.reasoning_content)
-        
+
         # Check reasoning_details array (OpenRouter unified format)
         # Format: [{"type": "reasoning.summary", "summary": "...", ...}, ...]
-        if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
+        if (
+            hasattr(assistant_message, "reasoning_details")
+            and assistant_message.reasoning_details
+        ):
             for detail in assistant_message.reasoning_details:
                 if isinstance(detail, dict):
                     # Extract summary from reasoning detail object
-                    summary = detail.get('summary') or detail.get('content') or detail.get('text')
+                    summary = (
+                        detail.get("summary")
+                        or detail.get("content")
+                        or detail.get("text")
+                    )
                     if summary and summary not in reasoning_parts:
                         reasoning_parts.append(summary)
-        
+
         # Combine all reasoning parts
         if reasoning_parts:
             return "\n\n".join(reasoning_parts)
-        
+
         return None
-    
+
     def _cleanup_task_resources(self, task_id: str) -> None:
         """Clean up VM and browser resources for a given task."""
         try:
@@ -805,7 +896,9 @@ class AIAgent:
             if self.verbose_logging:
                 logging.warning(f"Failed to cleanup browser for task {task_id}: {e}")
 
-    def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
+    def _persist_session(
+        self, messages: List[Dict], conversation_history: List[Dict] = None
+    ):
         """Save session state to both JSON log and SQLite on any exit path.
 
         Ensures conversations are never lost, even on errors or early returns.
@@ -814,7 +907,9 @@ class AIAgent:
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
 
-    def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
+    def _flush_messages_to_session_db(
+        self, messages: List[Dict], conversation_history: List[Dict] = None
+    ):
         """Persist any un-flushed messages to the SQLite session store.
 
         Uses _last_flushed_db_idx to track which messages have already been
@@ -853,44 +948,44 @@ class AIAgent:
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """
         Get messages up to (but not including) the last assistant turn.
-        
+
         This is used when we need to "roll back" to the last successful point
         in the conversation, typically when the final assistant message is
         incomplete or malformed.
-        
+
         Args:
             messages: Full message list
-            
+
         Returns:
             Messages up to the last complete assistant turn (ending with user/tool message)
         """
         if not messages:
             return []
-        
+
         # Find the index of the last assistant message
         last_assistant_idx = None
         for i in range(len(messages) - 1, -1, -1):
             if messages[i].get("role") == "assistant":
                 last_assistant_idx = i
                 break
-        
+
         if last_assistant_idx is None:
             # No assistant message found, return all messages
             return messages.copy()
-        
+
         # Return everything up to (not including) the last assistant message
         return messages[:last_assistant_idx]
-    
+
     def _format_tools_for_system_message(self) -> str:
         """
         Format tool definitions for the system message in the trajectory format.
-        
+
         Returns:
             str: JSON string representation of tool definitions
         """
         if not self.tools:
             return "[]"
-        
+
         # Convert tool definitions to the format expected in trajectories
         formatted_tools = []
         for tool in self.tools:
@@ -899,26 +994,28 @@ class AIAgent:
                 "name": func["name"],
                 "description": func.get("description", ""),
                 "parameters": func.get("parameters", {}),
-                "required": None  # Match the format in the example
+                "required": None,  # Match the format in the example
             }
             formatted_tools.append(formatted_tool)
-        
+
         return json.dumps(formatted_tools, ensure_ascii=False)
-    
-    def _convert_to_trajectory_format(self, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
+
+    def _convert_to_trajectory_format(
+        self, messages: List[Dict[str, Any]], user_query: str, completed: bool
+    ) -> List[Dict[str, Any]]:
         """
         Convert internal message format to trajectory format for saving.
-        
+
         Args:
             messages (List[Dict]): Internal message history
             user_query (str): Original user query
             completed (bool): Whether the conversation completed successfully
-            
+
         Returns:
             List[Dict]: Messages in trajectory format
         """
         trajectory = []
-        
+
         # Add system message with tool definitions
         system_msg = (
             "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
@@ -933,70 +1030,67 @@ class AIAgent:
             "Each function call should be enclosed within <tool_call> </tool_call> XML tags.\n"
             "Example:\n<tool_call>\n{'name': <function-name>,'arguments': <args-dict>}\n</tool_call>"
         )
-        
-        trajectory.append({
-            "from": "system",
-            "value": system_msg
-        })
-        
+
+        trajectory.append({"from": "system", "value": system_msg})
+
         # Add the actual user prompt (from the dataset) as the first human message
-        trajectory.append({
-            "from": "human",
-            "value": user_query
-        })
-        
+        trajectory.append({"from": "human", "value": user_query})
+
         # Skip the first message (the user query) since we already added it above.
         # Prefill messages are injected at API-call time only (not in the messages
         # list), so no offset adjustment is needed here.
         i = 1
-        
+
         while i < len(messages):
             msg = messages[i]
-            
+
             if msg["role"] == "assistant":
                 # Check if this message has tool calls
                 if "tool_calls" in msg and msg["tool_calls"]:
                     # Format assistant message with tool calls
                     # Add <think> tags around reasoning for trajectory storage
                     content = ""
-                    
+
                     # Prepend reasoning in <think> tags if available (native thinking tokens)
                     if msg.get("reasoning") and msg["reasoning"].strip():
                         content = f"<think>\n{msg['reasoning']}\n</think>\n"
-                    
+
                     if msg.get("content") and msg["content"].strip():
                         # Convert any <REASONING_SCRATCHPAD> tags to <think> tags
                         # (used when native thinking is disabled and model reasons via XML)
                         content += convert_scratchpad_to_think(msg["content"]) + "\n"
-                    
+
                     # Add tool calls wrapped in XML tags
                     for tool_call in msg["tool_calls"]:
                         # Parse arguments - should always succeed since we validate during conversation
                         # but keep try-except as safety net
                         try:
-                            arguments = json.loads(tool_call["function"]["arguments"]) if isinstance(tool_call["function"]["arguments"], str) else tool_call["function"]["arguments"]
+                            arguments = (
+                                json.loads(tool_call["function"]["arguments"])
+                                if isinstance(tool_call["function"]["arguments"], str)
+                                else tool_call["function"]["arguments"]
+                            )
                         except json.JSONDecodeError:
                             # This shouldn't happen since we validate and retry during conversation,
                             # but if it does, log warning and use empty dict
-                            logging.warning(f"Unexpected invalid JSON in trajectory conversion: {tool_call['function']['arguments'][:100]}")
+                            logging.warning(
+                                f"Unexpected invalid JSON in trajectory conversion: {tool_call['function']['arguments'][:100]}"
+                            )
                             arguments = {}
-                        
+
                         tool_call_json = {
                             "name": tool_call["function"]["name"],
-                            "arguments": arguments
+                            "arguments": arguments,
                         }
                         content += f"<tool_call>\n{json.dumps(tool_call_json, ensure_ascii=False)}\n</tool_call>\n"
-                    
+
                     # Ensure every gpt turn has a <think> block (empty if no reasoning)
                     # so the format is consistent for training data
                     if "<think>" not in content:
                         content = "<think>\n</think>\n" + content
-                    
-                    trajectory.append({
-                        "from": "gpt",
-                        "value": content.rstrip()
-                    })
-                    
+
+                    trajectory.append({"from": "gpt", "value": content.rstrip()})
+
                     # Collect all subsequent tool responses
                     tool_responses = []
                     j = i + 1
@@ -1004,7 +1098,7 @@ class AIAgent:
                         tool_msg = messages[j]
                         # Format tool response with XML tags
                         tool_response = f"<tool_response>\n"
-                        
+
                         # Try to parse tool content as JSON if it looks like JSON
                         tool_content = tool_msg["content"]
                         try:
@@ -1012,61 +1106,63 @@ class AIAgent:
                                 tool_content = json.loads(tool_content)
                         except (json.JSONDecodeError, AttributeError):
                             pass  # Keep as string if not valid JSON
-                        
-                        tool_response += json.dumps({
-                            "tool_call_id": tool_msg.get("tool_call_id", ""),
-                            "name": msg["tool_calls"][len(tool_responses)]["function"]["name"] if len(tool_responses) < len(msg["tool_calls"]) else "unknown",
-                            "content": tool_content
-                        }, ensure_ascii=False)
+
+                        tool_response += json.dumps(
+                            {
+                                "tool_call_id": tool_msg.get("tool_call_id", ""),
+                                "name": msg["tool_calls"][len(tool_responses)][
+                                    "function"
+                                ]["name"]
+                                if len(tool_responses) < len(msg["tool_calls"])
+                                else "unknown",
+                                "content": tool_content,
+                            },
+                            ensure_ascii=False,
+                        )
                         tool_response += "\n</tool_response>"
                         tool_responses.append(tool_response)
                         j += 1
-                    
+
                     # Add all tool responses as a single message
                     if tool_responses:
-                        trajectory.append({
-                            "from": "tool",
-                            "value": "\n".join(tool_responses)
-                        })
+                        trajectory.append(
+                            {"from": "tool", "value": "\n".join(tool_responses)}
+                        )
                         i = j - 1  # Skip the tool messages we just processed
-                
+
                 else:
                     # Regular assistant message without tool calls
                     # Add <think> tags around reasoning for trajectory storage
                     content = ""
-                    
+
                     # Prepend reasoning in <think> tags if available (native thinking tokens)
                     if msg.get("reasoning") and msg["reasoning"].strip():
                         content = f"<think>\n{msg['reasoning']}\n</think>\n"
-                    
+
                     # Convert any <REASONING_SCRATCHPAD> tags to <think> tags
                     # (used when native thinking is disabled and model reasons via XML)
                     raw_content = msg["content"] or ""
                     content += convert_scratchpad_to_think(raw_content)
-                    
+
                     # Ensure every gpt turn has a <think> block (empty if no reasoning)
                     if "<think>" not in content:
                         content = "<think>\n</think>\n" + content
-                    
-                    trajectory.append({
-                        "from": "gpt",
-                        "value": content.strip()
-                    })
-            
+
+                    trajectory.append({"from": "gpt", "value": content.strip()})
+
             elif msg["role"] == "user":
-                trajectory.append({
-                    "from": "human",
-                    "value": msg["content"]
-                })
-            
+                trajectory.append({"from": "human", "value": msg["content"]})
+
             i += 1
-        
+
         return trajectory
-    
-    def _save_trajectory(self, messages: List[Dict[str, Any]], user_query: str, completed: bool):
+
+    def _save_trajectory(
+        self, messages: List[Dict[str, Any]], user_query: str, completed: bool
+    ):
         """
         Save conversation trajectory to JSONL file.
-        
+
         Args:
             messages (List[Dict]): Complete message history
             user_query (str): Original user query
@@ -1074,10 +1170,10 @@ class AIAgent:
         """
         if not self.save_trajectories:
             return
-        
+
         trajectory = self._convert_to_trajectory_format(messages, user_query, completed)
         _save_trajectory_to_file(trajectory, self.model, completed)
-    
+
     def _mask_api_key_for_logs(self, key: Optional[str]) -> Optional[str]:
         if not key:
             return None
@@ -1142,7 +1238,9 @@ class AIAgent:
                 response_obj = getattr(error, "response", None)
                 if response_obj is not None:
                     try:
-                        error_info["response_status"] = getattr(response_obj, "status_code", None)
+                        error_info["response_status"] = getattr(
+                            response_obj, "status_code", None
+                        )
                         error_info["response_text"] = response_obj.text
                     except Exception as e:
                         logger.debug("Could not extract error response details: %s", e)
@@ -1150,7 +1248,9 @@ class AIAgent:
                 dump_payload["error"] = error_info
 
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-            dump_file = self.logs_dir / f"request_dump_{self.session_id}_{timestamp}.json"
+            dump_file = (
+                self.logs_dir / f"request_dump_{self.session_id}_{timestamp}.json"
+            )
             dump_file.write_text(
                 json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str),
                 encoding="utf-8",
@@ -1158,13 +1258,22 @@ class AIAgent:
 
             print(f"{self.log_prefix}🧾 Request debug dump written to: {dump_file}")
 
-            if os.getenv("HERMES_DUMP_REQUEST_STDOUT", "").strip().lower() in {"1", "true", "yes", "on"}:
-                print(json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str))
+            if os.getenv("HERMES_DUMP_REQUEST_STDOUT", "").strip().lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }:
+                print(
+                    json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str)
+                )
 
             return dump_file
         except Exception as dump_error:
             if self.verbose_logging:
-                logging.warning(f"Failed to dump API request debug payload: {dump_error}")
+                logging.warning(
+                    f"Failed to dump API request debug payload: {dump_error}"
+                )
             return None
 
     @staticmethod
@@ -1173,8 +1282,8 @@ class AIAgent:
         if not content:
             return content
         content = convert_scratchpad_to_think(content)
-        content = re.sub(r'\n+(<think>)', r'\n\1', content)
-        content = re.sub(r'(</think>)\n+', r'\1\n', content)
+        content = re.sub(r"\n+(<think>)", r"\n\1", content)
+        content = re.sub(r"(</think>)\n+", r"\1\n", content)
         return content.strip()
 
     def _save_session_log(self, messages: List[Dict[str, Any]] = None):
@@ -1221,26 +1330,26 @@ class AIAgent:
         except Exception as e:
             if self.verbose_logging:
                 logging.warning(f"Failed to save session log: {e}")
-    
+
     def interrupt(self, message: str = None) -> None:
         """
         Request the agent to interrupt its current tool-calling loop.
-        
+
         Call this from another thread (e.g., input handler, message receiver)
         to gracefully stop the agent and process a new message.
-        
+
         Also signals long-running tool executions (e.g. terminal commands)
         to terminate early, so the agent can respond immediately.
-        
+
         Args:
             message: Optional new message that triggered the interrupt.
                      If provided, the agent will include this in its response context.
-        
+
         Example (CLI):
             # In a separate input thread:
             if user_typed_something:
                 agent.interrupt(user_input)
-        
+
         Example (Messaging):
             # When new message arrives for active session:
             if session_has_running_agent:
@@ -1257,18 +1366,27 @@ class AIAgent:
             except Exception as e:
                 logger.debug("Failed to propagate interrupt to child agent: %s", e)
         if not self.quiet_mode:
-            print(f"\n⚡ Interrupt requested" + (f": '{message[:40]}...'" if message and len(message) > 40 else f": '{message}'" if message else ""))
-    
+            print(
+                f"\n⚡ Interrupt requested"
+                + (
+                    f": '{message[:40]}...'"
+                    if message and len(message) > 40
+                    else f": '{message}'"
+                    if message
+                    else ""
+                )
+            )
+
     def clear_interrupt(self) -> None:
         """Clear any pending interrupt request and the global tool interrupt signal."""
         self._interrupt_requested = False
         self._interrupt_message = None
         _set_interrupt(False)
-    
+
     def _hydrate_todo_store(self, history: List[Dict[str, Any]]) -> None:
         """
         Recover todo state from conversation history.
-        
+
         The gateway creates a fresh AIAgent per message, so the in-memory
         TodoStore is empty. We scan the history for the most recent todo
         tool response and replay it to reconstruct the state.
@@ -1289,14 +1407,16 @@ class AIAgent:
                     break
             except (json.JSONDecodeError, TypeError):
                 continue
-        
+
         if last_todo_response:
             # Replay the items into the store (replace mode)
             self._todo_store.write(last_todo_response, merge=False)
             if not self.quiet_mode:
-                print(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
+                print(
+                    f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history"
+                )
         _set_interrupt(False)
-    
+
     @property
     def is_interrupted(self) -> bool:
         """Check if an interrupt has been requested."""
@@ -1312,7 +1432,9 @@ class AIAgent:
         if not self._honcho or not self._honcho_session_key:
             return ""
         try:
-            ctx = self._honcho.get_prefetch_context(self._honcho_session_key, user_message)
+            ctx = self._honcho.get_prefetch_context(
+                self._honcho_session_key, user_message
+            )
             if not ctx:
                 return ""
             parts = []
@@ -1341,11 +1463,13 @@ class AIAgent:
             session = self._honcho.get_or_create(self._honcho_session_key)
             session.add_message("user", f"[observation] {content.strip()}")
             self._honcho.save(session)
-            return json.dumps({
-                "success": True,
-                "target": "user",
-                "message": "Saved to Honcho user model.",
-            })
+            return json.dumps(
+                {
+                    "success": True,
+                    "target": "user",
+                    "message": "Saved to Honcho user model.",
+                }
+            )
         except Exception as e:
             logger.debug("Honcho user observation failed: %s", e)
             return json.dumps({"success": False, "error": f"Honcho save failed: {e}"})
@@ -1365,7 +1489,7 @@ class AIAgent:
     def _build_system_prompt(self, system_message: str = None) -> str:
         """
         Assemble the full system prompt from all layers.
-        
+
         Called once per session (cached on self._cached_system_prompt) and only
         rebuilt after context compression events. This ensures the system prompt
         is stable across all turns in a session, maximizing prefix cache hits.
@@ -1407,7 +1531,10 @@ class AIAgent:
                 if user_block:
                     prompt_parts.append(user_block)
 
-        has_skills_tools = any(name in self.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
+        has_skills_tools = any(
+            name in self.valid_tool_names
+            for name in ["skills_list", "skill_view", "skill_manage"]
+        )
         skills_prompt = build_skills_system_prompt() if has_skills_tools else ""
         if skills_prompt:
             prompt_parts.append(skills_prompt)
@@ -1418,6 +1545,7 @@ class AIAgent:
                 prompt_parts.append(context_files_prompt)
 
         from hermes_time import now as _hermes_now
+
         now = _hermes_now()
         prompt_parts.append(
             f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
@@ -1428,7 +1556,7 @@ class AIAgent:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
 
         return "\n\n".join(prompt_parts)
-    
+
     def _repair_tool_call(self, tool_name: str) -> str | None:
         """Attempt to repair a mismatched tool name before aborting.
 
@@ -1460,7 +1588,7 @@ class AIAgent:
     def _invalidate_system_prompt(self):
         """
         Invalidate the cached system prompt, forcing a rebuild on the next turn.
-        
+
         Called after context compression events. Also reloads memory from disk
         so the rebuilt prompt captures any writes from this session.
         """
@@ -1468,7 +1596,9 @@ class AIAgent:
         if self._memory_store:
             self._memory_store.load_from_disk()
 
-    def _responses_tools(self, tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
+    def _responses_tools(
+        self, tools: Optional[List[Dict[str, Any]]] = None
+    ) -> Optional[List[Dict[str, Any]]]:
         """Convert chat-completions tool schemas to Responses function-tool schemas."""
         source_tools = tools if tools is not None else self.tools
         if not source_tools:
@@ -1480,13 +1610,17 @@ class AIAgent:
             name = fn.get("name")
             if not isinstance(name, str) or not name.strip():
                 continue
-            converted.append({
-                "type": "function",
-                "name": name,
-                "description": fn.get("description", ""),
-                "strict": False,
-                "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
-            })
+            converted.append(
+                {
+                    "type": "function",
+                    "name": name,
+                    "description": fn.get("description", ""),
+                    "strict": False,
+                    "parameters": fn.get(
+                        "parameters", {"type": "object", "properties": {}}
+                    ),
+                }
+            )
         return converted or None
 
     @staticmethod
@@ -1521,13 +1655,13 @@ class AIAgent:
         if source.startswith("fc_"):
             return source
         if source.startswith("call_") and len(source) > len("call_"):
-            return f"fc_{source[len('call_'):]}"
+            return f"fc_{source[len('call_') :]}"
 
         sanitized = re.sub(r"[^A-Za-z0-9_-]", "", source)
         if sanitized.startswith("fc_"):
             return sanitized
         if sanitized.startswith("call_") and len(sanitized) > len("call_"):
-            return f"fc_{sanitized[len('call_'):]}"
+            return f"fc_{sanitized[len('call_') :]}"
         if sanitized:
             return f"fc_{sanitized[:48]}"
 
@@ -1535,7 +1669,9 @@ class AIAgent:
         digest = hashlib.sha1(seed.encode("utf-8")).hexdigest()[:24]
         return f"fc_{digest}"
 
-    def _chat_messages_to_responses_input(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _chat_messages_to_responses_input(
+        self, messages: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
         """Convert internal chat-style messages to Responses input items."""
         items: List[Dict[str, Any]] = []
 
@@ -1572,8 +1708,8 @@ class AIAgent:
                             if not isinstance(fn_name, str) or not fn_name.strip():
                                 continue
 
-                            embedded_call_id, embedded_response_item_id = self._split_responses_tool_id(
-                                tc.get("id")
+                            embedded_call_id, embedded_response_item_id = (
+                                self._split_responses_tool_id(tc.get("id"))
                             )
                             call_id = tc.get("call_id")
                             if not isinstance(call_id, str) or not call_id.strip():
@@ -1584,7 +1720,7 @@ class AIAgent:
                                     and embedded_response_item_id.startswith("fc_")
                                     and len(embedded_response_item_id) > len("fc_")
                                 ):
-                                    call_id = f"call_{embedded_response_item_id[len('fc_'):]}"
+                                    call_id = f"call_{embedded_response_item_id[len('fc_') :]}"
                                 else:
                                     call_id = f"call_{uuid.uuid4().hex[:12]}"
                             call_id = call_id.strip()
@@ -1596,12 +1732,14 @@ class AIAgent:
                                 arguments = str(arguments)
                             arguments = arguments.strip() or "{}"
 
-                            items.append({
-                                "type": "function_call",
-                                "call_id": call_id,
-                                "name": fn_name,
-                                "arguments": arguments,
-                            })
+                            items.append(
+                                {
+                                    "type": "function_call",
+                                    "call_id": call_id,
+                                    "name": fn_name,
+                                    "arguments": arguments,
+                                }
+                            )
                     continue
 
                 items.append({"role": role, "content": content_text})
@@ -1615,11 +1753,13 @@ class AIAgent:
                         call_id = raw_tool_call_id.strip()
                 if not isinstance(call_id, str) or not call_id.strip():
                     continue
-                items.append({
-                    "type": "function_call_output",
-                    "call_id": call_id,
-                    "output": str(msg.get("content", "") or ""),
-                })
+                items.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": str(msg.get("content", "") or ""),
+                    }
+                )
 
         return items
 
@@ -1637,9 +1777,13 @@ class AIAgent:
                 call_id = item.get("call_id")
                 name = item.get("name")
                 if not isinstance(call_id, str) or not call_id.strip():
-                    raise ValueError(f"Codex Responses input[{idx}] function_call is missing call_id.")
+                    raise ValueError(
+                        f"Codex Responses input[{idx}] function_call is missing call_id."
+                    )
                 if not isinstance(name, str) or not name.strip():
-                    raise ValueError(f"Codex Responses input[{idx}] function_call is missing name.")
+                    raise ValueError(
+                        f"Codex Responses input[{idx}] function_call is missing name."
+                    )
 
                 arguments = item.get("arguments", "{}")
                 if isinstance(arguments, dict):
@@ -1661,7 +1805,9 @@ class AIAgent:
             if item_type == "function_call_output":
                 call_id = item.get("call_id")
                 if not isinstance(call_id, str) or not call_id.strip():
-                    raise ValueError(f"Codex Responses input[{idx}] function_call_output is missing call_id.")
+                    raise ValueError(
+                        f"Codex Responses input[{idx}] function_call_output is missing call_id."
+                    )
                 output = item.get("output", "")
                 if output is None:
                     output = ""
@@ -1680,7 +1826,10 @@ class AIAgent:
             if item_type == "reasoning":
                 encrypted = item.get("encrypted_content")
                 if isinstance(encrypted, str) and encrypted:
-                    reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
+                    reasoning_item = {
+                        "type": "reasoning",
+                        "encrypted_content": encrypted,
+                    }
                     item_id = item.get("id")
                     if isinstance(item_id, str) and item_id:
                         reasoning_item["id"] = item_id
@@ -1721,11 +1870,15 @@ class AIAgent:
         required = {"model", "instructions", "input"}
         missing = [key for key in required if key not in api_kwargs]
         if missing:
-            raise ValueError(f"Codex Responses request missing required field(s): {', '.join(sorted(missing))}.")
+            raise ValueError(
+                f"Codex Responses request missing required field(s): {', '.join(sorted(missing))}."
+            )
 
         model = api_kwargs.get("model")
         if not isinstance(model, str) or not model.strip():
-            raise ValueError("Codex Responses request 'model' must be a non-empty string.")
+            raise ValueError(
+                "Codex Responses request 'model' must be a non-empty string."
+            )
         model = model.strip()
 
         instructions = api_kwargs.get("instructions")
@@ -1741,20 +1894,28 @@ class AIAgent:
         normalized_tools = None
         if tools is not None:
             if not isinstance(tools, list):
-                raise ValueError("Codex Responses request 'tools' must be a list when provided.")
+                raise ValueError(
+                    "Codex Responses request 'tools' must be a list when provided."
+                )
             normalized_tools = []
             for idx, tool in enumerate(tools):
                 if not isinstance(tool, dict):
                     raise ValueError(f"Codex Responses tools[{idx}] must be an object.")
                 if tool.get("type") != "function":
-                    raise ValueError(f"Codex Responses tools[{idx}] has unsupported type {tool.get('type')!r}.")
+                    raise ValueError(
+                        f"Codex Responses tools[{idx}] has unsupported type {tool.get('type')!r}."
+                    )
 
                 name = tool.get("name")
                 parameters = tool.get("parameters")
                 if not isinstance(name, str) or not name.strip():
-                    raise ValueError(f"Codex Responses tools[{idx}] is missing a valid name.")
+                    raise ValueError(
+                        f"Codex Responses tools[{idx}] is missing a valid name."
+                    )
                 if not isinstance(parameters, dict):
-                    raise ValueError(f"Codex Responses tools[{idx}] is missing valid parameters.")
+                    raise ValueError(
+                        f"Codex Responses tools[{idx}] is missing valid parameters."
+                    )
 
                 description = tool.get("description", "")
                 if description is None:
@@ -1781,8 +1942,15 @@ class AIAgent:
             raise ValueError("Codex Responses contract requires 'store' to be false.")
 
         allowed_keys = {
-            "model", "instructions", "input", "tools", "store",
-            "reasoning", "include", "max_output_tokens", "temperature",
+            "model",
+            "instructions",
+            "input",
+            "tools",
+            "store",
+            "reasoning",
+            "include",
+            "max_output_tokens",
+            "temperature",
         }
         normalized: Dict[str, Any] = {
             "model": model,
@@ -1816,7 +1984,9 @@ class AIAgent:
                 normalized["stream"] = True
             allowed_keys.add("stream")
         elif "stream" in api_kwargs:
-            raise ValueError("Codex Responses stream flag is only allowed in fallback streaming requests.")
+            raise ValueError(
+                "Codex Responses stream flag is only allowed in fallback streaming requests."
+            )
 
         unexpected = sorted(key for key in api_kwargs.keys() if key not in allowed_keys)
         if unexpected:
@@ -1875,14 +2045,22 @@ class AIAgent:
             if isinstance(error_obj, dict):
                 error_msg = error_obj.get("message") or str(error_obj)
             else:
-                error_msg = str(error_obj) if error_obj else f"Responses API returned status '{response_status}'"
+                error_msg = (
+                    str(error_obj)
+                    if error_obj
+                    else f"Responses API returned status '{response_status}'"
+                )
             raise RuntimeError(error_msg)
 
         content_parts: List[str] = []
         reasoning_parts: List[str] = []
         reasoning_items_raw: List[Dict[str, Any]] = []
         tool_calls: List[Any] = []
-        has_incomplete_items = response_status in {"queued", "in_progress", "incomplete"}
+        has_incomplete_items = response_status in {
+            "queued",
+            "in_progress",
+            "incomplete",
+        }
         saw_commentary_phase = False
         saw_final_answer_phase = False
 
@@ -1928,7 +2106,9 @@ class AIAgent:
                         for part in summary:
                             text = getattr(part, "text", None)
                             if isinstance(text, str):
-                                raw_summary.append({"type": "summary_text", "text": text})
+                                raw_summary.append(
+                                    {"type": "summary_text", "text": text}
+                                )
                         raw_item["summary"] = raw_summary
                     reasoning_items_raw.append(raw_item)
             elif item_type == "function_call":
@@ -1941,19 +2121,27 @@ class AIAgent:
                 raw_call_id = getattr(item, "call_id", None)
                 raw_item_id = getattr(item, "id", None)
                 embedded_call_id, _ = self._split_responses_tool_id(raw_item_id)
-                call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id.strip() else embedded_call_id
+                call_id = (
+                    raw_call_id
+                    if isinstance(raw_call_id, str) and raw_call_id.strip()
+                    else embedded_call_id
+                )
                 if not isinstance(call_id, str) or not call_id.strip():
                     call_id = f"call_{uuid.uuid4().hex[:12]}"
                 call_id = call_id.strip()
                 response_item_id = raw_item_id if isinstance(raw_item_id, str) else None
-                response_item_id = self._derive_responses_function_call_id(call_id, response_item_id)
-                tool_calls.append(SimpleNamespace(
-                    id=call_id,
-                    call_id=call_id,
-                    response_item_id=response_item_id,
-                    type="function",
-                    function=SimpleNamespace(name=fn_name, arguments=arguments),
-                ))
+                response_item_id = self._derive_responses_function_call_id(
+                    call_id, response_item_id
+                )
+                tool_calls.append(
+                    SimpleNamespace(
+                        id=call_id,
+                        call_id=call_id,
+                        response_item_id=response_item_id,
+                        type="function",
+                        function=SimpleNamespace(name=fn_name, arguments=arguments),
+                    )
+                )
             elif item_type == "custom_tool_call":
                 fn_name = getattr(item, "name", "") or ""
                 arguments = getattr(item, "input", "{}")
@@ -1962,19 +2150,27 @@ class AIAgent:
                 raw_call_id = getattr(item, "call_id", None)
                 raw_item_id = getattr(item, "id", None)
                 embedded_call_id, _ = self._split_responses_tool_id(raw_item_id)
-                call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id.strip() else embedded_call_id
+                call_id = (
+                    raw_call_id
+                    if isinstance(raw_call_id, str) and raw_call_id.strip()
+                    else embedded_call_id
+                )
                 if not isinstance(call_id, str) or not call_id.strip():
                     call_id = f"call_{uuid.uuid4().hex[:12]}"
                 call_id = call_id.strip()
                 response_item_id = raw_item_id if isinstance(raw_item_id, str) else None
-                response_item_id = self._derive_responses_function_call_id(call_id, response_item_id)
-                tool_calls.append(SimpleNamespace(
-                    id=call_id,
-                    call_id=call_id,
-                    response_item_id=response_item_id,
-                    type="function",
-                    function=SimpleNamespace(name=fn_name, arguments=arguments),
-                ))
+                response_item_id = self._derive_responses_function_call_id(
+                    call_id, response_item_id
+                )
+                tool_calls.append(
+                    SimpleNamespace(
+                        id=call_id,
+                        call_id=call_id,
+                        response_item_id=response_item_id,
+                        type="function",
+                        function=SimpleNamespace(name=fn_name, arguments=arguments),
+                    )
+                )
 
         final_text = "\n".join([p for p in content_parts if p]).strip()
         if not final_text and hasattr(response, "output_text"):
@@ -1993,7 +2189,9 @@ class AIAgent:
 
         if tool_calls:
             finish_reason = "tool_calls"
-        elif has_incomplete_items or (saw_commentary_phase and not saw_final_answer_phase):
+        elif has_incomplete_items or (
+            saw_commentary_phase and not saw_final_answer_phase
+        ):
             finish_reason = "incomplete"
         else:
             finish_reason = "stop"
@@ -2029,7 +2227,9 @@ class AIAgent:
         """Fallback path for stream completion edge cases on Codex-style Responses backends."""
         fallback_kwargs = dict(api_kwargs)
         fallback_kwargs["stream"] = True
-        fallback_kwargs = self._preflight_codex_api_kwargs(fallback_kwargs, allow_stream=True)
+        fallback_kwargs = self._preflight_codex_api_kwargs(
+            fallback_kwargs, allow_stream=True
+        )
         stream_or_response = self.client.responses.create(**fallback_kwargs)
 
         # Compatibility shim for mocks or providers that still return a concrete response.
@@ -2044,7 +2244,11 @@ class AIAgent:
                 event_type = getattr(event, "type", None)
                 if not event_type and isinstance(event, dict):
                     event_type = event.get("type")
-                if event_type not in {"response.completed", "response.incomplete", "response.failed"}:
+                if event_type not in {
+                    "response.completed",
+                    "response.incomplete",
+                    "response.failed",
+                }:
                     continue
 
                 terminal_response = getattr(event, "response", None)
@@ -2062,7 +2266,9 @@ class AIAgent:
 
         if terminal_response is not None:
             return terminal_response
-        raise RuntimeError("Responses create(stream=True) fallback did not emit a terminal response.")
+        raise RuntimeError(
+            "Responses create(stream=True) fallback did not emit a terminal response."
+        )
 
     def _try_refresh_codex_client_credentials(self, *, force: bool = True) -> bool:
         if self.api_mode != "codex_responses" or self.provider != "openai-codex":
@@ -2096,7 +2302,9 @@ class AIAgent:
         try:
             self.client = OpenAI(**self._client_kwargs)
         except Exception as exc:
-            logger.warning("Failed to rebuild OpenAI client after Codex refresh: %s", exc)
+            logger.warning(
+                "Failed to rebuild OpenAI client after Codex refresh: %s", exc
+            )
             return False
 
         return True
@@ -2109,7 +2317,9 @@ class AIAgent:
             from hermes_cli.auth import resolve_nous_runtime_credentials
 
             creds = resolve_nous_runtime_credentials(
-                min_key_ttl_seconds=max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),
+                min_key_ttl_seconds=max(
+                    60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))
+                ),
                 timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
                 force_mint=force,
             )
@@ -2139,7 +2349,9 @@ class AIAgent:
         try:
             self.client = OpenAI(**self._client_kwargs)
         except Exception as exc:
-            logger.warning("Failed to rebuild OpenAI client after Nous refresh: %s", exc)
+            logger.warning(
+                "Failed to rebuild OpenAI client after Nous refresh: %s", exc
+            )
             return False
 
         return True
@@ -2148,7 +2360,7 @@ class AIAgent:
         """
         Run the API call in a background thread so the main conversation loop
         can detect interrupts without waiting for the full HTTP round-trip.
-        
+
         On interrupt, closes the HTTP client to cancel the in-flight request
         (stops token generation and avoids wasting money), then rebuilds the
         client for future calls.
@@ -2160,7 +2372,9 @@ class AIAgent:
                 if self.api_mode == "codex_responses":
                     result["response"] = self._run_codex_stream(api_kwargs)
                 else:
-                    result["response"] = self.client.chat.completions.create(**api_kwargs)
+                    result["response"] = self.client.chat.completions.create(
+                        **api_kwargs
+                    )
             except Exception as e:
                 result["error"] = e
 
@@ -2218,13 +2432,15 @@ class AIAgent:
             resolver_name, api_mode = self._FALLBACK_OAUTH_PROVIDERS[fb_provider]
             try:
                 import hermes_cli.auth as _auth
+
                 resolver = getattr(_auth, resolver_name)
                 creds = resolver()
                 return creds["api_key"], creds["base_url"], api_mode
             except Exception as e:
                 logging.warning(
                     "Fallback to %s failed (credential resolution): %s",
-                    fb_provider, e,
+                    fb_provider,
+                    e,
                 )
                 return None
 
@@ -2300,8 +2516,7 @@ class AIAgent:
 
             # Re-evaluate prompt caching for the new provider/model
             self._use_prompt_caching = (
-                "openrouter" in fb_base_url.lower()
-                and "claude" in fb_model.lower()
+                "openrouter" in fb_base_url.lower() and "claude" in fb_model.lower()
             )
 
             print(
@@ -2310,7 +2525,9 @@ class AIAgent:
             )
             logging.info(
                 "Fallback activated: %s → %s (%s)",
-                old_model, fb_model, fb_provider,
+                old_model,
+                fb_model,
+                fb_provider,
             )
             return True
         except Exception as e:
@@ -2395,10 +2612,7 @@ class AIAgent:
             if self.reasoning_config is not None:
                 extra_body["reasoning"] = self.reasoning_config
             else:
-                extra_body["reasoning"] = {
-                    "enabled": True,
-                    "effort": "medium"
-                }
+                extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
 
         # Nous Portal product attribution
         if _is_nous:
@@ -2418,8 +2632,14 @@ class AIAgent:
         reasoning_text = self._extract_reasoning(assistant_message)
 
         if reasoning_text and self.verbose_logging:
-            preview = reasoning_text[:100] + "..." if len(reasoning_text) > 100 else reasoning_text
-            logging.debug(f"Captured reasoning ({len(reasoning_text)} chars): {preview}")
+            preview = (
+                reasoning_text[:100] + "..."
+                if len(reasoning_text) > 100
+                else reasoning_text
+            )
+            logging.debug(
+                f"Captured reasoning ({len(reasoning_text)} chars): {preview}"
+            )
 
         msg = {
             "role": "assistant",
@@ -2428,7 +2648,10 @@ class AIAgent:
             "finish_reason": finish_reason,
         }
 
-        if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
+        if (
+            hasattr(assistant_message, "reasoning_details")
+            and assistant_message.reasoning_details
+        ):
             # Pass reasoning_details back unmodified so providers (OpenRouter,
             # Anthropic, OpenAI) can maintain reasoning continuity across turns.
             # Each provider may include opaque fields (signature, encrypted_content)
@@ -2467,7 +2690,10 @@ class AIAgent:
                 call_id = call_id.strip()
 
                 response_item_id = getattr(tool_call, "response_item_id", None)
-                if not isinstance(response_item_id, str) or not response_item_id.strip():
+                if (
+                    not isinstance(response_item_id, str)
+                    or not response_item_id.strip()
+                ):
                     _, embedded_response_item_id = self._split_responses_tool_id(raw_id)
                     response_item_id = embedded_response_item_id
 
@@ -2483,7 +2709,7 @@ class AIAgent:
                     "type": tool_call.type,
                     "function": {
                         "name": tool_call.function.name,
-                        "arguments": tool_call.function.arguments
+                        "arguments": tool_call.function.arguments,
                     },
                 }
                 # Preserve extra_content (e.g. Gemini thought_signature) so it
@@ -2517,12 +2743,14 @@ class AIAgent:
             return
         if "memory" not in self.valid_tool_names or not self._memory_store:
             return
-        effective_min = min_turns if min_turns is not None else self._memory_flush_min_turns
+        effective_min = (
+            min_turns if min_turns is not None else self._memory_flush_min_turns
+        )
         if self._user_turn_count < effective_min:
             return
 
         if messages is None:
-            messages = getattr(self, '_session_messages', None)
+            messages = getattr(self, "_session_messages", None)
         if not messages or len(messages) < 3:
             return
 
@@ -2531,7 +2759,11 @@ class AIAgent:
             "Please save anything worth remembering to your memories.]"
         )
         _sentinel = f"__flush_{id(self)}_{time.monotonic()}"
-        flush_msg = {"role": "user", "content": flush_content, "_flush_sentinel": _sentinel}
+        flush_msg = {
+            "role": "user",
+            "content": flush_content,
+            "_flush_sentinel": _sentinel,
+        }
         messages.append(flush_msg)
 
         try:
@@ -2549,11 +2781,13 @@ class AIAgent:
                 api_messages.append(api_msg)
 
             if self._cached_system_prompt:
-                api_messages = [{"role": "system", "content": self._cached_system_prompt}] + api_messages
+                api_messages = [
+                    {"role": "system", "content": self._cached_system_prompt}
+                ] + api_messages
 
             # Make one API call with only the memory tool available
             memory_tool_def = None
-            for t in (self.tools or []):
+            for t in self.tools or []:
                 if t.get("function", {}).get("name") == "memory":
                     memory_tool_def = t
                     break
@@ -2565,6 +2799,7 @@ class AIAgent:
             # Use auxiliary client for the flush call when available --
             # it's cheaper and avoids Codex Responses API incompatibility.
             from agent.auxiliary_client import get_text_auxiliary_client
+
             aux_client, aux_model = get_text_auxiliary_client()
 
             if aux_client:
@@ -2575,7 +2810,9 @@ class AIAgent:
                     "temperature": 0.3,
                     "max_tokens": 5120,
                 }
-                response = aux_client.chat.completions.create(**api_kwargs, timeout=30.0)
+                response = aux_client.chat.completions.create(
+                    **api_kwargs, timeout=30.0
+                )
             elif self.api_mode == "codex_responses":
                 # No auxiliary client -- use the Codex Responses path directly
                 codex_kwargs = self._build_api_kwargs(api_messages)
@@ -2592,7 +2829,9 @@ class AIAgent:
                     "temperature": 0.3,
                     **self._max_tokens_param(5120),
                 }
-                response = self.client.chat.completions.create(**api_kwargs, timeout=30.0)
+                response = self.client.chat.completions.create(
+                    **api_kwargs, timeout=30.0
+                )
 
             # Extract tool calls from the response, handling both API formats
             tool_calls = []
@@ -2611,6 +2850,7 @@ class AIAgent:
                         args = json.loads(tc.function.arguments)
                         flush_target = args.get("target", "memory")
                         from tools.memory_tool import memory_tool as _memory_tool
+
                         result = _memory_tool(
                             action=args.get("action"),
                             target=flush_target,
@@ -2618,10 +2858,16 @@ class AIAgent:
                             old_text=args.get("old_text"),
                             store=self._memory_store,
                         )
-                        if self._honcho and flush_target == "user" and args.get("action") == "add":
+                        if (
+                            self._honcho
+                            and flush_target == "user"
+                            and args.get("action") == "add"
+                        ):
                             self._honcho_save_user_observation(args.get("content", ""))
                         if not self.quiet_mode:
-                            print(f"  🧠 Memory flush: saved to {args.get('target', 'memory')}")
+                            print(
+                                f"  🧠 Memory flush: saved to {args.get('target', 'memory')}"
+                            )
                     except Exception as e:
                         logger.debug("Memory flush tool call failed: %s", e)
         except Exception as e:
@@ -2636,7 +2882,14 @@ class AIAgent:
             if messages and messages[-1].get("_flush_sentinel") == _sentinel:
                 messages.pop()
 
-    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default") -> tuple:
+    def _compress_context(
+        self,
+        messages: list,
+        system_message: str,
+        *,
+        approx_tokens: int = None,
+        task_id: str = "default",
+    ) -> tuple:
         """Compress conversation context and split the session in SQLite.
 
         Returns:
@@ -2645,7 +2898,9 @@ class AIAgent:
         # Pre-compression memory flush: let the model save memories before they're lost
         self.flush_memories(messages, min_turns=0)
 
-        compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
+        compressed = self.context_compressor.compress(
+            messages, current_tokens=approx_tokens
+        )
 
         todo_snapshot = self._todo_store.format_for_injection()
         if todo_snapshot:
@@ -2655,18 +2910,23 @@ class AIAgent:
         # it already examined before compression.
         try:
             from tools.file_tools import get_read_files_summary
+
             read_files = get_read_files_summary(task_id)
             if read_files:
                 file_list = "\n".join(
-                    f"  - {f['path']} ({', '.join(f['regions'])})"
-                    for f in read_files
+                    f"  - {f['path']} ({', '.join(f['regions'])})" for f in read_files
                 )
-                compressed.append({"role": "user", "content": (
-                    "[Files already read in this session — do NOT re-read these]\n"
-                    f"{file_list}\n"
-                    "Use the information from the context summary above. "
-                    "Proceed with writing, editing, or responding."
-                )})
+                compressed.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            "[Files already read in this session — do NOT re-read these]\n"
+                            f"{file_list}\n"
+                            "Use the information from the context summary above. "
+                            "Proceed with writing, editing, or responding."
+                        ),
+                    }
+                )
         except Exception:
             pass  # Don't break compression if file tracking fails
 
@@ -2680,7 +2940,9 @@ class AIAgent:
                 old_title = self._session_db.get_session_title(self.session_id)
                 self._session_db.end_session(self.session_id, "compression")
                 old_session_id = self.session_id
-                self.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+                self.session_id = (
+                    f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+                )
                 self._session_db.create_session(
                     session_id=self.session_id,
                     source=self.platform or "cli",
@@ -2690,11 +2952,15 @@ class AIAgent:
                 # Auto-number the title for the continuation session
                 if old_title:
                     try:
-                        new_title = self._session_db.get_next_title_in_lineage(old_title)
+                        new_title = self._session_db.get_next_title_in_lineage(
+                            old_title
+                        )
                         self._session_db.set_session_title(self.session_id, new_title)
                     except (ValueError, Exception) as e:
                         logger.debug("Could not propagate title on compression: %s", e)
-                self._session_db.update_system_prompt(self.session_id, new_system_prompt)
+                self._session_db.update_system_prompt(
+                    self.session_id, new_system_prompt
+                )
                 # Reset flush cursor — new session starts with no messages written
                 self._last_flushed_db_idx = 0
             except Exception as e:
@@ -2702,16 +2968,24 @@ class AIAgent:
 
         return compressed, new_system_prompt
 
-    def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+    def _execute_tool_calls(
+        self,
+        assistant_message,
+        messages: list,
+        effective_task_id: str,
+        api_call_count: int = 0,
+    ) -> None:
         """Execute tool calls from the assistant message and append results to messages."""
         for i, tool_call in enumerate(assistant_message.tool_calls, 1):
             # SAFETY: check interrupt BEFORE starting each tool.
             # If the user sent "stop" during a previous tool's execution,
             # do NOT start any more tools -- skip them all immediately.
             if self._interrupt_requested:
-                remaining_calls = assistant_message.tool_calls[i-1:]
+                remaining_calls = assistant_message.tool_calls[i - 1 :]
                 if remaining_calls:
-                    print(f"{self.log_prefix}⚡ Interrupt: skipping {len(remaining_calls)} tool call(s)")
+                    print(
+                        f"{self.log_prefix}⚡ Interrupt: skipping {len(remaining_calls)} tool call(s)"
+                    )
                 for skipped_tc in remaining_calls:
                     skipped_name = skipped_tc.function.name
                     skip_msg = {
@@ -2738,7 +3012,9 @@ class AIAgent:
             if not isinstance(function_args, dict):
                 function_args = {}
 
-            doom_loop_signature = self._make_doom_loop_signature(function_name, function_args)
+            doom_loop_signature = self._make_doom_loop_signature(
+                function_name, function_args
+            )
             if self._should_trigger_doom_loop(doom_loop_signature):
                 if self._handle_doom_loop(
                     assistant_message=assistant_message,
@@ -2750,8 +3026,14 @@ class AIAgent:
 
             if not self.quiet_mode:
                 args_str = json.dumps(function_args, ensure_ascii=False)
-                args_preview = args_str[:self.log_prefix_chars] + "..." if len(args_str) > self.log_prefix_chars else args_str
-                print(f"  📞 Tool {i}: {function_name}({list(function_args.keys())}) - {args_preview}")
+                args_preview = (
+                    args_str[: self.log_prefix_chars] + "..."
+                    if len(args_str) > self.log_prefix_chars
+                    else args_str
+                )
+                print(
+                    f"  📞 Tool {i}: {function_name}({list(function_args.keys())}) - {args_preview}"
+                )
 
             if self.tool_progress_callback:
                 try:
@@ -2761,11 +3043,16 @@ class AIAgent:
                     logging.debug(f"Tool progress callback error: {cb_err}")
 
             # Checkpoint: snapshot working dir before file-mutating tools
-            if function_name in ("write_file", "patch") and self._checkpoint_mgr.enabled:
+            if (
+                function_name in ("write_file", "patch")
+                and self._checkpoint_mgr.enabled
+            ):
                 try:
                     file_path = function_args.get("path", "")
                     if file_path:
-                        work_dir = self._checkpoint_mgr.get_working_dir_for_path(file_path)
+                        work_dir = self._checkpoint_mgr.get_working_dir_for_path(
+                            file_path
+                        )
                         self._checkpoint_mgr.ensure_checkpoint(
                             work_dir, f"before {function_name}"
                         )
@@ -2776,6 +3063,7 @@ class AIAgent:
 
             if function_name == "todo":
                 from tools.todo_tool import todo_tool as _todo_tool
+
                 function_result = _todo_tool(
                     todos=function_args.get("todos"),
                     merge=function_args.get("merge", False),
@@ -2783,12 +3071,19 @@ class AIAgent:
                 )
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
-                    print(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
+                    print(
+                        f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}"
+                    )
             elif function_name == "session_search":
                 if not self._session_db:
-                    function_result = json.dumps({"success": False, "error": "Session database not available."})
+                    function_result = json.dumps(
+                        {"success": False, "error": "Session database not available."}
+                    )
                 else:
-                    from tools.session_search_tool import session_search as _session_search
+                    from tools.session_search_tool import (
+                        session_search as _session_search,
+                    )
+
                     function_result = _session_search(
                         query=function_args.get("query", ""),
                         role_filter=function_args.get("role_filter"),
@@ -2798,10 +3093,13 @@ class AIAgent:
                     )
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
-                    print(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
+                    print(
+                        f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}"
+                    )
             elif function_name == "memory":
                 target = function_args.get("target", "memory")
                 from tools.memory_tool import memory_tool as _memory_tool
+
                 function_result = _memory_tool(
                     action=function_args.get("action"),
                     target=target,
@@ -2810,13 +3108,20 @@ class AIAgent:
                     store=self._memory_store,
                 )
                 # Also send user observations to Honcho when active
-                if self._honcho and target == "user" and function_args.get("action") == "add":
+                if (
+                    self._honcho
+                    and target == "user"
+                    and function_args.get("action") == "add"
+                ):
                     self._honcho_save_user_observation(function_args.get("content", ""))
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
-                    print(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
+                    print(
+                        f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}"
+                    )
             elif function_name == "clarify":
                 from tools.clarify_tool import clarify_tool as _clarify_tool
+
                 function_result = _clarify_tool(
                     question=function_args.get("question", ""),
                     choices=function_args.get("choices"),
@@ -2824,19 +3129,26 @@ class AIAgent:
                 )
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
-                    print(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
+                    print(
+                        f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}"
+                    )
             elif function_name == "delegate_task":
                 from tools.delegate_tool import delegate_task as _delegate_task
+
                 tasks_arg = function_args.get("tasks")
                 if tasks_arg and isinstance(tasks_arg, list):
                     spinner_label = f"🔀 delegating {len(tasks_arg)} tasks"
                 else:
                     goal_preview = (function_args.get("goal") or "")[:30]
-                    spinner_label = f"🔀 {goal_preview}" if goal_preview else "🔀 delegating"
+                    spinner_label = (
+                        f"🔀 {goal_preview}" if goal_preview else "🔀 delegating"
+                    )
                 spinner = None
                 if self.quiet_mode:
                     face = random.choice(KawaiiSpinner.KAWAII_WAITING)
-                    spinner = KawaiiSpinner(f"{face} {spinner_label}", spinner_type='dots')
+                    spinner = KawaiiSpinner(
+                        f"{face} {spinner_label}", spinner_type="dots"
+                    )
                     spinner.start()
                 self._delegate_spinner = spinner
                 _delegate_result = None
@@ -2853,7 +3165,12 @@ class AIAgent:
                 finally:
                     self._delegate_spinner = None
                     tool_duration = time.time() - tool_start_time
-                    cute_msg = _get_cute_tool_message_impl('delegate_task', function_args, tool_duration, result=_delegate_result)
+                    cute_msg = _get_cute_tool_message_impl(
+                        "delegate_task",
+                        function_args,
+                        tool_duration,
+                        result=_delegate_result,
+                    )
                     if spinner:
                         spinner.stop(cute_msg)
                     elif self.quiet_mode:
@@ -2861,60 +3178,119 @@ class AIAgent:
             elif self.quiet_mode:
                 face = random.choice(KawaiiSpinner.KAWAII_WAITING)
                 tool_emoji_map = {
-                    'web_search': '🔍', 'web_extract': '📄', 'web_crawl': '🕸️',
-                    'terminal': '💻', 'process': '⚙️',
-                    'read_file': '📖', 'write_file': '✍️', 'patch': '🔧', 'search_files': '🔎',
-                    'browser_navigate': '🌐', 'browser_snapshot': '📸',
-                    'browser_click': '👆', 'browser_type': '⌨️',
-                    'browser_scroll': '📜', 'browser_back': '◀️',
-                    'browser_press': '⌨️', 'browser_close': '🚪',
-                    'browser_get_images': '🖼️', 'browser_vision': '👁️',
-                    'image_generate': '🎨', 'text_to_speech': '🔊',
-                    'vision_analyze': '👁️', 'mixture_of_agents': '🧠',
-                    'skills_list': '📚', 'skill_view': '📚',
-                    'schedule_cronjob': '⏰', 'list_cronjobs': '⏰', 'remove_cronjob': '⏰',
-                    'send_message': '📨', 'todo': '📋', 'memory': '🧠', 'session_search': '🔍',
-                    'clarify': '❓', 'execute_code': '🐍', 'delegate_task': '🔀',
+                    "web_search": "🔍",
+                    "web_extract": "📄",
+                    "web_crawl": "🕸️",
+                    "terminal": "💻",
+                    "process": "⚙️",
+                    "read_file": "📖",
+                    "write_file": "✍️",
+                    "patch": "🔧",
+                    "search_files": "🔎",
+                    "browser_navigate": "🌐",
+                    "browser_snapshot": "📸",
+                    "browser_click": "👆",
+                    "browser_type": "⌨️",
+                    "browser_scroll": "📜",
+                    "browser_back": "◀️",
+                    "browser_press": "⌨️",
+                    "browser_close": "🚪",
+                    "browser_get_images": "🖼️",
+                    "browser_vision": "👁️",
+                    "image_generate": "🎨",
+                    "text_to_speech": "🔊",
+                    "vision_analyze": "👁️",
+                    "mixture_of_agents": "🧠",
+                    "skills_list": "📚",
+                    "skill_view": "📚",
+                    "schedule_cronjob": "⏰",
+                    "list_cronjobs": "⏰",
+                    "remove_cronjob": "⏰",
+                    "send_message": "📨",
+                    "todo": "📋",
+                    "memory": "🧠",
+                    "session_search": "🔍",
+                    "clarify": "❓",
+                    "execute_code": "🐍",
+                    "delegate_task": "🔀",
                 }
-                emoji = tool_emoji_map.get(function_name, '⚡')
-                preview = _build_tool_preview(function_name, function_args) or function_name
+                emoji = tool_emoji_map.get(function_name, "⚡")
+                preview = (
+                    _build_tool_preview(function_name, function_args) or function_name
+                )
                 if len(preview) > 30:
                     preview = preview[:27] + "..."
-                spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots')
+                spinner = KawaiiSpinner(
+                    f"{face} {emoji} {preview}", spinner_type="dots"
+                )
                 spinner.start()
                 _spinner_result = None
                 try:
                     function_result = handle_function_call(
-                        function_name, function_args, effective_task_id,
-                        enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                        function_name,
+                        function_args,
+                        effective_task_id,
+                        enabled_tools=list(self.valid_tool_names)
+                        if self.valid_tool_names
+                        else None,
                     )
                     _spinner_result = function_result
                 except Exception as tool_error:
-                    function_result = f"Error executing tool '{function_name}': {tool_error}"
-                    logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
+                    function_result = (
+                        f"Error executing tool '{function_name}': {tool_error}"
+                    )
+                    logger.error(
+                        "handle_function_call raised for %s: %s",
+                        function_name,
+                        tool_error,
+                        exc_info=True,
+                    )
                 finally:
                     tool_duration = time.time() - tool_start_time
-                    cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_spinner_result)
+                    cute_msg = _get_cute_tool_message_impl(
+                        function_name,
+                        function_args,
+                        tool_duration,
+                        result=_spinner_result,
+                    )
                     spinner.stop(cute_msg)
             else:
                 try:
                     function_result = handle_function_call(
-                        function_name, function_args, effective_task_id,
-                        enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                        function_name,
+                        function_args,
+                        effective_task_id,
+                        enabled_tools=list(self.valid_tool_names)
+                        if self.valid_tool_names
+                        else None,
                     )
                 except Exception as tool_error:
-                    function_result = f"Error executing tool '{function_name}': {tool_error}"
-                    logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
+                    function_result = (
+                        f"Error executing tool '{function_name}': {tool_error}"
+                    )
+                    logger.error(
+                        "handle_function_call raised for %s: %s",
+                        function_name,
+                        tool_error,
+                        exc_info=True,
+                    )
                 tool_duration = time.time() - tool_start_time
 
-            result_preview = function_result[:200] if len(function_result) > 200 else function_result
+            result_preview = (
+                function_result[:200] if len(function_result) > 200 else function_result
+            )
 
             # Log tool errors to the persistent error log so [error] tags
             # in the UI always have a corresponding detailed entry on disk.
             _is_error_result, _ = _detect_tool_failure(function_name, function_result)
             self._record_tool_call_result(doom_loop_signature, _is_error_result)
             if _is_error_result:
-                logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
+                logger.warning(
+                    "Tool %s returned error (%.2fs): %s",
+                    function_name,
+                    tool_duration,
+                    result_preview,
+                )
 
             if self.verbose_logging:
                 logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
@@ -2936,23 +3312,31 @@ class AIAgent:
             tool_msg = {
                 "role": "tool",
                 "content": function_result,
-                "tool_call_id": tool_call.id
+                "tool_call_id": tool_call.id,
             }
             messages.append(tool_msg)
 
             if not self.quiet_mode:
-                response_preview = function_result[:self.log_prefix_chars] + "..." if len(function_result) > self.log_prefix_chars else function_result
-                print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s - {response_preview}")
+                response_preview = (
+                    function_result[: self.log_prefix_chars] + "..."
+                    if len(function_result) > self.log_prefix_chars
+                    else function_result
+                )
+                print(
+                    f"  ✅ Tool {i} completed in {tool_duration:.2f}s - {response_preview}"
+                )
 
             if self._interrupt_requested and i < len(assistant_message.tool_calls):
                 remaining = len(assistant_message.tool_calls) - i
-                print(f"{self.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)")
+                print(
+                    f"{self.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)"
+                )
                 for skipped_tc in assistant_message.tool_calls[i:]:
                     skipped_name = skipped_tc.function.name
                     skip_msg = {
                         "role": "tool",
                         "content": f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
-                        "tool_call_id": skipped_tc.id
+                        "tool_call_id": skipped_tc.id,
                     }
                     messages.append(skip_msg)
                 break
@@ -2960,7 +3344,9 @@ class AIAgent:
             if self.tool_delay > 0 and i < len(assistant_message.tool_calls):
                 time.sleep(self.tool_delay)
 
-    def _make_doom_loop_signature(self, tool_name: str, function_args: dict) -> Optional[tuple[str, str]]:
+    def _make_doom_loop_signature(
+        self, tool_name: str, function_args: dict
+    ) -> Optional[tuple[str, str]]:
         if self._is_doom_loop_exempt(tool_name, function_args):
             return None
 
@@ -3027,7 +3413,11 @@ class AIAgent:
                 response = str(
                     self.clarify_callback(
                         question,
-                        ["Continue anyway", "Try different approach", "Stop and summarize"],
+                        [
+                            "Continue anyway",
+                            "Try different approach",
+                            "Stop and summarize",
+                        ],
                     )
                 ).strip()
             except Exception as exc:
@@ -3048,7 +3438,6 @@ class AIAgent:
                 "tool_call_id": skipped_tc.id,
             }
             messages.append(skip_msg)
-            self._log_msg_to_db(skip_msg)
 
         if "stop" in normalized_response:
             recovery_msg = (
@@ -3065,14 +3454,33 @@ class AIAgent:
 
         recovery_dict = {"role": "user", "content": recovery_msg}
         messages.append(recovery_dict)
-        self._log_msg_to_db(recovery_dict)
         self._doom_loop_signature = None
         self._doom_loop_count = 0
         return True
 
+    def _get_budget_warning(self, api_call_count: int) -> Optional[str]:
+        if not self._budget_pressure_enabled or self.max_iterations <= 0:
+            return None
+        progress = api_call_count / self.max_iterations
+        remaining = self.max_iterations - api_call_count
+        if progress >= self._budget_warning_threshold:
+            return (
+                f"[BUDGET WARNING: Iteration {api_call_count}/{self.max_iterations}. "
+                f"Only {remaining} iteration(s) left. "
+                "Provide your final response NOW. No more tool calls unless absolutely critical.]"
+            )
+        if progress >= self._budget_caution_threshold:
+            return (
+                f"[BUDGET: Iteration {api_call_count}/{self.max_iterations}. "
+                f"{remaining} iterations left. Start consolidating your work.]"
+            )
+        return None
+
     def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
         """Request a summary when max iterations are reached. Returns the final response text."""
-        print(f"⚠️  Reached maximum iterations ({self.max_iterations}). Requesting summary...")
+        print(
+            f"⚠️  Reached maximum iterations ({self.max_iterations}). Requesting summary..."
+        )
 
         summary_request = (
             "You've reached the maximum number of tool-calling iterations allowed. "
@@ -3093,9 +3501,13 @@ class AIAgent:
 
             effective_system = self._cached_system_prompt or ""
             if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+                effective_system = (
+                    effective_system + "\n\n" + self.ephemeral_system_prompt
+                ).strip()
             if effective_system:
-                api_messages = [{"role": "system", "content": effective_system}] + api_messages
+                api_messages = [
+                    {"role": "system", "content": effective_system}
+                ] + api_messages
             if self.prefill_messages:
                 sys_offset = 1 if effective_system else 0
                 for idx, pfm in enumerate(self.prefill_messages):
@@ -3110,7 +3522,7 @@ class AIAgent:
                 else:
                     summary_extra_body["reasoning"] = {
                         "enabled": True,
-                        "effort": "medium"
+                        "effort": "medium",
                     }
             if _is_nous:
                 summary_extra_body["tags"] = ["product=hermes-agent"]
@@ -3120,7 +3532,11 @@ class AIAgent:
                 codex_kwargs.pop("tools", None)
                 summary_response = self._run_codex_stream(codex_kwargs)
                 assistant_message, _ = self._normalize_codex_response(summary_response)
-                final_response = (assistant_message.content or "").strip() if assistant_message else ""
+                final_response = (
+                    (assistant_message.content or "").strip()
+                    if assistant_message
+                    else ""
+                )
             else:
                 summary_kwargs = {
                     "model": self.model,
@@ -3147,18 +3563,25 @@ class AIAgent:
 
                 summary_response = self.client.chat.completions.create(**summary_kwargs)
 
-                if summary_response.choices and summary_response.choices[0].message.content:
+                if (
+                    summary_response.choices
+                    and summary_response.choices[0].message.content
+                ):
                     final_response = summary_response.choices[0].message.content
                 else:
                     final_response = ""
 
             if final_response:
                 if "<think>" in final_response:
-                    final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+                    final_response = re.sub(
+                        r"<think>.*?</think>\s*", "", final_response, flags=re.DOTALL
+                    ).strip()
                 if final_response:
                     messages.append({"role": "assistant", "content": final_response})
                 else:
-                    final_response = "I reached the iteration limit and couldn't generate a summary."
+                    final_response = (
+                        "I reached the iteration limit and couldn't generate a summary."
+                    )
             else:
                 # Retry summary generation
                 if self.api_mode == "codex_responses":
@@ -3166,7 +3589,9 @@ class AIAgent:
                     codex_kwargs.pop("tools", None)
                     retry_response = self._run_codex_stream(codex_kwargs)
                     retry_msg, _ = self._normalize_codex_response(retry_response)
-                    final_response = (retry_msg.content or "").strip() if retry_msg else ""
+                    final_response = (
+                        (retry_msg.content or "").strip() if retry_msg else ""
+                    )
                 else:
                     summary_kwargs = {
                         "model": self.model,
@@ -3177,22 +3602,36 @@ class AIAgent:
                     if summary_extra_body:
                         summary_kwargs["extra_body"] = summary_extra_body
 
-                    summary_response = self.client.chat.completions.create(**summary_kwargs)
+                    summary_response = self.client.chat.completions.create(
+                        **summary_kwargs
+                    )
 
-                    if summary_response.choices and summary_response.choices[0].message.content:
+                    if (
+                        summary_response.choices
+                        and summary_response.choices[0].message.content
+                    ):
                         final_response = summary_response.choices[0].message.content
                     else:
                         final_response = ""
 
                 if final_response:
                     if "<think>" in final_response:
-                        final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+                        final_response = re.sub(
+                            r"<think>.*?</think>\s*",
+                            "",
+                            final_response,
+                            flags=re.DOTALL,
+                        ).strip()
                     if final_response:
-                        messages.append({"role": "assistant", "content": final_response})
+                        messages.append(
+                            {"role": "assistant", "content": final_response}
+                        )
                     else:
                         final_response = "I reached the iteration limit and couldn't generate a summary."
                 else:
-                    final_response = "I reached the iteration limit and couldn't generate a summary."
+                    final_response = (
+                        "I reached the iteration limit and couldn't generate a summary."
+                    )
 
         except Exception as e:
             logging.warning(f"Failed to get summary response: {e}")
@@ -3205,7 +3644,7 @@ class AIAgent:
         user_message: str,
         system_message: str = None,
         conversation_history: List[Dict[str, Any]] = None,
-        task_id: str = None
+        task_id: str = None,
     ) -> Dict[str, Any]:
         """
         Run a complete conversation with tool calling until completion.
@@ -3221,7 +3660,7 @@ class AIAgent:
         """
         # Generate unique task_id if not provided to isolate VMs between concurrent tasks
         effective_task_id = task_id or str(uuid.uuid4())
-        
+
         # Reset retry counters and iteration budget at the start of each turn
         # so subagent usage from a previous turn doesn't eat into the next one.
         self._invalid_tool_retries = 0
@@ -3233,21 +3672,21 @@ class AIAgent:
         self._turns_since_memory = 0
         self._iters_since_skill = 0
         self.iteration_budget = IterationBudget(self.max_iterations)
-        
+
         # Initialize conversation (copy to avoid mutating the caller's list)
         messages = list(conversation_history) if conversation_history else []
-        
+
         # Hydrate todo store from conversation history (gateway creates a fresh
         # AIAgent per message, so the in-memory store is empty -- we need to
         # recover the todo state from the most recent todo tool response in history)
         if conversation_history and not self._todo_store.has_items():
             self._hydrate_todo_store(conversation_history)
-        
+
         # Prefill messages (few-shot priming) are injected at API-call time only,
         # never stored in the messages list. This keeps them ephemeral: they won't
         # be saved to session DB, session logs, or batch trajectories, but they're
         # automatically re-applied on every API call (including session continuations).
-        
+
         # Track user turns for memory flush and periodic nudge logic
         self._user_turn_count += 1
 
@@ -3257,9 +3696,11 @@ class AIAgent:
 
         # Periodic memory nudge: remind the model to consider saving memories.
         # Counter resets whenever the memory tool is actually used.
-        if (self._memory_nudge_interval > 0
-                and "memory" in self.valid_tool_names
-                and self._memory_store):
+        if (
+            self._memory_nudge_interval > 0
+            and "memory" in self.valid_tool_names
+            and self._memory_store
+        ):
             self._turns_since_memory += 1
             if self._turns_since_memory >= self._memory_nudge_interval:
                 user_message += (
@@ -3270,9 +3711,11 @@ class AIAgent:
 
         # Skill creation nudge: fires on the first user message after a long tool loop.
         # The counter increments per API iteration in the tool loop and is checked here.
-        if (self._skill_nudge_interval > 0
-                and self._iters_since_skill >= self._skill_nudge_interval
-                and "skill_manage" in self.valid_tool_names):
+        if (
+            self._skill_nudge_interval > 0
+            and self._iters_since_skill >= self._skill_nudge_interval
+            and "skill_manage" in self.valid_tool_names
+        ):
             user_message += (
                 "\n\n[System: The previous task involved many steps. "
                 "If you discovered a reusable workflow, consider saving it as a skill.]"
@@ -3295,10 +3738,12 @@ class AIAgent:
         # Add user message
         user_msg = {"role": "user", "content": user_message}
         messages.append(user_msg)
-        
+
         if not self.quiet_mode:
-            print(f"💬 Starting conversation: '{user_message[:60]}{'...' if len(user_message) > 60 else ''}'")
-        
+            print(
+                f"💬 Starting conversation: '{user_message[:60]}{'...' if len(user_message) > 60 else ''}'"
+            )
+
         # ── System prompt (cached per session for prefix caching) ──
         # Built once on first call, reused for all subsequent calls.
         # Only rebuilt after context compression events (which invalidate
@@ -3336,7 +3781,9 @@ class AIAgent:
                 # Store the system prompt snapshot in SQLite
                 if self._session_db:
                     try:
-                        self._session_db.update_system_prompt(self.session_id, self._cached_system_prompt)
+                        self._session_db.update_system_prompt(
+                            self.session_id, self._cached_system_prompt
+                        )
                     except Exception as e:
                         logger.debug("Session DB update_system_prompt failed: %s", e)
 
@@ -3351,8 +3798,10 @@ class AIAgent:
         # 4xx and abort the request entirely).
         if (
             self.compression_enabled
-            and len(messages) > self.context_compressor.protect_first_n
-                                + self.context_compressor.protect_last_n + 1
+            and len(messages)
+            > self.context_compressor.protect_first_n
+            + self.context_compressor.protect_last_n
+            + 1
         ):
             _sys_tok_est = estimate_tokens_rough(active_system_prompt or "")
             _msg_tok_est = estimate_messages_tokens_rough(messages)
@@ -3376,7 +3825,9 @@ class AIAgent:
                 for _pass in range(3):
                     _orig_len = len(messages)
                     messages, active_system_prompt = self._compress_context(
-                        messages, system_message, approx_tokens=_preflight_tokens,
+                        messages,
+                        system_message,
+                        approx_tokens=_preflight_tokens,
                         task_id=effective_task_id,
                     )
                     if len(messages) >= _orig_len:
@@ -3395,11 +3846,13 @@ class AIAgent:
         codex_ack_continuations = 0
         length_continue_retries = 0
         truncated_response_prefix = ""
-        
+
         # Clear any stale interrupt state at start
         self.clear_interrupt()
-        
-        while api_call_count < self.max_iterations and self.iteration_budget.remaining > 0:
+
+        while (
+            api_call_count < self.max_iterations and self.iteration_budget.remaining > 0
+        ):
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot
             self._checkpoint_mgr.new_turn()
 
@@ -3409,11 +3862,13 @@ class AIAgent:
                 if not self.quiet_mode:
                     print(f"\n⚡ Breaking out of tool loop due to interrupt...")
                 break
-            
+
             api_call_count += 1
             if not self.iteration_budget.consume():
                 if not self.quiet_mode:
-                    print(f"\n⚠️  Session iteration budget exhausted ({self.iteration_budget.max_total} total across agent + subagents)")
+                    print(
+                        f"\n⚠️  Session iteration budget exhausted ({self.iteration_budget.max_total} total across agent + subagents)"
+                    )
                 break
 
             # Fire step_callback for gateway hooks (agent:step event)
@@ -3430,14 +3885,20 @@ class AIAgent:
                             break
                     self.step_callback(api_call_count, prev_tools)
                 except Exception as _step_err:
-                    logger.debug("step_callback error (iteration %s): %s", api_call_count, _step_err)
+                    logger.debug(
+                        "step_callback error (iteration %s): %s",
+                        api_call_count,
+                        _step_err,
+                    )
 
             # Track tool-calling iterations for skill nudge.
             # Counter resets whenever skill_manage is actually used.
-            if (self._skill_nudge_interval > 0
-                    and "skill_manage" in self.valid_tool_names):
+            if (
+                self._skill_nudge_interval > 0
+                and "skill_manage" in self.valid_tool_names
+            ):
                 self._iters_since_skill += 1
-            
+
             # Prepare messages for API call
             # If we have an ephemeral system prompt, prepend it to the messages
             # Note: Reasoning is embedded in content via <think> tags for trajectory storage.
@@ -3475,9 +3936,13 @@ class AIAgent:
             # session, maximizing Anthropic prompt cache hits.
             effective_system = active_system_prompt or ""
             if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+                effective_system = (
+                    effective_system + "\n\n" + self.ephemeral_system_prompt
+                ).strip()
             if effective_system:
-                api_messages = [{"role": "system", "content": effective_system}] + api_messages
+                api_messages = [
+                    {"role": "system", "content": effective_system}
+                ] + api_messages
 
             # Inject ephemeral prefill messages right after the system prompt
             # but before conversation history. Same API-call-time-only pattern.
@@ -3491,26 +3956,36 @@ class AIAgent:
             # inject cache_control breakpoints (system + last 3 messages) to reduce
             # input token costs by ~75% on multi-turn conversations.
             if self._use_prompt_caching:
-                api_messages = apply_anthropic_cache_control(api_messages, cache_ttl=self._cache_ttl)
+                api_messages = apply_anthropic_cache_control(
+                    api_messages, cache_ttl=self._cache_ttl
+                )
 
             # Safety net: strip orphaned tool results / add stubs for missing
             # results before sending to the API.  The compressor handles this
             # during compression, but orphans can also sneak in from session
             # loading or manual message manipulation.
-            if hasattr(self, 'context_compressor') and self.context_compressor:
-                api_messages = self.context_compressor._sanitize_tool_pairs(api_messages)
+            if hasattr(self, "context_compressor") and self.context_compressor:
+                api_messages = self.context_compressor._sanitize_tool_pairs(
+                    api_messages
+                )
 
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)
             approx_tokens = total_chars // 4  # Rough estimate: 4 chars per token
-            
+
             # Thinking spinner for quiet mode (animated during API call)
             thinking_spinner = None
-            
+
             if not self.quiet_mode:
-                print(f"\n{self.log_prefix}🔄 Making API call #{api_call_count}/{self.max_iterations}...")
-                print(f"{self.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)")
-                print(f"{self.log_prefix}   🔧 Available tools: {len(self.tools) if self.tools else 0}")
+                print(
+                    f"\n{self.log_prefix}🔄 Making API call #{api_call_count}/{self.max_iterations}..."
+                )
+                print(
+                    f"{self.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)"
+                )
+                print(
+                    f"{self.log_prefix}   🔧 Available tools: {len(self.tools) if self.tools else 0}"
+                )
             else:
                 # Animated thinking spinner in quiet mode
                 face = random.choice(KawaiiSpinner.KAWAII_THINKING)
@@ -3519,16 +3994,24 @@ class AIAgent:
                     # CLI TUI mode: use prompt_toolkit widget instead of raw spinner
                     self.thinking_callback(f"{face} {verb}...")
                 else:
-                    spinner_type = random.choice(['brain', 'sparkle', 'pulse', 'moon', 'star'])
-                    thinking_spinner = KawaiiSpinner(f"{face} {verb}...", spinner_type=spinner_type)
+                    spinner_type = random.choice(
+                        ["brain", "sparkle", "pulse", "moon", "star"]
+                    )
+                    thinking_spinner = KawaiiSpinner(
+                        f"{face} {verb}...", spinner_type=spinner_type
+                    )
                     thinking_spinner.start()
-            
+
             # Log request details if verbose
             if self.verbose_logging:
-                logging.debug(f"API Request - Model: {self.model}, Messages: {len(messages)}, Tools: {len(self.tools) if self.tools else 0}")
-                logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
+                logging.debug(
+                    f"API Request - Model: {self.model}, Messages: {len(messages)}, Tools: {len(self.tools) if self.tools else 0}"
+                )
+                logging.debug(
+                    f"Last message role: {messages[-1]['role'] if messages else 'none'}"
+                )
                 logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
-            
+
             api_start_time = time.time()
             retry_count = 0
             max_retries = 6  # Increased to allow longer backoff periods
@@ -3546,15 +4029,22 @@ class AIAgent:
                 try:
                     api_kwargs = self._build_api_kwargs(api_messages)
                     if self.api_mode == "codex_responses":
-                        api_kwargs = self._preflight_codex_api_kwargs(api_kwargs, allow_stream=False)
+                        api_kwargs = self._preflight_codex_api_kwargs(
+                            api_kwargs, allow_stream=False
+                        )
 
-                    if os.getenv("HERMES_DUMP_REQUESTS", "").strip().lower() in {"1", "true", "yes", "on"}:
+                    if os.getenv("HERMES_DUMP_REQUESTS", "").strip().lower() in {
+                        "1",
+                        "true",
+                        "yes",
+                        "on",
+                    }:
                         self._dump_api_request_debug(api_kwargs, reason="preflight")
 
                     response = self._interruptible_api_call(api_kwargs)
-                    
+
                     api_duration = time.time() - api_start_time
-                    
+
                     # Stop thinking spinner silently -- the response box or tool
                     # execution messages that follow are more informative.
                     if thinking_spinner:
@@ -3562,20 +4052,30 @@ class AIAgent:
                         thinking_spinner = None
                     if self.thinking_callback:
                         self.thinking_callback("")
-                    
+
                     if not self.quiet_mode:
-                        print(f"{self.log_prefix}⏱️  API call completed in {api_duration:.2f}s")
-                    
+                        print(
+                            f"{self.log_prefix}⏱️  API call completed in {api_duration:.2f}s"
+                        )
+
                     if self.verbose_logging:
                         # Log response with provider info if available
-                        resp_model = getattr(response, 'model', 'N/A') if response else 'N/A'
-                        logging.debug(f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}")
-                    
+                        resp_model = (
+                            getattr(response, "model", "N/A") if response else "N/A"
+                        )
+                        logging.debug(
+                            f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}"
+                        )
+
                     # Validate response shape before proceeding
                     response_invalid = False
                     error_details = []
                     if self.api_mode == "codex_responses":
-                        output_items = getattr(response, "output", None) if response is not None else None
+                        output_items = (
+                            getattr(response, "output", None)
+                            if response is not None
+                            else None
+                        )
                         if response is None:
                             response_invalid = True
                             error_details.append("response is None")
@@ -3586,12 +4086,19 @@ class AIAgent:
                             response_invalid = True
                             error_details.append("response.output is empty")
                     else:
-                        if response is None or not hasattr(response, 'choices') or response.choices is None or len(response.choices) == 0:
+                        if (
+                            response is None
+                            or not hasattr(response, "choices")
+                            or response.choices is None
+                            or len(response.choices) == 0
+                        ):
                             response_invalid = True
                             if response is None:
                                 error_details.append("response is None")
-                            elif not hasattr(response, 'choices'):
-                                error_details.append("response has no 'choices' attribute")
+                            elif not hasattr(response, "choices"):
+                                error_details.append(
+                                    "response has no 'choices' attribute"
+                                )
                             elif response.choices is None:
                                 error_details.append("response.choices is None")
                             else:
@@ -3604,63 +4111,101 @@ class AIAgent:
                             thinking_spinner = None
                         if self.thinking_callback:
                             self.thinking_callback("")
-                        
+
                         # This is often rate limiting or provider returning malformed response
                         retry_count += 1
-                        
+
                         # Check for error field in response (some providers include this)
                         error_msg = "Unknown"
                         provider_name = "Unknown"
-                        if response and hasattr(response, 'error') and response.error:
+                        if response and hasattr(response, "error") and response.error:
                             error_msg = str(response.error)
                             # Try to extract provider from error metadata
-                            if hasattr(response.error, 'metadata') and response.error.metadata:
-                                provider_name = response.error.metadata.get('provider_name', 'Unknown')
-                        elif response and hasattr(response, 'message') and response.message:
+                            if (
+                                hasattr(response.error, "metadata")
+                                and response.error.metadata
+                            ):
+                                provider_name = response.error.metadata.get(
+                                    "provider_name", "Unknown"
+                                )
+                        elif (
+                            response
+                            and hasattr(response, "message")
+                            and response.message
+                        ):
                             error_msg = str(response.message)
-                        
+
                         # Try to get provider from model field (OpenRouter often returns actual model used)
-                        if provider_name == "Unknown" and response and hasattr(response, 'model') and response.model:
+                        if (
+                            provider_name == "Unknown"
+                            and response
+                            and hasattr(response, "model")
+                            and response.model
+                        ):
                             provider_name = f"model={response.model}"
-                        
+
                         # Check for x-openrouter-provider or similar metadata
                         if provider_name == "Unknown" and response:
                             # Log all response attributes for debugging
-                            resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
+                            resp_attrs = {
+                                k: str(v)[:100]
+                                for k, v in vars(response).items()
+                                if not k.startswith("_")
+                            }
                             if self.verbose_logging:
-                                logging.debug(f"Response attributes for invalid response: {resp_attrs}")
-                        
-                        print(f"{self.log_prefix}⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}")
+                                logging.debug(
+                                    f"Response attributes for invalid response: {resp_attrs}"
+                                )
+
+                        print(
+                            f"{self.log_prefix}⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}"
+                        )
                         print(f"{self.log_prefix}   🏢 Provider: {provider_name}")
-                        print(f"{self.log_prefix}   📝 Provider message: {error_msg[:200]}")
-                        print(f"{self.log_prefix}   ⏱️  Response time: {api_duration:.2f}s (fast response often indicates rate limiting)")
-                        
+                        print(
+                            f"{self.log_prefix}   📝 Provider message: {error_msg[:200]}"
+                        )
+                        print(
+                            f"{self.log_prefix}   ⏱️  Response time: {api_duration:.2f}s (fast response often indicates rate limiting)"
+                        )
+
                         if retry_count >= max_retries:
                             # Try fallback before giving up
                             if self._try_activate_fallback():
                                 retry_count = 0
                                 continue
-                            print(f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
-                            logging.error(f"{self.log_prefix}Invalid API response after {max_retries} retries.")
+                            print(
+                                f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up."
+                            )
+                            logging.error(
+                                f"{self.log_prefix}Invalid API response after {max_retries} retries."
+                            )
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": "Invalid API response shape. Likely rate limited or malformed provider response.",
-                                "failed": True  # Mark as failure for filtering
+                                "failed": True,  # Mark as failure for filtering
                             }
-                        
+
                         # Longer backoff for rate limiting (likely cause of None choices)
-                        wait_time = min(5 * (2 ** (retry_count - 1)), 120)  # 5s, 10s, 20s, 40s, 80s, 120s
-                        print(f"{self.log_prefix}⏳ Retrying in {wait_time}s (extended backoff for possible rate limit)...")
-                        logging.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
-                        
+                        wait_time = min(
+                            5 * (2 ** (retry_count - 1)), 120
+                        )  # 5s, 10s, 20s, 40s, 80s, 120s
+                        print(
+                            f"{self.log_prefix}⏳ Retrying in {wait_time}s (extended backoff for possible rate limit)..."
+                        )
+                        logging.warning(
+                            f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}"
+                        )
+
                         # Sleep in small increments to stay responsive to interrupts
                         sleep_end = time.time() + wait_time
                         while time.time() < sleep_end:
                             if self._interrupt_requested:
-                                print(f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting.")
+                                print(
+                                    f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting."
+                                )
                                 self._persist_session(messages, conversation_history)
                                 self.clear_interrupt()
                                 return {
@@ -3676,13 +4221,20 @@ class AIAgent:
                     # Check finish_reason before proceeding
                     if self.api_mode == "codex_responses":
                         status = getattr(response, "status", None)
-                        incomplete_details = getattr(response, "incomplete_details", None)
+                        incomplete_details = getattr(
+                            response, "incomplete_details", None
+                        )
                         incomplete_reason = None
                         if isinstance(incomplete_details, dict):
                             incomplete_reason = incomplete_details.get("reason")
                         else:
-                            incomplete_reason = getattr(incomplete_details, "reason", None)
-                        if status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"}:
+                            incomplete_reason = getattr(
+                                incomplete_details, "reason", None
+                            )
+                        if status == "incomplete" and incomplete_reason in {
+                            "max_output_tokens",
+                            "length",
+                        }:
                             finish_reason = "length"
                         else:
                             finish_reason = "stop"
@@ -3690,16 +4242,22 @@ class AIAgent:
                         finish_reason = response.choices[0].finish_reason
 
                     if finish_reason == "length":
-                        print(f"{self.log_prefix}⚠️  Response truncated (finish_reason='length') - model hit max output tokens")
+                        print(
+                            f"{self.log_prefix}⚠️  Response truncated (finish_reason='length') - model hit max output tokens"
+                        )
 
                         if self.api_mode == "chat_completions":
                             assistant_message = response.choices[0].message
                             if not assistant_message.tool_calls:
                                 length_continue_retries += 1
-                                interim_msg = self._build_assistant_message(assistant_message, finish_reason)
+                                interim_msg = self._build_assistant_message(
+                                    assistant_message, finish_reason
+                                )
                                 messages.append(interim_msg)
                                 if assistant_message.content:
-                                    truncated_response_prefix += assistant_message.content
+                                    truncated_response_prefix += (
+                                        assistant_message.content
+                                    )
 
                                 if length_continue_retries < 3:
                                     print(
@@ -3720,7 +4278,9 @@ class AIAgent:
                                     restart_with_length_continuation = True
                                     break
 
-                                partial_response = self._strip_think_blocks(truncated_response_prefix).strip()
+                                partial_response = self._strip_think_blocks(
+                                    truncated_response_prefix
+                                ).strip()
                                 self._cleanup_task_resources(effective_task_id)
                                 self._persist_session(messages, conversation_history)
                                 return {
@@ -3734,8 +4294,12 @@ class AIAgent:
 
                         # If we have prior messages, roll back to last complete state
                         if len(messages) > 1:
-                            print(f"{self.log_prefix}   ⏪ Rolling back to last complete assistant turn")
-                            rolled_back_messages = self._get_messages_up_to_last_assistant(messages)
+                            print(
+                                f"{self.log_prefix}   ⏪ Rolling back to last complete assistant turn"
+                            )
+                            rolled_back_messages = (
+                                self._get_messages_up_to_last_assistant(messages)
+                            )
 
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
@@ -3746,11 +4310,13 @@ class AIAgent:
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
-                                "error": "Response truncated due to output length limit"
+                                "error": "Response truncated due to output length limit",
                             }
                         else:
                             # First message was truncated - mark as failed
-                            print(f"{self.log_prefix}❌ First response truncated - cannot recover")
+                            print(
+                                f"{self.log_prefix}❌ First response truncated - cannot recover"
+                            )
                             self._persist_session(messages, conversation_history)
                             return {
                                 "final_response": None,
@@ -3758,22 +4324,31 @@ class AIAgent:
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "failed": True,
-                                "error": "First response truncated due to output length limit"
+                                "error": "First response truncated due to output length limit",
                             }
-                    
+
                     # Track actual token usage from response for context management
-                    if hasattr(response, 'usage') and response.usage:
+                    if hasattr(response, "usage") and response.usage:
                         if self.api_mode == "codex_responses":
-                            prompt_tokens = getattr(response.usage, 'input_tokens', 0) or 0
-                            completion_tokens = getattr(response.usage, 'output_tokens', 0) or 0
-                            total_tokens = (
-                                getattr(response.usage, 'total_tokens', None)
-                                or (prompt_tokens + completion_tokens)
+                            prompt_tokens = (
+                                getattr(response.usage, "input_tokens", 0) or 0
                             )
+                            completion_tokens = (
+                                getattr(response.usage, "output_tokens", 0) or 0
+                            )
+                            total_tokens = getattr(
+                                response.usage, "total_tokens", None
+                            ) or (prompt_tokens + completion_tokens)
                         else:
-                            prompt_tokens = getattr(response.usage, 'prompt_tokens', 0) or 0
-                            completion_tokens = getattr(response.usage, 'completion_tokens', 0) or 0
-                            total_tokens = getattr(response.usage, 'total_tokens', 0) or 0
+                            prompt_tokens = (
+                                getattr(response.usage, "prompt_tokens", 0) or 0
+                            )
+                            completion_tokens = (
+                                getattr(response.usage, "completion_tokens", 0) or 0
+                            )
+                            total_tokens = (
+                                getattr(response.usage, "total_tokens", 0) or 0
+                            )
                         usage_dict = {
                             "prompt_tokens": prompt_tokens,
                             "completion_tokens": completion_tokens,
@@ -3785,27 +4360,43 @@ class AIAgent:
                         if self.context_compressor._context_probed:
                             ctx = self.context_compressor.context_length
                             save_context_length(self.model, self.base_url, ctx)
-                            print(f"{self.log_prefix}💾 Cached context length: {ctx:,} tokens for {self.model}")
+                            print(
+                                f"{self.log_prefix}💾 Cached context length: {ctx:,} tokens for {self.model}"
+                            )
                             self.context_compressor._context_probed = False
 
                         self.session_prompt_tokens += prompt_tokens
                         self.session_completion_tokens += completion_tokens
                         self.session_total_tokens += total_tokens
                         self.session_api_calls += 1
-                        
+
                         if self.verbose_logging:
-                            logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
-                        
+                            logging.debug(
+                                f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}"
+                            )
+
                         # Log cache hit stats when prompt caching is active
                         if self._use_prompt_caching:
-                            details = getattr(response.usage, 'prompt_tokens_details', None)
-                            cached = getattr(details, 'cached_tokens', 0) or 0 if details else 0
-                            written = getattr(details, 'cache_write_tokens', 0) or 0 if details else 0
+                            details = getattr(
+                                response.usage, "prompt_tokens_details", None
+                            )
+                            cached = (
+                                getattr(details, "cached_tokens", 0) or 0
+                                if details
+                                else 0
+                            )
+                            written = (
+                                getattr(details, "cache_write_tokens", 0) or 0
+                                if details
+                                else 0
+                            )
                             prompt = usage_dict["prompt_tokens"]
                             hit_pct = (cached / prompt * 100) if prompt > 0 else 0
                             if not self.quiet_mode:
-                                print(f"{self.log_prefix}   💾 Cache: {cached:,}/{prompt:,} tokens ({hit_pct:.0f}% hit, {written:,} written)")
-                    
+                                print(
+                                    f"{self.log_prefix}   💾 Cache: {cached:,}/{prompt:,} tokens ({hit_pct:.0f}% hit, {written:,} written)"
+                                )
+
                     break  # Success, exit retry loop
 
                 except InterruptedError:
@@ -3838,7 +4429,9 @@ class AIAgent:
                     ):
                         codex_auth_retry_attempted = True
                         if self._try_refresh_codex_client_credentials(force=True):
-                            print(f"{self.log_prefix}🔐 Codex auth refreshed after 401. Retrying request...")
+                            print(
+                                f"{self.log_prefix}🔐 Codex auth refreshed after 401. Retrying request..."
+                            )
                             continue
                     if (
                         self.api_mode == "chat_completions"
@@ -3848,24 +4441,34 @@ class AIAgent:
                     ):
                         nous_auth_retry_attempted = True
                         if self._try_refresh_nous_client_credentials(force=True):
-                            print(f"{self.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request...")
+                            print(
+                                f"{self.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request..."
+                            )
                             continue
 
                     retry_count += 1
                     elapsed_time = time.time() - api_start_time
-                    
+
                     # Enhanced error logging
                     error_type = type(api_error).__name__
                     error_msg = str(api_error).lower()
-                    
-                    print(f"{self.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}")
-                    print(f"{self.log_prefix}   ⏱️  Time elapsed before failure: {elapsed_time:.2f}s")
+
+                    print(
+                        f"{self.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}"
+                    )
+                    print(
+                        f"{self.log_prefix}   ⏱️  Time elapsed before failure: {elapsed_time:.2f}s"
+                    )
                     print(f"{self.log_prefix}   📝 Error: {str(api_error)[:200]}")
-                    print(f"{self.log_prefix}   📊 Request context: {len(api_messages)} messages, ~{approx_tokens:,} tokens, {len(self.tools) if self.tools else 0} tools")
-                    
+                    print(
+                        f"{self.log_prefix}   📊 Request context: {len(api_messages)} messages, ~{approx_tokens:,} tokens, {len(self.tools) if self.tools else 0} tools"
+                    )
+
                     # Check for interrupt before deciding to retry
                     if self._interrupt_requested:
-                        print(f"{self.log_prefix}⚡ Interrupt detected during error handling, aborting retries.")
+                        print(
+                            f"{self.log_prefix}⚡ Interrupt detected during error handling, aborting retries."
+                        )
                         self._persist_session(messages, conversation_history)
                         self.clear_interrupt()
                         return {
@@ -3875,67 +4478,89 @@ class AIAgent:
                             "completed": False,
                             "interrupted": True,
                         }
-                    
+
                     # Check for 413 payload-too-large BEFORE generic 4xx handler.
                     # A 413 is a payload-size error — the correct response is to
                     # compress history and retry, not abort immediately.
                     status_code = getattr(api_error, "status_code", None)
                     is_payload_too_large = (
                         status_code == 413
-                        or 'request entity too large' in error_msg
-                        or 'payload too large' in error_msg
-                        or 'error code: 413' in error_msg
+                        or "request entity too large" in error_msg
+                        or "payload too large" in error_msg
+                        or "error code: 413" in error_msg
                     )
 
                     if is_payload_too_large:
                         compression_attempts += 1
                         if compression_attempts > max_compression_attempts:
-                            print(f"{self.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached for payload-too-large error.")
-                            logging.error(f"{self.log_prefix}413 compression failed after {max_compression_attempts} attempts.")
+                            print(
+                                f"{self.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached for payload-too-large error."
+                            )
+                            logging.error(
+                                f"{self.log_prefix}413 compression failed after {max_compression_attempts} attempts."
+                            )
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": f"Request payload too large: max compression attempts ({max_compression_attempts}) reached.",
-                                "partial": True
+                                "partial": True,
                             }
-                        print(f"{self.log_prefix}⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
+                        print(
+                            f"{self.log_prefix}⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}..."
+                        )
 
                         original_len = len(messages)
                         messages, active_system_prompt = self._compress_context(
-                            messages, system_message, approx_tokens=approx_tokens,
+                            messages,
+                            system_message,
+                            approx_tokens=approx_tokens,
                             task_id=effective_task_id,
                         )
 
                         if len(messages) < original_len:
-                            print(f"{self.log_prefix}   🗜️  Compressed {original_len} → {len(messages)} messages, retrying...")
+                            print(
+                                f"{self.log_prefix}   🗜️  Compressed {original_len} → {len(messages)} messages, retrying..."
+                            )
                             time.sleep(2)  # Brief pause between compression retries
                             restart_with_compressed_messages = True
                             break
                         else:
-                            print(f"{self.log_prefix}❌ Payload too large and cannot compress further.")
-                            logging.error(f"{self.log_prefix}413 payload too large. Cannot compress further.")
+                            print(
+                                f"{self.log_prefix}❌ Payload too large and cannot compress further."
+                            )
+                            logging.error(
+                                f"{self.log_prefix}413 payload too large. Cannot compress further."
+                            )
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": "Request payload too large (413). Cannot compress further.",
-                                "partial": True
+                                "partial": True,
                             }
 
                     # Check for context-length errors BEFORE generic 4xx handler.
                     # Local backends (LM Studio, Ollama, llama.cpp) often return
                     # HTTP 400 with messages like "Context size has been exceeded"
                     # which must trigger compression, not an immediate abort.
-                    is_context_length_error = any(phrase in error_msg for phrase in [
-                        'context length', 'context size', 'maximum context',
-                        'token limit', 'too many tokens', 'reduce the length',
-                        'exceeds the limit', 'context window',
-                        'request entity too large',  # OpenRouter/Nous 413 safety net
-                    ])
-                    
+                    is_context_length_error = any(
+                        phrase in error_msg
+                        for phrase in [
+                            "context length",
+                            "context size",
+                            "maximum context",
+                            "token limit",
+                            "too many tokens",
+                            "reduce the length",
+                            "exceeds the limit",
+                            "context window",
+                            "request entity too large",  # OpenRouter/Nous 413 safety net
+                        ]
+                    )
+
                     if is_context_length_error:
                         compressor = self.context_compressor
                         old_ctx = compressor.context_length
@@ -3944,71 +4569,117 @@ class AIAgent:
                         parsed_limit = parse_context_limit_from_error(error_msg)
                         if parsed_limit and parsed_limit < old_ctx:
                             new_ctx = parsed_limit
-                            print(f"{self.log_prefix}⚠️  Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})")
+                            print(
+                                f"{self.log_prefix}⚠️  Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})"
+                            )
                         else:
                             # Step down to the next probe tier
                             new_ctx = get_next_probe_tier(old_ctx)
 
                         if new_ctx and new_ctx < old_ctx:
                             compressor.context_length = new_ctx
-                            compressor.threshold_tokens = int(new_ctx * compressor.threshold_percent)
+                            compressor.threshold_tokens = int(
+                                new_ctx * compressor.threshold_percent
+                            )
                             compressor._context_probed = True
-                            print(f"{self.log_prefix}⚠️  Context length exceeded — stepping down: {old_ctx:,} → {new_ctx:,} tokens")
+                            print(
+                                f"{self.log_prefix}⚠️  Context length exceeded — stepping down: {old_ctx:,} → {new_ctx:,} tokens"
+                            )
                         else:
-                            print(f"{self.log_prefix}⚠️  Context length exceeded at minimum tier — attempting compression...")
+                            print(
+                                f"{self.log_prefix}⚠️  Context length exceeded at minimum tier — attempting compression..."
+                            )
 
                         compression_attempts += 1
                         if compression_attempts > max_compression_attempts:
-                            print(f"{self.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.")
-                            logging.error(f"{self.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
+                            print(
+                                f"{self.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached."
+                            )
+                            logging.error(
+                                f"{self.log_prefix}Context compression failed after {max_compression_attempts} attempts."
+                            )
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached.",
-                                "partial": True
+                                "partial": True,
                             }
-                        print(f"{self.log_prefix}   🗜️  Context compression attempt {compression_attempts}/{max_compression_attempts}...")
+                        print(
+                            f"{self.log_prefix}   🗜️  Context compression attempt {compression_attempts}/{max_compression_attempts}..."
+                        )
 
                         original_len = len(messages)
                         messages, active_system_prompt = self._compress_context(
-                            messages, system_message, approx_tokens=approx_tokens,
+                            messages,
+                            system_message,
+                            approx_tokens=approx_tokens,
                             task_id=effective_task_id,
                         )
 
-                        if len(messages) < original_len or new_ctx and new_ctx < old_ctx:
+                        if (
+                            len(messages) < original_len
+                            or new_ctx
+                            and new_ctx < old_ctx
+                        ):
                             if len(messages) < original_len:
-                                print(f"{self.log_prefix}   🗜️  Compressed {original_len} → {len(messages)} messages, retrying...")
+                                print(
+                                    f"{self.log_prefix}   🗜️  Compressed {original_len} → {len(messages)} messages, retrying..."
+                                )
                             time.sleep(2)  # Brief pause between compression retries
                             restart_with_compressed_messages = True
                             break
                         else:
                             # Can't compress further and already at minimum tier
-                            print(f"{self.log_prefix}❌ Context length exceeded and cannot compress further.")
-                            print(f"{self.log_prefix}   💡 The conversation has accumulated too much content.")
-                            logging.error(f"{self.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")
+                            print(
+                                f"{self.log_prefix}❌ Context length exceeded and cannot compress further."
+                            )
+                            print(
+                                f"{self.log_prefix}   💡 The conversation has accumulated too much content."
+                            )
+                            logging.error(
+                                f"{self.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further."
+                            )
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": f"Context length exceeded ({approx_tokens:,} tokens). Cannot compress further.",
-                                "partial": True
+                                "partial": True,
                             }
 
                     # Check for non-retryable client errors (4xx HTTP status codes).
                     # These indicate a problem with the request itself (bad model ID,
                     # invalid API key, forbidden, etc.) and will never succeed on retry.
                     # Note: 413 and context-length errors are excluded — handled above.
-                    is_client_status_error = isinstance(status_code, int) and 400 <= status_code < 500 and status_code != 413
-                    is_client_error = (is_client_status_error or any(phrase in error_msg for phrase in [
-                        'error code: 401', 'error code: 403',
-                        'error code: 404', 'error code: 422',
-                        'is not a valid model', 'invalid model', 'model not found',
-                        'invalid api key', 'invalid_api_key', 'authentication',
-                        'unauthorized', 'forbidden', 'not found',
-                    ])) and not is_context_length_error
+                    is_client_status_error = (
+                        isinstance(status_code, int)
+                        and 400 <= status_code < 500
+                        and status_code != 413
+                    )
+                    is_client_error = (
+                        is_client_status_error
+                        or any(
+                            phrase in error_msg
+                            for phrase in [
+                                "error code: 401",
+                                "error code: 403",
+                                "error code: 404",
+                                "error code: 422",
+                                "is not a valid model",
+                                "invalid model",
+                                "model not found",
+                                "invalid api key",
+                                "invalid_api_key",
+                                "authentication",
+                                "unauthorized",
+                                "forbidden",
+                                "not found",
+                            ]
+                        )
+                    ) and not is_context_length_error
 
                     if is_client_error:
                         # Try fallback before aborting — a different provider
@@ -4017,11 +4688,19 @@ class AIAgent:
                             retry_count = 0
                             continue
                         self._dump_api_request_debug(
-                            api_kwargs, reason="non_retryable_client_error", error=api_error,
+                            api_kwargs,
+                            reason="non_retryable_client_error",
+                            error=api_error,
                         )
-                        print(f"{self.log_prefix}❌ Non-retryable client error detected. Aborting immediately.")
-                        print(f"{self.log_prefix}   💡 This type of error won't be fixed by retrying.")
-                        logging.error(f"{self.log_prefix}Non-retryable client error: {api_error}")
+                        print(
+                            f"{self.log_prefix}❌ Non-retryable client error detected. Aborting immediately."
+                        )
+                        print(
+                            f"{self.log_prefix}   💡 This type of error won't be fixed by retrying."
+                        )
+                        logging.error(
+                            f"{self.log_prefix}Non-retryable client error: {api_error}"
+                        )
                         self._persist_session(messages, conversation_history)
                         return {
                             "final_response": None,
@@ -4037,23 +4716,37 @@ class AIAgent:
                         if self._try_activate_fallback():
                             retry_count = 0
                             continue
-                        print(f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded. Giving up.")
-                        logging.error(f"{self.log_prefix}API call failed after {max_retries} retries. Last error: {api_error}")
-                        logging.error(f"{self.log_prefix}Request details - Messages: {len(api_messages)}, Approx tokens: {approx_tokens:,}")
+                        print(
+                            f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded. Giving up."
+                        )
+                        logging.error(
+                            f"{self.log_prefix}API call failed after {max_retries} retries. Last error: {api_error}"
+                        )
+                        logging.error(
+                            f"{self.log_prefix}Request details - Messages: {len(api_messages)}, Approx tokens: {approx_tokens:,}"
+                        )
                         raise api_error
 
-                    wait_time = min(2 ** retry_count, 60)  # Exponential backoff: 2s, 4s, 8s, 16s, 32s, 60s, 60s
-                    logging.warning(f"API retry {retry_count}/{max_retries} after error: {api_error}")
+                    wait_time = min(
+                        2**retry_count, 60
+                    )  # Exponential backoff: 2s, 4s, 8s, 16s, 32s, 60s, 60s
+                    logging.warning(
+                        f"API retry {retry_count}/{max_retries} after error: {api_error}"
+                    )
                     if retry_count >= max_retries:
-                        print(f"{self.log_prefix}⚠️  API call failed after {retry_count} attempts: {str(api_error)[:100]}")
+                        print(
+                            f"{self.log_prefix}⚠️  API call failed after {retry_count} attempts: {str(api_error)[:100]}"
+                        )
                         print(f"{self.log_prefix}⏳ Final retry in {wait_time}s...")
-                    
+
                     # Sleep in small increments so we can respond to interrupts quickly
                     # instead of blocking the entire wait_time in one sleep() call
                     sleep_end = time.time() + wait_time
                     while time.time() < sleep_end:
                         if self._interrupt_requested:
-                            print(f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting.")
+                            print(
+                                f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting."
+                            )
                             self._persist_session(messages, conversation_history)
                             self.clear_interrupt()
                             return {
@@ -4064,7 +4757,7 @@ class AIAgent:
                                 "interrupted": True,
                             }
                         time.sleep(0.2)  # Check interrupt every 200ms
-            
+
             # If the API call was interrupted, skip response processing
             if interrupted:
                 break
@@ -4081,23 +4774,33 @@ class AIAgent:
             # (e.g. repeated context-length errors that exhausted retry_count),
             # the `response` variable is still None. Break out cleanly.
             if response is None:
-                print(f"{self.log_prefix}❌ All API retries exhausted with no successful response.")
+                print(
+                    f"{self.log_prefix}❌ All API retries exhausted with no successful response."
+                )
                 self._persist_session(messages, conversation_history)
                 break
 
             try:
                 if self.api_mode == "codex_responses":
-                    assistant_message, finish_reason = self._normalize_codex_response(response)
+                    assistant_message, finish_reason = self._normalize_codex_response(
+                        response
+                    )
                 else:
                     assistant_message = response.choices[0].message
-                
+
                 # Normalize content to string — some OpenAI-compatible servers
                 # (llama-server, etc.) return content as a dict or list instead
                 # of a plain string, which crashes downstream .strip() calls.
-                if assistant_message.content is not None and not isinstance(assistant_message.content, str):
+                if assistant_message.content is not None and not isinstance(
+                    assistant_message.content, str
+                ):
                     raw = assistant_message.content
                     if isinstance(raw, dict):
-                        assistant_message.content = raw.get("text", "") or raw.get("content", "") or json.dumps(raw)
+                        assistant_message.content = (
+                            raw.get("text", "")
+                            or raw.get("content", "")
+                            or json.dumps(raw)
+                        )
                     elif isinstance(raw, list):
                         # Multimodal content list — extract text parts
                         parts = []
@@ -4114,59 +4817,72 @@ class AIAgent:
 
                 # Handle assistant response
                 if assistant_message.content and not self.quiet_mode:
-                    print(f"{self.log_prefix}🤖 Assistant: {assistant_message.content[:100]}{'...' if len(assistant_message.content) > 100 else ''}")
+                    print(
+                        f"{self.log_prefix}🤖 Assistant: {assistant_message.content[:100]}{'...' if len(assistant_message.content) > 100 else ''}"
+                    )
 
                 # Notify progress callback of model's thinking (used by subagent
                 # delegation to relay the child's reasoning to the parent display).
                 # Guard: only fire for subagents (_delegate_depth >= 1) to avoid
                 # spamming gateway platforms with the main agent's every thought.
-                if (assistant_message.content and self.tool_progress_callback
-                        and getattr(self, '_delegate_depth', 0) > 0):
+                if (
+                    assistant_message.content
+                    and self.tool_progress_callback
+                    and getattr(self, "_delegate_depth", 0) > 0
+                ):
                     _think_text = assistant_message.content.strip()
                     # Strip reasoning XML tags that shouldn't leak to parent display
                     _think_text = re.sub(
-                        r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
+                        r"</?(?:REASONING_SCRATCHPAD|think|reasoning)>", "", _think_text
                     ).strip()
-                    first_line = _think_text.split('\n')[0][:80] if _think_text else ""
+                    first_line = _think_text.split("\n")[0][:80] if _think_text else ""
                     if first_line:
                         try:
                             self.tool_progress_callback("_thinking", first_line)
                         except Exception:
                             pass
-                
+
                 # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
                 # This means the model ran out of output tokens mid-reasoning — retry up to 2 times
                 if has_incomplete_scratchpad(assistant_message.content or ""):
-                    if not hasattr(self, '_incomplete_scratchpad_retries'):
+                    if not hasattr(self, "_incomplete_scratchpad_retries"):
                         self._incomplete_scratchpad_retries = 0
                     self._incomplete_scratchpad_retries += 1
-                    
-                    print(f"{self.log_prefix}⚠️  Incomplete <REASONING_SCRATCHPAD> detected (opened but never closed)")
-                    
+
+                    print(
+                        f"{self.log_prefix}⚠️  Incomplete <REASONING_SCRATCHPAD> detected (opened but never closed)"
+                    )
+
                     if self._incomplete_scratchpad_retries <= 2:
-                        print(f"{self.log_prefix}🔄 Retrying API call ({self._incomplete_scratchpad_retries}/2)...")
+                        print(
+                            f"{self.log_prefix}🔄 Retrying API call ({self._incomplete_scratchpad_retries}/2)..."
+                        )
                         # Don't add the broken message, just retry
                         continue
                     else:
                         # Max retries - discard this turn and save as partial
-                        print(f"{self.log_prefix}❌ Max retries (2) for incomplete scratchpad. Saving as partial.")
+                        print(
+                            f"{self.log_prefix}❌ Max retries (2) for incomplete scratchpad. Saving as partial."
+                        )
                         self._incomplete_scratchpad_retries = 0
-                        
-                        rolled_back_messages = self._get_messages_up_to_last_assistant(messages)
+
+                        rolled_back_messages = self._get_messages_up_to_last_assistant(
+                            messages
+                        )
                         self._cleanup_task_resources(effective_task_id)
                         self._persist_session(messages, conversation_history)
-                        
+
                         return {
                             "final_response": None,
                             "messages": rolled_back_messages,
                             "api_calls": api_call_count,
                             "completed": False,
                             "partial": True,
-                            "error": "Incomplete REASONING_SCRATCHPAD after 2 retries"
+                            "error": "Incomplete REASONING_SCRATCHPAD after 2 retries",
                         }
-                
+
                 # Reset incomplete scratchpad counter on clean response
-                if hasattr(self, '_incomplete_scratchpad_retries'):
+                if hasattr(self, "_incomplete_scratchpad_retries"):
                     self._incomplete_scratchpad_retries = 0
 
                 if self.api_mode == "codex_responses" and finish_reason == "incomplete":
@@ -4174,9 +4890,17 @@ class AIAgent:
                         self._codex_incomplete_retries = 0
                     self._codex_incomplete_retries += 1
 
-                    interim_msg = self._build_assistant_message(assistant_message, finish_reason)
-                    interim_has_content = bool((interim_msg.get("content") or "").strip())
-                    interim_has_reasoning = bool(interim_msg.get("reasoning", "").strip()) if isinstance(interim_msg.get("reasoning"), str) else False
+                    interim_msg = self._build_assistant_message(
+                        assistant_message, finish_reason
+                    )
+                    interim_has_content = bool(
+                        (interim_msg.get("content") or "").strip()
+                    )
+                    interim_has_reasoning = (
+                        bool(interim_msg.get("reasoning", "").strip())
+                        if isinstance(interim_msg.get("reasoning"), str)
+                        else False
+                    )
 
                     if interim_has_content or interim_has_reasoning:
                         last_msg = messages[-1] if messages else None
@@ -4184,15 +4908,19 @@ class AIAgent:
                             isinstance(last_msg, dict)
                             and last_msg.get("role") == "assistant"
                             and last_msg.get("finish_reason") == "incomplete"
-                            and (last_msg.get("content") or "") == (interim_msg.get("content") or "")
-                            and (last_msg.get("reasoning") or "") == (interim_msg.get("reasoning") or "")
+                            and (last_msg.get("content") or "")
+                            == (interim_msg.get("content") or "")
+                            and (last_msg.get("reasoning") or "")
+                            == (interim_msg.get("reasoning") or "")
                         )
                         if not duplicate_interim:
                             messages.append(interim_msg)
 
                     if self._codex_incomplete_retries < 3:
                         if not self.quiet_mode:
-                            print(f"{self.log_prefix}↻ Codex response incomplete; continuing turn ({self._codex_incomplete_retries}/3)")
+                            print(
+                                f"{self.log_prefix}↻ Codex response incomplete; continuing turn ({self._codex_incomplete_retries}/3)"
+                            )
                         self._session_messages = messages
                         self._save_session_log(messages)
                         continue
@@ -4209,51 +4937,68 @@ class AIAgent:
                     }
                 elif hasattr(self, "_codex_incomplete_retries"):
                     self._codex_incomplete_retries = 0
-                
+
                 # Check for tool calls
                 if assistant_message.tool_calls:
                     if not self.quiet_mode:
-                        print(f"{self.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)...")
-                    
+                        print(
+                            f"{self.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)..."
+                        )
+
                     if self.verbose_logging:
                         for tc in assistant_message.tool_calls:
-                            logging.debug(f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}...")
-                    
+                            logging.debug(
+                                f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}..."
+                            )
+
                     # Validate tool call names - detect model hallucinations
                     # Repair mismatched tool names before validating
                     for tc in assistant_message.tool_calls:
                         if tc.function.name not in self.valid_tool_names:
                             repaired = self._repair_tool_call(tc.function.name)
                             if repaired:
-                                print(f"{self.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'")
+                                print(
+                                    f"{self.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'"
+                                )
                                 tc.function.name = repaired
                     invalid_tool_calls = [
-                        tc.function.name for tc in assistant_message.tool_calls
+                        tc.function.name
+                        for tc in assistant_message.tool_calls
                         if tc.function.name not in self.valid_tool_names
                     ]
                     if invalid_tool_calls:
                         # Return helpful error to model — model can self-correct next turn
                         available = ", ".join(sorted(self.valid_tool_names))
                         invalid_name = invalid_tool_calls[0]
-                        invalid_preview = invalid_name[:80] + "..." if len(invalid_name) > 80 else invalid_name
-                        print(f"{self.log_prefix}⚠️  Unknown tool '{invalid_preview}' — sending error to model for self-correction")
-                        assistant_msg = self._build_assistant_message(assistant_message, finish_reason)
+                        invalid_preview = (
+                            invalid_name[:80] + "..."
+                            if len(invalid_name) > 80
+                            else invalid_name
+                        )
+                        print(
+                            f"{self.log_prefix}⚠️  Unknown tool '{invalid_preview}' — sending error to model for self-correction"
+                        )
+                        assistant_msg = self._build_assistant_message(
+                            assistant_message, finish_reason
+                        )
                         messages.append(assistant_msg)
                         for tc in assistant_message.tool_calls:
                             if tc.function.name not in self.valid_tool_names:
                                 content = f"Tool '{tc.function.name}' does not exist. Available tools: {available}"
                             else:
                                 content = f"Skipped: another tool call in this turn used an invalid name. Please retry this tool call."
-                            messages.append({
-                                "role": "tool",
-                                "tool_call_id": tc.id,
-                                "content": content,
-                            })
+                            messages.append(
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": tc.id,
+                                    "content": content,
+                                }
+                            )
                         continue
                     # Reset retry counter on successful tool call validation
-                    if hasattr(self, '_invalid_tool_retries'):
+                    if hasattr(self, "_invalid_tool_retries"):
                         self._invalid_tool_retries = 0
-                    
+
                     # Validate tool call arguments are valid JSON
                     # Handle empty strings as empty objects (common model quirk)
                     invalid_json_args = []
@@ -4267,23 +5012,29 @@ class AIAgent:
                             json.loads(args)
                         except json.JSONDecodeError as e:
                             invalid_json_args.append((tc.function.name, str(e)))
-                    
+
                     if invalid_json_args:
                         # Track retries for invalid JSON arguments
                         self._invalid_json_retries += 1
-                        
+
                         tool_name, error_msg = invalid_json_args[0]
-                        print(f"{self.log_prefix}⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}")
-                        
+                        print(
+                            f"{self.log_prefix}⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}"
+                        )
+
                         if self._invalid_json_retries < 3:
-                            print(f"{self.log_prefix}🔄 Retrying API call ({self._invalid_json_retries}/3)...")
+                            print(
+                                f"{self.log_prefix}🔄 Retrying API call ({self._invalid_json_retries}/3)..."
+                            )
                             # Don't add anything to messages, just retry the API call
                             continue
                         else:
                             # Instead of returning partial, inject a helpful message and let model recover
-                            print(f"{self.log_prefix}⚠️  Injecting recovery message for invalid JSON...")
+                            print(
+                                f"{self.log_prefix}⚠️  Injecting recovery message for invalid JSON..."
+                            )
                             self._invalid_json_retries = 0  # Reset for next attempt
-                            
+
                             # Add a user message explaining the issue
                             recovery_msg = (
                                 f"Your tool call to '{tool_name}' had invalid JSON arguments. "
@@ -4294,119 +5045,157 @@ class AIAgent:
                             recovery_dict = {"role": "user", "content": recovery_msg}
                             messages.append(recovery_dict)
                             continue
-                    
+
                     # Reset retry counter on successful JSON validation
                     self._invalid_json_retries = 0
-                    
-                    assistant_msg = self._build_assistant_message(assistant_message, finish_reason)
-                    
+
+                    assistant_msg = self._build_assistant_message(
+                        assistant_message, finish_reason
+                    )
+
                     # If this turn has both content AND tool_calls, capture the content
                     # as a fallback final response. Common pattern: model delivers its
                     # answer and calls memory/skill tools as a side-effect in the same
                     # turn. If the follow-up turn after tools is empty, we use this.
                     turn_content = assistant_message.content or ""
-                    if turn_content and self._has_content_after_think_block(turn_content):
+                    if turn_content and self._has_content_after_think_block(
+                        turn_content
+                    ):
                         self._last_content_with_tools = turn_content
                         # Show intermediate commentary so the user can follow along
                         if self.quiet_mode:
                             clean = self._strip_think_blocks(turn_content).strip()
                             if clean:
                                 print(f"  ┊ 💬 {clean}")
-                    
+
                     messages.append(assistant_msg)
-                    
-                    self._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+
+                    self._execute_tool_calls(
+                        assistant_message, messages, effective_task_id, api_call_count
+                    )
 
                     # Refund the iteration if the ONLY tool(s) called were
                     # execute_code (programmatic tool calling).  These are
                     # cheap RPC-style calls that shouldn't eat the budget.
-                    _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
+                    _tc_names = {
+                        tc.function.name for tc in assistant_message.tool_calls
+                    }
                     if _tc_names == {"execute_code"}:
                         self.iteration_budget.refund()
-                    
-                    if self.compression_enabled and self.context_compressor.should_compress():
+
+                    if (
+                        self.compression_enabled
+                        and self.context_compressor.should_compress()
+                    ):
                         messages, active_system_prompt = self._compress_context(
-                            messages, system_message,
+                            messages,
+                            system_message,
                             approx_tokens=self.context_compressor.last_prompt_tokens,
                             task_id=effective_task_id,
                         )
-                    
+
                     # Save session log incrementally (so progress is visible even if interrupted)
                     self._session_messages = messages
                     self._save_session_log(messages)
-                    
+
                     # Continue loop for next response
                     continue
-                
+
                 else:
                     # No tool calls - this is the final response
                     final_response = assistant_message.content or ""
-                    
+
                     # Check if response only has think block with no actual content after it
                     if not self._has_content_after_think_block(final_response):
                         # If the previous turn already delivered real content alongside
                         # tool calls (e.g. "You're welcome!" + memory save), the model
                         # has nothing more to say. Use the earlier content immediately
                         # instead of wasting API calls on retries that won't help.
-                        fallback = getattr(self, '_last_content_with_tools', None)
+                        fallback = getattr(self, "_last_content_with_tools", None)
                         if fallback:
-                            logger.debug("Empty follow-up after tool calls — using prior turn content as final response")
+                            logger.debug(
+                                "Empty follow-up after tool calls — using prior turn content as final response"
+                            )
                             self._last_content_with_tools = None
                             self._empty_content_retries = 0
                             for i in range(len(messages) - 1, -1, -1):
                                 msg = messages[i]
-                                if msg.get("role") == "assistant" and msg.get("tool_calls"):
+                                if msg.get("role") == "assistant" and msg.get(
+                                    "tool_calls"
+                                ):
                                     tool_names = []
                                     for tc in msg["tool_calls"]:
                                         fn = tc.get("function", {})
                                         tool_names.append(fn.get("name", "unknown"))
-                                    msg["content"] = f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
+                                    msg["content"] = (
+                                        f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
+                                    )
                                     break
                             final_response = self._strip_think_blocks(fallback).strip()
                             break
 
                         # No fallback available — this is a genuine empty response.
                         # Retry in case the model just had a bad generation.
-                        if not hasattr(self, '_empty_content_retries'):
+                        if not hasattr(self, "_empty_content_retries"):
                             self._empty_content_retries = 0
                         self._empty_content_retries += 1
-                        
+
                         reasoning_text = self._extract_reasoning(assistant_message)
-                        print(f"{self.log_prefix}⚠️  Response only contains think block with no content after it")
+                        print(
+                            f"{self.log_prefix}⚠️  Response only contains think block with no content after it"
+                        )
                         if reasoning_text:
-                            reasoning_preview = reasoning_text[:500] + "..." if len(reasoning_text) > 500 else reasoning_text
+                            reasoning_preview = (
+                                reasoning_text[:500] + "..."
+                                if len(reasoning_text) > 500
+                                else reasoning_text
+                            )
                             print(f"{self.log_prefix}   Reasoning: {reasoning_preview}")
                         else:
-                            content_preview = final_response[:80] + "..." if len(final_response) > 80 else final_response
+                            content_preview = (
+                                final_response[:80] + "..."
+                                if len(final_response) > 80
+                                else final_response
+                            )
                             print(f"{self.log_prefix}   Content: '{content_preview}'")
-                        
+
                         if self._empty_content_retries < 3:
-                            print(f"{self.log_prefix}🔄 Retrying API call ({self._empty_content_retries}/3)...")
+                            print(
+                                f"{self.log_prefix}🔄 Retrying API call ({self._empty_content_retries}/3)..."
+                            )
                             continue
                         else:
-                            print(f"{self.log_prefix}❌ Max retries (3) for empty content exceeded.")
+                            print(
+                                f"{self.log_prefix}❌ Max retries (3) for empty content exceeded."
+                            )
                             self._empty_content_retries = 0
-                            
+
                             # If a prior tool_calls turn had real content, salvage it:
                             # rewrite that turn's content to a brief tool description,
                             # and use the original content as the final response here.
-                            fallback = getattr(self, '_last_content_with_tools', None)
+                            fallback = getattr(self, "_last_content_with_tools", None)
                             if fallback:
                                 self._last_content_with_tools = None
                                 # Find the last assistant message with tool_calls and rewrite it
                                 for i in range(len(messages) - 1, -1, -1):
                                     msg = messages[i]
-                                    if msg.get("role") == "assistant" and msg.get("tool_calls"):
+                                    if msg.get("role") == "assistant" and msg.get(
+                                        "tool_calls"
+                                    ):
                                         tool_names = []
                                         for tc in msg["tool_calls"]:
                                             fn = tc.get("function", {})
                                             tool_names.append(fn.get("name", "unknown"))
-                                        msg["content"] = f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
+                                        msg["content"] = (
+                                            f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
+                                        )
                                         break
                                 # Strip <think> blocks from fallback content for user display
-                                final_response = self._strip_think_blocks(fallback).strip()
+                                final_response = self._strip_think_blocks(
+                                    fallback
+                                ).strip()
                                 break
-                            
+
                             # No fallback -- append the empty message as-is
                             empty_msg = {
                                 "role": "assistant",
@@ -4415,21 +5204,21 @@ class AIAgent:
                                 "finish_reason": finish_reason,
                             }
                             messages.append(empty_msg)
-                            
+
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
-                            
+
                             return {
                                 "final_response": final_response or None,
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
-                                "error": "Model generated only think blocks with no actual response after 3 retries"
+                                "error": "Model generated only think blocks with no actual response after 3 retries",
                             }
-                    
+
                     # Reset retry counter on successful content
-                    if hasattr(self, '_empty_content_retries'):
+                    if hasattr(self, "_empty_content_retries"):
                         self._empty_content_retries = 0
 
                     if (
@@ -4443,7 +5232,9 @@ class AIAgent:
                         )
                     ):
                         codex_ack_continuations += 1
-                        interim_msg = self._build_assistant_message(assistant_message, "incomplete")
+                        interim_msg = self._build_assistant_message(
+                            assistant_message, "incomplete"
+                        )
                         messages.append(interim_msg)
 
                         continue_msg = {
@@ -4462,25 +5253,29 @@ class AIAgent:
 
                     if truncated_response_prefix:
                         final_response = truncated_response_prefix + final_response
-                    
+
                     # Strip <think> blocks from user-facing response (keep raw in messages for trajectory)
                     final_response = self._strip_think_blocks(final_response).strip()
-                    
-                    final_msg = self._build_assistant_message(assistant_message, finish_reason)
-                    
+
+                    final_msg = self._build_assistant_message(
+                        assistant_message, finish_reason
+                    )
+
                     messages.append(final_msg)
-                    
+
                     if not self.quiet_mode:
-                        print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
+                        print(
+                            f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)"
+                        )
                     break
-                
+
             except Exception as e:
                 error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
                 print(f"❌ {error_msg}")
-                
+
                 if self.verbose_logging:
                     logging.exception("Detailed error information:")
-                
+
                 # If an assistant message with tool_calls was already appended,
                 # the API expects a role="tool" result for every tool_call_id.
                 # Fill in error results for any that weren't answered yet.
@@ -4494,7 +5289,7 @@ class AIAgent:
                     if msg.get("role") == "assistant" and msg.get("tool_calls"):
                         answered_ids = {
                             m["tool_call_id"]
-                            for m in messages[idx + 1:]
+                            for m in messages[idx + 1 :]
                             if isinstance(m, dict) and m.get("role") == "tool"
                         }
                         for tc in msg["tool_calls"]:
@@ -4507,7 +5302,7 @@ class AIAgent:
                                 messages.append(err_msg)
                         pending_handled = True
                     break
-                
+
                 if not pending_handled:
                     # Error happened before tool processing (e.g. response parsing).
                     # Use a user-role message so the model can see what went wrong
@@ -4517,20 +5312,24 @@ class AIAgent:
                         "content": f"[System error during processing: {error_msg}]",
                     }
                     messages.append(sys_err_msg)
-                
+
                 # If we're near the limit, break to avoid infinite loops
                 if api_call_count >= self.max_iterations - 1:
-                    final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
+                    final_response = (
+                        f"I apologize, but I encountered repeated errors: {error_msg}"
+                    )
                     break
-        
+
         if final_response is None and (
             api_call_count >= self.max_iterations
             or self.iteration_budget.remaining <= 0
         ):
             if self.iteration_budget.remaining <= 0 and not self.quiet_mode:
-                print(f"\n⚠️  Session iteration budget exhausted ({self.iteration_budget.used}/{self.iteration_budget.max_total} used, including subagents)")
+                print(
+                    f"\n⚠️  Session iteration budget exhausted ({self.iteration_budget.used}/{self.iteration_budget.max_total} used, including subagents)"
+                )
             final_response = self._handle_max_iterations(messages, api_call_count)
-        
+
         # Determine if conversation completed successfully
         completed = final_response is not None and api_call_count < self.max_iterations
 
@@ -4556,23 +5355,23 @@ class AIAgent:
             "partial": False,  # True only when stopped due to invalid tool calls
             "interrupted": interrupted,
         }
-        
+
         # Include interrupt message if one triggered the interrupt
         if interrupted and self._interrupt_message:
             result["interrupt_message"] = self._interrupt_message
-        
+
         # Clear interrupt state after handling
         self.clear_interrupt()
-        
+
         return result
-    
+
     def chat(self, message: str) -> str:
         """
         Simple chat interface that returns just the final response.
-        
+
         Args:
             message (str): User message
-            
+
         Returns:
             str: Final assistant response
         """
@@ -4592,7 +5391,7 @@ def main(
     save_trajectories: bool = False,
     save_sample: bool = False,
     verbose: bool = False,
-    log_prefix_chars: int = 20
+    log_prefix_chars: int = 20,
 ):
     """
     Main function for running the agent directly.
@@ -4618,58 +5417,69 @@ def main(
     """
     print("🤖 AI Agent with Tool Calling")
     print("=" * 50)
-    
+
     # Handle tool listing
     if list_tools:
-        from model_tools import get_all_tool_names, get_toolset_for_tool, get_available_toolsets
+        from model_tools import (
+            get_all_tool_names,
+            get_toolset_for_tool,
+            get_available_toolsets,
+        )
         from toolsets import get_all_toolsets, get_toolset_info
-        
+
         print("📋 Available Tools & Toolsets:")
         print("-" * 50)
-        
+
         # Show new toolsets system
         print("\n🎯 Predefined Toolsets (New System):")
         print("-" * 40)
         all_toolsets = get_all_toolsets()
-        
+
         # Group by category
         basic_toolsets = []
         composite_toolsets = []
         scenario_toolsets = []
-        
+
         for name, toolset in all_toolsets.items():
             info = get_toolset_info(name)
             if info:
                 entry = (name, info)
                 if name in ["web", "terminal", "vision", "creative", "reasoning"]:
                     basic_toolsets.append(entry)
-                elif name in ["research", "development", "analysis", "content_creation", "full_stack"]:
+                elif name in [
+                    "research",
+                    "development",
+                    "analysis",
+                    "content_creation",
+                    "full_stack",
+                ]:
                     composite_toolsets.append(entry)
                 else:
                     scenario_toolsets.append(entry)
-        
+
         # Print basic toolsets
         print("\n📌 Basic Toolsets:")
         for name, info in basic_toolsets:
-            tools_str = ', '.join(info['resolved_tools']) if info['resolved_tools'] else 'none'
+            tools_str = (
+                ", ".join(info["resolved_tools"]) if info["resolved_tools"] else "none"
+            )
             print(f"  • {name:15} - {info['description']}")
             print(f"    Tools: {tools_str}")
-        
+
         # Print composite toolsets
         print("\n📂 Composite Toolsets (built from other toolsets):")
         for name, info in composite_toolsets:
-            includes_str = ', '.join(info['includes']) if info['includes'] else 'none'
+            includes_str = ", ".join(info["includes"]) if info["includes"] else "none"
             print(f"  • {name:15} - {info['description']}")
             print(f"    Includes: {includes_str}")
             print(f"    Total tools: {info['tool_count']}")
-        
+
         # Print scenario-specific toolsets
         print("\n🎭 Scenario-Specific Toolsets:")
         for name, info in scenario_toolsets:
             print(f"  • {name:20} - {info['description']}")
             print(f"    Total tools: {info['tool_count']}")
-        
-        
+
         # Show legacy toolset compatibility
         print("\n📦 Legacy Toolsets (for backward compatibility):")
         legacy_toolsets = get_available_toolsets()
@@ -4678,47 +5488,57 @@ def main(
             print(f"  {status} {name}: {info['description']}")
             if not info["available"]:
                 print(f"    Requirements: {', '.join(info['requirements'])}")
-        
+
         # Show individual tools
         all_tools = get_all_tool_names()
         print(f"\n🔧 Individual Tools ({len(all_tools)} available):")
         for tool_name in sorted(all_tools):
             toolset = get_toolset_for_tool(tool_name)
             print(f"  📌 {tool_name} (from {toolset})")
-        
+
         print(f"\n💡 Usage Examples:")
         print(f"  # Use predefined toolsets")
-        print(f"  python run_agent.py --enabled_toolsets=research --query='search for Python news'")
-        print(f"  python run_agent.py --enabled_toolsets=development --query='debug this code'")
-        print(f"  python run_agent.py --enabled_toolsets=safe --query='analyze without terminal'")
+        print(
+            f"  python run_agent.py --enabled_toolsets=research --query='search for Python news'"
+        )
+        print(
+            f"  python run_agent.py --enabled_toolsets=development --query='debug this code'"
+        )
+        print(
+            f"  python run_agent.py --enabled_toolsets=safe --query='analyze without terminal'"
+        )
         print(f"  ")
         print(f"  # Combine multiple toolsets")
-        print(f"  python run_agent.py --enabled_toolsets=web,vision --query='analyze website'")
+        print(
+            f"  python run_agent.py --enabled_toolsets=web,vision --query='analyze website'"
+        )
         print(f"  ")
         print(f"  # Disable toolsets")
-        print(f"  python run_agent.py --disabled_toolsets=terminal --query='no command execution'")
+        print(
+            f"  python run_agent.py --disabled_toolsets=terminal --query='no command execution'"
+        )
         print(f"  ")
         print(f"  # Run with trajectory saving enabled")
         print(f"  python run_agent.py --save_trajectories --query='your question here'")
         return
-    
+
     # Parse toolset selection arguments
     enabled_toolsets_list = None
     disabled_toolsets_list = None
-    
+
     if enabled_toolsets:
         enabled_toolsets_list = [t.strip() for t in enabled_toolsets.split(",")]
         print(f"🎯 Enabled toolsets: {enabled_toolsets_list}")
-    
+
     if disabled_toolsets:
         disabled_toolsets_list = [t.strip() for t in disabled_toolsets.split(",")]
         print(f"🚫 Disabled toolsets: {disabled_toolsets_list}")
-    
+
     if save_trajectories:
         print(f"💾 Trajectory saving: ENABLED")
         print(f"   - Successful conversations → trajectory_samples.jsonl")
         print(f"   - Failed conversations → failed_trajectories.jsonl")
-    
+
     # Initialize agent with provided parameters
     try:
         agent = AIAgent(
@@ -4730,12 +5550,12 @@ def main(
             disabled_toolsets=disabled_toolsets_list,
             save_trajectories=save_trajectories,
             verbose_logging=verbose,
-            log_prefix_chars=log_prefix_chars
+            log_prefix_chars=log_prefix_chars,
         )
     except RuntimeError as e:
         print(f"❌ Failed to initialize agent: {e}")
         return
-    
+
     # Use provided query or default to Python 3.13 example
     if query is None:
         user_query = (
@@ -4744,45 +5564,43 @@ def main(
         )
     else:
         user_query = query
-    
+
     print(f"\n📝 User Query: {user_query}")
     print("\n" + "=" * 50)
-    
+
     # Run conversation
     result = agent.run_conversation(user_query)
-    
+
     print("\n" + "=" * 50)
     print("📋 CONVERSATION SUMMARY")
     print("=" * 50)
     print(f"✅ Completed: {result['completed']}")
     print(f"📞 API Calls: {result['api_calls']}")
     print(f"💬 Messages: {len(result['messages'])}")
-    
-    if result['final_response']:
+
+    if result["final_response"]:
         print(f"\n🎯 FINAL RESPONSE:")
         print("-" * 30)
-        print(result['final_response'])
-    
+        print(result["final_response"])
+
     # Save sample trajectory to UUID-named file if requested
     if save_sample:
         sample_id = str(uuid.uuid4())[:8]
         sample_filename = f"sample_{sample_id}.json"
-        
+
         # Convert messages to trajectory format (same as batch_runner)
         trajectory = agent._convert_to_trajectory_format(
-            result['messages'], 
-            user_query, 
-            result['completed']
+            result["messages"], user_query, result["completed"]
         )
-        
+
         entry = {
             "conversations": trajectory,
             "timestamp": datetime.now().isoformat(),
             "model": model,
-            "completed": result['completed'],
-            "query": user_query
+            "completed": result["completed"],
+            "query": user_query,
         }
-        
+
         try:
             with open(sample_filename, "w", encoding="utf-8") as f:
                 # Pretty-print JSON with indent for readability
@@ -4790,7 +5608,7 @@ def main(
             print(f"\n💾 Sample trajectory saved to: {sample_filename}")
         except Exception as e:
             print(f"\n⚠️ Failed to save sample: {e}")
-    
+
     print("\n👋 Agent execution completed!")
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -15,7 +15,7 @@ Features:
 
 Usage:
     from run_agent import AIAgent
-
+    
     agent = AIAgent(base_url="http://localhost:30000/v1", model="claude-opus-4-20250514")
     response = agent.run_conversation("Tell me about the latest Python updates")
 """
@@ -24,7 +24,6 @@ import copy
 import hashlib
 import json
 import logging
-
 logger = logging.getLogger(__name__)
 import os
 import random
@@ -45,7 +44,7 @@ from dotenv import load_dotenv
 
 _hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
 _user_env = _hermes_home / ".env"
-_project_env = Path(__file__).parent / ".env"
+_project_env = Path(__file__).parent / '.env'
 if _user_env.exists():
     try:
         load_dotenv(dotenv_path=_user_env, encoding="utf-8")
@@ -66,11 +65,7 @@ os.environ.setdefault("MSWEA_GLOBAL_CONFIG_DIR", str(_hermes_home))
 os.environ.setdefault("MSWEA_SILENT_STARTUP", "1")
 
 # Import our tool system
-from model_tools import (
-    get_tool_definitions,
-    handle_function_call,
-    check_toolset_requirements,
-)
+from model_tools import get_tool_definitions, handle_function_call, check_toolset_requirements
 from tools.terminal_tool import cleanup_vm
 from tools.interrupt import set_interrupt as _set_interrupt
 from tools.browser_tool import cleanup_browser
@@ -81,35 +76,28 @@ from hermes_constants import OPENROUTER_BASE_URL, OPENROUTER_MODELS_URL
 
 # Agent internals extracted to agent/ package for modularity
 from agent.prompt_builder import (
-    DEFAULT_AGENT_IDENTITY,
-    PLATFORM_HINTS,
-    MEMORY_GUIDANCE,
-    SESSION_SEARCH_GUIDANCE,
-    SKILLS_GUIDANCE,
+    DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
+    MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
 )
 from agent.model_metadata import (
-    fetch_model_metadata,
-    get_model_context_length,
-    estimate_tokens_rough,
-    estimate_messages_tokens_rough,
-    get_next_probe_tier,
-    parse_context_limit_from_error,
+    fetch_model_metadata, get_model_context_length,
+    estimate_tokens_rough, estimate_messages_tokens_rough,
+    get_next_probe_tier, parse_context_limit_from_error,
     save_context_length,
 )
 from agent.context_compressor import ContextCompressor
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt
 from agent.display import (
-    KawaiiSpinner,
-    build_tool_preview as _build_tool_preview,
+    KawaiiSpinner, build_tool_preview as _build_tool_preview,
     get_cute_tool_message as _get_cute_tool_message_impl,
     _detect_tool_failure,
 )
 from agent.trajectory import (
-    convert_scratchpad_to_think,
-    has_incomplete_scratchpad,
+    convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
 )
+
 
 DOOM_LOOP_THRESHOLD = 3
 
@@ -157,11 +145,11 @@ class IterationBudget:
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
-
+    
     This class manages the conversation flow, tool execution, and response handling
     for AI models that support function calling.
     """
-
+    
     def __init__(
         self,
         base_url: str = None,
@@ -188,6 +176,7 @@ class AIAgent:
         session_id: str = None,
         tool_progress_callback: callable = None,
         thinking_callback: callable = None,
+        reasoning_callback: callable = None,
         clarify_callback: callable = None,
         step_callback: callable = None,
         max_tokens: int = None,
@@ -261,19 +250,13 @@ class AIAgent:
         # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
         # When no base_url is provided, the client defaults to OpenRouter, so reflect that here.
         self.base_url = base_url or OPENROUTER_BASE_URL
-        provider_name = (
-            provider.strip().lower()
-            if isinstance(provider, str) and provider.strip()
-            else None
-        )
+        provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
         self.provider = provider_name or "openrouter"
         if api_mode in {"chat_completions", "codex_responses"}:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
-        elif (
-            provider_name is None
-        ) and "chatgpt.com/backend-api/codex" in self.base_url.lower():
+        elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self.base_url.lower():
             self.api_mode = "codex_responses"
             self.provider = "openai-codex"
         else:
@@ -281,20 +264,21 @@ class AIAgent:
 
         self.tool_progress_callback = tool_progress_callback
         self.thinking_callback = thinking_callback
+        self.reasoning_callback = reasoning_callback
         self.clarify_callback = clarify_callback
         self.step_callback = step_callback
         self._last_reported_tool = None  # Track for "new tool" mode
         self._doom_loop_signature = None
         self._doom_loop_count = 0
-
+        
         # Interrupt mechanism for breaking out of tool loops
         self._interrupt_requested = False
         self._interrupt_message = None  # Optional message that triggered interrupt
-
+        
         # Subagent delegation state
-        self._delegate_depth = 0  # 0 = top-level agent, incremented for children
-        self._active_children = []  # Running child AIAgents (for interrupt propagation)
-
+        self._delegate_depth = 0        # 0 = top-level agent, incremented for children
+        self._active_children = []      # Running child AIAgents (for interrupt propagation)
+        
         # Store OpenRouter provider preferences
         self.providers_allowed = providers_allowed
         self.providers_ignored = providers_ignored
@@ -306,14 +290,12 @@ class AIAgent:
         # Store toolset filtering options
         self.enabled_toolsets = enabled_toolsets
         self.disabled_toolsets = disabled_toolsets
-
+        
         # Model response configuration
         self.max_tokens = max_tokens  # None = use model default
-        self.reasoning_config = (
-            reasoning_config  # None = use default (medium for OpenRouter)
-        )
+        self.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
-
+        
         # Anthropic prompt caching: auto-enabled for Claude models via OpenRouter.
         # Reduces input costs by ~75% on multi-turn conversations by caching the
         # conversation prefix. Uses system_and_3 strategy (4 breakpoints).
@@ -321,107 +303,97 @@ class AIAgent:
         is_claude = "claude" in self.model.lower()
         self._use_prompt_caching = is_openrouter and is_claude
         self._cache_ttl = "5m"  # Default 5-minute TTL (1.25x write cost)
-
+        
         # Iteration budget pressure: warn the LLM as it approaches max_iterations.
         # Warnings are injected into the last tool result JSON (not as separate
         # messages) so they don't break message structure or invalidate caching.
-        self._budget_caution_threshold = 0.7  # 70% — nudge to start wrapping up
-        self._budget_warning_threshold = 0.9  # 90% — urgent, respond now
+        self._budget_caution_threshold = 0.7   # 70% — nudge to start wrapping up
+        self._budget_warning_threshold = 0.9   # 90% — urgent, respond now
         self._budget_pressure_enabled = True
 
         # Persistent error log -- always writes WARNING+ to ~/.hermes/logs/errors.log
         # so tool failures, API errors, etc. are inspectable after the fact.
         from agent.redact import RedactingFormatter
-
         _error_log_dir = Path.home() / ".hermes" / "logs"
         _error_log_dir.mkdir(parents=True, exist_ok=True)
         _error_log_path = _error_log_dir / "errors.log"
         from logging.handlers import RotatingFileHandler
-
         _error_file_handler = RotatingFileHandler(
-            _error_log_path,
-            maxBytes=2 * 1024 * 1024,
-            backupCount=2,
+            _error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,
         )
         _error_file_handler.setLevel(logging.WARNING)
-        _error_file_handler.setFormatter(
-            RedactingFormatter(
-                "%(asctime)s %(levelname)s %(name)s: %(message)s",
-            )
-        )
+        _error_file_handler.setFormatter(RedactingFormatter(
+            '%(asctime)s %(levelname)s %(name)s: %(message)s',
+        ))
         logging.getLogger().addHandler(_error_file_handler)
 
         if self.verbose_logging:
             logging.basicConfig(
                 level=logging.DEBUG,
-                format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-                datefmt="%H:%M:%S",
+                format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                datefmt='%H:%M:%S'
             )
             for handler in logging.getLogger().handlers:
-                handler.setFormatter(
-                    RedactingFormatter(
-                        "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-                        datefmt="%H:%M:%S",
-                    )
-                )
+                handler.setFormatter(RedactingFormatter(
+                    '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                    datefmt='%H:%M:%S',
+                ))
             # Keep third-party libraries at WARNING level to reduce noise
             # We have our own retry and error logging that's more informative
-            logging.getLogger("openai").setLevel(logging.WARNING)
-            logging.getLogger("openai._base_client").setLevel(logging.WARNING)
-            logging.getLogger("httpx").setLevel(logging.WARNING)
-            logging.getLogger("httpcore").setLevel(logging.WARNING)
-            logging.getLogger("asyncio").setLevel(logging.WARNING)
+            logging.getLogger('openai').setLevel(logging.WARNING)
+            logging.getLogger('openai._base_client').setLevel(logging.WARNING)
+            logging.getLogger('httpx').setLevel(logging.WARNING)
+            logging.getLogger('httpcore').setLevel(logging.WARNING)
+            logging.getLogger('asyncio').setLevel(logging.WARNING)
             # Suppress Modal/gRPC related debug spam
-            logging.getLogger("hpack").setLevel(logging.WARNING)
-            logging.getLogger("hpack.hpack").setLevel(logging.WARNING)
-            logging.getLogger("grpc").setLevel(logging.WARNING)
-            logging.getLogger("modal").setLevel(logging.WARNING)
-            logging.getLogger("rex-deploy").setLevel(
-                logging.INFO
-            )  # Keep INFO for sandbox status
+            logging.getLogger('hpack').setLevel(logging.WARNING)
+            logging.getLogger('hpack.hpack').setLevel(logging.WARNING)
+            logging.getLogger('grpc').setLevel(logging.WARNING)
+            logging.getLogger('modal').setLevel(logging.WARNING)
+            logging.getLogger('rex-deploy').setLevel(logging.INFO)  # Keep INFO for sandbox status
             logger.info("Verbose logging enabled (third-party library logs suppressed)")
         else:
             # Set logging to INFO level for important messages only
             logging.basicConfig(
                 level=logging.INFO,
-                format="%(asctime)s - %(levelname)s - %(message)s",
-                datefmt="%H:%M:%S",
+                format='%(asctime)s - %(levelname)s - %(message)s',
+                datefmt='%H:%M:%S'
             )
             # Suppress noisy library logging
-            logging.getLogger("openai").setLevel(logging.ERROR)
-            logging.getLogger("openai._base_client").setLevel(logging.ERROR)
-            logging.getLogger("httpx").setLevel(logging.ERROR)
-            logging.getLogger("httpcore").setLevel(logging.ERROR)
+            logging.getLogger('openai').setLevel(logging.ERROR)
+            logging.getLogger('openai._base_client').setLevel(logging.ERROR)
+            logging.getLogger('httpx').setLevel(logging.ERROR)
+            logging.getLogger('httpcore').setLevel(logging.ERROR)
             if self.quiet_mode:
                 # In quiet mode (CLI default), suppress all tool/infra log
                 # noise. The TUI has its own rich display for status; logger
                 # INFO/WARNING messages just clutter it.
                 for quiet_logger in [
-                    "tools",  # all tools.* (terminal, browser, web, file, etc.)
-                    "minisweagent",  # mini-swe-agent execution backend
-                    "run_agent",  # agent runner internals
-                    "trajectory_compressor",
-                    "cron",  # scheduler (only relevant in daemon mode)
-                    "hermes_cli",  # CLI helpers
+                    'tools',               # all tools.* (terminal, browser, web, file, etc.)
+                    'minisweagent',         # mini-swe-agent execution backend
+                    'run_agent',            # agent runner internals
+                    'trajectory_compressor',
+                    'cron',                 # scheduler (only relevant in daemon mode)
+                    'hermes_cli',           # CLI helpers
                 ]:
                     logging.getLogger(quiet_logger).setLevel(logging.ERROR)
-
+        
         # Initialize OpenAI client - defaults to OpenRouter
         client_kwargs = {}
-
+        
         # Default to OpenRouter if no base_url provided
         if base_url:
             client_kwargs["base_url"] = base_url
         else:
             client_kwargs["base_url"] = OPENROUTER_BASE_URL
-
+        
         # Handle API key - OpenRouter is the primary provider
         if api_key:
             client_kwargs["api_key"] = api_key
         else:
             # Primary: OPENROUTER_API_KEY, fallback to direct provider keys
             client_kwargs["api_key"] = os.getenv("OPENROUTER_API_KEY", "")
-
+        
         # OpenRouter app attribution — shows hermes-agent in rankings/analytics
         effective_base = client_kwargs.get("base_url", "")
         if "openrouter" in effective_base.lower():
@@ -436,7 +408,7 @@ class AIAgent:
             client_kwargs["default_headers"] = {
                 "User-Agent": "KimiCLI/1.0",
             }
-
+        
         self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
         try:
             self.client = OpenAI(**client_kwargs)
@@ -449,18 +421,14 @@ class AIAgent:
                 if key_used and key_used != "dummy-key" and len(key_used) > 12:
                     print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
                 else:
-                    print(
-                        f"⚠️  Warning: API key appears invalid or missing (got: '{key_used[:20] if key_used else 'none'}...')"
-                    )
+                    print(f"⚠️  Warning: API key appears invalid or missing (got: '{key_used[:20] if key_used else 'none'}...')")
         except Exception as e:
             raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
-
+        
         # Provider fallback — a single backup model/provider tried when the
         # primary is exhausted (rate-limit, overload, connection failure).
         # Config shape: {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}
-        self._fallback_model = (
-            fallback_model if isinstance(fallback_model, dict) else None
-        )
+        self._fallback_model = fallback_model if isinstance(fallback_model, dict) else None
         self._fallback_activated = False
         if self._fallback_model:
             fb_p = self._fallback_model.get("provider", "")
@@ -474,7 +442,7 @@ class AIAgent:
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
         )
-
+        
         # Show tool configuration and store valid tool names for validation
         self.valid_tool_names = set()
         if self.tools:
@@ -482,7 +450,7 @@ class AIAgent:
             tool_names = sorted(self.valid_tool_names)
             if not self.quiet_mode:
                 print(f"🛠️  Loaded {len(self.tools)} tools: {', '.join(tool_names)}")
-
+                
                 # Show filtering info if applied
                 if enabled_toolsets:
                     print(f"   ✅ Enabled toolsets: {', '.join(enabled_toolsets)}")
@@ -490,39 +458,27 @@ class AIAgent:
                     print(f"   ❌ Disabled toolsets: {', '.join(disabled_toolsets)}")
         elif not self.quiet_mode:
             print("🛠️  No tools loaded (all tools filtered out or unavailable)")
-
+        
         # Check tool requirements
         if self.tools and not self.quiet_mode:
             requirements = check_toolset_requirements()
-            missing_reqs = [
-                name for name, available in requirements.items() if not available
-            ]
+            missing_reqs = [name for name, available in requirements.items() if not available]
             if missing_reqs:
-                print(
-                    f"⚠️  Some tools may not work due to missing requirements: {missing_reqs}"
-                )
-
+                print(f"⚠️  Some tools may not work due to missing requirements: {missing_reqs}")
+        
         # Show trajectory saving status
         if self.save_trajectories and not self.quiet_mode:
             print("📝 Trajectory saving enabled")
-
+        
         # Show ephemeral system prompt status
         if self.ephemeral_system_prompt and not self.quiet_mode:
-            prompt_preview = (
-                self.ephemeral_system_prompt[:60] + "..."
-                if len(self.ephemeral_system_prompt) > 60
-                else self.ephemeral_system_prompt
-            )
-            print(
-                f"🔒 Ephemeral system prompt: '{prompt_preview}' (not saved to trajectories)"
-            )
-
+            prompt_preview = self.ephemeral_system_prompt[:60] + "..." if len(self.ephemeral_system_prompt) > 60 else self.ephemeral_system_prompt
+            print(f"🔒 Ephemeral system prompt: '{prompt_preview}' (not saved to trajectories)")
+        
         # Show prompt caching status
         if self._use_prompt_caching and not self.quiet_mode:
-            print(
-                f"💾 Prompt caching: ENABLED (Claude via OpenRouter, {self._cache_ttl} TTL)"
-            )
-
+            print(f"💾 Prompt caching: ENABLED (Claude via OpenRouter, {self._cache_ttl} TTL)")
+        
         # Session logging setup - auto-save conversation trajectories for debugging
         self.session_start = datetime.now()
         if session_id:
@@ -533,32 +489,29 @@ class AIAgent:
             timestamp_str = self.session_start.strftime("%Y%m%d_%H%M%S")
             short_uuid = uuid.uuid4().hex[:6]
             self.session_id = f"{timestamp_str}_{short_uuid}"
-
+        
         # Session logs go into ~/.hermes/sessions/ alongside gateway sessions
         hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
         self.logs_dir = hermes_home / "sessions"
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
-
+        
         # Track conversation messages for session logging
         self._session_messages: List[Dict[str, Any]] = []
-
+        
         # Cached system prompt -- built once per session, only rebuilt on compression
         self._cached_system_prompt: Optional[str] = None
-
+        
         # Filesystem checkpoint manager (transparent — not a tool)
         from tools.checkpoint_manager import CheckpointManager
-
         self._checkpoint_mgr = CheckpointManager(
             enabled=checkpoints_enabled,
             max_snapshots=checkpoint_max_snapshots,
         )
-
+        
         # SQLite session store (optional -- provided by CLI or gateway)
         self._session_db = session_db
-        self._last_flushed_db_idx = (
-            0  # tracks DB-write cursor to prevent duplicate writes
-        )
+        self._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
         if self._session_db:
             try:
                 self._session_db.create_session(
@@ -574,12 +527,11 @@ class AIAgent:
                 )
             except Exception as e:
                 logger.debug("Session DB create_session failed: %s", e)
-
+        
         # In-memory todo list for task planning (one per agent/session)
         from tools.todo_tool import TodoStore
-
         self._todo_store = TodoStore()
-
+        
         # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
         self._memory_store = None
         self._memory_enabled = False
@@ -589,17 +541,13 @@ class AIAgent:
         if not skip_memory:
             try:
                 from hermes_cli.config import load_config as _load_mem_config
-
                 mem_config = _load_mem_config().get("memory", {})
                 self._memory_enabled = mem_config.get("memory_enabled", False)
-                self._user_profile_enabled = mem_config.get(
-                    "user_profile_enabled", False
-                )
+                self._user_profile_enabled = mem_config.get("user_profile_enabled", False)
                 self._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
                 self._memory_flush_min_turns = int(mem_config.get("flush_min_turns", 6))
                 if self._memory_enabled or self._user_profile_enabled:
                     from tools.memory_tool import MemoryStore
-
                     self._memory_store = MemoryStore(
                         memory_char_limit=mem_config.get("memory_char_limit", 2200),
                         user_char_limit=mem_config.get("user_char_limit", 1375),
@@ -607,22 +555,17 @@ class AIAgent:
                     self._memory_store.load_from_disk()
             except Exception:
                 pass  # Memory is optional -- don't break agent init
-
+        
         # Honcho AI-native memory (cross-session user modeling)
         # Reads ~/.honcho/config.json as the single source of truth.
         self._honcho = None  # HonchoSessionManager | None
         self._honcho_session_key = honcho_session_key
         if not skip_memory:
             try:
-                from honcho_integration.client import (
-                    HonchoClientConfig,
-                    get_honcho_client,
-                )
-
+                from honcho_integration.client import HonchoClientConfig, get_honcho_client
                 hcfg = HonchoClientConfig.from_global_config()
                 if hcfg.enabled and hcfg.api_key:
                     from honcho_integration.session import HonchoSessionManager
-
                     client = get_honcho_client(hcfg)
                     self._honcho = HonchoSessionManager(
                         honcho=client,
@@ -632,19 +575,17 @@ class AIAgent:
                     # Resolve session key: explicit arg > global sessions map > fallback
                     if not self._honcho_session_key:
                         self._honcho_session_key = (
-                            hcfg.resolve_session_name() or "hermes-default"
+                            hcfg.resolve_session_name()
+                            or "hermes-default"
                         )
                     # Ensure session exists in Honcho
                     self._honcho.get_or_create(self._honcho_session_key)
                     # Inject session context into the honcho tool module
                     from tools.honcho_tools import set_session_context
-
                     set_session_context(self._honcho, self._honcho_session_key)
                     logger.info(
                         "Honcho active (session: %s, user: %s, workspace: %s)",
-                        self._honcho_session_key,
-                        hcfg.peer_name,
-                        hcfg.workspace_id,
+                        self._honcho_session_key, hcfg.peer_name, hcfg.workspace_id,
                     )
                 else:
                     if not hcfg.enabled:
@@ -659,25 +600,18 @@ class AIAgent:
         self._skill_nudge_interval = 15
         try:
             from hermes_cli.config import load_config as _load_skills_config
-
             skills_config = _load_skills_config().get("skills", {})
-            self._skill_nudge_interval = int(
-                skills_config.get("creation_nudge_interval", 15)
-            )
+            self._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 15))
         except Exception:
             pass
-
+        
         # Initialize context compressor for automatic context management
         # Compresses conversation when approaching model's context limit
         # Configuration via config.yaml (compression section) or environment variables
-        compression_threshold = float(
-            os.getenv("CONTEXT_COMPRESSION_THRESHOLD", "0.85")
-        )
-        compression_enabled = os.getenv(
-            "CONTEXT_COMPRESSION_ENABLED", "true"
-        ).lower() in ("true", "1", "yes")
+        compression_threshold = float(os.getenv("CONTEXT_COMPRESSION_THRESHOLD", "0.85"))
+        compression_enabled = os.getenv("CONTEXT_COMPRESSION_ENABLED", "true").lower() in ("true", "1", "yes")
         compression_summary_model = os.getenv("CONTEXT_COMPRESSION_MODEL") or None
-
+        
         self.context_compressor = ContextCompressor(
             model=self.model,
             threshold_percent=compression_threshold,
@@ -696,20 +630,16 @@ class AIAgent:
         self.session_completion_tokens = 0
         self.session_total_tokens = 0
         self.session_api_calls = 0
-
+        
         if not self.quiet_mode:
             if compression_enabled:
-                print(
-                    f"📊 Context limit: {self.context_compressor.context_length:,} tokens (compress at {int(compression_threshold * 100)}% = {self.context_compressor.threshold_tokens:,})"
-                )
+                print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {self.context_compressor.threshold_tokens:,})")
             else:
-                print(
-                    f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)"
-                )
-
+                print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)")
+    
     def _max_tokens_param(self, value: int) -> dict:
         """Return the correct max tokens kwarg for the current provider.
-
+        
         OpenAI's newer models (gpt-4o, o-series, gpt-5+) require
         'max_completion_tokens'. OpenRouter, local models, and older
         OpenAI models use 'max_tokens'.
@@ -725,30 +655,30 @@ class AIAgent:
     def _has_content_after_think_block(self, content: str) -> bool:
         """
         Check if content has actual text after any <think></think> blocks.
-
+        
         This detects cases where the model only outputs reasoning but no actual
         response, which indicates an incomplete generation that should be retried.
-
+        
         Args:
             content: The assistant message content to check
-
+            
         Returns:
             True if there's meaningful content after think blocks, False otherwise
         """
         if not content:
             return False
-
+        
         # Remove all <think>...</think> blocks (including nested ones, non-greedy)
-        cleaned = re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL)
-
+        cleaned = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL)
+        
         # Check if there's any non-whitespace content remaining
         return bool(cleaned.strip())
-
+    
     def _strip_think_blocks(self, content: str) -> str:
         """Remove <think>...</think> blocks from content, returning only visible text."""
         if not content:
             return ""
-        return re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL)
+        return re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL)
 
     def _looks_like_codex_intermediate_ack(
         self,
@@ -760,19 +690,14 @@ class AIAgent:
         if any(isinstance(msg, dict) and msg.get("role") == "tool" for msg in messages):
             return False
 
-        assistant_text = (
-            self._strip_think_blocks(assistant_content or "").strip().lower()
-        )
+        assistant_text = self._strip_think_blocks(assistant_content or "").strip().lower()
         if not assistant_text:
             return False
         if len(assistant_text) > 1200:
             return False
 
         has_future_ack = bool(
-            re.search(
-                r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b",
-                assistant_text,
-            )
+            re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
         )
         if not has_future_ack:
             return False
@@ -820,69 +745,56 @@ class AIAgent:
             or "~/" in user_text
             or "/" in user_text
         )
-        assistant_mentions_action = any(
-            marker in assistant_text for marker in action_markers
-        )
+        assistant_mentions_action = any(marker in assistant_text for marker in action_markers)
         assistant_targets_workspace = any(
             marker in assistant_text for marker in workspace_markers
         )
-        return (
-            user_targets_workspace or assistant_targets_workspace
-        ) and assistant_mentions_action
-
+        return (user_targets_workspace or assistant_targets_workspace) and assistant_mentions_action
+    
+    
     def _extract_reasoning(self, assistant_message) -> Optional[str]:
         """
         Extract reasoning/thinking content from an assistant message.
-
+        
         OpenRouter and various providers can return reasoning in multiple formats:
         1. message.reasoning - Direct reasoning field (DeepSeek, Qwen, etc.)
         2. message.reasoning_content - Alternative field (Moonshot AI, Novita, etc.)
         3. message.reasoning_details - Array of {type, summary, ...} objects (OpenRouter unified)
-
+        
         Args:
             assistant_message: The assistant message object from the API response
-
+            
         Returns:
             Combined reasoning text, or None if no reasoning found
         """
         reasoning_parts = []
-
+        
         # Check direct reasoning field
-        if hasattr(assistant_message, "reasoning") and assistant_message.reasoning:
+        if hasattr(assistant_message, 'reasoning') and assistant_message.reasoning:
             reasoning_parts.append(assistant_message.reasoning)
-
+        
         # Check reasoning_content field (alternative name used by some providers)
-        if (
-            hasattr(assistant_message, "reasoning_content")
-            and assistant_message.reasoning_content
-        ):
+        if hasattr(assistant_message, 'reasoning_content') and assistant_message.reasoning_content:
             # Don't duplicate if same as reasoning
             if assistant_message.reasoning_content not in reasoning_parts:
                 reasoning_parts.append(assistant_message.reasoning_content)
-
+        
         # Check reasoning_details array (OpenRouter unified format)
         # Format: [{"type": "reasoning.summary", "summary": "...", ...}, ...]
-        if (
-            hasattr(assistant_message, "reasoning_details")
-            and assistant_message.reasoning_details
-        ):
+        if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
             for detail in assistant_message.reasoning_details:
                 if isinstance(detail, dict):
                     # Extract summary from reasoning detail object
-                    summary = (
-                        detail.get("summary")
-                        or detail.get("content")
-                        or detail.get("text")
-                    )
+                    summary = detail.get('summary') or detail.get('content') or detail.get('text')
                     if summary and summary not in reasoning_parts:
                         reasoning_parts.append(summary)
-
+        
         # Combine all reasoning parts
         if reasoning_parts:
             return "\n\n".join(reasoning_parts)
-
+        
         return None
-
+    
     def _cleanup_task_resources(self, task_id: str) -> None:
         """Clean up VM and browser resources for a given task."""
         try:
@@ -896,9 +808,7 @@ class AIAgent:
             if self.verbose_logging:
                 logging.warning(f"Failed to cleanup browser for task {task_id}: {e}")
 
-    def _persist_session(
-        self, messages: List[Dict], conversation_history: List[Dict] = None
-    ):
+    def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Save session state to both JSON log and SQLite on any exit path.
 
         Ensures conversations are never lost, even on errors or early returns.
@@ -907,9 +817,7 @@ class AIAgent:
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
 
-    def _flush_messages_to_session_db(
-        self, messages: List[Dict], conversation_history: List[Dict] = None
-    ):
+    def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Persist any un-flushed messages to the SQLite session store.
 
         Uses _last_flushed_db_idx to track which messages have already been
@@ -948,44 +856,44 @@ class AIAgent:
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """
         Get messages up to (but not including) the last assistant turn.
-
+        
         This is used when we need to "roll back" to the last successful point
         in the conversation, typically when the final assistant message is
         incomplete or malformed.
-
+        
         Args:
             messages: Full message list
-
+            
         Returns:
             Messages up to the last complete assistant turn (ending with user/tool message)
         """
         if not messages:
             return []
-
+        
         # Find the index of the last assistant message
         last_assistant_idx = None
         for i in range(len(messages) - 1, -1, -1):
             if messages[i].get("role") == "assistant":
                 last_assistant_idx = i
                 break
-
+        
         if last_assistant_idx is None:
             # No assistant message found, return all messages
             return messages.copy()
-
+        
         # Return everything up to (not including) the last assistant message
         return messages[:last_assistant_idx]
-
+    
     def _format_tools_for_system_message(self) -> str:
         """
         Format tool definitions for the system message in the trajectory format.
-
+        
         Returns:
             str: JSON string representation of tool definitions
         """
         if not self.tools:
             return "[]"
-
+        
         # Convert tool definitions to the format expected in trajectories
         formatted_tools = []
         for tool in self.tools:
@@ -994,28 +902,26 @@ class AIAgent:
                 "name": func["name"],
                 "description": func.get("description", ""),
                 "parameters": func.get("parameters", {}),
-                "required": None,  # Match the format in the example
+                "required": None  # Match the format in the example
             }
             formatted_tools.append(formatted_tool)
-
+        
         return json.dumps(formatted_tools, ensure_ascii=False)
-
-    def _convert_to_trajectory_format(
-        self, messages: List[Dict[str, Any]], user_query: str, completed: bool
-    ) -> List[Dict[str, Any]]:
+    
+    def _convert_to_trajectory_format(self, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
         """
         Convert internal message format to trajectory format for saving.
-
+        
         Args:
             messages (List[Dict]): Internal message history
             user_query (str): Original user query
             completed (bool): Whether the conversation completed successfully
-
+            
         Returns:
             List[Dict]: Messages in trajectory format
         """
         trajectory = []
-
+        
         # Add system message with tool definitions
         system_msg = (
             "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
@@ -1030,67 +936,70 @@ class AIAgent:
             "Each function call should be enclosed within <tool_call> </tool_call> XML tags.\n"
             "Example:\n<tool_call>\n{'name': <function-name>,'arguments': <args-dict>}\n</tool_call>"
         )
-
-        trajectory.append({"from": "system", "value": system_msg})
-
+        
+        trajectory.append({
+            "from": "system",
+            "value": system_msg
+        })
+        
         # Add the actual user prompt (from the dataset) as the first human message
-        trajectory.append({"from": "human", "value": user_query})
-
+        trajectory.append({
+            "from": "human",
+            "value": user_query
+        })
+        
         # Skip the first message (the user query) since we already added it above.
         # Prefill messages are injected at API-call time only (not in the messages
         # list), so no offset adjustment is needed here.
         i = 1
-
+        
         while i < len(messages):
             msg = messages[i]
-
+            
             if msg["role"] == "assistant":
                 # Check if this message has tool calls
                 if "tool_calls" in msg and msg["tool_calls"]:
                     # Format assistant message with tool calls
                     # Add <think> tags around reasoning for trajectory storage
                     content = ""
-
+                    
                     # Prepend reasoning in <think> tags if available (native thinking tokens)
                     if msg.get("reasoning") and msg["reasoning"].strip():
                         content = f"<think>\n{msg['reasoning']}\n</think>\n"
-
+                    
                     if msg.get("content") and msg["content"].strip():
                         # Convert any <REASONING_SCRATCHPAD> tags to <think> tags
                         # (used when native thinking is disabled and model reasons via XML)
                         content += convert_scratchpad_to_think(msg["content"]) + "\n"
-
+                    
                     # Add tool calls wrapped in XML tags
                     for tool_call in msg["tool_calls"]:
                         # Parse arguments - should always succeed since we validate during conversation
                         # but keep try-except as safety net
                         try:
-                            arguments = (
-                                json.loads(tool_call["function"]["arguments"])
-                                if isinstance(tool_call["function"]["arguments"], str)
-                                else tool_call["function"]["arguments"]
-                            )
+                            arguments = json.loads(tool_call["function"]["arguments"]) if isinstance(tool_call["function"]["arguments"], str) else tool_call["function"]["arguments"]
                         except json.JSONDecodeError:
                             # This shouldn't happen since we validate and retry during conversation,
                             # but if it does, log warning and use empty dict
-                            logging.warning(
-                                f"Unexpected invalid JSON in trajectory conversion: {tool_call['function']['arguments'][:100]}"
-                            )
+                            logging.warning(f"Unexpected invalid JSON in trajectory conversion: {tool_call['function']['arguments'][:100]}")
                             arguments = {}
-
+                        
                         tool_call_json = {
                             "name": tool_call["function"]["name"],
-                            "arguments": arguments,
+                            "arguments": arguments
                         }
                         content += f"<tool_call>\n{json.dumps(tool_call_json, ensure_ascii=False)}\n</tool_call>\n"
-
+                    
                     # Ensure every gpt turn has a <think> block (empty if no reasoning)
                     # so the format is consistent for training data
                     if "<think>" not in content:
                         content = "<think>\n</think>\n" + content
-
-                    trajectory.append({"from": "gpt", "value": content.rstrip()})
-
+                    
+                    trajectory.append({
+                        "from": "gpt",
+                        "value": content.rstrip()
+                    })
+                    
                     # Collect all subsequent tool responses
                     tool_responses = []
                     j = i + 1
@@ -1098,7 +1007,7 @@ class AIAgent:
                         tool_msg = messages[j]
                         # Format tool response with XML tags
                         tool_response = f"<tool_response>\n"
-
+                        
                         # Try to parse tool content as JSON if it looks like JSON
                         tool_content = tool_msg["content"]
                         try:
@@ -1106,63 +1015,61 @@ class AIAgent:
                                 tool_content = json.loads(tool_content)
                         except (json.JSONDecodeError, AttributeError):
                             pass  # Keep as string if not valid JSON
-
-                        tool_response += json.dumps(
-                            {
-                                "tool_call_id": tool_msg.get("tool_call_id", ""),
-                                "name": msg["tool_calls"][len(tool_responses)][
-                                    "function"
-                                ]["name"]
-                                if len(tool_responses) < len(msg["tool_calls"])
-                                else "unknown",
-                                "content": tool_content,
-                            },
-                            ensure_ascii=False,
-                        )
+                        
+                        tool_response += json.dumps({
+                            "tool_call_id": tool_msg.get("tool_call_id", ""),
+                            "name": msg["tool_calls"][len(tool_responses)]["function"]["name"] if len(tool_responses) < len(msg["tool_calls"]) else "unknown",
+                            "content": tool_content
+                        }, ensure_ascii=False)
                         tool_response += "\n</tool_response>"
                         tool_responses.append(tool_response)
                         j += 1
-
+                    
                     # Add all tool responses as a single message
                     if tool_responses:
-                        trajectory.append(
-                            {"from": "tool", "value": "\n".join(tool_responses)}
-                        )
+                        trajectory.append({
+                            "from": "tool",
+                            "value": "\n".join(tool_responses)
+                        })
                         i = j - 1  # Skip the tool messages we just processed
-
+                
                 else:
                     # Regular assistant message without tool calls
                     # Add <think> tags around reasoning for trajectory storage
                     content = ""
-
+                    
                     # Prepend reasoning in <think> tags if available (native thinking tokens)
                     if msg.get("reasoning") and msg["reasoning"].strip():
                         content = f"<think>\n{msg['reasoning']}\n</think>\n"
-
+                    
                     # Convert any <REASONING_SCRATCHPAD> tags to <think> tags
                     # (used when native thinking is disabled and model reasons via XML)
                     raw_content = msg["content"] or ""
                     content += convert_scratchpad_to_think(raw_content)
-
+                    
                     # Ensure every gpt turn has a <think> block (empty if no reasoning)
                     if "<think>" not in content:
                         content = "<think>\n</think>\n" + content
-
-                    trajectory.append({"from": "gpt", "value": content.strip()})
-
+                    
+                    trajectory.append({
+                        "from": "gpt",
+                        "value": content.strip()
+                    })
+            
             elif msg["role"] == "user":
-                trajectory.append({"from": "human", "value": msg["content"]})
-
+                trajectory.append({
+                    "from": "human",
+                    "value": msg["content"]
+                })
+            
             i += 1
-
+        
         return trajectory
-
-    def _save_trajectory(
-        self, messages: List[Dict[str, Any]], user_query: str, completed: bool
-    ):
+    
+    def _save_trajectory(self, messages: List[Dict[str, Any]], user_query: str, completed: bool):
         """
         Save conversation trajectory to JSONL file.
-
+        
         Args:
             messages (List[Dict]): Complete message history
             user_query (str): Original user query
@@ -1170,10 +1077,10 @@ class AIAgent:
         """
         if not self.save_trajectories:
             return
-
+        
         trajectory = self._convert_to_trajectory_format(messages, user_query, completed)
         _save_trajectory_to_file(trajectory, self.model, completed)
-
+    
     def _mask_api_key_for_logs(self, key: Optional[str]) -> Optional[str]:
         if not key:
             return None
@@ -1238,9 +1145,7 @@ class AIAgent:
                 response_obj = getattr(error, "response", None)
                 if response_obj is not None:
                     try:
-                        error_info["response_status"] = getattr(
-                            response_obj, "status_code", None
-                        )
+                        error_info["response_status"] = getattr(response_obj, "status_code", None)
                         error_info["response_text"] = response_obj.text
                     except Exception as e:
                         logger.debug("Could not extract error response details: %s", e)
@@ -1248,9 +1153,7 @@ class AIAgent:
                 dump_payload["error"] = error_info
 
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-            dump_file = (
-                self.logs_dir / f"request_dump_{self.session_id}_{timestamp}.json"
-            )
+            dump_file = self.logs_dir / f"request_dump_{self.session_id}_{timestamp}.json"
             dump_file.write_text(
                 json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str),
                 encoding="utf-8",
@@ -1258,22 +1161,13 @@ class AIAgent:
 
             print(f"{self.log_prefix}🧾 Request debug dump written to: {dump_file}")
 
-            if os.getenv("HERMES_DUMP_REQUEST_STDOUT", "").strip().lower() in {
-                "1",
-                "true",
-                "yes",
-                "on",
-            }:
-                print(
-                    json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str)
-                )
+            if os.getenv("HERMES_DUMP_REQUEST_STDOUT", "").strip().lower() in {"1", "true", "yes", "on"}:
+                print(json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str))
 
             return dump_file
         except Exception as dump_error:
             if self.verbose_logging:
-                logging.warning(
-                    f"Failed to dump API request debug payload: {dump_error}"
-                )
+                logging.warning(f"Failed to dump API request debug payload: {dump_error}")
             return None
 
     @staticmethod
@@ -1282,8 +1176,8 @@ class AIAgent:
         if not content:
             return content
         content = convert_scratchpad_to_think(content)
-        content = re.sub(r"\n+(<think>)", r"\n\1", content)
-        content = re.sub(r"(</think>)\n+", r"\1\n", content)
+        content = re.sub(r'\n+(<think>)', r'\n\1', content)
+        content = re.sub(r'(</think>)\n+', r'\1\n', content)
         return content.strip()
 
     def _save_session_log(self, messages: List[Dict[str, Any]] = None):
@@ -1330,26 +1224,26 @@ class AIAgent:
         except Exception as e:
             if self.verbose_logging:
                 logging.warning(f"Failed to save session log: {e}")
-
+    
     def interrupt(self, message: str = None) -> None:
         """
         Request the agent to interrupt its current tool-calling loop.
-
+        
         Call this from another thread (e.g., input handler, message receiver)
         to gracefully stop the agent and process a new message.
-
+        
         Also signals long-running tool executions (e.g. terminal commands)
         to terminate early, so the agent can respond immediately.
-
+        
         Args:
             message: Optional new message that triggered the interrupt.
                      If provided, the agent will include this in its response context.
-
+        
         Example (CLI):
             # In a separate input thread:
             if user_typed_something:
                 agent.interrupt(user_input)
-
+        
         Example (Messaging):
             # When new message arrives for active session:
             if session_has_running_agent:
@@ -1366,27 +1260,18 @@ class AIAgent:
             except Exception as e:
                 logger.debug("Failed to propagate interrupt to child agent: %s", e)
         if not self.quiet_mode:
-            print(
-                f"\n⚡ Interrupt requested"
-                + (
-                    f": '{message[:40]}...'"
-                    if message and len(message) > 40
-                    else f": '{message}'"
-                    if message
-                    else ""
-                )
-            )
-
+            print(f"\n⚡ Interrupt requested" + (f": '{message[:40]}...'" if message and len(message) > 40 else f": '{message}'" if message else ""))
+    
     def clear_interrupt(self) -> None:
         """Clear any pending interrupt request and the global tool interrupt signal."""
         self._interrupt_requested = False
         self._interrupt_message = None
         _set_interrupt(False)
-
+    
     def _hydrate_todo_store(self, history: List[Dict[str, Any]]) -> None:
         """
         Recover todo state from conversation history.
-
+        
         The gateway creates a fresh AIAgent per message, so the in-memory
         TodoStore is empty. We scan the history for the most recent todo
         tool response and replay it to reconstruct the state.
@@ -1407,16 +1292,14 @@ class AIAgent:
                     break
             except (json.JSONDecodeError, TypeError):
                 continue
-
+        
         if last_todo_response:
             # Replay the items into the store (replace mode)
             self._todo_store.write(last_todo_response, merge=False)
             if not self.quiet_mode:
-                print(
-                    f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history"
-                )
+                print(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
         _set_interrupt(False)
-
+    
     @property
     def is_interrupted(self) -> bool:
         """Check if an interrupt has been requested."""
@@ -1432,9 +1315,7 @@ class AIAgent:
         if not self._honcho or not self._honcho_session_key:
             return ""
         try:
-            ctx = self._honcho.get_prefetch_context(
-                self._honcho_session_key, user_message
-            )
+            ctx = self._honcho.get_prefetch_context(self._honcho_session_key, user_message)
             if not ctx:
                 return ""
             parts = []
@@ -1463,13 +1344,11 @@ class AIAgent:
             session = self._honcho.get_or_create(self._honcho_session_key)
             session.add_message("user", f"[observation] {content.strip()}")
             self._honcho.save(session)
-            return json.dumps(
-                {
-                    "success": True,
-                    "target": "user",
-                    "message": "Saved to Honcho user model.",
-                }
-            )
+            return json.dumps({
+                "success": True,
+                "target": "user",
+                "message": "Saved to Honcho user model.",
+            })
         except Exception as e:
             logger.debug("Honcho user observation failed: %s", e)
             return json.dumps({"success": False, "error": f"Honcho save failed: {e}"})
@@ -1489,7 +1368,7 @@ class AIAgent:
     def _build_system_prompt(self, system_message: str = None) -> str:
         """
         Assemble the full system prompt from all layers.
-
+        
         Called once per session (cached on self._cached_system_prompt) and only
         rebuilt after context compression events. This ensures the system prompt
         is stable across all turns in a session, maximizing prefix cache hits.
@@ -1531,10 +1410,7 @@ class AIAgent:
                 if user_block:
                     prompt_parts.append(user_block)
 
-        has_skills_tools = any(
-            name in self.valid_tool_names
-            for name in ["skills_list", "skill_view", "skill_manage"]
-        )
+        has_skills_tools = any(name in self.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
         skills_prompt = build_skills_system_prompt() if has_skills_tools else ""
         if skills_prompt:
             prompt_parts.append(skills_prompt)
@@ -1545,7 +1421,6 @@ class AIAgent:
                 prompt_parts.append(context_files_prompt)
 
         from hermes_time import now as _hermes_now
-
         now = _hermes_now()
         prompt_parts.append(
             f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
@@ -1556,7 +1431,7 @@ class AIAgent:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
 
         return "\n\n".join(prompt_parts)
-
+    
     def _repair_tool_call(self, tool_name: str) -> str | None:
         """Attempt to repair a mismatched tool name before aborting.
 
@@ -1588,7 +1463,7 @@ class AIAgent:
     def _invalidate_system_prompt(self):
         """
         Invalidate the cached system prompt, forcing a rebuild on the next turn.
-
+        
         Called after context compression events. Also reloads memory from disk
         so the rebuilt prompt captures any writes from this session.
         """
@@ -1596,9 +1471,7 @@ class AIAgent:
         if self._memory_store:
             self._memory_store.load_from_disk()
 
-    def _responses_tools(
-        self, tools: Optional[List[Dict[str, Any]]] = None
-    ) -> Optional[List[Dict[str, Any]]]:
+    def _responses_tools(self, tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
         """Convert chat-completions tool schemas to Responses function-tool schemas."""
         source_tools = tools if tools is not None else self.tools
         if not source_tools:
@@ -1610,17 +1483,13 @@ class AIAgent:
             name = fn.get("name")
             if not isinstance(name, str) or not name.strip():
                 continue
-            converted.append(
-                {
-                    "type": "function",
-                    "name": name,
-                    "description": fn.get("description", ""),
-                    "strict": False,
-                    "parameters": fn.get(
-                        "parameters", {"type": "object", "properties": {}}
-                    ),
-                }
-            )
+            converted.append({
+                "type": "function",
+                "name": name,
+                "description": fn.get("description", ""),
+                "strict": False,
+                "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
+            })
         return converted or None
 
     @staticmethod
@@ -1655,13 +1524,13 @@ class AIAgent:
         if source.startswith("fc_"):
             return source
         if source.startswith("call_") and len(source) > len("call_"):
-            return f"fc_{source[len('call_') :]}"
+            return f"fc_{source[len('call_'):]}"
 
         sanitized = re.sub(r"[^A-Za-z0-9_-]", "", source)
         if sanitized.startswith("fc_"):
             return sanitized
         if sanitized.startswith("call_") and len(sanitized) > len("call_"):
-            return f"fc_{sanitized[len('call_') :]}"
+            return f"fc_{sanitized[len('call_'):]}"
         if sanitized:
             return f"fc_{sanitized[:48]}"
 
@@ -1669,9 +1538,7 @@ class AIAgent:
         digest = hashlib.sha1(seed.encode("utf-8")).hexdigest()[:24]
         return f"fc_{digest}"
 
-    def _chat_messages_to_responses_input(
-        self, messages: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+    def _chat_messages_to_responses_input(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Convert internal chat-style messages to Responses input items."""
         items: List[Dict[str, Any]] = []
 
@@ -1708,8 +1575,8 @@ class AIAgent:
                             if not isinstance(fn_name, str) or not fn_name.strip():
                                 continue
 
-                            embedded_call_id, embedded_response_item_id = (
-                                self._split_responses_tool_id(tc.get("id"))
+                            embedded_call_id, embedded_response_item_id = self._split_responses_tool_id(
+                                tc.get("id")
                             )
                             call_id = tc.get("call_id")
                             if not isinstance(call_id, str) or not call_id.strip():
@@ -1720,7 +1587,7 @@ class AIAgent:
                                     and embedded_response_item_id.startswith("fc_")
                                     and len(embedded_response_item_id) > len("fc_")
                                 ):
-                                    call_id = f"call_{embedded_response_item_id[len('fc_') :]}"
+                                    call_id = f"call_{embedded_response_item_id[len('fc_'):]}"
                                 else:
                                     call_id = f"call_{uuid.uuid4().hex[:12]}"
                             call_id = call_id.strip()
@@ -1732,14 +1599,12 @@ class AIAgent:
                                 arguments = str(arguments)
                             arguments = arguments.strip() or "{}"
 
-                            items.append(
-                                {
-                                    "type": "function_call",
-                                    "call_id": call_id,
-                                    "name": fn_name,
-                                    "arguments": arguments,
-                                }
-                            )
+                            items.append({
+                                "type": "function_call",
+                                "call_id": call_id,
+                                "name": fn_name,
+                                "arguments": arguments,
+                            })
                     continue
 
                 items.append({"role": role, "content": content_text})
@@ -1753,13 +1618,11 @@ class AIAgent:
                         call_id = raw_tool_call_id.strip()
                 if not isinstance(call_id, str) or not call_id.strip():
                     continue
-                items.append(
-                    {
-                        "type": "function_call_output",
-                        "call_id": call_id,
-                        "output": str(msg.get("content", "") or ""),
-                    }
-                )
+                items.append({
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": str(msg.get("content", "") or ""),
+                })
 
         return items
 
@@ -1777,13 +1640,9 @@ class AIAgent:
                 call_id = item.get("call_id")
                 name = item.get("name")
                 if not isinstance(call_id, str) or not call_id.strip():
-                    raise ValueError(
-                        f"Codex Responses input[{idx}] function_call is missing call_id."
-                    )
+                    raise ValueError(f"Codex Responses input[{idx}] function_call is missing call_id.")
                 if not isinstance(name, str) or not name.strip():
-                    raise ValueError(
-                        f"Codex Responses input[{idx}] function_call is missing name."
-                    )
+                    raise ValueError(f"Codex Responses input[{idx}] function_call is missing name.")
 
                 arguments = item.get("arguments", "{}")
                 if isinstance(arguments, dict):
@@ -1805,9 +1664,7 @@ class AIAgent:
             if item_type == "function_call_output":
                 call_id = item.get("call_id")
                 if not isinstance(call_id, str) or not call_id.strip():
-                    raise ValueError(
-                        f"Codex Responses input[{idx}] function_call_output is missing call_id."
-                    )
+                    raise ValueError(f"Codex Responses input[{idx}] function_call_output is missing call_id.")
                 output = item.get("output", "")
                 if output is None:
                     output = ""
@@ -1826,10 +1683,7 @@ class AIAgent:
             if item_type == "reasoning":
                 encrypted = item.get("encrypted_content")
                 if isinstance(encrypted, str) and encrypted:
-                    reasoning_item = {
-                        "type": "reasoning",
-                        "encrypted_content": encrypted,
-                    }
+                    reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
                     item_id = item.get("id")
                     if isinstance(item_id, str) and item_id:
                         reasoning_item["id"] = item_id
@@ -1870,15 +1724,11 @@ class AIAgent:
         required = {"model", "instructions", "input"}
         missing = [key for key in required if key not in api_kwargs]
         if missing:
-            raise ValueError(
-                f"Codex Responses request missing required field(s): {', '.join(sorted(missing))}."
-            )
+            raise ValueError(f"Codex Responses request missing required field(s): {', '.join(sorted(missing))}.")
 
         model = api_kwargs.get("model")
         if not isinstance(model, str) or not model.strip():
-            raise ValueError(
-                "Codex Responses request 'model' must be a non-empty string."
-            )
+            raise ValueError("Codex Responses request 'model' must be a non-empty string.")
         model = model.strip()
 
         instructions = api_kwargs.get("instructions")
@@ -1894,28 +1744,20 @@ class AIAgent:
         normalized_tools = None
         if tools is not None:
             if not isinstance(tools, list):
-                raise ValueError(
-                    "Codex Responses request 'tools' must be a list when provided."
-                )
+                raise ValueError("Codex Responses request 'tools' must be a list when provided.")
             normalized_tools = []
             for idx, tool in enumerate(tools):
                 if not isinstance(tool, dict):
                     raise ValueError(f"Codex Responses tools[{idx}] must be an object.")
                 if tool.get("type") != "function":
-                    raise ValueError(
-                        f"Codex Responses tools[{idx}] has unsupported type {tool.get('type')!r}."
-                    )
+                    raise ValueError(f"Codex Responses tools[{idx}] has unsupported type {tool.get('type')!r}.")
 
                 name = tool.get("name")
                 parameters = tool.get("parameters")
                 if not isinstance(name, str) or not name.strip():
-                    raise ValueError(
-                        f"Codex Responses tools[{idx}] is missing a valid name."
-                    )
+                    raise ValueError(f"Codex Responses tools[{idx}] is missing a valid name.")
                 if not isinstance(parameters, dict):
-                    raise ValueError(
-                        f"Codex Responses tools[{idx}] is missing valid parameters."
-                    )
+                    raise ValueError(f"Codex Responses tools[{idx}] is missing valid parameters.")
 
                 description = tool.get("description", "")
                 if description is None:
@@ -1942,15 +1784,9 @@ class AIAgent:
             raise ValueError("Codex Responses contract requires 'store' to be false.")
 
         allowed_keys = {
-            "model",
-            "instructions",
-            "input",
-            "tools",
-            "store",
-            "reasoning",
-            "include",
-            "max_output_tokens",
-            "temperature",
+            "model", "instructions", "input", "tools", "store",
+            "reasoning", "include", "max_output_tokens", "temperature",
+            "tool_choice", "parallel_tool_calls", "prompt_cache_key",
         }
         normalized: Dict[str, Any] = {
             "model": model,
@@ -1976,6 +1812,12 @@ class AIAgent:
         if isinstance(temperature, (int, float)):
             normalized["temperature"] = float(temperature)
 
+        # Pass through tool_choice, parallel_tool_calls, prompt_cache_key
+        for passthrough_key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key"):
+            val = api_kwargs.get(passthrough_key)
+            if val is not None:
+                normalized[passthrough_key] = val
+
         if allow_stream:
             stream = api_kwargs.get("stream")
             if stream is not None and stream is not True:
@@ -1984,9 +1826,7 @@ class AIAgent:
                 normalized["stream"] = True
             allowed_keys.add("stream")
         elif "stream" in api_kwargs:
-            raise ValueError(
-                "Codex Responses stream flag is only allowed in fallback streaming requests."
-            )
+            raise ValueError("Codex Responses stream flag is only allowed in fallback streaming requests.")
 
         unexpected = sorted(key for key in api_kwargs.keys() if key not in allowed_keys)
         if unexpected:
@@ -2045,22 +1885,14 @@ class AIAgent:
             if isinstance(error_obj, dict):
                 error_msg = error_obj.get("message") or str(error_obj)
             else:
-                error_msg = (
-                    str(error_obj)
-                    if error_obj
-                    else f"Responses API returned status '{response_status}'"
-                )
+                error_msg = str(error_obj) if error_obj else f"Responses API returned status '{response_status}'"
             raise RuntimeError(error_msg)
 
         content_parts: List[str] = []
         reasoning_parts: List[str] = []
         reasoning_items_raw: List[Dict[str, Any]] = []
         tool_calls: List[Any] = []
-        has_incomplete_items = response_status in {
-            "queued",
-            "in_progress",
-            "incomplete",
-        }
+        has_incomplete_items = response_status in {"queued", "in_progress", "incomplete"}
         saw_commentary_phase = False
         saw_final_answer_phase = False
 
@@ -2106,9 +1938,7 @@ class AIAgent:
                         for part in summary:
                             text = getattr(part, "text", None)
                             if isinstance(text, str):
-                                raw_summary.append(
-                                    {"type": "summary_text", "text": text}
-                                )
+                                raw_summary.append({"type": "summary_text", "text": text})
                         raw_item["summary"] = raw_summary
                     reasoning_items_raw.append(raw_item)
             elif item_type == "function_call":
@@ -2121,27 +1951,19 @@ class AIAgent:
                 raw_call_id = getattr(item, "call_id", None)
                 raw_item_id = getattr(item, "id", None)
                 embedded_call_id, _ = self._split_responses_tool_id(raw_item_id)
-                call_id = (
-                    raw_call_id
-                    if isinstance(raw_call_id, str) and raw_call_id.strip()
-                    else embedded_call_id
-                )
+                call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id.strip() else embedded_call_id
                 if not isinstance(call_id, str) or not call_id.strip():
                     call_id = f"call_{uuid.uuid4().hex[:12]}"
                 call_id = call_id.strip()
                 response_item_id = raw_item_id if isinstance(raw_item_id, str) else None
-                response_item_id = self._derive_responses_function_call_id(
-                    call_id, response_item_id
-                )
-                tool_calls.append(
-                    SimpleNamespace(
-                        id=call_id,
-                        call_id=call_id,
-                        response_item_id=response_item_id,
-                        type="function",
-                        function=SimpleNamespace(name=fn_name, arguments=arguments),
-                    )
-                )
+                response_item_id = self._derive_responses_function_call_id(call_id, response_item_id)
+                tool_calls.append(SimpleNamespace(
+                    id=call_id,
+                    call_id=call_id,
+                    response_item_id=response_item_id,
+                    type="function",
+                    function=SimpleNamespace(name=fn_name, arguments=arguments),
+                ))
             elif item_type == "custom_tool_call":
                 fn_name = getattr(item, "name", "") or ""
                 arguments = getattr(item, "input", "{}")
@@ -2150,27 +1972,19 @@ class AIAgent:
                 raw_call_id = getattr(item, "call_id", None)
                 raw_item_id = getattr(item, "id", None)
                 embedded_call_id, _ = self._split_responses_tool_id(raw_item_id)
-                call_id = (
-                    raw_call_id
-                    if isinstance(raw_call_id, str) and raw_call_id.strip()
-                    else embedded_call_id
-                )
+                call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id.strip() else embedded_call_id
                 if not isinstance(call_id, str) or not call_id.strip():
                     call_id = f"call_{uuid.uuid4().hex[:12]}"
                 call_id = call_id.strip()
                 response_item_id = raw_item_id if isinstance(raw_item_id, str) else None
-                response_item_id = self._derive_responses_function_call_id(
-                    call_id, response_item_id
-                )
-                tool_calls.append(
-                    SimpleNamespace(
-                        id=call_id,
-                        call_id=call_id,
-                        response_item_id=response_item_id,
-                        type="function",
-                        function=SimpleNamespace(name=fn_name, arguments=arguments),
-                    )
-                )
+                response_item_id = self._derive_responses_function_call_id(call_id, response_item_id)
+                tool_calls.append(SimpleNamespace(
+                    id=call_id,
+                    call_id=call_id,
+                    response_item_id=response_item_id,
+                    type="function",
+                    function=SimpleNamespace(name=fn_name, arguments=arguments),
+                ))
 
         final_text = "\n".join([p for p in content_parts if p]).strip()
         if not final_text and hasattr(response, "output_text"):
@@ -2189,9 +2003,7 @@ class AIAgent:
 
         if tool_calls:
             finish_reason = "tool_calls"
-        elif has_incomplete_items or (
-            saw_commentary_phase and not saw_final_answer_phase
-        ):
+        elif has_incomplete_items or (saw_commentary_phase and not saw_final_answer_phase):
             finish_reason = "incomplete"
         else:
             finish_reason = "stop"
@@ -2227,9 +2039,7 @@ class AIAgent:
         """Fallback path for stream completion edge cases on Codex-style Responses backends."""
         fallback_kwargs = dict(api_kwargs)
         fallback_kwargs["stream"] = True
-        fallback_kwargs = self._preflight_codex_api_kwargs(
-            fallback_kwargs, allow_stream=True
-        )
+        fallback_kwargs = self._preflight_codex_api_kwargs(fallback_kwargs, allow_stream=True)
         stream_or_response = self.client.responses.create(**fallback_kwargs)
 
         # Compatibility shim for mocks or providers that still return a concrete response.
@@ -2244,11 +2054,7 @@ class AIAgent:
                 event_type = getattr(event, "type", None)
                 if not event_type and isinstance(event, dict):
                     event_type = event.get("type")
-                if event_type not in {
-                    "response.completed",
-                    "response.incomplete",
-                    "response.failed",
-                }:
+                if event_type not in {"response.completed", "response.incomplete", "response.failed"}:
                     continue
 
                 terminal_response = getattr(event, "response", None)
@@ -2266,9 +2072,7 @@ class AIAgent:
 
         if terminal_response is not None:
             return terminal_response
-        raise RuntimeError(
-            "Responses create(stream=True) fallback did not emit a terminal response."
-        )
+        raise RuntimeError("Responses create(stream=True) fallback did not emit a terminal response.")
 
     def _try_refresh_codex_client_credentials(self, *, force: bool = True) -> bool:
         if self.api_mode != "codex_responses" or self.provider != "openai-codex":
@@ -2302,9 +2106,7 @@ class AIAgent:
         try:
             self.client = OpenAI(**self._client_kwargs)
         except Exception as exc:
-            logger.warning(
-                "Failed to rebuild OpenAI client after Codex refresh: %s", exc
-            )
+            logger.warning("Failed to rebuild OpenAI client after Codex refresh: %s", exc)
             return False
 
         return True
@@ -2317,9 +2119,7 @@ class AIAgent:
             from hermes_cli.auth import resolve_nous_runtime_credentials
 
             creds = resolve_nous_runtime_credentials(
-                min_key_ttl_seconds=max(
-                    60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))
-                ),
+                min_key_ttl_seconds=max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),
                 timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
                 force_mint=force,
             )
@@ -2349,9 +2149,7 @@ class AIAgent:
         try:
             self.client = OpenAI(**self._client_kwargs)
         except Exception as exc:
-            logger.warning(
-                "Failed to rebuild OpenAI client after Nous refresh: %s", exc
-            )
+            logger.warning("Failed to rebuild OpenAI client after Nous refresh: %s", exc)
             return False
 
         return True
@@ -2360,7 +2158,7 @@ class AIAgent:
         """
         Run the API call in a background thread so the main conversation loop
         can detect interrupts without waiting for the full HTTP round-trip.
-
+        
         On interrupt, closes the HTTP client to cancel the in-flight request
         (stops token generation and avoids wasting money), then rebuilds the
         client for future calls.
@@ -2372,9 +2170,7 @@ class AIAgent:
                 if self.api_mode == "codex_responses":
                     result["response"] = self._run_codex_stream(api_kwargs)
                 else:
-                    result["response"] = self.client.chat.completions.create(
-                        **api_kwargs
-                    )
+                    result["response"] = self.client.chat.completions.create(**api_kwargs)
             except Exception as e:
                 result["error"] = e
 
@@ -2432,15 +2228,13 @@ class AIAgent:
             resolver_name, api_mode = self._FALLBACK_OAUTH_PROVIDERS[fb_provider]
             try:
                 import hermes_cli.auth as _auth
-
                 resolver = getattr(_auth, resolver_name)
                 creds = resolver()
                 return creds["api_key"], creds["base_url"], api_mode
             except Exception as e:
                 logging.warning(
                     "Fallback to %s failed (credential resolution): %s",
-                    fb_provider,
-                    e,
+                    fb_provider, e,
                 )
                 return None
 
@@ -2516,7 +2310,8 @@ class AIAgent:
 
             # Re-evaluate prompt caching for the new provider/model
             self._use_prompt_caching = (
-                "openrouter" in fb_base_url.lower() and "claude" in fb_model.lower()
+                "openrouter" in fb_base_url.lower()
+                and "claude" in fb_model.lower()
             )
 
             print(
@@ -2525,9 +2320,7 @@ class AIAgent:
             )
             logging.info(
                 "Fallback activated: %s → %s (%s)",
-                old_model,
-                fb_model,
-                fb_provider,
+                old_model, fb_model, fb_provider,
             )
             return True
         except Exception as e:
@@ -2561,7 +2354,10 @@ class AIAgent:
                 "instructions": instructions,
                 "input": self._chat_messages_to_responses_input(payload_messages),
                 "tools": self._responses_tools(),
+                "tool_choice": "auto",
+                "parallel_tool_calls": True,
                 "store": False,
+                "prompt_cache_key": self.session_id,
             }
 
             if reasoning_enabled:
@@ -2612,7 +2408,10 @@ class AIAgent:
             if self.reasoning_config is not None:
                 extra_body["reasoning"] = self.reasoning_config
             else:
-                extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
+                extra_body["reasoning"] = {
+                    "enabled": True,
+                    "effort": "medium"
+                }
 
         # Nous Portal product attribution
         if _is_nous:
@@ -2632,14 +2431,14 @@ class AIAgent:
         reasoning_text = self._extract_reasoning(assistant_message)
 
         if reasoning_text and self.verbose_logging:
-            preview = (
-                reasoning_text[:100] + "..."
-                if len(reasoning_text) > 100
-                else reasoning_text
-            )
-            logging.debug(
-                f"Captured reasoning ({len(reasoning_text)} chars): {preview}"
-            )
+            preview = reasoning_text[:100] + "..." if len(reasoning_text) > 100 else reasoning_text
+            logging.debug(f"Captured reasoning ({len(reasoning_text)} chars): {preview}")
+
+        if reasoning_text and self.reasoning_callback:
+            try:
+                self.reasoning_callback(reasoning_text)
+            except Exception:
+                pass
 
         msg = {
             "role": "assistant",
@@ -2648,10 +2447,7 @@ class AIAgent:
             "finish_reason": finish_reason,
         }
 
-        if (
-            hasattr(assistant_message, "reasoning_details")
-            and assistant_message.reasoning_details
-        ):
+        if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
             # Pass reasoning_details back unmodified so providers (OpenRouter,
             # Anthropic, OpenAI) can maintain reasoning continuity across turns.
             # Each provider may include opaque fields (signature, encrypted_content)
@@ -2690,10 +2486,7 @@ class AIAgent:
                 call_id = call_id.strip()
 
                 response_item_id = getattr(tool_call, "response_item_id", None)
-                if (
-                    not isinstance(response_item_id, str)
-                    or not response_item_id.strip()
-                ):
+                if not isinstance(response_item_id, str) or not response_item_id.strip():
                     _, embedded_response_item_id = self._split_responses_tool_id(raw_id)
                     response_item_id = embedded_response_item_id
 
@@ -2709,7 +2502,7 @@ class AIAgent:
                     "type": tool_call.type,
                     "function": {
                         "name": tool_call.function.name,
-                        "arguments": tool_call.function.arguments,
+                        "arguments": tool_call.function.arguments
                     },
                 }
                 # Preserve extra_content (e.g. Gemini thought_signature) so it
@@ -2743,14 +2536,12 @@ class AIAgent:
             return
         if "memory" not in self.valid_tool_names or not self._memory_store:
             return
-        effective_min = (
-            min_turns if min_turns is not None else self._memory_flush_min_turns
-        )
+        effective_min = min_turns if min_turns is not None else self._memory_flush_min_turns
         if self._user_turn_count < effective_min:
             return
 
         if messages is None:
-            messages = getattr(self, "_session_messages", None)
+            messages = getattr(self, '_session_messages', None)
         if not messages or len(messages) < 3:
             return
 
@@ -2759,11 +2550,7 @@ class AIAgent:
             "Please save anything worth remembering to your memories.]"
         )
         _sentinel = f"__flush_{id(self)}_{time.monotonic()}"
-        flush_msg = {
-            "role": "user",
-            "content": flush_content,
-            "_flush_sentinel": _sentinel,
-        }
+        flush_msg = {"role": "user", "content": flush_content, "_flush_sentinel": _sentinel}
         messages.append(flush_msg)
 
         try:
@@ -2781,13 +2568,11 @@ class AIAgent:
                 api_messages.append(api_msg)
 
             if self._cached_system_prompt:
-                api_messages = [
-                    {"role": "system", "content": self._cached_system_prompt}
-                ] + api_messages
+                api_messages = [{"role": "system", "content": self._cached_system_prompt}] + api_messages
 
             # Make one API call with only the memory tool available
             memory_tool_def = None
-            for t in self.tools or []:
+            for t in (self.tools or []):
                 if t.get("function", {}).get("name") == "memory":
                     memory_tool_def = t
                     break
@@ -2799,7 +2584,6 @@ class AIAgent:
             # Use auxiliary client for the flush call when available --
             # it's cheaper and avoids Codex Responses API incompatibility.
             from agent.auxiliary_client import get_text_auxiliary_client
-
             aux_client, aux_model = get_text_auxiliary_client()
 
             if aux_client:
@@ -2810,9 +2594,7 @@ class AIAgent:
                     "temperature": 0.3,
                     "max_tokens": 5120,
                 }
-                response = aux_client.chat.completions.create(
-                    **api_kwargs, timeout=30.0
-                )
+                response = aux_client.chat.completions.create(**api_kwargs, timeout=30.0)
             elif self.api_mode == "codex_responses":
                 # No auxiliary client -- use the Codex Responses path directly
                 codex_kwargs = self._build_api_kwargs(api_messages)
@@ -2829,9 +2611,7 @@ class AIAgent:
                     "temperature": 0.3,
                     **self._max_tokens_param(5120),
                 }
-                response = self.client.chat.completions.create(
-                    **api_kwargs, timeout=30.0
-                )
+                response = self.client.chat.completions.create(**api_kwargs, timeout=30.0)
 
             # Extract tool calls from the response, handling both API formats
             tool_calls = []
@@ -2850,7 +2630,6 @@ class AIAgent:
                         args = json.loads(tc.function.arguments)
                         flush_target = args.get("target", "memory")
                         from tools.memory_tool import memory_tool as _memory_tool
-
                         result = _memory_tool(
                             action=args.get("action"),
                             target=flush_target,
@@ -2858,16 +2637,10 @@ class AIAgent:
                             old_text=args.get("old_text"),
                             store=self._memory_store,
                         )
-                        if (
-                            self._honcho
-                            and flush_target == "user"
-                            and args.get("action") == "add"
-                        ):
+                        if self._honcho and flush_target == "user" and args.get("action") == "add":
                             self._honcho_save_user_observation(args.get("content", ""))
                         if not self.quiet_mode:
-                            print(
-                                f"  🧠 Memory flush: saved to {args.get('target', 'memory')}"
-                            )
+                            print(f"  🧠 Memory flush: saved to {args.get('target', 'memory')}")
                     except Exception as e:
                         logger.debug("Memory flush tool call failed: %s", e)
         except Exception as e:
@@ -2882,14 +2655,7 @@ class AIAgent:
             if messages and messages[-1].get("_flush_sentinel") == _sentinel:
                 messages.pop()
 
-    def _compress_context(
-        self,
-        messages: list,
-        system_message: str,
-        *,
-        approx_tokens: int = None,
-        task_id: str = "default",
-    ) -> tuple:
+    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default") -> tuple:
         """Compress conversation context and split the session in SQLite.
 
         Returns:
@@ -2898,9 +2664,7 @@ class AIAgent:
         # Pre-compression memory flush: let the model save memories before they're lost
         self.flush_memories(messages, min_turns=0)
 
-        compressed = self.context_compressor.compress(
-            messages, current_tokens=approx_tokens
-        )
+        compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
 
         todo_snapshot = self._todo_store.format_for_injection()
         if todo_snapshot:
@@ -2910,23 +2674,18 @@ class AIAgent:
         # it already examined before compression.
         try:
             from tools.file_tools import get_read_files_summary
-
             read_files = get_read_files_summary(task_id)
             if read_files:
                 file_list = "\n".join(
-                    f"  - {f['path']} ({', '.join(f['regions'])})" for f in read_files
+                    f"  - {f['path']} ({', '.join(f['regions'])})"
+                    for f in read_files
                 )
-                compressed.append(
-                    {
-                        "role": "user",
-                        "content": (
-                            "[Files already read in this session — do NOT re-read these]\n"
-                            f"{file_list}\n"
-                            "Use the information from the context summary above. "
-                            "Proceed with writing, editing, or responding."
-                        ),
-                    }
-                )
+                compressed.append({"role": "user", "content": (
+                    "[Files already read in this session — do NOT re-read these]\n"
+                    f"{file_list}\n"
+                    "Use the information from the context summary above. "
+                    "Proceed with writing, editing, or responding."
+                )})
         except Exception:
             pass  # Don't break compression if file tracking fails
 
@@ -2940,9 +2699,7 @@ class AIAgent:
                 old_title = self._session_db.get_session_title(self.session_id)
                 self._session_db.end_session(self.session_id, "compression")
                 old_session_id = self.session_id
-                self.session_id = (
-                    f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
-                )
+                self.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
                 self._session_db.create_session(
                     session_id=self.session_id,
                     source=self.platform or "cli",
@@ -2952,15 +2709,11 @@ class AIAgent:
                 # Auto-number the title for the continuation session
                 if old_title:
                     try:
-                        new_title = self._session_db.get_next_title_in_lineage(
-                            old_title
-                        )
+                        new_title = self._session_db.get_next_title_in_lineage(old_title)
                         self._session_db.set_session_title(self.session_id, new_title)
                     except (ValueError, Exception) as e:
                         logger.debug("Could not propagate title on compression: %s", e)
-                self._session_db.update_system_prompt(
-                    self.session_id, new_system_prompt
-                )
+                self._session_db.update_system_prompt(self.session_id, new_system_prompt)
                 # Reset flush cursor — new session starts with no messages written
                 self._last_flushed_db_idx = 0
             except Exception as e:
@@ -2968,24 +2721,16 @@ class AIAgent:
 
         return compressed, new_system_prompt
 
-    def _execute_tool_calls(
-        self,
-        assistant_message,
-        messages: list,
-        effective_task_id: str,
-        api_call_count: int = 0,
-    ) -> None:
+    def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute tool calls from the assistant message and append results to messages."""
         for i, tool_call in enumerate(assistant_message.tool_calls, 1):
             # SAFETY: check interrupt BEFORE starting each tool.
             # If the user sent "stop" during a previous tool's execution,
             # do NOT start any more tools -- skip them all immediately.
             if self._interrupt_requested:
-                remaining_calls = assistant_message.tool_calls[i - 1 :]
+                remaining_calls = assistant_message.tool_calls[i-1:]
                 if remaining_calls:
-                    print(
-                        f"{self.log_prefix}⚡ Interrupt: skipping {len(remaining_calls)} tool call(s)"
-                    )
+                    print(f"{self.log_prefix}⚡ Interrupt: skipping {len(remaining_calls)} tool call(s)")
                 for skipped_tc in remaining_calls:
                     skipped_name = skipped_tc.function.name
                     skip_msg = {
@@ -3012,9 +2757,7 @@ class AIAgent:
             if not isinstance(function_args, dict):
                 function_args = {}
 
-            doom_loop_signature = self._make_doom_loop_signature(
-                function_name, function_args
-            )
+            doom_loop_signature = self._make_doom_loop_signature(function_name, function_args)
             if self._should_trigger_doom_loop(doom_loop_signature):
                 if self._handle_doom_loop(
                     assistant_message=assistant_message,
@@ -3026,14 +2769,8 @@ class AIAgent:
 
             if not self.quiet_mode:
                 args_str = json.dumps(function_args, ensure_ascii=False)
-                args_preview = (
-                    args_str[: self.log_prefix_chars] + "..."
-                    if len(args_str) > self.log_prefix_chars
-                    else args_str
-                )
-                print(
-                    f"  📞 Tool {i}: {function_name}({list(function_args.keys())}) - {args_preview}"
-                )
+                args_preview = args_str[:self.log_prefix_chars] + "..." if len(args_str) > self.log_prefix_chars else args_str
+                print(f"  📞 Tool {i}: {function_name}({list(function_args.keys())}) - {args_preview}")
 
             if self.tool_progress_callback:
                 try:
@@ -3043,16 +2780,11 @@ class AIAgent:
                     logging.debug(f"Tool progress callback error: {cb_err}")
 
             # Checkpoint: snapshot working dir before file-mutating tools
-            if (
-                function_name in ("write_file", "patch")
-                and self._checkpoint_mgr.enabled
-            ):
+            if function_name in ("write_file", "patch") and self._checkpoint_mgr.enabled:
                 try:
                     file_path = function_args.get("path", "")
                     if file_path:
-                        work_dir = self._checkpoint_mgr.get_working_dir_for_path(
-                            file_path
-                        )
+                        work_dir = self._checkpoint_mgr.get_working_dir_for_path(file_path)
                         self._checkpoint_mgr.ensure_checkpoint(
                             work_dir, f"before {function_name}"
                         )
@@ -3063,7 +2795,6 @@ class AIAgent:
 
             if function_name == "todo":
                 from tools.todo_tool import todo_tool as _todo_tool
-
                 function_result = _todo_tool(
                     todos=function_args.get("todos"),
                     merge=function_args.get("merge", False),
@@ -3071,19 +2802,12 @@ class AIAgent:
                 )
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
-                    print(
-                        f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}"
-                    )
+                    print(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
             elif function_name == "session_search":
                 if not self._session_db:
-                    function_result = json.dumps(
-                        {"success": False, "error": "Session database not available."}
-                    )
+                    function_result = json.dumps({"success": False, "error": "Session database not available."})
                 else:
-                    from tools.session_search_tool import (
-                        session_search as _session_search,
-                    )
-
+                    from tools.session_search_tool import session_search as _session_search
                     function_result = _session_search(
                         query=function_args.get("query", ""),
                         role_filter=function_args.get("role_filter"),
@@ -3093,13 +2817,10 @@ class AIAgent:
                     )
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
-                    print(
-                        f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}"
-                    )
+                    print(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
             elif function_name == "memory":
                 target = function_args.get("target", "memory")
                 from tools.memory_tool import memory_tool as _memory_tool
-
                 function_result = _memory_tool(
                     action=function_args.get("action"),
                     target=target,
@@ -3108,20 +2829,13 @@ class AIAgent:
                     store=self._memory_store,
                 )
                 # Also send user observations to Honcho when active
-                if (
-                    self._honcho
-                    and target == "user"
-                    and function_args.get("action") == "add"
-                ):
+                if self._honcho and target == "user" and function_args.get("action") == "add":
                     self._honcho_save_user_observation(function_args.get("content", ""))
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
-                    print(
-                        f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}"
-                    )
+                    print(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
             elif function_name == "clarify":
                 from tools.clarify_tool import clarify_tool as _clarify_tool
-
                 function_result = _clarify_tool(
                     question=function_args.get("question", ""),
                     choices=function_args.get("choices"),
@@ -3129,26 +2843,19 @@ class AIAgent:
                 )
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
-                    print(
-                        f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}"
-                    )
+                    print(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
             elif function_name == "delegate_task":
                 from tools.delegate_tool import delegate_task as _delegate_task
-
                 tasks_arg = function_args.get("tasks")
                 if tasks_arg and isinstance(tasks_arg, list):
                     spinner_label = f"🔀 delegating {len(tasks_arg)} tasks"
                 else:
                     goal_preview = (function_args.get("goal") or "")[:30]
-                    spinner_label = (
-                        f"🔀 {goal_preview}" if goal_preview else "🔀 delegating"
-                    )
+                    spinner_label = f"🔀 {goal_preview}" if goal_preview else "🔀 delegating"
                 spinner = None
                 if self.quiet_mode:
                     face = random.choice(KawaiiSpinner.KAWAII_WAITING)
-                    spinner = KawaiiSpinner(
-                        f"{face} {spinner_label}", spinner_type="dots"
-                    )
+                    spinner = KawaiiSpinner(f"{face} {spinner_label}", spinner_type='dots')
                     spinner.start()
                 self._delegate_spinner = spinner
                 _delegate_result = None
@@ -3165,12 +2872,7 @@ class AIAgent:
                 finally:
                     self._delegate_spinner = None
                     tool_duration = time.time() - tool_start_time
-                    cute_msg = _get_cute_tool_message_impl(
-                        "delegate_task",
-                        function_args,
-                        tool_duration,
-                        result=_delegate_result,
-                    )
+                    cute_msg = _get_cute_tool_message_impl('delegate_task', function_args, tool_duration, result=_delegate_result)
                     if spinner:
                         spinner.stop(cute_msg)
                     elif self.quiet_mode:
@@ -3178,119 +2880,60 @@ class AIAgent:
             elif self.quiet_mode:
                 face = random.choice(KawaiiSpinner.KAWAII_WAITING)
                 tool_emoji_map = {
-                    "web_search": "🔍",
-                    "web_extract": "📄",
-                    "web_crawl": "🕸️",
-                    "terminal": "💻",
-                    "process": "⚙️",
-                    "read_file": "📖",
-                    "write_file": "✍️",
-                    "patch": "🔧",
-                    "search_files": "🔎",
-                    "browser_navigate": "🌐",
-                    "browser_snapshot": "📸",
-                    "browser_click": "👆",
-                    "browser_type": "⌨️",
-                    "browser_scroll": "📜",
-                    "browser_back": "◀️",
-                    "browser_press": "⌨️",
-                    "browser_close": "🚪",
-                    "browser_get_images": "🖼️",
-                    "browser_vision": "👁️",
-                    "image_generate": "🎨",
-                    "text_to_speech": "🔊",
-                    "vision_analyze": "👁️",
-                    "mixture_of_agents": "🧠",
-                    "skills_list": "📚",
-                    "skill_view": "📚",
-                    "schedule_cronjob": "⏰",
-                    "list_cronjobs": "⏰",
-                    "remove_cronjob": "⏰",
-                    "send_message": "📨",
-                    "todo": "📋",
-                    "memory": "🧠",
-                    "session_search": "🔍",
-                    "clarify": "❓",
-                    "execute_code": "🐍",
-                    "delegate_task": "🔀",
+                    'web_search': '🔍', 'web_extract': '📄', 'web_crawl': '🕸️',
+                    'terminal': '💻', 'process': '⚙️',
+                    'read_file': '📖', 'write_file': '✍️', 'patch': '🔧', 'search_files': '🔎',
+                    'browser_navigate': '🌐', 'browser_snapshot': '📸',
+                    'browser_click': '👆', 'browser_type': '⌨️',
+                    'browser_scroll': '📜', 'browser_back': '◀️',
+                    'browser_press': '⌨️', 'browser_close': '🚪',
+                    'browser_get_images': '🖼️', 'browser_vision': '👁️',
+                    'image_generate': '🎨', 'text_to_speech': '🔊',
+                    'vision_analyze': '👁️', 'mixture_of_agents': '🧠',
+                    'skills_list': '📚', 'skill_view': '📚',
+                    'schedule_cronjob': '⏰', 'list_cronjobs': '⏰', 'remove_cronjob': '⏰',
+                    'send_message': '📨', 'todo': '📋', 'memory': '🧠', 'session_search': '🔍',
+                    'clarify': '❓', 'execute_code': '🐍', 'delegate_task': '🔀',
                 }
-                emoji = tool_emoji_map.get(function_name, "⚡")
-                preview = (
-                    _build_tool_preview(function_name, function_args) or function_name
-                )
+                emoji = tool_emoji_map.get(function_name, '⚡')
+                preview = _build_tool_preview(function_name, function_args) or function_name
                 if len(preview) > 30:
                     preview = preview[:27] + "..."
-                spinner = KawaiiSpinner(
-                    f"{face} {emoji} {preview}", spinner_type="dots"
-                )
+                spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots')
                 spinner.start()
                 _spinner_result = None
                 try:
                     function_result = handle_function_call(
-                        function_name,
-                        function_args,
-                        effective_task_id,
-                        enabled_tools=list(self.valid_tool_names)
-                        if self.valid_tool_names
-                        else None,
+                        function_name, function_args, effective_task_id,
+                        enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                     )
                     _spinner_result = function_result
                 except Exception as tool_error:
-                    function_result = (
-                        f"Error executing tool '{function_name}': {tool_error}"
-                    )
-                    logger.error(
-                        "handle_function_call raised for %s: %s",
-                        function_name,
-                        tool_error,
-                        exc_info=True,
-                    )
+                    function_result = f"Error executing tool '{function_name}': {tool_error}"
+                    logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
                 finally:
                     tool_duration = time.time() - tool_start_time
-                    cute_msg = _get_cute_tool_message_impl(
-                        function_name,
-                        function_args,
-                        tool_duration,
-                        result=_spinner_result,
-                    )
+                    cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_spinner_result)
                     spinner.stop(cute_msg)
             else:
                 try:
                     function_result = handle_function_call(
-                        function_name,
-                        function_args,
-                        effective_task_id,
-                        enabled_tools=list(self.valid_tool_names)
-                        if self.valid_tool_names
-                        else None,
+                        function_name, function_args, effective_task_id,
+                        enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                     )
                 except Exception as tool_error:
-                    function_result = (
-                        f"Error executing tool '{function_name}': {tool_error}"
-                    )
-                    logger.error(
-                        "handle_function_call raised for %s: %s",
-                        function_name,
-                        tool_error,
-                        exc_info=True,
-                    )
+                    function_result = f"Error executing tool '{function_name}': {tool_error}"
+                    logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
                 tool_duration = time.time() - tool_start_time
 
-            result_preview = (
-                function_result[:200] if len(function_result) > 200 else function_result
-            )
+            result_preview = function_result[:200] if len(function_result) > 200 else function_result
 
             # Log tool errors to the persistent error log so [error] tags
             # in the UI always have a corresponding detailed entry on disk.
             _is_error_result, _ = _detect_tool_failure(function_name, function_result)
             self._record_tool_call_result(doom_loop_signature, _is_error_result)
             if _is_error_result:
-                logger.warning(
-                    "Tool %s returned error (%.2fs): %s",
-                    function_name,
-                    tool_duration,
-                    result_preview,
-                )
+                logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
 
             if self.verbose_logging:
                 logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
@@ -3312,37 +2955,74 @@ class AIAgent:
             tool_msg = {
                 "role": "tool",
                 "content": function_result,
-                "tool_call_id": tool_call.id,
+                "tool_call_id": tool_call.id
             }
             messages.append(tool_msg)
 
             if not self.quiet_mode:
-                response_preview = (
-                    function_result[: self.log_prefix_chars] + "..."
-                    if len(function_result) > self.log_prefix_chars
-                    else function_result
-                )
-                print(
-                    f"  ✅ Tool {i} completed in {tool_duration:.2f}s - {response_preview}"
-                )
+                response_preview = function_result[:self.log_prefix_chars] + "..." if len(function_result) > self.log_prefix_chars else function_result
+                print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s - {response_preview}")
 
             if self._interrupt_requested and i < len(assistant_message.tool_calls):
                 remaining = len(assistant_message.tool_calls) - i
-                print(
-                    f"{self.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)"
-                )
+                print(f"{self.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)")
                 for skipped_tc in assistant_message.tool_calls[i:]:
                     skipped_name = skipped_tc.function.name
                     skip_msg = {
                         "role": "tool",
                         "content": f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
-                        "tool_call_id": skipped_tc.id,
+                        "tool_call_id": skipped_tc.id
                     }
                     messages.append(skip_msg)
                 break
 
             if self.tool_delay > 0 and i < len(assistant_message.tool_calls):
                 time.sleep(self.tool_delay)
+
+        # ── Budget pressure injection ─────────────────────────────────
+        # After all tool calls in this turn are processed, check if we're
+        # approaching max_iterations. If so, inject a warning into the LAST
+        # tool result's JSON so the LLM sees it naturally when reading results.
+        budget_warning = self._get_budget_warning(api_call_count)
+        if budget_warning and messages and messages[-1].get("role") == "tool":
+            last_content = messages[-1]["content"]
+            try:
+                parsed = json.loads(last_content)
+                if isinstance(parsed, dict):
+                    parsed["_budget_warning"] = budget_warning
+                    messages[-1]["content"] = json.dumps(parsed, ensure_ascii=False)
+                else:
+                    messages[-1]["content"] = last_content + f"\n\n{budget_warning}"
+            except (json.JSONDecodeError, TypeError):
+                messages[-1]["content"] = last_content + f"\n\n{budget_warning}"
+            if not self.quiet_mode:
+                remaining = self.max_iterations - api_call_count
+                tier = "⚠️  WARNING" if remaining <= self.max_iterations * 0.1 else "💡 CAUTION"
+                print(f"{self.log_prefix}{tier}: {remaining} iterations remaining")
+
+    def _get_budget_warning(self, api_call_count: int) -> Optional[str]:
+        """Return a budget pressure string, or None if not yet needed.
+
+        Two-tier system:
+          - Caution (70%): nudge to consolidate work
+          - Warning (90%): urgent, must respond now
+        """
+        if not self._budget_pressure_enabled or self.max_iterations <= 0:
+            return None
+        progress = api_call_count / self.max_iterations
+        remaining = self.max_iterations - api_call_count
+        if progress >= self._budget_warning_threshold:
+            return (
+                f"[BUDGET WARNING: Iteration {api_call_count}/{self.max_iterations}. "
+                f"Only {remaining} iteration(s) left. "
+                "Provide your final response NOW. No more tool calls unless absolutely critical.]"
+            )
+        if progress >= self._budget_caution_threshold:
+            return (
+                f"[BUDGET: Iteration {api_call_count}/{self.max_iterations}. "
+                f"{remaining} iterations left. Start consolidating your work.]"
+            )
+        return None
 
     def _make_doom_loop_signature(
         self, tool_name: str, function_args: dict
@@ -3413,11 +3093,7 @@ class AIAgent:
                 response = str(
                     self.clarify_callback(
                         question,
-                        [
-                            "Continue anyway",
-                            "Try different approach",
-                            "Stop and summarize",
-                        ],
+                        ["Continue anyway", "Try different approach", "Stop and summarize"],
                     )
                 ).strip()
             except Exception as exc:
@@ -3458,29 +3134,9 @@ class AIAgent:
         self._doom_loop_count = 0
         return True
 
-    def _get_budget_warning(self, api_call_count: int) -> Optional[str]:
-        if not self._budget_pressure_enabled or self.max_iterations <= 0:
-            return None
-        progress = api_call_count / self.max_iterations
-        remaining = self.max_iterations - api_call_count
-        if progress >= self._budget_warning_threshold:
-            return (
-                f"[BUDGET WARNING: Iteration {api_call_count}/{self.max_iterations}. "
-                f"Only {remaining} iteration(s) left. "
-                "Provide your final response NOW. No more tool calls unless absolutely critical.]"
-            )
-        if progress >= self._budget_caution_threshold:
-            return (
-                f"[BUDGET: Iteration {api_call_count}/{self.max_iterations}. "
-                f"{remaining} iterations left. Start consolidating your work.]"
-            )
-        return None
-
     def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
         """Request a summary when max iterations are reached. Returns the final response text."""
-        print(
-            f"⚠️  Reached maximum iterations ({self.max_iterations}). Requesting summary..."
-        )
+        print(f"⚠️  Reached maximum iterations ({self.max_iterations}). Requesting summary...")
 
         summary_request = (
             "You've reached the maximum number of tool-calling iterations allowed. "
@@ -3501,13 +3157,9 @@ class AIAgent:
 
             effective_system = self._cached_system_prompt or ""
             if self.ephemeral_system_prompt:
-                effective_system = (
-                    effective_system + "\n\n" + self.ephemeral_system_prompt
-                ).strip()
+                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
             if effective_system:
-                api_messages = [
-                    {"role": "system", "content": effective_system}
-                ] + api_messages
+                api_messages = [{"role": "system", "content": effective_system}] + api_messages
             if self.prefill_messages:
                 sys_offset = 1 if effective_system else 0
                 for idx, pfm in enumerate(self.prefill_messages):
@@ -3522,7 +3174,7 @@ class AIAgent:
                 else:
                     summary_extra_body["reasoning"] = {
                         "enabled": True,
-                        "effort": "medium",
+                        "effort": "medium"
                     }
             if _is_nous:
                 summary_extra_body["tags"] = ["product=hermes-agent"]
@@ -3532,11 +3184,7 @@ class AIAgent:
                 codex_kwargs.pop("tools", None)
                 summary_response = self._run_codex_stream(codex_kwargs)
                 assistant_message, _ = self._normalize_codex_response(summary_response)
-                final_response = (
-                    (assistant_message.content or "").strip()
-                    if assistant_message
-                    else ""
-                )
+                final_response = (assistant_message.content or "").strip() if assistant_message else ""
             else:
                 summary_kwargs = {
                     "model": self.model,
@@ -3563,25 +3211,18 @@ class AIAgent:
 
                 summary_response = self.client.chat.completions.create(**summary_kwargs)
 
-                if (
-                    summary_response.choices
-                    and summary_response.choices[0].message.content
-                ):
+                if summary_response.choices and summary_response.choices[0].message.content:
                     final_response = summary_response.choices[0].message.content
                 else:
                     final_response = ""
 
             if final_response:
                 if "<think>" in final_response:
-                    final_response = re.sub(
-                        r"<think>.*?</think>\s*", "", final_response, flags=re.DOTALL
-                    ).strip()
+                    final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
                 if final_response:
                     messages.append({"role": "assistant", "content": final_response})
                 else:
-                    final_response = (
-                        "I reached the iteration limit and couldn't generate a summary."
-                    )
+                    final_response = "I reached the iteration limit and couldn't generate a summary."
             else:
                 # Retry summary generation
                 if self.api_mode == "codex_responses":
@@ -3589,9 +3230,7 @@ class AIAgent:
                     codex_kwargs.pop("tools", None)
                     retry_response = self._run_codex_stream(codex_kwargs)
                     retry_msg, _ = self._normalize_codex_response(retry_response)
-                    final_response = (
-                        (retry_msg.content or "").strip() if retry_msg else ""
-                    )
+                    final_response = (retry_msg.content or "").strip() if retry_msg else ""
                 else:
                     summary_kwargs = {
                         "model": self.model,
@@ -3602,36 +3241,22 @@ class AIAgent:
                     if summary_extra_body:
                         summary_kwargs["extra_body"] = summary_extra_body
 
-                    summary_response = self.client.chat.completions.create(
-                        **summary_kwargs
-                    )
+                    summary_response = self.client.chat.completions.create(**summary_kwargs)
 
-                    if (
-                        summary_response.choices
-                        and summary_response.choices[0].message.content
-                    ):
+                    if summary_response.choices and summary_response.choices[0].message.content:
                         final_response = summary_response.choices[0].message.content
                     else:
                         final_response = ""
 
                 if final_response:
                     if "<think>" in final_response:
-                        final_response = re.sub(
-                            r"<think>.*?</think>\s*",
-                            "",
-                            final_response,
-                            flags=re.DOTALL,
-                        ).strip()
+                        final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
                     if final_response:
-                        messages.append(
-                            {"role": "assistant", "content": final_response}
-                        )
+                        messages.append({"role": "assistant", "content": final_response})
                     else:
                         final_response = "I reached the iteration limit and couldn't generate a summary."
                 else:
-                    final_response = (
-                        "I reached the iteration limit and couldn't generate a summary."
-                    )
+                    final_response = "I reached the iteration limit and couldn't generate a summary."
 
         except Exception as e:
             logging.warning(f"Failed to get summary response: {e}")
@@ -3644,7 +3269,7 @@ class AIAgent:
         user_message: str,
         system_message: str = None,
         conversation_history: List[Dict[str, Any]] = None,
-        task_id: str = None,
+        task_id: str = None
     ) -> Dict[str, Any]:
         """
         Run a complete conversation with tool calling until completion.
@@ -3660,7 +3285,7 @@ class AIAgent:
         """
         # Generate unique task_id if not provided to isolate VMs between concurrent tasks
         effective_task_id = task_id or str(uuid.uuid4())
-
+        
         # Reset retry counters and iteration budget at the start of each turn
         # so subagent usage from a previous turn doesn't eat into the next one.
         self._invalid_tool_retries = 0
@@ -3668,25 +3293,27 @@ class AIAgent:
         self._empty_content_retries = 0
         self._doom_loop_signature = None
         self._doom_loop_count = 0
+        self._incomplete_scratchpad_retries = 0
+        self._codex_incomplete_retries = 0
         self._last_content_with_tools = None
         self._turns_since_memory = 0
         self._iters_since_skill = 0
         self.iteration_budget = IterationBudget(self.max_iterations)
-
+        
         # Initialize conversation (copy to avoid mutating the caller's list)
         messages = list(conversation_history) if conversation_history else []
-
+        
         # Hydrate todo store from conversation history (gateway creates a fresh
         # AIAgent per message, so the in-memory store is empty -- we need to
         # recover the todo state from the most recent todo tool response in history)
         if conversation_history and not self._todo_store.has_items():
             self._hydrate_todo_store(conversation_history)
-
+        
         # Prefill messages (few-shot priming) are injected at API-call time only,
         # never stored in the messages list. This keeps them ephemeral: they won't
         # be saved to session DB, session logs, or batch trajectories, but they're
         # automatically re-applied on every API call (including session continuations).
-
+        
         # Track user turns for memory flush and periodic nudge logic
         self._user_turn_count += 1
 
@@ -3696,11 +3323,9 @@ class AIAgent:
 
         # Periodic memory nudge: remind the model to consider saving memories.
         # Counter resets whenever the memory tool is actually used.
-        if (
-            self._memory_nudge_interval > 0
-            and "memory" in self.valid_tool_names
-            and self._memory_store
-        ):
+        if (self._memory_nudge_interval > 0
+                and "memory" in self.valid_tool_names
+                and self._memory_store):
             self._turns_since_memory += 1
             if self._turns_since_memory >= self._memory_nudge_interval:
                 user_message += (
@@ -3711,11 +3336,9 @@ class AIAgent:
 
         # Skill creation nudge: fires on the first user message after a long tool loop.
         # The counter increments per API iteration in the tool loop and is checked here.
-        if (
-            self._skill_nudge_interval > 0
-            and self._iters_since_skill >= self._skill_nudge_interval
-            and "skill_manage" in self.valid_tool_names
-        ):
+        if (self._skill_nudge_interval > 0
+                and self._iters_since_skill >= self._skill_nudge_interval
+                and "skill_manage" in self.valid_tool_names):
             user_message += (
                 "\n\n[System: The previous task involved many steps. "
                 "If you discovered a reusable workflow, consider saving it as a skill.]"
@@ -3738,12 +3361,10 @@ class AIAgent:
         # Add user message
         user_msg = {"role": "user", "content": user_message}
         messages.append(user_msg)
-
+        
         if not self.quiet_mode:
-            print(
-                f"💬 Starting conversation: '{user_message[:60]}{'...' if len(user_message) > 60 else ''}'"
-            )
-
+            print(f"💬 Starting conversation: '{user_message[:60]}{'...' if len(user_message) > 60 else ''}'")
+        
         # ── System prompt (cached per session for prefix caching) ──
         # Built once on first call, reused for all subsequent calls.
         # Only rebuilt after context compression events (which invalidate
@@ -3781,9 +3402,7 @@ class AIAgent:
                 # Store the system prompt snapshot in SQLite
                 if self._session_db:
                     try:
-                        self._session_db.update_system_prompt(
-                            self.session_id, self._cached_system_prompt
-                        )
+                        self._session_db.update_system_prompt(self.session_id, self._cached_system_prompt)
                     except Exception as e:
                         logger.debug("Session DB update_system_prompt failed: %s", e)
 
@@ -3798,10 +3417,8 @@ class AIAgent:
         # 4xx and abort the request entirely).
         if (
             self.compression_enabled
-            and len(messages)
-            > self.context_compressor.protect_first_n
-            + self.context_compressor.protect_last_n
-            + 1
+            and len(messages) > self.context_compressor.protect_first_n
+                                + self.context_compressor.protect_last_n + 1
         ):
             _sys_tok_est = estimate_tokens_rough(active_system_prompt or "")
             _msg_tok_est = estimate_messages_tokens_rough(messages)
@@ -3825,9 +3442,7 @@ class AIAgent:
                 for _pass in range(3):
                     _orig_len = len(messages)
                     messages, active_system_prompt = self._compress_context(
-                        messages,
-                        system_message,
-                        approx_tokens=_preflight_tokens,
+                        messages, system_message, approx_tokens=_preflight_tokens,
                         task_id=effective_task_id,
                     )
                     if len(messages) >= _orig_len:
@@ -3846,13 +3461,11 @@ class AIAgent:
         codex_ack_continuations = 0
         length_continue_retries = 0
         truncated_response_prefix = ""
-
+        
         # Clear any stale interrupt state at start
         self.clear_interrupt()
-
-        while (
-            api_call_count < self.max_iterations and self.iteration_budget.remaining > 0
-        ):
+        
+        while api_call_count < self.max_iterations and self.iteration_budget.remaining > 0:
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot
             self._checkpoint_mgr.new_turn()
 
@@ -3862,13 +3475,11 @@ class AIAgent:
                 if not self.quiet_mode:
                     print(f"\n⚡ Breaking out of tool loop due to interrupt...")
                 break
-
+            
             api_call_count += 1
             if not self.iteration_budget.consume():
                 if not self.quiet_mode:
-                    print(
-                        f"\n⚠️  Session iteration budget exhausted ({self.iteration_budget.max_total} total across agent + subagents)"
-                    )
+                    print(f"\n⚠️  Session iteration budget exhausted ({self.iteration_budget.max_total} total across agent + subagents)")
                 break
 
             # Fire step_callback for gateway hooks (agent:step event)
@@ -3885,20 +3496,14 @@ class AIAgent:
                             break
                     self.step_callback(api_call_count, prev_tools)
                 except Exception as _step_err:
-                    logger.debug(
-                        "step_callback error (iteration %s): %s",
-                        api_call_count,
-                        _step_err,
-                    )
+                    logger.debug("step_callback error (iteration %s): %s", api_call_count, _step_err)
 
             # Track tool-calling iterations for skill nudge.
             # Counter resets whenever skill_manage is actually used.
-            if (
-                self._skill_nudge_interval > 0
-                and "skill_manage" in self.valid_tool_names
-            ):
+            if (self._skill_nudge_interval > 0
+                    and "skill_manage" in self.valid_tool_names):
                 self._iters_since_skill += 1
-
+            
             # Prepare messages for API call
             # If we have an ephemeral system prompt, prepend it to the messages
             # Note: Reasoning is embedded in content via <think> tags for trajectory storage.
@@ -3936,13 +3541,9 @@ class AIAgent:
             # session, maximizing Anthropic prompt cache hits.
             effective_system = active_system_prompt or ""
             if self.ephemeral_system_prompt:
-                effective_system = (
-                    effective_system + "\n\n" + self.ephemeral_system_prompt
-                ).strip()
+                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
             if effective_system:
-                api_messages = [
-                    {"role": "system", "content": effective_system}
-                ] + api_messages
+                api_messages = [{"role": "system", "content": effective_system}] + api_messages
 
             # Inject ephemeral prefill messages right after the system prompt
             # but before conversation history. Same API-call-time-only pattern.
@@ -3956,36 +3557,26 @@ class AIAgent:
             # inject cache_control breakpoints (system + last 3 messages) to reduce
             # input token costs by ~75% on multi-turn conversations.
             if self._use_prompt_caching:
-                api_messages = apply_anthropic_cache_control(
-                    api_messages, cache_ttl=self._cache_ttl
-                )
+                api_messages = apply_anthropic_cache_control(api_messages, cache_ttl=self._cache_ttl)
 
             # Safety net: strip orphaned tool results / add stubs for missing
             # results before sending to the API.  The compressor handles this
             # during compression, but orphans can also sneak in from session
             # loading or manual message manipulation.
-            if hasattr(self, "context_compressor") and self.context_compressor:
-                api_messages = self.context_compressor._sanitize_tool_pairs(
-                    api_messages
-                )
+            if hasattr(self, 'context_compressor') and self.context_compressor:
+                api_messages = self.context_compressor._sanitize_tool_pairs(api_messages)
 
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)
             approx_tokens = total_chars // 4  # Rough estimate: 4 chars per token
-
+            
             # Thinking spinner for quiet mode (animated during API call)
             thinking_spinner = None
-
+            
             if not self.quiet_mode:
-                print(
-                    f"\n{self.log_prefix}🔄 Making API call #{api_call_count}/{self.max_iterations}..."
-                )
-                print(
-                    f"{self.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)"
-                )
-                print(
-                    f"{self.log_prefix}   🔧 Available tools: {len(self.tools) if self.tools else 0}"
-                )
+                print(f"\n{self.log_prefix}🔄 Making API call #{api_call_count}/{self.max_iterations}...")
+                print(f"{self.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)")
+                print(f"{self.log_prefix}   🔧 Available tools: {len(self.tools) if self.tools else 0}")
             else:
                 # Animated thinking spinner in quiet mode
                 face = random.choice(KawaiiSpinner.KAWAII_THINKING)
@@ -3994,27 +3585,19 @@ class AIAgent:
                     # CLI TUI mode: use prompt_toolkit widget instead of raw spinner
                     self.thinking_callback(f"{face} {verb}...")
                 else:
-                    spinner_type = random.choice(
-                        ["brain", "sparkle", "pulse", "moon", "star"]
-                    )
-                    thinking_spinner = KawaiiSpinner(
-                        f"{face} {verb}...", spinner_type=spinner_type
-                    )
+                    spinner_type = random.choice(['brain', 'sparkle', 'pulse', 'moon', 'star'])
+                    thinking_spinner = KawaiiSpinner(f"{face} {verb}...", spinner_type=spinner_type)
                     thinking_spinner.start()
-
+            
             # Log request details if verbose
             if self.verbose_logging:
-                logging.debug(
-                    f"API Request - Model: {self.model}, Messages: {len(messages)}, Tools: {len(self.tools) if self.tools else 0}"
-                )
-                logging.debug(
-                    f"Last message role: {messages[-1]['role'] if messages else 'none'}"
-                )
+                logging.debug(f"API Request - Model: {self.model}, Messages: {len(messages)}, Tools: {len(self.tools) if self.tools else 0}")
+                logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
                 logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
-
+            
             api_start_time = time.time()
             retry_count = 0
-            max_retries = 6  # Increased to allow longer backoff periods
+            max_retries = 3
             compression_attempts = 0
             max_compression_attempts = 3
             codex_auth_retry_attempted = False
@@ -4029,22 +3612,15 @@ class AIAgent:
                 try:
                     api_kwargs = self._build_api_kwargs(api_messages)
                     if self.api_mode == "codex_responses":
-                        api_kwargs = self._preflight_codex_api_kwargs(
-                            api_kwargs, allow_stream=False
-                        )
+                        api_kwargs = self._preflight_codex_api_kwargs(api_kwargs, allow_stream=False)
 
-                    if os.getenv("HERMES_DUMP_REQUESTS", "").strip().lower() in {
-                        "1",
-                        "true",
-                        "yes",
-                        "on",
-                    }:
+                    if os.getenv("HERMES_DUMP_REQUESTS", "").strip().lower() in {"1", "true", "yes", "on"}:
                         self._dump_api_request_debug(api_kwargs, reason="preflight")
 
                     response = self._interruptible_api_call(api_kwargs)
-
+                    
                     api_duration = time.time() - api_start_time
-
+                    
                     # Stop thinking spinner silently -- the response box or tool
                     # execution messages that follow are more informative.
                     if thinking_spinner:
@@ -4052,30 +3628,20 @@ class AIAgent:
                         thinking_spinner = None
                     if self.thinking_callback:
                         self.thinking_callback("")
-
+                    
                     if not self.quiet_mode:
-                        print(
-                            f"{self.log_prefix}⏱️  API call completed in {api_duration:.2f}s"
-                        )
-
+                        print(f"{self.log_prefix}⏱️  API call completed in {api_duration:.2f}s")
+                    
                     if self.verbose_logging:
                         # Log response with provider info if available
-                        resp_model = (
-                            getattr(response, "model", "N/A") if response else "N/A"
-                        )
-                        logging.debug(
-                            f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}"
-                        )
-
+                        resp_model = getattr(response, 'model', 'N/A') if response else 'N/A'
+                        logging.debug(f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}")
+                    
                     # Validate response shape before proceeding
                     response_invalid = False
                     error_details = []
                     if self.api_mode == "codex_responses":
-                        output_items = (
-                            getattr(response, "output", None)
-                            if response is not None
-                            else None
-                        )
+                        output_items = getattr(response, "output", None) if response is not None else None
                         if response is None:
                             response_invalid = True
                             error_details.append("response is None")
@@ -4086,19 +3652,12 @@ class AIAgent:
                             response_invalid = True
                             error_details.append("response.output is empty")
                     else:
-                        if (
-                            response is None
-                            or not hasattr(response, "choices")
-                            or response.choices is None
-                            or len(response.choices) == 0
-                        ):
+                        if response is None or not hasattr(response, 'choices') or response.choices is None or len(response.choices) == 0:
                             response_invalid = True
                             if response is None:
                                 error_details.append("response is None")
-                            elif not hasattr(response, "choices"):
-                                error_details.append(
-                                    "response has no 'choices' attribute"
-                                )
+                            elif not hasattr(response, 'choices'):
+                                error_details.append("response has no 'choices' attribute")
                             elif response.choices is None:
                                 error_details.append("response.choices is None")
                             else:
@@ -4111,101 +3670,63 @@ class AIAgent:
                             thinking_spinner = None
                         if self.thinking_callback:
                             self.thinking_callback("")
-
+                        
                         # This is often rate limiting or provider returning malformed response
                         retry_count += 1
-
+                        
                         # Check for error field in response (some providers include this)
                         error_msg = "Unknown"
                         provider_name = "Unknown"
-                        if response and hasattr(response, "error") and response.error:
+                        if response and hasattr(response, 'error') and response.error:
                             error_msg = str(response.error)
                             # Try to extract provider from error metadata
-                            if (
-                                hasattr(response.error, "metadata")
-                                and response.error.metadata
-                            ):
-                                provider_name = response.error.metadata.get(
-                                    "provider_name", "Unknown"
-                                )
-                        elif (
-                            response
-                            and hasattr(response, "message")
-                            and response.message
-                        ):
+                            if hasattr(response.error, 'metadata') and response.error.metadata:
+                                provider_name = response.error.metadata.get('provider_name', 'Unknown')
+                        elif response and hasattr(response, 'message') and response.message:
                             error_msg = str(response.message)
-
+                        
                         # Try to get provider from model field (OpenRouter often returns actual model used)
-                        if (
-                            provider_name == "Unknown"
-                            and response
-                            and hasattr(response, "model")
-                            and response.model
-                        ):
+                        if provider_name == "Unknown" and response and hasattr(response, 'model') and response.model:
                             provider_name = f"model={response.model}"
-
+                        
                         # Check for x-openrouter-provider or similar metadata
                         if provider_name == "Unknown" and response:
                             # Log all response attributes for debugging
-                            resp_attrs = {
-                                k: str(v)[:100]
-                                for k, v in vars(response).items()
-                                if not k.startswith("_")
-                            }
+                            resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
                             if self.verbose_logging:
-                                logging.debug(
-                                    f"Response attributes for invalid response: {resp_attrs}"
-                                )
-
-                        print(
-                            f"{self.log_prefix}⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}"
-                        )
+                                logging.debug(f"Response attributes for invalid response: {resp_attrs}")
+                        
+                        print(f"{self.log_prefix}⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}")
                         print(f"{self.log_prefix}   🏢 Provider: {provider_name}")
-                        print(
-                            f"{self.log_prefix}   📝 Provider message: {error_msg[:200]}"
-                        )
-                        print(
-                            f"{self.log_prefix}   ⏱️  Response time: {api_duration:.2f}s (fast response often indicates rate limiting)"
-                        )
-
+                        print(f"{self.log_prefix}   📝 Provider message: {error_msg[:200]}")
+                        print(f"{self.log_prefix}   ⏱️  Response time: {api_duration:.2f}s (fast response often indicates rate limiting)")
+                        
                         if retry_count >= max_retries:
                             # Try fallback before giving up
                             if self._try_activate_fallback():
                                 retry_count = 0
                                 continue
-                            print(
-                                f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up."
-                            )
-                            logging.error(
-                                f"{self.log_prefix}Invalid API response after {max_retries} retries."
-                            )
+                            print(f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
+                            logging.error(f"{self.log_prefix}Invalid API response after {max_retries} retries.")
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": "Invalid API response shape. Likely rate limited or malformed provider response.",
-                                "failed": True,  # Mark as failure for filtering
+                                "failed": True  # Mark as failure for filtering
                             }
-
+                        
                         # Longer backoff for rate limiting (likely cause of None choices)
-                        wait_time = min(
-                            5 * (2 ** (retry_count - 1)), 120
-                        )  # 5s, 10s, 20s, 40s, 80s, 120s
-                        print(
-                            f"{self.log_prefix}⏳ Retrying in {wait_time}s (extended backoff for possible rate limit)..."
-                        )
-                        logging.warning(
-                            f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}"
-                        )
-
+                        wait_time = min(5 * (2 ** (retry_count - 1)), 120)  # 5s, 10s, 20s, 40s, 80s, 120s
+                        print(f"{self.log_prefix}⏳ Retrying in {wait_time}s (extended backoff for possible rate limit)...")
+                        logging.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
+                        
                         # Sleep in small increments to stay responsive to interrupts
                         sleep_end = time.time() + wait_time
                         while time.time() < sleep_end:
                             if self._interrupt_requested:
-                                print(
-                                    f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting."
-                                )
+                                print(f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting.")
                                 self._persist_session(messages, conversation_history)
                                 self.clear_interrupt()
                                 return {
@@ -4221,20 +3742,13 @@ class AIAgent:
                     # Check finish_reason before proceeding
                     if self.api_mode == "codex_responses":
                         status = getattr(response, "status", None)
-                        incomplete_details = getattr(
-                            response, "incomplete_details", None
-                        )
+                        incomplete_details = getattr(response, "incomplete_details", None)
                         incomplete_reason = None
                         if isinstance(incomplete_details, dict):
                             incomplete_reason = incomplete_details.get("reason")
                         else:
-                            incomplete_reason = getattr(
-                                incomplete_details, "reason", None
-                            )
-                        if status == "incomplete" and incomplete_reason in {
-                            "max_output_tokens",
-                            "length",
-                        }:
+                            incomplete_reason = getattr(incomplete_details, "reason", None)
+                        if status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"}:
                             finish_reason = "length"
                         else:
                             finish_reason = "stop"
@@ -4242,22 +3756,16 @@ class AIAgent:
                         finish_reason = response.choices[0].finish_reason
 
                     if finish_reason == "length":
-                        print(
-                            f"{self.log_prefix}⚠️  Response truncated (finish_reason='length') - model hit max output tokens"
-                        )
+                        print(f"{self.log_prefix}⚠️  Response truncated (finish_reason='length') - model hit max output tokens")
 
                         if self.api_mode == "chat_completions":
                             assistant_message = response.choices[0].message
                             if not assistant_message.tool_calls:
                                 length_continue_retries += 1
-                                interim_msg = self._build_assistant_message(
-                                    assistant_message, finish_reason
-                                )
+                                interim_msg = self._build_assistant_message(assistant_message, finish_reason)
                                 messages.append(interim_msg)
                                 if assistant_message.content:
-                                    truncated_response_prefix += (
-                                        assistant_message.content
-                                    )
+                                    truncated_response_prefix += assistant_message.content
 
                                 if length_continue_retries < 3:
                                     print(
@@ -4278,9 +3786,7 @@ class AIAgent:
                                     restart_with_length_continuation = True
                                     break
 
-                                partial_response = self._strip_think_blocks(
-                                    truncated_response_prefix
-                                ).strip()
+                                partial_response = self._strip_think_blocks(truncated_response_prefix).strip()
                                 self._cleanup_task_resources(effective_task_id)
                                 self._persist_session(messages, conversation_history)
                                 return {
@@ -4294,12 +3800,8 @@ class AIAgent:
 
                         # If we have prior messages, roll back to last complete state
                         if len(messages) > 1:
-                            print(
-                                f"{self.log_prefix}   ⏪ Rolling back to last complete assistant turn"
-                            )
-                            rolled_back_messages = (
-                                self._get_messages_up_to_last_assistant(messages)
-                            )
+                            print(f"{self.log_prefix}   ⏪ Rolling back to last complete assistant turn")
+                            rolled_back_messages = self._get_messages_up_to_last_assistant(messages)
 
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
@@ -4310,13 +3812,11 @@ class AIAgent:
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
-                                "error": "Response truncated due to output length limit",
+                                "error": "Response truncated due to output length limit"
                             }
                         else:
                             # First message was truncated - mark as failed
-                            print(
-                                f"{self.log_prefix}❌ First response truncated - cannot recover"
-                            )
+                            print(f"{self.log_prefix}❌ First response truncated - cannot recover")
                             self._persist_session(messages, conversation_history)
                             return {
                                 "final_response": None,
@@ -4324,31 +3824,22 @@ class AIAgent:
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "failed": True,
-                                "error": "First response truncated due to output length limit",
+                                "error": "First response truncated due to output length limit"
                             }
-
+                    
                     # Track actual token usage from response for context management
-                    if hasattr(response, "usage") and response.usage:
+                    if hasattr(response, 'usage') and response.usage:
                         if self.api_mode == "codex_responses":
-                            prompt_tokens = (
-                                getattr(response.usage, "input_tokens", 0) or 0
-                            )
-                            completion_tokens = (
-                                getattr(response.usage, "output_tokens", 0) or 0
-                            )
-                            total_tokens = getattr(
-                                response.usage, "total_tokens", None
-                            ) or (prompt_tokens + completion_tokens)
-                        else:
-                            prompt_tokens = (
-                                getattr(response.usage, "prompt_tokens", 0) or 0
-                            )
-                            completion_tokens = (
-                                getattr(response.usage, "completion_tokens", 0) or 0
-                            )
+                            prompt_tokens = getattr(response.usage, 'input_tokens', 0) or 0
+                            completion_tokens = getattr(response.usage, 'output_tokens', 0) or 0
                             total_tokens = (
-                                getattr(response.usage, "total_tokens", 0) or 0
+                                getattr(response.usage, 'total_tokens', None)
+                                or (prompt_tokens + completion_tokens)
                             )
+                        else:
+                            prompt_tokens = getattr(response.usage, 'prompt_tokens', 0) or 0
+                            completion_tokens = getattr(response.usage, 'completion_tokens', 0) or 0
+                            total_tokens = getattr(response.usage, 'total_tokens', 0) or 0
                         usage_dict = {
                             "prompt_tokens": prompt_tokens,
                             "completion_tokens": completion_tokens,
@@ -4360,43 +3851,27 @@ class AIAgent:
                         if self.context_compressor._context_probed:
                             ctx = self.context_compressor.context_length
                             save_context_length(self.model, self.base_url, ctx)
-                            print(
-                                f"{self.log_prefix}💾 Cached context length: {ctx:,} tokens for {self.model}"
-                            )
+                            print(f"{self.log_prefix}💾 Cached context length: {ctx:,} tokens for {self.model}")
                             self.context_compressor._context_probed = False
 
                         self.session_prompt_tokens += prompt_tokens
                         self.session_completion_tokens += completion_tokens
                         self.session_total_tokens += total_tokens
                         self.session_api_calls += 1
-
+                        
                         if self.verbose_logging:
-                            logging.debug(
-                                f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}"
-                            )
-
+                            logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
+                        
                         # Log cache hit stats when prompt caching is active
                         if self._use_prompt_caching:
-                            details = getattr(
-                                response.usage, "prompt_tokens_details", None
-                            )
-                            cached = (
-                                getattr(details, "cached_tokens", 0) or 0
-                                if details
-                                else 0
-                            )
-                            written = (
-                                getattr(details, "cache_write_tokens", 0) or 0
-                                if details
-                                else 0
-                            )
+                            details = getattr(response.usage, 'prompt_tokens_details', None)
+                            cached = getattr(details, 'cached_tokens', 0) or 0 if details else 0
+                            written = getattr(details, 'cache_write_tokens', 0) or 0 if details else 0
                             prompt = usage_dict["prompt_tokens"]
                             hit_pct = (cached / prompt * 100) if prompt > 0 else 0
                             if not self.quiet_mode:
-                                print(
-                                    f"{self.log_prefix}   💾 Cache: {cached:,}/{prompt:,} tokens ({hit_pct:.0f}% hit, {written:,} written)"
-                                )
-
+                                print(f"{self.log_prefix}   💾 Cache: {cached:,}/{prompt:,} tokens ({hit_pct:.0f}% hit, {written:,} written)")
+                    
                     break  # Success, exit retry loop
 
                 except InterruptedError:
@@ -4429,9 +3904,7 @@ class AIAgent:
                     ):
                         codex_auth_retry_attempted = True
                         if self._try_refresh_codex_client_credentials(force=True):
-                            print(
-                                f"{self.log_prefix}🔐 Codex auth refreshed after 401. Retrying request..."
-                            )
+                            print(f"{self.log_prefix}🔐 Codex auth refreshed after 401. Retrying request...")
                             continue
                     if (
                         self.api_mode == "chat_completions"
@@ -4441,34 +3914,24 @@ class AIAgent:
                     ):
                         nous_auth_retry_attempted = True
                         if self._try_refresh_nous_client_credentials(force=True):
-                            print(
-                                f"{self.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request..."
-                            )
+                            print(f"{self.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request...")
                             continue
 
                     retry_count += 1
                     elapsed_time = time.time() - api_start_time
-
+                    
                     # Enhanced error logging
                     error_type = type(api_error).__name__
                     error_msg = str(api_error).lower()
-
-                    print(
-                        f"{self.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}"
-                    )
-                    print(
-                        f"{self.log_prefix}   ⏱️  Time elapsed before failure: {elapsed_time:.2f}s"
-                    )
+                    
+                    print(f"{self.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}")
+                    print(f"{self.log_prefix}   ⏱️  Time elapsed before failure: {elapsed_time:.2f}s")
                     print(f"{self.log_prefix}   📝 Error: {str(api_error)[:200]}")
-                    print(
-                        f"{self.log_prefix}   📊 Request context: {len(api_messages)} messages, ~{approx_tokens:,} tokens, {len(self.tools) if self.tools else 0} tools"
-                    )
-
+                    print(f"{self.log_prefix}   📊 Request context: {len(api_messages)} messages, ~{approx_tokens:,} tokens, {len(self.tools) if self.tools else 0} tools")
+                    
                     # Check for interrupt before deciding to retry
                     if self._interrupt_requested:
-                        print(
-                            f"{self.log_prefix}⚡ Interrupt detected during error handling, aborting retries."
-                        )
+                        print(f"{self.log_prefix}⚡ Interrupt detected during error handling, aborting retries.")
                         self._persist_session(messages, conversation_history)
                         self.clear_interrupt()
                         return {
@@ -4478,89 +3941,67 @@ class AIAgent:
                             "completed": False,
                             "interrupted": True,
                         }
-
+                    
                     # Check for 413 payload-too-large BEFORE generic 4xx handler.
                     # A 413 is a payload-size error — the correct response is to
                     # compress history and retry, not abort immediately.
                     status_code = getattr(api_error, "status_code", None)
                     is_payload_too_large = (
                         status_code == 413
-                        or "request entity too large" in error_msg
-                        or "payload too large" in error_msg
-                        or "error code: 413" in error_msg
+                        or 'request entity too large' in error_msg
+                        or 'payload too large' in error_msg
+                        or 'error code: 413' in error_msg
                     )
 
                     if is_payload_too_large:
                         compression_attempts += 1
                         if compression_attempts > max_compression_attempts:
-                            print(
-                                f"{self.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached for payload-too-large error."
-                            )
-                            logging.error(
-                                f"{self.log_prefix}413 compression failed after {max_compression_attempts} attempts."
-                            )
+                            print(f"{self.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached for payload-too-large error.")
+                            logging.error(f"{self.log_prefix}413 compression failed after {max_compression_attempts} attempts.")
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": f"Request payload too large: max compression attempts ({max_compression_attempts}) reached.",
-                                "partial": True,
+                                "partial": True
                             }
-                        print(
-                            f"{self.log_prefix}⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}..."
-                        )
+                        print(f"{self.log_prefix}⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
 
                         original_len = len(messages)
                         messages, active_system_prompt = self._compress_context(
-                            messages,
-                            system_message,
-                            approx_tokens=approx_tokens,
+                            messages, system_message, approx_tokens=approx_tokens,
                             task_id=effective_task_id,
                         )
 
                         if len(messages) < original_len:
-                            print(
-                                f"{self.log_prefix}   🗜️  Compressed {original_len} → {len(messages)} messages, retrying..."
-                            )
+                            print(f"{self.log_prefix}   🗜️  Compressed {original_len} → {len(messages)} messages, retrying...")
                             time.sleep(2)  # Brief pause between compression retries
                             restart_with_compressed_messages = True
                             break
                         else:
-                            print(
-                                f"{self.log_prefix}❌ Payload too large and cannot compress further."
-                            )
-                            logging.error(
-                                f"{self.log_prefix}413 payload too large. Cannot compress further."
-                            )
+                            print(f"{self.log_prefix}❌ Payload too large and cannot compress further.")
+                            logging.error(f"{self.log_prefix}413 payload too large. Cannot compress further.")
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": "Request payload too large (413). Cannot compress further.",
-                                "partial": True,
+                                "partial": True
                             }
 
                     # Check for context-length errors BEFORE generic 4xx handler.
                     # Local backends (LM Studio, Ollama, llama.cpp) often return
                     # HTTP 400 with messages like "Context size has been exceeded"
                     # which must trigger compression, not an immediate abort.
-                    is_context_length_error = any(
-                        phrase in error_msg
-                        for phrase in [
-                            "context length",
-                            "context size",
-                            "maximum context",
-                            "token limit",
-                            "too many tokens",
-                            "reduce the length",
-                            "exceeds the limit",
-                            "context window",
-                            "request entity too large",  # OpenRouter/Nous 413 safety net
-                        ]
-                    )
-
+                    is_context_length_error = any(phrase in error_msg for phrase in [
+                        'context length', 'context size', 'maximum context',
+                        'token limit', 'too many tokens', 'reduce the length',
+                        'exceeds the limit', 'context window',
+                        'request entity too large',  # OpenRouter/Nous 413 safety net
+                    ])
+                    
                     if is_context_length_error:
                         compressor = self.context_compressor
                         old_ctx = compressor.context_length
@@ -4569,117 +4010,74 @@ class AIAgent:
                         parsed_limit = parse_context_limit_from_error(error_msg)
                         if parsed_limit and parsed_limit < old_ctx:
                             new_ctx = parsed_limit
-                            print(
-                                f"{self.log_prefix}⚠️  Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})"
-                            )
+                            print(f"{self.log_prefix}⚠️  Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})")
                         else:
                             # Step down to the next probe tier
                             new_ctx = get_next_probe_tier(old_ctx)
 
                         if new_ctx and new_ctx < old_ctx:
                             compressor.context_length = new_ctx
-                            compressor.threshold_tokens = int(
-                                new_ctx * compressor.threshold_percent
-                            )
+                            compressor.threshold_tokens = int(new_ctx * compressor.threshold_percent)
                             compressor._context_probed = True
-                            print(
-                                f"{self.log_prefix}⚠️  Context length exceeded — stepping down: {old_ctx:,} → {new_ctx:,} tokens"
-                            )
+                            print(f"{self.log_prefix}⚠️  Context length exceeded — stepping down: {old_ctx:,} → {new_ctx:,} tokens")
                         else:
-                            print(
-                                f"{self.log_prefix}⚠️  Context length exceeded at minimum tier — attempting compression..."
-                            )
+                            print(f"{self.log_prefix}⚠️  Context length exceeded at minimum tier — attempting compression...")
 
                         compression_attempts += 1
                         if compression_attempts > max_compression_attempts:
-                            print(
-                                f"{self.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached."
-                            )
-                            logging.error(
-                                f"{self.log_prefix}Context compression failed after {max_compression_attempts} attempts."
-                            )
+                            print(f"{self.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.")
+                            logging.error(f"{self.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached.",
-                                "partial": True,
+                                "partial": True
                             }
-                        print(
-                            f"{self.log_prefix}   🗜️  Context compression attempt {compression_attempts}/{max_compression_attempts}..."
-                        )
+                        print(f"{self.log_prefix}   🗜️  Context compression attempt {compression_attempts}/{max_compression_attempts}...")
 
                         original_len = len(messages)
                         messages, active_system_prompt = self._compress_context(
-                            messages,
-                            system_message,
-                            approx_tokens=approx_tokens,
+                            messages, system_message, approx_tokens=approx_tokens,
                             task_id=effective_task_id,
                         )
 
-                        if (
-                            len(messages) < original_len
-                            or new_ctx
-                            and new_ctx < old_ctx
-                        ):
+                        if len(messages) < original_len or new_ctx and new_ctx < old_ctx:
                             if len(messages) < original_len:
-                                print(
-                                    f"{self.log_prefix}   🗜️  Compressed {original_len} → {len(messages)} messages, retrying..."
-                                )
+                                print(f"{self.log_prefix}   🗜️  Compressed {original_len} → {len(messages)} messages, retrying...")
                             time.sleep(2)  # Brief pause between compression retries
                             restart_with_compressed_messages = True
                             break
                         else:
                             # Can't compress further and already at minimum tier
-                            print(
-                                f"{self.log_prefix}❌ Context length exceeded and cannot compress further."
-                            )
-                            print(
-                                f"{self.log_prefix}   💡 The conversation has accumulated too much content."
-                            )
-                            logging.error(
-                                f"{self.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further."
-                            )
+                            print(f"{self.log_prefix}❌ Context length exceeded and cannot compress further.")
+                            print(f"{self.log_prefix}   💡 The conversation has accumulated too much content.")
+                            logging.error(f"{self.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": f"Context length exceeded ({approx_tokens:,} tokens). Cannot compress further.",
-                                "partial": True,
+                                "partial": True
                             }
 
                     # Check for non-retryable client errors (4xx HTTP status codes).
                     # These indicate a problem with the request itself (bad model ID,
                     # invalid API key, forbidden, etc.) and will never succeed on retry.
                     # Note: 413 and context-length errors are excluded — handled above.
-                    is_client_status_error = (
-                        isinstance(status_code, int)
-                        and 400 <= status_code < 500
-                        and status_code != 413
-                    )
-                    is_client_error = (
-                        is_client_status_error
-                        or any(
-                            phrase in error_msg
-                            for phrase in [
-                                "error code: 401",
-                                "error code: 403",
-                                "error code: 404",
-                                "error code: 422",
-                                "is not a valid model",
-                                "invalid model",
-                                "model not found",
-                                "invalid api key",
-                                "invalid_api_key",
-                                "authentication",
-                                "unauthorized",
-                                "forbidden",
-                                "not found",
-                            ]
-                        )
-                    ) and not is_context_length_error
+                    # Also catch local validation errors (ValueError, TypeError) — these
+                    # are programming bugs, not transient failures.
+                    is_local_validation_error = isinstance(api_error, (ValueError, TypeError))
+                    is_client_status_error = isinstance(status_code, int) and 400 <= status_code < 500 and status_code != 413
+                    is_client_error = (is_local_validation_error or is_client_status_error or any(phrase in error_msg for phrase in [
+                        'error code: 401', 'error code: 403',
+                        'error code: 404', 'error code: 422',
+                        'is not a valid model', 'invalid model', 'model not found',
+                        'invalid api key', 'invalid_api_key', 'authentication',
+                        'unauthorized', 'forbidden', 'not found',
+                    ])) and not is_context_length_error
 
                     if is_client_error:
                         # Try fallback before aborting — a different provider
@@ -4688,19 +4086,11 @@ class AIAgent:
                             retry_count = 0
                             continue
                         self._dump_api_request_debug(
-                            api_kwargs,
-                            reason="non_retryable_client_error",
-                            error=api_error,
+                            api_kwargs, reason="non_retryable_client_error", error=api_error,
                         )
-                        print(
-                            f"{self.log_prefix}❌ Non-retryable client error detected. Aborting immediately."
-                        )
-                        print(
-                            f"{self.log_prefix}   💡 This type of error won't be fixed by retrying."
-                        )
-                        logging.error(
-                            f"{self.log_prefix}Non-retryable client error: {api_error}"
-                        )
+                        print(f"{self.log_prefix}❌ Non-retryable client error detected. Aborting immediately.")
+                        print(f"{self.log_prefix}   💡 This type of error won't be fixed by retrying.")
+                        logging.error(f"{self.log_prefix}Non-retryable client error: {api_error}")
                         self._persist_session(messages, conversation_history)
                         return {
                             "final_response": None,
@@ -4716,37 +4106,23 @@ class AIAgent:
                         if self._try_activate_fallback():
                             retry_count = 0
                             continue
-                        print(
-                            f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded. Giving up."
-                        )
-                        logging.error(
-                            f"{self.log_prefix}API call failed after {max_retries} retries. Last error: {api_error}"
-                        )
-                        logging.error(
-                            f"{self.log_prefix}Request details - Messages: {len(api_messages)}, Approx tokens: {approx_tokens:,}"
-                        )
+                        print(f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded. Giving up.")
+                        logging.error(f"{self.log_prefix}API call failed after {max_retries} retries. Last error: {api_error}")
+                        logging.error(f"{self.log_prefix}Request details - Messages: {len(api_messages)}, Approx tokens: {approx_tokens:,}")
                         raise api_error
 
-                    wait_time = min(
-                        2**retry_count, 60
-                    )  # Exponential backoff: 2s, 4s, 8s, 16s, 32s, 60s, 60s
-                    logging.warning(
-                        f"API retry {retry_count}/{max_retries} after error: {api_error}"
-                    )
+                    wait_time = min(2 ** retry_count, 60)  # Exponential backoff: 2s, 4s, 8s, 16s, 32s, 60s, 60s
+                    logging.warning(f"API retry {retry_count}/{max_retries} after error: {api_error}")
                     if retry_count >= max_retries:
-                        print(
-                            f"{self.log_prefix}⚠️  API call failed after {retry_count} attempts: {str(api_error)[:100]}"
-                        )
+                        print(f"{self.log_prefix}⚠️  API call failed after {retry_count} attempts: {str(api_error)[:100]}")
                         print(f"{self.log_prefix}⏳ Final retry in {wait_time}s...")
-
+                    
                     # Sleep in small increments so we can respond to interrupts quickly
                     # instead of blocking the entire wait_time in one sleep() call
                     sleep_end = time.time() + wait_time
                     while time.time() < sleep_end:
                         if self._interrupt_requested:
-                            print(
-                                f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting."
-                            )
+                            print(f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting.")
                             self._persist_session(messages, conversation_history)
                             self.clear_interrupt()
                             return {
@@ -4757,7 +4133,7 @@ class AIAgent:
                                 "interrupted": True,
                             }
                         time.sleep(0.2)  # Check interrupt every 200ms
-
+            
             # If the API call was interrupted, skip response processing
             if interrupted:
                 break
@@ -4774,33 +4150,23 @@ class AIAgent:
             # (e.g. repeated context-length errors that exhausted retry_count),
             # the `response` variable is still None. Break out cleanly.
             if response is None:
-                print(
-                    f"{self.log_prefix}❌ All API retries exhausted with no successful response."
-                )
+                print(f"{self.log_prefix}❌ All API retries exhausted with no successful response.")
                 self._persist_session(messages, conversation_history)
                 break
 
             try:
                 if self.api_mode == "codex_responses":
-                    assistant_message, finish_reason = self._normalize_codex_response(
-                        response
-                    )
+                    assistant_message, finish_reason = self._normalize_codex_response(response)
                 else:
                     assistant_message = response.choices[0].message
-
+                
                 # Normalize content to string — some OpenAI-compatible servers
                 # (llama-server, etc.) return content as a dict or list instead
                 # of a plain string, which crashes downstream .strip() calls.
-                if assistant_message.content is not None and not isinstance(
-                    assistant_message.content, str
-                ):
+                if assistant_message.content is not None and not isinstance(assistant_message.content, str):
                     raw = assistant_message.content
                     if isinstance(raw, dict):
-                        assistant_message.content = (
-                            raw.get("text", "")
-                            or raw.get("content", "")
-                            or json.dumps(raw)
-                        )
+                        assistant_message.content = raw.get("text", "") or raw.get("content", "") or json.dumps(raw)
                     elif isinstance(raw, list):
                         # Multimodal content list — extract text parts
                         parts = []
@@ -4817,72 +4183,59 @@ class AIAgent:
 
                 # Handle assistant response
                 if assistant_message.content and not self.quiet_mode:
-                    print(
-                        f"{self.log_prefix}🤖 Assistant: {assistant_message.content[:100]}{'...' if len(assistant_message.content) > 100 else ''}"
-                    )
+                    print(f"{self.log_prefix}🤖 Assistant: {assistant_message.content[:100]}{'...' if len(assistant_message.content) > 100 else ''}")
 
                 # Notify progress callback of model's thinking (used by subagent
                 # delegation to relay the child's reasoning to the parent display).
                 # Guard: only fire for subagents (_delegate_depth >= 1) to avoid
                 # spamming gateway platforms with the main agent's every thought.
-                if (
-                    assistant_message.content
-                    and self.tool_progress_callback
-                    and getattr(self, "_delegate_depth", 0) > 0
-                ):
+                if (assistant_message.content and self.tool_progress_callback
+                        and getattr(self, '_delegate_depth', 0) > 0):
                     _think_text = assistant_message.content.strip()
                     # Strip reasoning XML tags that shouldn't leak to parent display
                     _think_text = re.sub(
-                        r"</?(?:REASONING_SCRATCHPAD|think|reasoning)>", "", _think_text
+                        r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
                     ).strip()
-                    first_line = _think_text.split("\n")[0][:80] if _think_text else ""
+                    first_line = _think_text.split('\n')[0][:80] if _think_text else ""
                     if first_line:
                         try:
                             self.tool_progress_callback("_thinking", first_line)
                         except Exception:
                             pass
-
+                
                 # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
                 # This means the model ran out of output tokens mid-reasoning — retry up to 2 times
                 if has_incomplete_scratchpad(assistant_message.content or ""):
-                    if not hasattr(self, "_incomplete_scratchpad_retries"):
+                    if not hasattr(self, '_incomplete_scratchpad_retries'):
                         self._incomplete_scratchpad_retries = 0
                     self._incomplete_scratchpad_retries += 1
-
-                    print(
-                        f"{self.log_prefix}⚠️  Incomplete <REASONING_SCRATCHPAD> detected (opened but never closed)"
-                    )
-
+                    
+                    print(f"{self.log_prefix}⚠️  Incomplete <REASONING_SCRATCHPAD> detected (opened but never closed)")
+                    
                     if self._incomplete_scratchpad_retries <= 2:
-                        print(
-                            f"{self.log_prefix}🔄 Retrying API call ({self._incomplete_scratchpad_retries}/2)..."
-                        )
+                        print(f"{self.log_prefix}🔄 Retrying API call ({self._incomplete_scratchpad_retries}/2)...")
                         # Don't add the broken message, just retry
                         continue
                     else:
                         # Max retries - discard this turn and save as partial
-                        print(
-                            f"{self.log_prefix}❌ Max retries (2) for incomplete scratchpad. Saving as partial."
-                        )
+                        print(f"{self.log_prefix}❌ Max retries (2) for incomplete scratchpad. Saving as partial.")
                         self._incomplete_scratchpad_retries = 0
-
-                        rolled_back_messages = self._get_messages_up_to_last_assistant(
-                            messages
-                        )
+                        
+                        rolled_back_messages = self._get_messages_up_to_last_assistant(messages)
                         self._cleanup_task_resources(effective_task_id)
                         self._persist_session(messages, conversation_history)
-
+                        
                         return {
                             "final_response": None,
                             "messages": rolled_back_messages,
                             "api_calls": api_call_count,
                             "completed": False,
                             "partial": True,
-                            "error": "Incomplete REASONING_SCRATCHPAD after 2 retries",
+                            "error": "Incomplete REASONING_SCRATCHPAD after 2 retries"
                         }
-
+                
                 # Reset incomplete scratchpad counter on clean response
-                if hasattr(self, "_incomplete_scratchpad_retries"):
+                if hasattr(self, '_incomplete_scratchpad_retries'):
                     self._incomplete_scratchpad_retries = 0
 
                 if self.api_mode == "codex_responses" and finish_reason == "incomplete":
@@ -4890,17 +4243,9 @@ class AIAgent:
                         self._codex_incomplete_retries = 0
                     self._codex_incomplete_retries += 1
 
-                    interim_msg = self._build_assistant_message(
-                        assistant_message, finish_reason
-                    )
-                    interim_has_content = bool(
-                        (interim_msg.get("content") or "").strip()
-                    )
-                    interim_has_reasoning = (
-                        bool(interim_msg.get("reasoning", "").strip())
-                        if isinstance(interim_msg.get("reasoning"), str)
-                        else False
-                    )
+                    interim_msg = self._build_assistant_message(assistant_message, finish_reason)
+                    interim_has_content = bool((interim_msg.get("content") or "").strip())
+                    interim_has_reasoning = bool(interim_msg.get("reasoning", "").strip()) if isinstance(interim_msg.get("reasoning"), str) else False
 
                     if interim_has_content or interim_has_reasoning:
                         last_msg = messages[-1] if messages else None
@@ -4908,19 +4253,15 @@ class AIAgent:
                             isinstance(last_msg, dict)
                             and last_msg.get("role") == "assistant"
                             and last_msg.get("finish_reason") == "incomplete"
-                            and (last_msg.get("content") or "")
-                            == (interim_msg.get("content") or "")
-                            and (last_msg.get("reasoning") or "")
-                            == (interim_msg.get("reasoning") or "")
+                            and (last_msg.get("content") or "") == (interim_msg.get("content") or "")
+                            and (last_msg.get("reasoning") or "") == (interim_msg.get("reasoning") or "")
                         )
                         if not duplicate_interim:
                             messages.append(interim_msg)
 
                     if self._codex_incomplete_retries < 3:
                         if not self.quiet_mode:
-                            print(
-                                f"{self.log_prefix}↻ Codex response incomplete; continuing turn ({self._codex_incomplete_retries}/3)"
-                            )
+                            print(f"{self.log_prefix}↻ Codex response incomplete; continuing turn ({self._codex_incomplete_retries}/3)")
                         self._session_messages = messages
                         self._save_session_log(messages)
                         continue
@@ -4937,68 +4278,51 @@ class AIAgent:
                     }
                 elif hasattr(self, "_codex_incomplete_retries"):
                     self._codex_incomplete_retries = 0
-
+                
                 # Check for tool calls
                 if assistant_message.tool_calls:
                     if not self.quiet_mode:
-                        print(
-                            f"{self.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)..."
-                        )
-
+                        print(f"{self.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)...")
+                    
                     if self.verbose_logging:
                         for tc in assistant_message.tool_calls:
-                            logging.debug(
-                                f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}..."
-                            )
-
+                            logging.debug(f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}...")
+                    
                     # Validate tool call names - detect model hallucinations
                     # Repair mismatched tool names before validating
                     for tc in assistant_message.tool_calls:
                         if tc.function.name not in self.valid_tool_names:
                             repaired = self._repair_tool_call(tc.function.name)
                             if repaired:
-                                print(
-                                    f"{self.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'"
-                                )
+                                print(f"{self.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'")
                                 tc.function.name = repaired
                     invalid_tool_calls = [
-                        tc.function.name
-                        for tc in assistant_message.tool_calls
+                        tc.function.name for tc in assistant_message.tool_calls
                         if tc.function.name not in self.valid_tool_names
                     ]
                     if invalid_tool_calls:
                         # Return helpful error to model — model can self-correct next turn
                         available = ", ".join(sorted(self.valid_tool_names))
                         invalid_name = invalid_tool_calls[0]
-                        invalid_preview = (
-                            invalid_name[:80] + "..."
-                            if len(invalid_name) > 80
-                            else invalid_name
-                        )
-                        print(
-                            f"{self.log_prefix}⚠️  Unknown tool '{invalid_preview}' — sending error to model for self-correction"
-                        )
-                        assistant_msg = self._build_assistant_message(
-                            assistant_message, finish_reason
-                        )
+                        invalid_preview = invalid_name[:80] + "..." if len(invalid_name) > 80 else invalid_name
+                        print(f"{self.log_prefix}⚠️  Unknown tool '{invalid_preview}' — sending error to model for self-correction")
+                        assistant_msg = self._build_assistant_message(assistant_message, finish_reason)
                         messages.append(assistant_msg)
                         for tc in assistant_message.tool_calls:
                             if tc.function.name not in self.valid_tool_names:
                                 content = f"Tool '{tc.function.name}' does not exist. Available tools: {available}"
                             else:
                                 content = f"Skipped: another tool call in this turn used an invalid name. Please retry this tool call."
-                            messages.append(
-                                {
-                                    "role": "tool",
-                                    "tool_call_id": tc.id,
-                                    "content": content,
-                                }
-                            )
+                            messages.append({
+                                "role": "tool",
+                                "tool_call_id": tc.id,
+                                "content": content,
+                            })
                         continue
                     # Reset retry counter on successful tool call validation
-                    if hasattr(self, "_invalid_tool_retries"):
+                    if hasattr(self, '_invalid_tool_retries'):
                         self._invalid_tool_retries = 0
-
+                    
                     # Validate tool call arguments are valid JSON
                     # Handle empty strings as empty objects (common model quirk)
                     invalid_json_args = []
@@ -5012,29 +4336,23 @@ class AIAgent:
                             json.loads(args)
                         except json.JSONDecodeError as e:
                             invalid_json_args.append((tc.function.name, str(e)))
-
+                    
                     if invalid_json_args:
                         # Track retries for invalid JSON arguments
                         self._invalid_json_retries += 1
-
+                        
                         tool_name, error_msg = invalid_json_args[0]
-                        print(
-                            f"{self.log_prefix}⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}"
-                        )
-
+                        print(f"{self.log_prefix}⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}")
+                        
                         if self._invalid_json_retries < 3:
-                            print(
-                                f"{self.log_prefix}🔄 Retrying API call ({self._invalid_json_retries}/3)..."
-                            )
+                            print(f"{self.log_prefix}🔄 Retrying API call ({self._invalid_json_retries}/3)...")
                             # Don't add anything to messages, just retry the API call
                             continue
                         else:
                             # Instead of returning partial, inject a helpful message and let model recover
-                            print(
-                                f"{self.log_prefix}⚠️  Injecting recovery message for invalid JSON..."
-                            )
+                            print(f"{self.log_prefix}⚠️  Injecting recovery message for invalid JSON...")
                             self._invalid_json_retries = 0  # Reset for next attempt
-
+                            
                             # Add a user message explaining the issue
                             recovery_msg = (
                                 f"Your tool call to '{tool_name}' had invalid JSON arguments. "
@@ -5045,157 +4363,119 @@ class AIAgent:
                             recovery_dict = {"role": "user", "content": recovery_msg}
                             messages.append(recovery_dict)
                             continue
-
+                    
                     # Reset retry counter on successful JSON validation
                     self._invalid_json_retries = 0
-
-                    assistant_msg = self._build_assistant_message(
-                        assistant_message, finish_reason
-                    )
-
+                    
+                    assistant_msg = self._build_assistant_message(assistant_message, finish_reason)
+                    
                     # If this turn has both content AND tool_calls, capture the content
                     # as a fallback final response. Common pattern: model delivers its
                     # answer and calls memory/skill tools as a side-effect in the same
                     # turn. If the follow-up turn after tools is empty, we use this.
                     turn_content = assistant_message.content or ""
-                    if turn_content and self._has_content_after_think_block(
-                        turn_content
-                    ):
+                    if turn_content and self._has_content_after_think_block(turn_content):
                         self._last_content_with_tools = turn_content
                         # Show intermediate commentary so the user can follow along
                         if self.quiet_mode:
                             clean = self._strip_think_blocks(turn_content).strip()
                             if clean:
                                 print(f"  ┊ 💬 {clean}")
-
+                    
                     messages.append(assistant_msg)
-
-                    self._execute_tool_calls(
-                        assistant_message, messages, effective_task_id, api_call_count
-                    )
+                    
+                    self._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
 
                     # Refund the iteration if the ONLY tool(s) called were
                     # execute_code (programmatic tool calling).  These are
                     # cheap RPC-style calls that shouldn't eat the budget.
-                    _tc_names = {
-                        tc.function.name for tc in assistant_message.tool_calls
-                    }
+                    _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
                     if _tc_names == {"execute_code"}:
                         self.iteration_budget.refund()
-
-                    if (
-                        self.compression_enabled
-                        and self.context_compressor.should_compress()
-                    ):
+                    
+                    if self.compression_enabled and self.context_compressor.should_compress():
                         messages, active_system_prompt = self._compress_context(
-                            messages,
-                            system_message,
+                            messages, system_message,
                             approx_tokens=self.context_compressor.last_prompt_tokens,
                             task_id=effective_task_id,
                         )
-
+                    
                     # Save session log incrementally (so progress is visible even if interrupted)
                     self._session_messages = messages
                     self._save_session_log(messages)
-
+                    
                     # Continue loop for next response
                     continue
-
+                
                 else:
                     # No tool calls - this is the final response
                     final_response = assistant_message.content or ""
-
+                    
                     # Check if response only has think block with no actual content after it
                     if not self._has_content_after_think_block(final_response):
                         # If the previous turn already delivered real content alongside
                         # tool calls (e.g. "You're welcome!" + memory save), the model
                         # has nothing more to say. Use the earlier content immediately
                         # instead of wasting API calls on retries that won't help.
-                        fallback = getattr(self, "_last_content_with_tools", None)
+                        fallback = getattr(self, '_last_content_with_tools', None)
                         if fallback:
-                            logger.debug(
-                                "Empty follow-up after tool calls — using prior turn content as final response"
-                            )
+                            logger.debug("Empty follow-up after tool calls — using prior turn content as final response")
                             self._last_content_with_tools = None
                             self._empty_content_retries = 0
                             for i in range(len(messages) - 1, -1, -1):
                                 msg = messages[i]
-                                if msg.get("role") == "assistant" and msg.get(
-                                    "tool_calls"
-                                ):
+                                if msg.get("role") == "assistant" and msg.get("tool_calls"):
                                     tool_names = []
                                     for tc in msg["tool_calls"]:
                                         fn = tc.get("function", {})
                                         tool_names.append(fn.get("name", "unknown"))
-                                    msg["content"] = (
-                                        f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
-                                    )
+                                    msg["content"] = f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
                                     break
                             final_response = self._strip_think_blocks(fallback).strip()
                             break
 
                         # No fallback available — this is a genuine empty response.
                         # Retry in case the model just had a bad generation.
-                        if not hasattr(self, "_empty_content_retries"):
+                        if not hasattr(self, '_empty_content_retries'):
                             self._empty_content_retries = 0
                         self._empty_content_retries += 1
-
+                        
                         reasoning_text = self._extract_reasoning(assistant_message)
-                        print(
-                            f"{self.log_prefix}⚠️  Response only contains think block with no content after it"
-                        )
+                        print(f"{self.log_prefix}⚠️  Response only contains think block with no content after it")
                         if reasoning_text:
-                            reasoning_preview = (
-                                reasoning_text[:500] + "..."
-                                if len(reasoning_text) > 500
-                                else reasoning_text
-                            )
+                            reasoning_preview = reasoning_text[:500] + "..." if len(reasoning_text) > 500 else reasoning_text
                             print(f"{self.log_prefix}   Reasoning: {reasoning_preview}")
                         else:
-                            content_preview = (
-                                final_response[:80] + "..."
-                                if len(final_response) > 80
-                                else final_response
-                            )
+                            content_preview = final_response[:80] + "..." if len(final_response) > 80 else final_response
                             print(f"{self.log_prefix}   Content: '{content_preview}'")
-
+                        
                         if self._empty_content_retries < 3:
-                            print(
-                                f"{self.log_prefix}🔄 Retrying API call ({self._empty_content_retries}/3)..."
-                            )
+                            print(f"{self.log_prefix}🔄 Retrying API call ({self._empty_content_retries}/3)...")
                             continue
                         else:
-                            print(
-                                f"{self.log_prefix}❌ Max retries (3) for empty content exceeded."
-                            )
+                            print(f"{self.log_prefix}❌ Max retries (3) for empty content exceeded.")
                             self._empty_content_retries = 0
-
+                            
                             # If a prior tool_calls turn had real content, salvage it:
                             # rewrite that turn's content to a brief tool description,
                             # and use the original content as the final response here.
-                            fallback = getattr(self, "_last_content_with_tools", None)
+                            fallback = getattr(self, '_last_content_with_tools', None)
                             if fallback:
                                 self._last_content_with_tools = None
                                 # Find the last assistant message with tool_calls and rewrite it
                                 for i in range(len(messages) - 1, -1, -1):
                                     msg = messages[i]
-                                    if msg.get("role") == "assistant" and msg.get(
-                                        "tool_calls"
-                                    ):
+                                    if msg.get("role") == "assistant" and msg.get("tool_calls"):
                                         tool_names = []
                                         for tc in msg["tool_calls"]:
                                             fn = tc.get("function", {})
                                             tool_names.append(fn.get("name", "unknown"))
-                                        msg["content"] = (
-                                            f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
-                                        )
+                                        msg["content"] = f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
                                         break
                                 # Strip <think> blocks from fallback content for user display
-                                final_response = self._strip_think_blocks(
-                                    fallback
-                                ).strip()
+                                final_response = self._strip_think_blocks(fallback).strip()
                                 break
-
+                            
                             # No fallback -- append the empty message as-is
                             empty_msg = {
                                 "role": "assistant",
@@ -5204,21 +4484,21 @@ class AIAgent:
                                 "finish_reason": finish_reason,
                             }
                             messages.append(empty_msg)
-
+                            
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
-
+                            
                             return {
                                 "final_response": final_response or None,
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
-                                "error": "Model generated only think blocks with no actual response after 3 retries",
+                                "error": "Model generated only think blocks with no actual response after 3 retries"
                             }
-
+                    
                     # Reset retry counter on successful content
-                    if hasattr(self, "_empty_content_retries"):
+                    if hasattr(self, '_empty_content_retries'):
                         self._empty_content_retries = 0
 
                     if (
@@ -5232,9 +4512,7 @@ class AIAgent:
                         )
                     ):
                         codex_ack_continuations += 1
-                        interim_msg = self._build_assistant_message(
-                            assistant_message, "incomplete"
-                        )
+                        interim_msg = self._build_assistant_message(assistant_message, "incomplete")
                         messages.append(interim_msg)
 
                         continue_msg = {
@@ -5253,29 +4531,25 @@ class AIAgent:
 
                     if truncated_response_prefix:
                         final_response = truncated_response_prefix + final_response
-
+                    
                     # Strip <think> blocks from user-facing response (keep raw in messages for trajectory)
                     final_response = self._strip_think_blocks(final_response).strip()
-
-                    final_msg = self._build_assistant_message(
-                        assistant_message, finish_reason
-                    )
-
+                    
+                    final_msg = self._build_assistant_message(assistant_message, finish_reason)
+                    
                     messages.append(final_msg)
-
+                    
                     if not self.quiet_mode:
-                        print(
-                            f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)"
-                        )
+                        print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
                     break
-
+                
             except Exception as e:
                 error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
                 print(f"❌ {error_msg}")
-
+                
                 if self.verbose_logging:
                     logging.exception("Detailed error information:")
-
+                
                 # If an assistant message with tool_calls was already appended,
                 # the API expects a role="tool" result for every tool_call_id.
                 # Fill in error results for any that weren't answered yet.
@@ -5289,7 +4563,7 @@ class AIAgent:
                     if msg.get("role") == "assistant" and msg.get("tool_calls"):
                         answered_ids = {
                             m["tool_call_id"]
-                            for m in messages[idx + 1 :]
+                            for m in messages[idx + 1:]
                             if isinstance(m, dict) and m.get("role") == "tool"
                         }
                         for tc in msg["tool_calls"]:
@@ -5302,7 +4576,7 @@ class AIAgent:
                                 messages.append(err_msg)
                         pending_handled = True
                     break
-
+                
                 if not pending_handled:
                     # Error happened before tool processing (e.g. response parsing).
                     # Use a user-role message so the model can see what went wrong
@@ -5312,24 +4586,20 @@ class AIAgent:
                         "content": f"[System error during processing: {error_msg}]",
                     }
                     messages.append(sys_err_msg)
-
+                
                 # If we're near the limit, break to avoid infinite loops
                 if api_call_count >= self.max_iterations - 1:
-                    final_response = (
-                        f"I apologize, but I encountered repeated errors: {error_msg}"
-                    )
+                    final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
                     break
-
+        
         if final_response is None and (
             api_call_count >= self.max_iterations
             or self.iteration_budget.remaining <= 0
         ):
             if self.iteration_budget.remaining <= 0 and not self.quiet_mode:
-                print(
-                    f"\n⚠️  Session iteration budget exhausted ({self.iteration_budget.used}/{self.iteration_budget.max_total} used, including subagents)"
-                )
+                print(f"\n⚠️  Session iteration budget exhausted ({self.iteration_budget.used}/{self.iteration_budget.max_total} used, including subagents)")
             final_response = self._handle_max_iterations(messages, api_call_count)
-
+        
         # Determine if conversation completed successfully
         completed = final_response is not None and api_call_count < self.max_iterations
 
@@ -5346,32 +4616,40 @@ class AIAgent:
         if final_response and not interrupted:
             self._honcho_sync(original_user_message, final_response)
 
+        # Extract reasoning from the last assistant message (if any)
+        last_reasoning = None
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant" and msg.get("reasoning"):
+                last_reasoning = msg["reasoning"]
+                break
+
         # Build result with interrupt info if applicable
         result = {
             "final_response": final_response,
+            "last_reasoning": last_reasoning,
             "messages": messages,
             "api_calls": api_call_count,
             "completed": completed,
             "partial": False,  # True only when stopped due to invalid tool calls
             "interrupted": interrupted,
         }
-
+        
         # Include interrupt message if one triggered the interrupt
         if interrupted and self._interrupt_message:
             result["interrupt_message"] = self._interrupt_message
-
+        
         # Clear interrupt state after handling
         self.clear_interrupt()
-
+        
         return result
-
+    
     def chat(self, message: str) -> str:
         """
         Simple chat interface that returns just the final response.
-
+        
         Args:
             message (str): User message
-
+            
         Returns:
             str: Final assistant response
         """
@@ -5391,7 +4669,7 @@ def main(
     save_trajectories: bool = False,
     save_sample: bool = False,
     verbose: bool = False,
-    log_prefix_chars: int = 20,
+    log_prefix_chars: int = 20
 ):
     """
     Main function for running the agent directly.
@@ -5417,69 +4695,58 @@ def main(
     """
     print("🤖 AI Agent with Tool Calling")
     print("=" * 50)
-
+    
     # Handle tool listing
     if list_tools:
-        from model_tools import (
-            get_all_tool_names,
-            get_toolset_for_tool,
-            get_available_toolsets,
-        )
+        from model_tools import get_all_tool_names, get_toolset_for_tool, get_available_toolsets
         from toolsets import get_all_toolsets, get_toolset_info
-
+        
         print("📋 Available Tools & Toolsets:")
         print("-" * 50)
-
+        
         # Show new toolsets system
         print("\n🎯 Predefined Toolsets (New System):")
         print("-" * 40)
         all_toolsets = get_all_toolsets()
-
+        
         # Group by category
         basic_toolsets = []
         composite_toolsets = []
         scenario_toolsets = []
-
+        
         for name, toolset in all_toolsets.items():
             info = get_toolset_info(name)
             if info:
                 entry = (name, info)
                 if name in ["web", "terminal", "vision", "creative", "reasoning"]:
                     basic_toolsets.append(entry)
-                elif name in [
-                    "research",
-                    "development",
-                    "analysis",
-                    "content_creation",
-                    "full_stack",
-                ]:
+                elif name in ["research", "development", "analysis", "content_creation", "full_stack"]:
                     composite_toolsets.append(entry)
                 else:
                     scenario_toolsets.append(entry)
-
+        
         # Print basic toolsets
         print("\n📌 Basic Toolsets:")
         for name, info in basic_toolsets:
-            tools_str = (
-                ", ".join(info["resolved_tools"]) if info["resolved_tools"] else "none"
-            )
+            tools_str = ', '.join(info['resolved_tools']) if info['resolved_tools'] else 'none'
             print(f"  • {name:15} - {info['description']}")
             print(f"    Tools: {tools_str}")
-
+        
         # Print composite toolsets
         print("\n📂 Composite Toolsets (built from other toolsets):")
         for name, info in composite_toolsets:
-            includes_str = ", ".join(info["includes"]) if info["includes"] else "none"
+            includes_str = ', '.join(info['includes']) if info['includes'] else 'none'
             print(f"  • {name:15} - {info['description']}")
             print(f"    Includes: {includes_str}")
             print(f"    Total tools: {info['tool_count']}")
-
+        
         # Print scenario-specific toolsets
         print("\n🎭 Scenario-Specific Toolsets:")
         for name, info in scenario_toolsets:
             print(f"  • {name:20} - {info['description']}")
             print(f"    Total tools: {info['tool_count']}")
-
+        
+        
         # Show legacy toolset compatibility
         print("\n📦 Legacy Toolsets (for backward compatibility):")
         legacy_toolsets = get_available_toolsets()
@@ -5488,57 +4755,47 @@ def main(
             print(f"  {status} {name}: {info['description']}")
             if not info["available"]:
                 print(f"    Requirements: {', '.join(info['requirements'])}")
-
+        
         # Show individual tools
         all_tools = get_all_tool_names()
         print(f"\n🔧 Individual Tools ({len(all_tools)} available):")
         for tool_name in sorted(all_tools):
             toolset = get_toolset_for_tool(tool_name)
             print(f"  📌 {tool_name} (from {toolset})")
-
+        
         print(f"\n💡 Usage Examples:")
         print(f"  # Use predefined toolsets")
-        print(
-            f"  python run_agent.py --enabled_toolsets=research --query='search for Python news'"
-        )
-        print(
-            f"  python run_agent.py --enabled_toolsets=development --query='debug this code'"
-        )
-        print(
-            f"  python run_agent.py --enabled_toolsets=safe --query='analyze without terminal'"
-        )
+        print(f"  python run_agent.py --enabled_toolsets=research --query='search for Python news'")
+        print(f"  python run_agent.py --enabled_toolsets=development --query='debug this code'")
+        print(f"  python run_agent.py --enabled_toolsets=safe --query='analyze without terminal'")
         print(f"  ")
         print(f"  # Combine multiple toolsets")
-        print(
-            f"  python run_agent.py --enabled_toolsets=web,vision --query='analyze website'"
-        )
+        print(f"  python run_agent.py --enabled_toolsets=web,vision --query='analyze website'")
         print(f"  ")
         print(f"  # Disable toolsets")
-        print(
-            f"  python run_agent.py --disabled_toolsets=terminal --query='no command execution'"
-        )
+        print(f"  python run_agent.py --disabled_toolsets=terminal --query='no command execution'")
         print(f"  ")
         print(f"  # Run with trajectory saving enabled")
         print(f"  python run_agent.py --save_trajectories --query='your question here'")
         return
-
+    
     # Parse toolset selection arguments
     enabled_toolsets_list = None
     disabled_toolsets_list = None
-
+    
     if enabled_toolsets:
         enabled_toolsets_list = [t.strip() for t in enabled_toolsets.split(",")]
         print(f"🎯 Enabled toolsets: {enabled_toolsets_list}")
-
+    
     if disabled_toolsets:
         disabled_toolsets_list = [t.strip() for t in disabled_toolsets.split(",")]
         print(f"🚫 Disabled toolsets: {disabled_toolsets_list}")
-
+    
     if save_trajectories:
         print(f"💾 Trajectory saving: ENABLED")
         print(f"   - Successful conversations → trajectory_samples.jsonl")
         print(f"   - Failed conversations → failed_trajectories.jsonl")
-
+    
     # Initialize agent with provided parameters
     try:
         agent = AIAgent(
@@ -5550,12 +4807,12 @@ def main(
             disabled_toolsets=disabled_toolsets_list,
             save_trajectories=save_trajectories,
             verbose_logging=verbose,
-            log_prefix_chars=log_prefix_chars,
+            log_prefix_chars=log_prefix_chars
         )
     except RuntimeError as e:
         print(f"❌ Failed to initialize agent: {e}")
         return
-
+    
     # Use provided query or default to Python 3.13 example
     if query is None:
         user_query = (
@@ -5564,43 +4821,45 @@ def main(
         )
     else:
         user_query = query
-
+    
     print(f"\n📝 User Query: {user_query}")
     print("\n" + "=" * 50)
-
+    
     # Run conversation
     result = agent.run_conversation(user_query)
-
+    
     print("\n" + "=" * 50)
     print("📋 CONVERSATION SUMMARY")
     print("=" * 50)
     print(f"✅ Completed: {result['completed']}")
     print(f"📞 API Calls: {result['api_calls']}")
     print(f"💬 Messages: {len(result['messages'])}")
-
-    if result["final_response"]:
+    
+    if result['final_response']:
         print(f"\n🎯 FINAL RESPONSE:")
         print("-" * 30)
-        print(result["final_response"])
-
+        print(result['final_response'])
+    
     # Save sample trajectory to UUID-named file if requested
     if save_sample:
         sample_id = str(uuid.uuid4())[:8]
         sample_filename = f"sample_{sample_id}.json"
-
+        
         # Convert messages to trajectory format (same as batch_runner)
         trajectory = agent._convert_to_trajectory_format(
-            result["messages"], user_query, result["completed"]
+            result['messages'], 
+            user_query, 
+            result['completed']
         )
-
+        
         entry = {
             "conversations": trajectory,
             "timestamp": datetime.now().isoformat(),
             "model": model,
-            "completed": result["completed"],
-            "query": user_query,
+            "completed": result['completed'],
+            "query": user_query
         }
-
+        
         try:
             with open(sample_filename, "w", encoding="utf-8") as f:
                 # Pretty-print JSON with indent for readability
@@ -5608,7 +4867,7 @@ def main(
             print(f"\n💾 Sample trajectory saved to: {sample_filename}")
         except Exception as e:
             print(f"\n⚠️ Failed to save sample: {e}")
-
+    
     print("\n👋 Agent execution completed!")
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -98,6 +98,8 @@ from agent.trajectory import (
     save_trajectory as _save_trajectory_to_file,
 )
 
+DOOM_LOOP_THRESHOLD = 3
+
 
 class IterationBudget:
     """Thread-safe shared iteration counter for parent and child agents.
@@ -263,6 +265,8 @@ class AIAgent:
         self.clarify_callback = clarify_callback
         self.step_callback = step_callback
         self._last_reported_tool = None  # Track for "new tool" mode
+        self._doom_loop_signature = None
+        self._doom_loop_count = 0
         
         # Interrupt mechanism for breaking out of tool loops
         self._interrupt_requested = False
@@ -2734,6 +2738,16 @@ class AIAgent:
             if not isinstance(function_args, dict):
                 function_args = {}
 
+            doom_loop_signature = self._make_doom_loop_signature(function_name, function_args)
+            if self._should_trigger_doom_loop(doom_loop_signature):
+                if self._handle_doom_loop(
+                    assistant_message=assistant_message,
+                    messages=messages,
+                    tool_call_index=i - 1,
+                    tool_name=function_name,
+                ):
+                    break
+
             if not self.quiet_mode:
                 args_str = json.dumps(function_args, ensure_ascii=False)
                 args_preview = args_str[:self.log_prefix_chars] + "..." if len(args_str) > self.log_prefix_chars else args_str
@@ -2898,6 +2912,7 @@ class AIAgent:
             # Log tool errors to the persistent error log so [error] tags
             # in the UI always have a corresponding detailed entry on disk.
             _is_error_result, _ = _detect_tool_failure(function_name, function_result)
+            self._record_tool_call_result(doom_loop_signature, _is_error_result)
             if _is_error_result:
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
 
@@ -2945,50 +2960,115 @@ class AIAgent:
             if self.tool_delay > 0 and i < len(assistant_message.tool_calls):
                 time.sleep(self.tool_delay)
 
-        # ── Budget pressure injection ─────────────────────────────────
-        # After all tool calls in this turn are processed, check if we're
-        # approaching max_iterations. If so, inject a warning into the LAST
-        # tool result's JSON so the LLM sees it naturally when reading results.
-        budget_warning = self._get_budget_warning(api_call_count)
-        if budget_warning and messages and messages[-1].get("role") == "tool":
-            last_content = messages[-1]["content"]
-            try:
-                parsed = json.loads(last_content)
-                if isinstance(parsed, dict):
-                    parsed["_budget_warning"] = budget_warning
-                    messages[-1]["content"] = json.dumps(parsed, ensure_ascii=False)
-                else:
-                    messages[-1]["content"] = last_content + f"\n\n{budget_warning}"
-            except (json.JSONDecodeError, TypeError):
-                messages[-1]["content"] = last_content + f"\n\n{budget_warning}"
-            if not self.quiet_mode:
-                remaining = self.max_iterations - api_call_count
-                tier = "⚠️  WARNING" if remaining <= self.max_iterations * 0.1 else "💡 CAUTION"
-                print(f"{self.log_prefix}{tier}: {remaining} iterations remaining")
-
-    def _get_budget_warning(self, api_call_count: int) -> Optional[str]:
-        """Return a budget pressure string, or None if not yet needed.
-
-        Two-tier system:
-          - Caution (70%): nudge to consolidate work
-          - Warning (90%): urgent, must respond now
-        """
-        if not self._budget_pressure_enabled or self.max_iterations <= 0:
+    def _make_doom_loop_signature(self, tool_name: str, function_args: dict) -> Optional[tuple[str, str]]:
+        if self._is_doom_loop_exempt(tool_name, function_args):
             return None
-        progress = api_call_count / self.max_iterations
-        remaining = self.max_iterations - api_call_count
-        if progress >= self._budget_warning_threshold:
-            return (
-                f"[BUDGET WARNING: Iteration {api_call_count}/{self.max_iterations}. "
-                f"Only {remaining} iteration(s) left. "
-                "Provide your final response NOW. No more tool calls unless absolutely critical.]"
+
+        normalized_args = json.dumps(
+            function_args,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        args_hash = hashlib.md5(normalized_args.encode("utf-8")).hexdigest()
+        return tool_name, args_hash
+
+    @staticmethod
+    def _is_doom_loop_exempt(tool_name: str, function_args: dict) -> bool:
+        if tool_name != "process":
+            return False
+
+        action = str(function_args.get("action", "")).lower()
+        return action in {"poll", "wait", "log"}
+
+    def _should_trigger_doom_loop(self, signature: Optional[tuple[str, str]]) -> bool:
+        return (
+            signature is not None
+            and self._doom_loop_signature == signature
+            and self._doom_loop_count >= DOOM_LOOP_THRESHOLD - 1
+        )
+
+    def _record_tool_call_result(self, signature: Optional[tuple[str, str]], is_error_result: bool) -> None:
+        if signature is None or is_error_result:
+            self._doom_loop_signature = None
+            self._doom_loop_count = 0
+            return
+
+        if self._doom_loop_signature == signature:
+            self._doom_loop_count += 1
+            return
+
+        self._doom_loop_signature = signature
+        self._doom_loop_count = 1
+
+    def _handle_doom_loop(
+        self,
+        assistant_message,
+        messages: list,
+        tool_call_index: int,
+        tool_name: str,
+    ) -> bool:
+        logger.warning(
+            "Doom loop detected for %s after %s identical calls",
+            tool_name,
+            DOOM_LOOP_THRESHOLD,
+        )
+
+        question = (
+            f"Hermes detected a doom loop: the agent has tried the same '{tool_name}' "
+            f"tool call with the same arguments {DOOM_LOOP_THRESHOLD} times in a row. "
+            "What should it do?"
+        )
+        response = ""
+        if self.platform == "cli" and self.clarify_callback is not None:
+            try:
+                response = str(
+                    self.clarify_callback(
+                        question,
+                        ["Continue anyway", "Try different approach", "Stop and summarize"],
+                    )
+                ).strip()
+            except Exception as exc:
+                logging.warning(f"Doom loop clarify callback failed: {exc}")
+
+        normalized_response = response.lower()
+        if "continue" in normalized_response:
+            self._doom_loop_signature = None
+            self._doom_loop_count = 0
+            return False
+
+        skip_content = (
+            f"[Tool execution skipped - doom loop detected: '{tool_name}' was about to be called "
+            f"{DOOM_LOOP_THRESHOLD} times in a row with the same arguments]"
+        )
+        for skipped_tc in assistant_message.tool_calls[tool_call_index:]:
+            skip_msg = {
+                "role": "tool",
+                "content": skip_content,
+                "tool_call_id": skipped_tc.id,
+            }
+            messages.append(skip_msg)
+            self._log_msg_to_db(skip_msg)
+
+        if "stop" in normalized_response:
+            recovery_msg = (
+                f"A doom loop was detected on the '{tool_name}' tool, and the user chose to stop. "
+                "Do not call more tools. Provide a final response summarizing what you found so far."
             )
-        if progress >= self._budget_caution_threshold:
-            return (
-                f"[BUDGET: Iteration {api_call_count}/{self.max_iterations}. "
-                f"{remaining} iterations left. Start consolidating your work.]"
+        else:
+            recovery_msg = (
+                f"A doom loop was detected on the '{tool_name}' tool: you attempted the same call "
+                f"with the same arguments {DOOM_LOOP_THRESHOLD} times in a row. "
+                "Do NOT repeat that exact tool call again. Try a different approach, use different "
+                "arguments, use another tool, or provide a final response if you are blocked."
             )
-        return None
+
+        recovery_dict = {"role": "user", "content": recovery_msg}
+        messages.append(recovery_dict)
+        self._log_msg_to_db(recovery_dict)
+        self._doom_loop_signature = None
+        self._doom_loop_count = 0
+        return True
 
     def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
         """Request a summary when max iterations are reached. Returns the final response text."""
@@ -3147,8 +3227,8 @@ class AIAgent:
         self._invalid_tool_retries = 0
         self._invalid_json_retries = 0
         self._empty_content_retries = 0
-        self._incomplete_scratchpad_retries = 0
-        self._codex_incomplete_retries = 0
+        self._doom_loop_signature = None
+        self._doom_loop_count = 0
         self._last_content_with_tools = None
         self._turns_since_memory = 0
         self._iters_since_skill = 0

--- a/run_agent.py
+++ b/run_agent.py
@@ -176,7 +176,6 @@ class AIAgent:
         session_id: str = None,
         tool_progress_callback: callable = None,
         thinking_callback: callable = None,
-        reasoning_callback: callable = None,
         clarify_callback: callable = None,
         step_callback: callable = None,
         max_tokens: int = None,
@@ -264,7 +263,6 @@ class AIAgent:
 
         self.tool_progress_callback = tool_progress_callback
         self.thinking_callback = thinking_callback
-        self.reasoning_callback = reasoning_callback
         self.clarify_callback = clarify_callback
         self.step_callback = step_callback
         self._last_reported_tool = None  # Track for "new tool" mode
@@ -1786,7 +1784,6 @@ class AIAgent:
         allowed_keys = {
             "model", "instructions", "input", "tools", "store",
             "reasoning", "include", "max_output_tokens", "temperature",
-            "tool_choice", "parallel_tool_calls", "prompt_cache_key",
         }
         normalized: Dict[str, Any] = {
             "model": model,
@@ -1811,12 +1808,6 @@ class AIAgent:
         temperature = api_kwargs.get("temperature")
         if isinstance(temperature, (int, float)):
             normalized["temperature"] = float(temperature)
-
-        # Pass through tool_choice, parallel_tool_calls, prompt_cache_key
-        for passthrough_key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key"):
-            val = api_kwargs.get(passthrough_key)
-            if val is not None:
-                normalized[passthrough_key] = val
 
         if allow_stream:
             stream = api_kwargs.get("stream")
@@ -2354,10 +2345,7 @@ class AIAgent:
                 "instructions": instructions,
                 "input": self._chat_messages_to_responses_input(payload_messages),
                 "tools": self._responses_tools(),
-                "tool_choice": "auto",
-                "parallel_tool_calls": True,
                 "store": False,
-                "prompt_cache_key": self.session_id,
             }
 
             if reasoning_enabled:
@@ -2433,12 +2421,6 @@ class AIAgent:
         if reasoning_text and self.verbose_logging:
             preview = reasoning_text[:100] + "..." if len(reasoning_text) > 100 else reasoning_text
             logging.debug(f"Captured reasoning ({len(reasoning_text)} chars): {preview}")
-
-        if reasoning_text and self.reasoning_callback:
-            try:
-                self.reasoning_callback(reasoning_text)
-            except Exception:
-                pass
 
         msg = {
             "role": "assistant",
@@ -3597,7 +3579,7 @@ class AIAgent:
             
             api_start_time = time.time()
             retry_count = 0
-            max_retries = 3
+            max_retries = 6  # Increased to allow longer backoff periods
             compression_attempts = 0
             max_compression_attempts = 3
             codex_auth_retry_attempted = False
@@ -4067,11 +4049,8 @@ class AIAgent:
                     # These indicate a problem with the request itself (bad model ID,
                     # invalid API key, forbidden, etc.) and will never succeed on retry.
                     # Note: 413 and context-length errors are excluded — handled above.
-                    # Also catch local validation errors (ValueError, TypeError) — these
-                    # are programming bugs, not transient failures.
-                    is_local_validation_error = isinstance(api_error, (ValueError, TypeError))
                     is_client_status_error = isinstance(status_code, int) and 400 <= status_code < 500 and status_code != 413
-                    is_client_error = (is_local_validation_error or is_client_status_error or any(phrase in error_msg for phrase in [
+                    is_client_error = (is_client_status_error or any(phrase in error_msg for phrase in [
                         'error code: 401', 'error code: 403',
                         'error code: 404', 'error code: 422',
                         'is not a valid model', 'invalid model', 'model not found',
@@ -4616,17 +4595,9 @@ class AIAgent:
         if final_response and not interrupted:
             self._honcho_sync(original_user_message, final_response)
 
-        # Extract reasoning from the last assistant message (if any)
-        last_reasoning = None
-        for msg in reversed(messages):
-            if msg.get("role") == "assistant" and msg.get("reasoning"):
-                last_reasoning = msg["reasoning"]
-                break
-
         # Build result with interrupt info if applicable
         result = {
             "final_response": final_response,
-            "last_reasoning": last_reasoning,
             "messages": messages,
             "api_calls": api_call_count,
             "completed": completed,

--- a/run_agent.py
+++ b/run_agent.py
@@ -2988,8 +2988,10 @@ class AIAgent:
             and self._doom_loop_count >= DOOM_LOOP_THRESHOLD - 1
         )
 
-    def _record_tool_call_result(self, signature: Optional[tuple[str, str]], is_error_result: bool) -> None:
-        if signature is None or is_error_result:
+    def _record_tool_call_result(
+        self, signature: Optional[tuple[str, str]], _is_error_result: bool
+    ) -> None:
+        if signature is None:
             self._doom_loop_signature = None
             self._doom_loop_count = 0
             return
@@ -3033,8 +3035,6 @@ class AIAgent:
 
         normalized_response = response.lower()
         if "continue" in normalized_response:
-            self._doom_loop_signature = None
-            self._doom_loop_count = 0
             return False
 
         skip_content = (

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -697,6 +697,25 @@ class TestExecuteToolCalls:
         assert mock_hfc.call_count == 4
         assert len(messages) == 4
 
+    def test_doom_loop_does_not_skip_unrelated_remaining_calls(self, agent):
+        t1 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1")
+        t2 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2")
+        t3 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3")
+        t4 = _mock_tool_call(name="read_file", arguments='{"path":"run_agent.py"}', call_id="c4")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[t1, t2, t3, t4])
+        messages = []
+
+        with patch("run_agent.handle_function_call", return_value="ok") as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        called_tools = [call.args[0] for call in mock_hfc.call_args_list]
+        assert called_tools == ["web_search", "web_search", "read_file"]
+        assert any(
+            msg["role"] == "tool" and "doom loop detected" in msg["content"].lower()
+            for msg in messages
+        )
+        assert messages[-1]["role"] == "user"
+
 
 class TestHandleMaxIterations:
     def test_returns_summary(self, agent):

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -9,17 +9,18 @@ import json
 import re
 import uuid
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from run_agent import AIAgent
-from agent.prompt_builder import DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS
+from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 def _make_tool_defs(*names: str) -> list:
     """Build minimal tool definition list accepted by AIAgent.__init__."""
@@ -40,7 +41,9 @@ def _make_tool_defs(*names: str) -> list:
 def agent():
     """Minimal AIAgent with mocked OpenAI client and tool loading."""
     with (
-        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch(
+            "run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")
+        ),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
     ):
@@ -58,7 +61,10 @@ def agent():
 def agent_with_memory_tool():
     """Agent whose valid_tool_names includes 'memory'."""
     with (
-        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search", "memory")),
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search", "memory"),
+        ),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
     ):
@@ -75,6 +81,7 @@ def agent_with_memory_tool():
 # ---------------------------------------------------------------------------
 # Helper to build mock assistant messages (API response objects)
 # ---------------------------------------------------------------------------
+
 
 def _mock_assistant_msg(
     content="Hello",
@@ -94,7 +101,7 @@ def _mock_assistant_msg(
     return msg
 
 
-def _mock_tool_call(name="web_search", arguments='{}', call_id=None):
+def _mock_tool_call(name="web_search", arguments="{}", call_id=None):
     """Return a SimpleNamespace mimicking a tool call object."""
     return SimpleNamespace(
         id=call_id or f"call_{uuid.uuid4().hex[:8]}",
@@ -103,8 +110,9 @@ def _mock_tool_call(name="web_search", arguments='{}', call_id=None):
     )
 
 
-def _mock_response(content="Hello", finish_reason="stop", tool_calls=None,
-                    reasoning=None, usage=None):
+def _mock_response(
+    content="Hello", finish_reason="stop", tool_calls=None, reasoning=None, usage=None
+):
     """Return a SimpleNamespace mimicking an OpenAI ChatCompletion response."""
     msg = _mock_assistant_msg(
         content=content,
@@ -136,7 +144,10 @@ class TestHasContentAfterThinkBlock:
         assert agent._has_content_after_think_block("<think>reasoning</think>") is False
 
     def test_content_after_think_returns_true(self, agent):
-        assert agent._has_content_after_think_block("<think>r</think> actual answer") is True
+        assert (
+            agent._has_content_after_think_block("<think>r</think> actual answer")
+            is True
+        )
 
     def test_no_think_block_returns_true(self, agent):
         assert agent._has_content_after_think_block("just normal content") is True
@@ -420,7 +431,11 @@ class TestHydrateTodoStore:
         history = [
             {"role": "user", "content": "plan"},
             {"role": "assistant", "content": "ok"},
-            {"role": "tool", "content": json.dumps({"todos": todos}), "tool_call_id": "c1"},
+            {
+                "role": "tool",
+                "content": json.dumps({"todos": todos}),
+                "tool_call_id": "c1",
+            },
         ]
         with patch("run_agent._set_interrupt"):
             agent._hydrate_todo_store(history)
@@ -428,7 +443,11 @@ class TestHydrateTodoStore:
 
     def test_skips_non_todo_tools(self, agent):
         history = [
-            {"role": "tool", "content": '{"result": "search done"}', "tool_call_id": "c1"},
+            {
+                "role": "tool",
+                "content": '{"result": "search done"}',
+                "tool_call_id": "c1",
+            },
         ]
         with patch("run_agent._set_interrupt"):
             agent._hydrate_todo_store(history)
@@ -436,7 +455,11 @@ class TestHydrateTodoStore:
 
     def test_invalid_json_skipped(self, agent):
         history = [
-            {"role": "tool", "content": 'not valid json "todos" oops', "tool_call_id": "c1"},
+            {
+                "role": "tool",
+                "content": 'not valid json "todos" oops',
+                "tool_call_id": "c1",
+            },
         ]
         with patch("run_agent._set_interrupt"):
             agent._hydrate_todo_store(history)
@@ -454,11 +477,13 @@ class TestBuildSystemPrompt:
 
     def test_memory_guidance_when_memory_tool_loaded(self, agent_with_memory_tool):
         from agent.prompt_builder import MEMORY_GUIDANCE
+
         prompt = agent_with_memory_tool._build_system_prompt()
         assert MEMORY_GUIDANCE in prompt
 
     def test_no_memory_guidance_without_tool(self, agent):
         from agent.prompt_builder import MEMORY_GUIDANCE
+
         prompt = agent._build_system_prompt()
         assert MEMORY_GUIDANCE not in prompt
 
@@ -552,7 +577,9 @@ class TestBuildAssistantMessage:
     def test_tool_call_extra_content_preserved(self, agent):
         """Gemini thinking models attach extra_content with thought_signature
         to tool calls. This must be preserved so subsequent API calls include it."""
-        tc = _mock_tool_call(name="get_weather", arguments='{"city":"NYC"}', call_id="c2")
+        tc = _mock_tool_call(
+            name="get_weather", arguments='{"city":"NYC"}', call_id="c2"
+        )
         tc.extra_content = {"google": {"thought_signature": "abc123"}}
         msg = _mock_assistant_msg(content="", tool_calls=[tc])
         result = agent._build_assistant_message(msg, "tool_calls")
@@ -562,7 +589,7 @@ class TestBuildAssistantMessage:
 
     def test_tool_call_without_extra_content(self, agent):
         """Standard tool calls (no thinking model) should not have extra_content."""
-        tc = _mock_tool_call(name="web_search", arguments='{}', call_id="c3")
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c3")
         msg = _mock_assistant_msg(content="", tool_calls=[tc])
         result = agent._build_assistant_message(msg, "tool_calls")
         assert "extra_content" not in result["tool_calls"][0]
@@ -599,7 +626,9 @@ class TestExecuteToolCalls:
         tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
         messages = []
-        with patch("run_agent.handle_function_call", return_value="search result") as mock_hfc:
+        with patch(
+            "run_agent.handle_function_call", return_value="search result"
+        ) as mock_hfc:
             agent._execute_tool_calls(mock_msg, messages, "task-1")
             # enabled_tools passes the agent's own valid_tool_names
             args, kwargs = mock_hfc.call_args
@@ -610,8 +639,8 @@ class TestExecuteToolCalls:
         assert "search result" in messages[0]["content"]
 
     def test_interrupt_skips_remaining(self, agent):
-        tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
-        tc2 = _mock_tool_call(name="web_search", arguments='{}', call_id="c2")
+        tc1 = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments="{}", call_id="c2")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
         messages = []
 
@@ -621,10 +650,15 @@ class TestExecuteToolCalls:
         agent._execute_tool_calls(mock_msg, messages, "task-1")
         # Both calls should be skipped with cancellation messages
         assert len(messages) == 2
-        assert "cancelled" in messages[0]["content"].lower() or "interrupted" in messages[0]["content"].lower()
+        assert (
+            "cancelled" in messages[0]["content"].lower()
+            or "interrupted" in messages[0]["content"].lower()
+        )
 
     def test_invalid_json_args_defaults_empty(self, agent):
-        tc = _mock_tool_call(name="web_search", arguments="not valid json", call_id="c1")
+        tc = _mock_tool_call(
+            name="web_search", arguments="not valid json", call_id="c1"
+        )
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
         messages = []
         with patch("run_agent.handle_function_call", return_value="ok") as mock_hfc:
@@ -638,7 +672,7 @@ class TestExecuteToolCalls:
         assert messages[0]["tool_call_id"] == "c1"
 
     def test_result_truncation_over_100k(self, agent):
-        tc = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
         messages = []
         big_result = "x" * 150_000
@@ -647,6 +681,202 @@ class TestExecuteToolCalls:
         # Content should be truncated
         assert len(messages[0]["content"]) < 150_000
         assert "Truncated" in messages[0]["content"]
+
+    def test_doom_loop_skips_third_identical_successful_call(self, agent):
+        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2")
+        tc3 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2, tc3])
+        messages = []
+
+        with patch(
+            "run_agent.handle_function_call", return_value='{"result":"ok"}'
+        ) as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert mock_hfc.call_count == 2
+        assert [msg["role"] for msg in messages] == ["tool", "tool", "tool", "user"]
+        assert messages[2]["tool_call_id"] == "c3"
+        assert "doom loop" in messages[2]["content"].lower()
+        assert "try a different approach" in messages[3]["content"].lower()
+
+    def test_doom_loop_resets_on_different_args(self, agent):
+        tool_calls = [
+            _mock_tool_call(name="web_search", arguments='{"q":"first"}', call_id="c1"),
+            _mock_tool_call(
+                name="web_search", arguments='{"q":"second"}', call_id="c2"
+            ),
+            _mock_tool_call(
+                name="web_search", arguments='{"q":"second"}', call_id="c3"
+            ),
+            _mock_tool_call(
+                name="web_search", arguments='{"q":"second"}', call_id="c4"
+            ),
+        ]
+        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
+        messages = []
+
+        with patch(
+            "run_agent.handle_function_call", return_value='{"result":"ok"}'
+        ) as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert mock_hfc.call_count == 3
+        assert messages[-1]["role"] == "user"
+        assert "same arguments" in messages[-2]["content"].lower()
+
+    def test_doom_loop_resets_after_failure(self, agent):
+        tool_calls = [
+            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1"),
+            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2"),
+            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3"),
+            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c4"),
+            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c5"),
+        ]
+        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
+        messages = []
+
+        with patch(
+            "run_agent.handle_function_call",
+            side_effect=[
+                '{"result":"ok"}',
+                '{"error":"bad"}',
+                '{"result":"ok"}',
+                '{"result":"ok"}',
+                '{"result":"ok"}',
+            ],
+        ) as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert mock_hfc.call_count == 4
+        assert messages[-1]["role"] == "user"
+        assert messages[-2]["tool_call_id"] == "c5"
+
+    def test_doom_loop_exempts_process_polling(self, agent):
+        tool_calls = [
+            _mock_tool_call(
+                name="process",
+                arguments='{"action":"poll","session_id":"p1"}',
+                call_id="c1",
+            ),
+            _mock_tool_call(
+                name="process",
+                arguments='{"action":"poll","session_id":"p1"}',
+                call_id="c2",
+            ),
+            _mock_tool_call(
+                name="process",
+                arguments='{"action":"poll","session_id":"p1"}',
+                call_id="c3",
+            ),
+            _mock_tool_call(
+                name="process",
+                arguments='{"action":"poll","session_id":"p1"}',
+                call_id="c4",
+            ),
+        ]
+        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
+        messages = []
+
+        with patch(
+            "run_agent.handle_function_call", return_value='{"result":"ok"}'
+        ) as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert mock_hfc.call_count == 4
+        assert all(msg["role"] == "tool" for msg in messages)
+
+    def test_cli_can_continue_after_doom_loop_prompt(self, agent):
+        agent.platform = "cli"
+        agent.clarify_callback = MagicMock(return_value="Continue anyway")
+        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2")
+        tc3 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2, tc3])
+        messages = []
+
+        with patch(
+            "run_agent.handle_function_call", return_value='{"result":"ok"}'
+        ) as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert mock_hfc.call_count == 3
+        agent.clarify_callback.assert_called_once()
+        assert all(msg["role"] == "tool" for msg in messages)
+
+    def test_cli_try_different_approach_injects_recovery_message(self, agent):
+        agent.platform = "cli"
+        agent.clarify_callback = MagicMock(return_value="Try different approach")
+        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2")
+        tc3 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2, tc3])
+        messages = []
+
+        with patch(
+            "run_agent.handle_function_call", return_value='{"result":"ok"}'
+        ) as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert mock_hfc.call_count == 2
+        assert messages[-2]["role"] == "tool"
+        assert "doom loop detected" in messages[-2]["content"].lower()
+        assert messages[-1]["role"] == "user"
+        assert "try a different approach" in messages[-1]["content"].lower()
+
+    def test_cli_stop_and_summarize_injects_summary_request(self, agent):
+        agent.platform = "cli"
+        agent.clarify_callback = MagicMock(return_value="Stop and summarize")
+        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2")
+        tc3 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2, tc3])
+        messages = []
+
+        with patch(
+            "run_agent.handle_function_call", return_value='{"result":"ok"}'
+        ) as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert mock_hfc.call_count == 2
+        assert messages[-1]["role"] == "user"
+        assert "do not call more tools" in messages[-1]["content"].lower()
+        assert "final response summarizing" in messages[-1]["content"].lower()
+
+    @pytest.mark.parametrize("action", ["wait", "log"])
+    def test_doom_loop_exempts_process_wait_and_log(self, agent, action):
+        tool_calls = [
+            _mock_tool_call(
+                name="process",
+                arguments=f'{{"action":"{action}","session_id":"p1"}}',
+                call_id="c1",
+            ),
+            _mock_tool_call(
+                name="process",
+                arguments=f'{{"action":"{action}","session_id":"p1"}}',
+                call_id="c2",
+            ),
+            _mock_tool_call(
+                name="process",
+                arguments=f'{{"action":"{action}","session_id":"p1"}}',
+                call_id="c3",
+            ),
+            _mock_tool_call(
+                name="process",
+                arguments=f'{{"action":"{action}","session_id":"p1"}}',
+                call_id="c4",
+            ),
+        ]
+        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
+        messages = []
+
+        with patch(
+            "run_agent.handle_function_call", return_value='{"result":"ok"}'
+        ) as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert mock_hfc.call_count == 4
+        assert all(msg["role"] == "tool" for msg in messages)
 
 
 class TestHandleMaxIterations:
@@ -700,7 +930,7 @@ class TestRunConversation:
 
     def test_tool_calls_then_stop(self, agent):
         self._setup_agent(agent)
-        tc = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
         resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
         resp2 = _mock_response(content="Done searching", finish_reason="stop")
         agent.client.chat.completions.create.side_effect = [resp1, resp2]
@@ -726,7 +956,9 @@ class TestRunConversation:
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
             patch("run_agent._set_interrupt"),
-            patch.object(agent, "_interruptible_api_call", side_effect=interrupt_side_effect),
+            patch.object(
+                agent, "_interruptible_api_call", side_effect=interrupt_side_effect
+            ),
         ):
             result = agent.run_conversation("hello")
         assert result["interrupted"] is True
@@ -734,8 +966,10 @@ class TestRunConversation:
     def test_invalid_tool_name_retry(self, agent):
         """Model hallucinates an invalid tool name, agent retries and succeeds."""
         self._setup_agent(agent)
-        bad_tc = _mock_tool_call(name="nonexistent_tool", arguments='{}', call_id="c1")
-        resp_bad = _mock_response(content="", finish_reason="tool_calls", tool_calls=[bad_tc])
+        bad_tc = _mock_tool_call(name="nonexistent_tool", arguments="{}", call_id="c1")
+        resp_bad = _mock_response(
+            content="", finish_reason="tool_calls", tool_calls=[bad_tc]
+        )
         resp_good = _mock_response(content="Got it", finish_reason="stop")
         agent.client.chat.completions.create.side_effect = [resp_bad, resp_good]
         with (
@@ -757,7 +991,9 @@ class TestRunConversation:
         )
         # Return empty 3 times to exhaust retries
         agent.client.chat.completions.create.side_effect = [
-            empty_resp, empty_resp, empty_resp,
+            empty_resp,
+            empty_resp,
+            empty_resp,
         ]
         with (
             patch.object(agent, "_persist_session"),
@@ -785,7 +1021,9 @@ class TestRunConversation:
             calls["api"] += 1
             if calls["api"] == 1:
                 raise _UnauthorizedError()
-            return _mock_response(content="Recovered after remint", finish_reason="stop")
+            return _mock_response(
+                content="Recovered after remint", finish_reason="stop"
+            )
 
         def _fake_refresh(*, force=True):
             calls["refresh"] += 1
@@ -797,7 +1035,9 @@ class TestRunConversation:
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
             patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
-            patch.object(agent, "_try_refresh_nous_client_credentials", side_effect=_fake_refresh),
+            patch.object(
+                agent, "_try_refresh_nous_client_credentials", side_effect=_fake_refresh
+            ),
         ):
             result = agent.run_conversation("hello")
 
@@ -811,14 +1051,16 @@ class TestRunConversation:
         self._setup_agent(agent)
         agent.compression_enabled = True
 
-        tc = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
         resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
         resp2 = _mock_response(content="All done", finish_reason="stop")
         agent.client.chat.completions.create.side_effect = [resp1, resp2]
 
         with (
             patch("run_agent.handle_function_call", return_value="result"),
-            patch.object(agent.context_compressor, "should_compress", return_value=True),
+            patch.object(
+                agent.context_compressor, "should_compress", return_value=True
+            ),
             patch.object(agent, "_compress_context") as mock_compress,
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
@@ -834,35 +1076,28 @@ class TestRunConversation:
         assert result["final_response"] == "All done"
         assert result["completed"] is True
 
-    @pytest.mark.parametrize(
-        ("first_content", "second_content", "expected_final"),
-        [
-            ("Part 1 ", "Part 2", "Part 1 Part 2"),
-            ("<think>internal reasoning</think>", "Recovered final answer", "Recovered final answer"),
-        ],
-    )
-    def test_length_finish_reason_requests_continuation(
-        self, agent, first_content, second_content, expected_final
-    ):
+    def test_run_conversation_resets_doom_loop_state_each_turn(self, agent):
         self._setup_agent(agent)
-        first = _mock_response(content=first_content, finish_reason="length")
-        second = _mock_response(content=second_content, finish_reason="stop")
-        agent.client.chat.completions.create.side_effect = [first, second]
+        agent._doom_loop_signature = ("web_search", "stale")
+        agent._doom_loop_count = 2
+
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        resp2 = _mock_response(content="Done searching", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
 
         with (
+            patch(
+                "run_agent.handle_function_call", return_value='{"result":"ok"}'
+            ) as mock_hfc,
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
         ):
-            result = agent.run_conversation("hello")
+            result = agent.run_conversation("search something")
 
-        assert result["completed"] is True
-        assert result["api_calls"] == 2
-        assert result["final_response"] == expected_final
-
-        second_call_messages = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
-        assert second_call_messages[-1]["role"] == "user"
-        assert "truncated by the output length limit" in second_call_messages[-1]["content"]
+        assert mock_hfc.call_count == 1
+        assert result["final_response"] == "Done searching"
 
 
 class TestRetryExhaustion:
@@ -912,7 +1147,9 @@ class TestRetryExhaustion:
             patch("run_agent.time", self._make_fast_time_mock()),
         ):
             result = agent.run_conversation("hello")
-        assert result.get("completed") is False, f"Expected completed=False, got: {result}"
+        assert result.get("completed") is False, (
+            f"Expected completed=False, got: {result}"
+        )
         assert result.get("failed") is True
         assert "error" in result
         assert "Invalid API response" in result["error"]
@@ -934,6 +1171,7 @@ class TestRetryExhaustion:
 # ---------------------------------------------------------------------------
 # Flush sentinel leak
 # ---------------------------------------------------------------------------
+
 
 class TestFlushSentinelNotLeaked:
     """_flush_sentinel must be stripped before sending messages to the API."""
@@ -959,7 +1197,10 @@ class TestFlushSentinelNotLeaked:
         agent.client.chat.completions.create.return_value = mock_response
 
         # Bypass auxiliary client so flush uses agent.client directly
-        with patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(None, None)):
+        with patch(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            return_value=(None, None),
+        ):
             agent.flush_memories(messages, min_turns=0)
 
         # Check what was actually sent to the API
@@ -975,6 +1216,7 @@ class TestFlushSentinelNotLeaked:
 # ---------------------------------------------------------------------------
 # Conversation history mutation
 # ---------------------------------------------------------------------------
+
 
 class TestConversationHistoryNotMutated:
     """run_conversation must not mutate the caller's conversation_history list."""
@@ -995,7 +1237,9 @@ class TestConversationHistoryNotMutated:
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
         ):
-            result = agent.run_conversation("new question", conversation_history=history)
+            result = agent.run_conversation(
+                "new question", conversation_history=history
+            )
 
         # Caller's list must be untouched
         assert len(history) == original_len, (
@@ -1009,10 +1253,13 @@ class TestConversationHistoryNotMutated:
 # _max_tokens_param consistency
 # ---------------------------------------------------------------------------
 
+
 class TestNousCredentialRefresh:
     """Verify Nous credential refresh rebuilds the runtime client."""
 
-    def test_try_refresh_nous_client_credentials_rebuilds_client(self, agent, monkeypatch):
+    def test_try_refresh_nous_client_credentials_rebuilds_client(
+        self, agent, monkeypatch
+    ):
         agent.provider = "nous"
         agent.api_mode = "chat_completions"
 
@@ -1038,7 +1285,9 @@ class TestNousCredentialRefresh:
             rebuilt["kwargs"] = kwargs
             return _RebuiltClient()
 
-        monkeypatch.setattr("hermes_cli.auth.resolve_nous_runtime_credentials", _fake_resolve)
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_nous_runtime_credentials", _fake_resolve
+        )
 
         agent.client = _ExistingClient()
         with patch("run_agent.OpenAI", side_effect=_fake_openai):
@@ -1048,7 +1297,9 @@ class TestNousCredentialRefresh:
         assert closed["value"] is True
         assert captured["force_mint"] is True
         assert rebuilt["kwargs"]["api_key"] == "new-nous-key"
-        assert rebuilt["kwargs"]["base_url"] == "https://inference-api.nousresearch.com/v1"
+        assert (
+            rebuilt["kwargs"]["base_url"] == "https://inference-api.nousresearch.com/v1"
+        )
         assert "default_headers" not in rebuilt["kwargs"]
         assert isinstance(agent.client, _RebuiltClient)
 
@@ -1080,6 +1331,7 @@ class TestMaxTokensParam:
 # ---------------------------------------------------------------------------
 # System prompt stability for prompt caching
 # ---------------------------------------------------------------------------
+
 
 class TestSystemPromptStability:
     """Verify that the system prompt stays stable across turns for cache hits."""

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -725,7 +725,7 @@ class TestExecuteToolCalls:
         assert messages[-1]["role"] == "user"
         assert "same arguments" in messages[-2]["content"].lower()
 
-    def test_doom_loop_resets_after_failure(self, agent):
+    def test_doom_loop_still_triggers_after_failure(self, agent):
         tool_calls = [
             _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1"),
             _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2"),
@@ -748,9 +748,10 @@ class TestExecuteToolCalls:
         ) as mock_hfc:
             agent._execute_tool_calls(mock_msg, messages, "task-1")
 
-        assert mock_hfc.call_count == 4
+        assert mock_hfc.call_count == 2
         assert messages[-1]["role"] == "user"
         assert messages[-2]["tool_call_id"] == "c5"
+        assert "try a different approach" in messages[-1]["content"].lower()
 
     def test_doom_loop_exempts_process_polling(self, agent):
         tool_calls = [
@@ -786,6 +787,26 @@ class TestExecuteToolCalls:
         assert mock_hfc.call_count == 4
         assert all(msg["role"] == "tool" for msg in messages)
 
+    def test_doom_loop_triggers_on_repeated_identical_failures(self, agent):
+        tool_calls = [
+            _mock_tool_call(name="patch", arguments='{"path":"a.py"}', call_id="c1"),
+            _mock_tool_call(name="patch", arguments='{"path":"a.py"}', call_id="c2"),
+            _mock_tool_call(name="patch", arguments='{"path":"a.py"}', call_id="c3"),
+        ]
+        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
+        messages = []
+
+        with patch(
+            "run_agent.handle_function_call", return_value='{"error":"patch failed"}'
+        ) as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert mock_hfc.call_count == 2
+        assert messages[-2]["role"] == "tool"
+        assert "doom loop detected" in messages[-2]["content"].lower()
+        assert messages[-1]["role"] == "user"
+        assert "try a different approach" in messages[-1]["content"].lower()
+
     def test_cli_can_continue_after_doom_loop_prompt(self, agent):
         agent.platform = "cli"
         agent.clarify_callback = MagicMock(return_value="Continue anyway")
@@ -802,6 +823,27 @@ class TestExecuteToolCalls:
 
         assert mock_hfc.call_count == 3
         agent.clarify_callback.assert_called_once()
+        assert all(msg["role"] == "tool" for msg in messages)
+
+    def test_continue_anyway_prompts_again_on_next_identical_call(self, agent):
+        agent.platform = "cli"
+        agent.clarify_callback = MagicMock(return_value="Continue anyway")
+        tool_calls = [
+            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1"),
+            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2"),
+            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3"),
+            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c4"),
+        ]
+        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
+        messages = []
+
+        with patch(
+            "run_agent.handle_function_call", return_value='{"result":"ok"}'
+        ) as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert mock_hfc.call_count == 4
+        assert agent.clarify_callback.call_count == 2
         assert all(msg["role"] == "tool" for msg in messages)
 
     def test_cli_try_different_approach_injects_recovery_message(self, agent):

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -9,18 +9,17 @@ import json
 import re
 import uuid
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
 
 from run_agent import AIAgent
-from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from agent.prompt_builder import DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
 
 def _make_tool_defs(*names: str) -> list:
     """Build minimal tool definition list accepted by AIAgent.__init__."""
@@ -41,9 +40,7 @@ def _make_tool_defs(*names: str) -> list:
 def agent():
     """Minimal AIAgent with mocked OpenAI client and tool loading."""
     with (
-        patch(
-            "run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")
-        ),
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
     ):
@@ -61,10 +58,7 @@ def agent():
 def agent_with_memory_tool():
     """Agent whose valid_tool_names includes 'memory'."""
     with (
-        patch(
-            "run_agent.get_tool_definitions",
-            return_value=_make_tool_defs("web_search", "memory"),
-        ),
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search", "memory")),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
     ):
@@ -81,7 +75,6 @@ def agent_with_memory_tool():
 # ---------------------------------------------------------------------------
 # Helper to build mock assistant messages (API response objects)
 # ---------------------------------------------------------------------------
-
 
 def _mock_assistant_msg(
     content="Hello",
@@ -101,7 +94,7 @@ def _mock_assistant_msg(
     return msg
 
 
-def _mock_tool_call(name="web_search", arguments="{}", call_id=None):
+def _mock_tool_call(name="web_search", arguments='{}', call_id=None):
     """Return a SimpleNamespace mimicking a tool call object."""
     return SimpleNamespace(
         id=call_id or f"call_{uuid.uuid4().hex[:8]}",
@@ -110,9 +103,8 @@ def _mock_tool_call(name="web_search", arguments="{}", call_id=None):
     )
 
 
-def _mock_response(
-    content="Hello", finish_reason="stop", tool_calls=None, reasoning=None, usage=None
-):
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None,
+                    reasoning=None, usage=None):
     """Return a SimpleNamespace mimicking an OpenAI ChatCompletion response."""
     msg = _mock_assistant_msg(
         content=content,
@@ -144,10 +136,7 @@ class TestHasContentAfterThinkBlock:
         assert agent._has_content_after_think_block("<think>reasoning</think>") is False
 
     def test_content_after_think_returns_true(self, agent):
-        assert (
-            agent._has_content_after_think_block("<think>r</think> actual answer")
-            is True
-        )
+        assert agent._has_content_after_think_block("<think>r</think> actual answer") is True
 
     def test_no_think_block_returns_true(self, agent):
         assert agent._has_content_after_think_block("just normal content") is True
@@ -431,11 +420,7 @@ class TestHydrateTodoStore:
         history = [
             {"role": "user", "content": "plan"},
             {"role": "assistant", "content": "ok"},
-            {
-                "role": "tool",
-                "content": json.dumps({"todos": todos}),
-                "tool_call_id": "c1",
-            },
+            {"role": "tool", "content": json.dumps({"todos": todos}), "tool_call_id": "c1"},
         ]
         with patch("run_agent._set_interrupt"):
             agent._hydrate_todo_store(history)
@@ -443,11 +428,7 @@ class TestHydrateTodoStore:
 
     def test_skips_non_todo_tools(self, agent):
         history = [
-            {
-                "role": "tool",
-                "content": '{"result": "search done"}',
-                "tool_call_id": "c1",
-            },
+            {"role": "tool", "content": '{"result": "search done"}', "tool_call_id": "c1"},
         ]
         with patch("run_agent._set_interrupt"):
             agent._hydrate_todo_store(history)
@@ -455,11 +436,7 @@ class TestHydrateTodoStore:
 
     def test_invalid_json_skipped(self, agent):
         history = [
-            {
-                "role": "tool",
-                "content": 'not valid json "todos" oops',
-                "tool_call_id": "c1",
-            },
+            {"role": "tool", "content": 'not valid json "todos" oops', "tool_call_id": "c1"},
         ]
         with patch("run_agent._set_interrupt"):
             agent._hydrate_todo_store(history)
@@ -477,13 +454,11 @@ class TestBuildSystemPrompt:
 
     def test_memory_guidance_when_memory_tool_loaded(self, agent_with_memory_tool):
         from agent.prompt_builder import MEMORY_GUIDANCE
-
         prompt = agent_with_memory_tool._build_system_prompt()
         assert MEMORY_GUIDANCE in prompt
 
     def test_no_memory_guidance_without_tool(self, agent):
         from agent.prompt_builder import MEMORY_GUIDANCE
-
         prompt = agent._build_system_prompt()
         assert MEMORY_GUIDANCE not in prompt
 
@@ -577,9 +552,7 @@ class TestBuildAssistantMessage:
     def test_tool_call_extra_content_preserved(self, agent):
         """Gemini thinking models attach extra_content with thought_signature
         to tool calls. This must be preserved so subsequent API calls include it."""
-        tc = _mock_tool_call(
-            name="get_weather", arguments='{"city":"NYC"}', call_id="c2"
-        )
+        tc = _mock_tool_call(name="get_weather", arguments='{"city":"NYC"}', call_id="c2")
         tc.extra_content = {"google": {"thought_signature": "abc123"}}
         msg = _mock_assistant_msg(content="", tool_calls=[tc])
         result = agent._build_assistant_message(msg, "tool_calls")
@@ -589,7 +562,7 @@ class TestBuildAssistantMessage:
 
     def test_tool_call_without_extra_content(self, agent):
         """Standard tool calls (no thinking model) should not have extra_content."""
-        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c3")
+        tc = _mock_tool_call(name="web_search", arguments='{}', call_id="c3")
         msg = _mock_assistant_msg(content="", tool_calls=[tc])
         result = agent._build_assistant_message(msg, "tool_calls")
         assert "extra_content" not in result["tool_calls"][0]
@@ -626,9 +599,7 @@ class TestExecuteToolCalls:
         tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
         messages = []
-        with patch(
-            "run_agent.handle_function_call", return_value="search result"
-        ) as mock_hfc:
+        with patch("run_agent.handle_function_call", return_value="search result") as mock_hfc:
             agent._execute_tool_calls(mock_msg, messages, "task-1")
             # enabled_tools passes the agent's own valid_tool_names
             args, kwargs = mock_hfc.call_args
@@ -639,8 +610,8 @@ class TestExecuteToolCalls:
         assert "search result" in messages[0]["content"]
 
     def test_interrupt_skips_remaining(self, agent):
-        tc1 = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
-        tc2 = _mock_tool_call(name="web_search", arguments="{}", call_id="c2")
+        tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{}', call_id="c2")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
         messages = []
 
@@ -650,15 +621,10 @@ class TestExecuteToolCalls:
         agent._execute_tool_calls(mock_msg, messages, "task-1")
         # Both calls should be skipped with cancellation messages
         assert len(messages) == 2
-        assert (
-            "cancelled" in messages[0]["content"].lower()
-            or "interrupted" in messages[0]["content"].lower()
-        )
+        assert "cancelled" in messages[0]["content"].lower() or "interrupted" in messages[0]["content"].lower()
 
     def test_invalid_json_args_defaults_empty(self, agent):
-        tc = _mock_tool_call(
-            name="web_search", arguments="not valid json", call_id="c1"
-        )
+        tc = _mock_tool_call(name="web_search", arguments="not valid json", call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
         messages = []
         with patch("run_agent.handle_function_call", return_value="ok") as mock_hfc:
@@ -672,7 +638,7 @@ class TestExecuteToolCalls:
         assert messages[0]["tool_call_id"] == "c1"
 
     def test_result_truncation_over_100k(self, agent):
-        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        tc = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
         messages = []
         big_result = "x" * 150_000
@@ -682,243 +648,54 @@ class TestExecuteToolCalls:
         assert len(messages[0]["content"]) < 150_000
         assert "Truncated" in messages[0]["content"]
 
-    def test_doom_loop_skips_third_identical_successful_call(self, agent):
-        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1")
-        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2")
-        tc3 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3")
-        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2, tc3])
+    def test_doom_loop_stops_third_identical_call(self, agent):
+        t1 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1")
+        t2 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2")
+        t3 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[t1, t2, t3])
         messages = []
 
-        with patch(
-            "run_agent.handle_function_call", return_value='{"result":"ok"}'
-        ) as mock_hfc:
+        with patch("run_agent.handle_function_call", return_value="search result") as mock_hfc:
             agent._execute_tool_calls(mock_msg, messages, "task-1")
 
         assert mock_hfc.call_count == 2
-        assert [msg["role"] for msg in messages] == ["tool", "tool", "tool", "user"]
-        assert messages[2]["tool_call_id"] == "c3"
-        assert "doom loop" in messages[2]["content"].lower()
-        assert "try a different approach" in messages[3]["content"].lower()
+        assert len(messages) == 4
+        assert messages[2]["role"] == "tool"
+        assert "doom loop detected" in messages[2]["content"].lower()
+        assert messages[3]["role"] == "user"
+        assert "Do NOT repeat that exact tool call" in messages[3]["content"]
 
-    def test_doom_loop_resets_on_different_args(self, agent):
-        tool_calls = [
-            _mock_tool_call(name="web_search", arguments='{"q":"first"}', call_id="c1"),
-            _mock_tool_call(
-                name="web_search", arguments='{"q":"second"}', call_id="c2"
-            ),
-            _mock_tool_call(
-                name="web_search", arguments='{"q":"second"}', call_id="c3"
-            ),
-            _mock_tool_call(
-                name="web_search", arguments='{"q":"second"}', call_id="c4"
-            ),
-        ]
-        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
+    def test_doom_loop_continue_option_allows_execution(self, agent):
+        t1 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1")
+        t2 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2")
+        t3 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[t1, t2, t3])
         messages = []
+        agent.platform = "cli"
+        agent.clarify_callback = lambda _q, _choices: "Continue anyway"
 
-        with patch(
-            "run_agent.handle_function_call", return_value='{"result":"ok"}'
-        ) as mock_hfc:
+        with patch("run_agent.handle_function_call", return_value="search result") as mock_hfc:
             agent._execute_tool_calls(mock_msg, messages, "task-1")
 
         assert mock_hfc.call_count == 3
-        assert messages[-1]["role"] == "user"
-        assert "same arguments" in messages[-2]["content"].lower()
+        assert len(messages) == 3
+        assert all(msg["role"] == "tool" for msg in messages)
 
-    def test_doom_loop_still_triggers_after_failure(self, agent):
-        tool_calls = [
-            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1"),
-            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2"),
-            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3"),
-            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c4"),
-            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c5"),
+    def test_doom_loop_exempts_process_poll_wait_log(self, agent):
+        poll_calls = [
+            _mock_tool_call(name="process", arguments='{"action":"poll","id":"p1"}', call_id="c1"),
+            _mock_tool_call(name="process", arguments='{"action":"poll","id":"p1"}', call_id="c2"),
+            _mock_tool_call(name="process", arguments='{"action":"poll","id":"p1"}', call_id="c3"),
+            _mock_tool_call(name="process", arguments='{"action":"poll","id":"p1"}', call_id="c4"),
         ]
-        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
+        mock_msg = _mock_assistant_msg(content="", tool_calls=poll_calls)
         messages = []
 
-        with patch(
-            "run_agent.handle_function_call",
-            side_effect=[
-                '{"result":"ok"}',
-                '{"error":"bad"}',
-                '{"result":"ok"}',
-                '{"result":"ok"}',
-                '{"result":"ok"}',
-            ],
-        ) as mock_hfc:
-            agent._execute_tool_calls(mock_msg, messages, "task-1")
-
-        assert mock_hfc.call_count == 2
-        assert messages[-1]["role"] == "user"
-        assert messages[-2]["tool_call_id"] == "c5"
-        assert "try a different approach" in messages[-1]["content"].lower()
-
-    def test_doom_loop_exempts_process_polling(self, agent):
-        tool_calls = [
-            _mock_tool_call(
-                name="process",
-                arguments='{"action":"poll","session_id":"p1"}',
-                call_id="c1",
-            ),
-            _mock_tool_call(
-                name="process",
-                arguments='{"action":"poll","session_id":"p1"}',
-                call_id="c2",
-            ),
-            _mock_tool_call(
-                name="process",
-                arguments='{"action":"poll","session_id":"p1"}',
-                call_id="c3",
-            ),
-            _mock_tool_call(
-                name="process",
-                arguments='{"action":"poll","session_id":"p1"}',
-                call_id="c4",
-            ),
-        ]
-        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
-        messages = []
-
-        with patch(
-            "run_agent.handle_function_call", return_value='{"result":"ok"}'
-        ) as mock_hfc:
+        with patch("run_agent.handle_function_call", return_value="ok") as mock_hfc:
             agent._execute_tool_calls(mock_msg, messages, "task-1")
 
         assert mock_hfc.call_count == 4
-        assert all(msg["role"] == "tool" for msg in messages)
-
-    def test_doom_loop_triggers_on_repeated_identical_failures(self, agent):
-        tool_calls = [
-            _mock_tool_call(name="patch", arguments='{"path":"a.py"}', call_id="c1"),
-            _mock_tool_call(name="patch", arguments='{"path":"a.py"}', call_id="c2"),
-            _mock_tool_call(name="patch", arguments='{"path":"a.py"}', call_id="c3"),
-        ]
-        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
-        messages = []
-
-        with patch(
-            "run_agent.handle_function_call", return_value='{"error":"patch failed"}'
-        ) as mock_hfc:
-            agent._execute_tool_calls(mock_msg, messages, "task-1")
-
-        assert mock_hfc.call_count == 2
-        assert messages[-2]["role"] == "tool"
-        assert "doom loop detected" in messages[-2]["content"].lower()
-        assert messages[-1]["role"] == "user"
-        assert "try a different approach" in messages[-1]["content"].lower()
-
-    def test_cli_can_continue_after_doom_loop_prompt(self, agent):
-        agent.platform = "cli"
-        agent.clarify_callback = MagicMock(return_value="Continue anyway")
-        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1")
-        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2")
-        tc3 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3")
-        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2, tc3])
-        messages = []
-
-        with patch(
-            "run_agent.handle_function_call", return_value='{"result":"ok"}'
-        ) as mock_hfc:
-            agent._execute_tool_calls(mock_msg, messages, "task-1")
-
-        assert mock_hfc.call_count == 3
-        agent.clarify_callback.assert_called_once()
-        assert all(msg["role"] == "tool" for msg in messages)
-
-    def test_continue_anyway_prompts_again_on_next_identical_call(self, agent):
-        agent.platform = "cli"
-        agent.clarify_callback = MagicMock(return_value="Continue anyway")
-        tool_calls = [
-            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1"),
-            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2"),
-            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3"),
-            _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c4"),
-        ]
-        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
-        messages = []
-
-        with patch(
-            "run_agent.handle_function_call", return_value='{"result":"ok"}'
-        ) as mock_hfc:
-            agent._execute_tool_calls(mock_msg, messages, "task-1")
-
-        assert mock_hfc.call_count == 4
-        assert agent.clarify_callback.call_count == 2
-        assert all(msg["role"] == "tool" for msg in messages)
-
-    def test_cli_try_different_approach_injects_recovery_message(self, agent):
-        agent.platform = "cli"
-        agent.clarify_callback = MagicMock(return_value="Try different approach")
-        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1")
-        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2")
-        tc3 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3")
-        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2, tc3])
-        messages = []
-
-        with patch(
-            "run_agent.handle_function_call", return_value='{"result":"ok"}'
-        ) as mock_hfc:
-            agent._execute_tool_calls(mock_msg, messages, "task-1")
-
-        assert mock_hfc.call_count == 2
-        assert messages[-2]["role"] == "tool"
-        assert "doom loop detected" in messages[-2]["content"].lower()
-        assert messages[-1]["role"] == "user"
-        assert "try a different approach" in messages[-1]["content"].lower()
-
-    def test_cli_stop_and_summarize_injects_summary_request(self, agent):
-        agent.platform = "cli"
-        agent.clarify_callback = MagicMock(return_value="Stop and summarize")
-        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c1")
-        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c2")
-        tc3 = _mock_tool_call(name="web_search", arguments='{"q":"same"}', call_id="c3")
-        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2, tc3])
-        messages = []
-
-        with patch(
-            "run_agent.handle_function_call", return_value='{"result":"ok"}'
-        ) as mock_hfc:
-            agent._execute_tool_calls(mock_msg, messages, "task-1")
-
-        assert mock_hfc.call_count == 2
-        assert messages[-1]["role"] == "user"
-        assert "do not call more tools" in messages[-1]["content"].lower()
-        assert "final response summarizing" in messages[-1]["content"].lower()
-
-    @pytest.mark.parametrize("action", ["wait", "log"])
-    def test_doom_loop_exempts_process_wait_and_log(self, agent, action):
-        tool_calls = [
-            _mock_tool_call(
-                name="process",
-                arguments=f'{{"action":"{action}","session_id":"p1"}}',
-                call_id="c1",
-            ),
-            _mock_tool_call(
-                name="process",
-                arguments=f'{{"action":"{action}","session_id":"p1"}}',
-                call_id="c2",
-            ),
-            _mock_tool_call(
-                name="process",
-                arguments=f'{{"action":"{action}","session_id":"p1"}}',
-                call_id="c3",
-            ),
-            _mock_tool_call(
-                name="process",
-                arguments=f'{{"action":"{action}","session_id":"p1"}}',
-                call_id="c4",
-            ),
-        ]
-        mock_msg = _mock_assistant_msg(content="", tool_calls=tool_calls)
-        messages = []
-
-        with patch(
-            "run_agent.handle_function_call", return_value='{"result":"ok"}'
-        ) as mock_hfc:
-            agent._execute_tool_calls(mock_msg, messages, "task-1")
-
-        assert mock_hfc.call_count == 4
-        assert all(msg["role"] == "tool" for msg in messages)
+        assert len(messages) == 4
 
 
 class TestHandleMaxIterations:
@@ -972,7 +749,7 @@ class TestRunConversation:
 
     def test_tool_calls_then_stop(self, agent):
         self._setup_agent(agent)
-        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        tc = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
         resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
         resp2 = _mock_response(content="Done searching", finish_reason="stop")
         agent.client.chat.completions.create.side_effect = [resp1, resp2]
@@ -986,6 +763,24 @@ class TestRunConversation:
         assert result["final_response"] == "Done searching"
         assert result["api_calls"] == 2
 
+    def test_resets_doom_loop_state_each_turn(self, agent):
+        self._setup_agent(agent)
+        agent._doom_loop_signature = ("web_search", "abc")
+        agent._doom_loop_count = 99
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert agent._doom_loop_signature is None
+        assert agent._doom_loop_count == 0
+
     def test_interrupt_breaks_loop(self, agent):
         self._setup_agent(agent)
 
@@ -998,9 +793,7 @@ class TestRunConversation:
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
             patch("run_agent._set_interrupt"),
-            patch.object(
-                agent, "_interruptible_api_call", side_effect=interrupt_side_effect
-            ),
+            patch.object(agent, "_interruptible_api_call", side_effect=interrupt_side_effect),
         ):
             result = agent.run_conversation("hello")
         assert result["interrupted"] is True
@@ -1008,10 +801,8 @@ class TestRunConversation:
     def test_invalid_tool_name_retry(self, agent):
         """Model hallucinates an invalid tool name, agent retries and succeeds."""
         self._setup_agent(agent)
-        bad_tc = _mock_tool_call(name="nonexistent_tool", arguments="{}", call_id="c1")
-        resp_bad = _mock_response(
-            content="", finish_reason="tool_calls", tool_calls=[bad_tc]
-        )
+        bad_tc = _mock_tool_call(name="nonexistent_tool", arguments='{}', call_id="c1")
+        resp_bad = _mock_response(content="", finish_reason="tool_calls", tool_calls=[bad_tc])
         resp_good = _mock_response(content="Got it", finish_reason="stop")
         agent.client.chat.completions.create.side_effect = [resp_bad, resp_good]
         with (
@@ -1033,9 +824,7 @@ class TestRunConversation:
         )
         # Return empty 3 times to exhaust retries
         agent.client.chat.completions.create.side_effect = [
-            empty_resp,
-            empty_resp,
-            empty_resp,
+            empty_resp, empty_resp, empty_resp,
         ]
         with (
             patch.object(agent, "_persist_session"),
@@ -1063,9 +852,7 @@ class TestRunConversation:
             calls["api"] += 1
             if calls["api"] == 1:
                 raise _UnauthorizedError()
-            return _mock_response(
-                content="Recovered after remint", finish_reason="stop"
-            )
+            return _mock_response(content="Recovered after remint", finish_reason="stop")
 
         def _fake_refresh(*, force=True):
             calls["refresh"] += 1
@@ -1077,9 +864,7 @@ class TestRunConversation:
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
             patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
-            patch.object(
-                agent, "_try_refresh_nous_client_credentials", side_effect=_fake_refresh
-            ),
+            patch.object(agent, "_try_refresh_nous_client_credentials", side_effect=_fake_refresh),
         ):
             result = agent.run_conversation("hello")
 
@@ -1093,16 +878,14 @@ class TestRunConversation:
         self._setup_agent(agent)
         agent.compression_enabled = True
 
-        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        tc = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
         resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
         resp2 = _mock_response(content="All done", finish_reason="stop")
         agent.client.chat.completions.create.side_effect = [resp1, resp2]
 
         with (
             patch("run_agent.handle_function_call", return_value="result"),
-            patch.object(
-                agent.context_compressor, "should_compress", return_value=True
-            ),
+            patch.object(agent.context_compressor, "should_compress", return_value=True),
             patch.object(agent, "_compress_context") as mock_compress,
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
@@ -1118,28 +901,35 @@ class TestRunConversation:
         assert result["final_response"] == "All done"
         assert result["completed"] is True
 
-    def test_run_conversation_resets_doom_loop_state_each_turn(self, agent):
+    @pytest.mark.parametrize(
+        ("first_content", "second_content", "expected_final"),
+        [
+            ("Part 1 ", "Part 2", "Part 1 Part 2"),
+            ("<think>internal reasoning</think>", "Recovered final answer", "Recovered final answer"),
+        ],
+    )
+    def test_length_finish_reason_requests_continuation(
+        self, agent, first_content, second_content, expected_final
+    ):
         self._setup_agent(agent)
-        agent._doom_loop_signature = ("web_search", "stale")
-        agent._doom_loop_count = 2
-
-        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
-        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
-        resp2 = _mock_response(content="Done searching", finish_reason="stop")
-        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+        first = _mock_response(content=first_content, finish_reason="length")
+        second = _mock_response(content=second_content, finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [first, second]
 
         with (
-            patch(
-                "run_agent.handle_function_call", return_value='{"result":"ok"}'
-            ) as mock_hfc,
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
         ):
-            result = agent.run_conversation("search something")
+            result = agent.run_conversation("hello")
 
-        assert mock_hfc.call_count == 1
-        assert result["final_response"] == "Done searching"
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert result["final_response"] == expected_final
+
+        second_call_messages = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
+        assert second_call_messages[-1]["role"] == "user"
+        assert "truncated by the output length limit" in second_call_messages[-1]["content"]
 
 
 class TestRetryExhaustion:
@@ -1189,9 +979,7 @@ class TestRetryExhaustion:
             patch("run_agent.time", self._make_fast_time_mock()),
         ):
             result = agent.run_conversation("hello")
-        assert result.get("completed") is False, (
-            f"Expected completed=False, got: {result}"
-        )
+        assert result.get("completed") is False, f"Expected completed=False, got: {result}"
         assert result.get("failed") is True
         assert "error" in result
         assert "Invalid API response" in result["error"]
@@ -1213,7 +1001,6 @@ class TestRetryExhaustion:
 # ---------------------------------------------------------------------------
 # Flush sentinel leak
 # ---------------------------------------------------------------------------
-
 
 class TestFlushSentinelNotLeaked:
     """_flush_sentinel must be stripped before sending messages to the API."""
@@ -1239,10 +1026,7 @@ class TestFlushSentinelNotLeaked:
         agent.client.chat.completions.create.return_value = mock_response
 
         # Bypass auxiliary client so flush uses agent.client directly
-        with patch(
-            "agent.auxiliary_client.get_text_auxiliary_client",
-            return_value=(None, None),
-        ):
+        with patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(None, None)):
             agent.flush_memories(messages, min_turns=0)
 
         # Check what was actually sent to the API
@@ -1258,7 +1042,6 @@ class TestFlushSentinelNotLeaked:
 # ---------------------------------------------------------------------------
 # Conversation history mutation
 # ---------------------------------------------------------------------------
-
 
 class TestConversationHistoryNotMutated:
     """run_conversation must not mutate the caller's conversation_history list."""
@@ -1279,9 +1062,7 @@ class TestConversationHistoryNotMutated:
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
         ):
-            result = agent.run_conversation(
-                "new question", conversation_history=history
-            )
+            result = agent.run_conversation("new question", conversation_history=history)
 
         # Caller's list must be untouched
         assert len(history) == original_len, (
@@ -1295,13 +1076,10 @@ class TestConversationHistoryNotMutated:
 # _max_tokens_param consistency
 # ---------------------------------------------------------------------------
 
-
 class TestNousCredentialRefresh:
     """Verify Nous credential refresh rebuilds the runtime client."""
 
-    def test_try_refresh_nous_client_credentials_rebuilds_client(
-        self, agent, monkeypatch
-    ):
+    def test_try_refresh_nous_client_credentials_rebuilds_client(self, agent, monkeypatch):
         agent.provider = "nous"
         agent.api_mode = "chat_completions"
 
@@ -1327,9 +1105,7 @@ class TestNousCredentialRefresh:
             rebuilt["kwargs"] = kwargs
             return _RebuiltClient()
 
-        monkeypatch.setattr(
-            "hermes_cli.auth.resolve_nous_runtime_credentials", _fake_resolve
-        )
+        monkeypatch.setattr("hermes_cli.auth.resolve_nous_runtime_credentials", _fake_resolve)
 
         agent.client = _ExistingClient()
         with patch("run_agent.OpenAI", side_effect=_fake_openai):
@@ -1339,9 +1115,7 @@ class TestNousCredentialRefresh:
         assert closed["value"] is True
         assert captured["force_mint"] is True
         assert rebuilt["kwargs"]["api_key"] == "new-nous-key"
-        assert (
-            rebuilt["kwargs"]["base_url"] == "https://inference-api.nousresearch.com/v1"
-        )
+        assert rebuilt["kwargs"]["base_url"] == "https://inference-api.nousresearch.com/v1"
         assert "default_headers" not in rebuilt["kwargs"]
         assert isinstance(agent.client, _RebuiltClient)
 
@@ -1373,7 +1147,6 @@ class TestMaxTokensParam:
 # ---------------------------------------------------------------------------
 # System prompt stability for prompt caching
 # ---------------------------------------------------------------------------
-
 
 class TestSystemPromptStability:
     """Verify that the system prompt stays stable across turns for cache hits."""


### PR DESCRIPTION
## Summary
- Detect and interrupt repeated identical tool calls to prevent doom loops.
- Add recovery behavior that skips the repeated call and prompts the model to change approach or summarize.
- Add regression coverage for repeated-call handling, CLI continue/stop paths, and per-turn state reset behavior.

## Scope
- Includes: `run_agent.py`, `tests/test_run_agent.py`
- Excludes: adapter/CLI/browser cleanup work (moved to #939)
- Issue scope tags: #512 (doom-loop handling), #481 (hash-based repeated-call signature detection)

## Approach
- Build a call signature from tool name + normalized argument hash.
- Trigger protection after 3 identical consecutive calls.
- Exempt long-running process polling/wait/log actions.
- On trigger, inject an explicit recovery prompt to avoid repeating the same call.

## Related
- Closes #512
- Addresses #481
- Split cleanup follow-up: #939

## Validation
- `python -m pytest -o addopts='' tests/test_run_agent.py -q`
- `python -m pytest -o addopts='' tests/test_run_agent.py -k "doom_loop or resets_doom_loop_state_each_turn" -q`