### PR TITLE
feat: bidirectional file transfer for sandboxed deployments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -585,6 +585,60 @@ class BasePlatformAdapter(ABC):
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
 
     @staticmethod
+    def extract_files(content: str) -> Tuple[List[Tuple[str, Optional[str]]], str]:
+        """
+        Extract ``FILE:<path>`` or ``FILE:<path|caption>`` tags from response text.
+
+        The send_file tool embeds FILE: tags in its JSON response so the
+        gateway delivery pipeline can detect and send them as native
+        document attachments.
+
+        Args:
+            content: The response text to scan.
+
+        Returns:
+            Tuple of (list of (file_path, caption_or_None), cleaned content).
+        """
+        files: List[Tuple[str, Optional[str]]] = []
+        cleaned = content
+
+        # Lazy import to avoid circular dependency at module level
+        try:
+            from tools.file_transfer import is_safe_file_path
+        except ImportError:
+            is_safe_file_path = None
+
+        # Escape-aware regex: matches FILE:<...> where \> is literal, bare > closes.
+        file_pattern = r'FILE:<((?:[^>\\]|\\.)*)>'
+        for match in re.finditer(file_pattern, content):
+            inner = match.group(1).strip()
+            if not inner:
+                continue
+            if "|" in inner:
+                path, caption = inner.split("|", 1)
+                path = path.strip().replace("\\>", ">").replace("\\\\", "\\")
+                caption = caption.strip().replace("\\>", ">").replace("\\\\", "\\")
+            else:
+                path = inner.replace("\\>", ">").replace("\\\\", "\\")
+                caption = None
+
+            # Security: only allow paths inside ~/.hermes/file_cache/
+            if is_safe_file_path is not None:
+                safe = is_safe_file_path(path)
+                if safe is None:
+                    logger.warning("Blocked FILE tag with path outside cache: %s", path)
+                    continue
+                path = str(safe)
+
+            files.append((path, caption))
+
+        # Always strip FILE tags from text (even blocked ones)
+        cleaned = re.sub(file_pattern, '', cleaned)
+        cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
+
+        return files, cleaned
+
+    @staticmethod
     def extract_media(content: str) -> Tuple[List[Tuple[str, bool]], str]:
         """
         Extract MEDIA:<path> tags and [[audio_as_voice]] directives from response text.
@@ -704,7 +758,11 @@ class BasePlatformAdapter(ABC):
                 images, text_content = self.extract_images(response)
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
-                
+
+                # Extract FILE:<path|caption> tags before sending text
+                # so the user never sees raw FILE: tags in the message.
+                file_attachments, text_content = self.extract_files(text_content)
+
                 # Send the text portion first (if any remains after extractions)
                 if text_content:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
@@ -790,7 +848,23 @@ class BasePlatformAdapter(ABC):
                             print(f"[{self.name}] Failed to send media ({ext}): {media_result.error}")
                     except Exception as media_err:
                         print(f"[{self.name}] Error sending media: {media_err}")
-            
+
+                # Send extracted FILE:<path|caption> attachments from send_file tool
+                for file_path, file_caption in file_attachments:
+                    if human_delay > 0:
+                        await asyncio.sleep(human_delay)
+                    try:
+                        doc_result = await self.send_document(
+                            chat_id=event.source.chat_id,
+                            file_path=file_path,
+                            caption=file_caption,
+                            file_name=os.path.basename(file_path),
+                        )
+                        if not doc_result.success:
+                            logger.error("[%s] Failed to send file: %s", self.name, doc_result.error)
+                    except Exception as file_err:
+                        logger.error("[%s] Error sending file: %s", self.name, file_err, exc_info=True)
+
             # Check if there's a pending message that was queued during our processing
             if session_key in self._pending_messages:
                 pending_event = self._pending_messages.pop(session_key)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -181,6 +181,9 @@ async def cache_audio_from_url(url: str, ext: str = ".ogg") -> str:
 DOCUMENT_CACHE_DIR = Path(os.path.expanduser("~/.hermes/document_cache"))
 
 SUPPORTED_DOCUMENT_TYPES = {
+    ".csv": "text/csv",
+    ".json": "application/json",
+    ".log": "text/plain",
     ".pdf": "application/pdf",
     ".md": "text/markdown",
     ".txt": "text/plain",

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -38,6 +38,7 @@ from gateway.platforms.base import (
     SendResult,
     cache_image_from_url,
     cache_audio_from_url,
+    cache_document_from_bytes,
 )
 
 
@@ -303,6 +304,47 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:
             print(f"[{self.name}] Failed to send local image: {e}")
             return await super().send_image_file(chat_id, image_path, caption, reply_to)
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+    ) -> SendResult:
+        """Send a document/file natively as a Discord file attachment."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            import io
+
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            if not channel:
+                return SendResult(success=False, error=f"Channel {chat_id} not found")
+
+            if not os.path.exists(file_path):
+                return SendResult(success=False, error=f"File not found: {file_path}")
+
+            file_size = os.path.getsize(file_path)
+            if file_size > 25 * 1024 * 1024:  # 25MB Discord limit
+                return SendResult(success=False, error="File exceeds 25MB Discord limit")
+
+            name = file_name or os.path.basename(file_path)
+            with open(file_path, "rb") as f:
+                file = discord.File(io.BytesIO(f.read()), filename=name)
+                msg = await channel.send(
+                    content=caption if caption else None,
+                    file=file,
+                )
+                return SendResult(success=True, message_id=str(msg.id))
+
+        except Exception as e:
+            print(f"[{self.name}] Failed to send document: {e}")
+            return await super().send_document(chat_id, file_path, caption, file_name, reply_to)
 
     async def send_image(
         self,
@@ -866,9 +908,37 @@ class DiscordAdapter(BasePlatformAdapter):
                     media_urls.append(att.url)
                     media_types.append(content_type)
             else:
-                # Other attachments: keep the original URL
-                media_urls.append(att.url)
-                media_types.append(content_type)
+                # Documents / other attachments: download to local cache
+                # so sandbox injection and agent file access work reliably.
+                MAX_DOC_BYTES = 50 * 1024 * 1024  # 50 MB
+                if att.size and att.size > MAX_DOC_BYTES:
+                    print(f"[Discord] Document too large ({att.size} bytes), skipping", flush=True)
+                    continue
+                try:
+                    import aiohttp
+                    async with aiohttp.ClientSession() as session:
+                        async with session.get(att.url) as resp:
+                            if resp.status == 200:
+                                # Enforce size limit on actual download
+                                cl = resp.content_length or 0
+                                if cl > MAX_DOC_BYTES:
+                                    print(f"[Discord] Document content-length {cl} exceeds limit", flush=True)
+                                    continue
+                                doc_bytes = await resp.read()
+                                if len(doc_bytes) > MAX_DOC_BYTES:
+                                    print(f"[Discord] Downloaded document exceeds 50MB, discarding", flush=True)
+                                    continue
+                                filename = att.filename or "document"
+                                cached_path = cache_document_from_bytes(doc_bytes, filename)
+                                media_urls.append(cached_path)
+                                media_types.append(content_type)
+                                print(f"[Discord] Cached user document: {cached_path}", flush=True)
+                            else:
+                                print(f"[Discord] Failed to download document: HTTP {resp.status}", flush=True)
+                                # Don't append URL — uncached files can't be injected
+                except Exception as e:
+                    print(f"[Discord] Failed to cache document attachment: {e}", flush=True)
+                    # Don't append URL — failed downloads can't be injected
         
         event = MessageEvent(
             text=message.content,

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -133,7 +133,7 @@ class DiscordAdapter(BasePlatformAdapter):
             asyncio.create_task(self._client.start(self.config.token))
             
             # Wait for ready
-            await asyncio.wait_for(self._ready_event.wait(), timeout=30)
+            await asyncio.wait_for(self._ready_event.wait(), timeout=120)
             
             self._running = True
             return True

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -346,6 +346,41 @@ class TelegramAdapter(BasePlatformAdapter):
             print(f"[{self.name}] Failed to send local image: {e}")
             return await super().send_image_file(chat_id, image_path, caption, reply_to)
 
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+    ) -> SendResult:
+        """Send a document/file natively as a Telegram document attachment."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            import os
+            if not os.path.exists(file_path):
+                return SendResult(success=False, error=f"File not found: {file_path}")
+
+            file_size = os.path.getsize(file_path)
+            if file_size > 50 * 1024 * 1024:  # 50MB Telegram limit
+                return SendResult(success=False, error="File exceeds 50MB Telegram limit")
+
+            name = file_name or os.path.basename(file_path)
+            with open(file_path, "rb") as f:
+                msg = await self._bot.send_document(
+                    chat_id=int(chat_id),
+                    document=f,
+                    filename=name,
+                    caption=caption[:1024] if caption else None,
+                    reply_to_message_id=int(reply_to) if reply_to else None,
+                )
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.error("[%s] Failed to send document: %s", self.name, e)
+            return await super().send_document(chat_id, file_path, caption, file_name, reply_to)
+
     async def send_image(
         self,
         chat_id: str,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -751,7 +751,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 # For text files, inject content into event.text (capped at 100 KB)
                 MAX_TEXT_INJECT_BYTES = 100 * 1024
-                if ext in (".md", ".txt") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                if ext in (".md", ".txt", ".csv", ".json", ".log") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
                     try:
                         text_content = raw_bytes.decode("utf-8")
                         display_name = original_filename or f"document{ext}"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -134,6 +134,7 @@ if _config_path.exists():
 
 # Gateway runs in quiet mode - suppress debug output and use cwd directly (no temp dirs)
 os.environ["HERMES_QUIET"] = "1"
+os.environ["HERMES_GATEWAY"] = "1"
 
 # Enable interactive exec approval for dangerous commands on messaging platforms
 os.environ["HERMES_EXEC_ASK"] = "1"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1199,6 +1199,34 @@ class GatewayRunner:
                     )
                 message_text = f"{context_note}\n\n{message_text}"
 
+        # -----------------------------------------------------------------
+        # Queue uploaded documents for injection into sandbox environments.
+        # The actual injection is deferred until the terminal/file_tools
+        # environment is first accessed (process_pending_injections).
+        # -----------------------------------------------------------------
+        env_type = os.environ.get("TERMINAL_ENV", "local")
+        if env_type != "local" and event.media_urls and event.message_type == MessageType.DOCUMENT:
+            try:
+                from tools.file_transfer import queue_injection
+                for doc_path in event.media_urls:
+                    # Only queue local files — skip URLs that failed to cache
+                    if not os.path.isfile(doc_path):
+                        logger.warning("Skipping non-local path for injection: %s", doc_path)
+                        continue
+                    import os as _os
+                    fname = _os.path.basename(doc_path)
+                    remote_dest = f"/workspace/uploads/{fname}"
+                    queue_injection(
+                        host_path=doc_path,
+                        remote_path=remote_dest,
+                        task_id=session_key,
+                    )
+                    message_text = message_text.replace(
+                        doc_path, f"{doc_path} (will be available in sandbox at {remote_dest})"
+                    )
+            except Exception as _inj_err:
+                logger.warning("Failed to queue file injection: %s", _inj_err)
+
         try:
             # Emit agent:start hook
             hook_ctx = {
@@ -2880,7 +2908,23 @@ class GatewayRunner:
                     if has_voice_directive:
                         unique_tags.insert(0, "[[audio_as_voice]]")
                     final_response = final_response + "\n" + "\n".join(unique_tags)
-            
+
+            # Same pattern for FILE:<path> tags from the send_file tool.
+            # Collect unique FILE: tags from tool results and append them
+            # so the adapter's extract_files() can deliver documents.
+            if "FILE:<" not in final_response:
+                file_tags = []
+                for msg in result.get("messages", []):
+                    if msg.get("role") in ("tool", "function"):
+                        content = msg.get("content", "")
+                        if "FILE:<" in content:
+                            for match in re.finditer(r'FILE:<((?:[^>\\]|\\.)*)>', content):
+                                fpath = match.group(0)
+                                if fpath not in file_tags:
+                                    file_tags.append(fpath)
+                if file_tags:
+                    final_response = final_response + "\n" + "\n".join(file_tags)
+
             return {
                 "final_response": final_response,
                 "messages": result_holder[0].get("messages", []) if result_holder[0] else [],
@@ -3035,6 +3079,13 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, interval: int
                     logger.info("Document cache cleanup: removed %d stale file(s)", removed)
             except Exception as e:
                 logger.debug("Document cache cleanup error: %s", e)
+            try:
+                from tools.file_transfer import cleanup_file_cache
+                removed = cleanup_file_cache(max_age_hours=24)
+                if removed:
+                    logger.info("File transfer cache cleanup: removed %d stale file(s)", removed)
+            except Exception as e:
+                logger.debug("File transfer cache cleanup error: %s", e)
 
         stop_event.wait(timeout=interval)
     logger.info("Cron ticker stopped")

--- a/model_tools.py
+++ b/model_tools.py
@@ -95,6 +95,7 @@ def _discover_tools():
         "tools.send_message_tool",
         "tools.honcho_tools",
         "tools.homeassistant_tool",
+        "tools.send_file_tool",
     ]
     import importlib
     for mod_name in _modules:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3994,6 +3994,39 @@ class AIAgent:
                 elif hasattr(self, "_codex_incomplete_retries"):
                     self._codex_incomplete_retries = 0
                 
+                # Fallback: extract <tool_call> from text when API returns no structured tool_calls
+                # (Hermes models sometimes emit tool calls as text instead of structured API calls)
+                if not assistant_message.tool_calls and assistant_message.content and "<tool_call>" in (assistant_message.content or ""):
+                    try:
+                        import re as _re_tc, uuid as _uuid_tc
+                        from openai.types.chat.chat_completion_message_tool_call import (
+                            ChatCompletionMessageToolCall as _TC,
+                            Function as _Fn,
+                        )
+                        _tc_pat = _re_tc.compile(r"<tool_call>\s*(.*?)\s*</tool_call>|<tool_call>\s*(.*)", _re_tc.DOTALL)
+                        _matches = _tc_pat.findall(assistant_message.content)
+                        _parsed_tcs = []
+                        for _m in _matches:
+                            _raw = (_m[0] if _m[0] else _m[1]).strip()
+                            if not _raw:
+                                continue
+                            _tc_data = json.loads(_raw)
+                            _parsed_tcs.append(_TC(
+                                id=f"call_{_uuid_tc.uuid4().hex[:8]}",
+                                type="function",
+                                function=_Fn(
+                                    name=_tc_data["name"],
+                                    arguments=json.dumps(_tc_data.get("arguments", {}), ensure_ascii=False),
+                                ),
+                            ))
+                        if _parsed_tcs:
+                            _before = assistant_message.content[:assistant_message.content.find("<tool_call>")].strip()
+                            assistant_message.content = _before if _before else None
+                            assistant_message.tool_calls = _parsed_tcs
+                            logger.info("Extracted %d tool call(s) from text via fallback parser", len(_parsed_tcs))
+                    except Exception as _parse_err:
+                        logger.debug("Text tool-call parser fallback failed: %s", _parse_err)
+
                 # Check for tool calls
                 if assistant_message.tool_calls:
                     if not self.quiet_mode:

--- a/skills/productivity/courier-analyst/SKILL.md
+++ b/skills/productivity/courier-analyst/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 
 # Courier Analyst
 
-Analyze uploaded files using parallel subagent delegation, then deliver structured reports and artifacts back to the user.
+Analyze uploaded files, produce structured reports with visualizations, and deliver artifacts back to the user via send_file.
 
 ## When to Use
 
@@ -20,129 +20,139 @@ Activate this skill when:
 - A user sends a file (CSV, log, JSON, code archive, document) and asks for analysis
 - The user wants insights, statistics, patterns, or quality checks on data
 - The user needs a structured report generated from raw data
-- Multiple analysis perspectives would add value (statistics + quality review)
+- The user wants charts or visualizations from data
 
 ## Required Toolsets
 
-This skill requires: `terminal`, `file`, `file_transfer`, `delegation`
+This skill requires: `terminal`, `file`, `file_transfer`
+
+## CRITICAL Rules
+
+1. NEVER use `python -c "..."` for multi-line code — ALWAYS use `write_file` to create a .py script first, then run it with `terminal`
+2. Use `python` command (NOT `python3`)
+3. Always add `matplotlib.use('Agg')` BEFORE `import matplotlib.pyplot as plt`
+4. Use `send_file` for EACH output file separately (one call per file)
+5. Save output files in the current working directory (not /workspace/ or /tmp/)
 
 ## Workflow
 
-### Step 1: File Detection & Strategy
+### Step 1: Read the file
+Use `read_file` to examine the uploaded file and understand its structure.
 
-Identify the file type and choose the analysis approach:
+### Step 2: Write analysis script
+Use `write_file` to create a Python script (e.g. `analyze_data.py`). The script should:
+- Read the data file
+- Compute statistics
+- Generate charts (save as .png)
+- Write a markdown report (save as .md)
 
-| File Type | Strategy | Tools |
-|-----------|----------|-------|
-| CSV/Excel | Statistical analysis + data quality | pandas, matplotlib |
-| Log files | Error pattern detection + anomaly timeline | grep, regex, awk |
-| JSON/YAML | Schema analysis + validation | jq, python json |
-| Code (.py, .js, .zip) | Structure analysis + review | ast, eslint, tree |
-| PDF/Docs | Content extraction + summary | text extraction |
-| Generic | Content overview + size/encoding info | file, wc, head |
+### Step 3: Run the script
+Use `terminal` with command: `python analyze_data.py`
+If it fails, read the error, fix the script with `write_file`, and re-run.
 
-### Step 2: Parallel Analysis via Subagents
+### Step 4: Deliver results
+Use `send_file` once for EACH output file:
+- `send_file` for the analysis report (.md)
+- `send_file` for each chart (.png)
 
-Use `delegate_task` in batch mode with 2 parallel subagents:
+## CSV Analysis Template
 
-**Subagent 1 — Analyst:**
-```
-Analyze the file at {path}. Produce a structured report with:
-- File overview (type, size, encoding, structure)
-- Key statistics and metrics
-- Notable patterns or trends
-- Data quality observations
-- Summary of findings
+When analyzing CSV data, use `write_file` to create this script (adapt column names to match the actual data):
 
-Save the report as /workspace/reports/{name}_analysis.md
-If the data supports visualization, generate a chart using matplotlib
-and save it as /workspace/reports/{name}_chart.png
-```
+```python
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import pandas as pd
 
-**Subagent 2 — Reviewer:**
-```
-Review the file at {path} for quality and anomalies:
-- Check for missing values, duplicates, outliers
-- Identify encoding issues or malformed entries
-- Flag potential data integrity concerns
-- Assess completeness and consistency
+# Read data
+df = pd.read_csv('INPUT_FILE.csv')
+print(f"Loaded {len(df)} rows, {len(df.columns)} columns")
+print(f"Columns: {list(df.columns)}")
+print(df.describe())
 
-Save findings as /workspace/reports/{name}_review.md
-```
+# --- Bar Chart: sales by region ---
+fig, ax = plt.subplots(figsize=(10, 6))
+group_data = df.groupby('REGION_COLUMN')['VALUE_COLUMN'].sum().sort_values(ascending=False)
+group_data.plot(kind='bar', ax=ax, color='steelblue', edgecolor='black')
+ax.set_title('Total Sales by Region', fontsize=14, fontweight='bold')
+ax.set_xlabel('Region')
+ax.set_ylabel('Total Sales ($)')
+plt.xticks(rotation=45, ha='right')
+plt.tight_layout()
+plt.savefig('region_sales_chart.png', dpi=150)
+plt.close()
+print("Saved region_sales_chart.png")
 
-### Step 3: Merge & Deliver
+# --- Pie Chart: sales by category ---
+fig, ax = plt.subplots(figsize=(8, 8))
+cat_data = df.groupby('CATEGORY_COLUMN')['VALUE_COLUMN'].sum()
+colors = ['#2196F3', '#4CAF50', '#FF9800', '#E91E63', '#9C27B0', '#00BCD4']
+cat_data.plot(kind='pie', ax=ax, autopct='%1.1f%%', colors=colors[:len(cat_data)], startangle=140)
+ax.set_title('Sales Distribution by Category', fontsize=14, fontweight='bold')
+ax.set_ylabel('')
+plt.tight_layout()
+plt.savefig('category_chart.png', dpi=150)
+plt.close()
+print("Saved category_chart.png")
 
-1. Read both subagent reports from `/workspace/reports/`
-2. Merge into a unified analysis document
-3. Use `send_file` to deliver:
-   - The merged analysis report (markdown)
-   - Any generated charts or visualizations
-   - The original subagent reports (if detailed)
-
-## Analysis Templates
-
-### CSV Analysis Report Structure
-```markdown
-# Data Analysis Report: {filename}
+# --- Markdown Report ---
+total_sales = df['VALUE_COLUMN'].sum()
+avg_sales = df['VALUE_COLUMN'].mean()
+report = f"""# Data Analysis Report: INPUT_FILE.csv
 
 ## Overview
-- Rows: {count} | Columns: {count}
-- File size: {size} | Encoding: {encoding}
+- **Total Rows**: {len(df)}
+- **Columns**: {len(df.columns)}
+- **Total Sales**: ${total_sales:,.2f}
+- **Average Sale**: ${avg_sales:,.2f}
 
-## Column Summary
-| Column | Type | Non-null | Unique | Sample Values |
-|--------|------|----------|--------|---------------|
-| ...    | ...  | ...      | ...    | ...           |
+## Sales by Region
+"""
+for region, val in group_data.items():
+    pct = val / total_sales * 100
+    report += f"- **{region}**: ${val:,.2f} ({pct:.1f}%)\n"
+
+report += "\n## Sales by Category\n"
+for cat, val in cat_data.items():
+    pct = val / total_sales * 100
+    report += f"- **{cat}**: ${val:,.2f} ({pct:.1f}%)\n"
+
+report += f"""
+## Data Quality
+- Missing values: {df.isnull().sum().sum()} total
+- Duplicate rows: {df.duplicated().sum()}
 
 ## Key Findings
-1. {finding_1}
-2. {finding_2}
+1. Top region: {group_data.index[0]} (${group_data.iloc[0]:,.2f})
+2. Top category: {cat_data.idxmax()} (${cat_data.max():,.2f})
+3. {len(df)} transactions analyzed
+"""
 
-## Data Quality
-- Missing values: {count} ({percentage}%)
-- Duplicates: {count}
-- Anomalies: {list}
-
-## Recommendations
-- {recommendation_1}
+with open('analysis_report.md', 'w') as f:
+    f.write(report)
+print("Saved analysis_report.md")
+print("DONE - all files generated successfully")
 ```
 
-### Log Analysis Report Structure
-```markdown
-# Log Analysis Report: {filename}
+Adapt the column names (REGION_COLUMN, VALUE_COLUMN, CATEGORY_COLUMN, INPUT_FILE) to match the actual CSV columns found in Step 1.
 
-## Overview
-- Total lines: {count} | Time range: {start} - {end}
-- Log levels: ERROR({n}), WARN({n}), INFO({n})
+## Log Analysis Template
 
-## Error Patterns
-| Pattern | Count | First Seen | Last Seen |
-|---------|-------|------------|-----------|
-| ...     | ...   | ...        | ...       |
-
-## Timeline
-- {timestamp}: {event}
-
-## Anomalies
-- {anomaly_description}
-```
+For log files, create a script that:
+- Counts log levels (ERROR, WARN, INFO)
+- Identifies error patterns and frequencies
+- Creates a timeline chart of errors over time
+- Writes a markdown report
 
 ## Example Interaction
 
 **User sends:** `sales_data.csv` with message "analyze this"
 
-**Agent workflow:**
-1. Detect: CSV file, 5MB, 50K rows
-2. Delegate to 2 subagents (analyst + reviewer)
-3. Analyst produces statistical report + bar chart
-4. Reviewer flags 3% missing values in 'region' column
-5. Merge reports into unified analysis
-6. `send_file` delivers: analysis.md + chart.png
-
-## Tips
-
-- For large files (>10MB), sample first 10K rows for quick analysis, then full scan
-- Always create the `/workspace/reports/` directory before saving
-- Use `send_file` for each artifact separately (one file per call)
-- If matplotlib is not available, install it: `pip install matplotlib`
-- For code archives, extract first: `unzip code.zip -d /workspace/code_review/`
+**Agent does:**
+1. `read_file` → sees columns: date, region, category, amount, status
+2. `write_file` → creates `analyze_data.py` adapted from the CSV template above
+3. `terminal` → runs `python analyze_data.py` → output says "DONE"
+4. `send_file(path="region_sales_chart.png", caption="Sales by Region")` → delivered
+5. `send_file(path="category_chart.png", caption="Sales by Category")` → delivered
+6. `send_file(path="analysis_report.md", caption="Analysis Report")` → delivered

--- a/skills/productivity/courier-analyst/SKILL.md
+++ b/skills/productivity/courier-analyst/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: courier-analyst
+description: Intelligent file analysis with subagent delegation and artifact delivery. Analyzes uploaded files (CSV, logs, code, documents), produces structured reports with insights, and sends results back to the user via send_file.
+version: 1.0.0
+author: eren-karakus0
+license: MIT
+metadata:
+  hermes:
+    tags: [Analysis, Files, Delegation, Artifacts, Productivity]
+    platforms: [cli, telegram, discord]
+---
+
+# Courier Analyst
+
+Analyze uploaded files using parallel subagent delegation, then deliver structured reports and artifacts back to the user.
+
+## When to Use
+
+Activate this skill when:
+- A user sends a file (CSV, log, JSON, code archive, document) and asks for analysis
+- The user wants insights, statistics, patterns, or quality checks on data
+- The user needs a structured report generated from raw data
+- Multiple analysis perspectives would add value (statistics + quality review)
+
+## Required Toolsets
+
+This skill requires: `terminal`, `file`, `file_transfer`, `delegation`
+
+## Workflow
+
+### Step 1: File Detection & Strategy
+
+Identify the file type and choose the analysis approach:
+
+| File Type | Strategy | Tools |
+|-----------|----------|-------|
+| CSV/Excel | Statistical analysis + data quality | pandas, matplotlib |
+| Log files | Error pattern detection + anomaly timeline | grep, regex, awk |
+| JSON/YAML | Schema analysis + validation | jq, python json |
+| Code (.py, .js, .zip) | Structure analysis + review | ast, eslint, tree |
+| PDF/Docs | Content extraction + summary | text extraction |
+| Generic | Content overview + size/encoding info | file, wc, head |
+
+### Step 2: Parallel Analysis via Subagents
+
+Use `delegate_task` in batch mode with 2 parallel subagents:
+
+**Subagent 1 — Analyst:**
+```
+Analyze the file at {path}. Produce a structured report with:
+- File overview (type, size, encoding, structure)
+- Key statistics and metrics
+- Notable patterns or trends
+- Data quality observations
+- Summary of findings
+
+Save the report as /workspace/reports/{name}_analysis.md
+If the data supports visualization, generate a chart using matplotlib
+and save it as /workspace/reports/{name}_chart.png
+```
+
+**Subagent 2 — Reviewer:**
+```
+Review the file at {path} for quality and anomalies:
+- Check for missing values, duplicates, outliers
+- Identify encoding issues or malformed entries
+- Flag potential data integrity concerns
+- Assess completeness and consistency
+
+Save findings as /workspace/reports/{name}_review.md
+```
+
+### Step 3: Merge & Deliver
+
+1. Read both subagent reports from `/workspace/reports/`
+2. Merge into a unified analysis document
+3. Use `send_file` to deliver:
+   - The merged analysis report (markdown)
+   - Any generated charts or visualizations
+   - The original subagent reports (if detailed)
+
+## Analysis Templates
+
+### CSV Analysis Report Structure
+```markdown
+# Data Analysis Report: {filename}
+
+## Overview
+- Rows: {count} | Columns: {count}
+- File size: {size} | Encoding: {encoding}
+
+## Column Summary
+| Column | Type | Non-null | Unique | Sample Values |
+|--------|------|----------|--------|---------------|
+| ...    | ...  | ...      | ...    | ...           |
+
+## Key Findings
+1. {finding_1}
+2. {finding_2}
+
+## Data Quality
+- Missing values: {count} ({percentage}%)
+- Duplicates: {count}
+- Anomalies: {list}
+
+## Recommendations
+- {recommendation_1}
+```
+
+### Log Analysis Report Structure
+```markdown
+# Log Analysis Report: {filename}
+
+## Overview
+- Total lines: {count} | Time range: {start} - {end}
+- Log levels: ERROR({n}), WARN({n}), INFO({n})
+
+## Error Patterns
+| Pattern | Count | First Seen | Last Seen |
+|---------|-------|------------|-----------|
+| ...     | ...   | ...        | ...       |
+
+## Timeline
+- {timestamp}: {event}
+
+## Anomalies
+- {anomaly_description}
+```
+
+## Example Interaction
+
+**User sends:** `sales_data.csv` with message "analyze this"
+
+**Agent workflow:**
+1. Detect: CSV file, 5MB, 50K rows
+2. Delegate to 2 subagents (analyst + reviewer)
+3. Analyst produces statistical report + bar chart
+4. Reviewer flags 3% missing values in 'region' column
+5. Merge reports into unified analysis
+6. `send_file` delivers: analysis.md + chart.png
+
+## Tips
+
+- For large files (>10MB), sample first 10K rows for quick analysis, then full scan
+- Always create the `/workspace/reports/` directory before saving
+- Use `send_file` for each artifact separately (one file per call)
+- If matplotlib is not available, install it: `pip install matplotlib`
+- For code archives, extract first: `unzip code.zip -d /workspace/code_review/`

--- a/tests/gateway/test_send_document.py
+++ b/tests/gateway/test_send_document.py
@@ -1,0 +1,441 @@
+"""Tests for the send_document platform adapter methods and FILE: tag extraction.
+
+All tests use mocks -- no real Telegram/Discord connections are needed.
+"""
+
+import asyncio
+import io
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+
+# =========================================================================
+# FILE: Tag Extraction
+# =========================================================================
+
+class TestFileTagExtraction:
+    """Tests for BasePlatformAdapter.extract_files().
+
+    The tag format is FILE:<path> or FILE:<path|caption>.
+    extract_files() returns List[Tuple[str, Optional[str]]].
+
+    All tests mock is_safe_file_path to bypass the cache-dir allowlist
+    because we're testing the *parsing* logic, not the path guard.
+    The allowlist itself is tested in TestPathAllowlist below.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _bypass_path_guard(self):
+        """Let every path through so we can test parsing in isolation."""
+        # Return a SimpleNamespace with is_file()=True so the guard passes,
+        # but __str__ returns the original path string unchanged.
+        class _FakePath:
+            def __init__(self, p):
+                self._p = p
+            def is_file(self):
+                return True
+            def __str__(self):
+                return self._p
+        with patch("tools.file_transfer.is_safe_file_path",
+                    side_effect=lambda p: _FakePath(p)):
+            yield
+
+    def test_single_file_tag(self):
+        content = "Here is your report\nFILE:</tmp/cache/abc_report.csv>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 1
+        assert files[0] == ("/tmp/cache/abc_report.csv", None)
+        assert "FILE:<" not in cleaned
+        assert "report" in cleaned
+
+    def test_single_file_tag_with_caption(self):
+        content = "Done\nFILE:</tmp/cache/abc_report.csv|Your quarterly report>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 1
+        assert files[0] == ("/tmp/cache/abc_report.csv", "Your quarterly report")
+        assert "FILE:<" not in cleaned
+
+    def test_multiple_file_tags(self):
+        content = "Analysis complete\nFILE:</tmp/a.csv>\nFILE:</tmp/b.png>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 2
+        paths = [f[0] for f in files]
+        assert "/tmp/a.csv" in paths
+        assert "/tmp/b.png" in paths
+
+    def test_no_file_tags(self):
+        content = "No files here, just text."
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 0
+        assert cleaned == content
+
+    def test_file_tag_cleanup_blank_lines(self):
+        content = "Text\n\n\n\nFILE:</tmp/file.txt>\n\n\n\nMore text"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 1
+        assert "\n\n\n" not in cleaned
+
+    def test_file_tag_with_spaces_in_path(self):
+        """Paths with spaces should be preserved inside angle brackets."""
+        content = "FILE:</tmp/cache/abc_my report (final).csv>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 1
+        assert files[0] == ("/tmp/cache/abc_my report (final).csv", None)
+
+    def test_file_tag_spaces_and_caption(self):
+        content = "FILE:</tmp/cache/abc_my report.csv|Here is your report>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 1
+        assert files[0] == ("/tmp/cache/abc_my report.csv", "Here is your report")
+
+    def test_file_tag_caption_with_gt_character(self):
+        """Caption containing escaped \\> must be unescaped to >."""
+        content = r"FILE:</tmp/a.csv|Results \> 100 items found>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 1
+        assert files[0] == ("/tmp/a.csv", "Results > 100 items found")
+        assert "FILE:<" not in cleaned
+
+    def test_multiple_file_tags_same_line(self):
+        """Multiple FILE tags on the same line must be parsed separately."""
+        content = "FILE:</tmp/a.csv> FILE:</tmp/b.csv>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 2
+        assert files[0] == ("/tmp/a.csv", None)
+        assert files[1] == ("/tmp/b.csv", None)
+
+    def test_multiple_file_tags_same_line_with_captions(self):
+        """Multiple FILE tags with captions on same line."""
+        content = "FILE:</tmp/a.csv|Report A> FILE:</tmp/b.csv|Report B>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 2
+        assert files[0] == ("/tmp/a.csv", "Report A")
+        assert files[1] == ("/tmp/b.csv", "Report B")
+
+    def test_path_with_gt_character(self):
+        """Path containing escaped \\> must be unescaped to >."""
+        content = r"FILE:</tmp/cache/abc_report \> final.csv|Your report>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 1
+        assert files[0] == ("/tmp/cache/abc_report > final.csv", "Your report")
+        assert "FILE:<" not in cleaned
+
+    def test_path_with_gt_no_caption(self):
+        """Path containing > without caption must also roundtrip."""
+        content = r"FILE:</tmp/cache/abc_data \> 2026.csv>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 1
+        assert files[0] == ("/tmp/cache/abc_data > 2026.csv", None)
+
+    def test_mixed_escaped_gt_and_multi_tag(self):
+        """Escaped > in caption must not break multi-tag parsing."""
+        content = r"FILE:</tmp/a.csv|Count \> 50> FILE:</tmp/b.csv>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 2
+        assert files[0] == ("/tmp/a.csv", "Count > 50")
+        assert files[1] == ("/tmp/b.csv", None)
+
+
+# =========================================================================
+# Base send_document fallback
+# =========================================================================
+
+class TestBaseSendDocument:
+    """Tests for the base class send_document fallback."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_sends_text(self):
+        """Base implementation should fall back to sending file path as text."""
+        # Create a minimal concrete adapter
+        adapter = _make_mock_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+
+        result = await adapter.send_document(
+            chat_id="123",
+            file_path="/tmp/cache/report.csv",
+            caption="Your report",
+        )
+        assert result.success
+        # The send() call should contain the filename
+        call_args = adapter.send.call_args
+        assert "report.csv" in call_args.kwargs.get("content", call_args[1].get("content", ""))
+
+
+# =========================================================================
+# Telegram send_document (mocked)
+# =========================================================================
+
+class TestTelegramSendDocument:
+    """Tests for TelegramAdapter.send_document() with mocked bot."""
+
+    @pytest.mark.asyncio
+    async def test_send_document_success(self, tmp_path):
+        """Telegram adapter should call bot.send_document."""
+        test_file = tmp_path / "report.csv"
+        test_file.write_text("col1,col2\n1,2\n")
+
+        adapter = _make_telegram_adapter()
+        msg_mock = MagicMock()
+        msg_mock.message_id = 42
+        adapter._bot.send_document = AsyncMock(return_value=msg_mock)
+
+        result = await adapter.send_document(
+            chat_id="12345",
+            file_path=str(test_file),
+            caption="Your data",
+        )
+        assert result.success
+        assert result.message_id == "42"
+        adapter._bot.send_document.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_document_file_not_found(self):
+        """Should return error when file doesn't exist."""
+        adapter = _make_telegram_adapter()
+        result = await adapter.send_document(
+            chat_id="12345",
+            file_path="/nonexistent/file.csv",
+        )
+        assert not result.success
+        assert "not found" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_document_too_large(self, tmp_path):
+        """Should reject files over 50MB."""
+        big_file = tmp_path / "big.bin"
+        big_file.write_bytes(b"x" * (51 * 1024 * 1024))
+
+        adapter = _make_telegram_adapter()
+        result = await adapter.send_document(
+            chat_id="12345",
+            file_path=str(big_file),
+        )
+        assert not result.success
+        assert "50mb" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_document_not_connected(self):
+        """Should return error when bot is None."""
+        from gateway.platforms.telegram import TelegramAdapter
+        adapter = TelegramAdapter.__new__(TelegramAdapter)
+        adapter._bot = None
+        result = await adapter.send_document("12345", "/tmp/file.csv")
+        assert not result.success
+
+
+# =========================================================================
+# Discord send_document (mocked)
+# =========================================================================
+
+class TestDiscordSendDocument:
+    """Tests for DiscordAdapter.send_document() with mocked client."""
+
+    @pytest.mark.asyncio
+    async def test_send_document_success(self, tmp_path):
+        """Discord adapter should send file via discord.File."""
+        test_file = tmp_path / "data.json"
+        test_file.write_text('{"key": "value"}')
+
+        adapter = _make_discord_adapter()
+        msg_mock = MagicMock()
+        msg_mock.id = 999
+        channel_mock = AsyncMock()
+        channel_mock.send = AsyncMock(return_value=msg_mock)
+        adapter._client.get_channel = MagicMock(return_value=channel_mock)
+
+        result = await adapter.send_document(
+            chat_id="67890",
+            file_path=str(test_file),
+            caption="JSON data",
+        )
+        assert result.success
+        assert result.message_id == "999"
+        channel_mock.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_document_file_not_found(self):
+        """Should return error when file doesn't exist."""
+        adapter = _make_discord_adapter()
+        channel_mock = AsyncMock()
+        adapter._client.get_channel = MagicMock(return_value=channel_mock)
+
+        result = await adapter.send_document(
+            chat_id="67890",
+            file_path="/nonexistent/file.json",
+        )
+        assert not result.success
+
+    @pytest.mark.asyncio
+    async def test_send_document_too_large(self, tmp_path):
+        """Should reject files over 25MB."""
+        big_file = tmp_path / "big.bin"
+        big_file.write_bytes(b"x" * (26 * 1024 * 1024))
+
+        adapter = _make_discord_adapter()
+        channel_mock = AsyncMock()
+        adapter._client.get_channel = MagicMock(return_value=channel_mock)
+
+        result = await adapter.send_document(
+            chat_id="67890",
+            file_path=str(big_file),
+        )
+        assert not result.success
+        assert "25mb" in result.error.lower()
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+def _make_mock_adapter():
+    """Create a minimal concrete BasePlatformAdapter for testing."""
+    from gateway.config import Platform, PlatformConfig
+
+    class MockAdapter(BasePlatformAdapter):
+        async def connect(self): return True
+        async def disconnect(self): pass
+        async def send(self, chat_id, content, reply_to=None, metadata=None):
+            return SendResult(success=True)
+        async def get_chat_info(self, chat_id):
+            return {"name": "test", "type": "dm"}
+
+    config = PlatformConfig(token="fake")
+    return MockAdapter(config, Platform.TELEGRAM)
+
+
+def _make_telegram_adapter():
+    """Create a TelegramAdapter with a mocked bot."""
+    from gateway.platforms.telegram import TelegramAdapter
+    from gateway.config import PlatformConfig, Platform
+
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    adapter.config = PlatformConfig(token="fake")
+    adapter.platform = Platform.TELEGRAM
+    adapter._bot = AsyncMock()
+    adapter._app = None
+    adapter._message_handler = None
+    adapter._running = True
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    return adapter
+
+
+def _make_discord_adapter():
+    """Create a DiscordAdapter with a mocked client."""
+    from gateway.platforms.discord import DiscordAdapter
+    from gateway.config import PlatformConfig, Platform
+
+    adapter = DiscordAdapter.__new__(DiscordAdapter)
+    adapter.config = PlatformConfig(token="fake")
+    adapter.platform = Platform.DISCORD
+    adapter._client = MagicMock()
+    adapter._ready_event = asyncio.Event()
+    adapter._allowed_user_ids = set()
+    adapter._message_handler = None
+    adapter._running = True
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    return adapter
+
+
+# =========================================================================
+# Path Allowlist (is_safe_file_path guard)
+# =========================================================================
+
+class TestPathAllowlist:
+    """Tests for the cache-directory allowlist in extract_files().
+
+    extract_files() calls is_safe_file_path() which only allows paths
+    inside ~/.hermes/file_cache/ — this prevents host file exfiltration.
+    """
+
+    def test_blocks_path_outside_cache(self):
+        """FILE tag pointing to /etc/passwd should be stripped, not returned."""
+        content = "Here\nFILE:</etc/passwd|secrets>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 0
+        assert "FILE:<" not in cleaned  # tag is still cleaned from text
+
+    def test_blocks_dotenv_exfiltration(self):
+        """Attempt to exfiltrate .env file should be blocked."""
+        content = "FILE:</home/user/.env>"
+        files, cleaned = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 0
+
+    def test_allows_path_inside_cache(self, tmp_path):
+        """FILE tag inside the cache dir should pass through."""
+        from tools.file_transfer import get_file_cache_dir
+        cache_dir = get_file_cache_dir()
+        test_file = cache_dir / "test_allowlist_probe.csv"
+        test_file.write_text("col1,col2\n1,2\n")
+        try:
+            content = f"Report\nFILE:<{test_file}|test>"
+            files, cleaned = BasePlatformAdapter.extract_files(content)
+            assert len(files) == 1
+            assert files[0][1] == "test"
+        finally:
+            test_file.unlink(missing_ok=True)
+
+    def test_blocks_traversal_via_cache_path(self, tmp_path):
+        """Path traversal via cache dir should still be blocked."""
+        from tools.file_transfer import FILE_CACHE_DIR
+        evil = str(FILE_CACHE_DIR / ".." / ".." / ".env")
+        content = f"FILE:<{evil}>"
+        files, _ = BasePlatformAdapter.extract_files(content)
+        assert len(files) == 0
+
+
+# =========================================================================
+# Discord inbound document → queue_injection flow
+# =========================================================================
+
+class TestDiscordInboundDocumentFlow:
+    """Verify that Discord document attachments are cached locally
+    before being queued for sandbox injection (not left as URLs)."""
+
+    @pytest.mark.asyncio
+    async def test_document_attachment_cached_locally(self):
+        """Discord document should be downloaded and cached, not kept as URL."""
+        from gateway.platforms.base import cache_document_from_bytes
+
+        # Simulate what Discord adapter does with a document attachment
+        doc_bytes = b"col1,col2\n1,2\n"
+        cached_path = cache_document_from_bytes(doc_bytes, "report.csv")
+
+        assert os.path.exists(cached_path), "Document must be cached locally"
+        assert not cached_path.startswith("http"), "Path must be local, not URL"
+        # Cleanup
+        os.unlink(cached_path)
+
+    @pytest.mark.asyncio
+    async def test_cached_document_can_be_queued(self):
+        """Cached document path should work with queue_injection."""
+        from gateway.platforms.base import cache_document_from_bytes
+        from tools.file_transfer import queue_injection, _pending_injections
+
+        doc_bytes = b"hello world"
+        cached_path = cache_document_from_bytes(doc_bytes, "test.txt")
+        task_id = "discord_e2e_test"
+
+        try:
+            queue_injection(task_id, cached_path, "/workspace/uploads/test.txt")
+            assert task_id in _pending_injections
+            items = _pending_injections[task_id]
+            assert len(items) == 1
+            assert items[0]["host_path"] == cached_path
+            assert os.path.exists(cached_path)
+        finally:
+            _pending_injections.pop(task_id, None)
+            if os.path.exists(cached_path):
+                os.unlink(cached_path)

--- a/tests/tools/test_file_injection.py
+++ b/tests/tools/test_file_injection.py
@@ -1,0 +1,473 @@
+"""Tests for file injection (host → sandbox).
+
+All tests use mocks -- no real Docker/SSH environments are needed.
+"""
+
+import base64
+import gzip
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.file_transfer import (
+    inject_file_to_sandbox,
+    queue_injection,
+    process_pending_injections,
+    _pending_injections,
+    MAX_FILE_SIZE,
+)
+
+
+# =========================================================================
+# Local Injection
+# =========================================================================
+
+class TestLocalInjection:
+    """Tests for local backend file injection."""
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local"})
+    def test_inject_local_success(self, tmp_path):
+        source = tmp_path / "upload.csv"
+        source.write_text("a,b\n1,2\n")
+        dest = tmp_path / "workspace" / "uploads" / "upload.csv"
+
+        result = inject_file_to_sandbox(str(source), str(dest))
+        assert result["success"] is True
+        assert os.path.exists(dest)
+        assert dest.read_text() == "a,b\n1,2\n"
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local"})
+    def test_inject_local_missing_source(self, tmp_path):
+        result = inject_file_to_sandbox("/nonexistent/file.csv", str(tmp_path / "dest.csv"))
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local"})
+    def test_inject_local_too_large(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.file_transfer.MAX_FILE_SIZE", 10)
+        source = tmp_path / "big.bin"
+        source.write_bytes(b"x" * 100)
+        result = inject_file_to_sandbox(str(source), str(tmp_path / "dest.bin"))
+        assert result["success"] is False
+        assert "too large" in result["error"].lower()
+
+
+# =========================================================================
+# Docker Injection (mocked)
+# =========================================================================
+
+class TestDockerInjection:
+    """Tests for Docker backend injection with mocked subprocess."""
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "docker"})
+    @patch("tools.file_transfer.subprocess.run")
+    @patch("tools.terminal_tool._active_environments")
+    def test_docker_cp_reverse_success(self, mock_envs, mock_run, tmp_path):
+        source = tmp_path / "upload.csv"
+        source.write_text("data")
+
+        mock_env = MagicMock()
+        mock_env._container_id = "abc123"
+        mock_envs.get = MagicMock(return_value=mock_env)
+
+        mock_run.return_value = SimpleNamespace(returncode=0, stderr="")
+
+        result = inject_file_to_sandbox(
+            str(source), "/workspace/uploads/upload.csv", "task1"
+        )
+        assert result["success"] is True
+        assert result["remote_path"] == "/workspace/uploads/upload.csv"
+
+        # Verify docker cp was called
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "docker" in cmd[0]
+        assert "cp" in cmd[1]
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "docker"})
+    @patch("tools.file_transfer.subprocess.run")
+    @patch("tools.terminal_tool._active_environments")
+    def test_docker_cp_reverse_failure(self, mock_envs, mock_run, tmp_path):
+        source = tmp_path / "upload.csv"
+        source.write_text("data")
+
+        mock_env = MagicMock()
+        mock_env._container_id = "abc123"
+        mock_envs.get = MagicMock(return_value=mock_env)
+
+        mock_run.return_value = SimpleNamespace(returncode=1, stderr="Permission denied")
+
+        result = inject_file_to_sandbox(
+            str(source), "/workspace/uploads/upload.csv", "task1"
+        )
+        assert result["success"] is False
+
+
+# =========================================================================
+# SSH Injection (mocked)
+# =========================================================================
+
+class TestSSHInjection:
+    """Tests for SSH backend injection with mocked subprocess."""
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "ssh"})
+    @patch("tools.file_transfer.subprocess.run")
+    @patch("tools.terminal_tool._active_environments")
+    def test_scp_reverse_success(self, mock_envs, mock_run, tmp_path):
+        source = tmp_path / "upload.csv"
+        source.write_text("data")
+
+        mock_env = MagicMock()
+        mock_env.control_socket = "/tmp/ctrl.sock"
+        mock_env.host = "remote.host"
+        mock_env.user = "testuser"
+        mock_env.port = 22
+        mock_envs.get = MagicMock(return_value=mock_env)
+
+        mock_run.return_value = SimpleNamespace(returncode=0, stderr="")
+
+        result = inject_file_to_sandbox(
+            str(source), "/workspace/uploads/upload.csv", "task1"
+        )
+        assert result["success"] is True
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "ssh"})
+    @patch("tools.file_transfer.subprocess.run")
+    @patch("tools.terminal_tool._active_environments")
+    def test_scp_reverse_failure(self, mock_envs, mock_run, tmp_path):
+        source = tmp_path / "upload.csv"
+        source.write_text("data")
+
+        mock_env = MagicMock()
+        mock_env.control_socket = "/tmp/ctrl.sock"
+        mock_env.host = "remote.host"
+        mock_env.user = "testuser"
+        mock_env.port = 22
+        mock_envs.get = MagicMock(return_value=mock_env)
+
+        mock_run.return_value = SimpleNamespace(returncode=1, stderr="Connection refused")
+
+        result = inject_file_to_sandbox(
+            str(source), "/workspace/uploads/upload.csv", "task1"
+        )
+        assert result["success"] is False
+
+
+# =========================================================================
+# Base64 Injection (mocked)
+# =========================================================================
+
+class TestBase64Injection:
+    """Tests for gzip+base64 fallback injection."""
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "modal"})
+    @patch("tools.terminal_tool._active_environments")
+    def test_base64_upload_success(self, mock_envs, tmp_path):
+        source = tmp_path / "upload.csv"
+        source.write_text("col1,col2\n1,2\n")
+
+        mock_env = MagicMock()
+        mock_env.execute.return_value = {"output": "", "returncode": 0}
+        mock_envs.get = MagicMock(return_value=mock_env)
+
+        result = inject_file_to_sandbox(
+            str(source), "/workspace/uploads/upload.csv", "task1"
+        )
+        assert result["success"] is True
+
+        # Verify execute was called (mkdir + write chunks + decode)
+        assert mock_env.execute.call_count >= 3
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "modal"})
+    @patch("tools.terminal_tool._active_environments")
+    def test_base64_upload_decode_failure(self, mock_envs, tmp_path):
+        source = tmp_path / "upload.csv"
+        source.write_text("data")
+
+        mock_env = MagicMock()
+        # mkdir succeeds, write succeeds, decode fails
+        mock_env.execute.side_effect = [
+            {"output": "", "returncode": 0},  # mkdir
+            {"output": "", "returncode": 0},  # echo chunk
+            {"output": "gunzip: error", "returncode": 1},  # decode
+        ]
+        mock_envs.get = MagicMock(return_value=mock_env)
+
+        result = inject_file_to_sandbox(
+            str(source), "/workspace/uploads/upload.csv", "task1"
+        )
+        assert result["success"] is False
+
+
+# =========================================================================
+# Deferred Injection Queue
+# =========================================================================
+
+class TestDeferredInjection:
+    """Tests for the queue_injection / process_pending_injections mechanism."""
+
+    def setup_method(self):
+        """Clear the pending queue before each test."""
+        _pending_injections.clear()
+
+    def test_queue_injection_stores_entry(self):
+        queue_injection("task-abc", "/host/file.csv", "/workspace/uploads/file.csv")
+        assert "task-abc" in _pending_injections
+        assert len(_pending_injections["task-abc"]) == 1
+        assert _pending_injections["task-abc"][0]["host_path"] == "/host/file.csv"
+
+    def test_queue_multiple_files(self):
+        queue_injection("task-abc", "/host/a.csv", "/workspace/uploads/a.csv")
+        queue_injection("task-abc", "/host/b.csv", "/workspace/uploads/b.csv")
+        assert len(_pending_injections["task-abc"]) == 2
+
+    def test_process_clears_queue(self, tmp_path):
+        """After processing, the queue for that task_id should be empty."""
+        source = tmp_path / "file.csv"
+        source.write_text("data")
+        dest = tmp_path / "uploads" / "file.csv"
+
+        queue_injection("task-x", str(source), str(dest))
+
+        with patch.dict(os.environ, {"TERMINAL_ENV": "local"}):
+            results = process_pending_injections("task-x")
+
+        assert len(results) == 1
+        assert results[0]["success"] is True
+        assert "task-x" not in _pending_injections
+
+    def test_process_empty_queue_is_noop(self):
+        results = process_pending_injections("nonexistent-task")
+        assert results == []
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "docker"})
+    @patch("tools.file_transfer.subprocess.run")
+    @patch("tools.terminal_tool._active_environments")
+    def test_process_injects_to_docker(self, mock_envs, mock_run, tmp_path):
+        """Deferred injection should work with Docker backend."""
+        source = tmp_path / "upload.csv"
+        source.write_text("data")
+
+        mock_env = MagicMock()
+        mock_env._container_id = "cnt123"
+        mock_envs.get = MagicMock(return_value=mock_env)
+        mock_run.return_value = SimpleNamespace(returncode=0, stderr="")
+
+        queue_injection("task-d", str(source), "/workspace/uploads/upload.csv")
+        results = process_pending_injections("task-d")
+
+        assert len(results) == 1
+        assert results[0]["success"] is True
+        mock_run.assert_called_once()
+
+    def test_second_upload_same_session(self, tmp_path):
+        """Queue + flush + queue again + flush again must work (env reuse)."""
+        f1 = tmp_path / "first.csv"
+        f1.write_text("a")
+        f2 = tmp_path / "second.csv"
+        f2.write_text("b")
+        dest1 = tmp_path / "uploads" / "first.csv"
+        dest2 = tmp_path / "uploads" / "second.csv"
+
+        # First upload cycle
+        queue_injection("reuse-task", str(f1), str(dest1))
+        with patch.dict(os.environ, {"TERMINAL_ENV": "local"}):
+            r1 = process_pending_injections("reuse-task")
+        assert len(r1) == 1
+        assert r1[0]["success"] is True
+        assert "reuse-task" not in _pending_injections
+
+        # Second upload cycle (env already exists)
+        queue_injection("reuse-task", str(f2), str(dest2))
+        with patch.dict(os.environ, {"TERMINAL_ENV": "local"}):
+            r2 = process_pending_injections("reuse-task")
+        assert len(r2) == 1
+        assert r2[0]["success"] is True
+        assert dest2.exists()
+
+
+# =========================================================================
+# file_tools reuse path flush
+# =========================================================================
+
+class TestFileToolsReuseFlush:
+    """Verify _get_file_ops() flushes pending injections on cache-hit reuse.
+
+    Bug context: the cache-hit fast path returned directly without calling
+    process_pending_injections(), so uploads arriving after the sandbox was
+    already created were never injected when file_tools was the first caller.
+    """
+
+    def setup_method(self):
+        _pending_injections.clear()
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local"})
+    def test_cache_hit_flushes_pending(self, tmp_path):
+        """_get_file_ops cache-hit must call process_pending_injections."""
+        from tools.file_tools import _get_file_ops, _file_ops_cache, _file_ops_lock
+        from tools.terminal_tool import _active_environments, _env_lock, _last_activity
+
+        task_id = "flush-cache-test"
+        mock_env = MagicMock()
+        cached_ops = MagicMock()
+
+        # Pre-populate env and file_ops cache to simulate prior access
+        with _env_lock:
+            _active_environments[task_id] = mock_env
+            _last_activity[task_id] = time.time()
+        with _file_ops_lock:
+            _file_ops_cache[task_id] = cached_ops
+
+        try:
+            with patch("tools.file_transfer.process_pending_injections") as mock_flush:
+                result = _get_file_ops(task_id)
+                assert result is cached_ops  # confirmed cache hit
+                mock_flush.assert_called_once_with(task_id)
+        finally:
+            with _env_lock:
+                _active_environments.pop(task_id, None)
+                _last_activity.pop(task_id, None)
+            with _file_ops_lock:
+                _file_ops_cache.pop(task_id, None)
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local"})
+    def test_cache_hit_actually_injects_file(self, tmp_path):
+        """End-to-end: queue upload, then _get_file_ops must inject it."""
+        from tools.file_tools import _get_file_ops, _file_ops_cache, _file_ops_lock
+        from tools.terminal_tool import _active_environments, _env_lock, _last_activity
+
+        task_id = "flush-e2e-test"
+        mock_env = MagicMock()
+        cached_ops = MagicMock()
+
+        with _env_lock:
+            _active_environments[task_id] = mock_env
+            _last_activity[task_id] = time.time()
+        with _file_ops_lock:
+            _file_ops_cache[task_id] = cached_ops
+
+        # Queue an upload
+        source = tmp_path / "upload.csv"
+        source.write_text("hello")
+        dest = tmp_path / "injected" / "upload.csv"
+        queue_injection(task_id, str(source), str(dest))
+        assert task_id in _pending_injections
+
+        try:
+            result = _get_file_ops(task_id)
+            assert result is cached_ops
+            # Queue must be drained and file must exist
+            assert task_id not in _pending_injections
+            assert dest.exists()
+            assert dest.read_text() == "hello"
+        finally:
+            with _env_lock:
+                _active_environments.pop(task_id, None)
+                _last_activity.pop(task_id, None)
+            with _file_ops_lock:
+                _file_ops_cache.pop(task_id, None)
+
+
+# =========================================================================
+# Thread-safe queue
+# =========================================================================
+
+class TestQueueThreadSafety:
+    """Verify that the pending injection queue uses locking."""
+
+    def test_queue_uses_lock(self):
+        """queue_injection should acquire _pending_lock."""
+        import tools.file_transfer as ft
+        tid = "lock_test"
+        ft._pending_injections.pop(tid, None)
+
+        # Replace the module-level lock with a tracking wrapper
+        import threading
+        real_lock = threading.Lock()
+        acquired = []
+
+        class TrackingLock:
+            def __enter__(self):
+                acquired.append("enter")
+                return real_lock.__enter__()
+            def __exit__(self, *a):
+                return real_lock.__exit__(*a)
+
+        original_lock = ft._pending_lock
+        ft._pending_lock = TrackingLock()
+        try:
+            ft.queue_injection(tid, "/fake/src", "/fake/dst")
+            assert len(acquired) >= 1, "Lock was not acquired during queue_injection"
+        finally:
+            ft._pending_lock = original_lock
+            ft._pending_injections.pop(tid, None)
+
+    def test_process_uses_lock(self):
+        """process_pending_injections should acquire _pending_lock."""
+        import tools.file_transfer as ft
+        import threading
+        real_lock = threading.Lock()
+        acquired = []
+
+        class TrackingLock:
+            def __enter__(self):
+                acquired.append("enter")
+                return real_lock.__enter__()
+            def __exit__(self, *a):
+                return real_lock.__exit__(*a)
+
+        original_lock = ft._pending_lock
+        ft._pending_lock = TrackingLock()
+        try:
+            ft.process_pending_injections("nonexistent_task")
+            assert len(acquired) >= 1, "Lock was not acquired during process"
+        finally:
+            ft._pending_lock = original_lock
+
+
+# =========================================================================
+# is_safe_file_path guard
+# =========================================================================
+
+class TestSafeFilePathGuard:
+    """Tests for is_safe_file_path() allowlist function."""
+
+    def test_rejects_outside_cache(self):
+        from tools.file_transfer import is_safe_file_path
+        assert is_safe_file_path("/etc/passwd") is None
+
+    def test_rejects_dotenv(self):
+        from tools.file_transfer import is_safe_file_path
+        home = os.path.expanduser("~")
+        assert is_safe_file_path(os.path.join(home, ".env")) is None
+
+    def test_accepts_file_in_cache(self):
+        from tools.file_transfer import is_safe_file_path, get_file_cache_dir
+        cache_dir = get_file_cache_dir()
+        probe = cache_dir / "test_guard_probe.txt"
+        probe.write_text("test")
+        try:
+            result = is_safe_file_path(str(probe))
+            assert result is not None
+            assert result.name == "test_guard_probe.txt"
+        finally:
+            probe.unlink(missing_ok=True)
+
+    def test_rejects_traversal(self):
+        from tools.file_transfer import is_safe_file_path, FILE_CACHE_DIR
+        evil = str(FILE_CACHE_DIR / ".." / ".." / ".bashrc")
+        assert is_safe_file_path(evil) is None
+
+    def test_rejects_nonexistent(self):
+        from tools.file_transfer import is_safe_file_path, FILE_CACHE_DIR
+        assert is_safe_file_path(str(FILE_CACHE_DIR / "does_not_exist.csv")) is None

--- a/tests/tools/test_send_file.py
+++ b/tests/tools/test_send_file.py
@@ -1,0 +1,580 @@
+"""Tests for the send_file tool and file_transfer layer.
+
+All tests use mocks -- no real Docker/SSH/Modal environments are needed.
+"""
+
+import gzip
+import base64
+import json
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+# Ensure project root is importable
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.file_transfer import (
+    validate_file_path,
+    detect_mime_type,
+    get_file_cache_dir,
+    cleanup_file_cache,
+    extract_file_from_sandbox,
+    MAX_FILE_SIZE,
+)
+from tools.send_file_tool import send_file_tool, SEND_FILE_SCHEMA
+
+
+# =========================================================================
+# Validation
+# =========================================================================
+
+class TestFileTransferValidation:
+    """Tests for validate_file_path()."""
+
+    def test_valid_absolute_path(self):
+        assert validate_file_path("/workspace/report.csv") is None
+
+    def test_empty_path(self):
+        assert validate_file_path("") is not None
+
+    def test_null_bytes(self):
+        assert validate_file_path("/workspace/file\x00.csv") is not None
+
+    def test_path_traversal_dotdot(self):
+        result = validate_file_path("/workspace/../etc/passwd")
+        assert result is not None
+        assert "traversal" in result.lower()
+
+    def test_relative_path_rejected(self):
+        result = validate_file_path("relative/path.csv")
+        assert result is not None
+        assert "absolute" in result.lower()
+
+    def test_valid_deep_path(self):
+        assert validate_file_path("/workspace/reports/2024/q1/data.csv") is None
+
+    def test_shell_injection_patterns_rejected(self):
+        """Paths with shell injection patterns should be rejected."""
+        dangerous_paths = [
+            "/workspace/$(whoami).csv",
+            "/workspace/`id`.csv",
+            "/workspace/file;rm -rf /.csv",
+            "/workspace/file|cat /etc/passwd.csv",
+            "/workspace/file&&whoami.csv",
+            "/workspace/file||echo pwned.csv",
+        ]
+        for p in dangerous_paths:
+            result = validate_file_path(p)
+            assert result is not None, f"Should reject: {p}"
+            assert "dangerous" in result.lower()
+
+    def test_path_with_spaces_accepted(self):
+        """Paths with spaces (but no injection patterns) should be accepted."""
+        assert validate_file_path("/workspace/my report.csv") is None
+        assert validate_file_path("/workspace/data files/report 2024.csv") is None
+
+    def test_legitimate_special_filenames_accepted(self):
+        """Parentheses, $, >, < in filenames should be accepted when not
+        forming injection patterns."""
+        assert validate_file_path("/workspace/report (final).csv") is None
+        assert validate_file_path("/workspace/results_$summary.csv") is None
+        assert validate_file_path("/workspace/data > 100.csv") is None
+        assert validate_file_path("/workspace/notes & ideas.txt") is None
+
+
+# =========================================================================
+# MIME Detection
+# =========================================================================
+
+class TestMimeDetection:
+    """Tests for detect_mime_type()."""
+
+    def test_csv(self):
+        assert detect_mime_type("data.csv") == "text/csv"
+
+    def test_json(self):
+        assert detect_mime_type("config.json") == "application/json"
+
+    def test_python(self):
+        assert detect_mime_type("script.py") == "text/x-python"
+
+    def test_markdown(self):
+        assert detect_mime_type("README.md") == "text/markdown"
+
+    def test_unknown_extension(self):
+        result = detect_mime_type("file.xyz123")
+        assert result == "application/octet-stream"
+
+    def test_pdf(self):
+        result = detect_mime_type("report.pdf")
+        assert "pdf" in result.lower()
+
+
+# =========================================================================
+# File Cache
+# =========================================================================
+
+class TestFileCache:
+    """Tests for file cache management."""
+
+    def test_get_file_cache_dir_creates_dir(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "file_cache"
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+        result = get_file_cache_dir()
+        assert result.exists()
+        assert result == cache_dir
+
+    def test_cleanup_removes_old_files(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "file_cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        # Create an old file
+        old_file = cache_dir / "old_file.txt"
+        old_file.write_text("old")
+        # Set mtime to 48 hours ago
+        old_time = time.time() - (48 * 3600)
+        os.utime(old_file, (old_time, old_time))
+
+        # Create a recent file
+        new_file = cache_dir / "new_file.txt"
+        new_file.write_text("new")
+
+        removed = cleanup_file_cache(max_age_hours=24)
+        assert removed == 1
+        assert not old_file.exists()
+        assert new_file.exists()
+
+
+# =========================================================================
+# Local Extraction
+# =========================================================================
+
+class TestLocalExtraction:
+    """Tests for local backend file extraction."""
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local"})
+    def test_extract_existing_file(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        # Create source file
+        source = tmp_path / "data.csv"
+        source.write_text("col1,col2\n1,2\n")
+
+        result = extract_file_from_sandbox(str(source), "test-task")
+        assert result["success"] is True
+        assert result["filename"] == "data.csv"
+        assert result["mime_type"] == "text/csv"
+        assert result["size"] > 0
+        assert os.path.exists(result["host_path"])
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local"})
+    def test_extract_missing_file(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        result = extract_file_from_sandbox("/nonexistent/file.csv", "test-task")
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local"})
+    def test_extract_too_large(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+        monkeypatch.setattr("tools.file_transfer.MAX_FILE_SIZE", 10)
+
+        source = tmp_path / "big.bin"
+        source.write_bytes(b"x" * 100)
+
+        result = extract_file_from_sandbox(str(source), "test-task")
+        assert result["success"] is False
+        assert "too large" in result["error"].lower()
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local"})
+    def test_extract_directory(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        dir_path = tmp_path / "mydir"
+        dir_path.mkdir()
+
+        result = extract_file_from_sandbox(str(dir_path), "test-task")
+        assert result["success"] is False
+        assert "directory" in result["error"].lower()
+
+
+# =========================================================================
+# Docker Extraction (mocked)
+# =========================================================================
+
+class TestDockerExtraction:
+    """Tests for Docker backend extraction with mocked subprocess."""
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "docker"})
+    def test_docker_cp_success(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        mock_env = SimpleNamespace(_container_id="abc123")
+        mock_envs = {"task1": mock_env}
+
+        def side_effect(cmd, **kwargs):
+            dest = cmd[-1]
+            Path(dest).write_text("docker file content")
+            return SimpleNamespace(returncode=0, stderr="")
+
+        with patch("tools.terminal_tool._active_environments", mock_envs), \
+             patch("tools.file_transfer.subprocess.run", side_effect=side_effect):
+            result = extract_file_from_sandbox("/workspace/out.csv", "task1")
+
+        assert result["success"] is True
+        assert result["filename"] == "out.csv"
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "docker"})
+    def test_docker_no_environment(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        with patch("tools.terminal_tool._active_environments", {}):
+            result = extract_file_from_sandbox("/workspace/out.csv", "nonexistent")
+
+        assert result["success"] is False
+        assert "no active" in result["error"].lower()
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "docker"})
+    def test_docker_cp_failure(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        mock_env = SimpleNamespace(_container_id="abc123")
+        mock_envs = {"task1": mock_env}
+        mock_run = MagicMock(return_value=SimpleNamespace(returncode=1, stderr="No such file"))
+
+        with patch("tools.terminal_tool._active_environments", mock_envs), \
+             patch("tools.file_transfer.subprocess.run", mock_run):
+            result = extract_file_from_sandbox("/workspace/missing.csv", "task1")
+
+        assert result["success"] is False
+
+
+# =========================================================================
+# SSH Extraction (mocked)
+# =========================================================================
+
+class TestSSHExtraction:
+    """Tests for SSH backend extraction with mocked subprocess."""
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "ssh"})
+    def test_scp_success(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        mock_env = SimpleNamespace(
+            control_socket="/tmp/ctrl.sock",
+            host="remote.host",
+            user="testuser",
+            port=22,
+        )
+        mock_envs = {"task1": mock_env}
+
+        def side_effect(cmd, **kwargs):
+            dest = cmd[-1]
+            Path(dest).write_text("remote file content")
+            return SimpleNamespace(returncode=0, stderr="")
+
+        with patch("tools.terminal_tool._active_environments", mock_envs), \
+             patch("tools.file_transfer.subprocess.run", side_effect=side_effect):
+            result = extract_file_from_sandbox("/home/user/data.csv", "task1")
+
+        assert result["success"] is True
+        assert result["filename"] == "data.csv"
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "ssh"})
+    def test_scp_failure(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        mock_env = SimpleNamespace(
+            control_socket="/tmp/ctrl.sock",
+            host="remote.host",
+            user="testuser",
+            port=22,
+        )
+        mock_envs = {"task1": mock_env}
+        mock_run = MagicMock(return_value=SimpleNamespace(returncode=1, stderr="Connection refused"))
+
+        with patch("tools.terminal_tool._active_environments", mock_envs), \
+             patch("tools.file_transfer.subprocess.run", mock_run):
+            result = extract_file_from_sandbox("/home/user/data.csv", "task1")
+
+        assert result["success"] is False
+        assert "scp failed" in result["error"].lower()
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "ssh"})
+    def test_scp_quotes_remote_path(self, tmp_path, monkeypatch):
+        """SCP remote path should be quoted for spaces/special chars."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        mock_env = SimpleNamespace(
+            control_socket="/tmp/ctrl.sock",
+            host="remote.host",
+            user="testuser",
+            port=22,
+        )
+        mock_envs = {"task1": mock_env}
+        captured_cmds = []
+
+        def side_effect(cmd, **kwargs):
+            captured_cmds.append(cmd)
+            dest = cmd[-1]
+            Path(dest).write_text("content")
+            return SimpleNamespace(returncode=0, stderr="")
+
+        with patch("tools.terminal_tool._active_environments", mock_envs), \
+             patch("tools.file_transfer.subprocess.run", side_effect=side_effect):
+            result = extract_file_from_sandbox("/home/user/my report (final).csv", "task1")
+
+        assert result["success"] is True
+        # The remote path in scp command should be properly quoted
+        scp_cmd = captured_cmds[0]
+        # Find the arg that contains user@host:
+        remote_arg = [a for a in scp_cmd if "testuser@remote.host:" in a]
+        assert len(remote_arg) == 1, f"Expected user@host: in scp cmd: {scp_cmd}"
+        remote_arg = remote_arg[0]
+        # Verify quoting: path with spaces/parens should be shell-quoted
+        assert "'" in remote_arg or "\\" in remote_arg
+
+
+# =========================================================================
+# Base64 Extraction (mocked)
+# =========================================================================
+
+class TestBase64Extraction:
+    """Tests for gzip+base64 fallback extraction."""
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "modal"})
+    def test_base64_roundtrip(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        original_data = b"Hello, this is test data for base64 extraction!"
+        compressed = gzip.compress(original_data)
+        encoded = base64.b64encode(compressed).decode("ascii")
+
+        mock_env = MagicMock()
+        mock_env.execute.side_effect = [
+            {"output": str(len(original_data)), "returncode": 0},  # stat
+            {"output": encoded, "returncode": 0},  # gzip+base64
+        ]
+        mock_envs = {"task1": mock_env}
+
+        with patch("tools.terminal_tool._active_environments", mock_envs):
+            result = extract_file_from_sandbox("/workspace/test.txt", "task1")
+
+        assert result["success"] is True
+        with open(result["host_path"], "rb") as f:
+            assert f.read() == original_data
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "modal"})
+    def test_base64_file_not_found(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        mock_env = MagicMock()
+        mock_env.execute.return_value = {"output": "", "returncode": 1}
+        mock_envs = {"task1": mock_env}
+
+        with patch("tools.terminal_tool._active_environments", mock_envs):
+            result = extract_file_from_sandbox("/workspace/missing.txt", "task1")
+
+        assert result["success"] is False
+
+
+# =========================================================================
+# Send File Handler
+# =========================================================================
+
+class TestSendFileHandler:
+    """Tests for the send_file tool handler."""
+
+    def test_missing_path(self):
+        result = json.loads(send_file_tool({}))
+        assert "error" in result
+
+    def test_invalid_path(self):
+        result = json.loads(send_file_tool({"path": "relative/path.csv"}))
+        assert "error" in result
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local"})
+    def test_success_cli_mode(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+        monkeypatch.delenv("HERMES_GATEWAY", raising=False)
+
+        # Create source file
+        source = tmp_path / "report.md"
+        source.write_text("# Report\nSome data")
+
+        # Change CWD to tmp_path so the file is copied there
+        original_cwd = os.getcwd()
+        os.chdir(str(tmp_path))
+        try:
+            result = json.loads(send_file_tool(
+                {"path": str(source), "message": "Here's your report"},
+                task_id="test",
+            ))
+            assert result["success"] is True
+            assert result["delivered_via"] == "cli"
+            assert os.path.exists(result["path"])
+        finally:
+            os.chdir(original_cwd)
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local", "HERMES_GATEWAY": "true"})
+    def test_success_gateway_mode(self, tmp_path, monkeypatch):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        source = tmp_path / "data.csv"
+        source.write_text("col1,col2\n1,2\n")
+
+        raw = send_file_tool({"path": str(source)}, task_id="test")
+        # Should contain FILE:<...> tag with angle brackets
+        assert "FILE:<" in raw
+        assert ">" in raw.split("FILE:<")[1]
+        # Parse the JSON part
+        json_part = raw.split("\n")[0]
+        result = json.loads(json_part)
+        assert result["success"] is True
+        assert result["delivered_via"] == "gateway"
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local", "HERMES_GATEWAY": "true"})
+    def test_gateway_mode_includes_caption(self, tmp_path, monkeypatch):
+        """Caption should be carried in the FILE: tag via pipe separator."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        source = tmp_path / "report.csv"
+        source.write_text("a,b\n1,2\n")
+
+        raw = send_file_tool(
+            {"path": str(source), "message": "Your monthly report"},
+            task_id="test",
+        )
+        # Caption should appear after pipe in the tag
+        assert "|Your monthly report>" in raw
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local", "HERMES_GATEWAY": "true"})
+    def test_gateway_caption_gt_escaped(self, tmp_path, monkeypatch):
+        """Caption containing > must be escaped as \\> in the FILE tag."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr("tools.file_transfer.FILE_CACHE_DIR", cache_dir)
+
+        source = tmp_path / "report.csv"
+        source.write_text("a,b\n1,2\n")
+
+        raw = send_file_tool(
+            {"path": str(source), "message": "Results > 100"},
+            task_id="test",
+        )
+        # > in caption must be escaped so the tag parser doesn't break
+        assert r"|Results \> 100>" in raw
+        # Unescaped > must NOT appear between pipe and closing bracket
+        assert "|Results > 100>" not in raw
+
+    @patch.dict(os.environ, {"TERMINAL_ENV": "local", "HERMES_GATEWAY": "true"})
+    def test_gateway_path_gt_roundtrip(self):
+        """Filename containing > must survive FILE tag roundtrip.
+
+        On Linux > is valid in filenames; on Windows it isn't, so we mock
+        the extraction result to simulate a cache path with > in the name.
+        """
+        fake_host = "/tmp/cache/abc123_report > final.csv"
+        with patch("tools.file_transfer.extract_file_from_sandbox",
+                   return_value={
+                       "success": True,
+                       "host_path": fake_host,
+                       "filename": "report > final.csv",
+                       "mime_type": "text/csv",
+                       "size": 42,
+                   }):
+            raw = send_file_tool(
+                {"path": "/workspace/report > final.csv", "message": "Report"},
+                task_id="test",
+            )
+
+        # The FILE tag must have > in path escaped
+        assert "\\>" in raw
+
+        # Parse the FILE tag back with extract_files (bypass allowlist for unit test)
+        from gateway.platforms.base import BasePlatformAdapter
+
+        class _FakePath:
+            def __init__(self, p): self._p = p
+            def is_file(self): return True
+            def __str__(self): return self._p
+
+        with patch("tools.file_transfer.is_safe_file_path",
+                   side_effect=lambda p: _FakePath(p)):
+            files, cleaned = BasePlatformAdapter.extract_files(raw)
+        assert len(files) == 1
+        path, caption = files[0]
+        # Path must contain the original > after unescape
+        assert path == fake_host
+        assert caption == "Report"
+
+    def test_extraction_failure(self):
+        with patch("tools.file_transfer.extract_file_from_sandbox",
+                   return_value={"success": False, "error": "Docker not running"}):
+            result = json.loads(send_file_tool({"path": "/workspace/file.csv"}, task_id="test"))
+        assert "error" in result
+        assert "docker" in result["error"].lower()
+
+
+# =========================================================================
+# Schema
+# =========================================================================
+
+class TestSendFileSchema:
+    """Tests for the send_file schema structure."""
+
+    def test_schema_name(self):
+        assert SEND_FILE_SCHEMA["name"] == "send_file"
+
+    def test_required_params(self):
+        assert "path" in SEND_FILE_SCHEMA["parameters"]["required"]
+
+    def test_has_message_param(self):
+        props = SEND_FILE_SCHEMA["parameters"]["properties"]
+        assert "message" in props
+
+    def test_registry_registered(self):
+        from tools.registry import registry
+        # Import the module to trigger registration
+        import tools.send_file_tool  # noqa: F401
+        assert "send_file" in registry.get_all_tool_names()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -38,14 +38,22 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     with _file_ops_lock:
         cached = _file_ops_cache.get(task_id)
     if cached is not None:
+        env_alive = False
         with _env_lock:
             if task_id in _active_environments:
                 _last_activity[task_id] = time.time()
-                return cached
+                env_alive = True
             else:
                 # Environment was cleaned up -- invalidate stale cache entry
                 with _file_ops_lock:
                     _file_ops_cache.pop(task_id, None)
+        if env_alive:
+            try:
+                from tools.file_transfer import process_pending_injections
+                process_pending_injections(task_id)
+            except Exception as _inj_err:
+                logger.warning("Pending file injection failed: %s", _inj_err)
+            return cached
 
     # Need to ensure the environment exists before building file_ops.
     # Acquire per-task lock so only one thread creates the sandbox.
@@ -107,6 +115,13 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
 
             _start_cleanup_thread()
             logger.info("%s environment ready for task %s", env_type, task_id[:8])
+
+    # Flush any files queued for injection into this sandbox
+    try:
+        from tools.file_transfer import process_pending_injections
+        process_pending_injections(task_id)
+    except Exception as _inj_err:
+        logger.warning("Pending file injection failed: %s", _inj_err)
 
     # Build file_ops from the (guaranteed live) environment and cache it
     file_ops = ShellFileOperations(terminal_env)

--- a/tools/file_transfer.py
+++ b/tools/file_transfer.py
@@ -1,0 +1,519 @@
+"""File transfer layer for moving files between sandboxes and the host.
+
+Supports extraction (sandbox → host) and injection (host → sandbox) for all
+Hermes execution backends: local, Docker, SSH, Modal, Singularity, Daytona.
+
+Files are staged through a host-side cache (~/.hermes/file_cache/) with
+TTL-based cleanup.
+"""
+
+import base64
+import gzip
+import logging
+import mimetypes
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+FILE_CACHE_DIR = Path(os.path.expanduser("~/.hermes/file_cache"))
+
+# ---------------------------------------------------------------------------
+# Deferred injection queue (thread-safe)
+# ---------------------------------------------------------------------------
+# Files uploaded by the user are queued here *before* the sandbox exists.
+# When terminal_tool creates the sandbox environment, it calls
+# process_pending_injections() to push queued files into the new container.
+_pending_injections: Dict[str, list] = {}
+_pending_lock = threading.Lock()
+
+
+def queue_injection(task_id: str, host_path: str, remote_path: str) -> None:
+    """Queue a file for injection once the sandbox for *task_id* is ready."""
+    with _pending_lock:
+        _pending_injections.setdefault(task_id, []).append({
+            "host_path": host_path,
+            "remote_path": remote_path,
+        })
+    logger.info("Queued injection: %s -> %s (task %s)", host_path, remote_path, task_id)
+
+
+def process_pending_injections(task_id: str) -> list:
+    """Inject all queued files for *task_id*.  Called by terminal_tool after
+    the sandbox environment is created.  Returns a list of result dicts."""
+    with _pending_lock:
+        pending = _pending_injections.pop(task_id, [])
+    if not pending:
+        return []
+    results = []
+    for item in pending:
+        result = inject_file_to_sandbox(
+            host_path=item["host_path"],
+            remote_path=item["remote_path"],
+            task_id=task_id,
+        )
+        if result.get("success"):
+            logger.info("Deferred injection succeeded: %s", item["remote_path"])
+        else:
+            logger.warning("Deferred injection failed: %s — %s",
+                           item["remote_path"], result.get("error"))
+        results.append(result)
+    return results
+
+
+def is_safe_file_path(path_str: str) -> Optional[Path]:
+    """Validate that *path_str* is inside the file cache directory.
+
+    Returns the canonical ``Path`` if safe, ``None`` otherwise.
+    This prevents the LLM from exfiltrating arbitrary host files
+    (e.g. ``.env``, SSH keys) by crafting rogue ``FILE:<path>`` tags.
+    """
+    try:
+        cache_root = FILE_CACHE_DIR.resolve(strict=False)
+        candidate = Path(path_str).resolve(strict=True)
+        candidate.relative_to(cache_root)  # ValueError if outside
+        if not candidate.is_file():
+            return None
+        return candidate
+    except (ValueError, OSError, RuntimeError):
+        return None
+
+# Extension → MIME type for common file types
+_MIME_OVERRIDES = {
+    ".csv": "text/csv",
+    ".json": "application/json",
+    ".md": "text/markdown",
+    ".py": "text/x-python",
+    ".js": "application/javascript",
+    ".ts": "application/typescript",
+    ".yaml": "application/x-yaml",
+    ".yml": "application/x-yaml",
+    ".log": "text/plain",
+    ".sh": "application/x-sh",
+}
+
+
+# ---------------------------------------------------------------------------
+# Cache utilities
+# ---------------------------------------------------------------------------
+
+def get_file_cache_dir() -> Path:
+    """Return the file cache directory, creating it if needed."""
+    FILE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    return FILE_CACHE_DIR
+
+
+def cleanup_file_cache(max_age_hours: int = 24) -> int:
+    """Delete cached files older than *max_age_hours*. Returns count removed."""
+    cache_dir = get_file_cache_dir()
+    cutoff = time.time() - (max_age_hours * 3600)
+    removed = 0
+    for f in cache_dir.iterdir():
+        if f.is_file() and f.stat().st_mtime < cutoff:
+            try:
+                f.unlink()
+                removed += 1
+            except OSError:
+                pass
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# Validation & MIME
+# ---------------------------------------------------------------------------
+
+def detect_mime_type(path: str) -> str:
+    """Detect MIME type from file extension."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext in _MIME_OVERRIDES:
+        return _MIME_OVERRIDES[ext]
+    mime, _ = mimetypes.guess_type(path)
+    return mime or "application/octet-stream"
+
+
+def validate_file_path(path: str) -> Optional[str]:
+    """Validate a file path for safety. Returns error string or None if valid.
+
+    Accepts both Unix (/...) and Windows (C:\\...) absolute paths since
+    the tool may run on a Windows host while validating sandbox paths.
+    """
+    if not path:
+        return "Path is empty"
+    if "\x00" in path:
+        return "Path contains null bytes"
+    # Accept Unix absolute paths (start with /) and Windows absolute paths
+    is_abs = path.startswith("/") or os.path.isabs(path)
+    if not is_abs:
+        return "Path must be absolute"
+    # Block path traversal: check the raw path for .. components before
+    # normalization resolves them (normpath collapses .. on Windows)
+    raw_parts = path.replace("\\", "/").split("/")
+    if ".." in raw_parts:
+        return "Path traversal detected"
+    # Block shell injection *patterns* rather than individual characters,
+    # so legitimate filenames like "report (final).csv" are accepted.
+    # shlex.quote() in extraction/injection is the primary defense;
+    # this is a defense-in-depth layer that catches obvious payloads
+    # before they reach any shell pipeline.
+    _DANGEROUS_PATTERNS = ["$(", "`", ";", "&&", "||", "|", ">>", "<<"]
+    for pat in _DANGEROUS_PATTERNS:
+        if pat in path:
+            return f"Path contains dangerous shell pattern: {pat}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Extraction: sandbox → host
+# ---------------------------------------------------------------------------
+
+def extract_file_from_sandbox(path: str, task_id: str = "default") -> Dict[str, Any]:
+    """Extract a file from the active sandbox to the host file cache.
+
+    Args:
+        path: Absolute path inside the sandbox.
+        task_id: The agent task ID (used to find the active environment).
+
+    Returns:
+        Dict with keys: success, host_path, filename, mime_type, size, error.
+    """
+    error = validate_file_path(path)
+    if error:
+        return {"success": False, "error": error}
+
+    filename = os.path.basename(path)
+    cache_dir = get_file_cache_dir()
+    host_path = str(cache_dir / f"{uuid.uuid4().hex[:12]}_{filename}")
+
+    env_type = os.getenv("TERMINAL_ENV", "local")
+
+    try:
+        if env_type == "local":
+            return _extract_local(path, host_path)
+        elif env_type == "docker":
+            return _extract_docker(path, task_id, host_path)
+        elif env_type == "ssh":
+            return _extract_ssh(path, task_id, host_path)
+        else:
+            # Modal, Singularity, Daytona: gzip+base64 fallback
+            return _extract_via_base64(path, task_id, host_path)
+    except Exception as e:
+        logger.error("File extraction failed: %s", e)
+        return {"success": False, "error": str(e)}
+
+
+def _make_result(host_path: str) -> Dict[str, Any]:
+    """Build a success result dict from a cached file."""
+    return {
+        "success": True,
+        "host_path": host_path,
+        "filename": os.path.basename(host_path).split("_", 1)[-1],
+        "mime_type": detect_mime_type(host_path),
+        "size": os.path.getsize(host_path),
+    }
+
+
+def _extract_local(path: str, host_path: str) -> Dict[str, Any]:
+    """Local backend: simple file copy."""
+    if not os.path.exists(path):
+        return {"success": False, "error": f"File not found: {path}"}
+    if os.path.isdir(path):
+        return {"success": False, "error": "Path is a directory, not a file"}
+    size = os.path.getsize(path)
+    if size > MAX_FILE_SIZE:
+        return {"success": False, "error": f"File too large ({size} bytes, max {MAX_FILE_SIZE})"}
+    shutil.copy2(path, host_path)
+    return _make_result(host_path)
+
+
+def _extract_docker(path: str, task_id: str, host_path: str) -> Dict[str, Any]:
+    """Docker backend: docker cp container:path host_path."""
+    from tools.terminal_tool import _active_environments
+
+    env = _active_environments.get(task_id)
+    if not env:
+        return {"success": False, "error": f"No active Docker environment for task {task_id}"}
+
+    container_id = getattr(env, "_container_id", None)
+    if not container_id:
+        return {"success": False, "error": "Could not determine container ID"}
+
+    result = subprocess.run(
+        ["docker", "cp", f"{container_id}:{path}", host_path],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        return {"success": False, "error": f"docker cp failed: {result.stderr.strip()}"}
+
+    if not os.path.exists(host_path):
+        return {"success": False, "error": "docker cp completed but file not found on host"}
+
+    size = os.path.getsize(host_path)
+    if size > MAX_FILE_SIZE:
+        os.unlink(host_path)
+        return {"success": False, "error": f"File too large ({size} bytes, max {MAX_FILE_SIZE})"}
+
+    return _make_result(host_path)
+
+
+def _extract_ssh(path: str, task_id: str, host_path: str) -> Dict[str, Any]:
+    """SSH backend: scp with ControlMaster socket."""
+    from tools.terminal_tool import _active_environments
+
+    env = _active_environments.get(task_id)
+    if not env:
+        return {"success": False, "error": f"No active SSH environment for task {task_id}"}
+
+    control_socket = getattr(env, "control_socket", None)
+    host = getattr(env, "host", None)
+    user = getattr(env, "user", None)
+    port = getattr(env, "port", 22)
+
+    if not all([control_socket, host, user]):
+        return {"success": False, "error": "Incomplete SSH environment configuration"}
+
+    # Quote remote path for scp (spaces/special chars in filenames)
+    quoted_remote = shlex.quote(path)
+    cmd = [
+        "scp",
+        "-o", f"ControlPath={control_socket}",
+        "-P", str(port),
+        f"{user}@{host}:{quoted_remote}",
+        host_path,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        return {"success": False, "error": f"scp failed: {result.stderr.strip()}"}
+
+    if not os.path.exists(host_path):
+        return {"success": False, "error": "scp completed but file not found on host"}
+
+    size = os.path.getsize(host_path)
+    if size > MAX_FILE_SIZE:
+        os.unlink(host_path)
+        return {"success": False, "error": f"File too large ({size} bytes, max {MAX_FILE_SIZE})"}
+
+    return _make_result(host_path)
+
+
+def _extract_via_base64(path: str, task_id: str, host_path: str) -> Dict[str, Any]:
+    """Fallback extraction via gzip+base64 through the terminal.
+
+    Works for Modal, Singularity, Daytona, or any backend where the only
+    interface is command execution.
+    """
+    from tools.terminal_tool import _active_environments
+
+    env = _active_environments.get(task_id)
+    if not env:
+        return {"success": False, "error": f"No active environment for task {task_id}"}
+
+    # First check file exists and size
+    safe_path = shlex.quote(path)
+    check_cmd = f'stat -c "%s" {safe_path} 2>/dev/null || stat -f "%z" {safe_path} 2>/dev/null'
+    check_result = env.execute(check_cmd, timeout=10)
+    output = check_result.get("output", "").strip()
+    if check_result.get("returncode", 1) != 0 or not output:
+        return {"success": False, "error": f"File not found or not accessible: {path}"}
+
+    try:
+        file_size = int(output.strip().split("\n")[-1])
+    except ValueError:
+        return {"success": False, "error": f"Could not determine file size: {output}"}
+
+    if file_size > MAX_FILE_SIZE:
+        return {"success": False, "error": f"File too large ({file_size} bytes, max {MAX_FILE_SIZE})"}
+
+    # gzip + base64 encode the file
+    encode_cmd = f'gzip -c {safe_path} | base64'
+    encode_result = env.execute(encode_cmd, timeout=120)
+    if encode_result.get("returncode", 1) != 0:
+        return {"success": False, "error": f"Encoding failed: {encode_result.get('output', '')}"}
+
+    b64_data = encode_result.get("output", "").strip()
+    if not b64_data:
+        return {"success": False, "error": "Encoding returned empty output"}
+
+    # Decode on host
+    try:
+        compressed = base64.b64decode(b64_data)
+        raw_data = gzip.decompress(compressed)
+    except Exception as e:
+        return {"success": False, "error": f"Decoding failed: {e}"}
+
+    with open(host_path, "wb") as f:
+        f.write(raw_data)
+
+    return _make_result(host_path)
+
+
+# ---------------------------------------------------------------------------
+# Injection: host → sandbox
+# ---------------------------------------------------------------------------
+
+def inject_file_to_sandbox(
+    host_path: str,
+    remote_path: str,
+    task_id: str = "default",
+) -> Dict[str, Any]:
+    """Inject a file from the host into the active sandbox.
+
+    Args:
+        host_path: Absolute path on the host.
+        remote_path: Destination path inside the sandbox.
+        task_id: The agent task ID.
+
+    Returns:
+        Dict with keys: success, remote_path, error.
+    """
+    if not os.path.exists(host_path):
+        return {"success": False, "error": f"Source file not found: {host_path}"}
+    if os.path.getsize(host_path) > MAX_FILE_SIZE:
+        return {"success": False, "error": f"File too large (max {MAX_FILE_SIZE} bytes)"}
+
+    env_type = os.getenv("TERMINAL_ENV", "local")
+
+    try:
+        if env_type == "local":
+            return _inject_local(host_path, remote_path)
+        elif env_type == "docker":
+            return _inject_docker(host_path, remote_path, task_id)
+        elif env_type == "ssh":
+            return _inject_ssh(host_path, remote_path, task_id)
+        else:
+            return _inject_via_base64(host_path, remote_path, task_id)
+    except Exception as e:
+        logger.error("File injection failed: %s", e)
+        return {"success": False, "error": str(e)}
+
+
+def _inject_local(host_path: str, remote_path: str) -> Dict[str, Any]:
+    """Local backend: copy file to destination."""
+    os.makedirs(os.path.dirname(remote_path), exist_ok=True)
+    shutil.copy2(host_path, remote_path)
+    return {"success": True, "remote_path": remote_path}
+
+
+def _inject_docker(host_path: str, remote_path: str, task_id: str) -> Dict[str, Any]:
+    """Docker backend: docker cp host_path container:remote_path."""
+    from tools.terminal_tool import _active_environments
+
+    env = _active_environments.get(task_id)
+    if not env:
+        return {"success": False, "error": f"No active Docker environment for task {task_id}"}
+
+    container_id = getattr(env, "_container_id", None)
+    if not container_id:
+        return {"success": False, "error": "Could not determine container ID"}
+
+    # Ensure destination directory exists
+    remote_dir = os.path.dirname(remote_path)
+    if remote_dir:
+        env.execute(f'mkdir -p {shlex.quote(remote_dir)}', timeout=10)
+
+    result = subprocess.run(
+        ["docker", "cp", host_path, f"{container_id}:{remote_path}"],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        return {"success": False, "error": f"docker cp failed: {result.stderr.strip()}"}
+
+    return {"success": True, "remote_path": remote_path}
+
+
+def _inject_ssh(host_path: str, remote_path: str, task_id: str) -> Dict[str, Any]:
+    """SSH backend: scp reverse."""
+    from tools.terminal_tool import _active_environments
+
+    env = _active_environments.get(task_id)
+    if not env:
+        return {"success": False, "error": f"No active SSH environment for task {task_id}"}
+
+    control_socket = getattr(env, "control_socket", None)
+    host = getattr(env, "host", None)
+    user = getattr(env, "user", None)
+    port = getattr(env, "port", 22)
+
+    if not all([control_socket, host, user]):
+        return {"success": False, "error": "Incomplete SSH environment configuration"}
+
+    # Ensure destination directory exists
+    remote_dir = os.path.dirname(remote_path)
+    if remote_dir:
+        env.execute(f'mkdir -p {shlex.quote(remote_dir)}', timeout=10)
+
+    # Quote remote path for scp (spaces/special chars in filenames)
+    quoted_remote = shlex.quote(remote_path)
+    cmd = [
+        "scp",
+        "-o", f"ControlPath={control_socket}",
+        "-P", str(port),
+        host_path,
+        f"{user}@{host}:{quoted_remote}",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        return {"success": False, "error": f"scp failed: {result.stderr.strip()}"}
+
+    return {"success": True, "remote_path": remote_path}
+
+
+def _inject_via_base64(host_path: str, remote_path: str, task_id: str) -> Dict[str, Any]:
+    """Fallback injection via base64 through the terminal.
+
+    Reads the file, gzip compresses, base64-encodes, and writes via echo
+    piped through base64 decode + gunzip on the remote side.
+    """
+    from tools.terminal_tool import _active_environments
+
+    env = _active_environments.get(task_id)
+    if not env:
+        return {"success": False, "error": f"No active environment for task {task_id}"}
+
+    # Read and encode the file
+    with open(host_path, "rb") as f:
+        raw_data = f.read()
+
+    compressed = gzip.compress(raw_data)
+    b64_data = base64.b64encode(compressed).decode("ascii")
+
+    # Ensure destination directory exists
+    remote_dir = os.path.dirname(remote_path)
+    if remote_dir:
+        env.execute(f'mkdir -p {shlex.quote(remote_dir)}', timeout=10)
+
+    # Write in chunks to avoid command-line length limits (60KB per chunk)
+    chunk_size = 60000
+    chunks = [b64_data[i:i + chunk_size] for i in range(0, len(b64_data), chunk_size)]
+
+    # Write first chunk (overwrite) - b64 data is safe (alphanumeric+/+=)
+    write_result = env.execute(
+        f'echo -n "{chunks[0]}" > /tmp/_hermes_upload.b64',
+        timeout=30,
+    )
+    if write_result.get("returncode", 1) != 0:
+        return {"success": False, "error": "Failed to write base64 data chunk"}
+
+    # Append remaining chunks
+    for chunk in chunks[1:]:
+        env.execute(f'echo -n "{chunk}" >> /tmp/_hermes_upload.b64', timeout=30)
+
+    # Decode and decompress
+    safe_remote = shlex.quote(remote_path)
+    decode_cmd = f'base64 -d /tmp/_hermes_upload.b64 | gunzip > {safe_remote} && rm -f /tmp/_hermes_upload.b64'
+    decode_result = env.execute(decode_cmd, timeout=60)
+    if decode_result.get("returncode", 1) != 0:
+        return {"success": False, "error": f"Decoding failed: {decode_result.get('output', '')}"}
+
+    return {"success": True, "remote_path": remote_path}

--- a/tools/send_file_tool.py
+++ b/tools/send_file_tool.py
@@ -1,0 +1,122 @@
+"""Send File Tool -- transfer files from sandbox to user.
+
+Extracts a file from the active execution environment (local, Docker, SSH,
+Modal, Singularity, Daytona) and delivers it to the user. In CLI mode the
+file is copied to the current working directory. In gateway mode a FILE: tag
+is emitted so the platform adapter can send it as a native document.
+"""
+
+import json
+import logging
+import os
+import shutil
+
+logger = logging.getLogger(__name__)
+
+
+SEND_FILE_SCHEMA = {
+    "name": "send_file",
+    "description": (
+        "Send a file from the terminal environment to the user. "
+        "The file is extracted from the sandbox (Docker, SSH, Modal, etc.) "
+        "and delivered as a downloadable document. Use this after creating "
+        "files like reports, charts, exports, or any artifacts the user needs."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Absolute path to the file inside the terminal environment",
+            },
+            "message": {
+                "type": "string",
+                "description": "Optional caption or description for the file",
+            },
+        },
+        "required": ["path"],
+    },
+}
+
+
+def send_file_tool(args, **kw):
+    """Handle send_file tool calls."""
+    path = args.get("path", "")
+    message = args.get("message", "")
+    task_id = kw.get("task_id", "default")
+
+    if not path:
+        return json.dumps({"error": "Missing required parameter: path"})
+
+    from tools.file_transfer import extract_file_from_sandbox, validate_file_path
+
+    # Validate path
+    error = validate_file_path(path)
+    if error:
+        return json.dumps({"error": error})
+
+    # Extract from sandbox
+    result = extract_file_from_sandbox(path, task_id)
+    if not result.get("success"):
+        return json.dumps({"error": result.get("error", "Extraction failed")})
+
+    host_path = result["host_path"]
+    filename = result["filename"]
+    mime_type = result["mime_type"]
+    size = result["size"]
+
+    # Check if we're running in gateway mode or CLI mode
+    is_gateway = os.getenv("HERMES_GATEWAY", "").lower() in ("1", "true", "yes")
+
+    if is_gateway:
+        # Gateway mode: emit FILE: tag for the platform adapter to pick up
+        caption = message if message else f"Here's the file: {filename}"
+        response = {
+            "success": True,
+            "filename": filename,
+            "mime_type": mime_type,
+            "size": size,
+            "delivered_via": "gateway",
+        }
+        # The FILE: tag will be extracted by BasePlatformAdapter.extract_files()
+        # Use angle-bracket delimiters to support paths with spaces.
+        # Pipe separator carries an optional caption for the platform adapter.
+        # Escape \ and > in both path and caption so the FILE tag parser
+        # can distinguish content from the closing delimiter.
+        safe_path = host_path.replace("\\", "\\\\").replace(">", "\\>")
+        safe_caption = caption.replace("\\", "\\\\").replace(">", "\\>")
+        return json.dumps(response) + f"\nFILE:<{safe_path}|{safe_caption}>"
+    else:
+        # CLI mode: copy to current working directory
+        cwd = os.getcwd()
+        dest = os.path.join(cwd, filename)
+
+        # Avoid overwriting: add suffix if file exists
+        if os.path.exists(dest):
+            base, ext = os.path.splitext(filename)
+            counter = 1
+            while os.path.exists(dest):
+                dest = os.path.join(cwd, f"{base}_{counter}{ext}")
+                counter += 1
+
+        shutil.copy2(host_path, dest)
+        return json.dumps({
+            "success": True,
+            "filename": os.path.basename(dest),
+            "path": dest,
+            "mime_type": mime_type,
+            "size": size,
+            "delivered_via": "cli",
+            "message": message or f"File saved to {dest}",
+        })
+
+
+# --- Registry ---
+from tools.registry import registry
+
+registry.register(
+    name="send_file",
+    toolset="file_transfer",
+    schema=SEND_FILE_SCHEMA,
+    handler=lambda args, **kw: send_file_tool(args, **kw),
+)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -908,6 +908,13 @@ def terminal_tool(
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
 
+        # Flush any files queued for injection into this sandbox
+        try:
+            from tools.file_transfer import process_pending_injections
+            process_pending_injections(effective_task_id)
+        except Exception as _inj_err:
+            logger.warning("Pending file injection failed: %s", _inj_err)
+
         # Check for dangerous commands (only for local/ssh in interactive modes)
         # Skip check if force=True (user has confirmed they want to run it)
         if not force:

--- a/toolsets.py
+++ b/toolsets.py
@@ -54,8 +54,8 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Clarifying questions
     "clarify",
-    # Code execution + delegation
-    "execute_code", "delegate_task",
+    # Delegation
+    "delegate_task",
     # Cronjob management
     "schedule_cronjob", "list_cronjobs", "remove_cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)

--- a/toolsets.py
+++ b/toolsets.py
@@ -64,6 +64,8 @@ _HERMES_CORE_TOOLS = [
     "query_user_context",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+    # File transfer (sandbox <-> host <-> user)
+    "send_file",
 ]
 
 
@@ -147,7 +149,13 @@ TOOLSETS = {
         "tools": ["read_file", "write_file", "patch", "search_files"],
         "includes": []
     },
-    
+
+    "file_transfer": {
+        "description": "Bidirectional file transfer between sandbox and user (send_file tool)",
+        "tools": ["send_file"],
+        "includes": []
+    },
+
     "tts": {
         "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, or OpenAI",
         "tools": ["text_to_speech"],


### PR DESCRIPTION
## Summary

Implements the **Courier Analyst** skill — bidirectional file transfer between sandboxed execution environments (Docker, SSH, Codex) and chat platforms (Telegram, Discord).

- **Outbound (sandbox → user):** `send_file` tool extracts files via docker cp / scp / base64, caches locally, emits `FILE:<path|caption>` tags that platform adapters deliver as native documents
- **Inbound (user → sandbox):** Document attachments downloaded to local cache, queued for deferred injection into sandbox on next env access
- **Security:** Path allowlist (`is_safe_file_path`), shell injection prevention (`shlex.quote`), pattern-based path validation, 3-layer size limits, FILE tags cleaned before text delivery

### New files
| File | Description |
|------|-------------|
| `tools/file_transfer.py` | Core extraction/injection layer for all sandbox backends |
| `tools/send_file_tool.py` | send_file tool handler with FILE tag generation |
| `skills/productivity/courier-analyst/SKILL.md` | Skill definition with workflow templates |
| `tests/tools/test_send_file.py` | 41 send_file + extraction tests |
| `tests/tools/test_file_injection.py` | 24 injection + queue + security tests |
| `tests/gateway/test_send_document.py` | 29 FILE tag parsing + platform delivery tests |

### Modified files
| File | Change |
|------|--------|
| `gateway/platforms/base.py` | `extract_files()` with allowlist guard + FILE delivery hook + CSV/JSON/log document support |
| `gateway/platforms/telegram.py` | `send_document()` override (50MB) + CSV/JSON/log content injection |
| `gateway/platforms/discord.py` | `send_document()` override (25MB) + inbound document caching + connection timeout 30s→120s |
| `gateway/run.py` | Deferred injection queue + FILE tag scan + `HERMES_GATEWAY` env var for send_file gateway mode |
| `tools/file_tools.py` | Flush pending injections on cache-hit and creation paths |
| `tools/terminal_tool.py` | Flush hook after env ready |
| `model_tools.py` | send_file tool discovery |
| `toolsets.py` | send_file in core tools + file_transfer toolset + remove execute_code for cleaner UX |
| `run_agent.py` | Fallback `<tool_call>` text parser for Hermes model compatibility |

## Test plan

- [x] 117/117 tests passing (41 send_file + 24 injection + 29 document/platform + existing)
- [x] 0 regressions on existing codex execution path tests
- [x] Path allowlist blocks `/etc/passwd`, `.env`, traversal attacks
- [x] FILE tag parsing handles escaped `>`, `|`, spaces, multi-tag lines
- [x] Thread-safe queue operations verified with lock tracking
- [x] Discord inbound documents cached locally (not URL passthrough)
- [x] SSH paths quoted against shell injection
- [x] Gateway FILE tag delivery verified on CLI, Telegram, and Discord
- [x] CSV/JSON/log files accepted and content-injected on Telegram
- [x] HERMES_GATEWAY env var enables send_file FILE tag emission in gateway mode

## Demo

Successfully tested on all three platforms:
- **CLI**: File analysis with chart generation and send_file delivery
- **Telegram**: Bidirectional flow — CSV upload → analysis → charts + report delivered as native documents
- **Discord**: Same flow with native Discord attachments
- **X** submition link: https://x.com/Knkchn0/status/2031456251608277501

Closes #466