### PR TITLE
fix(gateway): pass model to temporary AIAgent instances

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -187,6 +187,30 @@ def _resolve_runtime_agent_kwargs() -> dict:
     }
 
 
+def _resolve_gateway_model() -> str:
+    """Read model from env/config — mirrors the resolution in _run_agent_sync.
+
+    Without this, temporary AIAgent instances (memory flush, /compress) fall
+    back to the hardcoded default ("anthropic/claude-opus-4.6") which fails
+    when the active provider is openai-codex.
+    """
+    model = os.getenv("HERMES_MODEL") or os.getenv("LLM_MODEL") or "anthropic/claude-opus-4.6"
+    try:
+        import yaml as _y
+        _cfg_path = _hermes_home / "config.yaml"
+        if _cfg_path.exists():
+            with open(_cfg_path, encoding="utf-8") as _f:
+                _cfg = _y.safe_load(_f) or {}
+            _model_cfg = _cfg.get("model", {})
+            if isinstance(_model_cfg, str):
+                model = _model_cfg
+            elif isinstance(_model_cfg, dict):
+                model = _model_cfg.get("default", model)
+    except Exception:
+        pass
+    return model
+
+
 class GatewayRunner:
     """
     Main gateway controller.
@@ -258,8 +282,14 @@ class GatewayRunner:
             if not runtime_kwargs.get("api_key"):
                 return
 
+            # Resolve model from config — AIAgent's default is OpenRouter-
+            # formatted ("anthropic/claude-opus-4.6") which fails when the
+            # active provider is openai-codex.
+            model = _resolve_gateway_model()
+
             tmp_agent = AIAgent(
                 **runtime_kwargs,
+                model=model,
                 max_iterations=8,
                 quiet_mode=True,
                 enabled_toolsets=["memory", "skills"],
@@ -1047,6 +1077,7 @@ class GatewayRunner:
                             if len(_hyg_msgs) >= 4:
                                 _hyg_agent = AIAgent(
                                     **_hyg_runtime,
+                                    model=_hyg_model,
                                     max_iterations=4,
                                     quiet_mode=True,
                                     enabled_toolsets=["memory"],
@@ -1867,6 +1898,9 @@ class GatewayRunner:
             if not runtime_kwargs.get("api_key"):
                 return "No provider configured -- cannot compress."
 
+            # Resolve model from config (same reason as memory flush above).
+            model = _resolve_gateway_model()
+
             msgs = [
                 {"role": m.get("role"), "content": m.get("content")}
                 for m in history
@@ -1877,6 +1911,7 @@ class GatewayRunner:
 
             tmp_agent = AIAgent(
                 **runtime_kwargs,
+                model=model,
                 max_iterations=4,
                 quiet_mode=True,
                 enabled_toolsets=["memory"],


### PR DESCRIPTION
## Summary

- Memory flush (`_flush_memories_for_session`), session hygiene auto-compressor, and `/compress` command create temporary `AIAgent` instances without passing `model=`, so they fall back to the hardcoded default `"anthropic/claude-opus-4.6"`
- This fails with a 400 error when the active provider is `openai-codex` (Codex only accepts its own model names like `gpt-5.1-codex-mini`)
- Added `_resolve_gateway_model()` helper that mirrors the env/config resolution already used by `_run_agent_sync` and the cron scheduler
- Wired it into all three temporary agent creation sites (session hygiene already had the model resolved into `_hyg_model` but never passed it to the constructor)

## Error reproduced

```
Error code: 400 - {'detail': "The 'anthropic/claude-opus-4.6' model is not supported when using Codex with a ChatGPT account."}
```

Triggered during pre-reset memory flush when `provider: openai-codex` is configured in `config.yaml`.

## Test plan

- [x] All 473 gateway tests pass
- [x] Full suite: 2755 passed (1 pre-existing flaky in `test_vision_tools`, see `fix/vision-test-flake` branch)
- [x] End-to-end: memory flush on real Pili session via Codex provider — completed successfully, zero errors
- [x] Live Telegram: sent messages + `/reset` to Pili bot — flush completed, no new errors in log