### PR TITLE
Fix #747: Add explicit terminal/shell access awareness to system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -88,6 +88,13 @@ SKILLS_GUIDANCE = (
     "skill with skill_manage so you can reuse it next time."
 )
 
+TERMINAL_GUIDANCE = (
+    "You have terminal/shell access. When you need to execute commands, run scripts, "
+    "or interact with the system, use the terminal tool directly — do not output code "
+    "blocks for the user to copy-paste. You can run commands, manage background processes, "
+    "and work with the filesystem programmatically."
+)
+
 PLATFORM_HINTS = {
     "whatsapp": (
         "You are on a text messaging communication platform, WhatsApp. "

--- a/run_agent.py
+++ b/run_agent.py
@@ -78,6 +78,7 @@ from hermes_constants import OPENROUTER_BASE_URL, OPENROUTER_MODELS_URL
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
+    TERMINAL_GUIDANCE,
 )
 from agent.model_metadata import (
     fetch_model_metadata, get_model_context_length,
@@ -1401,6 +1402,9 @@ class AIAgent:
             tool_guidance.append(SESSION_SEARCH_GUIDANCE)
         if "skill_manage" in self.valid_tool_names:
             tool_guidance.append(SKILLS_GUIDANCE)
+        # Terminal/shell access awareness (fixes #747)
+        if "terminal" in self.valid_tool_names:
+            tool_guidance.append(TERMINAL_GUIDANCE)
         if tool_guidance:
             prompt_parts.append(" ".join(tool_guidance))
 


### PR DESCRIPTION
## Summary

Fixes #747 - Agent consistently forgets it has shell access

## Problem

Users reported that Hermes Agent would 'forget' it has shell access and output code blocks for the user to copy-paste instead of using the terminal tool directly.

From the issue:
> i have to keep reminding hermesagent he/it/she has shell access. this seems like a bug for an autonomous agent that grows?

## Solution

Add explicit `TERMINAL_GUIDANCE` that gets injected into the system prompt when the `terminal` tool is available. This follows the same pattern as existing guidance constants (`MEMORY_GUIDANCE`, `SKILLS_GUIDANCE`, `SESSION_SEARCH_GUIDANCE`).

The guidance explicitly tells the agent:
- It has terminal/shell access
- To use the terminal tool directly (not output code blocks)
- It can run commands, manage background processes, and work with the filesystem programmatically

## Changes

```
agent/prompt_builder.py | 7 +++++++
run_agent.py            | 4 ++++
```

- Add `TERMINAL_GUIDANCE` constant in `agent/prompt_builder.py`
- Import and inject `TERMINAL_GUIDANCE` in `_build_system_prompt()` when `terminal` tool is available

## Testing

- Verified imports work correctly
- The guidance is injected alongside other tool-awareness guidance (memory, skills, session_search)

## How it works

When the agent initializes, it checks which tools are available. If the `terminal` tool is in `valid_tool_names`, the `TERMINAL_GUIDANCE` string is appended to the system prompt. This ensures the agent is explicitly aware of its shell access capabilities at the start of every session.