### PR TITLE
fix(config): atomic write for .env to prevent API key loss on crash

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -17,6 +17,7 @@ import platform
 import stat
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
 
@@ -903,8 +904,19 @@ def save_env_value(key: str, value: str):
             lines[-1] += "\n"
         lines.append(f"{key}={value}\n")
     
-    with open(env_path, 'w', **write_kw) as f:
-        f.writelines(lines)
+    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+    try:
+        with os.fdopen(fd, 'w', **write_kw) as f:
+            f.writelines(lines)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, env_path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
     # Restrict .env permissions to owner-only (contains API keys)
     if not _IS_WINDOWS:


### PR DESCRIPTION
## What

`save_env_value()` uses bare `open('w')` which truncates `.env` immediately.
A crash or OOM kill between truncation and the completed write silently 
wipes every credential in the file.

## How It Works

Write goes to a temp file in the same directory first, then `os.replace()` 
swaps it atomically. Either the old `.env` exists or the new one does — 
never a truncated half-write.

Same pattern already used in `save_jobs()` in `cron/jobs.py`.

## Impact

Prevents silent loss of `OPENROUTER_API_KEY`, `TELEGRAM_BOT_TOKEN`, 
`DISCORD_BOT_TOKEN`, `NOUS_API_KEY`, and every other key stored in `.env`.

## Tests

173 hermes_cli tests pass.