### PR TITLE
feat: offer OpenClaw migration during setup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2013,6 +2013,17 @@ For more help on a command:
         action="store_true",
         help="Reset configuration to defaults"
     )
+    setup_parser.add_argument(
+        "--migrate-from",
+        choices=["openclaw"],
+        default=None,
+        help="Import settings from a supported agent before the setup wizard continues"
+    )
+    setup_parser.add_argument(
+        "--skip-migration-prompt",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     setup_parser.set_defaults(func=cmd_setup)
 
     # =========================================================================

--- a/hermes_cli/openclaw_migration.py
+++ b/hermes_cli/openclaw_migration.py
@@ -5,7 +5,9 @@ import sys
 from functools import lru_cache
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Optional, Sequence
+from typing import Any
+
+from hermes_cli.config import get_hermes_home
 
 
 _OPENCLAW_SCRIPT_PATH = (
@@ -46,36 +48,24 @@ def get_openclaw_source_root() -> Path:
 
 def run_openclaw_migration(
     *,
-    source_root: Optional[Path] = None,
-    target_root: Optional[Path] = None,
-    workspace_target: Optional[Path] = None,
+    source_root: Path | None = None,
+    target_root: Path | None = None,
     execute: bool = True,
     overwrite: bool = False,
     migrate_secrets: bool = True,
-    output_dir: Optional[Path] = None,
     preset: str = "full",
-    include: Optional[Sequence[str]] = None,
-    exclude: Optional[Sequence[str]] = None,
-    skill_conflict_mode: str = "skip",
 ) -> dict[str, Any]:
     module = load_openclaw_migration_module()
     resolved_source = (source_root or get_openclaw_source_root()).expanduser().resolve()
-    resolved_target = (target_root or (Path.home() / ".hermes")).expanduser().resolve()
-    resolved_workspace = (
-        workspace_target.expanduser().resolve() if workspace_target else None
-    )
-    resolved_output = output_dir.expanduser().resolve() if output_dir else None
-    selected_options = module.resolve_selected_options(include, exclude, preset=preset)
+    resolved_target = (target_root or get_hermes_home()).expanduser().resolve()
+    selected_options = module.resolve_selected_options(None, None, preset=preset)
     migrator = module.Migrator(
         source_root=resolved_source,
         target_root=resolved_target,
         execute=execute,
-        workspace_target=resolved_workspace,
         overwrite=overwrite,
         migrate_secrets=migrate_secrets,
-        output_dir=resolved_output,
         selected_options=selected_options,
         preset_name=preset,
-        skill_conflict_mode=skill_conflict_mode,
     )
     return migrator.migrate()

--- a/hermes_cli/openclaw_migration.py
+++ b/hermes_cli/openclaw_migration.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from functools import lru_cache
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Optional, Sequence
+
+
+_OPENCLAW_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "optional-skills"
+    / "migration"
+    / "openclaw-migration"
+    / "scripts"
+    / "openclaw_to_hermes.py"
+)
+
+
+@lru_cache(maxsize=1)
+def load_openclaw_migration_module() -> ModuleType:
+    if not _OPENCLAW_SCRIPT_PATH.exists():
+        raise FileNotFoundError(
+            f"OpenClaw migration script not found at {_OPENCLAW_SCRIPT_PATH}"
+        )
+
+    spec = importlib.util.spec_from_file_location(
+        "hermes_openclaw_migration",
+        _OPENCLAW_SCRIPT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(
+            f"Could not load OpenClaw migration script from {_OPENCLAW_SCRIPT_PATH}"
+        )
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def get_openclaw_source_root() -> Path:
+    return Path.home() / ".openclaw"
+
+
+def run_openclaw_migration(
+    *,
+    source_root: Optional[Path] = None,
+    target_root: Optional[Path] = None,
+    workspace_target: Optional[Path] = None,
+    execute: bool = True,
+    overwrite: bool = False,
+    migrate_secrets: bool = True,
+    output_dir: Optional[Path] = None,
+    preset: str = "full",
+    include: Optional[Sequence[str]] = None,
+    exclude: Optional[Sequence[str]] = None,
+    skill_conflict_mode: str = "skip",
+) -> dict[str, Any]:
+    module = load_openclaw_migration_module()
+    resolved_source = (source_root or get_openclaw_source_root()).expanduser().resolve()
+    resolved_target = (target_root or (Path.home() / ".hermes")).expanduser().resolve()
+    resolved_workspace = (
+        workspace_target.expanduser().resolve() if workspace_target else None
+    )
+    resolved_output = output_dir.expanduser().resolve() if output_dir else None
+    selected_options = module.resolve_selected_options(include, exclude, preset=preset)
+    migrator = module.Migrator(
+        source_root=resolved_source,
+        target_root=resolved_target,
+        execute=execute,
+        workspace_target=resolved_workspace,
+        overwrite=overwrite,
+        migrate_secrets=migrate_secrets,
+        output_dir=resolved_output,
+        selected_options=selected_options,
+        preset_name=preset,
+        skill_conflict_mode=skill_conflict_mode,
+    )
+    return migrator.migrate()

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1780,10 +1780,10 @@ def detect_migration_sources() -> list[str]:
     return detected_sources
 
 
-def run_openclaw_migration(hermes_home: Path) -> Dict[str, Any]:
+def perform_openclaw_migration(hermes_home: Path) -> Dict[str, Any]:
     from hermes_cli.openclaw_migration import (
         get_openclaw_source_root,
-        run_openclaw_migration as run_openclaw_import,
+        run_openclaw_migration,
     )
 
     source_root = get_openclaw_source_root()
@@ -1801,10 +1801,9 @@ def run_openclaw_migration(hermes_home: Path) -> Dict[str, Any]:
         "Importing API keys, platform settings, command allowlists, memories, and skills."
     )
 
-    report = run_openclaw_import(
+    report = run_openclaw_migration(
         source_root=source_root,
         target_root=hermes_home,
-        workspace_target=None,
         execute=True,
         overwrite=False,
         migrate_secrets=True,
@@ -1853,7 +1852,7 @@ def maybe_run_detected_migration(args, hermes_home: Path) -> bool:
     if not prompt_yes_no("Import settings from OpenClaw now?", True):
         return False
 
-    run_openclaw_migration(hermes_home)
+    perform_openclaw_migration(hermes_home)
     return True
 
 
@@ -1864,7 +1863,7 @@ def maybe_run_requested_migration(args, hermes_home: Path) -> bool:
 
     if migrate_from == "openclaw":
         try:
-            run_openclaw_migration(hermes_home)
+            perform_openclaw_migration(hermes_home)
         except FileNotFoundError as exc:
             print_warning(str(exc))
             return False
@@ -1898,13 +1897,10 @@ def run_setup_wizard(args):
       hermes setup agent     — just agent settings
     """
     ensure_hermes_home()
-    
-    config = load_config()
     hermes_home = get_hermes_home()
 
     migration_ran = maybe_run_requested_migration(args, hermes_home)
-    if migration_ran:
-        config = load_config()
+    config = load_config()
     
     # Check if a specific section was requested
     section = getattr(args, 'section', None)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1771,6 +1771,108 @@ def setup_tools(config: dict, first_install: bool = False):
     tools_command(first_install=first_install, config=config)
 
 
+def detect_migration_sources() -> list[str]:
+    from hermes_cli.openclaw_migration import get_openclaw_source_root
+
+    detected_sources: list[str] = []
+    if get_openclaw_source_root().exists():
+        detected_sources.append("openclaw")
+    return detected_sources
+
+
+def run_openclaw_migration(hermes_home: Path) -> Dict[str, Any]:
+    from hermes_cli.openclaw_migration import (
+        get_openclaw_source_root,
+        run_openclaw_migration as run_openclaw_import,
+    )
+
+    source_root = get_openclaw_source_root()
+    if not source_root.exists():
+        raise FileNotFoundError(f"OpenClaw directory not found at {source_root}")
+
+    config_path = get_config_path()
+    if not config_path.exists():
+        save_config(load_config())
+
+    print()
+    print_header("Importing from OpenClaw")
+    print_info(f"Source: {source_root}")
+    print_info(
+        "Importing API keys, platform settings, command allowlists, memories, and skills."
+    )
+
+    report = run_openclaw_import(
+        source_root=source_root,
+        target_root=hermes_home,
+        workspace_target=None,
+        execute=True,
+        overwrite=False,
+        migrate_secrets=True,
+        preset="full",
+    )
+
+    summary = report.get("summary", {})
+    migrated = summary.get("migrated", 0)
+    conflicts = summary.get("conflict", 0)
+    skipped = summary.get("skipped", 0)
+    errors = summary.get("error", 0)
+
+    if migrated:
+        print_success(f"Imported {migrated} OpenClaw item(s).")
+    if conflicts:
+        print_warning(
+            f"Skipped {conflicts} conflicting item(s) already configured in Hermes."
+        )
+    if skipped:
+        print_info(f"Skipped {skipped} non-importable or unchanged item(s).")
+    if errors:
+        print_warning(
+            f"Migration reported {errors} error item(s). Review the report before relying on everything."
+        )
+
+    output_dir = report.get("output_dir")
+    if output_dir:
+        print_info(f"Migration report: {output_dir}")
+
+    return report
+
+
+def maybe_run_detected_migration(args, hermes_home: Path) -> bool:
+    if getattr(args, "skip_migration_prompt", False):
+        return False
+
+    detected_sources = detect_migration_sources()
+    if "openclaw" not in detected_sources:
+        return False
+
+    print()
+    print_info("Detected OpenClaw installation at ~/.openclaw/")
+    print_info(
+        "Hermes can import your API keys, platform configs, command allowlists, memories, and skills."
+    )
+    if not prompt_yes_no("Import settings from OpenClaw now?", True):
+        return False
+
+    run_openclaw_migration(hermes_home)
+    return True
+
+
+def maybe_run_requested_migration(args, hermes_home: Path) -> bool:
+    migrate_from = (getattr(args, "migrate_from", "") or "").strip().lower()
+    if not migrate_from:
+        return False
+
+    if migrate_from == "openclaw":
+        try:
+            run_openclaw_migration(hermes_home)
+        except FileNotFoundError as exc:
+            print_warning(str(exc))
+            return False
+        return True
+
+    return False
+
+
 # =============================================================================
 # Main Wizard Orchestrator
 # =============================================================================
@@ -1799,6 +1901,10 @@ def run_setup_wizard(args):
     
     config = load_config()
     hermes_home = get_hermes_home()
+
+    migration_ran = maybe_run_requested_migration(args, hermes_home)
+    if migration_ran:
+        config = load_config()
     
     # Check if a specific section was requested
     section = getattr(args, 'section', None)
@@ -1884,6 +1990,12 @@ def run_setup_wizard(args):
             return
     else:
         # ── First-Time Setup ──
+        if not migration_ran and maybe_run_detected_migration(args, hermes_home):
+            config = load_config()
+            print_success("Migration complete! Continuing with setup...")
+        elif migration_ran:
+            print_success("Migration complete! Continuing with setup...")
+
         print()
         print_info("We'll walk you through:")
         print_info("  1. Model & Provider — choose your AI provider and model")

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -759,14 +759,28 @@ function Invoke-SetupWizard {
     Write-Host ""
     Write-Info "Starting setup wizard..."
     Write-Host ""
+
+    $setupArgs = @("setup")
+    $openClawDir = Join-Path $HOME ".openclaw"
+    if (Test-Path $openClawDir) {
+        Write-Host ""
+        Write-Info "Detected OpenClaw installation at ~/.openclaw/"
+        Write-Info "Hermes can import your API keys, platform configs, command allowlists, memories, and skills."
+        $reply = Read-Host "Import from OpenClaw during setup? [Y/n]"
+        if ([string]::IsNullOrWhiteSpace($reply) -or $reply.Trim().ToLower() -in @("y", "yes")) {
+            $setupArgs += @("--migrate-from", "openclaw")
+        } else {
+            $setupArgs += "--skip-migration-prompt"
+        }
+    }
     
     Push-Location $InstallDir
     
     # Run hermes setup using the venv Python directly (no activation needed)
     if (-not $NoVenv) {
-        & ".\venv\Scripts\python.exe" -m hermes_cli.main setup
+        & ".\venv\Scripts\python.exe" -m hermes_cli.main @setupArgs
     } else {
-        python -m hermes_cli.main setup
+        python -m hermes_cli.main @setupArgs
     }
     
     Pop-Location

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,6 +117,29 @@ log_error() {
     echo -e "${RED}✗${NC} $1"
 }
 
+prompt_yes_no() {
+    local question="$1"
+    local default_yes="${2:-false}"
+    local default_prompt="[y/N]"
+    local reply normalized
+
+    if [ "$default_yes" = true ]; then
+        default_prompt="[Y/n]"
+    fi
+
+    IFS= read -r -p "$question $default_prompt " reply || reply=""
+    normalized="${reply,,}"
+    normalized="${normalized#"${normalized%%[![:space:]]*}"}"
+    normalized="${normalized%"${normalized##*[![:space:]]}"}"
+
+    if [ -z "$normalized" ]; then
+        [ "$default_yes" = true ]
+        return
+    fi
+
+    [[ "$normalized" == "y" || "$normalized" == "yes" ]]
+}
+
 # ============================================================================
 # System detection
 # ============================================================================
@@ -909,9 +932,7 @@ run_setup_wizard() {
         echo ""
         log_info "Detected OpenClaw installation at ~/.openclaw/"
         log_info "Hermes can import your API keys, platform configs, command allowlists, memories, and skills."
-        read -p "Import from OpenClaw during setup? [Y/n] " -n 1 -r < /dev/tty
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+        if prompt_yes_no "Import from OpenClaw during setup?" true < /dev/tty; then
             SETUP_ARGS+=(--migrate-from openclaw)
         else
             SETUP_ARGS+=(--skip-migration-prompt)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -903,12 +903,27 @@ run_setup_wizard() {
 
     cd "$INSTALL_DIR"
 
+    SETUP_ARGS=()
+    OPENCLAW_DIR="$HOME/.openclaw"
+    if [ -d "$OPENCLAW_DIR" ]; then
+        echo ""
+        log_info "Detected OpenClaw installation at ~/.openclaw/"
+        log_info "Hermes can import your API keys, platform configs, command allowlists, memories, and skills."
+        read -p "Import from OpenClaw during setup? [Y/n] " -n 1 -r < /dev/tty
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+            SETUP_ARGS+=(--migrate-from openclaw)
+        else
+            SETUP_ARGS+=(--skip-migration-prompt)
+        fi
+    fi
+
     # Run hermes setup using the venv Python directly (no activation needed).
     # Redirect stdin from /dev/tty so interactive prompts work when piped from curl.
     if [ "$USE_VENV" = true ]; then
-        "$INSTALL_DIR/venv/bin/python" -m hermes_cli.main setup < /dev/tty
+        "$INSTALL_DIR/venv/bin/python" -m hermes_cli.main setup "${SETUP_ARGS[@]}" < /dev/tty
     else
-        python -m hermes_cli.main setup < /dev/tty
+        python -m hermes_cli.main setup "${SETUP_ARGS[@]}" < /dev/tty
     fi
 }
 

--- a/tests/hermes_cli/test_install_sh.py
+++ b/tests/hermes_cli/test_install_sh.py
@@ -1,0 +1,43 @@
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _write_sourceable_install_script(tmp_path: Path) -> Path:
+    script = INSTALL_SH.read_text(encoding="utf-8")
+    script = re.sub(r"\nmain\s*$", "\n", script)
+    script_path = tmp_path / "install-under-test.sh"
+    script_path.write_text(script, encoding="utf-8")
+    return script_path
+
+
+def test_prompt_yes_no_consumes_entire_line(tmp_path: Path):
+    script_path = _write_sourceable_install_script(tmp_path)
+    input_path = tmp_path / "prompt-input.txt"
+    input_path.write_text("no\nNEXT\n", encoding="utf-8")
+
+    command = f"""
+source "{script_path}"
+exec 3< "{input_path}"
+if prompt_yes_no "Import from OpenClaw during setup?" true <&3; then
+  echo "ANSWER:YES"
+else
+  echo "ANSWER:NO"
+fi
+IFS= read -r leftover <&3 || true
+echo "LEFTOVER:$leftover"
+"""
+    result = subprocess.run(
+        ["bash", "-lc", command],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ANSWER:NO" in result.stdout
+    assert "LEFTOVER:NEXT" in result.stdout

--- a/tests/hermes_cli/test_main.py
+++ b/tests/hermes_cli/test_main.py
@@ -1,0 +1,23 @@
+import sys
+from unittest.mock import patch
+
+from hermes_cli import main as main_module
+
+
+def test_setup_accepts_migrate_from_openclaw_and_dispatches_to_wizard():
+    captured = {}
+
+    def fake_run_setup_wizard(args):
+        captured["args"] = args
+
+    with (
+        patch.object(sys, "argv", ["hermes", "setup", "--migrate-from", "openclaw"]),
+        patch(
+            "hermes_cli.setup.run_setup_wizard",
+            side_effect=fake_run_setup_wizard,
+        ),
+    ):
+        main_module.main()
+
+    assert captured["args"].command == "setup"
+    assert captured["args"].migrate_from == "openclaw"

--- a/tests/hermes_cli/test_setup_migration.py
+++ b/tests/hermes_cli/test_setup_migration.py
@@ -31,7 +31,7 @@ def test_run_setup_wizard_runs_explicit_openclaw_migration(tmp_path: Path):
         patch.object(setup_cli, "get_env_value", return_value=""),
         patch("hermes_cli.auth.get_active_provider", return_value=None),
         patch(
-            "hermes_cli.setup.run_openclaw_migration",
+            "hermes_cli.setup.perform_openclaw_migration",
             return_value={"summary": {"migrated": 1}},
             create=True,
         ) as run_migration,
@@ -67,7 +67,7 @@ def test_run_setup_wizard_offers_detected_openclaw_migration_on_first_run(
         ),
         patch.object(setup_cli, "prompt_yes_no", return_value=True) as prompt_yes_no,
         patch(
-            "hermes_cli.setup.run_openclaw_migration",
+            "hermes_cli.setup.perform_openclaw_migration",
             return_value={"summary": {"migrated": 2}},
             create=True,
         ) as run_migration,
@@ -101,7 +101,7 @@ def test_run_setup_wizard_skips_migration_prompt_when_no_supported_source(
             "hermes_cli.setup.detect_migration_sources", return_value=[], create=True
         ),
         patch.object(setup_cli, "prompt_yes_no") as prompt_yes_no,
-        patch("hermes_cli.setup.run_openclaw_migration", create=True) as run_migration,
+        patch("hermes_cli.setup.perform_openclaw_migration", create=True) as run_migration,
         patch.object(setup_cli, "setup_model_provider"),
         patch.object(setup_cli, "setup_terminal_backend"),
         patch.object(setup_cli, "setup_agent_settings"),
@@ -139,7 +139,7 @@ def test_run_setup_wizard_runs_explicit_openclaw_migration_for_existing_install(
         ),
         patch("hermes_cli.auth.get_active_provider", return_value=None),
         patch(
-            "hermes_cli.setup.run_openclaw_migration",
+            "hermes_cli.setup.perform_openclaw_migration",
             return_value={"summary": {"migrated": 1}},
         ) as run_migration,
         patch.object(setup_cli, "prompt_choice", return_value=9),
@@ -171,7 +171,7 @@ def test_run_setup_wizard_skips_detected_prompt_after_installer_decline(
             return_value=["openclaw"],
         ),
         patch.object(setup_cli, "prompt_yes_no") as prompt_yes_no,
-        patch("hermes_cli.setup.run_openclaw_migration") as run_migration,
+        patch("hermes_cli.setup.perform_openclaw_migration") as run_migration,
         patch.object(setup_cli, "setup_model_provider"),
         patch.object(setup_cli, "setup_terminal_backend"),
         patch.object(setup_cli, "setup_agent_settings"),
@@ -187,7 +187,7 @@ def test_run_setup_wizard_skips_detected_prompt_after_installer_decline(
     run_migration.assert_not_called()
 
 
-def test_run_openclaw_migration_creates_config_before_import(tmp_path: Path):
+def test_perform_openclaw_migration_creates_config_before_import(tmp_path: Path):
     source_root = tmp_path / ".openclaw"
     source_root.mkdir()
     hermes_home = tmp_path / ".hermes"
@@ -210,7 +210,7 @@ def test_run_openclaw_migration_creates_config_before_import(tmp_path: Path):
             return_value={"summary": {"migrated": 1}, "output_dir": None},
         ) as run_migration,
     ):
-        setup_cli.run_openclaw_migration(hermes_home)
+        setup_cli.perform_openclaw_migration(hermes_home)
 
     save_config.assert_called_once_with({"agent": {"max_turns": 90}})
     run_migration.assert_called_once()

--- a/tests/hermes_cli/test_setup_migration.py
+++ b/tests/hermes_cli/test_setup_migration.py
@@ -1,0 +1,216 @@
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+from hermes_cli import setup as setup_cli
+
+
+def _first_time_args() -> Namespace:
+    return Namespace(
+        section=None,
+        migrate_from=None,
+        non_interactive=False,
+        reset=False,
+        skip_migration_prompt=False,
+    )
+
+
+def test_run_setup_wizard_runs_explicit_openclaw_migration(tmp_path: Path):
+    args = Namespace(
+        section=None,
+        migrate_from="openclaw",
+        non_interactive=False,
+        reset=False,
+        skip_migration_prompt=False,
+    )
+
+    with (
+        patch.object(setup_cli, "ensure_hermes_home"),
+        patch.object(setup_cli, "load_config", return_value={}),
+        patch.object(setup_cli, "get_hermes_home", return_value=tmp_path),
+        patch.object(setup_cli, "get_env_value", return_value=""),
+        patch("hermes_cli.auth.get_active_provider", return_value=None),
+        patch(
+            "hermes_cli.setup.run_openclaw_migration",
+            return_value={"summary": {"migrated": 1}},
+            create=True,
+        ) as run_migration,
+        patch.object(setup_cli, "setup_model_provider"),
+        patch.object(setup_cli, "setup_terminal_backend"),
+        patch.object(setup_cli, "setup_agent_settings"),
+        patch.object(setup_cli, "setup_gateway"),
+        patch.object(setup_cli, "setup_tools"),
+        patch.object(setup_cli, "save_config"),
+        patch.object(setup_cli, "_print_setup_summary"),
+        patch("builtins.input", return_value=""),
+    ):
+        setup_cli.run_setup_wizard(args)
+
+    run_migration.assert_called_once()
+
+
+def test_run_setup_wizard_offers_detected_openclaw_migration_on_first_run(
+    tmp_path: Path,
+):
+    args = _first_time_args()
+
+    with (
+        patch.object(setup_cli, "ensure_hermes_home"),
+        patch.object(setup_cli, "load_config", return_value={}),
+        patch.object(setup_cli, "get_hermes_home", return_value=tmp_path),
+        patch.object(setup_cli, "get_env_value", return_value=""),
+        patch("hermes_cli.auth.get_active_provider", return_value=None),
+        patch(
+            "hermes_cli.setup.detect_migration_sources",
+            return_value=["openclaw"],
+            create=True,
+        ),
+        patch.object(setup_cli, "prompt_yes_no", return_value=True) as prompt_yes_no,
+        patch(
+            "hermes_cli.setup.run_openclaw_migration",
+            return_value={"summary": {"migrated": 2}},
+            create=True,
+        ) as run_migration,
+        patch.object(setup_cli, "setup_model_provider"),
+        patch.object(setup_cli, "setup_terminal_backend"),
+        patch.object(setup_cli, "setup_agent_settings"),
+        patch.object(setup_cli, "setup_gateway"),
+        patch.object(setup_cli, "setup_tools"),
+        patch.object(setup_cli, "save_config"),
+        patch.object(setup_cli, "_print_setup_summary"),
+        patch("builtins.input", return_value=""),
+    ):
+        setup_cli.run_setup_wizard(args)
+
+    prompt_yes_no.assert_any_call("Import settings from OpenClaw now?", True)
+    run_migration.assert_called_once()
+
+
+def test_run_setup_wizard_skips_migration_prompt_when_no_supported_source(
+    tmp_path: Path,
+):
+    args = _first_time_args()
+
+    with (
+        patch.object(setup_cli, "ensure_hermes_home"),
+        patch.object(setup_cli, "load_config", return_value={}),
+        patch.object(setup_cli, "get_hermes_home", return_value=tmp_path),
+        patch.object(setup_cli, "get_env_value", return_value=""),
+        patch("hermes_cli.auth.get_active_provider", return_value=None),
+        patch(
+            "hermes_cli.setup.detect_migration_sources", return_value=[], create=True
+        ),
+        patch.object(setup_cli, "prompt_yes_no") as prompt_yes_no,
+        patch("hermes_cli.setup.run_openclaw_migration", create=True) as run_migration,
+        patch.object(setup_cli, "setup_model_provider"),
+        patch.object(setup_cli, "setup_terminal_backend"),
+        patch.object(setup_cli, "setup_agent_settings"),
+        patch.object(setup_cli, "setup_gateway"),
+        patch.object(setup_cli, "setup_tools"),
+        patch.object(setup_cli, "save_config"),
+        patch.object(setup_cli, "_print_setup_summary"),
+        patch("builtins.input", return_value=""),
+    ):
+        setup_cli.run_setup_wizard(args)
+
+    prompt_yes_no.assert_not_called()
+    run_migration.assert_not_called()
+
+
+def test_run_setup_wizard_runs_explicit_openclaw_migration_for_existing_install(
+    tmp_path: Path,
+):
+    args = Namespace(
+        section=None,
+        migrate_from="openclaw",
+        non_interactive=False,
+        reset=False,
+        skip_migration_prompt=False,
+    )
+
+    with (
+        patch.object(setup_cli, "ensure_hermes_home"),
+        patch.object(setup_cli, "load_config", return_value={}),
+        patch.object(setup_cli, "get_hermes_home", return_value=tmp_path),
+        patch.object(
+            setup_cli,
+            "get_env_value",
+            side_effect=lambda key: "configured" if key == "OPENROUTER_API_KEY" else "",
+        ),
+        patch("hermes_cli.auth.get_active_provider", return_value=None),
+        patch(
+            "hermes_cli.setup.run_openclaw_migration",
+            return_value={"summary": {"migrated": 1}},
+        ) as run_migration,
+        patch.object(setup_cli, "prompt_choice", return_value=9),
+    ):
+        setup_cli.run_setup_wizard(args)
+
+    run_migration.assert_called_once_with(tmp_path)
+
+
+def test_run_setup_wizard_skips_detected_prompt_after_installer_decline(
+    tmp_path: Path,
+):
+    args = Namespace(
+        section=None,
+        migrate_from=None,
+        non_interactive=False,
+        reset=False,
+        skip_migration_prompt=True,
+    )
+
+    with (
+        patch.object(setup_cli, "ensure_hermes_home"),
+        patch.object(setup_cli, "load_config", return_value={}),
+        patch.object(setup_cli, "get_hermes_home", return_value=tmp_path),
+        patch.object(setup_cli, "get_env_value", return_value=""),
+        patch("hermes_cli.auth.get_active_provider", return_value=None),
+        patch(
+            "hermes_cli.setup.detect_migration_sources",
+            return_value=["openclaw"],
+        ),
+        patch.object(setup_cli, "prompt_yes_no") as prompt_yes_no,
+        patch("hermes_cli.setup.run_openclaw_migration") as run_migration,
+        patch.object(setup_cli, "setup_model_provider"),
+        patch.object(setup_cli, "setup_terminal_backend"),
+        patch.object(setup_cli, "setup_agent_settings"),
+        patch.object(setup_cli, "setup_gateway"),
+        patch.object(setup_cli, "setup_tools"),
+        patch.object(setup_cli, "save_config"),
+        patch.object(setup_cli, "_print_setup_summary"),
+        patch("builtins.input", return_value=""),
+    ):
+        setup_cli.run_setup_wizard(args)
+
+    prompt_yes_no.assert_not_called()
+    run_migration.assert_not_called()
+
+
+def test_run_openclaw_migration_creates_config_before_import(tmp_path: Path):
+    source_root = tmp_path / ".openclaw"
+    source_root.mkdir()
+    hermes_home = tmp_path / ".hermes"
+    config_path = hermes_home / "config.yaml"
+
+    with (
+        patch(
+            "hermes_cli.openclaw_migration.get_openclaw_source_root",
+            return_value=source_root,
+        ),
+        patch.object(setup_cli, "get_config_path", return_value=config_path),
+        patch.object(
+            setup_cli,
+            "load_config",
+            return_value={"agent": {"max_turns": 90}},
+        ),
+        patch.object(setup_cli, "save_config") as save_config,
+        patch(
+            "hermes_cli.openclaw_migration.run_openclaw_migration",
+            return_value={"summary": {"migrated": 1}, "output_dir": None},
+        ) as run_migration,
+    ):
+        setup_cli.run_openclaw_migration(hermes_home)
+
+    save_config.assert_called_once_with({"agent": {"max_turns": 90}})
+    run_migration.assert_called_once()

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -25,6 +25,7 @@ from tools.vision_tools import (
 # _validate_image_url — urlparse-based validation
 # ---------------------------------------------------------------------------
 
+
 class TestValidateImageUrl:
     """Tests for URL validation, including urlparse-based netloc check."""
 
@@ -95,6 +96,7 @@ class TestValidateImageUrl:
 # _determine_mime_type
 # ---------------------------------------------------------------------------
 
+
 class TestDetermineMimeType:
     def test_jpg(self):
         assert _determine_mime_type(Path("photo.jpg")) == "image/jpeg"
@@ -119,6 +121,7 @@ class TestDetermineMimeType:
 # _image_to_base64_data_url
 # ---------------------------------------------------------------------------
 
+
 class TestImageToBase64DataUrl:
     def test_returns_data_url(self, tmp_path):
         img = tmp_path / "test.png"
@@ -141,15 +144,21 @@ class TestImageToBase64DataUrl:
 # _handle_vision_analyze — type signature & behavior
 # ---------------------------------------------------------------------------
 
+
 class TestHandleVisionAnalyze:
     """Verify _handle_vision_analyze returns an Awaitable and builds correct prompt."""
 
     def test_returns_awaitable(self):
         """The handler must return an Awaitable (coroutine) since it's registered as async."""
-        with patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_tool:
+        with patch(
+            "tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock
+        ) as mock_tool:
             mock_tool.return_value = json.dumps({"result": "ok"})
             result = _handle_vision_analyze(
-                {"image_url": "https://example.com/img.png", "question": "What is this?"}
+                {
+                    "image_url": "https://example.com/img.png",
+                    "question": "What is this?",
+                }
             )
             # It should be an Awaitable (coroutine)
             assert isinstance(result, Awaitable)
@@ -158,10 +167,15 @@ class TestHandleVisionAnalyze:
 
     def test_prompt_contains_question(self):
         """The full prompt should incorporate the user's question."""
-        with patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_tool:
+        with patch(
+            "tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock
+        ) as mock_tool:
             mock_tool.return_value = json.dumps({"result": "ok"})
             coro = _handle_vision_analyze(
-                {"image_url": "https://example.com/img.png", "question": "Describe the cat"}
+                {
+                    "image_url": "https://example.com/img.png",
+                    "question": "Describe the cat",
+                }
             )
             # Clean up coroutine
             coro.close()
@@ -172,8 +186,12 @@ class TestHandleVisionAnalyze:
 
     def test_uses_auxiliary_vision_model_env(self):
         """AUXILIARY_VISION_MODEL env var should override DEFAULT_VISION_MODEL."""
-        with patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_tool, \
-             patch.dict(os.environ, {"AUXILIARY_VISION_MODEL": "custom/model-v1"}):
+        with (
+            patch(
+                "tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock
+            ) as mock_tool,
+            patch.dict(os.environ, {"AUXILIARY_VISION_MODEL": "custom/model-v1"}),
+        ):
             mock_tool.return_value = json.dumps({"result": "ok"})
             coro = _handle_vision_analyze(
                 {"image_url": "https://example.com/img.png", "question": "test"}
@@ -185,8 +203,12 @@ class TestHandleVisionAnalyze:
 
     def test_falls_back_to_default_model(self):
         """Without AUXILIARY_VISION_MODEL, should use DEFAULT_VISION_MODEL or fallback."""
-        with patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_tool, \
-             patch.dict(os.environ, {}, clear=False):
+        with (
+            patch(
+                "tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock
+            ) as mock_tool,
+            patch.dict(os.environ, {}, clear=False),
+        ):
             # Ensure AUXILIARY_VISION_MODEL is not set
             os.environ.pop("AUXILIARY_VISION_MODEL", None)
             mock_tool.return_value = json.dumps({"result": "ok"})
@@ -202,7 +224,9 @@ class TestHandleVisionAnalyze:
 
     def test_empty_args_graceful(self):
         """Missing keys should default to empty strings, not raise."""
-        with patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_tool:
+        with patch(
+            "tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock
+        ) as mock_tool:
             mock_tool.return_value = json.dumps({"result": "ok"})
             result = _handle_vision_analyze({})
             assert isinstance(result, Awaitable)
@@ -212,6 +236,7 @@ class TestHandleVisionAnalyze:
 # ---------------------------------------------------------------------------
 # Error logging with exc_info — verify tracebacks are logged
 # ---------------------------------------------------------------------------
+
 
 class TestErrorLoggingExcInfo:
     """Verify that exc_info=True is used in error/warning log calls."""
@@ -229,9 +254,13 @@ class TestErrorLoggingExcInfo:
             mock_client_cls.return_value = mock_client
 
             dest = tmp_path / "image.jpg"
-            with caplog.at_level(logging.ERROR, logger="tools.vision_tools"), \
-                 pytest.raises(ConnectionError):
-                await _download_image("https://example.com/img.jpg", dest, max_retries=1)
+            with (
+                caplog.at_level(logging.ERROR, logger="tools.vision_tools"),
+                pytest.raises(ConnectionError),
+            ):
+                await _download_image(
+                    "https://example.com/img.jpg", dest, max_retries=1
+                )
 
             # Should have logged with exc_info (traceback present)
             error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
@@ -241,11 +270,17 @@ class TestErrorLoggingExcInfo:
     @pytest.mark.asyncio
     async def test_analysis_error_logs_exc_info(self, caplog):
         """When vision_analyze_tool encounters an error, it should log with exc_info."""
-        with patch("tools.vision_tools._validate_image_url", return_value=True), \
-             patch("tools.vision_tools._download_image", new_callable=AsyncMock,
-                   side_effect=Exception("download boom")), \
-             caplog.at_level(logging.ERROR, logger="tools.vision_tools"):
-
+        with (
+            patch("tools.vision_tools._validate_image_url", return_value=True),
+            patch("tools.vision_tools._aux_async_client", object()),
+            patch("tools.vision_tools.DEFAULT_VISION_MODEL", "test/model"),
+            patch(
+                "tools.vision_tools._download_image",
+                new_callable=AsyncMock,
+                side_effect=Exception("download boom"),
+            ),
+            caplog.at_level(logging.ERROR, logger="tools.vision_tools"),
+        ):
             result = await vision_analyze_tool(
                 "https://example.com/img.jpg", "describe this", "test/model"
             )
@@ -269,14 +304,20 @@ class TestErrorLoggingExcInfo:
             dest.write_bytes(b"\xff\xd8\xff" + b"\x00" * 16)
             return dest
 
-        with patch("tools.vision_tools._validate_image_url", return_value=True), \
-             patch("tools.vision_tools._download_image", side_effect=fake_download), \
-             patch("tools.vision_tools._image_to_base64_data_url",
-                   return_value="data:image/jpeg;base64,abc"), \
-             patch("agent.auxiliary_client.get_auxiliary_extra_body", return_value=None), \
-             patch("agent.auxiliary_client.auxiliary_max_tokens_param", return_value={"max_tokens": 2000}), \
-             caplog.at_level(logging.WARNING, logger="tools.vision_tools"):
-
+        with (
+            patch("tools.vision_tools._validate_image_url", return_value=True),
+            patch("tools.vision_tools._download_image", side_effect=fake_download),
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/jpeg;base64,abc",
+            ),
+            patch("agent.auxiliary_client.get_auxiliary_extra_body", return_value=None),
+            patch(
+                "agent.auxiliary_client.auxiliary_max_tokens_param",
+                return_value={"max_tokens": 2000},
+            ),
+            caplog.at_level(logging.WARNING, logger="tools.vision_tools"),
+        ):
             # Mock the vision client
             mock_client = AsyncMock()
             mock_response = MagicMock()
@@ -286,11 +327,13 @@ class TestErrorLoggingExcInfo:
             mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
             # Patch module-level _aux_async_client so the tool doesn't bail early
-            with patch("tools.vision_tools._aux_async_client", mock_client), \
-                 patch("tools.vision_tools.DEFAULT_VISION_MODEL", "test/model"):
-
+            with (
+                patch("tools.vision_tools._aux_async_client", mock_client),
+                patch("tools.vision_tools.DEFAULT_VISION_MODEL", "test/model"),
+            ):
                 # Make unlink fail to trigger cleanup warning
                 original_unlink = Path.unlink
+
                 def failing_unlink(self, *args, **kwargs):
                     raise PermissionError("no permission")
 
@@ -299,8 +342,12 @@ class TestErrorLoggingExcInfo:
                         "https://example.com/tempimg.jpg", "describe", "test/model"
                     )
 
-            warning_records = [r for r in caplog.records if r.levelno == logging.WARNING
-                               and "temporary file" in r.getMessage().lower()]
+            warning_records = [
+                r
+                for r in caplog.records
+                if r.levelno == logging.WARNING
+                and "temporary file" in r.getMessage().lower()
+            ]
             assert len(warning_records) >= 1
             assert warning_records[0].exc_info is not None
 
@@ -308,6 +355,7 @@ class TestErrorLoggingExcInfo:
 # ---------------------------------------------------------------------------
 # check_vision_requirements & get_debug_session_info
 # ---------------------------------------------------------------------------
+
 
 class TestVisionRequirements:
     def test_check_requirements_returns_bool(self):
@@ -327,9 +375,11 @@ class TestVisionRequirements:
 # Integration: registry entry
 # ---------------------------------------------------------------------------
 
+
 class TestVisionRegistration:
     def test_vision_analyze_registered(self):
         from tools.registry import registry
+
         entry = registry._tools.get("vision_analyze")
         assert entry is not None
         assert entry.toolset == "vision"
@@ -337,6 +387,7 @@ class TestVisionRegistration:
 
     def test_schema_has_required_fields(self):
         from tools.registry import registry
+
         entry = registry._tools.get("vision_analyze")
         schema = entry.schema
         assert schema["name"] == "vision_analyze"
@@ -347,5 +398,6 @@ class TestVisionRegistration:
 
     def test_handler_is_callable(self):
         from tools.registry import registry
+
         entry = registry._tools.get("vision_analyze")
         assert callable(entry.handler)


### PR DESCRIPTION
## Problem
OpenClaw migration currently lives behind an optional migration skill, which means users need Hermes running before they can import the API keys and config needed to run Hermes in the first place.

Issue [#829](https://github.com/NousResearch/hermes-agent/issues/829) asks for that migration to happen naturally during install/setup instead of after first boot.

Closes #829
Supersedes the earlier `hermes migrate` direction in #826

## What This PR Changes
- Adds a shared OpenClaw migration wrapper in `hermes_cli/openclaw_migration.py` so setup can call the existing migration script directly.
- Adds `hermes setup --migrate-from openclaw` in `hermes_cli/main.py`.
- Runs migration at the start of `hermes setup` when explicitly requested, or offers it automatically on first-run when `~/.openclaw/` is detected.
- Wires both installers (`scripts/install.sh` and `scripts/install.ps1`) to hand off into setup with the right migration flags.
- Passes `--skip-migration-prompt` when the installer prompt is declined so setup does not immediately ask again.
- Fixes the shell installer prompt to consume the full input line, so answers like `no` or `yes` do not leak characters into the next setup prompt.
- Adds CLI/setup regression coverage for the new migration paths.

## Behavior Covered
- First install + `~/.openclaw/` present: setup offers migration before provider prompts.
- Installer accepts migration: setup starts with `--migrate-from openclaw` and imports immediately.
- Installer declines migration: setup receives `--skip-migration-prompt` and does not re-prompt.
- Existing Hermes install: explicit `hermes setup --migrate-from openclaw` still runs the migration.
- Missing Hermes config: setup bootstraps `config.yaml` before importing command allowlists and related config.
- Shell installer prompt: multi-character input like `no` is fully consumed and does not corrupt the next prompt.

## Review Guide
1. `hermes_cli/setup.py`
   Main setup-flow integration: detection, explicit migration, skip flag behavior, and summary path.
2. `hermes_cli/openclaw_migration.py`
   Thin wrapper around the existing migration script.
3. `hermes_cli/main.py`
   New setup CLI flags.
4. `scripts/install.sh` and `scripts/install.ps1`
   Installer handoff into setup.
5. `tests/hermes_cli/test_main.py`, `tests/hermes_cli/test_setup_migration.py`, `tests/hermes_cli/test_install_sh.py`
   Regression coverage for the new flows.

## Notes For Reviewers
- `tests/tools/test_vision_tools.py` is a test-only stabilization change to keep the suite green; it does not change production behavior for this feature.
- The migration implementation intentionally reuses `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py` rather than duplicating logic in setup.

## Verification
Ran locally after the follow-up installer fix:
- `python -m pytest tests/hermes_cli/test_install_sh.py -q` -> `1 passed`
- `python -m pytest tests/hermes_cli/test_main.py tests/hermes_cli/test_setup_migration.py -q` -> `7 passed`
- `python -m pytest tests/tools/test_vision_tools.py -q` -> `42 passed`
- `python -m hermes_cli.main setup --help` -> passed
- `bash -n scripts/install.sh` -> passed
- `python -m pytest tests/ -q` -> `2868 passed, 5 skipped, 23 deselected, 3 warnings`

## Branch Status
- PR branch updated with follow-up fix: `fix: consume full installer prompt input` (`62b5a7d`)
