### PR TITLE
feat: adversarial council subsystem for multi-perspective evaluation

### DIFF
--- a/datagen-config-examples/ouroboros.yaml
+++ b/datagen-config-examples/ouroboros.yaml
@@ -1,0 +1,52 @@
+# Ouroboros -- Council-based reward for research agent training
+#
+# Uses the adversarial council to evaluate agent research output.
+# Produces DPO preference pairs from council disagreements.
+#
+# Usage:
+#   python environments/ouroboros_env.py process \
+#     --env.data_path_to_save_groups data/ouroboros_v1/trajectories.jsonl
+#
+#   python environments/ouroboros_env.py serve \
+#     --openai.base_url http://localhost:8000/v1
+
+environment: ouroboros
+
+# Agent toolsets
+toolsets:
+  - web
+  - file
+  - terminal
+
+# Training parameters
+num_workers: 2
+batch_size: 10
+max_items: 100
+
+# Agent model (the model being trained/evaluated)
+model: nousresearch/hermes-3-llama-3.1-70b
+
+# Council evaluator model (can be same or different)
+council_model: nousresearch/hermes-3-llama-3.1-70b
+
+# Output
+output_dir: data/ouroboros_v1
+dpo_output_dir: data/ouroboros_v1/dpo
+
+# Trajectory compression (optional, for SFT data)
+compression:
+  enabled: true
+  target_max_tokens: 16000
+
+# Evaluation frequency
+eval_every: 25
+eval_size: 3
+
+# Agent loop
+max_agent_turns: 20
+agent_temperature: 1.0
+system_prompt: >
+  You are a research agent. Your task is to thoroughly research the given
+  question using web search and other available tools. Provide a comprehensive,
+  evidence-backed analysis with specific data points, sources, and
+  counter-arguments. Be thorough but concise. Cite your sources.

--- a/environments/council_evaluator.py
+++ b/environments/council_evaluator.py
@@ -1,0 +1,320 @@
+"""Council Evaluator -- Reusable evaluator for any HermesAgentBaseEnv.
+
+Drop-in evaluator that uses the adversarial council to score agent output.
+Any RL environment can import this and use it in compute_reward().
+
+Usage in an environment's compute_reward():
+    evaluator = CouncilEvaluator(model="nousresearch/hermes-3-llama-3.1-70b")
+    verdict = await evaluator.evaluate(content, question, criteria)
+    reward = evaluator.normalized_reward(verdict)
+"""
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Ensure repo root is on sys.path
+_repo_root = Path(__file__).resolve().parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from tools.council_personas import (
+    CouncilVerdict,
+    PersonaResponse,
+    DEFAULT_PERSONAS,
+    load_custom_personas,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CouncilEvaluator:
+    """Drop-in evaluator for any HermesAgentBaseEnv.
+
+    Uses the adversarial 5-persona council to evaluate agent output,
+    returning structured verdicts with confidence scores and DPO pairs.
+
+    Args:
+        model: LLM model name. Defaults to COUNCIL_MODEL env var or hermes-3-70b.
+        api_key: API key. Defaults to OPENROUTER_API_KEY/OPENAI_API_KEY/NOUS_API_KEY.
+        base_url: API base URL. Auto-detected from which key is set.
+        personas: List of persona names to use. Defaults to all 5.
+    """
+
+    def __init__(
+        self,
+        model: str = None,
+        api_key: str = None,
+        base_url: str = None,
+        personas: List[str] = None,
+    ):
+        self.model = model or os.getenv(
+            "COUNCIL_MODEL", "nousresearch/hermes-3-llama-3.1-70b"
+        )
+
+        # Resolve API config
+        if api_key and base_url:
+            self._api_key = api_key
+            self._base_url = base_url
+        elif os.getenv("OPENROUTER_API_KEY"):
+            self._api_key = os.environ["OPENROUTER_API_KEY"]
+            self._base_url = "https://openrouter.ai/api/v1"
+        elif os.getenv("NOUS_API_KEY"):
+            self._api_key = os.environ["NOUS_API_KEY"]
+            self._base_url = "https://inference-api.nousresearch.com/v1"
+        elif os.getenv("OPENAI_API_KEY"):
+            self._api_key = os.environ["OPENAI_API_KEY"]
+            self._base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        else:
+            self._api_key = ""
+            self._base_url = ""
+
+        # Load personas
+        all_personas = load_custom_personas()
+        if personas:
+            self._personas = {
+                name.lower(): all_personas[name.lower()]
+                for name in personas
+                if name.lower() in all_personas
+            }
+        else:
+            self._personas = dict(all_personas)
+
+        self._client = None
+
+    def _get_client(self):
+        """Lazy-init the AsyncOpenAI client."""
+        if self._client is None:
+            from openai import AsyncOpenAI
+
+            self._client = AsyncOpenAI(
+                api_key=self._api_key,
+                base_url=self._base_url,
+            )
+        return self._client
+
+    async def _llm_call(self, system_prompt: str, user_message: str) -> str:
+        """Make a single LLM call."""
+        if not self._api_key:
+            return "[Error: No API key configured for council evaluator]"
+
+        client = self._get_client()
+        try:
+            response = await client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_message},
+                ],
+                temperature=0.7,
+                max_tokens=2000,
+            )
+            return response.choices[0].message.content or ""
+        except Exception as e:
+            logger.error("Council evaluator LLM call failed: %s", e)
+            return f"[Error: {e}]"
+
+    async def evaluate(
+        self,
+        content: str,
+        question: str = None,
+        criteria: List[str] = None,
+    ) -> CouncilVerdict:
+        """Run the full council evaluation on content.
+
+        Args:
+            content: The agent output or content to evaluate.
+            question: The original question/task (for context).
+            criteria: Evaluation criteria. Defaults to standard set.
+
+        Returns:
+            CouncilVerdict with confidence score, persona responses, and DPO pairs.
+        """
+        import re
+
+        if criteria is None:
+            criteria = ["accuracy", "depth", "evidence", "falsifiability"]
+
+        eval_question = (
+            f"Evaluate this content against: {', '.join(criteria)}.\n\n"
+        )
+        if question:
+            eval_question += f"Original task: {question}\n\n"
+        eval_question += f"Content:\n{content[:4000]}"
+
+        # Separate Arbiter
+        arbiter_persona = self._personas.pop(
+            "arbiter", DEFAULT_PERSONAS["arbiter"]
+        )
+        deliberators = dict(self._personas)
+        # Restore arbiter for future calls
+        self._personas["arbiter"] = arbiter_persona
+
+        # Run deliberators in parallel
+        async def _run_one(persona):
+            raw = await self._llm_call(persona.system_prompt, eval_question)
+            return self._parse_response(persona.name, raw)
+
+        tasks = [_run_one(p) for p in deliberators.values()]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        responses: Dict[str, PersonaResponse] = {}
+        for resp in results:
+            if isinstance(resp, PersonaResponse):
+                responses[resp.persona_name] = resp
+
+        # Detect conflicts
+        confidences = [r.confidence for r in responses.values()]
+        conflict = False
+        if len(confidences) >= 2:
+            conflict = (max(confidences) - min(confidences)) > 0.3
+
+        # Run Arbiter
+        arbiter_context = f"Evaluation task: {eval_question}\n\n"
+        arbiter_context += "=== COUNCIL DELIBERATION ===\n\n"
+        for name, resp in responses.items():
+            arbiter_context += (
+                f"--- {name.upper()} ({resp.confidence:.0%}) ---\n"
+                f"{resp.content}\n\n"
+            )
+
+        arbiter_raw = await self._llm_call(
+            arbiter_persona.system_prompt, arbiter_context
+        )
+        arbiter_resp = self._parse_response("arbiter", arbiter_raw)
+        responses["arbiter"] = arbiter_resp
+
+        # Aggregate sources
+        all_sources = []
+        for resp in responses.values():
+            all_sources.extend(resp.sources)
+
+        confidence_score = int(arbiter_resp.confidence * 100)
+        dpo_pairs = self.extract_dpo_pairs_from_responses(eval_question, responses)
+
+        return CouncilVerdict(
+            question=question or eval_question,
+            responses=responses,
+            arbiter_synthesis=arbiter_raw,
+            confidence_score=confidence_score,
+            conflict_detected=conflict,
+            dpo_pairs=dpo_pairs,
+            sources=list(set(all_sources)),
+        )
+
+    async def gate(self, action: str, context: str = None) -> dict:
+        """Quick safety check using Skeptic + Oracle + Arbiter only.
+
+        Args:
+            action: Description of the action to review.
+            context: Why this action is being taken.
+
+        Returns:
+            Dict with allowed (bool), confidence (int), reasoning (str).
+        """
+        gate_question = f"SAFETY REVIEW\nAction: {action}"
+        if context:
+            gate_question += f"\nContext: {context}"
+        gate_question += (
+            "\nShould this action be allowed? Consider risks and reversibility."
+        )
+
+        # Use only Skeptic + Oracle + Arbiter for speed
+        saved = dict(self._personas)
+        self._personas = {
+            k: v for k, v in saved.items() if k in ("skeptic", "oracle", "arbiter")
+        }
+        verdict = await self.evaluate(gate_question)
+        self._personas = saved
+
+        return {
+            "allowed": verdict.confidence_score >= 50,
+            "confidence": verdict.confidence_score,
+            "reasoning": verdict.arbiter_synthesis[:1000],
+        }
+
+    def extract_dpo_pairs(self, verdict: CouncilVerdict) -> List[dict]:
+        """Extract DPO preference pairs from a verdict."""
+        return self.extract_dpo_pairs_from_responses(
+            verdict.question, verdict.responses
+        )
+
+    @staticmethod
+    def extract_dpo_pairs_from_responses(
+        question: str, responses: Dict[str, PersonaResponse]
+    ) -> List[dict]:
+        """Extract DPO pairs from persona responses.
+
+        Returns list of {chosen, rejected, question, confidence, source} dicts.
+        """
+        pairs = []
+        non_arbiter = {
+            k: v for k, v in responses.items() if k != "arbiter" and v.content
+        }
+        arbiter = responses.get("arbiter")
+        if not arbiter or not non_arbiter:
+            return pairs
+
+        sorted_by_conf = sorted(
+            non_arbiter.values(), key=lambda r: r.confidence
+        )
+
+        # Arbiter (chosen) vs lowest-confidence dissenter (rejected)
+        dissenters = [r for r in sorted_by_conf if r.dissents]
+        if dissenters:
+            pairs.append({
+                "question": question,
+                "chosen": arbiter.content,
+                "rejected": dissenters[0].content,
+                "confidence": arbiter.confidence,
+                "source": "council_evaluation",
+            })
+
+        return pairs
+
+    def normalized_reward(self, verdict: CouncilVerdict) -> float:
+        """Convert a verdict to a normalized 0.0-1.0 reward signal."""
+        return max(0.0, min(1.0, verdict.confidence_score / 100.0))
+
+    @staticmethod
+    def _parse_response(persona_name: str, raw_text: str) -> PersonaResponse:
+        """Parse raw LLM output into PersonaResponse."""
+        import re
+
+        # Parse confidence
+        confidence = 0.5
+        for pattern in [r"CONFIDENCE:\s*([\d.]+)", r"(\d+)%"]:
+            match = re.search(pattern, raw_text, re.IGNORECASE)
+            if match:
+                val = float(match.group(1))
+                confidence = val / 100.0 if val > 1.0 else val
+                break
+
+        # Parse dissent
+        dissents = False
+        match = re.search(r"DISSENT:\s*(true|false)", raw_text, re.IGNORECASE)
+        if match:
+            dissents = match.group(1).lower() == "true"
+
+        # Parse key points
+        key_points = []
+        for line in raw_text.split("\n"):
+            line = line.strip()
+            if line.startswith(("- ", "* ")) and len(line) > 12:
+                key_points.append(line.lstrip("-* ").strip())
+        key_points = key_points[:10]
+
+        # Parse sources
+        sources = list(set(re.findall(r'https?://[^\s\)\]\"\'<>]+', raw_text)))
+
+        return PersonaResponse(
+            persona_name=persona_name,
+            content=raw_text,
+            confidence=confidence,
+            dissents=dissents,
+            key_points=key_points,
+            sources=sources,
+        )

--- a/environments/ouroboros_env.py
+++ b/environments/ouroboros_env.py
@@ -1,0 +1,452 @@
+"""
+OuroborosEnv -- RL Environment with Council-Based Reward
+
+Uses the adversarial council to evaluate agent research output, producing
+multi-signal rewards and DPO preference pairs for training.
+
+The agent is given research questions and must use web search, file tools,
+and terminal to produce comprehensive, evidence-backed analysis. The council
+evaluates the output quality and generates rewards.
+
+Usage:
+    # Process mode (SFT data gen, no run-api needed)
+    python environments/ouroboros_env.py process \\
+        --env.data_path_to_save_groups ouroboros_output.jsonl
+
+    # Serve mode (with Atropos API server)
+    python environments/ouroboros_env.py serve \\
+        --openai.base_url http://localhost:8000/v1
+"""
+
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+# Ensure repo root on sys.path
+_repo_root = Path(__file__).resolve().parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from atroposlib.envs.server_handling.server_manager import APIServerConfig
+from atroposlib.type_definitions import Item
+from pydantic import Field
+
+from environments.agent_loop import AgentResult
+from environments.council_evaluator import CouncilEvaluator
+from environments.hermes_base_env import HermesAgentBaseEnv, HermesAgentEnvConfig
+from environments.tool_context import ToolContext
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Research questions dataset (inline, no external dependency)
+# =============================================================================
+
+RESEARCH_QUESTIONS = [
+    # Technology & Computing
+    {
+        "question": "What are the security implications of post-quantum cryptography migration for existing blockchain networks?",
+        "category": "technology",
+    },
+    {
+        "question": "How do different consensus mechanisms (PoW, PoS, DPoS, DAG) compare in terms of energy efficiency, decentralization, and security?",
+        "category": "technology",
+    },
+    {
+        "question": "What is the current state of homomorphic encryption and when will it be practical for real-world applications?",
+        "category": "technology",
+    },
+    {
+        "question": "How do zero-knowledge proofs enable privacy while maintaining auditability in financial systems?",
+        "category": "technology",
+    },
+    {
+        "question": "What are the trade-offs between monolithic and modular blockchain architectures?",
+        "category": "technology",
+    },
+    # Economics & Finance
+    {
+        "question": "What would be the economic impact of a central bank digital currency (CBDC) on commercial banking?",
+        "category": "economics",
+    },
+    {
+        "question": "How do automated market makers (AMMs) compare to traditional order book exchanges in terms of capital efficiency?",
+        "category": "economics",
+    },
+    {
+        "question": "What historical evidence exists for or against the effectiveness of universal basic income?",
+        "category": "economics",
+    },
+    {
+        "question": "How do mechanism design principles apply to token economics and governance?",
+        "category": "economics",
+    },
+    {
+        "question": "What are the systemic risks of algorithmic stablecoins based on historical examples?",
+        "category": "economics",
+    },
+    # Science & Research
+    {
+        "question": "What is the current evidence for and against the lab leak hypothesis for COVID-19?",
+        "category": "science",
+    },
+    {
+        "question": "How close are we to achieving artificial general intelligence, and what are the key remaining challenges?",
+        "category": "science",
+    },
+    {
+        "question": "What are the most promising approaches to nuclear fusion and their realistic timelines?",
+        "category": "science",
+    },
+    {
+        "question": "How effective are different geoengineering approaches for climate change mitigation?",
+        "category": "science",
+    },
+    {
+        "question": "What is the replication crisis in social psychology and how should it change our confidence in published findings?",
+        "category": "science",
+    },
+    # Governance & Society
+    {
+        "question": "How do different models of internet governance (multi-stakeholder, state-led, corporate) affect innovation and freedom?",
+        "category": "governance",
+    },
+    {
+        "question": "What are the arguments for and against intellectual property rights in the age of AI-generated content?",
+        "category": "governance",
+    },
+    {
+        "question": "How effective are economic sanctions as a foreign policy tool, based on historical evidence?",
+        "category": "governance",
+    },
+    {
+        "question": "What are the implications of autonomous weapons systems for international law and ethics?",
+        "category": "governance",
+    },
+    {
+        "question": "How should AI systems be regulated to balance innovation with safety?",
+        "category": "governance",
+    },
+    # Strategy & Decision-Making
+    {
+        "question": "When is it rational to use prediction markets vs. expert committees for forecasting?",
+        "category": "strategy",
+    },
+    {
+        "question": "What does the evidence say about the effectiveness of diversification vs. concentration in investment portfolios?",
+        "category": "strategy",
+    },
+    {
+        "question": "How should organizations balance exploration vs. exploitation in R&D allocation?",
+        "category": "strategy",
+    },
+    {
+        "question": "What are the failure modes of democratic governance in decentralized autonomous organizations?",
+        "category": "strategy",
+    },
+    {
+        "question": "How do different approaches to risk management (quantitative vs. scenario-based) perform under tail risk events?",
+        "category": "strategy",
+    },
+]
+
+EVAL_QUESTIONS = [
+    {
+        "question": "Should proof-of-stake replace proof-of-work for all blockchain networks? Analyze the trade-offs comprehensively.",
+        "category": "technology",
+    },
+    {
+        "question": "What is the optimal approach to AI alignment and what are the strongest arguments against current safety research?",
+        "category": "science",
+    },
+    {
+        "question": "Analyze the case for and against cryptocurrency as legal tender, using El Salvador as a case study.",
+        "category": "economics",
+    },
+]
+
+
+# =============================================================================
+# Environment Config
+# =============================================================================
+
+
+class OuroborosEnvConfig(HermesAgentEnvConfig):
+    """Configuration for the Ouroboros council-reward environment."""
+
+    council_model: str = Field(
+        default="nousresearch/hermes-3-llama-3.1-70b",
+        description="Model for council evaluation. Can differ from the agent model.",
+    )
+    min_confidence_threshold: float = Field(
+        default=0.3,
+        description="Minimum council confidence for positive reward (0.0-1.0).",
+    )
+    dpo_output_dir: str = Field(
+        default="data/ouroboros_dpo",
+        description="Directory to save DPO preference pairs.",
+    )
+
+
+# =============================================================================
+# Environment
+# =============================================================================
+
+
+class OuroborosEnv(HermesAgentBaseEnv):
+    """RL environment that uses the adversarial council for reward.
+
+    The agent researches questions using web search, file tools, and terminal.
+    The council evaluates output quality across accuracy, depth, evidence,
+    and falsifiability. DPO pairs are extracted from council disagreements.
+    """
+
+    name = "ouroboros"
+    env_config_cls = OuroborosEnvConfig
+
+    @classmethod
+    def config_init(cls) -> Tuple[OuroborosEnvConfig, List[APIServerConfig]]:
+        """Default configuration for the ouroboros environment."""
+        env_config = OuroborosEnvConfig(
+            # Enable web + file + terminal for research
+            enabled_toolsets=["web", "file", "terminal", "council"],
+            disabled_toolsets=None,
+            distribution=None,
+            # Agent settings
+            max_agent_turns=20,
+            max_token_length=16000,
+            agent_temperature=1.0,
+            system_prompt=(
+                "You are a research agent. Your task is to thoroughly research "
+                "the given question using web search and other available tools. "
+                "Provide a comprehensive, evidence-backed analysis with specific "
+                "data points, sources, and counter-arguments. "
+                "Be thorough but concise. Cite your sources."
+            ),
+            # Terminal backend
+            terminal_backend="local",
+            terminal_timeout=120,
+            # Council evaluation
+            council_model="nousresearch/hermes-3-llama-3.1-70b",
+            min_confidence_threshold=0.3,
+            # Atropos settings
+            group_size=2,
+            tokenizer_name="NousResearch/Hermes-3-Llama-3.1-8B",
+            steps_per_eval=10,
+            total_steps=50,
+            use_wandb=True,
+            wandb_name="ouroboros",
+            ensure_scores_are_not_same=False,
+            dataset_name=None,
+        )
+
+        # Default to OpenRouter
+        server_configs = [
+            APIServerConfig(
+                base_url=os.getenv(
+                    "OPENAI_BASE_URL", "https://openrouter.ai/api/v1"
+                ),
+                model_name=os.getenv(
+                    "OPENAI_MODEL", "nousresearch/hermes-3-llama-3.1-70b"
+                ),
+                server_type="openai",
+                api_key=os.getenv("OPENROUTER_API_KEY", os.getenv("OPENAI_API_KEY", "")),
+                health_check=False,
+            )
+        ]
+
+        return env_config, server_configs
+
+    async def setup(self):
+        """Initialize research questions and council evaluator."""
+        self.questions = list(RESEARCH_QUESTIONS)
+        self.eval_questions = list(EVAL_QUESTIONS)
+        self.iter = 0
+        self.evaluator = CouncilEvaluator(model=self.config.council_model)
+        self.dpo_buffer: List[Dict] = []
+        self.reward_buffer: List[float] = []
+
+        # Create DPO output directory
+        dpo_dir = Path(self.config.dpo_output_dir)
+        dpo_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.info(
+            "Ouroboros env initialized: %d train questions, %d eval questions",
+            len(self.questions),
+            len(self.eval_questions),
+        )
+
+    async def get_next_item(self) -> Dict[str, str]:
+        """Cycle through research questions."""
+        item = self.questions[self.iter % len(self.questions)]
+        self.iter += 1
+        return item
+
+    def format_prompt(self, item: Dict[str, str]) -> str:
+        """Format the research question as a prompt."""
+        return (
+            f"Research this question thoroughly using web search and analysis:\n\n"
+            f"{item['question']}\n\n"
+            f"Provide a comprehensive, evidence-backed analysis. Include specific "
+            f"data points, historical examples, and counter-arguments. Cite sources."
+        )
+
+    async def compute_reward(
+        self, item: Dict[str, str], result: AgentResult, ctx: ToolContext
+    ) -> float:
+        """Score the rollout using the council evaluator.
+
+        Multi-signal reward:
+          - 60% council confidence score
+          - 20% tool usage (did the agent actually use tools?)
+          - 20% source citation (did the response include evidence?)
+        """
+        # Extract agent's final response from messages
+        agent_output = self._extract_final_response(result.messages)
+
+        if not agent_output or len(agent_output) < 50:
+            self.reward_buffer.append(0.0)
+            return 0.0
+
+        try:
+            # Council evaluates the research
+            verdict = await self.evaluator.evaluate(
+                content=agent_output,
+                question=item["question"],
+                criteria=["accuracy", "depth", "evidence", "falsifiability"],
+            )
+
+            # Store DPO pairs
+            dpo_pairs = self.evaluator.extract_dpo_pairs(verdict)
+            self.dpo_buffer.extend(dpo_pairs)
+
+            # Multi-signal reward
+            council_score = verdict.confidence_score / 100.0
+            tool_usage = min(1.0, result.turns_used / 5)  # reward using tools
+            has_sources = 1.0 if verdict.sources else 0.0
+
+            reward = 0.6 * council_score + 0.2 * tool_usage + 0.2 * has_sources
+            reward = max(0.0, min(1.0, reward))
+
+        except Exception as e:
+            logger.error("Council evaluation failed: %s", e)
+            # Fallback: simple length-based reward
+            reward = min(1.0, len(agent_output) / 2000) * 0.3
+
+        self.reward_buffer.append(reward)
+        return reward
+
+    async def evaluate(self, *args, **kwargs):
+        """Run evaluation on held-out questions and log metrics."""
+        start_time = time.time()
+        samples = []
+
+        for eval_item in self.eval_questions[:3]:
+            try:
+                completion = await self.server.chat_completion(
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": self.config.system_prompt or "",
+                        },
+                        {"role": "user", "content": self.format_prompt(eval_item)},
+                    ],
+                    n=1,
+                    max_tokens=self.config.max_token_length,
+                    temperature=0.0,
+                    split="eval",
+                )
+
+                response = (
+                    completion.choices[0].message.content
+                    if completion.choices
+                    else ""
+                )
+                samples.append({
+                    "prompt": eval_item["question"],
+                    "response": response[:500],
+                    "category": eval_item.get("category", ""),
+                })
+            except Exception as e:
+                logger.error("Eval failed: %s", e)
+                samples.append({
+                    "prompt": eval_item["question"],
+                    "response": f"ERROR: {e}",
+                    "category": eval_item.get("category", ""),
+                })
+
+        end_time = time.time()
+
+        eval_metrics = {
+            "eval/num_samples": len(samples),
+            "eval/dpo_pairs_total": len(self.dpo_buffer),
+        }
+
+        await self.evaluate_log(
+            metrics=eval_metrics,
+            samples=samples,
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+        # Save accumulated DPO pairs
+        self._save_dpo_pairs()
+
+    async def wandb_log(self, wandb_metrics: Optional[Dict] = None):
+        """Log training metrics including council scores."""
+        if wandb_metrics is None:
+            wandb_metrics = {}
+
+        if self.reward_buffer:
+            total = len(self.reward_buffer)
+            wandb_metrics["train/avg_reward"] = sum(self.reward_buffer) / total
+            wandb_metrics["train/total_rollouts"] = total
+            wandb_metrics["train/dpo_pairs_buffered"] = len(self.dpo_buffer)
+            self.reward_buffer = []
+
+        await super().wandb_log(wandb_metrics)
+
+    # =========================================================================
+    # Helpers
+    # =========================================================================
+
+    @staticmethod
+    def _extract_final_response(messages: List[Dict[str, Any]]) -> str:
+        """Extract the agent's final text response from conversation messages."""
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant" and msg.get("content"):
+                content = msg["content"]
+                if len(content) > 50:  # skip short tool-call-only turns
+                    return content
+        # Fallback: concatenate all assistant messages
+        parts = []
+        for msg in messages:
+            if msg.get("role") == "assistant" and msg.get("content"):
+                parts.append(msg["content"])
+        return "\n".join(parts)
+
+    def _save_dpo_pairs(self):
+        """Save accumulated DPO pairs to disk."""
+        if not self.dpo_buffer:
+            return
+
+        output_path = Path(self.config.dpo_output_dir) / "dpo_pairs.jsonl"
+        try:
+            with open(output_path, "a", encoding="utf-8") as f:
+                for pair in self.dpo_buffer:
+                    f.write(json.dumps(pair, ensure_ascii=False) + "\n")
+            logger.info(
+                "Saved %d DPO pairs to %s", len(self.dpo_buffer), output_path
+            )
+            self.dpo_buffer = []
+        except Exception as e:
+            logger.error("Failed to save DPO pairs: %s", e)
+
+
+if __name__ == "__main__":
+    OuroborosEnv.cli()

--- a/model_tools.py
+++ b/model_tools.py
@@ -95,6 +95,7 @@ def _discover_tools():
         "tools.send_message_tool",
         "tools.honcho_tools",
         "tools.homeassistant_tool",
+        "tools.council_tool",
     ]
     import importlib
     for mod_name in _modules:

--- a/skills/council/DESCRIPTION.md
+++ b/skills/council/DESCRIPTION.md
@@ -1,0 +1,3 @@
+Council skills for multi-perspective analysis. The council uses adversarial deliberation
+with distinct intellectual traditions to evaluate questions, critique research, and
+provide evidence-backed verdicts.

--- a/skills/council/adversarial-critique/SKILL.md
+++ b/skills/council/adversarial-critique/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: adversarial-critique
+description: Use the council to stress-test your work before publishing or deploying. Identifies blind spots through adversarial evaluation and safety gating.
+version: 1.0.0
+author: Hermes Ouroboros
+license: MIT
+metadata:
+  hermes:
+    tags: [Council, Critique, Safety, Quality, Review]
+    related_skills: [multi-perspective-analysis, bayesian-synthesis]
+---
+
+# Adversarial Critique
+
+Use `council_evaluate` and `council_gate` to stress-test your work before it goes live. The council's adversarial structure surfaces blind spots that self-review misses.
+
+## When to Use
+
+- **Before publishing**: Evaluate research, articles, or analysis
+- **Before deploying**: Gate code deployments with safety review
+- **Before sending**: Review messages or communications for tone and accuracy
+- **During development**: Get structured feedback on design decisions
+- **After completion**: Retrospective quality check on finished work
+
+## Tools
+
+### council_evaluate -- Quality Assessment
+```
+council_evaluate(
+    content="[your work product]",
+    question="[what task it was supposed to accomplish]",
+    criteria=["accuracy", "depth", "falsifiability", "evidence"]
+)
+```
+
+Returns per-persona feedback and an overall confidence score.
+
+### council_gate -- Safety Check
+```
+council_gate(
+    action="Deploy v2.0 to production with new authentication system",
+    risk_level="high",
+    context="New auth uses JWT tokens instead of session cookies. All tests pass."
+)
+```
+
+Returns `allowed` (bool) + reasoning. Uses abbreviated council (Skeptic + Oracle + Arbiter) for speed.
+
+**Risk level thresholds**:
+- `low`: Allowed if confidence >= 30%
+- `medium`: Allowed if confidence >= 50%
+- `high`: Allowed if confidence >= 70%
+
+## Workflow: Evaluate Then Improve
+
+1. **Do your work**: Research, write, code, analyze
+2. **Evaluate with council**: `council_evaluate(content=your_output)`
+3. **Read the Skeptic's critique**: What did you miss? What assumptions did you make?
+4. **Read the Contrarian's reframe**: Is there a better way to think about this?
+5. **Revise**: Address the council's concerns
+6. **Re-evaluate**: Run council_evaluate again on the revised version
+7. **Track improvement**: Compare confidence scores between versions
+
+## Skill Evolution Pattern
+
+The council can help improve your other skills:
+
+1. Complete a task using a skill (e.g., coding, research)
+2. Run `council_evaluate` on the output
+3. Read the Skeptic's critique carefully
+4. If the critique reveals a systematic gap, update the skill:
+   ```
+   skill_manage(
+       action="patch",
+       name="coding-best-practices",
+       content="## Error Handling\nAlways handle timeout errors in API calls..."
+   )
+   ```
+5. Future uses of that skill now include the lesson learned
+
+This creates a self-improving loop: council critique -> skill update -> better output -> higher council scores.
+
+## Example: Research Critique
+
+```
+# Step 1: Research a topic
+research_output = web_search("quantum computing threat to RSA encryption timeline")
+
+# Step 2: Write analysis
+analysis = "Based on current progress..."
+
+# Step 3: Council critique
+council_evaluate(
+    content=analysis,
+    question="Is quantum computing a near-term threat to RSA?",
+    criteria=["accuracy", "evidence", "nuance", "completeness"]
+)
+
+# Step 4: Read feedback, revise, repeat
+```
+
+## Example: Deployment Gate
+
+```
+# Before deploying
+council_gate(
+    action="Push database migration that adds NOT NULL constraint to users.email",
+    risk_level="high",
+    context="Production has 50k rows. 12 rows have NULL email. Migration includes backfill."
+)
+
+# If allowed=false, review skeptic_concerns before proceeding
+```
+
+## Safety Philosophy
+
+> Before irreversible actions (deploying code, sending external messages, deleting data),
+> consider using council_gate to get a safety review.
+
+The cost of a 30-second council review is far less than the cost of an irreversible mistake.
+The gate is not a replacement for testing -- it's an additional perspective check.

--- a/skills/council/bayesian-synthesis/SKILL.md
+++ b/skills/council/bayesian-synthesis/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: bayesian-synthesis
+description: Use Bayesian reasoning to synthesize evidence and update beliefs. Leverages the Arbiter persona's methodology for calibrated decision-making.
+version: 1.0.0
+author: Hermes Ouroboros
+license: MIT
+metadata:
+  hermes:
+    tags: [Council, Bayesian, Decision-Making, Synthesis, Reasoning]
+    related_skills: [multi-perspective-analysis, adversarial-critique]
+---
+
+# Bayesian Synthesis
+
+The Arbiter persona uses explicit Bayesian reasoning to synthesize multiple perspectives into a calibrated verdict. Use this approach when you need to make decisions under uncertainty.
+
+## The Bayesian Method
+
+1. **State your prior**: What do you believe before seeing any arguments? (0-100%)
+2. **Update on evidence**: For each new piece of evidence, adjust your belief
+3. **State your posterior**: Final belief after all updates, with confidence interval
+4. **Identify remaining uncertainty**: What would change your mind?
+
+## When to Use
+
+- **Decision-making under uncertainty**: Multiple valid options, unclear trade-offs
+- **Forecasting**: Predicting outcomes with limited information
+- **Evidence synthesis**: Combining multiple studies or data sources
+- **Belief calibration**: Checking if your confidence matches available evidence
+
+## How to Use
+
+### Full Council (recommended for important decisions)
+```
+council_query(
+    question="What is the probability that Ethereum's market cap surpasses Bitcoin's by 2028?",
+    context="Consider technical fundamentals, adoption metrics, regulatory landscape, and historical precedent."
+)
+```
+
+The Arbiter's synthesis will include:
+- **PRIOR**: Starting belief before arguments
+- **EVIDENCE UPDATES**: How each persona's argument shifts the belief
+- **POSTERIOR**: Final calibrated estimate
+- **KEY DISAGREEMENTS**: Unresolved tensions
+- **FINAL VERDICT**: Actionable recommendation
+
+### Quick Evaluation
+```
+council_evaluate(
+    content="[your analysis here]",
+    question="Is this analysis well-calibrated?",
+    criteria=["calibration", "evidence_quality", "uncertainty_handling"]
+)
+```
+
+## Interpreting Bayesian Updates
+
+The Arbiter reports updates like:
+```
+PRIOR: 40%
+Advocate's impact: +15% (strong technical argument, but speculative)
+Skeptic's impact: -10% (valid concern about regulatory risk)
+Oracle's impact: +5% (base rate of paradigm shifts is low but non-zero)
+Contrarian's impact: -5% (alternative framing worth considering)
+POSTERIOR: 45% (40 + 15 - 10 + 5 - 5)
+```
+
+**Key insight**: The magnitude of each update reflects evidence quality:
+- Large updates (>10%): Strong empirical evidence or fatal logical flaw
+- Medium updates (5-10%): Credible argument with partial evidence
+- Small updates (<5%): Theoretical concern or weak analogy
+
+## Evidence Hierarchy
+
+The Arbiter weights evidence by quality:
+1. **Empirical data** (strongest): Controlled studies, historical statistics
+2. **Logical argument**: Valid deductive reasoning from established premises
+3. **Expert consensus**: Agreement among domain experts
+4. **Historical analogies**: Similar past situations and their outcomes
+5. **Intuition** (weakest): Gut feeling or aesthetic preference
+
+## Common Pitfalls
+
+- **Anchoring**: Don't let your prior dominate. If evidence is strong, update significantly.
+- **Base rate neglect**: Oracle's data matters. Most ventures fail, most predictions are overconfident.
+- **Conjunction fallacy**: A specific story isn't more likely just because it's detailed.
+- **Confirmation bias**: Pay special attention to the Skeptic's counter-evidence.

--- a/skills/council/multi-perspective-analysis/SKILL.md
+++ b/skills/council/multi-perspective-analysis/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: multi-perspective-analysis
+description: Run adversarial multi-perspective analysis on complex questions using the council tool. Five personas debate from distinct intellectual traditions.
+version: 1.0.0
+author: Hermes Ouroboros
+license: MIT
+metadata:
+  hermes:
+    tags: [Council, Analysis, Reasoning, Critical-Thinking, Evaluation]
+    related_skills: [bayesian-synthesis, adversarial-critique]
+---
+
+# Multi-Perspective Analysis
+
+Use the `council_query` tool to submit complex questions for adversarial deliberation by five personas, each representing a distinct intellectual tradition.
+
+## When to Use
+
+- **Complex questions** with no clear right answer
+- **High-stakes decisions** where multiple viewpoints matter
+- **Research evaluation** to stress-test findings
+- **Strategic planning** to surface blind spots
+- **Contentious topics** where bias is likely
+
+## The Five Personas
+
+| Persona | Tradition | Role |
+|---------|-----------|------|
+| **Advocate** | Steel-manning | Builds the strongest case FOR the position |
+| **Skeptic** | Popperian falsificationism | Finds the observation that kills the claim |
+| **Oracle** | Empirical base-rate reasoning | Grounds debate in historical data and statistics |
+| **Contrarian** | Kuhnian paradigm critique | Rejects the framing, proposes alternative paradigms |
+| **Arbiter** | Bayesian synthesis | Synthesizes all views with explicit prior/posterior updates |
+
+## How to Use
+
+### Basic Query
+```
+council_query(question="Should we migrate our monolith to microservices?")
+```
+
+### With Context
+```
+council_query(
+    question="Is proof-of-stake more secure than proof-of-work?",
+    context="We're evaluating consensus mechanisms for a new L1 blockchain targeting institutional users."
+)
+```
+
+### Subset of Personas
+```
+council_query(
+    question="Will quantum computing break RSA by 2030?",
+    personas=["skeptic", "oracle", "arbiter"]
+)
+```
+
+## Interpreting Results
+
+The council returns a structured verdict:
+
+- **confidence_score** (0-100): Arbiter's posterior confidence after weighing all arguments
+- **conflict_detected**: True if personas strongly disagree (confidence spread > 30%)
+- **persona_responses**: Each persona's analysis with their individual confidence
+- **arbiter_synthesis**: The Arbiter's Bayesian synthesis with prior/posterior reasoning
+- **dpo_pairs**: Preference pairs for training (aligned vs overruled responses)
+- **sources**: Evidence URLs cited by personas
+
+### Confidence Guidelines
+- **80-100**: Strong consensus, high-quality evidence
+- **60-79**: Moderate confidence, some unresolved tensions
+- **40-59**: Mixed signals, significant uncertainty
+- **0-39**: Low confidence, major disagreements or insufficient evidence
+
+## Workflow: Research Then Evaluate
+
+For best results, combine web research with council evaluation:
+
+1. Use `web_search` to gather initial data
+2. Use `web_extract` to read key sources
+3. Synthesize findings into a draft analysis
+4. Use `council_evaluate` to stress-test your analysis
+5. Revise based on council feedback
+
+## Custom Personas
+
+Add custom personas in `~/.hermes/config.yaml`:
+
+```yaml
+council:
+  personas:
+    security_analyst:
+      tradition: "Adversarial security thinking"
+      system_prompt: "You are a security analyst. Find every attack vector..."
+      tags: ["security", "adversarial"]
+```
+
+Custom personas are merged with defaults. Use the same name to override a default.

--- a/tests/environments/test_ouroboros.py
+++ b/tests/environments/test_ouroboros.py
@@ -1,0 +1,348 @@
+"""Tests for the ouroboros RL environment and council evaluator.
+
+Tests environment setup, prompt formatting, reward computation,
+DPO pair accumulation, and council evaluator functionality.
+
+Note: atroposlib is an RL-only dependency not always installed locally.
+Tests that require it are skipped if unavailable. Tests for council_evaluator
+import it directly (no environments/__init__.py trigger).
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Ensure repo root on path
+_repo_root = Path(__file__).resolve().parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+# Check if atroposlib is available (RL dependency)
+try:
+    import atroposlib
+    HAS_ATROPOS = True
+except ImportError:
+    HAS_ATROPOS = False
+
+
+def _import_council_evaluator():
+    """Import council_evaluator directly, bypassing environments/__init__.py."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "council_evaluator",
+        str(_repo_root / "environments" / "council_evaluator.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# =========================================================================
+# Council Evaluator tests (no atroposlib needed)
+# =========================================================================
+
+
+class TestCouncilEvaluator:
+    """Tests for environments/council_evaluator.py."""
+
+    @pytest.fixture(autouse=True)
+    def mock_env(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key-123")
+
+    def test_init_default(self):
+        mod = _import_council_evaluator()
+        evaluator = mod.CouncilEvaluator()
+        assert evaluator.model == "nousresearch/hermes-3-llama-3.1-70b"
+        assert evaluator._api_key == "test-key-123"
+        assert "openrouter" in evaluator._base_url
+
+    def test_init_custom(self):
+        mod = _import_council_evaluator()
+        evaluator = mod.CouncilEvaluator(
+            model="custom/model",
+            api_key="custom-key",
+            base_url="https://custom.api/v1",
+        )
+        assert evaluator.model == "custom/model"
+        assert evaluator._api_key == "custom-key"
+
+    def test_init_with_persona_subset(self):
+        mod = _import_council_evaluator()
+        evaluator = mod.CouncilEvaluator(personas=["skeptic", "arbiter"])
+        assert "skeptic" in evaluator._personas
+        assert "arbiter" in evaluator._personas
+        assert len(evaluator._personas) == 2
+
+    def test_normalized_reward(self):
+        mod = _import_council_evaluator()
+        from tools.council_personas import CouncilVerdict
+
+        evaluator = mod.CouncilEvaluator()
+
+        verdict_high = CouncilVerdict(
+            question="q", responses={}, arbiter_synthesis="s",
+            confidence_score=85, conflict_detected=False,
+        )
+        assert abs(evaluator.normalized_reward(verdict_high) - 0.85) < 0.01
+
+        verdict_low = CouncilVerdict(
+            question="q", responses={}, arbiter_synthesis="s",
+            confidence_score=20, conflict_detected=True,
+        )
+        assert abs(evaluator.normalized_reward(verdict_low) - 0.20) < 0.01
+
+    def test_normalized_reward_clamped(self):
+        mod = _import_council_evaluator()
+        from tools.council_personas import CouncilVerdict
+
+        evaluator = mod.CouncilEvaluator()
+
+        verdict = CouncilVerdict(
+            question="q", responses={}, arbiter_synthesis="s",
+            confidence_score=150, conflict_detected=False,
+        )
+        assert evaluator.normalized_reward(verdict) == 1.0
+
+        verdict_neg = CouncilVerdict(
+            question="q", responses={}, arbiter_synthesis="s",
+            confidence_score=-10, conflict_detected=False,
+        )
+        assert evaluator.normalized_reward(verdict_neg) == 0.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_mocked(self):
+        mod = _import_council_evaluator()
+        evaluator = mod.CouncilEvaluator()
+
+        mock_response = (
+            "Evaluation of content.\n"
+            "- Good depth of analysis provided\n"
+            "- Needs more supporting evidence\n"
+            "CONFIDENCE: 0.72\n"
+            "DISSENT: false\n"
+        )
+
+        with patch.object(evaluator, "_llm_call", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = mock_response
+            verdict = await evaluator.evaluate(
+                content="Some agent output to evaluate thoroughly",
+                question="Was the research thorough?",
+            )
+
+        assert verdict.confidence_score > 0
+        assert verdict.question is not None
+        assert len(verdict.responses) > 0
+
+    @pytest.mark.asyncio
+    async def test_gate_mocked(self):
+        mod = _import_council_evaluator()
+        evaluator = mod.CouncilEvaluator()
+
+        mock_response = (
+            "Safety check passed.\n"
+            "CONFIDENCE: 0.8\n"
+            "DISSENT: false\n"
+        )
+
+        with patch.object(evaluator, "_llm_call", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = mock_response
+            gate_result = await evaluator.gate(
+                action="Deploy to staging",
+                context="All tests pass",
+            )
+
+        assert "allowed" in gate_result
+        assert "confidence" in gate_result
+        assert "reasoning" in gate_result
+
+    def test_parse_response(self):
+        mod = _import_council_evaluator()
+
+        raw = (
+            "Analysis here.\n"
+            "- Key point one about the topic\n"
+            "CONFIDENCE: 0.65\n"
+            "DISSENT: true\n"
+            "See https://example.com for more.\n"
+        )
+        resp = mod.CouncilEvaluator._parse_response("skeptic", raw)
+        assert resp.persona_name == "skeptic"
+        assert abs(resp.confidence - 0.65) < 0.01
+        assert resp.dissents is True
+        assert len(resp.sources) >= 1
+
+    def test_extract_dpo_pairs_from_responses(self):
+        mod = _import_council_evaluator()
+        from tools.council_personas import PersonaResponse
+
+        responses = {
+            "advocate": PersonaResponse(
+                persona_name="advocate", content="Strong for",
+                confidence=0.9, dissents=False,
+            ),
+            "skeptic": PersonaResponse(
+                persona_name="skeptic", content="Weak against",
+                confidence=0.3, dissents=True,
+            ),
+            "arbiter": PersonaResponse(
+                persona_name="arbiter", content="Synthesis",
+                confidence=0.7, dissents=False,
+            ),
+        }
+        pairs = mod.CouncilEvaluator.extract_dpo_pairs_from_responses("q", responses)
+        assert len(pairs) >= 1
+        assert pairs[0]["source"] == "council_evaluation"
+
+
+# =========================================================================
+# Ouroboros Environment tests (require atroposlib)
+# =========================================================================
+
+
+@pytest.mark.skipif(not HAS_ATROPOS, reason="atroposlib not installed")
+class TestOuroborosEnvFull:
+    """Tests requiring full atroposlib installation."""
+
+    def test_env_imports(self):
+        from environments.ouroboros_env import OuroborosEnv
+        assert OuroborosEnv.name == "ouroboros"
+
+
+class TestOuroborosEnvData:
+    """Tests for ouroboros env data that don't require atroposlib.
+
+    Import the data directly from the module file.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _load_module(self):
+        """Load ouroboros_env module data without triggering atroposlib imports."""
+        import importlib.util
+
+        # Read the file and extract just the data constants
+        env_file = _repo_root / "environments" / "ouroboros_env.py"
+        source = env_file.read_text(encoding="utf-8")
+
+        # Extract RESEARCH_QUESTIONS and EVAL_QUESTIONS via exec
+        # (they're defined before any atroposlib imports)
+        namespace = {}
+        # Execute up to the first non-data import
+        lines = source.split("\n")
+        data_lines = []
+        in_data = False
+        for line in lines:
+            if line.startswith("RESEARCH_QUESTIONS"):
+                in_data = True
+            if in_data:
+                data_lines.append(line)
+            if in_data and line.startswith("]") and not line.strip().startswith('"'):
+                # Check if this closes EVAL_QUESTIONS
+                if "EVAL_QUESTIONS" in "\n".join(data_lines):
+                    data_lines.append(line)
+                    break
+
+        # Simpler approach: just regex extract
+        import re
+        rq_match = re.search(
+            r"RESEARCH_QUESTIONS\s*=\s*\[(.*?)\]\s*\n\s*EVAL_QUESTIONS",
+            source,
+            re.DOTALL,
+        )
+        eq_match = re.search(
+            r"EVAL_QUESTIONS\s*=\s*\[(.*?)\]",
+            source,
+            re.DOTALL,
+        )
+
+        self.research_questions = []
+        self.eval_questions = []
+
+        if rq_match:
+            try:
+                self.research_questions = eval(f"[{rq_match.group(1)}]")
+            except Exception:
+                pass
+        if eq_match:
+            try:
+                self.eval_questions = eval(f"[{eq_match.group(1)}]")
+            except Exception:
+                pass
+
+    def test_research_questions_loaded(self):
+        assert len(self.research_questions) >= 20
+
+    def test_question_structure(self):
+        for q in self.research_questions:
+            assert "question" in q
+            assert "category" in q
+            assert len(q["question"]) > 20
+
+    def test_question_categories(self):
+        categories = set(q["category"] for q in self.research_questions)
+        assert "technology" in categories
+        assert "economics" in categories
+        assert "science" in categories
+
+    def test_eval_questions_loaded(self):
+        assert len(self.eval_questions) >= 3
+
+    def test_eval_question_structure(self):
+        for q in self.eval_questions:
+            assert "question" in q
+            assert "category" in q
+
+
+class TestOuroborosHelpers:
+    """Test static helper methods from OuroborosEnv without importing the class."""
+
+    def test_extract_final_response(self):
+        """Test _extract_final_response logic."""
+        # Replicate the static method logic here
+        def _extract_final_response(messages):
+            for msg in reversed(messages):
+                if msg.get("role") == "assistant" and msg.get("content"):
+                    content = msg["content"]
+                    if len(content) > 50:
+                        return content
+            parts = []
+            for msg in messages:
+                if msg.get("role") == "assistant" and msg.get("content"):
+                    parts.append(msg["content"])
+            return "\n".join(parts)
+
+        messages = [
+            {"role": "system", "content": "You are a researcher"},
+            {"role": "user", "content": "Research this question"},
+            {"role": "assistant", "content": None, "tool_calls": [{"function": {"name": "web_search"}}]},
+            {"role": "tool", "content": "Search results..."},
+            {"role": "assistant", "content": "Based on my research, here is a comprehensive analysis of the topic that covers multiple perspectives and provides evidence-backed conclusions."},
+        ]
+
+        result = _extract_final_response(messages)
+        assert "comprehensive analysis" in result
+
+    def test_extract_final_response_empty(self):
+        def _extract_final_response(messages):
+            for msg in reversed(messages):
+                if msg.get("role") == "assistant" and msg.get("content"):
+                    content = msg["content"]
+                    if len(content) > 50:
+                        return content
+            parts = []
+            for msg in messages:
+                if msg.get("role") == "assistant" and msg.get("content"):
+                    parts.append(msg["content"])
+            return "\n".join(parts)
+
+        messages = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Question"},
+        ]
+        result = _extract_final_response(messages)
+        assert result == ""

--- a/tests/tools/test_council.py
+++ b/tests/tools/test_council.py
@@ -1,0 +1,501 @@
+"""Tests for the council tool subsystem.
+
+Tests persona loading, council query/evaluate/gate handlers,
+DPO extraction, tool registration, and toolset membership.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Ensure repo root on path
+_repo_root = Path(__file__).resolve().parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+
+# =========================================================================
+# Persona tests
+# =========================================================================
+
+
+class TestCouncilPersonas:
+    """Tests for tools/council_personas.py."""
+
+    def test_default_personas_loaded(self):
+        from tools.council_personas import DEFAULT_PERSONAS
+
+        assert len(DEFAULT_PERSONAS) == 5
+        assert set(DEFAULT_PERSONAS.keys()) == {
+            "advocate", "skeptic", "oracle", "contrarian", "arbiter"
+        }
+
+    def test_persona_fields(self):
+        from tools.council_personas import DEFAULT_PERSONAS
+
+        for name, persona in DEFAULT_PERSONAS.items():
+            assert persona.name == name
+            assert len(persona.tradition) > 0
+            assert len(persona.system_prompt) > 50
+            assert isinstance(persona.scoring_weights, dict)
+            assert len(persona.scoring_weights) > 0
+            assert isinstance(persona.tags, list)
+            assert len(persona.tags) > 0
+
+    def test_get_persona(self):
+        from tools.council_personas import get_persona
+
+        advocate = get_persona("advocate")
+        assert advocate is not None
+        assert advocate.name == "advocate"
+
+        # Case insensitive
+        skeptic = get_persona("Skeptic")
+        assert skeptic is not None
+        assert skeptic.name == "skeptic"
+
+        # Non-existent
+        assert get_persona("nonexistent") is None
+
+    def test_list_personas(self):
+        from tools.council_personas import list_personas
+
+        names = list_personas()
+        assert len(names) == 5
+        assert "advocate" in names
+        assert "arbiter" in names
+
+    def test_scoring_weights_sum(self):
+        from tools.council_personas import DEFAULT_PERSONAS
+
+        for name, persona in DEFAULT_PERSONAS.items():
+            total = sum(persona.scoring_weights.values())
+            assert abs(total - 1.0) < 0.01, (
+                f"{name} scoring weights sum to {total}, expected ~1.0"
+            )
+
+    def test_load_custom_personas_no_file(self):
+        from tools.council_personas import load_custom_personas
+
+        merged = load_custom_personas("/nonexistent/path.yaml")
+        assert len(merged) == 5  # defaults only
+
+    def test_load_custom_personas_with_yaml(self, tmp_path):
+        from tools.council_personas import load_custom_personas
+
+        config = tmp_path / "config.yaml"
+        config.write_text(
+            "council:\n"
+            "  personas:\n"
+            "    red_team:\n"
+            "      tradition: 'Adversarial security'\n"
+            "      system_prompt: 'You are a red team analyst'\n"
+            "      tags: ['security']\n"
+        )
+        merged = load_custom_personas(str(config))
+        assert "red_team" in merged
+        assert merged["red_team"].tradition == "Adversarial security"
+        assert len(merged) == 6  # 5 defaults + 1 custom
+
+
+# =========================================================================
+# PersonaResponse / CouncilVerdict dataclass tests
+# =========================================================================
+
+
+class TestCouncilDataclasses:
+    """Tests for dataclass construction."""
+
+    def test_persona_response(self):
+        from tools.council_personas import PersonaResponse
+
+        resp = PersonaResponse(
+            persona_name="skeptic",
+            content="This is flawed because...",
+            confidence=0.8,
+            dissents=True,
+            key_points=["point 1", "point 2"],
+            sources=["https://example.com"],
+        )
+        assert resp.persona_name == "skeptic"
+        assert resp.dissents is True
+        assert len(resp.key_points) == 2
+
+    def test_council_verdict(self):
+        from tools.council_personas import CouncilVerdict, PersonaResponse
+
+        verdict = CouncilVerdict(
+            question="test question",
+            responses={"arbiter": PersonaResponse(
+                persona_name="arbiter", content="synthesis",
+                confidence=0.75, dissents=False,
+            )},
+            arbiter_synthesis="synthesis",
+            confidence_score=75,
+            conflict_detected=False,
+        )
+        assert verdict.confidence_score == 75
+        assert verdict.conflict_detected is False
+        assert len(verdict.dpo_pairs) == 0
+        assert len(verdict.sources) == 0
+
+
+# =========================================================================
+# Response parsing tests
+# =========================================================================
+
+
+class TestResponseParsing:
+    """Tests for response text parsing in council_tool.py."""
+
+    def test_parse_confidence_decimal(self):
+        from tools.council_tool import _parse_confidence
+
+        assert abs(_parse_confidence("CONFIDENCE: 0.85") - 0.85) < 0.01
+
+    def test_parse_confidence_percentage(self):
+        from tools.council_tool import _parse_confidence
+
+        assert abs(_parse_confidence("My confidence is 75%") - 0.75) < 0.01
+
+    def test_parse_confidence_missing(self):
+        from tools.council_tool import _parse_confidence
+
+        assert abs(_parse_confidence("No confidence here") - 0.5) < 0.01
+
+    def test_parse_dissent_true(self):
+        from tools.council_tool import _parse_dissent
+
+        assert _parse_dissent("DISSENT: true") is True
+        assert _parse_dissent("DISSENT: True") is True
+
+    def test_parse_dissent_false(self):
+        from tools.council_tool import _parse_dissent
+
+        assert _parse_dissent("DISSENT: false") is False
+        assert _parse_dissent("no dissent info") is False
+
+    def test_parse_key_points(self):
+        from tools.council_tool import _parse_key_points
+
+        text = (
+            "Some text\n"
+            "- First important point about the topic\n"
+            "- Second point with more detail here\n"
+            "* Third asterisk point is also valid\n"
+            "- Short\n"  # too short, should be skipped
+        )
+        points = _parse_key_points(text)
+        assert len(points) == 3
+
+    def test_extract_sources(self):
+        from tools.council_tool import _extract_sources
+
+        text = "See https://example.com and https://data.gov/stats for more."
+        sources = _extract_sources(text)
+        assert len(sources) == 2
+        assert "https://example.com" in sources
+
+    def test_build_persona_response(self):
+        from tools.council_tool import _build_persona_response
+
+        raw = (
+            "Analysis here.\n"
+            "- Key point one about the topic discussed\n"
+            "- Another point with supporting detail\n"
+            "CONFIDENCE: 0.7\n"
+            "DISSENT: true\n"
+            "Source: https://example.com/evidence\n"
+        )
+        resp = _build_persona_response("skeptic", raw)
+        assert resp.persona_name == "skeptic"
+        assert abs(resp.confidence - 0.7) < 0.01
+        assert resp.dissents is True
+        assert len(resp.key_points) >= 2
+        assert len(resp.sources) >= 1
+
+
+# =========================================================================
+# DPO extraction tests
+# =========================================================================
+
+
+class TestDPOExtraction:
+    """Tests for DPO pair extraction."""
+
+    def test_dpo_with_dissenter(self):
+        from tools.council_personas import PersonaResponse
+        from tools.council_tool import _extract_dpo_pairs
+
+        responses = {
+            "advocate": PersonaResponse(
+                persona_name="advocate", content="Strong case for",
+                confidence=0.9, dissents=False,
+            ),
+            "skeptic": PersonaResponse(
+                persona_name="skeptic", content="Fatal flaw found",
+                confidence=0.8, dissents=True,
+            ),
+            "arbiter": PersonaResponse(
+                persona_name="arbiter", content="Synthesis here",
+                confidence=0.75, dissents=False,
+            ),
+        }
+        pairs = _extract_dpo_pairs("test q", responses)
+        assert len(pairs) >= 1
+        assert pairs[0]["chosen_persona"] == "arbiter"
+        assert pairs[0]["rejected_persona"] == "skeptic"
+
+    def test_dpo_no_dissenters(self):
+        from tools.council_personas import PersonaResponse
+        from tools.council_tool import _extract_dpo_pairs
+
+        responses = {
+            "advocate": PersonaResponse(
+                persona_name="advocate", content="All agree",
+                confidence=0.9, dissents=False,
+            ),
+            "arbiter": PersonaResponse(
+                persona_name="arbiter", content="Synthesis",
+                confidence=0.85, dissents=False,
+            ),
+        }
+        pairs = _extract_dpo_pairs("test q", responses)
+        # No dissenters = no primary pair
+        assert len(pairs) == 0
+
+    def test_dpo_empty_responses(self):
+        from tools.council_tool import _extract_dpo_pairs
+
+        pairs = _extract_dpo_pairs("test q", {})
+        assert pairs == []
+
+
+# =========================================================================
+# Tool handler tests (mocked LLM)
+# =========================================================================
+
+
+class TestCouncilHandlers:
+    """Tests for council tool handlers with mocked LLM calls."""
+
+    @pytest.fixture(autouse=True)
+    def mock_env(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key-123")
+
+    @pytest.mark.asyncio
+    async def test_council_query_missing_question(self):
+        from tools.council_tool import council_query_handler
+
+        result = json.loads(await council_query_handler({}))
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_council_query_success(self):
+        from tools.council_tool import council_query_handler
+
+        mock_response = (
+            "Analysis content here.\n"
+            "- Key point about the topic\n"
+            "- Another important observation\n"
+            "CONFIDENCE: 0.7\n"
+            "DISSENT: false\n"
+        )
+
+        with patch("tools.council_tool._llm_call", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = mock_response
+            result = json.loads(
+                await council_query_handler({"question": "Is X better than Y?"})
+            )
+
+        assert result["success"] is True
+        assert "confidence_score" in result
+        assert "arbiter_synthesis" in result
+        assert "persona_responses" in result
+        assert isinstance(result["dpo_pairs"], list)
+
+    @pytest.mark.asyncio
+    async def test_council_evaluate_missing_content(self):
+        from tools.council_tool import council_evaluate_handler
+
+        result = json.loads(await council_evaluate_handler({}))
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_council_evaluate_success(self):
+        from tools.council_tool import council_evaluate_handler
+
+        mock_response = (
+            "Evaluation content.\n"
+            "- This is well-researched\n"
+            "- Could improve depth\n"
+            "CONFIDENCE: 0.65\n"
+            "DISSENT: false\n"
+        )
+
+        with patch("tools.council_tool._llm_call", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = mock_response
+            result = json.loads(
+                await council_evaluate_handler({
+                    "content": "Some research output to evaluate",
+                    "question": "Is the analysis thorough?",
+                })
+            )
+
+        assert result["success"] is True
+        assert "confidence_score" in result
+        assert "persona_feedback" in result
+
+    @pytest.mark.asyncio
+    async def test_council_gate_missing_action(self):
+        from tools.council_tool import council_gate_handler
+
+        result = json.loads(await council_gate_handler({}))
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_council_gate_success(self):
+        from tools.council_tool import council_gate_handler
+
+        mock_response = (
+            "Safety analysis.\n"
+            "- Low risk action\n"
+            "CONFIDENCE: 0.8\n"
+            "DISSENT: false\n"
+        )
+
+        with patch("tools.council_tool._llm_call", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = mock_response
+            result = json.loads(
+                await council_gate_handler({
+                    "action": "Deploy to staging",
+                    "risk_level": "low",
+                })
+            )
+
+        assert result["success"] is True
+        assert "allowed" in result
+        assert isinstance(result["allowed"], bool)
+        assert "confidence" in result
+        assert "reasoning" in result
+
+
+# =========================================================================
+# Registration tests
+# =========================================================================
+
+
+class TestCouncilRegistration:
+    """Tests for tool registration and toolset membership."""
+
+    def test_tools_registered(self):
+        from tools.registry import registry
+
+        # Force import to trigger registration
+        import tools.council_tool  # noqa: F401
+
+        all_names = registry.get_all_tool_names()
+        assert "council_query" in all_names
+        assert "council_evaluate" in all_names
+        assert "council_gate" in all_names
+
+    def test_toolset_membership(self):
+        from tools.registry import registry
+
+        import tools.council_tool  # noqa: F401
+
+        assert registry.get_toolset_for_tool("council_query") == "council"
+        assert registry.get_toolset_for_tool("council_evaluate") == "council"
+        assert registry.get_toolset_for_tool("council_gate") == "council"
+
+    def test_check_fn_with_key(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        from tools.council_tool import check_council_requirements
+
+        assert check_council_requirements() is True
+
+    def test_check_fn_without_key(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("NOUS_API_KEY", raising=False)
+        from tools.council_tool import check_council_requirements
+
+        assert check_council_requirements() is False
+
+    def test_toolset_resolution(self):
+        from toolsets import resolve_toolset
+
+        tools = resolve_toolset("council")
+        assert "council_query" in tools
+        assert "council_evaluate" in tools
+        assert "council_gate" in tools
+
+    def test_council_query_in_core_tools(self):
+        from toolsets import _HERMES_CORE_TOOLS
+
+        assert "council_query" in _HERMES_CORE_TOOLS
+
+    def test_schema_structure(self):
+        from tools.council_tool import (
+            COUNCIL_QUERY_SCHEMA,
+            COUNCIL_EVALUATE_SCHEMA,
+            COUNCIL_GATE_SCHEMA,
+        )
+
+        for schema in [COUNCIL_QUERY_SCHEMA, COUNCIL_EVALUATE_SCHEMA, COUNCIL_GATE_SCHEMA]:
+            assert "name" in schema
+            assert "description" in schema
+            assert "parameters" in schema
+            assert schema["parameters"]["type"] == "object"
+            assert "properties" in schema["parameters"]
+            assert "required" in schema["parameters"]
+
+
+# =========================================================================
+# API config tests
+# =========================================================================
+
+
+class TestAPIConfig:
+    """Tests for API configuration resolution."""
+
+    def test_openrouter_priority(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        monkeypatch.setenv("OPENAI_API_KEY", "oa-key")
+        from tools.council_tool import _get_api_config
+
+        config = _get_api_config()
+        assert config["api_key"] == "or-key"
+        assert "openrouter" in config["base_url"]
+
+    def test_nous_fallback(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("NOUS_API_KEY", "nous-key")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        from tools.council_tool import _get_api_config
+
+        config = _get_api_config()
+        assert config["api_key"] == "nous-key"
+        assert "nousresearch" in config["base_url"]
+
+    def test_openai_fallback(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("NOUS_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "oa-key")
+        from tools.council_tool import _get_api_config
+
+        config = _get_api_config()
+        assert config["api_key"] == "oa-key"
+
+    def test_no_keys(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("NOUS_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        from tools.council_tool import _get_api_config
+
+        config = _get_api_config()
+        assert config == {}

--- a/tools/council_personas.py
+++ b/tools/council_personas.py
@@ -1,0 +1,276 @@
+"""Council Personas -- Pure data module for adversarial council deliberation.
+
+Defines the five default personas (Advocate, Skeptic, Oracle, Contrarian, Arbiter)
+and their dataclasses. No imports from other council files -- this is Layer 0.
+"""
+
+import os
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Persona:
+    """A council persona with its intellectual tradition and scoring weights."""
+
+    name: str
+    tradition: str
+    system_prompt: str
+    scoring_weights: Dict[str, float] = field(default_factory=dict)
+    tags: List[str] = field(default_factory=list)
+
+
+@dataclass
+class PersonaResponse:
+    """A single persona's response to a council query."""
+
+    persona_name: str
+    content: str
+    confidence: float  # 0.0-1.0
+    dissents: bool
+    key_points: List[str] = field(default_factory=list)
+    sources: List[str] = field(default_factory=list)
+
+
+@dataclass
+class CouncilVerdict:
+    """The full result of a council deliberation."""
+
+    question: str
+    responses: Dict[str, PersonaResponse]
+    arbiter_synthesis: str
+    confidence_score: int  # 0-100
+    conflict_detected: bool
+    dpo_pairs: List[Dict] = field(default_factory=list)
+    sources: List[str] = field(default_factory=list)
+
+
+# =============================================================================
+# Default Personas
+# =============================================================================
+
+DEFAULT_PERSONAS: Dict[str, Persona] = {
+    "advocate": Persona(
+        name="advocate",
+        tradition="Steel-manning",
+        system_prompt=(
+            "You are the Advocate on an adversarial deliberation council. "
+            "Your role is to construct the STRONGEST POSSIBLE case in favor of the claim or proposal.\n\n"
+            "Your intellectual tradition is steel-manning: you take the most charitable interpretation "
+            "of the position and build the most rigorous argument FOR it, even if you personally disagree.\n\n"
+            "Guidelines:\n"
+            "- Find the strongest evidence, precedents, and logical arguments supporting the position\n"
+            "- Anticipate objections and preemptively address them\n"
+            "- Identify the best-case scenarios and most favorable interpretations\n"
+            "- Cite specific evidence, data, or historical examples when possible\n"
+            "- Be intellectually honest -- strengthen the argument, don't fabricate\n\n"
+            "Output format:\n"
+            "1. STRONGEST ARGUMENT: Your best case in 2-3 paragraphs\n"
+            "2. KEY EVIDENCE: Bullet points of supporting data/precedents\n"
+            "3. CONFIDENCE: A number 0.0-1.0 indicating your confidence in this position\n"
+            "4. DISSENT: false (you advocate FOR the position by definition)\n"
+        ),
+        scoring_weights={
+            "evidence": 0.3,
+            "coherence": 0.3,
+            "completeness": 0.2,
+            "originality": 0.2,
+        },
+        tags=["steel-man", "pro", "constructive"],
+    ),
+    "skeptic": Persona(
+        name="skeptic",
+        tradition="Popperian falsificationism",
+        system_prompt=(
+            "You are the Skeptic on an adversarial deliberation council. "
+            "Your role is to find the observation that KILLS the claim.\n\n"
+            "Your intellectual tradition is Popperian falsificationism: a theory is only scientific "
+            "if it can be falsified. Your job is to identify the critical test, the decisive experiment, "
+            "the overlooked counter-evidence that would disprove the position.\n\n"
+            "Guidelines:\n"
+            "- Search for counter-evidence, failed precedents, and logical flaws\n"
+            "- Identify unfalsifiable claims and call them out\n"
+            "- Find the weakest assumptions the argument depends on\n"
+            "- Look for survivorship bias, selection effects, and cherry-picked data\n"
+            "- Propose specific tests that would falsify the claim\n"
+            "- Use web search to find counter-evidence when available\n\n"
+            "Output format:\n"
+            "1. FATAL FLAW: The single most damaging objection in 2-3 paragraphs\n"
+            "2. COUNTER-EVIDENCE: Bullet points of evidence against the position\n"
+            "3. FALSIFICATION TEST: What observation would definitively disprove this?\n"
+            "4. CONFIDENCE: A number 0.0-1.0 (how confident you are that the claim is WRONG)\n"
+            "5. DISSENT: true/false (true if you believe the claim is substantially wrong)\n"
+        ),
+        scoring_weights={
+            "falsifiability": 0.4,
+            "evidence": 0.3,
+            "rigor": 0.2,
+            "specificity": 0.1,
+        },
+        tags=["falsification", "contra", "critical"],
+    ),
+    "oracle": Persona(
+        name="oracle",
+        tradition="Empirical base-rate reasoning",
+        system_prompt=(
+            "You are the Oracle on an adversarial deliberation council. "
+            "Your role is to ground the debate in HISTORICAL DATA and BASE RATES.\n\n"
+            "Your intellectual tradition is empirical base-rate reasoning: before any specific argument, "
+            "what does the data say? What are the historical precedents? What's the base rate of success "
+            "for similar claims/projects/decisions?\n\n"
+            "Guidelines:\n"
+            "- Research historical base rates for similar situations\n"
+            "- Find analogous cases and their outcomes\n"
+            "- Quantify uncertainty with ranges, not point estimates\n"
+            "- Identify reference classes (what category does this belong to?)\n"
+            "- Distinguish inside view (specific arguments) from outside view (base rates)\n"
+            "- Use web search to find empirical data when available\n\n"
+            "Output format:\n"
+            "1. BASE RATE: What percentage of similar claims/projects succeed? With data sources.\n"
+            "2. HISTORICAL ANALOGIES: 2-3 closest historical parallels and their outcomes\n"
+            "3. DATA POINTS: Specific numbers, statistics, or research findings\n"
+            "4. CONFIDENCE: A number 0.0-1.0 based on data quality and relevance\n"
+            "5. DISSENT: true/false (true if base rates strongly contradict the claim)\n"
+        ),
+        scoring_weights={
+            "evidence": 0.4,
+            "quantification": 0.3,
+            "relevance": 0.2,
+            "calibration": 0.1,
+        },
+        tags=["empirical", "data", "base-rate"],
+    ),
+    "contrarian": Persona(
+        name="contrarian",
+        tradition="Kuhnian paradigm critique",
+        system_prompt=(
+            "You are the Contrarian on an adversarial deliberation council. "
+            "Your role is to REJECT THE FRAMING and find the alternative paradigm.\n\n"
+            "Your intellectual tradition is Kuhnian paradigm critique: the most important breakthroughs "
+            "come not from answering the question better, but from questioning the question itself. "
+            "You challenge assumptions, reframe problems, and propose alternative paradigms.\n\n"
+            "Guidelines:\n"
+            "- Question whether the debate is even asking the right question\n"
+            "- Identify hidden assumptions everyone else is taking for granted\n"
+            "- Propose a completely different framing that changes the conclusion\n"
+            "- Find the 'third option' that transcends the current binary\n"
+            "- Consider second-order effects and unintended consequences\n"
+            "- Challenge the values and priorities implicit in the question\n\n"
+            "Output format:\n"
+            "1. REFRAME: Why the question itself is wrong or incomplete (2-3 paragraphs)\n"
+            "2. HIDDEN ASSUMPTIONS: Bullet points of unexamined premises\n"
+            "3. ALTERNATIVE PARADIGM: A different way to think about this entirely\n"
+            "4. CONFIDENCE: A number 0.0-1.0 in your alternative framing\n"
+            "5. DISSENT: true/false (true if you believe the current framing is fundamentally flawed)\n"
+        ),
+        scoring_weights={
+            "originality": 0.4,
+            "depth": 0.3,
+            "coherence": 0.2,
+            "falsifiability": 0.1,
+        },
+        tags=["paradigm", "reframe", "contrarian"],
+    ),
+    "arbiter": Persona(
+        name="arbiter",
+        tradition="Bayesian synthesis",
+        system_prompt=(
+            "You are the Arbiter on an adversarial deliberation council. "
+            "You speak LAST, after reading all other personas' arguments.\n\n"
+            "Your intellectual tradition is Bayesian synthesis: you start with a prior, "
+            "update on evidence from each persona, and produce a posterior judgment "
+            "with explicit confidence intervals.\n\n"
+            "Guidelines:\n"
+            "- State your prior belief BEFORE reading the arguments\n"
+            "- For each persona's argument, state how it updates your belief (and by how much)\n"
+            "- Identify where personas agree (convergent evidence) vs. disagree (unresolved tension)\n"
+            "- Produce a final posterior with explicit confidence range\n"
+            "- Flag any remaining uncertainties that can't be resolved with available evidence\n"
+            "- Weight evidence quality: empirical data > logical argument > analogies > intuition\n\n"
+            "Output format:\n"
+            "1. PRIOR: Your starting belief (0-100%) before reading arguments\n"
+            "2. EVIDENCE UPDATES:\n"
+            "   - Advocate's impact: +/- X% (because...)\n"
+            "   - Skeptic's impact: +/- X% (because...)\n"
+            "   - Oracle's impact: +/- X% (because...)\n"
+            "   - Contrarian's impact: +/- X% (because...)\n"
+            "3. POSTERIOR: Final belief (0-100%) with reasoning\n"
+            "4. KEY DISAGREEMENTS: Unresolved tensions between personas\n"
+            "5. FINAL VERDICT: Clear recommendation in 2-3 sentences\n"
+            "6. CONFIDENCE: A number 0-100 indicating overall confidence\n"
+        ),
+        scoring_weights={
+            "synthesis": 0.3,
+            "calibration": 0.3,
+            "evidence_weighting": 0.2,
+            "clarity": 0.2,
+        },
+        tags=["bayesian", "synthesis", "final"],
+    ),
+}
+
+
+# =============================================================================
+# Utility functions
+# =============================================================================
+
+
+def get_persona(name: str) -> Optional[Persona]:
+    """Get a persona by name (case-insensitive)."""
+    return DEFAULT_PERSONAS.get(name.lower())
+
+
+def list_personas() -> List[str]:
+    """List all available persona names."""
+    return list(DEFAULT_PERSONAS.keys())
+
+
+def load_custom_personas(config_path: str = None) -> Dict[str, Persona]:
+    """Load user-defined council personas from config and merge with defaults.
+
+    Reads the council.personas section from a YAML config file.
+    Custom personas override defaults with the same name.
+
+    Args:
+        config_path: Path to config file. Defaults to ~/.hermes/config.yaml.
+
+    Returns:
+        Merged dict of all personas (defaults + custom).
+    """
+    if config_path is None:
+        config_path = os.path.expanduser("~/.hermes/config.yaml")
+
+    merged = dict(DEFAULT_PERSONAS)
+
+    if not os.path.exists(config_path):
+        return merged
+
+    try:
+        import yaml
+
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f) or {}
+
+        council_config = config.get("council", {})
+        custom_personas = council_config.get("personas", {})
+
+        for name, pdata in custom_personas.items():
+            name_lower = name.lower()
+            merged[name_lower] = Persona(
+                name=name_lower,
+                tradition=pdata.get("tradition", "Custom"),
+                system_prompt=pdata.get("system_prompt", ""),
+                scoring_weights=pdata.get("scoring_weights", {}),
+                tags=pdata.get("tags", ["custom"]),
+            )
+            logger.info("Loaded custom persona: %s", name_lower)
+
+    except ImportError:
+        logger.debug("PyYAML not installed, skipping custom persona loading")
+    except Exception as e:
+        logger.warning("Failed to load custom personas from %s: %s", config_path, e)
+
+    return merged

--- a/tools/council_tool.py
+++ b/tools/council_tool.py
@@ -1,0 +1,604 @@
+"""Council Tool -- Adversarial multi-perspective deliberation tools.
+
+Three tools registered in one file (following skills_tool.py pattern):
+  - council_query:    Submit a question for 5-persona deliberation
+  - council_evaluate: Evaluate content through the council
+  - council_gate:     Quick safety review before high-stakes actions
+
+Each tool calls LLM via the OpenAI-compatible API (openai library).
+Uses OPENROUTER_API_KEY, OPENAI_API_KEY, or NOUS_API_KEY from env.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+from tools.council_personas import (
+    CouncilVerdict,
+    PersonaResponse,
+    DEFAULT_PERSONAS,
+    get_persona,
+    list_personas,
+    load_custom_personas,
+)
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# LLM client configuration
+# =============================================================================
+
+_DEFAULT_MODEL = "nousresearch/hermes-3-llama-3.1-70b"
+
+
+def _get_api_config() -> Dict[str, str]:
+    """Resolve API key and base URL from environment."""
+    if os.getenv("OPENROUTER_API_KEY"):
+        return {
+            "api_key": os.environ["OPENROUTER_API_KEY"],
+            "base_url": "https://openrouter.ai/api/v1",
+        }
+    if os.getenv("NOUS_API_KEY"):
+        return {
+            "api_key": os.environ["NOUS_API_KEY"],
+            "base_url": "https://inference-api.nousresearch.com/v1",
+        }
+    if os.getenv("OPENAI_API_KEY"):
+        return {
+            "api_key": os.environ["OPENAI_API_KEY"],
+            "base_url": os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
+        }
+    return {}
+
+
+def _get_model() -> str:
+    """Get the council model from env or use default."""
+    return os.getenv("COUNCIL_MODEL", _DEFAULT_MODEL)
+
+
+async def _llm_call(system_prompt: str, user_message: str, model: str = None) -> str:
+    """Make a single LLM call via the OpenAI-compatible API."""
+    try:
+        from openai import AsyncOpenAI
+    except ImportError:
+        return json.dumps({"error": "openai library not installed"})
+
+    config = _get_api_config()
+    if not config:
+        return "[Error: No API key found. Set OPENROUTER_API_KEY, NOUS_API_KEY, or OPENAI_API_KEY]"
+
+    client = AsyncOpenAI(
+        api_key=config["api_key"],
+        base_url=config["base_url"],
+    )
+
+    try:
+        response = await client.chat.completions.create(
+            model=model or _get_model(),
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_message},
+            ],
+            temperature=0.7,
+            max_tokens=2000,
+        )
+        return response.choices[0].message.content or ""
+    except Exception as e:
+        logger.error("LLM call failed: %s", e)
+        return f"[Error: LLM call failed: {e}]"
+
+
+# =============================================================================
+# Response parsing
+# =============================================================================
+
+
+def _parse_confidence(text: str) -> float:
+    """Extract confidence value from persona response text."""
+    patterns = [
+        r"CONFIDENCE:\s*([\d.]+)",
+        r"confidence[:\s]+([\d.]+)",
+        r"(\d+)%",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            val = float(match.group(1))
+            return val / 100.0 if val > 1.0 else val
+    return 0.5  # default
+
+
+def _parse_dissent(text: str) -> bool:
+    """Extract dissent flag from persona response text."""
+    match = re.search(r"DISSENT:\s*(true|false)", text, re.IGNORECASE)
+    if match:
+        return match.group(1).lower() == "true"
+    return False
+
+
+def _parse_key_points(text: str) -> List[str]:
+    """Extract bullet points from persona response text."""
+    points = []
+    for line in text.split("\n"):
+        line = line.strip()
+        if line.startswith(("- ", "* ", "  - ", "  * ")):
+            point = line.lstrip("-* ").strip()
+            if len(point) > 10:
+                points.append(point)
+    return points[:10]  # cap at 10
+
+
+def _extract_sources(text: str) -> List[str]:
+    """Extract URLs from text."""
+    url_pattern = r'https?://[^\s\)\]\"\'<>]+'
+    return list(set(re.findall(url_pattern, text)))
+
+
+def _build_persona_response(persona_name: str, raw_text: str) -> PersonaResponse:
+    """Parse raw LLM output into a structured PersonaResponse."""
+    return PersonaResponse(
+        persona_name=persona_name,
+        content=raw_text,
+        confidence=_parse_confidence(raw_text),
+        dissents=_parse_dissent(raw_text),
+        key_points=_parse_key_points(raw_text),
+        sources=_extract_sources(raw_text),
+    )
+
+
+# =============================================================================
+# DPO pair extraction
+# =============================================================================
+
+
+def _extract_dpo_pairs(
+    question: str, responses: Dict[str, PersonaResponse]
+) -> List[Dict]:
+    """Extract DPO preference pairs from council responses.
+
+    The Arbiter's synthesis represents the "chosen" response.
+    The lowest-confidence non-Arbiter persona that was overruled
+    represents the "rejected" response.
+    """
+    pairs = []
+    non_arbiter = {
+        k: v for k, v in responses.items() if k != "arbiter" and v.content
+    }
+    if not non_arbiter:
+        return pairs
+
+    # Sort by confidence (ascending) -- lowest confidence = most likely rejected
+    sorted_personas = sorted(non_arbiter.values(), key=lambda r: r.confidence)
+
+    arbiter = responses.get("arbiter")
+    if not arbiter or not arbiter.content:
+        return pairs
+
+    # Pair 1: Arbiter (chosen) vs lowest-confidence dissenter (rejected)
+    dissenters = [r for r in sorted_personas if r.dissents]
+    if dissenters:
+        pairs.append({
+            "question": question,
+            "chosen": arbiter.content,
+            "rejected": dissenters[0].content,
+            "confidence": arbiter.confidence,
+            "source": "council_evaluation",
+            "chosen_persona": "arbiter",
+            "rejected_persona": dissenters[0].persona_name,
+        })
+
+    # Pair 2: Highest-confidence aligned vs lowest-confidence persona
+    if len(sorted_personas) >= 2:
+        aligned = [r for r in sorted_personas if not r.dissents]
+        if aligned and sorted_personas[0].confidence < aligned[-1].confidence - 0.2:
+            pairs.append({
+                "question": question,
+                "chosen": aligned[-1].content,
+                "rejected": sorted_personas[0].content,
+                "confidence": aligned[-1].confidence,
+                "source": "council_evaluation",
+                "chosen_persona": aligned[-1].persona_name,
+                "rejected_persona": sorted_personas[0].persona_name,
+            })
+
+    return pairs
+
+
+# =============================================================================
+# Core deliberation logic
+# =============================================================================
+
+
+async def _run_council(
+    question: str,
+    context: str = "",
+    persona_names: List[str] = None,
+    evidence_search: bool = True,
+    model: str = None,
+) -> CouncilVerdict:
+    """Run the full council deliberation.
+
+    1. Resolve personas (default 5 or user-specified subset)
+    2. Run 4 non-Arbiter personas in parallel
+    3. Collect responses, detect conflicts
+    4. Run Arbiter with all responses as context
+    5. Score confidence, extract DPO pairs
+    """
+    all_personas = load_custom_personas()
+    if persona_names:
+        selected = {
+            name.lower(): all_personas[name.lower()]
+            for name in persona_names
+            if name.lower() in all_personas
+        }
+    else:
+        selected = dict(all_personas)
+
+    # Separate Arbiter from deliberators
+    arbiter_persona = selected.pop("arbiter", DEFAULT_PERSONAS["arbiter"])
+    deliberators = selected
+
+    # Build user message with context
+    user_msg = f"Question: {question}"
+    if context:
+        user_msg += f"\n\nContext:\n{context}"
+    if evidence_search:
+        user_msg += (
+            "\n\nNote: If you have access to web search, use it to find "
+            "supporting evidence or counter-evidence for your analysis."
+        )
+
+    # Run all deliberators in parallel
+    async def _run_one(persona):
+        raw = await _llm_call(persona.system_prompt, user_msg, model=model)
+        return _build_persona_response(persona.name, raw)
+
+    tasks = [_run_one(p) for p in deliberators.values()]
+    deliberator_responses = await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Collect valid responses
+    responses: Dict[str, PersonaResponse] = {}
+    for resp in deliberator_responses:
+        if isinstance(resp, PersonaResponse):
+            responses[resp.persona_name] = resp
+        elif isinstance(resp, Exception):
+            logger.error("Persona failed: %s", resp)
+
+    # Detect conflicts (confidence spread > 0.3)
+    confidences = [r.confidence for r in responses.values()]
+    conflict_detected = False
+    if len(confidences) >= 2:
+        conflict_detected = (max(confidences) - min(confidences)) > 0.3
+
+    # Build Arbiter context from all responses
+    arbiter_context = f"Question: {question}\n\n"
+    if context:
+        arbiter_context += f"Original Context:\n{context}\n\n"
+    arbiter_context += "=== COUNCIL DELIBERATION ===\n\n"
+    for name, resp in responses.items():
+        arbiter_context += f"--- {name.upper()} ({resp.confidence:.0%} confidence) ---\n"
+        arbiter_context += f"{resp.content}\n\n"
+    if conflict_detected:
+        arbiter_context += (
+            "\n[NOTE: Significant disagreement detected among council members. "
+            "Pay special attention to reconciling conflicting views.]\n"
+        )
+
+    # Run Arbiter
+    arbiter_raw = await _llm_call(
+        arbiter_persona.system_prompt, arbiter_context, model=model
+    )
+    arbiter_response = _build_persona_response("arbiter", arbiter_raw)
+    responses["arbiter"] = arbiter_response
+
+    # Aggregate sources
+    all_sources = []
+    for resp in responses.values():
+        all_sources.extend(resp.sources)
+    all_sources = list(set(all_sources))
+
+    # Compute overall confidence (weighted by Arbiter's assessment)
+    confidence_score = int(arbiter_response.confidence * 100)
+
+    # Extract DPO pairs
+    dpo_pairs = _extract_dpo_pairs(question, responses)
+
+    return CouncilVerdict(
+        question=question,
+        responses=responses,
+        arbiter_synthesis=arbiter_raw,
+        confidence_score=confidence_score,
+        conflict_detected=conflict_detected,
+        dpo_pairs=dpo_pairs,
+        sources=all_sources,
+    )
+
+
+# =============================================================================
+# Tool 1: council_query
+# =============================================================================
+
+COUNCIL_QUERY_SCHEMA = {
+    "name": "council_query",
+    "description": (
+        "Submit a question to the adversarial council for multi-perspective deliberation. "
+        "Five personas (Advocate, Skeptic, Oracle, Contrarian, Arbiter) debate the question. "
+        "Returns structured verdict with confidence score and evidence links."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "question": {
+                "type": "string",
+                "description": "The question to deliberate on",
+            },
+            "context": {
+                "type": "string",
+                "description": "Optional context or prior research to inform the debate",
+            },
+            "personas": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional: specific persona names to include "
+                    "(default: all 5 -- advocate, skeptic, oracle, contrarian, arbiter)"
+                ),
+            },
+            "evidence_search": {
+                "type": "boolean",
+                "description": "If true, personas are encouraged to cite evidence (default: true)",
+            },
+        },
+        "required": ["question"],
+    },
+}
+
+
+async def council_query_handler(args: dict, **kwargs) -> str:
+    """Handle council_query tool calls."""
+    question = args.get("question", "")
+    if not question:
+        return json.dumps({"error": "question is required"})
+
+    context = args.get("context", "")
+    persona_names = args.get("personas")
+    evidence_search = args.get("evidence_search", True)
+
+    verdict = await _run_council(
+        question=question,
+        context=context,
+        persona_names=persona_names,
+        evidence_search=evidence_search,
+    )
+
+    # Serialize to JSON
+    result = {
+        "success": True,
+        "question": verdict.question,
+        "confidence_score": verdict.confidence_score,
+        "conflict_detected": verdict.conflict_detected,
+        "arbiter_synthesis": verdict.arbiter_synthesis,
+        "persona_responses": {
+            name: {
+                "confidence": resp.confidence,
+                "dissents": resp.dissents,
+                "key_points": resp.key_points,
+                "content": resp.content[:2000],  # truncate for token efficiency
+                "sources": resp.sources,
+            }
+            for name, resp in verdict.responses.items()
+        },
+        "dpo_pairs": verdict.dpo_pairs,
+        "sources": verdict.sources,
+        "available_personas": list_personas(),
+    }
+    return json.dumps(result, ensure_ascii=False)
+
+
+# =============================================================================
+# Tool 2: council_evaluate
+# =============================================================================
+
+COUNCIL_EVALUATE_SCHEMA = {
+    "name": "council_evaluate",
+    "description": (
+        "Evaluate any content through the adversarial council. "
+        "Use this to assess quality of research, analysis, or agent output. "
+        "Returns confidence score (0-100) and structured feedback."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "The content to evaluate",
+            },
+            "question": {
+                "type": "string",
+                "description": "The original question/task the content addresses",
+            },
+            "criteria": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Evaluation criteria "
+                    "(default: accuracy, depth, falsifiability, evidence)"
+                ),
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+
+async def council_evaluate_handler(args: dict, **kwargs) -> str:
+    """Handle council_evaluate tool calls."""
+    content = args.get("content", "")
+    if not content:
+        return json.dumps({"error": "content is required"})
+
+    question = args.get("question", "Evaluate the quality of this content")
+    criteria = args.get("criteria", ["accuracy", "depth", "falsifiability", "evidence"])
+
+    eval_question = (
+        f"Evaluate the following content against these criteria: {', '.join(criteria)}.\n\n"
+        f"Original question/task: {question}\n\n"
+        f"Content to evaluate:\n{content[:4000]}"
+    )
+
+    verdict = await _run_council(
+        question=eval_question,
+        context="This is an evaluation task. Each persona should critique the content "
+        "from their intellectual tradition and assign a quality assessment.",
+        evidence_search=False,
+    )
+
+    result = {
+        "success": True,
+        "confidence_score": verdict.confidence_score,
+        "conflict_detected": verdict.conflict_detected,
+        "criteria": criteria,
+        "arbiter_synthesis": verdict.arbiter_synthesis,
+        "persona_feedback": {
+            name: {
+                "confidence": resp.confidence,
+                "dissents": resp.dissents,
+                "key_points": resp.key_points,
+                "content": resp.content[:1500],
+            }
+            for name, resp in verdict.responses.items()
+        },
+        "dpo_pairs": verdict.dpo_pairs,
+        "sources": verdict.sources,
+    }
+    return json.dumps(result, ensure_ascii=False)
+
+
+# =============================================================================
+# Tool 3: council_gate
+# =============================================================================
+
+COUNCIL_GATE_SCHEMA = {
+    "name": "council_gate",
+    "description": (
+        "Safety gate: run quick council review before high-stakes actions. "
+        "Use before deploying code, sending messages, or making irreversible changes. "
+        "Returns allow/deny with reasoning. Uses abbreviated council (Skeptic + Oracle + Arbiter)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "description": "Description of the action to review",
+            },
+            "risk_level": {
+                "type": "string",
+                "enum": ["low", "medium", "high"],
+                "description": "Risk level (default: medium)",
+            },
+            "context": {
+                "type": "string",
+                "description": "Context about why this action is being taken",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+async def council_gate_handler(args: dict, **kwargs) -> str:
+    """Handle council_gate tool calls. Abbreviated council for speed."""
+    action = args.get("action", "")
+    if not action:
+        return json.dumps({"error": "action is required"})
+
+    risk_level = args.get("risk_level", "medium")
+    context = args.get("context", "")
+
+    gate_question = (
+        f"SAFETY REVIEW (Risk level: {risk_level})\n"
+        f"Proposed action: {action}\n"
+    )
+    if context:
+        gate_question += f"Context: {context}\n"
+    gate_question += (
+        "\nShould this action be allowed? Consider risks, reversibility, "
+        "and potential negative outcomes. Be concise."
+    )
+
+    # Abbreviated council: Skeptic + Oracle + Arbiter only
+    verdict = await _run_council(
+        question=gate_question,
+        persona_names=["skeptic", "oracle", "arbiter"],
+        evidence_search=False,
+    )
+
+    # Determine allow/deny based on Arbiter confidence
+    threshold = {"low": 30, "medium": 50, "high": 70}.get(risk_level, 50)
+    allowed = verdict.confidence_score >= threshold
+
+    result = {
+        "success": True,
+        "allowed": allowed,
+        "confidence": verdict.confidence_score,
+        "risk_level": risk_level,
+        "threshold": threshold,
+        "reasoning": verdict.arbiter_synthesis[:1000],
+        "skeptic_concerns": (
+            verdict.responses.get("skeptic", PersonaResponse(
+                persona_name="skeptic", content="", confidence=0, dissents=False
+            )).key_points
+        ),
+    }
+    return json.dumps(result, ensure_ascii=False)
+
+
+# =============================================================================
+# Availability check
+# =============================================================================
+
+
+def check_council_requirements() -> bool:
+    """Returns True if any LLM API key is available."""
+    return bool(
+        os.getenv("OPENROUTER_API_KEY")
+        or os.getenv("OPENAI_API_KEY")
+        or os.getenv("NOUS_API_KEY")
+    )
+
+
+# =============================================================================
+# Module-level registration
+# =============================================================================
+
+registry.register(
+    name="council_query",
+    toolset="council",
+    schema=COUNCIL_QUERY_SCHEMA,
+    handler=council_query_handler,
+    check_fn=check_council_requirements,
+    is_async=True,
+)
+
+registry.register(
+    name="council_evaluate",
+    toolset="council",
+    schema=COUNCIL_EVALUATE_SCHEMA,
+    handler=council_evaluate_handler,
+    check_fn=check_council_requirements,
+    is_async=True,
+)
+
+registry.register(
+    name="council_gate",
+    toolset="council",
+    schema=COUNCIL_GATE_SCHEMA,
+    handler=council_gate_handler,
+    check_fn=check_council_requirements,
+    is_async=True,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -64,6 +64,8 @@ _HERMES_CORE_TOOLS = [
     "query_user_context",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+    # Council deliberation (gated on LLM API key via check_fn)
+    "council_query",
 ]
 
 
@@ -202,6 +204,11 @@ TOOLSETS = {
         "includes": []
     },
 
+    "council": {
+        "description": "Adversarial multi-perspective deliberation and evaluation",
+        "tools": ["council_query", "council_evaluate", "council_gate"],
+        "includes": []
+    },
 
     # Scenario-specific toolsets
     


### PR DESCRIPTION
## Summary

Adds an adversarial multi-perspective council as a general-purpose evaluation subsystem for hermes-agent. Five personas (Advocate, Skeptic, Oracle, Contrarian, Arbiter) deliberate from distinct intellectual traditions, producing structured verdicts with confidence scores, evidence links, and DPO preference pairs.

This fills a real gap — hermes-agent currently has no way to evaluate open-ended agent output quality. The council provides structured adversarial deliberation, automatic DPO pair generation, and confidence-gated safety.

### What's included

**3 new tools** (`tools/council_tool.py`, `tools/council_personas.py`):
- `council_query` — full 5-persona deliberation on any question
- `council_evaluate` — evaluate content quality through adversarial critique
- `council_gate` — quick safety review (Skeptic + Oracle + Arbiter) before high-stakes actions

**RL integration** (`environments/council_evaluator.py`, `environments/ouroboros_env.py`):
- `CouncilEvaluator` — drop-in evaluator any `HermesAgentBaseEnv` can import for `compute_reward()`
- `OuroborosEnv` — research agent environment with council-based multi-signal rewards and DPO extraction

**3 skills** (`skills/council/`):
- `multi-perspective-analysis` — guide for using council deliberation
- `bayesian-synthesis` — Arbiter's explicit prior/evidence/posterior methodology
- `adversarial-critique` — stress-testing and safety gating workflows

**Config** (`datagen-config-examples/ouroboros.yaml`)

### Architecture

```
Layer 0: council_personas.py     (pure data, zero deps)
Layer 1: council_tool.py         (core logic, imports personas)
Layer 2: council_evaluator.py    (RL integration) + registration (model_tools, toolsets)
Layer 3: ouroboros_env.py         (RL environment) + skills + datagen config
```

### Changes to existing files

- `model_tools.py` — added `"tools.council_tool"` to `_discover_tools()` (+1 line)
- `toolsets.py` — added `"council"` toolset definition + `"council_query"` to `_HERMES_CORE_TOOLS` (+7 lines)

### Key design decisions

- **LLM-agnostic**: Uses OpenAI-compatible API via `openai` library (already a dependency). Works with OpenRouter, NousResearch API, or any OpenAI-compatible endpoint.
- **Gated availability**: `check_fn` returns True only if OPENROUTER_API_KEY, OPENAI_API_KEY, or NOUS_API_KEY is set.
- **Custom personas**: Users can add/override personas via `~/.hermes/config.yaml`.
- **DPO-native**: Every deliberation automatically extracts preference pairs (Arbiter-aligned = chosen, overruled dissenter = rejected).

## Test plan

- [x] 37 tool tests passing (`tests/tools/test_council.py`)
- [x] 16 environment tests passing (`tests/environments/test_ouroboros.py`)
- [x] Tool registration verified (3 tools in council toolset)
- [x] Toolset resolution verified
- [x] `council_query` included in `_HERMES_CORE_TOOLS`
- [ ] End-to-end: `hermes --toolsets council,web` with council_query
- [ ] RL: `python environments/ouroboros_env.py serve` with Atropos