### PR TITLE
fix(cli): support Shift+Enter for newline in modern terminals

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -43,6 +43,8 @@ from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.widgets import TextArea
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.input.vt100_parser import ANSI_SEQUENCES
+from prompt_toolkit.keys import Keys
 from prompt_toolkit import print_formatted_text as _pt_print
 from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
 import threading
@@ -1806,7 +1808,7 @@ class HermesCLI:
                 _cprint(f"  {_GOLD}{cmd:<22}{_RST} {_DIM}-{_RST} {info['description']}")
 
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
-        _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
+        _cprint(f"  {_DIM}Multi-line: Shift+Enter, Alt+Enter, or Ctrl+Enter{_RST}")
         _cprint(f"  {_DIM}Paste image: Alt+V (or /paste){_RST}\n")
     
     def show_tools(self):
@@ -3340,6 +3342,13 @@ class HermesCLI:
                     self._pending_input.put(payload)
                 event.app.current_buffer.reset(append_to_history=True)
         
+        # Shift+Enter via Kitty keyboard protocol (Ghostty, Kitty, WezTerm, etc.)
+        # These terminals send distinct escape sequences for Shift+Enter, but
+        # prompt_toolkit maps them to plain ControlM (Enter). Remap them to
+        # ControlJ so they insert a newline instead of submitting.
+        ANSI_SEQUENCES['\x1b[27;2;13~'] = Keys.ControlJ  # xterm modifyOtherKeys
+        ANSI_SEQUENCES['\x1b[13;2u'] = Keys.ControlJ      # CSI u / Kitty protocol
+
         @kb.add('escape', 'enter')
         def handle_alt_enter(event):
             """Alt+Enter inserts a newline for multi-line input."""
@@ -3465,8 +3474,6 @@ class HermesCLI:
             """Handle Ctrl+D - exit."""
             self._should_exit = True
             event.app.exit()
-
-        from prompt_toolkit.keys import Keys
 
         @kb.add(Keys.BracketedPaste, eager=True)
         def handle_paste(event):


### PR DESCRIPTION
## Summary

- Modern terminals using the **Kitty keyboard protocol** (Ghostty, Kitty, WezTerm) or **xterm modifyOtherKeys** send distinct escape sequences for Shift+Enter (`\x1b[13;2u` and `\x1b[27;2;13~`), but `prompt_toolkit` maps both to plain `ControlM` (Enter) — so pressing Shift+Enter submits the message instead of inserting a newline.
- This remaps both sequences to `Keys.ControlJ`, which triggers the existing Ctrl+Enter handler that inserts a newline. Shift+Enter now works identically to Alt+Enter and Ctrl+Enter for multi-line input.
- Moves the `from prompt_toolkit.keys import Keys` import from a local scope to module level, fixing an `UnboundLocalError` that could occur when `Keys` was referenced before the local import line.
- Updates `/help` text to list all three multi-line shortcuts.

## Details

The Kitty keyboard protocol encodes modifier+key as CSI sequences:

| Shortcut | Escape Sequence | prompt_toolkit default | After this PR |
|---|---|---|---|
| Shift+Enter | `\x1b[13;2u` | `Keys.ControlM` (submit) | `Keys.ControlJ` (newline) |
| Shift+Enter | `\x1b[27;2;13~` | `Keys.ControlM` (submit) | `Keys.ControlJ` (newline) |

No behavioral change for terminals that don't use these protocols — plain Enter still submits as before.

## Test plan

- [x] Verified in Ghostty: Shift+Enter inserts newline, Enter submits
- [x] Alt+Enter and Ctrl+Enter continue to work as before
- [x] Hermes launches without `ValueError` or `UnboundLocalError`
- [ ] Verify in Kitty terminal
- [ ] Verify in WezTerm

🤖 Generated with [Claude Code](https://claude.com/claude-code)