### PR TITLE
feat(gateway): isolate sessions per forum topic and thread

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -295,12 +295,17 @@ def build_session_key(source: SessionSource) -> str:
 
     This is the single source of truth for session key construction.
     WhatsApp DMs include chat_id (multi-user), other DMs do not (single owner).
+    Forum topics (Telegram) and Discord threads include thread_id so each
+    topic/thread gets its own isolated session.
     """
     platform = source.platform.value
     if source.chat_type == "dm":
         if platform == "whatsapp" and source.chat_id:
             return f"agent:main:{platform}:dm:{source.chat_id}"
         return f"agent:main:{platform}:dm"
+    # Isolate sessions per forum topic / thread when thread_id is present
+    if source.thread_id:
+        return f"agent:main:{platform}:{source.chat_type}:{source.chat_id}:{source.thread_id}"
     return f"agent:main:{platform}:{source.chat_type}:{source.chat_id}"
 
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -368,6 +368,49 @@ class TestWhatsAppDMSessionKeyConsistency:
         key = build_session_key(source)
         assert key == "agent:main:discord:group:guild-123"
 
+    def test_forum_topic_includes_thread_id(self):
+        """Forum topics should include thread_id for session isolation."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001234567890",
+            chat_type="forum",
+            thread_id="42",
+        )
+        key = build_session_key(source)
+        assert key == "agent:main:telegram:forum:-1001234567890:42"
+
+    def test_forum_without_thread_id_omits_it(self):
+        """Forum chat without thread_id (e.g. General topic) omits suffix."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001234567890",
+            chat_type="forum",
+        )
+        key = build_session_key(source)
+        assert key == "agent:main:telegram:forum:-1001234567890"
+
+    def test_discord_thread_includes_thread_id(self):
+        """Discord threads should also get isolated sessions."""
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-123",
+            chat_type="group",
+            thread_id="thread-99",
+        )
+        key = build_session_key(source)
+        assert key == "agent:main:discord:group:guild-123:thread-99"
+
+    def test_dm_with_thread_id_ignores_it(self):
+        """DM sessions should not be affected by thread_id."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="99",
+            chat_type="dm",
+            thread_id="should-be-ignored",
+        )
+        key = build_session_key(source)
+        assert key == "agent:main:telegram:dm"
+
 
 class TestSessionStoreEntriesAttribute:
     """Regression: /reset must access _entries, not _sessions."""


### PR DESCRIPTION
## Problem

All forum topics within a Telegram supergroup (and Discord threads within a channel) share a single session key:

```
agent:main:telegram:forum:-1001234567890
```

This means conversations in different topics bleed into each other — the agent carries context from Topic A into Topic B, which is confusing and defeats the purpose of using forum topics for conversation organization.

## Solution

Include `thread_id` in the session key when present for non-DM chat types:

```
agent:main:telegram:forum:-1001234567890:42
```

This is a minimal change to `build_session_key()` — 2 lines added. Each forum topic / Discord thread now gets its own independent session with separate conversation history and memory.

### Changed behavior

| Scenario | Before | After |
|----------|--------|-------|
| Telegram forum topic | Shared session across all topics | Isolated session per topic |
| Discord thread | Shared session across all threads | Isolated session per thread |
| DM with thread_id | N/A (DMs ignore thread_id) | No change |
| Group without thread_id | Single session | No change |

### Why this matters

Users who organize their Hermes conversations via Telegram forum topics (or Discord threads) expect each topic to be an independent conversation — similar to how `/new` resets a DM session. Without this fix, the only way to get session isolation is to create separate groups, which is impractical.

## Tests

Added 4 test cases to `tests/gateway/test_session.py`:
- `test_forum_topic_includes_thread_id` — Telegram forum with thread_id
- `test_forum_without_thread_id_omits_it` — Forum General topic (no thread_id)
- `test_discord_thread_includes_thread_id` — Discord threaded channel
- `test_dm_with_thread_id_ignores_it` — DMs remain unaffected

All 34 tests pass (30 existing + 4 new).