### PR TITLE
fix: deduplicate SQLite session writes via _last_flushed_db_idx

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -839,7 +839,7 @@ class AIAgent:
         if not self._session_db:
             return
         try:
-            start_idx = len(conversation_history) if conversation_history else 0
+            start_idx = getattr(self, '_last_flushed_db_idx', len(conversation_history) if conversation_history else 0)
             for msg in messages[start_idx:]:
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
@@ -860,6 +860,7 @@ class AIAgent:
                     tool_call_id=msg.get("tool_call_id"),
                     finish_reason=msg.get("finish_reason"),
                 )
+            self._last_flushed_db_idx = len(messages)
         except Exception as e:
             logger.debug("Session DB append_message failed: %s", e)
 

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1208,3 +1208,63 @@ class TestSystemPromptStability:
         conversation_history = []
         should_prefetch = not conversation_history
         assert should_prefetch is True
+
+
+class TestFlushMessagesDeduplication:
+    """Verify _flush_messages_to_session_db does not write duplicate messages."""
+
+    def test_flush_tracks_last_flushed_idx(self, agent):
+        """Second flush call should only write new messages, not re-write already flushed ones."""
+        mock_db = MagicMock()
+        agent._session_db = mock_db
+        agent.session_id = "test-session"
+
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "how are you"},
+            {"role": "assistant", "content": "fine"},
+        ]
+        conversation_history = []
+
+        # First flush — should write all 4 messages
+        agent._flush_messages_to_session_db(messages[:2], conversation_history)
+        assert mock_db.append_message.call_count == 2
+        assert agent._last_flushed_db_idx == 2
+
+        # Second flush — should only write the 2 new messages
+        mock_db.reset_mock()
+        agent._flush_messages_to_session_db(messages, conversation_history)
+        assert mock_db.append_message.call_count == 2
+        assert agent._last_flushed_db_idx == 4
+
+    def test_flush_no_duplicates_on_repeated_calls(self, agent):
+        """Calling flush multiple times with same messages should not write duplicates."""
+        mock_db = MagicMock()
+        agent._session_db = mock_db
+        agent.session_id = "test-session"
+
+        messages = [{"role": "user", "content": "hello"}]
+        conversation_history = []
+
+        agent._flush_messages_to_session_db(messages, conversation_history)
+        assert mock_db.append_message.call_count == 1
+
+        mock_db.reset_mock()
+        agent._flush_messages_to_session_db(messages, conversation_history)
+        assert mock_db.append_message.call_count == 0
+
+    def test_flush_without_prior_state_uses_conversation_history_length(self, agent):
+        """Without _last_flushed_db_idx, start_idx falls back to len(conversation_history)."""
+        mock_db = MagicMock()
+        agent._session_db = mock_db
+        agent.session_id = "test-session"
+
+        if hasattr(agent, '_last_flushed_db_idx'):
+            del agent._last_flushed_db_idx
+
+        conversation_history = [{"role": "user", "content": "old msg"}]
+        messages = conversation_history + [{"role": "assistant", "content": "new reply"}]
+
+        agent._flush_messages_to_session_db(messages, conversation_history)
+        assert mock_db.append_message.call_count == 1


### PR DESCRIPTION
Closes #860

## Problem
`_flush_messages_to_session_db()` was called from 15+ exit paths in `run_conversation()`, each time re-flushing all messages from `len(conversation_history)`. Combined with `_log_msg_to_db()` and the gateway's `append_to_transcript()`, messages were written 3–4x to SQLite — causing proportionally inflated token usage on every API call.

## Fix (Option A from issue)
Track `_last_flushed_db_idx` on the agent instance. Each flush call starts from the last written index instead of from `len(conversation_history)`, so only truly new messages are written.

```python
start_idx = getattr(self, '_last_flushed_db_idx', len(conversation_history) if conversation_history else 0)
# ... write messages[start_idx:] ...
self._last_flushed_db_idx = len(messages)
```

Uses `getattr()` fallback for backward compatibility with existing agent instances.

## Testing
3 new tests in `TestFlushMessagesDeduplication`:
- Second flush only writes new messages
- Repeated flush with same messages writes nothing
- Without prior state, falls back to `len(conversation_history)`

Full suite: 2863 passed.