### PR TITLE
feat(delegate): add observability metadata to subagent results

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -245,6 +245,121 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["api_mode"], parent.api_mode)
 
 
+class TestDelegateObservability(unittest.TestCase):
+    """Tests for enriched metadata returned by _run_single_child."""
+
+    def test_observability_fields_present(self):
+        """Completed child should return tool_trace, tokens, model, iterations, exit_reason."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 5000
+            mock_child.session_completion_tokens = 1200
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 3,
+                "messages": [
+                    {"role": "user", "content": "do something"},
+                    {"role": "assistant", "tool_calls": [
+                        {"function": {"name": "web_search", "arguments": '{"query": "test"}'}}
+                    ]},
+                    {"role": "tool", "content": '{"results": [1,2,3]}'},
+                    {"role": "assistant", "content": "done"},
+                ],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test observability", parent_agent=parent))
+            entry = result["results"][0]
+
+            # Core observability fields
+            self.assertEqual(entry["model"], "claude-sonnet-4-6")
+            self.assertEqual(entry["iterations"], 3)
+            self.assertEqual(entry["exit_reason"], "completed")
+            self.assertEqual(entry["tokens"]["input"], 5000)
+            self.assertEqual(entry["tokens"]["output"], 1200)
+
+            # Tool trace
+            self.assertEqual(len(entry["tool_trace"]), 1)
+            self.assertEqual(entry["tool_trace"][0]["tool"], "web_search")
+            self.assertIn("args_bytes", entry["tool_trace"][0])
+            self.assertIn("result_bytes", entry["tool_trace"][0])
+            self.assertEqual(entry["tool_trace"][0]["status"], "ok")
+
+    def test_tool_trace_detects_error(self):
+        """Tool results containing 'error' should be marked as error status."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "failed",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [
+                    {"role": "assistant", "tool_calls": [
+                        {"function": {"name": "terminal", "arguments": '{"cmd": "ls"}'}}
+                    ]},
+                    {"role": "tool", "content": "Error: command not found"},
+                ],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test error trace", parent_agent=parent))
+            trace = result["results"][0]["tool_trace"]
+            self.assertEqual(trace[0]["status"], "error")
+
+    def test_exit_reason_interrupted(self):
+        """Interrupted child should report exit_reason='interrupted'."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "",
+                "completed": False,
+                "interrupted": True,
+                "api_calls": 2,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test interrupt", parent_agent=parent))
+            self.assertEqual(result["results"][0]["exit_reason"], "interrupted")
+
+    def test_exit_reason_max_iterations(self):
+        """Child that didn't complete and wasn't interrupted hit max_iterations."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "",
+                "completed": False,
+                "interrupted": False,
+                "api_calls": 50,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test max iter", parent_agent=parent))
+            self.assertEqual(result["results"][0]["exit_reason"], "max_iterations")
+
+
 class TestBlockedTools(unittest.TestCase):
     def test_blocked_tools_constant(self):
         for tool in ["delegate_task", "clarify", "memory", "send_message", "execute_code"]:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -259,12 +259,54 @@ def _run_single_child(
         else:
             status = "failed"
 
+        # Build tool trace from conversation messages (already in memory)
+        tool_trace = []
+        messages = result.get("messages") or []
+        if isinstance(messages, list):
+            for msg in messages:
+                if not isinstance(msg, dict):
+                    continue
+                if msg.get("role") == "assistant":
+                    for tc in (msg.get("tool_calls") or []):
+                        fn = tc.get("function", {})
+                        tool_trace.append({
+                            "tool": fn.get("name", "unknown"),
+                            "args_bytes": len(fn.get("arguments", "")),
+                        })
+                elif msg.get("role") == "tool" and tool_trace:
+                    content = msg.get("content", "")
+                    tool_trace[-1]["result_bytes"] = len(content)
+                    tool_trace[-1]["status"] = (
+                        "error" if content and "error" in content[:80].lower() else "ok"
+                    )
+
+        # Determine exit reason
+        if interrupted:
+            exit_reason = "interrupted"
+        elif completed:
+            exit_reason = "completed"
+        else:
+            exit_reason = "max_iterations"
+
+        # Extract token counts (safe for mock objects)
+        _input_tokens = getattr(child, "session_prompt_tokens", 0)
+        _output_tokens = getattr(child, "session_completion_tokens", 0)
+        _model = getattr(child, "model", None)
+
         entry: Dict[str, Any] = {
             "task_index": task_index,
             "status": status,
             "summary": summary,
             "api_calls": api_calls,
             "duration_seconds": duration,
+            "iterations": api_calls,
+            "model": _model if isinstance(_model, str) else None,
+            "exit_reason": exit_reason,
+            "tokens": {
+                "input": _input_tokens if isinstance(_input_tokens, (int, float)) else 0,
+                "output": _output_tokens if isinstance(_output_tokens, (int, float)) else 0,
+            },
+            "tool_trace": tool_trace,
         }
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")


### PR DESCRIPTION
## Problem

`delegate_task` currently returns minimal metadata per child task:

```json
{"task_index": 0, "status": "completed", "summary": "...", "api_calls": 3, "duration_seconds": 12.5}
```

When a subagent fails, gets stuck, or produces unexpected results, the parent agent (and the operator) has no visibility into *what happened inside* — which tools were called, whether they errored, how many tokens were consumed, or why the child stopped.

## Solution

Extract observability data that **already exists** on the child `AIAgent` instance and its conversation messages. Zero additional API calls, zero extra memory allocation.

### New fields

| Field | Type | Source | Description |
|-------|------|--------|-------------|
| `iterations` | int | `api_calls` | Number of API call iterations |
| `model` | string | `child.model` | Model used by the child |
| `exit_reason` | enum | derived | `completed` \| `interrupted` \| `max_iterations` |
| `tokens.input` | int | `child.session_prompt_tokens` | Input tokens consumed |
| `tokens.output` | int | `child.session_completion_tokens` | Output tokens consumed |
| `tool_trace` | array | `result["messages"]` | Per-tool-call trace (see below) |

### Tool trace format

```json
{"tool": "web_search", "args_bytes": 45, "result_bytes": 2400, "status": "ok"}
```

- **args_bytes**: byte length of serialized arguments (no content logged — privacy safe)
- **result_bytes**: byte length of tool result
- **status**: `ok` or `error` (detected from first 80 chars of result content)

### Example enriched result

```json
{
  "task_index": 0,
  "status": "completed",
  "summary": "Found 3 relevant articles...",
  "api_calls": 3,
  "duration_seconds": 12.5,
  "iterations": 3,
  "model": "claude-sonnet-4-6",
  "exit_reason": "completed",
  "tokens": {"input": 12400, "output": 3200},
  "tool_trace": [
    {"tool": "web_search", "args_bytes": 45, "result_bytes": 2400, "status": "ok"},
    {"tool": "web_extract", "args_bytes": 120, "result_bytes": 4200, "status": "ok"},
    {"tool": "terminal", "args_bytes": 30, "result_bytes": 800, "status": "error"}
  ]
}
```

## Implementation

Single function changed: `_run_single_child()` in `tools/delegate_tool.py`.

- Iterates over `result["messages"]` to build tool trace (messages are already in memory)
- Reads `child.session_prompt_tokens` / `child.session_completion_tokens` (already tracked by AIAgent)
- Type-safe: gracefully handles non-primitive values (e.g., MagicMock in tests)
- Fully backward compatible: existing fields unchanged, new fields are additive

## Tests

4 new test cases in `tests/tools/test_delegate.py`:
- `test_observability_fields_present` — all new fields present and correct
- `test_tool_trace_detects_error` — error keyword detection in tool results
- `test_exit_reason_interrupted` — interrupted child reports correctly
- `test_exit_reason_max_iterations` — max iteration child reports correctly

All 27 tests pass (23 existing + 4 new).