### PR TITLE
fix(cron): use atomic write in save_job_output to prevent data loss on crash

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -404,7 +404,15 @@ def save_job_output(job_id: str, output: str):
     timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S")
     output_file = job_output_dir / f"{timestamp}.md"
     
-    with open(output_file, 'w', encoding='utf-8') as f:
-        f.write(output)
+    fd, tmp_path = tempfile.mkstemp(dir=str(job_output_dir), suffix='.tmp', prefix='.output_')
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            f.write(output)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, output_file)
+    except:
+        os.unlink(tmp_path)
+        raise
     
     return output_file


### PR DESCRIPTION
**What**
save_job_output() uses bare open('w') which truncates the output file immediately. A crash or OOM kill between truncation and the completed write silently wipes the job output.

**How It Works**
Write goes to a temp file in the same directory first, then os.replace() swaps it atomically. Either the old file exists or the new one does — never a truncated half-write.

Same pattern already used in save_jobs() in cron/jobs.py.

**Tests**
75 cron tests pass.