### PR TITLE
refactor(runtime): add transport profiles for provider execution

### DIFF
--- a/agent/transport_adapters.py
+++ b/agent/transport_adapters.py
@@ -1,0 +1,460 @@
+"""Protocol adapters for non-OpenAI chat transports.
+
+These adapters expose an OpenAI chat-completions-like interface so Hermes can
+keep its tool loop and message store stable while routing requests to providers
+that speak Anthropic Messages or Google GenerateContent.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, Dict, Iterable, List, Optional
+
+import httpx
+
+
+def _ns(value: Any) -> Any:
+    if isinstance(value, dict):
+        return SimpleNamespace(**{k: _ns(v) for k, v in value.items()})
+    if isinstance(value, list):
+        return [_ns(v) for v in value]
+    return value
+
+
+class _CompletionsNamespace:
+    def __init__(self, adapter: Any):
+        self.create = adapter.create
+
+
+class _ChatNamespace:
+    def __init__(self, adapter: Any):
+        self.completions = _CompletionsNamespace(adapter)
+
+
+class _BaseTransportClient:
+    def __init__(self, *, base_url: str, api_key: str, default_headers: Optional[dict[str, str]] = None):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self._default_headers = dict(default_headers or {})
+        self._client = httpx.Client(headers=self._default_headers)
+        self.chat = _ChatNamespace(self)
+
+    def close(self):
+        self._client.close()
+
+    def create(self, **kwargs):
+        raise NotImplementedError
+
+
+class AnthropicMessagesClient(_BaseTransportClient):
+    """Expose Anthropic Messages as chat.completions.create()."""
+
+    def create(self, **kwargs):
+        timeout = kwargs.pop("timeout", None)
+        payload = _to_anthropic_request(kwargs)
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": "2023-06-01",
+        }
+        response = self._client.post(
+            f"{self.base_url}/messages",
+            json=payload,
+            headers=headers,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        return _from_anthropic_response(response.json(), kwargs.get("model"))
+
+
+class GoogleGenerateContentClient(_BaseTransportClient):
+    """Expose Google GenerateContent as chat.completions.create()."""
+
+    def create(self, **kwargs):
+        timeout = kwargs.pop("timeout", None)
+        model = (kwargs.get("model") or "").strip()
+        if not model:
+            raise ValueError("Google transport requires a non-empty model id.")
+        payload = _to_google_generate_content_request(kwargs)
+        response = self._client.post(
+            f"{self.base_url}/models/{model}:generateContent",
+            json=payload,
+            headers={"x-goog-api-key": self.api_key},
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        return _from_google_generate_content_response(response.json(), model)
+
+
+# -- Anthropic conversion -------------------------------------------------
+
+
+def _normalize_openai_tools(tools: Any) -> Optional[list[dict[str, Any]]]:
+    if not isinstance(tools, list):
+        return None
+    normalized = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function", {}) if tool.get("type") == "function" else {}
+        name = fn.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        normalized.append(
+            {
+                "name": name.strip(),
+                "description": fn.get("description", ""),
+                "input_schema": fn.get("parameters", {"type": "object", "properties": {}}),
+            }
+        )
+    return normalized or None
+
+
+def _coerce_json_object(raw: Any) -> Any:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return {}
+        try:
+            return json.loads(stripped)
+        except Exception:
+            return {"value": stripped}
+    return raw if raw is not None else {}
+
+
+def _to_anthropic_request(kwargs: dict[str, Any]) -> dict[str, Any]:
+    messages = kwargs.get("messages") or []
+    system_blocks: list[dict[str, Any]] = []
+    anthropic_messages: list[dict[str, Any]] = []
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        content = message.get("content")
+        if role == "system":
+            text = content if isinstance(content, str) else ""
+            if text:
+                system_blocks.append({"type": "text", "text": text})
+            continue
+
+        if role == "user":
+            if isinstance(content, str):
+                anthropic_messages.append({"role": "user", "content": [{"type": "text", "text": content}]})
+            elif isinstance(content, list):
+                parts = []
+                for part in content:
+                    if not isinstance(part, dict):
+                        continue
+                    if part.get("type") == "text" and isinstance(part.get("text"), str):
+                        parts.append({"type": "text", "text": part["text"]})
+                if parts:
+                    anthropic_messages.append({"role": "user", "content": parts})
+            continue
+
+        if role == "assistant":
+            parts: list[dict[str, Any]] = []
+            if isinstance(content, str) and content:
+                parts.append({"type": "text", "text": content})
+            tool_calls = message.get("tool_calls")
+            if isinstance(tool_calls, list):
+                for tool_call in tool_calls:
+                    if not isinstance(tool_call, dict):
+                        continue
+                    fn = tool_call.get("function", {})
+                    name = fn.get("name")
+                    if not isinstance(name, str) or not name.strip():
+                        continue
+                    parts.append(
+                        {
+                            "type": "tool_use",
+                            "id": tool_call.get("id") or tool_call.get("call_id") or "tool_call",
+                            "name": name.strip(),
+                            "input": _coerce_json_object(fn.get("arguments", {})),
+                        }
+                    )
+            if parts:
+                anthropic_messages.append({"role": "assistant", "content": parts})
+            continue
+
+        if role == "tool":
+            anthropic_messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": message.get("tool_call_id", ""),
+                            "content": str(message.get("content", "") or ""),
+                        }
+                    ],
+                }
+            )
+
+    payload: dict[str, Any] = {
+        "model": kwargs.get("model"),
+        "messages": anthropic_messages,
+        "stream": False,
+        "max_tokens": int(kwargs.get("max_tokens") or 32000),
+    }
+    if system_blocks:
+        payload["system"] = system_blocks
+    if kwargs.get("temperature") is not None:
+        payload["temperature"] = kwargs["temperature"]
+    if kwargs.get("top_p") is not None:
+        payload["top_p"] = kwargs["top_p"]
+    tools = _normalize_openai_tools(kwargs.get("tools"))
+    if tools:
+        payload["tools"] = tools
+    return payload
+
+
+def _from_anthropic_response(data: dict[str, Any], model: Optional[str]) -> Any:
+    blocks = data.get("content") or []
+    text_parts: list[str] = []
+    tool_calls: list[Any] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text" and isinstance(block.get("text"), str):
+            text_parts.append(block["text"])
+        elif block_type == "tool_use":
+            tool_calls.append(
+                SimpleNamespace(
+                    id=block.get("id") or "toolu_generated",
+                    type="function",
+                    function=SimpleNamespace(
+                        name=block.get("name", ""),
+                        arguments=json.dumps(block.get("input", {}), ensure_ascii=False),
+                    ),
+                )
+            )
+
+    stop_reason = data.get("stop_reason")
+    finish_reason = {
+        "end_turn": "stop",
+        "tool_use": "tool_calls",
+        "max_tokens": "length",
+        "content_filter": "content_filter",
+    }.get(stop_reason, None)
+
+    usage = data.get("usage") or {}
+    prompt_tokens = usage.get("input_tokens")
+    completion_tokens = usage.get("output_tokens")
+    cached_tokens = usage.get("cache_read_input_tokens")
+    usage_ns = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=(prompt_tokens or 0) + (completion_tokens or 0),
+        prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens) if cached_tokens is not None else None,
+    )
+
+    message = SimpleNamespace(
+        role="assistant",
+        content="".join(text_parts),
+        tool_calls=tool_calls or None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    choice = SimpleNamespace(index=0, message=message, finish_reason=finish_reason)
+    return SimpleNamespace(
+        id=data.get("id"),
+        object="chat.completion",
+        created=0,
+        model=data.get("model") or model,
+        choices=[choice],
+        usage=usage_ns,
+    )
+
+
+# -- Google conversion ----------------------------------------------------
+
+
+def _tool_name_map(messages: Iterable[dict[str, Any]]) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            fn = tool_call.get("function", {})
+            name = fn.get("name")
+            call_id = tool_call.get("id") or tool_call.get("call_id")
+            if isinstance(name, str) and name and isinstance(call_id, str) and call_id:
+                mapping[call_id] = name
+    return mapping
+
+
+def _to_google_generate_content_request(kwargs: dict[str, Any]) -> dict[str, Any]:
+    messages = kwargs.get("messages") or []
+    call_names = _tool_name_map(messages)
+    contents: list[dict[str, Any]] = []
+    system_parts: list[dict[str, Any]] = []
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        content = message.get("content")
+        if role == "system":
+            if isinstance(content, str) and content:
+                system_parts.append({"text": content})
+            continue
+
+        if role == "user":
+            if isinstance(content, str) and content:
+                contents.append({"role": "user", "parts": [{"text": content}]})
+            elif isinstance(content, list):
+                parts = [
+                    {"text": part.get("text")}
+                    for part in content
+                    if isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str)
+                ]
+                if parts:
+                    contents.append({"role": "user", "parts": parts})
+            continue
+
+        if role == "assistant":
+            parts: list[dict[str, Any]] = []
+            if isinstance(content, str) and content:
+                parts.append({"text": content})
+            tool_calls = message.get("tool_calls")
+            if isinstance(tool_calls, list):
+                for tool_call in tool_calls:
+                    if not isinstance(tool_call, dict):
+                        continue
+                    fn = tool_call.get("function", {})
+                    name = fn.get("name")
+                    if not isinstance(name, str) or not name.strip():
+                        continue
+                    parts.append(
+                        {
+                            "functionCall": {
+                                "name": name.strip(),
+                                "args": _coerce_json_object(fn.get("arguments", {})),
+                            }
+                        }
+                    )
+            if parts:
+                contents.append({"role": "model", "parts": parts})
+            continue
+
+        if role == "tool":
+            call_id = message.get("tool_call_id", "")
+            name = call_names.get(call_id, "tool")
+            result_text = str(message.get("content", "") or "")
+            try:
+                payload = json.loads(result_text)
+            except Exception:
+                payload = {"content": result_text}
+            contents.append(
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "functionResponse": {
+                                "name": name,
+                                "response": payload,
+                            }
+                        }
+                    ],
+                }
+            )
+
+    generation_config: dict[str, Any] = {}
+    if kwargs.get("temperature") is not None:
+        generation_config["temperature"] = kwargs["temperature"]
+    if kwargs.get("top_p") is not None:
+        generation_config["topP"] = kwargs["top_p"]
+    if kwargs.get("max_tokens") is not None:
+        generation_config["maxOutputTokens"] = kwargs["max_tokens"]
+
+    payload: dict[str, Any] = {"contents": contents}
+    if system_parts:
+        payload["systemInstruction"] = {"parts": system_parts}
+    if generation_config:
+        payload["generationConfig"] = generation_config
+
+    tools = _normalize_openai_tools(kwargs.get("tools"))
+    if tools:
+        payload["tools"] = [{"functionDeclarations": tools}]
+    return payload
+
+
+def _from_google_generate_content_response(data: dict[str, Any], model: str) -> Any:
+    candidates = data.get("candidates") or []
+    candidate = candidates[0] if candidates else {}
+    content = candidate.get("content") or {}
+    parts = content.get("parts") or []
+
+    text_parts: list[str] = []
+    tool_calls: list[Any] = []
+    for index, part in enumerate(parts):
+        if not isinstance(part, dict):
+            continue
+        text = part.get("text")
+        if isinstance(text, str) and text:
+            text_parts.append(text)
+        function_call = part.get("functionCall") or part.get("function_call")
+        if isinstance(function_call, dict):
+            arguments = function_call.get("args", {})
+            if isinstance(arguments, str):
+                arg_text = arguments
+            else:
+                arg_text = json.dumps(arguments, ensure_ascii=False)
+            tool_call = SimpleNamespace(
+                id=function_call.get("id") or f"call_google_{index}",
+                type="function",
+                function=SimpleNamespace(
+                    name=function_call.get("name", ""),
+                    arguments=arg_text,
+                ),
+            )
+            tool_calls.append(tool_call)
+
+    finish_reason = {
+        "STOP": "stop",
+        "MAX_TOKENS": "length",
+        "SAFETY": "content_filter",
+    }.get(candidate.get("finishReason"), None)
+    if tool_calls:
+        finish_reason = "tool_calls"
+
+    usage = data.get("usageMetadata") or {}
+    prompt_tokens = usage.get("promptTokenCount")
+    completion_tokens = usage.get("candidatesTokenCount")
+    reasoning_tokens = usage.get("thoughtsTokenCount")
+    cached_tokens = usage.get("cachedContentTokenCount")
+    usage_ns = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=usage.get("totalTokenCount") or ((prompt_tokens or 0) + (completion_tokens or 0)),
+        prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens) if cached_tokens is not None else None,
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=reasoning_tokens) if reasoning_tokens is not None else None,
+    )
+
+    message = SimpleNamespace(
+        role="assistant",
+        content="".join(text_parts),
+        tool_calls=tool_calls or None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    choice = SimpleNamespace(index=0, message=message, finish_reason=finish_reason)
+    return SimpleNamespace(
+        id=data.get("responseId") or "google-generate-content",
+        object="chat.completion",
+        created=0,
+        model=model,
+        choices=[choice],
+        usage=usage_ns,
+    )

--- a/cli.py
+++ b/cli.py
@@ -1133,6 +1133,7 @@ class HermesCLI:
         self._provider_source: Optional[str] = None
         self.provider = self.requested_provider
         self.api_mode = "chat_completions"
+        self.transport = "openai_chat_completions"
         self.base_url = (
             base_url
             or os.getenv("OPENAI_BASE_URL")
@@ -1331,6 +1332,7 @@ class HermesCLI:
         base_url = runtime.get("base_url")
         resolved_provider = runtime.get("provider", "openrouter")
         resolved_api_mode = runtime.get("api_mode", self.api_mode)
+        resolved_transport = runtime.get("transport", self.transport)
         if not isinstance(api_key, str) or not api_key:
             self.console.print("[bold red]Provider resolver returned an empty API key.[/]")
             return False
@@ -1342,9 +1344,11 @@ class HermesCLI:
         routing_changed = (
             resolved_provider != self.provider
             or resolved_api_mode != self.api_mode
+            or resolved_transport != self.transport
         )
         self.provider = resolved_provider
         self.api_mode = resolved_api_mode
+        self.transport = resolved_transport
         self._provider_source = runtime.get("source")
         self.api_key = api_key
         self.base_url = base_url
@@ -1423,6 +1427,7 @@ class HermesCLI:
                 base_url=self.base_url,
                 provider=self.provider,
                 api_mode=self.api_mode,
+                transport=self.transport,
                 max_iterations=self.max_turns,
                 enabled_toolsets=self.enabled_toolsets,
                 verbose_logging=self.verbose,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -246,6 +246,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             base_url=runtime.get("base_url"),
             provider=runtime.get("provider"),
             api_mode=runtime.get("api_mode"),
+            transport=runtime.get("transport"),
             max_iterations=max_iterations,
             reasoning_config=reasoning_config,
             prefill_messages=prefill_messages,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -184,6 +184,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
         "api_mode": runtime.get("api_mode"),
+        "transport": runtime.get("transport"),
     }
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -15,6 +15,7 @@ from hermes_cli.auth import (
     resolve_api_key_provider_credentials,
 )
 from hermes_cli.config import load_config
+from hermes_cli.transport_profiles import build_transport_profile
 from hermes_constants import OPENROUTER_BASE_URL
 
 
@@ -97,9 +98,11 @@ def _resolve_openrouter_runtime(
 
     source = "explicit" if (explicit_api_key or explicit_base_url) else "env/config"
 
+    profile = build_transport_profile("openrouter", base_url=base_url)
     return {
         "provider": "openrouter",
-        "api_mode": "chat_completions",
+        "api_mode": profile.api_mode,
+        "transport": profile.transport,
         "base_url": base_url,
         "api_key": api_key,
         "source": source,
@@ -111,6 +114,7 @@ def resolve_runtime_provider(
     requested: Optional[str] = None,
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Resolve runtime provider credentials for agent execution."""
     requested_provider = resolve_requested_provider(requested)
@@ -126,9 +130,11 @@ def resolve_runtime_provider(
             min_key_ttl_seconds=max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),
             timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
         )
+        profile = build_transport_profile("nous", base_url=creds.get("base_url", ""), model=model)
         return {
             "provider": "nous",
-            "api_mode": "chat_completions",
+            "api_mode": profile.api_mode,
+            "transport": profile.transport,
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "portal"),
@@ -138,9 +144,11 @@ def resolve_runtime_provider(
 
     if provider == "openai-codex":
         creds = resolve_codex_runtime_credentials()
+        profile = build_transport_profile("openai-codex", base_url=creds.get("base_url", ""), model=model)
         return {
             "provider": "openai-codex",
-            "api_mode": "codex_responses",
+            "api_mode": profile.api_mode,
+            "transport": profile.transport,
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "hermes-auth-store"),
@@ -152,9 +160,11 @@ def resolve_runtime_provider(
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":
         creds = resolve_api_key_provider_credentials(provider)
+        profile = build_transport_profile(provider, base_url=creds.get("base_url", ""), model=model)
         return {
             "provider": provider,
-            "api_mode": "chat_completions",
+            "api_mode": profile.api_mode,
+            "transport": profile.transport,
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "env"),

--- a/hermes_cli/transport_profiles.py
+++ b/hermes_cli/transport_profiles.py
@@ -1,0 +1,87 @@
+"""Runtime transport profiles for provider/model execution.
+
+Hermes historically routed requests with a provider-wide ``api_mode`` flag.
+This module adds an explicit transport profile so future providers can resolve
+execution protocol from ``provider + model`` while preserving the legacy
+``api_mode`` contract for existing callers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+OPENAI_CHAT_COMPLETIONS = "openai_chat_completions"
+OPENAI_RESPONSES = "openai_responses"
+ANTHROPIC_MESSAGES = "anthropic_messages"
+GOOGLE_GENERATE_CONTENT = "google_generate_content"
+
+LEGACY_API_MODES = {
+    OPENAI_CHAT_COMPLETIONS: "chat_completions",
+    OPENAI_RESPONSES: "codex_responses",
+    ANTHROPIC_MESSAGES: "chat_completions",
+    GOOGLE_GENERATE_CONTENT: "chat_completions",
+}
+
+_PROVIDER_DEFAULT_TRANSPORTS = {
+    "openrouter": OPENAI_CHAT_COMPLETIONS,
+    "custom": OPENAI_CHAT_COMPLETIONS,
+    "nous": OPENAI_CHAT_COMPLETIONS,
+    "nous-api": OPENAI_CHAT_COMPLETIONS,
+    "openai-codex": OPENAI_RESPONSES,
+    "zai": OPENAI_CHAT_COMPLETIONS,
+    "kimi-coding": OPENAI_CHAT_COMPLETIONS,
+    "minimax": OPENAI_CHAT_COMPLETIONS,
+    "minimax-cn": OPENAI_CHAT_COMPLETIONS,
+}
+
+
+@dataclass(frozen=True)
+class TransportProfile:
+    provider: str
+    transport: str
+    api_mode: str
+    base_url: str = ""
+    model: str = ""
+    metadata: dict[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        if data["metadata"] is None:
+            data.pop("metadata")
+        return data
+
+
+def legacy_api_mode_for_transport(transport: Optional[str]) -> str:
+    return LEGACY_API_MODES.get((transport or "").strip(), "chat_completions")
+
+
+def default_transport_for_provider(provider: Optional[str]) -> str:
+    normalized = (provider or "openrouter").strip().lower()
+    return _PROVIDER_DEFAULT_TRANSPORTS.get(normalized, OPENAI_CHAT_COMPLETIONS)
+
+
+def build_transport_profile(
+    provider: Optional[str],
+    *,
+    base_url: Optional[str] = None,
+    model: Optional[str] = None,
+    transport: Optional[str] = None,
+    metadata: Optional[dict[str, Any]] = None,
+) -> TransportProfile:
+    normalized_provider = (provider or "openrouter").strip().lower()
+    resolved_transport = (transport or default_transport_for_provider(normalized_provider)).strip().lower()
+    return TransportProfile(
+        provider=normalized_provider,
+        transport=resolved_transport,
+        api_mode=legacy_api_mode_for_transport(resolved_transport),
+        base_url=(base_url or "").rstrip("/"),
+        model=(model or "").strip(),
+        metadata=dict(metadata) if metadata else None,
+    )
+
+
+def is_responses_transport(value: TransportProfile | str | None) -> bool:
+    if isinstance(value, TransportProfile):
+        return value.transport == OPENAI_RESPONSES
+    return (value or "").strip().lower() == OPENAI_RESPONSES

--- a/run_agent.py
+++ b/run_agent.py
@@ -73,6 +73,14 @@ from tools.browser_tool import cleanup_browser
 import requests
 
 from hermes_constants import OPENROUTER_BASE_URL, OPENROUTER_MODELS_URL
+from hermes_cli.transport_profiles import (
+    ANTHROPIC_MESSAGES,
+    GOOGLE_GENERATE_CONTENT,
+    OPENAI_CHAT_COMPLETIONS,
+    OPENAI_RESPONSES,
+    legacy_api_mode_for_transport,
+)
+from agent.transport_adapters import AnthropicMessagesClient, GoogleGenerateContentClient
 
 # Agent internals extracted to agent/ package for modularity
 from agent.prompt_builder import (
@@ -153,6 +161,7 @@ class AIAgent:
         api_key: str = None,
         provider: str = None,
         api_mode: str = None,
+        transport: str = None,
         model: str = "anthropic/claude-opus-4.6",  # OpenRouter format
         max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
         tool_delay: float = 1.0,
@@ -195,7 +204,8 @@ class AIAgent:
             base_url (str): Base URL for the model API (optional)
             api_key (str): API key for authentication (optional, uses env var if not provided)
             provider (str): Provider identifier (optional; used for telemetry/routing hints)
-            api_mode (str): API mode override: "chat_completions" or "codex_responses"
+            api_mode (str): Legacy API mode override: "chat_completions" or "codex_responses"
+            transport (str): Explicit transport override for provider/model execution
             model (str): Model name to use (default: "anthropic/claude-opus-4.6")
             max_iterations (int): Maximum number of tool calling iterations (default: 90)
             tool_delay (float): Delay between tool calls in seconds (default: 1.0)
@@ -248,15 +258,15 @@ class AIAgent:
         self.base_url = base_url or OPENROUTER_BASE_URL
         provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
         self.provider = provider_name or "openrouter"
-        if api_mode in {"chat_completions", "codex_responses"}:
-            self.api_mode = api_mode
-        elif self.provider == "openai-codex":
-            self.api_mode = "codex_responses"
-        elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self.base_url.lower():
-            self.api_mode = "codex_responses"
+        self.transport = self._resolve_transport(
+            provider_name=provider_name,
+            base_url=self.base_url,
+            api_mode=api_mode,
+            transport=transport,
+        )
+        if (provider_name is None) and self.transport == OPENAI_RESPONSES:
             self.provider = "openai-codex"
-        else:
-            self.api_mode = "chat_completions"
+        self.api_mode = legacy_api_mode_for_transport(self.transport)
 
         self.tool_progress_callback = tool_progress_callback
         self.thinking_callback = thinking_callback
@@ -364,7 +374,7 @@ class AIAgent:
                 ]:
                     logging.getLogger(quiet_logger).setLevel(logging.ERROR)
         
-        # Initialize OpenAI client - defaults to OpenRouter
+        # Initialize transport client - defaults to OpenAI chat via OpenRouter
         client_kwargs = {}
         
         # Default to OpenRouter if no base_url provided
@@ -397,7 +407,7 @@ class AIAgent:
         
         self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
         try:
-            self.client = OpenAI(**client_kwargs)
+            self.client = self._create_api_client()
             if not self.quiet_mode:
                 print(f"🤖 AI Agent initialized with model: {self.model}")
                 if base_url:
@@ -1441,6 +1451,55 @@ class AIAgent:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
 
         return "\n\n".join(prompt_parts)
+
+    @staticmethod
+    def _resolve_transport(
+        *,
+        provider_name: Optional[str],
+        base_url: str,
+        api_mode: Optional[str],
+        transport: Optional[str],
+    ) -> str:
+        if isinstance(transport, str) and transport.strip():
+            return transport.strip().lower()
+        if api_mode == "codex_responses":
+            return OPENAI_RESPONSES
+        if isinstance(provider_name, str) and provider_name.strip().lower() == "openai-codex":
+            return OPENAI_RESPONSES
+        if provider_name is None and "chatgpt.com/backend-api/codex" in (base_url or "").lower():
+            return OPENAI_RESPONSES
+        return OPENAI_CHAT_COMPLETIONS
+
+    def _uses_responses_transport(self) -> bool:
+        return self.transport == OPENAI_RESPONSES
+
+    def _create_api_client(self):
+        if self.transport == ANTHROPIC_MESSAGES:
+            return AnthropicMessagesClient(
+                base_url=self._client_kwargs["base_url"],
+                api_key=self._client_kwargs["api_key"],
+                default_headers=self._client_kwargs.get("default_headers"),
+            )
+        if self.transport == GOOGLE_GENERATE_CONTENT:
+            return GoogleGenerateContentClient(
+                base_url=self._client_kwargs["base_url"],
+                api_key=self._client_kwargs["api_key"],
+                default_headers=self._client_kwargs.get("default_headers"),
+            )
+        return OpenAI(**self._client_kwargs)
+
+    def _rebuild_api_client(self) -> bool:
+        try:
+            self.client.close()
+        except Exception:
+            pass
+
+        try:
+            self.client = self._create_api_client()
+            return True
+        except Exception as exc:
+            logger.warning("Failed to rebuild API client: %s", exc)
+            return False
     
     def _repair_tool_call(self, tool_name: str) -> str | None:
         """Attempt to repair a mismatched tool name before aborting.
@@ -1636,7 +1695,7 @@ class AIAgent:
 
         return items
 
-    def _preflight_codex_input_items(self, raw_items: Any) -> List[Dict[str, Any]]:
+    def _preflight_responses_input_items(self, raw_items: Any) -> List[Dict[str, Any]]:
         if not isinstance(raw_items, list):
             raise ValueError("Codex Responses input must be a list of input items.")
 
@@ -1722,7 +1781,7 @@ class AIAgent:
 
         return normalized
 
-    def _preflight_codex_api_kwargs(
+    def _preflight_responses_api_kwargs(
         self,
         api_kwargs: Any,
         *,
@@ -1748,7 +1807,7 @@ class AIAgent:
             instructions = str(instructions)
         instructions = instructions.strip() or DEFAULT_AGENT_IDENTITY
 
-        normalized_input = self._preflight_codex_input_items(api_kwargs.get("input"))
+        normalized_input = self._preflight_responses_input_items(api_kwargs.get("input"))
 
         tools = api_kwargs.get("tools")
         normalized_tools = None
@@ -1839,6 +1898,19 @@ class AIAgent:
 
         return normalized
 
+    def _preflight_codex_input_items(self, raw_items: Any) -> List[Dict[str, Any]]:
+        """Backward-compatible wrapper for older tests and callers."""
+        return self._preflight_responses_input_items(raw_items)
+
+    def _preflight_codex_api_kwargs(
+        self,
+        api_kwargs: Any,
+        *,
+        allow_stream: bool = False,
+    ) -> Dict[str, Any]:
+        """Backward-compatible wrapper for older tests and callers."""
+        return self._preflight_responses_api_kwargs(api_kwargs, allow_stream=allow_stream)
+
     def _extract_responses_message_text(self, item: Any) -> str:
         """Extract assistant text from a Responses message output item."""
         content = getattr(item, "content", None)
@@ -1871,7 +1943,7 @@ class AIAgent:
             return text.strip()
         return ""
 
-    def _normalize_codex_response(self, response: Any) -> tuple[Any, str]:
+    def _normalize_responses_response(self, response: Any) -> tuple[Any, str]:
         """Normalize a Responses API object to an assistant_message-like object."""
         output = getattr(response, "output", None)
         if not isinstance(output, list) or not output:
@@ -2012,7 +2084,11 @@ class AIAgent:
             finish_reason = "stop"
         return assistant_message, finish_reason
 
-    def _run_codex_stream(self, api_kwargs: dict):
+    def _normalize_codex_response(self, response: Any) -> tuple[Any, str]:
+        """Backward-compatible wrapper for older tests and callers."""
+        return self._normalize_responses_response(response)
+
+    def _run_responses_stream(self, api_kwargs: dict):
         """Execute one streaming Responses API request and return the final response."""
         max_stream_retries = 1
         for attempt in range(max_stream_retries + 1):
@@ -2035,14 +2111,18 @@ class AIAgent:
                     logger.debug(
                         "Responses stream did not emit response.completed; falling back to create(stream=True)."
                     )
-                    return self._run_codex_create_stream_fallback(api_kwargs)
+                    return self._run_responses_create_stream_fallback(api_kwargs)
                 raise
 
-    def _run_codex_create_stream_fallback(self, api_kwargs: dict):
-        """Fallback path for stream completion edge cases on Codex-style Responses backends."""
+    def _run_codex_stream(self, api_kwargs: dict):
+        """Backward-compatible wrapper for older tests and callers."""
+        return self._run_responses_stream(api_kwargs)
+
+    def _run_responses_create_stream_fallback(self, api_kwargs: dict):
+        """Fallback path for stream completion edge cases on Responses backends."""
         fallback_kwargs = dict(api_kwargs)
         fallback_kwargs["stream"] = True
-        fallback_kwargs = self._preflight_codex_api_kwargs(fallback_kwargs, allow_stream=True)
+        fallback_kwargs = self._preflight_responses_api_kwargs(fallback_kwargs, allow_stream=True)
         stream_or_response = self.client.responses.create(**fallback_kwargs)
 
         # Compatibility shim for mocks or providers that still return a concrete response.
@@ -2077,8 +2157,12 @@ class AIAgent:
             return terminal_response
         raise RuntimeError("Responses create(stream=True) fallback did not emit a terminal response.")
 
+    def _run_codex_create_stream_fallback(self, api_kwargs: dict):
+        """Backward-compatible wrapper for older tests and callers."""
+        return self._run_responses_create_stream_fallback(api_kwargs)
+
     def _try_refresh_codex_client_credentials(self, *, force: bool = True) -> bool:
-        if self.api_mode != "codex_responses" or self.provider != "openai-codex":
+        if not self._uses_responses_transport() or self.provider != "openai-codex":
             return False
 
         try:
@@ -2101,15 +2185,8 @@ class AIAgent:
         self._client_kwargs["api_key"] = self.api_key
         self._client_kwargs["base_url"] = self.base_url
 
-        try:
-            self.client.close()
-        except Exception:
-            pass
-
-        try:
-            self.client = OpenAI(**self._client_kwargs)
-        except Exception as exc:
-            logger.warning("Failed to rebuild OpenAI client after Codex refresh: %s", exc)
+        if not self._rebuild_api_client():
+            logger.warning("Failed to rebuild API client after Codex refresh.")
             return False
 
         return True
@@ -2144,15 +2221,8 @@ class AIAgent:
         # Nous requests should not inherit OpenRouter-only attribution headers.
         self._client_kwargs.pop("default_headers", None)
 
-        try:
-            self.client.close()
-        except Exception:
-            pass
-
-        try:
-            self.client = OpenAI(**self._client_kwargs)
-        except Exception as exc:
-            logger.warning("Failed to rebuild OpenAI client after Nous refresh: %s", exc)
+        if not self._rebuild_api_client():
+            logger.warning("Failed to rebuild API client after Nous refresh.")
             return False
 
         return True
@@ -2170,7 +2240,7 @@ class AIAgent:
 
         def _call():
             try:
-                if self.api_mode == "codex_responses":
+                if self._uses_responses_transport():
                     result["response"] = self._run_codex_stream(api_kwargs)
                 else:
                     result["response"] = self.client.chat.completions.create(**api_kwargs)
@@ -2189,7 +2259,7 @@ class AIAgent:
                     pass
                 # Rebuild the client for future calls (cheap, no network)
                 try:
-                    self.client = OpenAI(**self._client_kwargs)
+                    self.client = self._create_api_client()
                 except Exception:
                     pass
                 raise InterruptedError("Agent interrupted during API call")
@@ -2302,13 +2372,14 @@ class AIAgent:
             elif "api.kimi.com" in fb_base_url.lower():
                 client_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.0"}
 
-            self.client = OpenAI(**client_kwargs)
             self._client_kwargs = client_kwargs
             old_model = self.model
             self.model = fb_model
             self.provider = fb_provider
             self.base_url = fb_base_url
-            self.api_mode = fb_api_mode
+            self.transport = OPENAI_RESPONSES if fb_api_mode == "codex_responses" else OPENAI_CHAT_COMPLETIONS
+            self.api_mode = legacy_api_mode_for_transport(self.transport)
+            self.client = self._create_api_client()
             self._fallback_activated = True
 
             # Re-evaluate prompt caching for the new provider/model
@@ -2334,7 +2405,7 @@ class AIAgent:
 
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
-        if self.api_mode == "codex_responses":
+        if self._uses_responses_transport():
             instructions = ""
             payload_messages = api_messages
             if api_messages and api_messages[0].get("role") == "system":
@@ -2589,7 +2660,7 @@ class AIAgent:
                     "max_tokens": 5120,
                 }
                 response = aux_client.chat.completions.create(**api_kwargs, timeout=30.0)
-            elif self.api_mode == "codex_responses":
+            elif self._uses_responses_transport():
                 # No auxiliary client -- use the Codex Responses path directly
                 codex_kwargs = self._build_api_kwargs(api_messages)
                 codex_kwargs["tools"] = self._responses_tools([memory_tool_def])
@@ -2609,7 +2680,7 @@ class AIAgent:
 
             # Extract tool calls from the response, handling both API formats
             tool_calls = []
-            if self.api_mode == "codex_responses" and not aux_client:
+            if self._uses_responses_transport() and not aux_client:
                 assistant_msg, _ = self._normalize_codex_response(response)
                 if assistant_msg and assistant_msg.tool_calls:
                     tool_calls = assistant_msg.tool_calls
@@ -2989,7 +3060,7 @@ class AIAgent:
             if _is_nous:
                 summary_extra_body["tags"] = ["product=hermes-agent"]
 
-            if self.api_mode == "codex_responses":
+            if self._uses_responses_transport():
                 codex_kwargs = self._build_api_kwargs(api_messages)
                 codex_kwargs.pop("tools", None)
                 summary_response = self._run_codex_stream(codex_kwargs)
@@ -3035,7 +3106,7 @@ class AIAgent:
                     final_response = "I reached the iteration limit and couldn't generate a summary."
             else:
                 # Retry summary generation
-                if self.api_mode == "codex_responses":
+                if self._uses_responses_transport():
                     codex_kwargs = self._build_api_kwargs(api_messages)
                     codex_kwargs.pop("tools", None)
                     retry_response = self._run_codex_stream(codex_kwargs)
@@ -3419,7 +3490,7 @@ class AIAgent:
             while retry_count < max_retries:
                 try:
                     api_kwargs = self._build_api_kwargs(api_messages)
-                    if self.api_mode == "codex_responses":
+                    if self._uses_responses_transport():
                         api_kwargs = self._preflight_codex_api_kwargs(api_kwargs, allow_stream=False)
 
                     if os.getenv("HERMES_DUMP_REQUESTS", "").strip().lower() in {"1", "true", "yes", "on"}:
@@ -3448,7 +3519,7 @@ class AIAgent:
                     # Validate response shape before proceeding
                     response_invalid = False
                     error_details = []
-                    if self.api_mode == "codex_responses":
+                    if self._uses_responses_transport():
                         output_items = getattr(response, "output", None) if response is not None else None
                         if response is None:
                             response_invalid = True
@@ -3548,7 +3619,7 @@ class AIAgent:
                         continue  # Retry the API call
 
                     # Check finish_reason before proceeding
-                    if self.api_mode == "codex_responses":
+                    if self._uses_responses_transport():
                         status = getattr(response, "status", None)
                         incomplete_details = getattr(response, "incomplete_details", None)
                         incomplete_reason = None
@@ -3639,7 +3710,7 @@ class AIAgent:
                     
                     # Track actual token usage from response for context management
                     if hasattr(response, 'usage') and response.usage:
-                        if self.api_mode == "codex_responses":
+                        if self._uses_responses_transport():
                             prompt_tokens = getattr(response.usage, 'input_tokens', 0) or 0
                             completion_tokens = getattr(response.usage, 'output_tokens', 0) or 0
                             total_tokens = (
@@ -3707,7 +3778,7 @@ class AIAgent:
 
                     status_code = getattr(api_error, "status_code", None)
                     if (
-                        self.api_mode == "codex_responses"
+                        self._uses_responses_transport()
                         and self.provider == "openai-codex"
                         and status_code == 401
                         and not codex_auth_retry_attempted
@@ -3960,7 +4031,7 @@ class AIAgent:
                 break
 
             try:
-                if self.api_mode == "codex_responses":
+                if self._uses_responses_transport():
                     assistant_message, finish_reason = self._normalize_codex_response(response)
                 else:
                     assistant_message = response.choices[0].message
@@ -4043,7 +4114,7 @@ class AIAgent:
                 if hasattr(self, '_incomplete_scratchpad_retries'):
                     self._incomplete_scratchpad_retries = 0
 
-                if self.api_mode == "codex_responses" and finish_reason == "incomplete":
+                if self._uses_responses_transport() and finish_reason == "incomplete":
                     if not hasattr(self, "_codex_incomplete_retries"):
                         self._codex_incomplete_retries = 0
                     self._codex_incomplete_retries += 1
@@ -4311,7 +4382,7 @@ class AIAgent:
                         self._empty_content_retries = 0
 
                     if (
-                        self.api_mode == "codex_responses"
+                        self._uses_responses_transport()
                         and self.valid_tool_names
                         and codex_ack_continuations < 2
                         and self._looks_like_codex_intermediate_ack(

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -21,6 +21,7 @@ def test_resolve_runtime_provider_codex(monkeypatch):
 
     assert resolved["provider"] == "openai-codex"
     assert resolved["api_mode"] == "codex_responses"
+    assert resolved["transport"] == "openai_responses"
     assert resolved["base_url"] == "https://chatgpt.com/backend-api/codex"
     assert resolved["api_key"] == "codex-token"
     assert resolved["requested_provider"] == "openai-codex"
@@ -42,6 +43,7 @@ def test_resolve_runtime_provider_openrouter_explicit(monkeypatch):
 
     assert resolved["provider"] == "openrouter"
     assert resolved["api_mode"] == "chat_completions"
+    assert resolved["transport"] == "openai_chat_completions"
     assert resolved["api_key"] == "test-key"
     assert resolved["base_url"] == "https://example.com/v1"
     assert resolved["source"] == "explicit"
@@ -176,6 +178,7 @@ def test_resolve_runtime_provider_nous_api(monkeypatch):
 
     assert resolved["provider"] == "nous-api"
     assert resolved["api_mode"] == "chat_completions"
+    assert resolved["transport"] == "openai_chat_completions"
     assert resolved["base_url"] == "https://inference-api.nousresearch.com/v1"
     assert resolved["api_key"] == "nous-test-key"
     assert resolved["requested_provider"] == "nous-api"

--- a/tests/test_transport_adapters.py
+++ b/tests/test_transport_adapters.py
@@ -1,0 +1,152 @@
+import json
+
+import httpx
+
+from agent.transport_adapters import AnthropicMessagesClient, GoogleGenerateContentClient
+
+
+def _tool_def(name="web_search"):
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"{name} tool",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+            },
+        },
+    }
+
+
+def test_anthropic_messages_client_converts_request_and_response(monkeypatch):
+    client = AnthropicMessagesClient(base_url="https://api.example.test/v1", api_key="ant-key")
+    captured = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_123",
+                "model": "claude-sonnet-4-6",
+                "content": [
+                    {"type": "text", "text": "Found it."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "web_search",
+                        "input": {"query": "Hermes"},
+                    },
+                ],
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 11, "output_tokens": 7, "cache_read_input_tokens": 2},
+            },
+            request=request,
+        )
+
+    monkeypatch.setattr(client._client, "post", fake_post)
+    response = client.chat.completions.create(
+        model="claude-sonnet-4-6",
+        messages=[
+            {"role": "system", "content": "Be terse."},
+            {"role": "user", "content": "Search for Hermes"},
+        ],
+        tools=[_tool_def()],
+        max_tokens=512,
+        timeout=12.0,
+    )
+
+    assert captured["url"] == "https://api.example.test/v1/messages"
+    assert captured["headers"]["x-api-key"] == "ant-key"
+    assert captured["headers"]["anthropic-version"] == "2023-06-01"
+    assert captured["timeout"] == 12.0
+    assert captured["json"]["model"] == "claude-sonnet-4-6"
+    assert captured["json"]["system"] == [{"type": "text", "text": "Be terse."}]
+    assert captured["json"]["tools"][0]["name"] == "web_search"
+    assert response.choices[0].finish_reason == "tool_calls"
+    assert response.choices[0].message.content == "Found it."
+    assert response.choices[0].message.tool_calls[0].function.name == "web_search"
+    assert json.loads(response.choices[0].message.tool_calls[0].function.arguments) == {"query": "Hermes"}
+    assert response.usage.prompt_tokens == 11
+    assert response.usage.prompt_tokens_details.cached_tokens == 2
+
+
+def test_google_generate_content_client_converts_request_and_response(monkeypatch):
+    client = GoogleGenerateContentClient(base_url="https://opencode.ai/zen/v1", api_key="goo-key")
+    captured = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200,
+            json={
+                "responseId": "resp_google_1",
+                "candidates": [
+                    {
+                        "content": {
+                            "role": "model",
+                            "parts": [
+                                {"text": "Need a tool."},
+                                {"functionCall": {"name": "web_search", "args": {"query": "Hermes"}}},
+                            ],
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 13,
+                    "candidatesTokenCount": 5,
+                    "totalTokenCount": 18,
+                    "cachedContentTokenCount": 4,
+                    "thoughtsTokenCount": 3,
+                },
+            },
+            request=request,
+        )
+
+    monkeypatch.setattr(client._client, "post", fake_post)
+    response = client.chat.completions.create(
+        model="gemini-3-pro",
+        messages=[
+            {"role": "system", "content": "Use tools when needed."},
+            {"role": "user", "content": "Search for Hermes"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": '{"query": "Hermes"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": '{"result": "done"}'},
+        ],
+        tools=[_tool_def()],
+        max_tokens=256,
+        timeout=9.0,
+    )
+
+    assert captured["url"] == "https://opencode.ai/zen/v1/models/gemini-3-pro:generateContent"
+    assert captured["headers"]["x-goog-api-key"] == "goo-key"
+    assert captured["timeout"] == 9.0
+    assert captured["json"]["systemInstruction"] == {"parts": [{"text": "Use tools when needed."}]}
+    assert captured["json"]["tools"][0]["functionDeclarations"][0]["name"] == "web_search"
+    assert any(part.get("functionCall") for part in captured["json"]["contents"][1]["parts"])
+    assert any(part.get("functionResponse") for part in captured["json"]["contents"][2]["parts"])
+    assert response.choices[0].finish_reason == "tool_calls"
+    assert response.choices[0].message.content == "Need a tool."
+    assert response.choices[0].message.tool_calls[0].function.name == "web_search"
+    assert json.loads(response.choices[0].message.tool_calls[0].function.arguments) == {"query": "Hermes"}
+    assert response.usage.prompt_tokens == 13
+    assert response.usage.completion_tokens_details.reasoning_tokens == 3

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -205,6 +205,7 @@ def _run_single_child(
             model=model or parent_agent.model,
             provider=getattr(parent_agent, "provider", None),
             api_mode=getattr(parent_agent, "api_mode", None),
+            transport=getattr(parent_agent, "transport", None),
             max_iterations=max_iterations,
             max_tokens=getattr(parent_agent, "max_tokens", None),
             reasoning_config=getattr(parent_agent, "reasoning_config", None),


### PR DESCRIPTION
## Summary
- add explicit runtime transport profiles so execution can be resolved from `provider + model`
- generalize OpenAI Responses support beyond the Codex-specific path
- add transport adapters for Anthropic Messages and Google GenerateContent while preserving existing provider behavior

## Why
Hermes currently resolves one runtime protocol per provider. That works for providers like OpenRouter or Codex, but it is too narrow for providers whose supported protocol depends on the selected model family.

OpenCode Zen is the motivating case:
- GPT models use OpenAI Responses
- Claude models use Anthropic Messages
- Gemini models use Google's GenerateContent transport
- other OpenCode models use OpenAI-compatible chat completions

Without an explicit transport profile, Hermes cannot add first-class OpenCode support cleanly.

## What changed
- add `hermes_cli.transport_profiles` with explicit transports and legacy `api_mode` compatibility
- route runtime resolution through transport profiles instead of provider-wide `api_mode` assumptions
- add lightweight protocol adapters in `agent.transport_adapters` for:
  - Anthropic Messages
  - Google GenerateContent
- keep existing providers behaviorally unchanged unless a caller opts into the new transport metadata
- preserve current Codex tests and backward-compatible wrapper methods while shifting Responses handling to a generic transport path

## Validation
- `./.venv/bin/python -m py_compile hermes_cli/transport_profiles.py hermes_cli/runtime_provider.py agent/transport_adapters.py run_agent.py cli.py gateway/run.py cron/scheduler.py tools/delegate_tool.py`
- `./.venv/bin/pytest tests/test_runtime_provider_resolution.py tests/test_transport_adapters.py tests/test_provider_parity.py tests/test_run_agent_codex_responses.py tests/test_cli_provider_resolution.py tests/test_api_key_providers.py -q`

## Notes
- This is the enabling layer for first-class OpenCode Go / OpenCode Zen support.
- Follow-up provider/onboarding support is prepared separately so the runtime abstraction stays reviewable on its own.
- This follows the design concerns raised in #765 without changing existing provider UX in the same PR.
