### PR TITLE
feat(providers): add OpenCode Go and Zen support

### DIFF
--- a/agent/transport_adapters.py
+++ b/agent/transport_adapters.py
@@ -1,0 +1,460 @@
+"""Protocol adapters for non-OpenAI chat transports.
+
+These adapters expose an OpenAI chat-completions-like interface so Hermes can
+keep its tool loop and message store stable while routing requests to providers
+that speak Anthropic Messages or Google GenerateContent.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, Dict, Iterable, List, Optional
+
+import httpx
+
+
+def _ns(value: Any) -> Any:
+    if isinstance(value, dict):
+        return SimpleNamespace(**{k: _ns(v) for k, v in value.items()})
+    if isinstance(value, list):
+        return [_ns(v) for v in value]
+    return value
+
+
+class _CompletionsNamespace:
+    def __init__(self, adapter: Any):
+        self.create = adapter.create
+
+
+class _ChatNamespace:
+    def __init__(self, adapter: Any):
+        self.completions = _CompletionsNamespace(adapter)
+
+
+class _BaseTransportClient:
+    def __init__(self, *, base_url: str, api_key: str, default_headers: Optional[dict[str, str]] = None):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self._default_headers = dict(default_headers or {})
+        self._client = httpx.Client(headers=self._default_headers)
+        self.chat = _ChatNamespace(self)
+
+    def close(self):
+        self._client.close()
+
+    def create(self, **kwargs):
+        raise NotImplementedError
+
+
+class AnthropicMessagesClient(_BaseTransportClient):
+    """Expose Anthropic Messages as chat.completions.create()."""
+
+    def create(self, **kwargs):
+        timeout = kwargs.pop("timeout", None)
+        payload = _to_anthropic_request(kwargs)
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": "2023-06-01",
+        }
+        response = self._client.post(
+            f"{self.base_url}/messages",
+            json=payload,
+            headers=headers,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        return _from_anthropic_response(response.json(), kwargs.get("model"))
+
+
+class GoogleGenerateContentClient(_BaseTransportClient):
+    """Expose Google GenerateContent as chat.completions.create()."""
+
+    def create(self, **kwargs):
+        timeout = kwargs.pop("timeout", None)
+        model = (kwargs.get("model") or "").strip()
+        if not model:
+            raise ValueError("Google transport requires a non-empty model id.")
+        payload = _to_google_generate_content_request(kwargs)
+        response = self._client.post(
+            f"{self.base_url}/models/{model}:generateContent",
+            json=payload,
+            headers={"x-goog-api-key": self.api_key},
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        return _from_google_generate_content_response(response.json(), model)
+
+
+# -- Anthropic conversion -------------------------------------------------
+
+
+def _normalize_openai_tools(tools: Any) -> Optional[list[dict[str, Any]]]:
+    if not isinstance(tools, list):
+        return None
+    normalized = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function", {}) if tool.get("type") == "function" else {}
+        name = fn.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        normalized.append(
+            {
+                "name": name.strip(),
+                "description": fn.get("description", ""),
+                "input_schema": fn.get("parameters", {"type": "object", "properties": {}}),
+            }
+        )
+    return normalized or None
+
+
+def _coerce_json_object(raw: Any) -> Any:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return {}
+        try:
+            return json.loads(stripped)
+        except Exception:
+            return {"value": stripped}
+    return raw if raw is not None else {}
+
+
+def _to_anthropic_request(kwargs: dict[str, Any]) -> dict[str, Any]:
+    messages = kwargs.get("messages") or []
+    system_blocks: list[dict[str, Any]] = []
+    anthropic_messages: list[dict[str, Any]] = []
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        content = message.get("content")
+        if role == "system":
+            text = content if isinstance(content, str) else ""
+            if text:
+                system_blocks.append({"type": "text", "text": text})
+            continue
+
+        if role == "user":
+            if isinstance(content, str):
+                anthropic_messages.append({"role": "user", "content": [{"type": "text", "text": content}]})
+            elif isinstance(content, list):
+                parts = []
+                for part in content:
+                    if not isinstance(part, dict):
+                        continue
+                    if part.get("type") == "text" and isinstance(part.get("text"), str):
+                        parts.append({"type": "text", "text": part["text"]})
+                if parts:
+                    anthropic_messages.append({"role": "user", "content": parts})
+            continue
+
+        if role == "assistant":
+            parts: list[dict[str, Any]] = []
+            if isinstance(content, str) and content:
+                parts.append({"type": "text", "text": content})
+            tool_calls = message.get("tool_calls")
+            if isinstance(tool_calls, list):
+                for tool_call in tool_calls:
+                    if not isinstance(tool_call, dict):
+                        continue
+                    fn = tool_call.get("function", {})
+                    name = fn.get("name")
+                    if not isinstance(name, str) or not name.strip():
+                        continue
+                    parts.append(
+                        {
+                            "type": "tool_use",
+                            "id": tool_call.get("id") or tool_call.get("call_id") or "tool_call",
+                            "name": name.strip(),
+                            "input": _coerce_json_object(fn.get("arguments", {})),
+                        }
+                    )
+            if parts:
+                anthropic_messages.append({"role": "assistant", "content": parts})
+            continue
+
+        if role == "tool":
+            anthropic_messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": message.get("tool_call_id", ""),
+                            "content": str(message.get("content", "") or ""),
+                        }
+                    ],
+                }
+            )
+
+    payload: dict[str, Any] = {
+        "model": kwargs.get("model"),
+        "messages": anthropic_messages,
+        "stream": False,
+        "max_tokens": int(kwargs.get("max_tokens") or 32000),
+    }
+    if system_blocks:
+        payload["system"] = system_blocks
+    if kwargs.get("temperature") is not None:
+        payload["temperature"] = kwargs["temperature"]
+    if kwargs.get("top_p") is not None:
+        payload["top_p"] = kwargs["top_p"]
+    tools = _normalize_openai_tools(kwargs.get("tools"))
+    if tools:
+        payload["tools"] = tools
+    return payload
+
+
+def _from_anthropic_response(data: dict[str, Any], model: Optional[str]) -> Any:
+    blocks = data.get("content") or []
+    text_parts: list[str] = []
+    tool_calls: list[Any] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text" and isinstance(block.get("text"), str):
+            text_parts.append(block["text"])
+        elif block_type == "tool_use":
+            tool_calls.append(
+                SimpleNamespace(
+                    id=block.get("id") or "toolu_generated",
+                    type="function",
+                    function=SimpleNamespace(
+                        name=block.get("name", ""),
+                        arguments=json.dumps(block.get("input", {}), ensure_ascii=False),
+                    ),
+                )
+            )
+
+    stop_reason = data.get("stop_reason")
+    finish_reason = {
+        "end_turn": "stop",
+        "tool_use": "tool_calls",
+        "max_tokens": "length",
+        "content_filter": "content_filter",
+    }.get(stop_reason, None)
+
+    usage = data.get("usage") or {}
+    prompt_tokens = usage.get("input_tokens")
+    completion_tokens = usage.get("output_tokens")
+    cached_tokens = usage.get("cache_read_input_tokens")
+    usage_ns = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=(prompt_tokens or 0) + (completion_tokens or 0),
+        prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens) if cached_tokens is not None else None,
+    )
+
+    message = SimpleNamespace(
+        role="assistant",
+        content="".join(text_parts),
+        tool_calls=tool_calls or None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    choice = SimpleNamespace(index=0, message=message, finish_reason=finish_reason)
+    return SimpleNamespace(
+        id=data.get("id"),
+        object="chat.completion",
+        created=0,
+        model=data.get("model") or model,
+        choices=[choice],
+        usage=usage_ns,
+    )
+
+
+# -- Google conversion ----------------------------------------------------
+
+
+def _tool_name_map(messages: Iterable[dict[str, Any]]) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            fn = tool_call.get("function", {})
+            name = fn.get("name")
+            call_id = tool_call.get("id") or tool_call.get("call_id")
+            if isinstance(name, str) and name and isinstance(call_id, str) and call_id:
+                mapping[call_id] = name
+    return mapping
+
+
+def _to_google_generate_content_request(kwargs: dict[str, Any]) -> dict[str, Any]:
+    messages = kwargs.get("messages") or []
+    call_names = _tool_name_map(messages)
+    contents: list[dict[str, Any]] = []
+    system_parts: list[dict[str, Any]] = []
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        content = message.get("content")
+        if role == "system":
+            if isinstance(content, str) and content:
+                system_parts.append({"text": content})
+            continue
+
+        if role == "user":
+            if isinstance(content, str) and content:
+                contents.append({"role": "user", "parts": [{"text": content}]})
+            elif isinstance(content, list):
+                parts = [
+                    {"text": part.get("text")}
+                    for part in content
+                    if isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str)
+                ]
+                if parts:
+                    contents.append({"role": "user", "parts": parts})
+            continue
+
+        if role == "assistant":
+            parts: list[dict[str, Any]] = []
+            if isinstance(content, str) and content:
+                parts.append({"text": content})
+            tool_calls = message.get("tool_calls")
+            if isinstance(tool_calls, list):
+                for tool_call in tool_calls:
+                    if not isinstance(tool_call, dict):
+                        continue
+                    fn = tool_call.get("function", {})
+                    name = fn.get("name")
+                    if not isinstance(name, str) or not name.strip():
+                        continue
+                    parts.append(
+                        {
+                            "functionCall": {
+                                "name": name.strip(),
+                                "args": _coerce_json_object(fn.get("arguments", {})),
+                            }
+                        }
+                    )
+            if parts:
+                contents.append({"role": "model", "parts": parts})
+            continue
+
+        if role == "tool":
+            call_id = message.get("tool_call_id", "")
+            name = call_names.get(call_id, "tool")
+            result_text = str(message.get("content", "") or "")
+            try:
+                payload = json.loads(result_text)
+            except Exception:
+                payload = {"content": result_text}
+            contents.append(
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "functionResponse": {
+                                "name": name,
+                                "response": payload,
+                            }
+                        }
+                    ],
+                }
+            )
+
+    generation_config: dict[str, Any] = {}
+    if kwargs.get("temperature") is not None:
+        generation_config["temperature"] = kwargs["temperature"]
+    if kwargs.get("top_p") is not None:
+        generation_config["topP"] = kwargs["top_p"]
+    if kwargs.get("max_tokens") is not None:
+        generation_config["maxOutputTokens"] = kwargs["max_tokens"]
+
+    payload: dict[str, Any] = {"contents": contents}
+    if system_parts:
+        payload["systemInstruction"] = {"parts": system_parts}
+    if generation_config:
+        payload["generationConfig"] = generation_config
+
+    tools = _normalize_openai_tools(kwargs.get("tools"))
+    if tools:
+        payload["tools"] = [{"functionDeclarations": tools}]
+    return payload
+
+
+def _from_google_generate_content_response(data: dict[str, Any], model: str) -> Any:
+    candidates = data.get("candidates") or []
+    candidate = candidates[0] if candidates else {}
+    content = candidate.get("content") or {}
+    parts = content.get("parts") or []
+
+    text_parts: list[str] = []
+    tool_calls: list[Any] = []
+    for index, part in enumerate(parts):
+        if not isinstance(part, dict):
+            continue
+        text = part.get("text")
+        if isinstance(text, str) and text:
+            text_parts.append(text)
+        function_call = part.get("functionCall") or part.get("function_call")
+        if isinstance(function_call, dict):
+            arguments = function_call.get("args", {})
+            if isinstance(arguments, str):
+                arg_text = arguments
+            else:
+                arg_text = json.dumps(arguments, ensure_ascii=False)
+            tool_call = SimpleNamespace(
+                id=function_call.get("id") or f"call_google_{index}",
+                type="function",
+                function=SimpleNamespace(
+                    name=function_call.get("name", ""),
+                    arguments=arg_text,
+                ),
+            )
+            tool_calls.append(tool_call)
+
+    finish_reason = {
+        "STOP": "stop",
+        "MAX_TOKENS": "length",
+        "SAFETY": "content_filter",
+    }.get(candidate.get("finishReason"), None)
+    if tool_calls:
+        finish_reason = "tool_calls"
+
+    usage = data.get("usageMetadata") or {}
+    prompt_tokens = usage.get("promptTokenCount")
+    completion_tokens = usage.get("candidatesTokenCount")
+    reasoning_tokens = usage.get("thoughtsTokenCount")
+    cached_tokens = usage.get("cachedContentTokenCount")
+    usage_ns = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=usage.get("totalTokenCount") or ((prompt_tokens or 0) + (completion_tokens or 0)),
+        prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens) if cached_tokens is not None else None,
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=reasoning_tokens) if reasoning_tokens is not None else None,
+    )
+
+    message = SimpleNamespace(
+        role="assistant",
+        content="".join(text_parts),
+        tool_calls=tool_calls or None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    choice = SimpleNamespace(index=0, message=message, finish_reason=finish_reason)
+    return SimpleNamespace(
+        id=data.get("responseId") or "google-generate-content",
+        object="chat.completion",
+        created=0,
+        model=model,
+        choices=[choice],
+        usage=usage_ns,
+    )

--- a/cli.py
+++ b/cli.py
@@ -2628,20 +2628,25 @@ class HermesCLI:
                 target_provider, new_model = parse_model_input(raw_input, current_provider)
                 provider_changed = target_provider != current_provider
 
-                # If provider is changing, re-resolve credentials for the new provider
+                # Always resolve runtime credentials for the target provider before
+                # validating the requested model. The shell can start with a stale
+                # base URL from env/config that does not match the active provider.
                 api_key_for_probe = self.api_key
                 base_url_for_probe = self.base_url
-                if provider_changed:
-                    try:
-                        from hermes_cli.runtime_provider import resolve_runtime_provider
-                        runtime = resolve_runtime_provider(requested=target_provider)
-                        api_key_for_probe = runtime.get("api_key", "")
-                        base_url_for_probe = runtime.get("base_url", "")
-                    except Exception as e:
-                        provider_label = _PROVIDER_LABELS.get(target_provider, target_provider)
-                        print(f"(>_<) Could not resolve credentials for provider '{provider_label}': {e}")
-                        print(f"(^_^) Current model unchanged: {self.model}")
-                        return True
+                try:
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
+                    runtime = resolve_runtime_provider(requested=target_provider)
+                    api_key_for_probe = runtime.get("api_key", "")
+                    base_url_for_probe = runtime.get("base_url", "")
+                    self.requested_provider = target_provider
+                    self.provider = target_provider
+                    self.api_key = api_key_for_probe
+                    self.base_url = base_url_for_probe
+                except Exception as e:
+                    provider_label = _PROVIDER_LABELS.get(target_provider, target_provider)
+                    print(f"(>_<) Could not resolve credentials for provider '{provider_label}': {e}")
+                    print(f"(^_^) Current model unchanged: {self.model}")
+                    return True
 
                 try:
                     validation = validate_requested_model(
@@ -2661,12 +2666,6 @@ class HermesCLI:
                 else:
                     self.model = new_model
                     self.agent = None  # Force re-init
-
-                    if provider_changed:
-                        self.requested_provider = target_provider
-                        self.provider = target_provider
-                        self.api_key = api_key_for_probe
-                        self.base_url = base_url_for_probe
 
                     provider_label = _PROVIDER_LABELS.get(target_provider, target_provider)
                     provider_note = f" [provider: {provider_label}]" if provider_changed else ""

--- a/cli.py
+++ b/cli.py
@@ -1133,6 +1133,7 @@ class HermesCLI:
         self._provider_source: Optional[str] = None
         self.provider = self.requested_provider
         self.api_mode = "chat_completions"
+        self.transport = "openai_chat_completions"
         self.base_url = (
             base_url
             or os.getenv("OPENAI_BASE_URL")
@@ -1331,6 +1332,7 @@ class HermesCLI:
         base_url = runtime.get("base_url")
         resolved_provider = runtime.get("provider", "openrouter")
         resolved_api_mode = runtime.get("api_mode", self.api_mode)
+        resolved_transport = runtime.get("transport", self.transport)
         if not isinstance(api_key, str) or not api_key:
             self.console.print("[bold red]Provider resolver returned an empty API key.[/]")
             return False
@@ -1342,9 +1344,11 @@ class HermesCLI:
         routing_changed = (
             resolved_provider != self.provider
             or resolved_api_mode != self.api_mode
+            or resolved_transport != self.transport
         )
         self.provider = resolved_provider
         self.api_mode = resolved_api_mode
+        self.transport = resolved_transport
         self._provider_source = runtime.get("source")
         self.api_key = api_key
         self.base_url = base_url
@@ -1423,6 +1427,7 @@ class HermesCLI:
                 base_url=self.base_url,
                 provider=self.provider,
                 api_mode=self.api_mode,
+                transport=self.transport,
                 max_iterations=self.max_turns,
                 enabled_toolsets=self.enabled_toolsets,
                 verbose_logging=self.verbose,

--- a/cli.py
+++ b/cli.py
@@ -1322,6 +1322,7 @@ class HermesCLI:
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                model=self.model,
             )
         except Exception as exc:
             message = format_runtime_provider_error(exc)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -235,6 +235,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         try:
             runtime = resolve_runtime_provider(
                 requested=os.getenv("HERMES_INFERENCE_PROVIDER"),
+                model=model,
             )
         except Exception as exc:
             message = format_runtime_provider_error(exc)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -246,6 +246,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             base_url=runtime.get("base_url"),
             provider=runtime.get("provider"),
             api_mode=runtime.get("api_mode"),
+            transport=runtime.get("transport"),
             max_iterations=max_iterations,
             reasoning_config=reasoning_config,
             prefill_messages=prefill_messages,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -165,16 +165,33 @@ from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageTyp
 logger = logging.getLogger(__name__)
 
 
-def _resolve_runtime_agent_kwargs() -> dict:
+def _resolve_runtime_agent_kwargs(model: Optional[str] = None) -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances."""
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
     )
 
+    resolved_model = (model or "").strip()
+    if not resolved_model:
+        try:
+            import yaml as _yaml
+
+            if _config_path.exists():
+                with open(_config_path, encoding="utf-8") as _f:
+                    _cfg = _yaml.safe_load(_f) or {}
+                _model_cfg = _cfg.get("model", {})
+                if isinstance(_model_cfg, str):
+                    resolved_model = _model_cfg.strip()
+                elif isinstance(_model_cfg, dict):
+                    resolved_model = str(_model_cfg.get("default", "") or "").strip()
+        except Exception:
+            resolved_model = ""
+
     try:
         runtime = resolve_runtime_provider(
             requested=os.getenv("HERMES_INFERENCE_PROVIDER"),
+            model=resolved_model or None,
         )
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
@@ -2797,7 +2814,7 @@ class GatewayRunner:
                 pass
 
             try:
-                runtime_kwargs = _resolve_runtime_agent_kwargs()
+                runtime_kwargs = _resolve_runtime_agent_kwargs(model=model)
             except Exception as exc:
                 return {
                     "final_response": f"⚠️ Provider authentication failed: {exc}",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -184,6 +184,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
         "api_mode": runtime.get("api_mode"),
+        "transport": runtime.get("transport"),
     }
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -90,6 +90,8 @@ class ProviderConfig:
     api_key_env_vars: tuple = ()
     # Optional env var for base URL override
     base_url_env_var: str = ""
+    # Whether resolve_provider("auto") may infer this provider from env vars alone.
+    auto_detect: bool = True
 
 
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
@@ -147,6 +149,22 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://api.minimaxi.com/v1",
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
+    ),
+    "opencode-go": ProviderConfig(
+        id="opencode-go",
+        name="OpenCode Go",
+        auth_type="api_key",
+        inference_base_url="https://opencode.ai/zen/go/v1",
+        api_key_env_vars=("OPENCODE_API_KEY",),
+        auto_detect=False,
+    ),
+    "opencode-zen": ProviderConfig(
+        id="opencode-zen",
+        name="OpenCode Zen",
+        auth_type="api_key",
+        inference_base_url="https://opencode.ai/zen/v1",
+        api_key_env_vars=("OPENCODE_API_KEY",),
+        auto_detect=False,
     ),
 }
 
@@ -525,6 +543,7 @@ def resolve_provider(
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "kimi": "kimi-coding", "moonshot": "kimi-coding",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
+        "opencode_go": "opencode-go", "opencode_zen": "opencode-zen",
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 
@@ -559,6 +578,8 @@ def resolve_provider(
     # Auto-detect API-key providers by checking their env vars
     for pid, pconfig in PROVIDER_REGISTRY.items():
         if pconfig.auth_type != "api_key":
+            continue
+        if not pconfig.auto_detect:
             continue
         for env_var in pconfig.api_key_env_vars:
             if os.getenv(env_var, "").strip():
@@ -1589,8 +1610,13 @@ def _reset_config_provider() -> Path:
     return config_path
 
 
-def _prompt_model_selection(model_ids: List[str], current_model: str = "") -> Optional[str]:
-    """Interactive model selection. Puts current_model first with a marker. Returns chosen model ID or None."""
+def _prompt_model_selection(
+    model_ids: List[str],
+    current_model: str = "",
+    *,
+    allow_custom: bool = True,
+) -> Optional[str]:
+    """Interactive model selection. Puts current_model first with a marker."""
     # Reorder: current model first, then the rest (deduplicated)
     ordered = []
     if current_model and current_model in model_ids:
@@ -1612,7 +1638,8 @@ def _prompt_model_selection(model_ids: List[str], current_model: str = "") -> Op
     try:
         from simple_term_menu import TerminalMenu
         choices = [f"  {_label(mid)}" for mid in ordered]
-        choices.append("  Enter custom model name")
+        if allow_custom:
+            choices.append("  Enter custom model name")
         choices.append("  Skip (keep current)")
         menu = TerminalMenu(
             choices,
@@ -1630,7 +1657,7 @@ def _prompt_model_selection(model_ids: List[str], current_model: str = "") -> Op
         print()
         if idx < len(ordered):
             return ordered[idx]
-        elif idx == len(ordered):
+        elif allow_custom and idx == len(ordered):
             custom = input("Enter model name: ").strip()
             return custom if custom else None
         return None
@@ -1642,24 +1669,29 @@ def _prompt_model_selection(model_ids: List[str], current_model: str = "") -> Op
     for i, mid in enumerate(ordered, 1):
         print(f"  {i}. {_label(mid)}")
     n = len(ordered)
-    print(f"  {n + 1}. Enter custom model name")
-    print(f"  {n + 2}. Skip (keep current)")
+    if allow_custom:
+        print(f"  {n + 1}. Enter custom model name")
+        print(f"  {n + 2}. Skip (keep current)")
+        max_choice = n + 2
+    else:
+        print(f"  {n + 1}. Skip (keep current)")
+        max_choice = n + 1
     print()
 
     while True:
         try:
-            choice = input(f"Choice [1-{n + 2}] (default: skip): ").strip()
+            choice = input(f"Choice [1-{max_choice}] (default: skip): ").strip()
             if not choice:
                 return None
             idx = int(choice)
             if 1 <= idx <= n:
                 return ordered[idx - 1]
-            elif idx == n + 1:
+            elif allow_custom and idx == n + 1:
                 custom = input("Enter model name: ").strip()
                 return custom if custom else None
-            elif idx == n + 2:
+            elif idx == max_choice:
                 return None
-            print(f"Please enter 1-{n + 2}")
+            print(f"Please enter 1-{max_choice}")
         except ValueError:
             print("Please enter a number")
         except (KeyboardInterrupt, EOFError):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -69,8 +69,22 @@ def _has_any_provider_configured() -> bool:
 
     # Collect all provider env vars
     provider_env_vars = {"OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_BASE_URL"}
-    for pconfig in PROVIDER_REGISTRY.values():
-        if pconfig.auth_type == "api_key":
+    explicit_provider = os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower()
+    try:
+        from hermes_cli.config import load_config
+
+        model_cfg = load_config().get("model", {})
+        if not explicit_provider and isinstance(model_cfg, dict):
+            explicit_provider = str(model_cfg.get("provider", "") or "").strip().lower()
+    except Exception:
+        pass
+
+    for pid, pconfig in PROVIDER_REGISTRY.items():
+        if pconfig.auth_type != "api_key":
+            continue
+        if not pconfig.auto_detect and pid != explicit_provider:
+            continue
+        if pconfig.api_key_env_vars:
             provider_env_vars.update(pconfig.api_key_env_vars)
     if any(os.getenv(v) for v in provider_env_vars):
         return True
@@ -738,6 +752,8 @@ def cmd_model(args):
 
     provider_labels = {
         "openrouter": "OpenRouter",
+        "opencode-go": "OpenCode Go",
+        "opencode-zen": "OpenCode Zen",
         "nous": "Nous Portal",
         "openai-codex": "OpenAI Codex",
         "zai": "Z.AI / GLM",
@@ -756,6 +772,8 @@ def cmd_model(args):
     # Step 1: Provider selection — put active provider first with marker
     providers = [
         ("openrouter", "OpenRouter (100+ models, pay-per-use)"),
+        ("opencode-go", "OpenCode Go (shared OpenCode API key, curated open models)"),
+        ("opencode-zen", "OpenCode Zen (shared OpenCode API key, curated multi-provider gateway)"),
         ("nous", "Nous Portal (Nous Research subscription)"),
         ("openai-codex", "OpenAI Codex"),
         ("zai", "Z.AI / GLM (Zhipu AI direct API)"),
@@ -826,7 +844,7 @@ def cmd_model(args):
         _model_flow_named_custom(config, _custom_provider_map[selected_provider])
     elif selected_provider == "remove-custom":
         _remove_custom_provider(config)
-    elif selected_provider in ("zai", "kimi-coding", "minimax", "minimax-cn"):
+    elif selected_provider in ("zai", "kimi-coding", "minimax", "minimax-cn", "opencode-go", "opencode-zen"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
 
@@ -1320,40 +1338,17 @@ def _model_flow_named_custom(config, provider_info):
     print(f"   Provider: {name} ({base_url})")
 
 
-# Curated model lists for direct API-key providers
-_PROVIDER_MODELS = {
-    "zai": [
-        "glm-5",
-        "glm-4.7",
-        "glm-4.5",
-        "glm-4.5-flash",
-    ],
-    "kimi-coding": [
-        "kimi-k2.5",
-        "kimi-k2-thinking",
-        "kimi-k2-turbo-preview",
-        "kimi-k2-0905-preview",
-    ],
-    "minimax": [
-        "MiniMax-M2.5",
-        "MiniMax-M2.5-highspeed",
-        "MiniMax-M2.1",
-    ],
-    "minimax-cn": [
-        "MiniMax-M2.5",
-        "MiniMax-M2.5-highspeed",
-        "MiniMax-M2.1",
-    ],
-}
-
-
 def _model_flow_api_key_provider(config, provider_id, current_model=""):
-    """Generic flow for API-key providers (z.ai, Kimi, MiniMax)."""
+    """Generic flow for direct API-key providers."""
     from hermes_cli.auth import (
         PROVIDER_REGISTRY, _prompt_model_selection, _save_model_choice,
-        _update_config_for_provider, deactivate_provider,
+        deactivate_provider,
     )
     from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
+    from hermes_cli.models import (
+        curated_model_specs,
+        provider_requires_explicit_model_mapping,
+    )
 
     pconfig = PROVIDER_REGISTRY[provider_id]
     key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
@@ -1390,19 +1385,24 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         current_base = get_env_value(base_url_env) or os.getenv(base_url_env, "")
     effective_base = current_base or pconfig.inference_base_url
 
-    try:
-        override = input(f"Base URL [{effective_base}]: ").strip()
-    except (KeyboardInterrupt, EOFError):
-        print()
-        override = ""
-    if override and base_url_env:
-        save_env_value(base_url_env, override)
-        effective_base = override
+    if base_url_env:
+        try:
+            override = input(f"Base URL [{effective_base}]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            override = ""
+        if override:
+            save_env_value(base_url_env, override)
+            effective_base = override
 
-    # Model selection
-    model_list = _PROVIDER_MODELS.get(provider_id, [])
+    model_specs = curated_model_specs(provider_id)
+    model_list = [entry.id for entry in model_specs]
     if model_list:
-        selected = _prompt_model_selection(model_list, current_model=current_model)
+        selected = _prompt_model_selection(
+            model_list,
+            current_model=current_model,
+            allow_custom=not provider_requires_explicit_model_mapping(provider_id),
+        )
     else:
         try:
             selected = input("Model name: ").strip()

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1,68 +1,137 @@
 """
-Canonical model catalogs and lightweight validation helpers.
+Canonical model catalogs and provider-aware validation helpers.
 
-Add, remove, or reorder entries here — both `hermes setup` and
-`hermes` provider-selection will pick up the change automatically.
+Add, remove, or reorder entries here — `hermes setup`, `hermes model`, and
+runtime transport resolution all use the same provider/model definitions.
 """
 
 from __future__ import annotations
 
 import json
-import urllib.request
 import urllib.error
+import urllib.request
+from dataclasses import dataclass
 from difflib import get_close_matches
 from typing import Any, Optional
 
+from hermes_cli.transport_profiles import (
+    ANTHROPIC_MESSAGES,
+    GOOGLE_GENERATE_CONTENT,
+    OPENAI_CHAT_COMPLETIONS,
+    OPENAI_RESPONSES,
+)
+
+
+@dataclass(frozen=True)
+class CuratedModel:
+    id: str
+    description: str = ""
+    transport: Optional[str] = None
+
+
 # (model_id, display description shown in menus)
 OPENROUTER_MODELS: list[tuple[str, str]] = [
-    ("anthropic/claude-opus-4.6",       "recommended"),
-    ("anthropic/claude-sonnet-4.5",     ""),
-    ("openai/gpt-5.4-pro",              ""),
-    ("openai/gpt-5.4",                  ""),
-    ("openai/gpt-5.3-codex",            ""),
-    ("google/gemini-3-pro-preview",     ""),
-    ("google/gemini-3-flash-preview",   ""),
-    ("qwen/qwen3.5-plus-02-15",         ""),
-    ("qwen/qwen3.5-35b-a3b",            ""),
-    ("stepfun/step-3.5-flash",          ""),
-    ("z-ai/glm-5",                      ""),
-    ("moonshotai/kimi-k2.5",            ""),
-    ("minimax/minimax-m2.5",            ""),
+    ("anthropic/claude-opus-4.6", "recommended"),
+    ("anthropic/claude-sonnet-4.5", ""),
+    ("openai/gpt-5.4-pro", ""),
+    ("openai/gpt-5.4", ""),
+    ("openai/gpt-5.3-codex", ""),
+    ("google/gemini-3-pro-preview", ""),
+    ("google/gemini-3-flash-preview", ""),
+    ("qwen/qwen3.5-plus-02-15", ""),
+    ("qwen/qwen3.5-35b-a3b", ""),
+    ("stepfun/step-3.5-flash", ""),
+    ("z-ai/glm-5", ""),
+    ("moonshotai/kimi-k2.5", ""),
+    ("minimax/minimax-m2.5", ""),
 ]
 
-_PROVIDER_MODELS: dict[str, list[str]] = {
-    "zai": [
-        "glm-5",
-        "glm-4.7",
-        "glm-4.5",
-        "glm-4.5-flash",
-    ],
-    "kimi-coding": [
-        "kimi-k2.5",
-        "kimi-k2-thinking",
-        "kimi-k2-turbo-preview",
-        "kimi-k2-0905-preview",
-    ],
-    "minimax": [
-        "MiniMax-M2.5",
-        "MiniMax-M2.5-highspeed",
-        "MiniMax-M2.1",
-    ],
-    "minimax-cn": [
-        "MiniMax-M2.5",
-        "MiniMax-M2.5-highspeed",
-        "MiniMax-M2.1",
-    ],
+_PROVIDER_CATALOGS: dict[str, tuple[CuratedModel, ...]] = {
+    "zai": (
+        CuratedModel("glm-5"),
+        CuratedModel("glm-4.7"),
+        CuratedModel("glm-4.5"),
+        CuratedModel("glm-4.5-flash"),
+    ),
+    "kimi-coding": (
+        CuratedModel("kimi-k2.5"),
+        CuratedModel("kimi-k2-thinking"),
+        CuratedModel("kimi-k2-turbo-preview"),
+        CuratedModel("kimi-k2-0905-preview"),
+    ),
+    "minimax": (
+        CuratedModel("MiniMax-M2.5"),
+        CuratedModel("MiniMax-M2.5-highspeed"),
+        CuratedModel("MiniMax-M2.1"),
+    ),
+    "minimax-cn": (
+        CuratedModel("MiniMax-M2.5"),
+        CuratedModel("MiniMax-M2.5-highspeed"),
+        CuratedModel("MiniMax-M2.1"),
+    ),
+    "opencode-go": (
+        CuratedModel("glm-5", transport=OPENAI_CHAT_COMPLETIONS),
+        CuratedModel("kimi-k2.5", transport=OPENAI_CHAT_COMPLETIONS),
+        CuratedModel("minimax-m2.5", transport=ANTHROPIC_MESSAGES),
+    ),
+    "opencode-zen": (
+        CuratedModel("gpt-5.4-pro", transport=OPENAI_RESPONSES),
+        CuratedModel("gpt-5.4", transport=OPENAI_RESPONSES),
+        CuratedModel("gpt-5.3-codex", transport=OPENAI_RESPONSES),
+        CuratedModel("gpt-5.3-codex-spark", transport=OPENAI_RESPONSES),
+        CuratedModel("gpt-5.2", transport=OPENAI_RESPONSES),
+        CuratedModel("gpt-5.2-codex", transport=OPENAI_RESPONSES),
+        CuratedModel("gpt-5.1", transport=OPENAI_RESPONSES),
+        CuratedModel("gpt-5.1-codex", transport=OPENAI_RESPONSES),
+        CuratedModel("gpt-5.1-codex-max", transport=OPENAI_RESPONSES),
+        CuratedModel("gpt-5.1-codex-mini", transport=OPENAI_RESPONSES),
+        CuratedModel("gpt-5", transport=OPENAI_RESPONSES),
+        CuratedModel("gpt-5-codex", transport=OPENAI_RESPONSES),
+        CuratedModel("gpt-5-nano", transport=OPENAI_RESPONSES),
+        CuratedModel("claude-opus-4-6", transport=ANTHROPIC_MESSAGES),
+        CuratedModel("claude-opus-4-5", transport=ANTHROPIC_MESSAGES),
+        CuratedModel("claude-opus-4-1", transport=ANTHROPIC_MESSAGES),
+        CuratedModel("claude-sonnet-4-6", transport=ANTHROPIC_MESSAGES),
+        CuratedModel("claude-sonnet-4-5", transport=ANTHROPIC_MESSAGES),
+        CuratedModel("claude-sonnet-4", transport=ANTHROPIC_MESSAGES),
+        CuratedModel("claude-haiku-4-5", transport=ANTHROPIC_MESSAGES),
+        CuratedModel("claude-3-5-haiku", transport=ANTHROPIC_MESSAGES),
+        CuratedModel("gemini-3.1-pro", transport=GOOGLE_GENERATE_CONTENT),
+        CuratedModel("gemini-3-pro", transport=GOOGLE_GENERATE_CONTENT),
+        CuratedModel("gemini-3-flash", transport=GOOGLE_GENERATE_CONTENT),
+        CuratedModel("minimax-m2.5", transport=OPENAI_CHAT_COMPLETIONS),
+        CuratedModel("minimax-m2.5-free", transport=OPENAI_CHAT_COMPLETIONS),
+        CuratedModel("minimax-m2.1", transport=OPENAI_CHAT_COMPLETIONS),
+        CuratedModel("glm-5", transport=OPENAI_CHAT_COMPLETIONS),
+        CuratedModel("glm-4.7", transport=OPENAI_CHAT_COMPLETIONS),
+        CuratedModel("glm-4.6", transport=OPENAI_CHAT_COMPLETIONS),
+        CuratedModel("kimi-k2.5", transport=OPENAI_CHAT_COMPLETIONS),
+        CuratedModel("kimi-k2-thinking", transport=OPENAI_CHAT_COMPLETIONS),
+        CuratedModel("kimi-k2", transport=OPENAI_CHAT_COMPLETIONS),
+        CuratedModel("qwen3-coder", transport=OPENAI_CHAT_COMPLETIONS),
+        CuratedModel("big-pickle", transport=OPENAI_CHAT_COMPLETIONS),
+    ),
 }
+
+_PROVIDER_MODELS: dict[str, list[str]] = {
+    provider: [entry.id for entry in entries]
+    for provider, entries in _PROVIDER_CATALOGS.items()
+}
+
+_STRICT_CURATED_PROVIDERS = {"opencode-go", "opencode-zen"}
+_LIVE_DISCOVERY_PROVIDERS = {"openrouter", "custom", "opencode-zen"}
 
 _PROVIDER_LABELS = {
     "openrouter": "OpenRouter",
     "openai-codex": "OpenAI Codex",
     "nous": "Nous Portal",
+    "nous-api": "Nous Portal API Key",
     "zai": "Z.AI / GLM",
     "kimi-coding": "Kimi / Moonshot",
     "minimax": "MiniMax",
     "minimax-cn": "MiniMax (China)",
+    "opencode-go": "OpenCode Go",
+    "opencode-zen": "OpenCode Zen",
     "custom": "Custom endpoint",
 }
 
@@ -75,6 +144,10 @@ _PROVIDER_ALIASES = {
     "moonshot": "kimi-coding",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
+    "opencode_go": "opencode-go",
+    "opencode-go": "opencode-go",
+    "opencode_zen": "opencode-zen",
+    "opencode-zen": "opencode-zen",
 }
 
 
@@ -91,85 +164,21 @@ def menu_labels() -> list[str]:
     return labels
 
 
-# All provider IDs and aliases that are valid for the provider:model syntax.
-_KNOWN_PROVIDER_NAMES: set[str] = (
-    set(_PROVIDER_LABELS.keys())
-    | set(_PROVIDER_ALIASES.keys())
-    | {"openrouter", "custom"}
-)
+def provider_label(provider: Optional[str]) -> str:
+    normalized = normalize_provider(provider)
+    return _PROVIDER_LABELS.get(normalized, normalized)
 
 
-def list_available_providers() -> list[dict[str, str]]:
-    """Return info about all providers the user could use with ``provider:model``.
-
-    Each dict has ``id``, ``label``, and ``aliases``.
-    Checks which providers have valid credentials configured.
-    """
-    # Canonical providers in display order
-    _PROVIDER_ORDER = [
-        "openrouter", "nous", "openai-codex",
-        "zai", "kimi-coding", "minimax", "minimax-cn",
-    ]
-    # Build reverse alias map
-    aliases_for: dict[str, list[str]] = {}
-    for alias, canonical in _PROVIDER_ALIASES.items():
-        aliases_for.setdefault(canonical, []).append(alias)
-
-    result = []
-    for pid in _PROVIDER_ORDER:
-        label = _PROVIDER_LABELS.get(pid, pid)
-        alias_list = aliases_for.get(pid, [])
-        # Check if this provider has credentials available
-        has_creds = False
-        try:
-            from hermes_cli.runtime_provider import resolve_runtime_provider
-            runtime = resolve_runtime_provider(requested=pid)
-            has_creds = bool(runtime.get("api_key"))
-        except Exception:
-            pass
-        result.append({
-            "id": pid,
-            "label": label,
-            "aliases": alias_list,
-            "authenticated": has_creds,
-        })
-    return result
-
-
-def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
-    """Parse ``/model`` input into ``(provider, model)``.
-
-    Supports ``provider:model`` syntax to switch providers at runtime::
-
-        openrouter:anthropic/claude-sonnet-4.5  →  ("openrouter", "anthropic/claude-sonnet-4.5")
-        nous:hermes-3                           →  ("nous", "hermes-3")
-        anthropic/claude-sonnet-4.5             →  (current_provider, "anthropic/claude-sonnet-4.5")
-        gpt-5.4                                 →  (current_provider, "gpt-5.4")
-
-    The colon is only treated as a provider delimiter if the left side is a
-    recognized provider name or alias.  This avoids misinterpreting model names
-    that happen to contain colons (e.g. ``anthropic/claude-3.5-sonnet:beta``).
-
-    Returns ``(provider, model)`` where *provider* is either the explicit
-    provider from the input or *current_provider* if none was specified.
-    """
-    stripped = raw.strip()
-    colon = stripped.find(":")
-    if colon > 0:
-        provider_part = stripped[:colon].strip().lower()
-        model_part = stripped[colon + 1:].strip()
-        if provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES:
-            return (normalize_provider(provider_part), model_part)
-    return (current_provider, stripped)
+def curated_model_specs(provider: Optional[str]) -> list[CuratedModel]:
+    normalized = normalize_provider(provider)
+    if normalized == "openrouter":
+        return [CuratedModel(mid, desc, OPENAI_CHAT_COMPLETIONS) for mid, desc in OPENROUTER_MODELS]
+    return list(_PROVIDER_CATALOGS.get(normalized, ()))
 
 
 def curated_models_for_provider(provider: Optional[str]) -> list[tuple[str, str]]:
     """Return ``(model_id, description)`` tuples for a provider's curated list."""
-    normalized = normalize_provider(provider)
-    if normalized == "openrouter":
-        return list(OPENROUTER_MODELS)
-    models = _PROVIDER_MODELS.get(normalized, [])
-    return [(m, "") for m in models]
+    return [(entry.id, entry.description) for entry in curated_model_specs(provider)]
 
 
 def normalize_provider(provider: Optional[str]) -> str:
@@ -192,7 +201,91 @@ def provider_model_ids(provider: Optional[str]) -> list[str]:
         from hermes_cli.codex_models import get_codex_model_ids
 
         return get_codex_model_ids()
-    return list(_PROVIDER_MODELS.get(normalized, []))
+    return [entry.id for entry in curated_model_specs(normalized)]
+
+
+def provider_transport_for_model(provider: Optional[str], model: Optional[str]) -> Optional[str]:
+    normalized = normalize_provider(provider)
+    requested = (model or "").strip()
+    if not requested:
+        return None
+    for entry in curated_model_specs(normalized):
+        if entry.id == requested:
+            return entry.transport
+    return None
+
+
+def provider_requires_explicit_model_mapping(provider: Optional[str]) -> bool:
+    return normalize_provider(provider) in _STRICT_CURATED_PROVIDERS
+
+
+def provider_uses_live_model_discovery(provider: Optional[str]) -> bool:
+    return normalize_provider(provider) in _LIVE_DISCOVERY_PROVIDERS
+
+
+# All provider IDs and aliases that are valid for the provider:model syntax.
+_KNOWN_PROVIDER_NAMES: set[str] = (
+    set(_PROVIDER_LABELS.keys())
+    | set(_PROVIDER_ALIASES.keys())
+    | {"openrouter", "custom"}
+)
+
+
+def list_available_providers() -> list[dict[str, str]]:
+    """Return info about all providers the user could use with ``provider:model``.
+
+    Each dict has ``id``, ``label``, and ``aliases``.
+    Checks which providers have valid credentials configured.
+    """
+    provider_order = [
+        "openrouter",
+        "opencode-go",
+        "opencode-zen",
+        "nous",
+        "nous-api",
+        "openai-codex",
+        "zai",
+        "kimi-coding",
+        "minimax",
+        "minimax-cn",
+    ]
+    aliases_for: dict[str, list[str]] = {}
+    for alias, canonical in _PROVIDER_ALIASES.items():
+        aliases_for.setdefault(canonical, []).append(alias)
+
+    result = []
+    for pid in provider_order:
+        label = _PROVIDER_LABELS.get(pid, pid)
+        alias_list = aliases_for.get(pid, [])
+        has_creds = False
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            runtime = resolve_runtime_provider(requested=pid)
+            has_creds = bool(runtime.get("api_key"))
+        except Exception:
+            pass
+        result.append(
+            {
+                "id": pid,
+                "label": label,
+                "aliases": alias_list,
+                "authenticated": has_creds,
+            }
+        )
+    return result
+
+
+def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
+    """Parse ``/model`` input into ``(provider, model)``."""
+    stripped = raw.strip()
+    colon = stripped.find(":")
+    if colon > 0:
+        provider_part = stripped[:colon].strip().lower()
+        model_part = stripped[colon + 1:].strip()
+        if provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES:
+            return (normalize_provider(provider_part), model_part)
+    return (current_provider, stripped)
 
 
 def fetch_api_models(
@@ -200,11 +293,7 @@ def fetch_api_models(
     base_url: Optional[str],
     timeout: float = 5.0,
 ) -> Optional[list[str]]:
-    """Fetch the list of available model IDs from the provider's ``/models`` endpoint.
-
-    Returns a list of model ID strings, or ``None`` if the endpoint could not
-    be reached (network error, timeout, auth failure, etc.).
-    """
+    """Fetch model IDs from the provider's ``/models`` endpoint when supported."""
     if not base_url:
         return None
 
@@ -217,10 +306,28 @@ def fetch_api_models(
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             data = json.loads(resp.read().decode())
-            # Standard OpenAI format: {"data": [{"id": "model-name", ...}, ...]}
             return [m.get("id", "") for m in data.get("data", [])]
     except Exception:
         return None
+
+
+def _invalid_model_response(
+    *,
+    requested: str,
+    provider: str,
+    known_models: list[str],
+    message_prefix: str,
+) -> dict[str, Any]:
+    suggestions = get_close_matches(requested, known_models, n=3, cutoff=0.5)
+    suggestion_text = ""
+    if suggestions:
+        suggestion_text = "\n  Did you mean: " + ", ".join(f"`{s}`" for s in suggestions)
+    return {
+        "accepted": False,
+        "persist": False,
+        "recognized": False,
+        "message": f"{message_prefix}{suggestion_text}",
+    }
 
 
 def validate_requested_model(
@@ -232,9 +339,6 @@ def validate_requested_model(
 ) -> dict[str, Any]:
     """
     Validate a ``/model`` value for the active provider.
-
-    Performs format checks first, then probes the live API to confirm
-    the model actually exists.
 
     Returns a dict with:
       - accepted: whether the CLI should switch to the requested model now
@@ -263,38 +367,54 @@ def validate_requested_model(
             "message": "Model names cannot contain spaces.",
         }
 
-    # Probe the live API to check if the model actually exists
+    provider_label_text = _PROVIDER_LABELS.get(normalized, normalized)
+    known_models = provider_model_ids(normalized)
+
+    if provider_requires_explicit_model_mapping(normalized):
+        if requested not in known_models:
+            return _invalid_model_response(
+                requested=requested,
+                provider=normalized,
+                known_models=known_models,
+                message_prefix=(
+                    f"Error: `{requested}` is not a supported model for {provider_label_text}. "
+                    "Choose one of the curated OpenCode models."
+                ),
+            )
+
+        if provider_uses_live_model_discovery(normalized):
+            api_models = fetch_api_models(api_key, base_url)
+            if api_models is not None and requested not in set(api_models):
+                return _invalid_model_response(
+                    requested=requested,
+                    provider=normalized,
+                    known_models=[mid for mid in known_models if mid in set(api_models)] or known_models,
+                    message_prefix=f"Error: `{requested}` is not currently available from {provider_label_text}.",
+                )
+
+        return {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "message": None,
+        }
+
     api_models = fetch_api_models(api_key, base_url)
 
     if api_models is not None:
         if requested in set(api_models):
-            # API confirmed the model exists
             return {
                 "accepted": True,
                 "persist": True,
                 "recognized": True,
                 "message": None,
             }
-        else:
-            # API responded but model is not listed
-            suggestions = get_close_matches(requested, api_models, n=3, cutoff=0.5)
-            suggestion_text = ""
-            if suggestions:
-                suggestion_text = "\n  Did you mean: " + ", ".join(f"`{s}`" for s in suggestions)
-
-            return {
-                "accepted": False,
-                "persist": False,
-                "recognized": False,
-                "message": (
-                    f"Error: `{requested}` is not a valid model for this provider."
-                    f"{suggestion_text}"
-                ),
-            }
-
-    # api_models is None — couldn't reach API, fall back to catalog check
-    provider_label = _PROVIDER_LABELS.get(normalized, normalized)
-    known_models = provider_model_ids(normalized)
+        return _invalid_model_response(
+            requested=requested,
+            provider=normalized,
+            known_models=api_models,
+            message_prefix=f"Error: `{requested}` is not a valid model for this provider.",
+        )
 
     if requested in known_models:
         return {
@@ -304,7 +424,6 @@ def validate_requested_model(
             "message": None,
         }
 
-    # Can't validate — accept for session only
     suggestion = get_close_matches(requested, known_models, n=1, cutoff=0.6)
     suggestion_text = f" Did you mean `{suggestion[0]}`?" if suggestion else ""
     return {
@@ -312,7 +431,7 @@ def validate_requested_model(
         "persist": False,
         "recognized": False,
         "message": (
-            f"Could not validate `{requested}` against the live {provider_label} API. "
+            f"Could not validate `{requested}` against the live {provider_label_text} API. "
             "Using it for this session only; config unchanged."
             f"{suggestion_text}"
         ),

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -15,6 +15,10 @@ from hermes_cli.auth import (
     resolve_api_key_provider_credentials,
 )
 from hermes_cli.config import load_config
+from hermes_cli.models import (
+    provider_requires_explicit_model_mapping,
+    provider_transport_for_model,
+)
 from hermes_cli.transport_profiles import build_transport_profile
 from hermes_constants import OPENROUTER_BASE_URL
 
@@ -160,7 +164,19 @@ def resolve_runtime_provider(
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":
         creds = resolve_api_key_provider_credentials(provider)
-        profile = build_transport_profile(provider, base_url=creds.get("base_url", ""), model=model)
+        transport = provider_transport_for_model(provider, model)
+        if model and provider_requires_explicit_model_mapping(provider) and not transport:
+            raise AuthError(
+                f"Model '{model}' is not mapped for provider '{provider}'.",
+                provider=provider,
+                code="invalid_model_for_provider",
+            )
+        profile = build_transport_profile(
+            provider,
+            base_url=creds.get("base_url", ""),
+            model=model,
+            transport=transport,
+        )
         return {
             "provider": provider,
             "api_mode": profile.api_mode,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -15,6 +15,7 @@ from hermes_cli.auth import (
     resolve_api_key_provider_credentials,
 )
 from hermes_cli.config import load_config
+from hermes_cli.transport_profiles import build_transport_profile
 from hermes_constants import OPENROUTER_BASE_URL
 
 
@@ -97,9 +98,11 @@ def _resolve_openrouter_runtime(
 
     source = "explicit" if (explicit_api_key or explicit_base_url) else "env/config"
 
+    profile = build_transport_profile("openrouter", base_url=base_url)
     return {
         "provider": "openrouter",
-        "api_mode": "chat_completions",
+        "api_mode": profile.api_mode,
+        "transport": profile.transport,
         "base_url": base_url,
         "api_key": api_key,
         "source": source,
@@ -111,6 +114,7 @@ def resolve_runtime_provider(
     requested: Optional[str] = None,
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Resolve runtime provider credentials for agent execution."""
     requested_provider = resolve_requested_provider(requested)
@@ -126,9 +130,11 @@ def resolve_runtime_provider(
             min_key_ttl_seconds=max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),
             timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
         )
+        profile = build_transport_profile("nous", base_url=creds.get("base_url", ""), model=model)
         return {
             "provider": "nous",
-            "api_mode": "chat_completions",
+            "api_mode": profile.api_mode,
+            "transport": profile.transport,
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "portal"),
@@ -138,9 +144,11 @@ def resolve_runtime_provider(
 
     if provider == "openai-codex":
         creds = resolve_codex_runtime_credentials()
+        profile = build_transport_profile("openai-codex", base_url=creds.get("base_url", ""), model=model)
         return {
             "provider": "openai-codex",
-            "api_mode": "codex_responses",
+            "api_mode": profile.api_mode,
+            "transport": profile.transport,
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "hermes-auth-store"),
@@ -152,9 +160,11 @@ def resolve_runtime_provider(
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":
         creds = resolve_api_key_provider_credentials(provider)
+        profile = build_transport_profile(provider, base_url=creds.get("base_url", ""), model=model)
         return {
             "provider": provider,
-            "api_mode": "chat_completions",
+            "api_mode": profile.api_mode,
+            "transport": profile.transport,
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "env"),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -480,8 +480,9 @@ def setup_model_provider(config: dict):
         format_auth_error, AuthError, fetch_nous_models,
         resolve_nous_runtime_credentials, _update_config_for_provider,
         _login_openai_codex, get_codex_auth_status, DEFAULT_CODEX_BASE_URL,
-        detect_external_credentials,
+        detect_external_credentials, _prompt_model_selection,
     )
+    from hermes_cli.models import curated_model_specs, provider_requires_explicit_model_mapping
 
     print_header("Inference Provider")
     print_info("Choose how to connect to your main chat model.")
@@ -525,6 +526,8 @@ def setup_model_provider(config: dict):
         "Kimi / Moonshot (Kimi coding models)",
         "MiniMax (global endpoint)",
         "MiniMax China (mainland China endpoint)",
+        "OpenCode Go (shared OpenCode API key)",
+        "OpenCode Zen (shared OpenCode API key)",
     ]
     if keep_label:
         provider_choices.append(keep_label)
@@ -887,12 +890,78 @@ def setup_model_provider(config: dict):
             save_env_value("OPENAI_API_KEY", "")
         _update_config_for_provider("minimax-cn", pconfig.inference_base_url)
 
-    # else: provider_idx == 9 (Keep current) — only shown when a provider already exists
+    elif provider_idx == 9:  # OpenCode Go
+        selected_provider = "opencode-go"
+        print()
+        print_header("OpenCode Go API Key")
+        pconfig = PROVIDER_REGISTRY["opencode-go"]
+        print_info(f"Provider: {pconfig.name}")
+        print_info("OpenCode Go and OpenCode Zen share the same API key.")
+        print_info("Get your API key from the OpenCode console, then select Go or Zen here.")
+        print()
+
+        existing_key = get_env_value("OPENCODE_API_KEY")
+        if existing_key:
+            print_info(f"Current: {existing_key[:8]}... (configured)")
+            if prompt_yes_no("Update OpenCode API key?", False):
+                api_key = prompt("  OpenCode API key", password=True)
+                if api_key:
+                    save_env_value("OPENCODE_API_KEY", api_key)
+                    print_success("OpenCode API key updated")
+        else:
+            api_key = prompt("  OpenCode API key", password=True)
+            if api_key:
+                save_env_value("OPENCODE_API_KEY", api_key)
+                print_success("OpenCode API key saved")
+            else:
+                print_warning("Skipped - agent won't work without an API key")
+
+        if existing_custom:
+            save_env_value("OPENAI_BASE_URL", "")
+            save_env_value("OPENAI_API_KEY", "")
+        _update_config_for_provider("opencode-go", pconfig.inference_base_url)
+
+    elif provider_idx == 10:  # OpenCode Zen
+        selected_provider = "opencode-zen"
+        print()
+        print_header("OpenCode Zen API Key")
+        pconfig = PROVIDER_REGISTRY["opencode-zen"]
+        print_info(f"Provider: {pconfig.name}")
+        print_info("OpenCode Go and OpenCode Zen share the same API key.")
+        print_info("Use Zen when you want the curated multi-provider model gateway.")
+        print()
+
+        existing_key = get_env_value("OPENCODE_API_KEY")
+        if existing_key:
+            print_info(f"Current: {existing_key[:8]}... (configured)")
+            if prompt_yes_no("Update OpenCode API key?", False):
+                api_key = prompt("  OpenCode API key", password=True)
+                if api_key:
+                    save_env_value("OPENCODE_API_KEY", api_key)
+                    print_success("OpenCode API key updated")
+        else:
+            api_key = prompt("  OpenCode API key", password=True)
+            if api_key:
+                save_env_value("OPENCODE_API_KEY", api_key)
+                print_success("OpenCode API key saved")
+            else:
+                print_warning("Skipped - agent won't work without an API key")
+
+        if existing_custom:
+            save_env_value("OPENAI_BASE_URL", "")
+            save_env_value("OPENAI_API_KEY", "")
+        _update_config_for_provider("opencode-zen", pconfig.inference_base_url)
+
+    # else: keep current — only shown when a provider already exists
 
     # ── OpenRouter API Key for tools (if not already set) ──
     # Tools (vision, web, MoA) use OpenRouter independently of the main provider.
     # Prompt for OpenRouter key if not set and a non-OpenRouter provider was chosen.
-    if selected_provider in ("nous", "nous-api", "openai-codex", "custom", "zai", "kimi-coding", "minimax", "minimax-cn") and not get_env_value("OPENROUTER_API_KEY"):
+    if selected_provider in (
+        "nous", "nous-api", "openai-codex", "custom",
+        "zai", "kimi-coding", "minimax", "minimax-cn",
+        "opencode-go", "opencode-zen",
+    ) and not get_env_value("OPENROUTER_API_KEY"):
         print()
         print_header("OpenRouter API Key (for tools)")
         print_info("Tools like vision analysis, web search, and MoA use OpenRouter")
@@ -1032,6 +1101,16 @@ def setup_model_provider(config: dict):
                     config['model'] = custom
                     save_env_value("LLM_MODEL", custom)
             # else: keep current
+        elif selected_provider in ("opencode-go", "opencode-zen"):
+            opencode_models = [entry.id for entry in curated_model_specs(selected_provider)]
+            selected = _prompt_model_selection(
+                opencode_models,
+                current_model=current_model,
+                allow_custom=not provider_requires_explicit_model_mapping(selected_provider),
+            )
+            if selected:
+                config['model'] = selected
+                save_env_value("LLM_MODEL", selected)
         else:
             # Static list for OpenRouter / fallback (from canonical list)
             from hermes_cli.models import model_ids, menu_labels

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -79,6 +79,7 @@ def show_status(args):
         "OpenRouter": "OPENROUTER_API_KEY",
         "Anthropic": "ANTHROPIC_API_KEY", 
         "OpenAI": "OPENAI_API_KEY",
+        "OpenCode": "OPENCODE_API_KEY",
         "Z.AI/GLM": "GLM_API_KEY",
         "Kimi": "KIMI_API_KEY",
         "MiniMax": "MINIMAX_API_KEY",

--- a/hermes_cli/transport_profiles.py
+++ b/hermes_cli/transport_profiles.py
@@ -33,6 +33,8 @@ _PROVIDER_DEFAULT_TRANSPORTS = {
     "kimi-coding": OPENAI_CHAT_COMPLETIONS,
     "minimax": OPENAI_CHAT_COMPLETIONS,
     "minimax-cn": OPENAI_CHAT_COMPLETIONS,
+    "opencode-go": OPENAI_CHAT_COMPLETIONS,
+    "opencode-zen": OPENAI_CHAT_COMPLETIONS,
 }
 
 

--- a/hermes_cli/transport_profiles.py
+++ b/hermes_cli/transport_profiles.py
@@ -1,0 +1,87 @@
+"""Runtime transport profiles for provider/model execution.
+
+Hermes historically routed requests with a provider-wide ``api_mode`` flag.
+This module adds an explicit transport profile so future providers can resolve
+execution protocol from ``provider + model`` while preserving the legacy
+``api_mode`` contract for existing callers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+OPENAI_CHAT_COMPLETIONS = "openai_chat_completions"
+OPENAI_RESPONSES = "openai_responses"
+ANTHROPIC_MESSAGES = "anthropic_messages"
+GOOGLE_GENERATE_CONTENT = "google_generate_content"
+
+LEGACY_API_MODES = {
+    OPENAI_CHAT_COMPLETIONS: "chat_completions",
+    OPENAI_RESPONSES: "codex_responses",
+    ANTHROPIC_MESSAGES: "chat_completions",
+    GOOGLE_GENERATE_CONTENT: "chat_completions",
+}
+
+_PROVIDER_DEFAULT_TRANSPORTS = {
+    "openrouter": OPENAI_CHAT_COMPLETIONS,
+    "custom": OPENAI_CHAT_COMPLETIONS,
+    "nous": OPENAI_CHAT_COMPLETIONS,
+    "nous-api": OPENAI_CHAT_COMPLETIONS,
+    "openai-codex": OPENAI_RESPONSES,
+    "zai": OPENAI_CHAT_COMPLETIONS,
+    "kimi-coding": OPENAI_CHAT_COMPLETIONS,
+    "minimax": OPENAI_CHAT_COMPLETIONS,
+    "minimax-cn": OPENAI_CHAT_COMPLETIONS,
+}
+
+
+@dataclass(frozen=True)
+class TransportProfile:
+    provider: str
+    transport: str
+    api_mode: str
+    base_url: str = ""
+    model: str = ""
+    metadata: dict[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        if data["metadata"] is None:
+            data.pop("metadata")
+        return data
+
+
+def legacy_api_mode_for_transport(transport: Optional[str]) -> str:
+    return LEGACY_API_MODES.get((transport or "").strip(), "chat_completions")
+
+
+def default_transport_for_provider(provider: Optional[str]) -> str:
+    normalized = (provider or "openrouter").strip().lower()
+    return _PROVIDER_DEFAULT_TRANSPORTS.get(normalized, OPENAI_CHAT_COMPLETIONS)
+
+
+def build_transport_profile(
+    provider: Optional[str],
+    *,
+    base_url: Optional[str] = None,
+    model: Optional[str] = None,
+    transport: Optional[str] = None,
+    metadata: Optional[dict[str, Any]] = None,
+) -> TransportProfile:
+    normalized_provider = (provider or "openrouter").strip().lower()
+    resolved_transport = (transport or default_transport_for_provider(normalized_provider)).strip().lower()
+    return TransportProfile(
+        provider=normalized_provider,
+        transport=resolved_transport,
+        api_mode=legacy_api_mode_for_transport(resolved_transport),
+        base_url=(base_url or "").rstrip("/"),
+        model=(model or "").strip(),
+        metadata=dict(metadata) if metadata else None,
+    )
+
+
+def is_responses_transport(value: TransportProfile | str | None) -> bool:
+    if isinstance(value, TransportProfile):
+        return value.transport == OPENAI_RESPONSES
+    return (value or "").strip().lower() == OPENAI_RESPONSES

--- a/run_agent.py
+++ b/run_agent.py
@@ -73,6 +73,14 @@ from tools.browser_tool import cleanup_browser
 import requests
 
 from hermes_constants import OPENROUTER_BASE_URL, OPENROUTER_MODELS_URL
+from hermes_cli.transport_profiles import (
+    ANTHROPIC_MESSAGES,
+    GOOGLE_GENERATE_CONTENT,
+    OPENAI_CHAT_COMPLETIONS,
+    OPENAI_RESPONSES,
+    legacy_api_mode_for_transport,
+)
+from agent.transport_adapters import AnthropicMessagesClient, GoogleGenerateContentClient
 
 # Agent internals extracted to agent/ package for modularity
 from agent.prompt_builder import (
@@ -153,6 +161,7 @@ class AIAgent:
         api_key: str = None,
         provider: str = None,
         api_mode: str = None,
+        transport: str = None,
         model: str = "anthropic/claude-opus-4.6",  # OpenRouter format
         max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
         tool_delay: float = 1.0,
@@ -195,7 +204,8 @@ class AIAgent:
             base_url (str): Base URL for the model API (optional)
             api_key (str): API key for authentication (optional, uses env var if not provided)
             provider (str): Provider identifier (optional; used for telemetry/routing hints)
-            api_mode (str): API mode override: "chat_completions" or "codex_responses"
+            api_mode (str): Legacy API mode override: "chat_completions" or "codex_responses"
+            transport (str): Explicit transport override for provider/model execution
             model (str): Model name to use (default: "anthropic/claude-opus-4.6")
             max_iterations (int): Maximum number of tool calling iterations (default: 90)
             tool_delay (float): Delay between tool calls in seconds (default: 1.0)
@@ -248,15 +258,15 @@ class AIAgent:
         self.base_url = base_url or OPENROUTER_BASE_URL
         provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
         self.provider = provider_name or "openrouter"
-        if api_mode in {"chat_completions", "codex_responses"}:
-            self.api_mode = api_mode
-        elif self.provider == "openai-codex":
-            self.api_mode = "codex_responses"
-        elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self.base_url.lower():
-            self.api_mode = "codex_responses"
+        self.transport = self._resolve_transport(
+            provider_name=provider_name,
+            base_url=self.base_url,
+            api_mode=api_mode,
+            transport=transport,
+        )
+        if (provider_name is None) and self.transport == OPENAI_RESPONSES:
             self.provider = "openai-codex"
-        else:
-            self.api_mode = "chat_completions"
+        self.api_mode = legacy_api_mode_for_transport(self.transport)
 
         self.tool_progress_callback = tool_progress_callback
         self.thinking_callback = thinking_callback
@@ -364,7 +374,7 @@ class AIAgent:
                 ]:
                     logging.getLogger(quiet_logger).setLevel(logging.ERROR)
         
-        # Initialize OpenAI client - defaults to OpenRouter
+        # Initialize transport client - defaults to OpenAI chat via OpenRouter
         client_kwargs = {}
         
         # Default to OpenRouter if no base_url provided
@@ -397,7 +407,7 @@ class AIAgent:
         
         self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
         try:
-            self.client = OpenAI(**client_kwargs)
+            self.client = self._create_api_client()
             if not self.quiet_mode:
                 print(f"🤖 AI Agent initialized with model: {self.model}")
                 if base_url:
@@ -1441,6 +1451,55 @@ class AIAgent:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
 
         return "\n\n".join(prompt_parts)
+
+    @staticmethod
+    def _resolve_transport(
+        *,
+        provider_name: Optional[str],
+        base_url: str,
+        api_mode: Optional[str],
+        transport: Optional[str],
+    ) -> str:
+        if isinstance(transport, str) and transport.strip():
+            return transport.strip().lower()
+        if api_mode == "codex_responses":
+            return OPENAI_RESPONSES
+        if isinstance(provider_name, str) and provider_name.strip().lower() == "openai-codex":
+            return OPENAI_RESPONSES
+        if provider_name is None and "chatgpt.com/backend-api/codex" in (base_url or "").lower():
+            return OPENAI_RESPONSES
+        return OPENAI_CHAT_COMPLETIONS
+
+    def _uses_responses_transport(self) -> bool:
+        return self.transport == OPENAI_RESPONSES
+
+    def _create_api_client(self):
+        if self.transport == ANTHROPIC_MESSAGES:
+            return AnthropicMessagesClient(
+                base_url=self._client_kwargs["base_url"],
+                api_key=self._client_kwargs["api_key"],
+                default_headers=self._client_kwargs.get("default_headers"),
+            )
+        if self.transport == GOOGLE_GENERATE_CONTENT:
+            return GoogleGenerateContentClient(
+                base_url=self._client_kwargs["base_url"],
+                api_key=self._client_kwargs["api_key"],
+                default_headers=self._client_kwargs.get("default_headers"),
+            )
+        return OpenAI(**self._client_kwargs)
+
+    def _rebuild_api_client(self) -> bool:
+        try:
+            self.client.close()
+        except Exception:
+            pass
+
+        try:
+            self.client = self._create_api_client()
+            return True
+        except Exception as exc:
+            logger.warning("Failed to rebuild API client: %s", exc)
+            return False
     
     def _repair_tool_call(self, tool_name: str) -> str | None:
         """Attempt to repair a mismatched tool name before aborting.
@@ -1636,7 +1695,7 @@ class AIAgent:
 
         return items
 
-    def _preflight_codex_input_items(self, raw_items: Any) -> List[Dict[str, Any]]:
+    def _preflight_responses_input_items(self, raw_items: Any) -> List[Dict[str, Any]]:
         if not isinstance(raw_items, list):
             raise ValueError("Codex Responses input must be a list of input items.")
 
@@ -1722,7 +1781,7 @@ class AIAgent:
 
         return normalized
 
-    def _preflight_codex_api_kwargs(
+    def _preflight_responses_api_kwargs(
         self,
         api_kwargs: Any,
         *,
@@ -1748,7 +1807,7 @@ class AIAgent:
             instructions = str(instructions)
         instructions = instructions.strip() or DEFAULT_AGENT_IDENTITY
 
-        normalized_input = self._preflight_codex_input_items(api_kwargs.get("input"))
+        normalized_input = self._preflight_responses_input_items(api_kwargs.get("input"))
 
         tools = api_kwargs.get("tools")
         normalized_tools = None
@@ -1839,6 +1898,19 @@ class AIAgent:
 
         return normalized
 
+    def _preflight_codex_input_items(self, raw_items: Any) -> List[Dict[str, Any]]:
+        """Backward-compatible wrapper for older tests and callers."""
+        return self._preflight_responses_input_items(raw_items)
+
+    def _preflight_codex_api_kwargs(
+        self,
+        api_kwargs: Any,
+        *,
+        allow_stream: bool = False,
+    ) -> Dict[str, Any]:
+        """Backward-compatible wrapper for older tests and callers."""
+        return self._preflight_responses_api_kwargs(api_kwargs, allow_stream=allow_stream)
+
     def _extract_responses_message_text(self, item: Any) -> str:
         """Extract assistant text from a Responses message output item."""
         content = getattr(item, "content", None)
@@ -1871,7 +1943,7 @@ class AIAgent:
             return text.strip()
         return ""
 
-    def _normalize_codex_response(self, response: Any) -> tuple[Any, str]:
+    def _normalize_responses_response(self, response: Any) -> tuple[Any, str]:
         """Normalize a Responses API object to an assistant_message-like object."""
         output = getattr(response, "output", None)
         if not isinstance(output, list) or not output:
@@ -2012,7 +2084,11 @@ class AIAgent:
             finish_reason = "stop"
         return assistant_message, finish_reason
 
-    def _run_codex_stream(self, api_kwargs: dict):
+    def _normalize_codex_response(self, response: Any) -> tuple[Any, str]:
+        """Backward-compatible wrapper for older tests and callers."""
+        return self._normalize_responses_response(response)
+
+    def _run_responses_stream(self, api_kwargs: dict):
         """Execute one streaming Responses API request and return the final response."""
         max_stream_retries = 1
         for attempt in range(max_stream_retries + 1):
@@ -2035,14 +2111,18 @@ class AIAgent:
                     logger.debug(
                         "Responses stream did not emit response.completed; falling back to create(stream=True)."
                     )
-                    return self._run_codex_create_stream_fallback(api_kwargs)
+                    return self._run_responses_create_stream_fallback(api_kwargs)
                 raise
 
-    def _run_codex_create_stream_fallback(self, api_kwargs: dict):
-        """Fallback path for stream completion edge cases on Codex-style Responses backends."""
+    def _run_codex_stream(self, api_kwargs: dict):
+        """Backward-compatible wrapper for older tests and callers."""
+        return self._run_responses_stream(api_kwargs)
+
+    def _run_responses_create_stream_fallback(self, api_kwargs: dict):
+        """Fallback path for stream completion edge cases on Responses backends."""
         fallback_kwargs = dict(api_kwargs)
         fallback_kwargs["stream"] = True
-        fallback_kwargs = self._preflight_codex_api_kwargs(fallback_kwargs, allow_stream=True)
+        fallback_kwargs = self._preflight_responses_api_kwargs(fallback_kwargs, allow_stream=True)
         stream_or_response = self.client.responses.create(**fallback_kwargs)
 
         # Compatibility shim for mocks or providers that still return a concrete response.
@@ -2077,8 +2157,12 @@ class AIAgent:
             return terminal_response
         raise RuntimeError("Responses create(stream=True) fallback did not emit a terminal response.")
 
+    def _run_codex_create_stream_fallback(self, api_kwargs: dict):
+        """Backward-compatible wrapper for older tests and callers."""
+        return self._run_responses_create_stream_fallback(api_kwargs)
+
     def _try_refresh_codex_client_credentials(self, *, force: bool = True) -> bool:
-        if self.api_mode != "codex_responses" or self.provider != "openai-codex":
+        if not self._uses_responses_transport() or self.provider != "openai-codex":
             return False
 
         try:
@@ -2101,15 +2185,8 @@ class AIAgent:
         self._client_kwargs["api_key"] = self.api_key
         self._client_kwargs["base_url"] = self.base_url
 
-        try:
-            self.client.close()
-        except Exception:
-            pass
-
-        try:
-            self.client = OpenAI(**self._client_kwargs)
-        except Exception as exc:
-            logger.warning("Failed to rebuild OpenAI client after Codex refresh: %s", exc)
+        if not self._rebuild_api_client():
+            logger.warning("Failed to rebuild API client after Codex refresh.")
             return False
 
         return True
@@ -2144,15 +2221,8 @@ class AIAgent:
         # Nous requests should not inherit OpenRouter-only attribution headers.
         self._client_kwargs.pop("default_headers", None)
 
-        try:
-            self.client.close()
-        except Exception:
-            pass
-
-        try:
-            self.client = OpenAI(**self._client_kwargs)
-        except Exception as exc:
-            logger.warning("Failed to rebuild OpenAI client after Nous refresh: %s", exc)
+        if not self._rebuild_api_client():
+            logger.warning("Failed to rebuild API client after Nous refresh.")
             return False
 
         return True
@@ -2170,7 +2240,7 @@ class AIAgent:
 
         def _call():
             try:
-                if self.api_mode == "codex_responses":
+                if self._uses_responses_transport():
                     result["response"] = self._run_codex_stream(api_kwargs)
                 else:
                     result["response"] = self.client.chat.completions.create(**api_kwargs)
@@ -2189,7 +2259,7 @@ class AIAgent:
                     pass
                 # Rebuild the client for future calls (cheap, no network)
                 try:
-                    self.client = OpenAI(**self._client_kwargs)
+                    self.client = self._create_api_client()
                 except Exception:
                     pass
                 raise InterruptedError("Agent interrupted during API call")
@@ -2302,13 +2372,14 @@ class AIAgent:
             elif "api.kimi.com" in fb_base_url.lower():
                 client_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.0"}
 
-            self.client = OpenAI(**client_kwargs)
             self._client_kwargs = client_kwargs
             old_model = self.model
             self.model = fb_model
             self.provider = fb_provider
             self.base_url = fb_base_url
-            self.api_mode = fb_api_mode
+            self.transport = OPENAI_RESPONSES if fb_api_mode == "codex_responses" else OPENAI_CHAT_COMPLETIONS
+            self.api_mode = legacy_api_mode_for_transport(self.transport)
+            self.client = self._create_api_client()
             self._fallback_activated = True
 
             # Re-evaluate prompt caching for the new provider/model
@@ -2334,7 +2405,7 @@ class AIAgent:
 
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
-        if self.api_mode == "codex_responses":
+        if self._uses_responses_transport():
             instructions = ""
             payload_messages = api_messages
             if api_messages and api_messages[0].get("role") == "system":
@@ -2589,7 +2660,7 @@ class AIAgent:
                     "max_tokens": 5120,
                 }
                 response = aux_client.chat.completions.create(**api_kwargs, timeout=30.0)
-            elif self.api_mode == "codex_responses":
+            elif self._uses_responses_transport():
                 # No auxiliary client -- use the Codex Responses path directly
                 codex_kwargs = self._build_api_kwargs(api_messages)
                 codex_kwargs["tools"] = self._responses_tools([memory_tool_def])
@@ -2609,7 +2680,7 @@ class AIAgent:
 
             # Extract tool calls from the response, handling both API formats
             tool_calls = []
-            if self.api_mode == "codex_responses" and not aux_client:
+            if self._uses_responses_transport() and not aux_client:
                 assistant_msg, _ = self._normalize_codex_response(response)
                 if assistant_msg and assistant_msg.tool_calls:
                     tool_calls = assistant_msg.tool_calls
@@ -2989,7 +3060,7 @@ class AIAgent:
             if _is_nous:
                 summary_extra_body["tags"] = ["product=hermes-agent"]
 
-            if self.api_mode == "codex_responses":
+            if self._uses_responses_transport():
                 codex_kwargs = self._build_api_kwargs(api_messages)
                 codex_kwargs.pop("tools", None)
                 summary_response = self._run_codex_stream(codex_kwargs)
@@ -3035,7 +3106,7 @@ class AIAgent:
                     final_response = "I reached the iteration limit and couldn't generate a summary."
             else:
                 # Retry summary generation
-                if self.api_mode == "codex_responses":
+                if self._uses_responses_transport():
                     codex_kwargs = self._build_api_kwargs(api_messages)
                     codex_kwargs.pop("tools", None)
                     retry_response = self._run_codex_stream(codex_kwargs)
@@ -3419,7 +3490,7 @@ class AIAgent:
             while retry_count < max_retries:
                 try:
                     api_kwargs = self._build_api_kwargs(api_messages)
-                    if self.api_mode == "codex_responses":
+                    if self._uses_responses_transport():
                         api_kwargs = self._preflight_codex_api_kwargs(api_kwargs, allow_stream=False)
 
                     if os.getenv("HERMES_DUMP_REQUESTS", "").strip().lower() in {"1", "true", "yes", "on"}:
@@ -3448,7 +3519,7 @@ class AIAgent:
                     # Validate response shape before proceeding
                     response_invalid = False
                     error_details = []
-                    if self.api_mode == "codex_responses":
+                    if self._uses_responses_transport():
                         output_items = getattr(response, "output", None) if response is not None else None
                         if response is None:
                             response_invalid = True
@@ -3548,7 +3619,7 @@ class AIAgent:
                         continue  # Retry the API call
 
                     # Check finish_reason before proceeding
-                    if self.api_mode == "codex_responses":
+                    if self._uses_responses_transport():
                         status = getattr(response, "status", None)
                         incomplete_details = getattr(response, "incomplete_details", None)
                         incomplete_reason = None
@@ -3639,7 +3710,7 @@ class AIAgent:
                     
                     # Track actual token usage from response for context management
                     if hasattr(response, 'usage') and response.usage:
-                        if self.api_mode == "codex_responses":
+                        if self._uses_responses_transport():
                             prompt_tokens = getattr(response.usage, 'input_tokens', 0) or 0
                             completion_tokens = getattr(response.usage, 'output_tokens', 0) or 0
                             total_tokens = (
@@ -3707,7 +3778,7 @@ class AIAgent:
 
                     status_code = getattr(api_error, "status_code", None)
                     if (
-                        self.api_mode == "codex_responses"
+                        self._uses_responses_transport()
                         and self.provider == "openai-codex"
                         and status_code == 401
                         and not codex_auth_retry_attempted
@@ -3960,7 +4031,7 @@ class AIAgent:
                 break
 
             try:
-                if self.api_mode == "codex_responses":
+                if self._uses_responses_transport():
                     assistant_message, finish_reason = self._normalize_codex_response(response)
                 else:
                     assistant_message = response.choices[0].message
@@ -4043,7 +4114,7 @@ class AIAgent:
                 if hasattr(self, '_incomplete_scratchpad_retries'):
                     self._incomplete_scratchpad_retries = 0
 
-                if self.api_mode == "codex_responses" and finish_reason == "incomplete":
+                if self._uses_responses_transport() and finish_reason == "incomplete":
                     if not hasattr(self, "_codex_incomplete_retries"):
                         self._codex_incomplete_retries = 0
                     self._codex_incomplete_retries += 1
@@ -4311,7 +4382,7 @@ class AIAgent:
                         self._empty_content_retries = 0
 
                     if (
-                        self.api_mode == "codex_responses"
+                        self._uses_responses_transport()
                         and self.valid_tool_names
                         and codex_ack_continuations < 2
                         and self._looks_like_codex_intermediate_ack(

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -94,6 +94,11 @@ class TestCuratedModelsForProvider:
     def test_unknown_provider_returns_empty(self):
         assert curated_models_for_provider("totally-unknown") == []
 
+    def test_opencode_zen_returns_curated_models(self):
+        models = curated_models_for_provider("opencode-zen")
+        assert ("gpt-5.4", "") in models
+        assert ("gemini-3-pro", "") in models
+
 
 # -- normalize_provider ------------------------------------------------------
 
@@ -124,6 +129,9 @@ class TestProviderModelIds:
 
     def test_zai_returns_glm_models(self):
         assert "glm-5" in provider_model_ids("zai")
+
+    def test_opencode_go_returns_curated_models(self):
+        assert provider_model_ids("opencode-go") == ["glm-5", "kimi-k2.5", "minimax-m2.5"]
 
 
 # -- fetch_api_models --------------------------------------------------------
@@ -217,4 +225,24 @@ class TestValidateApiFallback:
     def test_unknown_provider_session_only_when_api_down(self):
         result = _validate("some-model", provider="totally-unknown", api_models=None)
         assert result["accepted"] is True
+        assert result["persist"] is False
+
+    def test_opencode_go_known_model_persists_without_live_api(self):
+        result = _validate("glm-5", provider="opencode-go", api_models=None)
+        assert result["accepted"] is True
+        assert result["persist"] is True
+
+    def test_opencode_go_unknown_model_rejected_without_live_api(self):
+        result = _validate("glm-4.7", provider="opencode-go", api_models=None)
+        assert result["accepted"] is False
+        assert result["persist"] is False
+
+    def test_opencode_zen_unknown_model_rejected_even_if_api_down(self):
+        result = _validate("unknown-zen-model", provider="opencode-zen", api_models=None)
+        assert result["accepted"] is False
+        assert result["persist"] is False
+
+    def test_opencode_zen_mapped_model_rejected_when_live_catalog_disagrees(self):
+        result = _validate("gpt-5.4", provider="opencode-zen", api_models=["claude-sonnet-4-6"])
+        assert result["accepted"] is False
         assert result["persist"] is False

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -37,6 +37,8 @@ class TestProviderRegistry:
         ("kimi-coding", "Kimi / Moonshot", "api_key"),
         ("minimax", "MiniMax", "api_key"),
         ("minimax-cn", "MiniMax (China)", "api_key"),
+        ("opencode-go", "OpenCode Go", "api_key"),
+        ("opencode-zen", "OpenCode Zen", "api_key"),
     ])
     def test_provider_registered(self, provider_id, name, auth_type):
         assert provider_id in PROVIDER_REGISTRY
@@ -65,11 +67,19 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("MINIMAX_CN_API_KEY",)
         assert pconfig.base_url_env_var == "MINIMAX_CN_BASE_URL"
 
+    def test_opencode_env_vars(self):
+        assert PROVIDER_REGISTRY["opencode-go"].api_key_env_vars == ("OPENCODE_API_KEY",)
+        assert PROVIDER_REGISTRY["opencode-zen"].api_key_env_vars == ("OPENCODE_API_KEY",)
+        assert PROVIDER_REGISTRY["opencode-go"].auto_detect is False
+        assert PROVIDER_REGISTRY["opencode-zen"].auto_detect is False
+
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["minimax"].inference_base_url == "https://api.minimax.io/v1"
         assert PROVIDER_REGISTRY["minimax-cn"].inference_base_url == "https://api.minimaxi.com/v1"
+        assert PROVIDER_REGISTRY["opencode-go"].inference_base_url == "https://opencode.ai/zen/go/v1"
+        assert PROVIDER_REGISTRY["opencode-zen"].inference_base_url == "https://opencode.ai/zen/v1"
 
     def test_oauth_providers_unchanged(self):
         """Ensure we didn't break the existing OAuth providers."""
@@ -85,6 +95,7 @@ class TestProviderRegistry:
 
 PROVIDER_ENV_VARS = (
     "OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+    "OPENCODE_API_KEY",
     "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
     "KIMI_API_KEY", "KIMI_BASE_URL", "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
     "OPENAI_BASE_URL",
@@ -111,6 +122,12 @@ class TestResolveProvider:
 
     def test_explicit_minimax_cn(self):
         assert resolve_provider("minimax-cn") == "minimax-cn"
+
+    def test_explicit_opencode_go(self):
+        assert resolve_provider("opencode-go") == "opencode-go"
+
+    def test_explicit_opencode_zen(self):
+        assert resolve_provider("opencode-zen") == "opencode-zen"
 
     def test_alias_glm(self):
         assert resolve_provider("glm") == "zai"
@@ -167,6 +184,10 @@ class TestResolveProvider:
         """OpenRouter API key should win over GLM in auto-detection."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
         monkeypatch.setenv("GLM_API_KEY", "glm-key")
+        assert resolve_provider("auto") == "openrouter"
+
+    def test_opencode_key_does_not_trigger_ambiguous_auto_detection(self, monkeypatch):
+        monkeypatch.setenv("OPENCODE_API_KEY", "opencode-key")
         assert resolve_provider("auto") == "openrouter"
 
 
@@ -248,6 +269,20 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["api_key"] == "mmcn-secret-key"
         assert creds["base_url"] == "https://api.minimaxi.com/v1"
 
+    def test_resolve_opencode_go_with_shared_key(self, monkeypatch):
+        monkeypatch.setenv("OPENCODE_API_KEY", "opencode-secret-key")
+        creds = resolve_api_key_provider_credentials("opencode-go")
+        assert creds["provider"] == "opencode-go"
+        assert creds["api_key"] == "opencode-secret-key"
+        assert creds["base_url"] == "https://opencode.ai/zen/go/v1"
+
+    def test_resolve_opencode_zen_with_shared_key(self, monkeypatch):
+        monkeypatch.setenv("OPENCODE_API_KEY", "opencode-secret-key")
+        creds = resolve_api_key_provider_credentials("opencode-zen")
+        assert creds["provider"] == "opencode-zen"
+        assert creds["api_key"] == "opencode-secret-key"
+        assert creds["base_url"] == "https://opencode.ai/zen/v1"
+
     def test_resolve_with_custom_base_url(self, monkeypatch):
         monkeypatch.setenv("GLM_API_KEY", "glm-key")
         monkeypatch.setenv("GLM_BASE_URL", "https://custom.glm.example/v4")
@@ -316,6 +351,35 @@ class TestRuntimeProviderResolution:
         assert result["provider"] == "kimi-coding"
         assert result["api_key"] == "auto-kimi-key"
 
+    def test_runtime_opencode_go_uses_model_transport(self, monkeypatch):
+        monkeypatch.setenv("OPENCODE_API_KEY", "go-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="opencode-go", model="minimax-m2.5")
+
+        assert result["provider"] == "opencode-go"
+        assert result["transport"] == "anthropic_messages"
+        assert result["api_mode"] == "chat_completions"
+        assert result["base_url"] == "https://opencode.ai/zen/go/v1"
+
+    def test_runtime_opencode_zen_uses_model_transport(self, monkeypatch):
+        monkeypatch.setenv("OPENCODE_API_KEY", "zen-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="opencode-zen", model="gpt-5.4")
+
+        assert result["provider"] == "opencode-zen"
+        assert result["transport"] == "openai_responses"
+        assert result["api_mode"] == "codex_responses"
+        assert result["base_url"] == "https://opencode.ai/zen/v1"
+
+    def test_runtime_opencode_rejects_unmapped_model(self, monkeypatch):
+        monkeypatch.setenv("OPENCODE_API_KEY", "zen-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        with pytest.raises(AuthError):
+            resolve_runtime_provider(requested="opencode-zen", model="totally-unknown-model")
+
 
 # =============================================================================
 # _has_any_provider_configured tests
@@ -341,6 +405,32 @@ class TestHasAnyProviderConfigured:
         monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
         monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
         from hermes_cli.main import _has_any_provider_configured
+        assert _has_any_provider_configured() is True
+
+    def test_opencode_key_alone_does_not_count_without_explicit_provider(self, monkeypatch, tmp_path):
+        from hermes_cli import config as config_module
+
+        monkeypatch.setenv("OPENCODE_API_KEY", "test-key")
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
+        monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(config_module, "load_config", lambda: {})
+        from hermes_cli.main import _has_any_provider_configured
+
+        assert _has_any_provider_configured() is False
+
+    def test_opencode_key_counts_with_explicit_provider(self, monkeypatch, tmp_path):
+        from hermes_cli import config as config_module
+
+        monkeypatch.setenv("OPENCODE_API_KEY", "test-key")
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
+        monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(config_module, "load_config", lambda: {"model": {"provider": "opencode-go"}})
+        from hermes_cli.main import _has_any_provider_configured
+
         assert _has_any_provider_configured() is True
 
 

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -184,6 +184,46 @@ def test_resolve_runtime_provider_nous_api(monkeypatch):
     assert resolved["requested_provider"] == "nous-api"
 
 
+def test_resolve_runtime_provider_opencode_go_transport(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda pid: {
+            "provider": "opencode-go",
+            "api_key": "go-key",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "source": "OPENCODE_API_KEY",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="opencode-go", model="minimax-m2.5")
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["transport"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
+
+
+def test_resolve_runtime_provider_opencode_zen_transport(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-zen")
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda pid: {
+            "provider": "opencode-zen",
+            "api_key": "zen-key",
+            "base_url": "https://opencode.ai/zen/v1",
+            "source": "OPENCODE_API_KEY",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="opencode-zen", model="gemini-3-pro")
+
+    assert resolved["provider"] == "opencode-zen"
+    assert resolved["transport"] == "google_generate_content"
+    assert resolved["base_url"] == "https://opencode.ai/zen/v1"
+
+
 def test_resolve_requested_provider_precedence(monkeypatch):
     monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "nous")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openai-codex"})

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -21,6 +21,7 @@ def test_resolve_runtime_provider_codex(monkeypatch):
 
     assert resolved["provider"] == "openai-codex"
     assert resolved["api_mode"] == "codex_responses"
+    assert resolved["transport"] == "openai_responses"
     assert resolved["base_url"] == "https://chatgpt.com/backend-api/codex"
     assert resolved["api_key"] == "codex-token"
     assert resolved["requested_provider"] == "openai-codex"
@@ -42,6 +43,7 @@ def test_resolve_runtime_provider_openrouter_explicit(monkeypatch):
 
     assert resolved["provider"] == "openrouter"
     assert resolved["api_mode"] == "chat_completions"
+    assert resolved["transport"] == "openai_chat_completions"
     assert resolved["api_key"] == "test-key"
     assert resolved["base_url"] == "https://example.com/v1"
     assert resolved["source"] == "explicit"
@@ -176,6 +178,7 @@ def test_resolve_runtime_provider_nous_api(monkeypatch):
 
     assert resolved["provider"] == "nous-api"
     assert resolved["api_mode"] == "chat_completions"
+    assert resolved["transport"] == "openai_chat_completions"
     assert resolved["base_url"] == "https://inference-api.nousresearch.com/v1"
     assert resolved["api_key"] == "nous-test-key"
     assert resolved["requested_provider"] == "nous-api"

--- a/tests/test_transport_adapters.py
+++ b/tests/test_transport_adapters.py
@@ -1,0 +1,152 @@
+import json
+
+import httpx
+
+from agent.transport_adapters import AnthropicMessagesClient, GoogleGenerateContentClient
+
+
+def _tool_def(name="web_search"):
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"{name} tool",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+            },
+        },
+    }
+
+
+def test_anthropic_messages_client_converts_request_and_response(monkeypatch):
+    client = AnthropicMessagesClient(base_url="https://api.example.test/v1", api_key="ant-key")
+    captured = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_123",
+                "model": "claude-sonnet-4-6",
+                "content": [
+                    {"type": "text", "text": "Found it."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "web_search",
+                        "input": {"query": "Hermes"},
+                    },
+                ],
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 11, "output_tokens": 7, "cache_read_input_tokens": 2},
+            },
+            request=request,
+        )
+
+    monkeypatch.setattr(client._client, "post", fake_post)
+    response = client.chat.completions.create(
+        model="claude-sonnet-4-6",
+        messages=[
+            {"role": "system", "content": "Be terse."},
+            {"role": "user", "content": "Search for Hermes"},
+        ],
+        tools=[_tool_def()],
+        max_tokens=512,
+        timeout=12.0,
+    )
+
+    assert captured["url"] == "https://api.example.test/v1/messages"
+    assert captured["headers"]["x-api-key"] == "ant-key"
+    assert captured["headers"]["anthropic-version"] == "2023-06-01"
+    assert captured["timeout"] == 12.0
+    assert captured["json"]["model"] == "claude-sonnet-4-6"
+    assert captured["json"]["system"] == [{"type": "text", "text": "Be terse."}]
+    assert captured["json"]["tools"][0]["name"] == "web_search"
+    assert response.choices[0].finish_reason == "tool_calls"
+    assert response.choices[0].message.content == "Found it."
+    assert response.choices[0].message.tool_calls[0].function.name == "web_search"
+    assert json.loads(response.choices[0].message.tool_calls[0].function.arguments) == {"query": "Hermes"}
+    assert response.usage.prompt_tokens == 11
+    assert response.usage.prompt_tokens_details.cached_tokens == 2
+
+
+def test_google_generate_content_client_converts_request_and_response(monkeypatch):
+    client = GoogleGenerateContentClient(base_url="https://opencode.ai/zen/v1", api_key="goo-key")
+    captured = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200,
+            json={
+                "responseId": "resp_google_1",
+                "candidates": [
+                    {
+                        "content": {
+                            "role": "model",
+                            "parts": [
+                                {"text": "Need a tool."},
+                                {"functionCall": {"name": "web_search", "args": {"query": "Hermes"}}},
+                            ],
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 13,
+                    "candidatesTokenCount": 5,
+                    "totalTokenCount": 18,
+                    "cachedContentTokenCount": 4,
+                    "thoughtsTokenCount": 3,
+                },
+            },
+            request=request,
+        )
+
+    monkeypatch.setattr(client._client, "post", fake_post)
+    response = client.chat.completions.create(
+        model="gemini-3-pro",
+        messages=[
+            {"role": "system", "content": "Use tools when needed."},
+            {"role": "user", "content": "Search for Hermes"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": '{"query": "Hermes"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": '{"result": "done"}'},
+        ],
+        tools=[_tool_def()],
+        max_tokens=256,
+        timeout=9.0,
+    )
+
+    assert captured["url"] == "https://opencode.ai/zen/v1/models/gemini-3-pro:generateContent"
+    assert captured["headers"]["x-goog-api-key"] == "goo-key"
+    assert captured["timeout"] == 9.0
+    assert captured["json"]["systemInstruction"] == {"parts": [{"text": "Use tools when needed."}]}
+    assert captured["json"]["tools"][0]["functionDeclarations"][0]["name"] == "web_search"
+    assert any(part.get("functionCall") for part in captured["json"]["contents"][1]["parts"])
+    assert any(part.get("functionResponse") for part in captured["json"]["contents"][2]["parts"])
+    assert response.choices[0].finish_reason == "tool_calls"
+    assert response.choices[0].message.content == "Need a tool."
+    assert response.choices[0].message.tool_calls[0].function.name == "web_search"
+    assert json.loads(response.choices[0].message.tool_calls[0].function.arguments) == {"query": "Hermes"}
+    assert response.usage.prompt_tokens == 13
+    assert response.usage.completion_tokens_details.reasoning_tokens == 3

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -205,6 +205,7 @@ def _run_single_child(
             model=model or parent_agent.model,
             provider=getattr(parent_agent, "provider", None),
             api_mode=getattr(parent_agent, "api_mode", None),
+            transport=getattr(parent_agent, "transport", None),
             max_iterations=max_iterations,
             max_tokens=getattr(parent_agent, "max_tokens", None),
             reasoning_config=getattr(parent_agent, "reasoning_config", None),


### PR DESCRIPTION
## Summary
- add first-class `OpenCode Go` and `OpenCode Zen` providers
- use one canonical shared credential: `OPENCODE_API_KEY`
- make onboarding explicit so users choose Go or Zen before entering their API key
- add transport-aware curated model catalogs and strict model validation for both providers

## Depends on
This branch is stacked on top of #876.

GitHub will show the runtime-transport commit in this diff until #876 merges. The provider-specific review surface is the top commit in this branch:
- `feat(providers): add OpenCode Go and Zen support`

## Why
OpenCode Go and OpenCode Zen are separate products, but they share the same OpenCode account/API key surface. Modeling them as separate credentials makes onboarding and runtime routing harder than necessary.

This PR keeps those concerns separate:
- provider identity is explicit: `opencode-go` vs `opencode-zen`
- credential identity is shared: `OPENCODE_API_KEY`
- runtime transport comes from `provider + model`, not from the provider alone

## What changed
- register `opencode-go` and `opencode-zen` as first-class API-key providers
- add explicit provider choices in setup/model flows for both OpenCode products
- keep `OPENCODE_API_KEY` as the only canonical OpenCode credential env var
- do not add an ambiguous bare `opencode` alias
- add a single provider/model catalog in `hermes_cli.models` with transport metadata
- make OpenCode providers strict about supported models:
  - `OpenCode Go`: curated-only, no `/models` discovery dependency
  - `OpenCode Zen`: mapped curated models plus optional live `/models` availability checks
- reject unknown/unmapped OpenCode models instead of accepting them session-only
- thread the selected model into runtime resolution so agent creation picks the correct transport

## Provider scope in this PR
### OpenCode Go
- `glm-5`
- `kimi-k2.5`
- `minimax-m2.5`

### OpenCode Zen
- OpenAI Responses models documented by OpenCode Zen
- Claude models via Anthropic Messages
- Gemini 3.x models via Google GenerateContent
- curated OpenAI-compatible chat models documented by OpenCode Zen

## Validation
- `./.venv/bin/python -m py_compile hermes_cli/models.py hermes_cli/auth.py hermes_cli/runtime_provider.py hermes_cli/main.py hermes_cli/setup.py cli.py gateway/run.py cron/scheduler.py hermes_cli/status.py`
- `./.venv/bin/pytest tests/hermes_cli/test_model_validation.py tests/test_api_key_providers.py tests/test_runtime_provider_resolution.py -q`
- `./.venv/bin/pytest tests/test_provider_parity.py tests/test_run_agent_codex_responses.py tests/test_cli_provider_resolution.py tests/test_cli_model_command.py tests/test_api_key_providers.py tests/test_runtime_provider_resolution.py tests/hermes_cli/test_model_validation.py -q`

## Notes
- This follows up on the design issues discussed in #765.
- The shared-key approach is intentional: Go and Zen are separate provider choices, not separate credentials.
