### PR TITLE
feat(skills): add bundled opencode autonomous-agent skill

### DIFF
--- a/skills/autonomous-ai-agents/opencode/SKILL.md
+++ b/skills/autonomous-ai-agents/opencode/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: opencode
-description: Delegate coding tasks to OpenCode CLI agent for feature implementation, refactoring, and PR review workflows. Requires the opencode CLI installed and authenticated.
-version: 1.0.0
+description: Delegate coding tasks to OpenCode CLI agent for feature implementation, refactoring, PR review, and long-running autonomous sessions. Requires the opencode CLI installed and authenticated.
+version: 1.1.0
 author: Hermes Agent
 license: MIT
 metadata:
@@ -12,44 +12,75 @@ metadata:
 
 # OpenCode CLI
 
-Use OpenCode as an autonomous coding worker orchestrated by Hermes.
+Use OpenCode as an autonomous coding worker orchestrated by Hermes terminal/process tools.
 
-## When to use
+## When to Use
 
-- User asks to run work through OpenCode specifically
+- User explicitly asks to use OpenCode
 - You want an external coding agent to implement/refactor/review code
-- You need long-running coding sessions with progress monitoring
+- You need long-running coding sessions with progress checks
+- You want parallel task execution in isolated workdirs/worktrees
 
 ## Prerequisites
 
-- OpenCode installed and on PATH (`opencode`)
-- OpenCode authenticated (`opencode auth`)
-- A git repository for code tasks
+- OpenCode installed (`opencode`)
+- Auth configured (`opencode auth list` should show at least one provider)
+- Git repository for code tasks (recommended)
 - `pty=true` for interactive sessions
 
-## Quick reference
+## Binary Resolution (Important)
 
-One-shot execution:
+Shell environments may resolve different OpenCode binaries. If behavior differs between your terminal and Hermes, check:
+
+terminal(command="which -a opencode")
+terminal(command="opencode --version")
+
+If needed, pin an explicit binary path in commands:
+
+terminal(command="$HOME/.opencode/bin/opencode run '...'", workdir="~/project", pty=true)
+
+## Quick Reference
+
+One-shot task:
 
 terminal(command="opencode run 'Add retry logic to API calls and update tests'", workdir="~/project", pty=true)
 
-Interactive background session:
+Interactive session (background):
 
 terminal(command="opencode", workdir="~/project", background=true, pty=true)
 process(action="submit", session_id="<id>", data="Implement OAuth refresh flow and add tests")
 process(action="log", session_id="<id>")
 process(action="submit", session_id="<id>", data="/exit")
 
+## Common Flags
+
+| Flag | Use |
+|------|-----|
+| `run 'prompt'` | One-shot execution and exit |
+| `--continue` / `-c` | Continue the last OpenCode session |
+| `--session <id>` / `-s` | Continue a specific session |
+| `--agent <name>` | Choose OpenCode agent/profile |
+| `--model provider/model` | Force specific model |
+| `--format json` | Machine-readable output/events |
+
 ## Procedure
 
-1. Verify OpenCode availability:
+1. Verify tool readiness:
    - `terminal(command="opencode --version")`
-2. Use one-shot mode (`opencode run`) for bounded tasks.
-3. Use interactive mode (`opencode`) for iterative collaboration.
-4. For long tasks, run in background and monitor with `process(action="poll"|"log")`.
-5. Summarize resulting file changes and test outcomes before reporting completion.
+   - `terminal(command="opencode auth list")`
+2. For bounded tasks, use `opencode run '...'`.
+3. For iterative tasks, start `opencode` with `background=true, pty=true`.
+4. Monitor long tasks with `process(action="poll"|"log")`.
+5. If OpenCode asks for input, respond via `process(action="submit", ...)`.
+6. Summarize file changes, test results, and next steps back to user.
 
-## Parallel work pattern
+## PR Review Workflow
+
+Safe review in temporary clone:
+
+terminal(command="REVIEW=$(mktemp -d) && git clone https://github.com/user/repo.git $REVIEW && cd $REVIEW && gh pr checkout 42 && opencode run 'Review this PR vs main. Report bugs, security risks, test gaps, and style issues.'", pty=true)
+
+## Parallel Work Pattern
 
 Use separate workdirs/worktrees to avoid collisions:
 
@@ -59,14 +90,27 @@ process(action="list")
 
 ## Pitfalls
 
-- `pty=true` is required for interactive `opencode` sessions.
-- If command behavior differs between shells, check which binary is being resolved:
-  - `terminal(command="which -a opencode")`
-- If OpenCode asks follow-up questions, respond with `process(action="submit", ...)`.
+- Interactive `opencode` sessions require `pty=true`.
+- PATH mismatch can select the wrong OpenCode binary/model config.
+- If OpenCode appears stuck, inspect logs before killing:
+  - `process(action="log", session_id="<id>")`
+- Avoid sharing one working directory across parallel OpenCode sessions.
 
 ## Verification
 
-- Smoke test:
-  - `terminal(command="opencode run 'Respond with exactly: OPENCODE_SMOKE_OK'", pty=true)`
-- Confirm output contains `OPENCODE_SMOKE_OK`.
-- Confirm any requested code changes and tests were applied successfully.
+Smoke test:
+
+terminal(command="opencode run 'Respond with exactly: OPENCODE_SMOKE_OK'", pty=true)
+
+Success criteria:
+- Output includes `OPENCODE_SMOKE_OK`
+- Command exits without provider/model errors
+- For code tasks: expected files changed and tests pass
+
+## Rules
+
+1. Prefer `opencode run` for one-shot automation.
+2. Use interactive background mode only when iteration is needed.
+3. Always scope OpenCode sessions to a single repo/workdir.
+4. For long tasks, provide progress updates from `process` logs.
+5. Report concrete outcomes (files changed, tests, remaining risks).

--- a/skills/autonomous-ai-agents/opencode/SKILL.md
+++ b/skills/autonomous-ai-agents/opencode/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: opencode
+description: Delegate coding tasks to OpenCode CLI agent for feature implementation, refactoring, and PR review workflows. Requires the opencode CLI installed and authenticated.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [Coding-Agent, OpenCode, Autonomous, Refactoring, Code-Review]
+    related_skills: [claude-code, codex, hermes-agent]
+---
+
+# OpenCode CLI
+
+Use OpenCode as an autonomous coding worker orchestrated by Hermes.
+
+## When to use
+
+- User asks to run work through OpenCode specifically
+- You want an external coding agent to implement/refactor/review code
+- You need long-running coding sessions with progress monitoring
+
+## Prerequisites
+
+- OpenCode installed and on PATH (`opencode`)
+- OpenCode authenticated (`opencode auth`)
+- A git repository for code tasks
+- `pty=true` for interactive sessions
+
+## Quick reference
+
+One-shot execution:
+
+terminal(command="opencode run 'Add retry logic to API calls and update tests'", workdir="~/project", pty=true)
+
+Interactive background session:
+
+terminal(command="opencode", workdir="~/project", background=true, pty=true)
+process(action="submit", session_id="<id>", data="Implement OAuth refresh flow and add tests")
+process(action="log", session_id="<id>")
+process(action="submit", session_id="<id>", data="/exit")
+
+## Procedure
+
+1. Verify OpenCode availability:
+   - `terminal(command="opencode --version")`
+2. Use one-shot mode (`opencode run`) for bounded tasks.
+3. Use interactive mode (`opencode`) for iterative collaboration.
+4. For long tasks, run in background and monitor with `process(action="poll"|"log")`.
+5. Summarize resulting file changes and test outcomes before reporting completion.
+
+## Parallel work pattern
+
+Use separate workdirs/worktrees to avoid collisions:
+
+terminal(command="opencode run 'Fix issue #101 and commit'", workdir="/tmp/issue-101", background=true, pty=true)
+terminal(command="opencode run 'Add parser regression tests and commit'", workdir="/tmp/issue-102", background=true, pty=true)
+process(action="list")
+
+## Pitfalls
+
+- `pty=true` is required for interactive `opencode` sessions.
+- If command behavior differs between shells, check which binary is being resolved:
+  - `terminal(command="which -a opencode")`
+- If OpenCode asks follow-up questions, respond with `process(action="submit", ...)`.
+
+## Verification
+
+- Smoke test:
+  - `terminal(command="opencode run 'Respond with exactly: OPENCODE_SMOKE_OK'", pty=true)`
+- Confirm output contains `OPENCODE_SMOKE_OK`.
+- Confirm any requested code changes and tests were applied successfully.


### PR DESCRIPTION
## What does this PR do?

Adds a new bundled skill: `opencode` under `skills/autonomous-ai-agents/`.

This gives Hermes a first-class autonomous-agent workflow for OpenCode, similar to existing `claude-code` and `codex` skills.

## Related Issue

N/A (skill addition)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- Added file:
  - `skills/autonomous-ai-agents/opencode/SKILL.md`
- Skill includes:
  - one-shot `opencode run` workflow
  - interactive/background session workflow via `terminal` + `process`
  - parallel work patterns
  - troubleshooting + smoke verification

## How to Test

1. Ensure OpenCode CLI is installed and authenticated:
   - `opencode --version`
   - `opencode auth list`
2. Run Hermes with skills enabled and ask it to use `opencode`.
3. Smoke test:
   - `opencode run 'Respond with exactly: OPENCODE_SMOKE_OK'`
4. Confirm output includes `OPENCODE_SMOKE_OK`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: macOS
- [x] N/A for this skill-only PR: no Python runtime/codepath changes, so no new unit tests required

### Documentation & Housekeeping

- [x] N/A for this skill-only PR: README/docs/docstrings updates
- [x] N/A for this skill-only PR: `cli-config.yaml.example`
- [x] N/A for this skill-only PR: `CONTRIBUTING.md` or `AGENTS.md`
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] N/A for this skill-only PR: tool descriptions/schemas

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format)
- [x] No external dependencies that aren't already available (OpenCode CLI is required by design)
- [x] I've tested the skill end-to-end

## Screenshots / Logs

- Local OpenCode smoke test output included: `OPENCODE_SMOKE_OK`
- Targeted pytest run (not full suite): `./venv/bin/pytest tests/tools/test_skills_hub.py -q` -> `43 passed`
- Explicit check: no existing skill-specific tests found for bundled `claude-code`/`codex` SKILL.md files in `tests/`
