### PR TITLE
feat(skills): add official optional 1password skill

### DIFF
--- a/optional-skills/security/1password/SKILL.md
+++ b/optional-skills/security/1password/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: 1password
+description: Set up and use 1Password CLI (op). Use when installing the CLI, enabling desktop app integration, signing in, and reading/injecting secrets for commands.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [security, secrets, 1password, op, cli]
+    category: security
+---
+
+# 1Password CLI
+
+Use this skill when the user wants secrets managed through 1Password instead of plaintext env vars or files.
+
+## Requirements
+
+- 1Password account
+- 1Password desktop app installed and unlocked
+- 1Password CLI (`op`) installed
+- `tmux` available for stable authenticated sessions during Hermes terminal calls
+
+## When to Use
+
+- Install or configure 1Password CLI
+- Sign in with `op signin`
+- Read secret references like `op://Vault/Item/field`
+- Inject secrets into config/templates using `op inject`
+- Run commands with secret env vars via `op run`
+
+## Setup
+
+1. Install CLI:
+
+```bash
+# macOS
+brew install 1password-cli
+
+# Linux (official package/install docs)
+# See references/get-started.md for distro-specific links.
+
+# Windows (winget)
+winget install AgileBits.1Password.CLI
+```
+
+2. Verify:
+
+```bash
+op --version
+```
+
+3. Enable app integration in 1Password desktop app:
+- macOS: Settings -> Developer -> Integrate with 1Password CLI
+- Linux/Windows: Settings -> Developer -> Integrate with 1Password CLI
+
+4. Ensure app is unlocked.
+
+## Hermes Execution Pattern (important)
+
+Hermes terminal commands are non-interactive by default and can lose auth context between calls.
+For reliable `op` use, run sign-in and secret operations inside a dedicated tmux session.
+
+```bash
+SOCKET_DIR="${TMPDIR:-/tmp}/hermes-tmux-sockets"
+mkdir -p "$SOCKET_DIR"
+SOCKET="$SOCKET_DIR/hermes-op.sock"
+SESSION="op-auth-$(date +%Y%m%d-%H%M%S)"
+
+tmux -S "$SOCKET" new -d -s "$SESSION" -n shell
+
+# Sign in (approve in desktop app when prompted)
+tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -- "eval \"\$(op signin --account my.1password.com)\"" Enter
+
+# Verify auth
+tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -- "op whoami" Enter
+
+# Example read
+tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -- "op read 'op://Private/Npmjs/one-time password?attribute=otp'" Enter
+
+# Capture output when needed
+tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":0.0 -S -200
+
+# Cleanup
+tmux -S "$SOCKET" kill-session -t "$SESSION"
+```
+
+## Common Operations
+
+### Read a secret
+
+```bash
+op read "op://app-prod/db/password"
+```
+
+### Get OTP
+
+```bash
+op read "op://app-prod/npm/one-time password?attribute=otp"
+```
+
+### Inject into template
+
+```bash
+echo "db_password: {{ op://app-prod/db/password }}" | op inject
+```
+
+### Run a command with secret env var
+
+```bash
+export OPENAI_API_KEY="op://.../api key"
+op run -- sh -c '[ -n "$OPENAI_API_KEY" ] && echo "OPENAI_API_KEY is set" || echo "OPENAI_API_KEY missing"'
+```
+
+## Guardrails
+
+- Never print raw secrets back to user unless they explicitly request the value.
+- Prefer `op run` / `op inject` instead of writing secrets into files.
+- If command fails with "account is not signed in", run `op signin` again in the same tmux session.
+- If desktop app integration is unavailable (headless/CI), use service account token flow.
+
+## CI / Headless note
+
+For non-interactive use, authenticate with `OP_SERVICE_ACCOUNT_TOKEN` and avoid interactive `op signin`.
+
+## References
+
+- `references/get-started.md`
+- `references/cli-examples.md`
+- https://developer.1password.com/docs/cli/

--- a/optional-skills/security/1password/references/cli-examples.md
+++ b/optional-skills/security/1password/references/cli-examples.md
@@ -1,0 +1,31 @@
+# op CLI examples
+
+## Sign-in and identity
+
+```bash
+op signin
+op signin --account my.1password.com
+op whoami
+op account list
+```
+
+## Read secrets
+
+```bash
+op read "op://app-prod/db/password"
+op read "op://app-prod/one-time password?attribute=otp"
+```
+
+## Inject secrets
+
+```bash
+echo "api_key: {{ op://app-prod/openai/api key }}" | op inject
+op inject -i config.tpl.yml -o config.yml
+```
+
+## Run command with secrets
+
+```bash
+export DB_PASSWORD="op://app-prod/db/password"
+op run -- sh -c '[ -n "$DB_PASSWORD" ] && echo "DB_PASSWORD is set"'
+```

--- a/optional-skills/security/1password/references/get-started.md
+++ b/optional-skills/security/1password/references/get-started.md
@@ -1,0 +1,21 @@
+# 1Password CLI get-started (summary)
+
+Official docs: https://developer.1password.com/docs/cli/get-started/
+
+## Core flow
+
+1. Install `op` CLI.
+2. Enable desktop app integration in 1Password app.
+3. Unlock app.
+4. Run `op signin` and approve prompt.
+5. Verify with `op whoami`.
+
+## Multiple accounts
+
+- Use `op signin --account <subdomain.1password.com>`
+- Or set `OP_ACCOUNT`
+
+## Non-interactive / automation
+
+- Use service accounts and `OP_SERVICE_ACCOUNT_TOKEN`
+- Prefer `op run` and `op inject` for runtime secret handling


### PR DESCRIPTION
## What does this PR do?

Adds a new official optional skill for 1Password CLI (`op`) under `optional-skills/security/1password`.

The skill documents install/auth flows, Hermes-safe execution guidance (tmux session pattern), and safe examples for `op read`, `op inject`, and `op run`.

## Type of Change

- [x] ✨ Feature (new skill)
- [x] 📚 Documentation/content update

## Changes Made

- Added `optional-skills/security/1password/SKILL.md`
  - Includes prerequisites, setup, and usage guidance for 1Password CLI
  - Includes Hermes reliability guidance for running `op` commands in tmux
  - Includes guardrails for secret handling
- Added `optional-skills/security/1password/references/get-started.md`
- Added `optional-skills/security/1password/references/cli-examples.md`
- Set metadata author to `Hermes Agent` to match existing skill conventions.
- Updated `op run` examples to avoid printing secret values (scanner-safe examples).

## How to Test

I tested this end-to-end on macOS in a local clone:

1. Discoverability:
   - `venv/bin/hermes skills search 1password`
   - Verify result appears as `official/security/1password`.
2. Inspect:
   - `venv/bin/hermes skills inspect official/security/1password`
3. Install:
   - `printf 'y\n' | venv/bin/hermes skills install official/security/1password`
   - Verify scan verdict is `SAFE`.
4. Verify installed listing:
   - `venv/bin/hermes skills list --source all`
   - Confirm `1password` appears as `Source=official`.
5. Runtime load smoke test:
   - `venv/bin/hermes chat -t skills -q "Use the 1password skill and answer in one sentence: should op commands be run in tmux for Hermes reliability?"`
   - Confirm skill load + guidance response.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits
- [x] PR contains only this scoped skill addition
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] This PR is skill-content only; no runtime/tooling code changes
- [x] No secrets or tokens are committed (examples/placeholders only)
