### PR TITLE
fix: prefer Codex creds for isolated Hermes homes

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -506,6 +506,17 @@ def resolve_provider(
     except Exception as e:
         logger.debug("Could not detect active auth provider: %s", e)
 
+    # If this HERMES_HOME has no auth store yet, but Codex CLI credentials exist
+    # in the shared external location, prefer Codex so runtime resolution can
+    # import them into Hermes's own auth store. This fixes isolated HERMES_HOME
+    # profiles (like the Paperclip gateway runtime) defaulting to OpenRouter with
+    # an empty API key even though valid Codex credentials are available.
+    try:
+        if _import_codex_cli_tokens():
+            return "openai-codex"
+    except Exception as e:
+        logger.debug("Could not detect external Codex credentials: %s", e)
+
     if os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY"):
         return "openrouter"
 

--- a/tests/test_auth_codex_provider.py
+++ b/tests/test_auth_codex_provider.py
@@ -128,6 +128,23 @@ def test_resolve_provider_explicit_codex_does_not_fallback(monkeypatch):
     assert resolve_provider("openai-codex") == "openai-codex"
 
 
+def test_resolve_provider_auto_prefers_external_codex_cli_when_runtime_home_is_empty(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    codex_home = tmp_path / "codex-cli"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "auth.json").write_text(json.dumps({
+        "tokens": {"access_token": "cli-at", "refresh_token": "cli-rt"},
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    assert resolve_provider("auto") == "openai-codex"
+
+
 def test_save_codex_tokens_roundtrip(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What does this PR do?

Fixes isolated Hermes homes created by the Paperclip gateway resolving to the wrong inference provider.

In the broken path, wake-created Paperclip sessions could ignore the Codex runtime configured under the isolated `HERMES_HOME` and drift to OpenRouter instead. That produced misleading upstream 401s (`Missing Authentication header`) even though the Paperclip API bearer token path was already correct.

This change makes the auth/provider resolution prefer the external Codex credentials in that isolated-home case so Paperclip wake runs honor the configured Codex runtime.

## Related Issue

Fixes the Paperclip wake regression where gateway-created runs targeted OpenRouter instead of Codex and failed upstream with 401s.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `hermes_cli/auth.py` to prefer/import external Codex credentials for isolated Hermes homes used by Paperclip wakes
- Add regression coverage in `tests/test_auth_codex_provider.py`

## How to Test

1. `source venv/bin/activate`
2. `pytest tests/test_auth_codex_provider.py -q`
3. Run a Paperclip wake flow with an isolated `HERMES_HOME` configured for Codex and confirm the resulting session resolves `base_url=https://chatgpt.com/backend-api/codex` instead of OpenRouter

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Regression reproduced before the fix via Paperclip wake-created sessions resolving `base_url=https://openrouter.ai/api/v1`; verified after the fix with live Paperclip smoke showing Codex resolution and successful follow-up issue creation.
