### PR TITLE
fix: sort Nous Portal model list (opus first, sonnet lower)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1103,6 +1103,19 @@ def fetch_nous_models(
                 continue
             model_ids.append(mid)
 
+    # Sort: prefer opus > pro > haiku/flash > sonnet (sonnet is cheap/fast,
+    # users who want the best model should see opus first).
+    def _model_priority(mid: str) -> tuple:
+        low = mid.lower()
+        if "opus" in low:
+            return (0, mid)
+        if "pro" in low and "sonnet" not in low:
+            return (1, mid)
+        if "sonnet" in low:
+            return (3, mid)
+        return (2, mid)
+
+    model_ids.sort(key=_model_priority)
     return list(dict.fromkeys(model_ids))
 
 


### PR DESCRIPTION
fetch_nous_models() returned models in whatever order the API provided, which could put sonnet near the top. Adds a priority sort: opus > pro > other > sonnet.

One-file change in hermes_cli/auth.py, 13 lines added. 2877 tests pass.