### PR TITLE
fix: report cronjob tool as available in hermes doctor

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -69,6 +69,10 @@ def check_info(text: str):
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
+
+    # Doctor runs from the interactive CLI, so CLI-gated tool availability
+    # checks (like cronjob management) should see the same context as `hermes`.
+    os.environ.setdefault("HERMES_INTERACTIVE", "1")
     
     issues = []
     manual_issues = []  # issues that can't be auto-fixed

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1,5 +1,13 @@
-"""Tests for hermes doctor helpers."""
+"""Tests for hermes_cli.doctor."""
 
+import os
+import sys
+import types
+from argparse import Namespace
+
+import pytest
+
+from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
 
 
@@ -15,3 +23,32 @@ class TestProviderEnvDetection:
     def test_returns_false_when_no_provider_settings(self):
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)
+
+
+def test_run_doctor_sets_interactive_env_for_tool_checks(monkeypatch, tmp_path):
+    """Doctor should present CLI-gated tools as available in CLI context."""
+    project_root = tmp_path / "project"
+    hermes_home = tmp_path / ".hermes"
+    project_root.mkdir()
+    hermes_home.mkdir()
+
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", hermes_home)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    seen = {}
+
+    def fake_check_tool_availability(*args, **kwargs):
+        seen["interactive"] = os.getenv("HERMES_INTERACTIVE")
+        raise SystemExit(0)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=fake_check_tool_availability,
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    with pytest.raises(SystemExit):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    assert seen["interactive"] == "1"


### PR DESCRIPTION
## Summary
- set `HERMES_INTERACTIVE=1` when running `hermes doctor` so CLI-gated tool checks run in the same context as the interactive CLI
- keep cronjob tool availability from being misreported as a missing system dependency
- add a regression test for doctor's tool-availability path

## Testing
- pytest -q tests/hermes_cli/test_doctor.py

Fixes #878