### PR TITLE
Fix duplicate 'skills' subparser causing CLI crash

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2329,17 +2329,16 @@ For more help on a command:
     tools_parser.set_defaults(func=cmd_tools)
 
     # =========================================================================
-    # skills command
+    # skills config subcommand (added under existing skills parser)
     # =========================================================================
-    skills_parser = subparsers.add_parser(
-        "skills",
+    skills_config_sub = skills_subparsers.add_parser(
+        "config",
         help="Configure which skills are enabled",
-        description="Interactive skill configuration — enable/disable individual skills."
     )
     def cmd_skills(args):
         from hermes_cli.skills_config import skills_command
         skills_command(args)
-    skills_parser.set_defaults(func=cmd_skills)
+    skills_config_sub.set_defaults(func=cmd_skills)
     # =========================================================================
     # sessions command
     # =========================================================================


### PR DESCRIPTION
## Summary

- The `skills` name is registered twice as a top-level argparse subparser: once for the Skills Hub (line ~2253, with subcommands like `search`, `install`, `browse`) and again for the skills config toggle (line ~2334). Python's argparse raises `ArgumentError: conflicting subparser: skills` on the duplicate, **preventing the entire CLI from starting**.
- This moves the config toggle to `hermes skills config` as a subcommand under the existing `skills` parser, resolving the conflict.

## Repro

```
$ hermes setup
Traceback (most recent call last):
  ...
  File ".../hermes_cli/main.py", line 2334, in main
    skills_parser = subparsers.add_parser(
argparse.ArgumentError: argument command: conflicting subparser: skills
```

## Test plan

- [x] `hermes setup` no longer crashes
- [ ] `hermes skills search <query>` still works (Skills Hub)
- [ ] `hermes skills config` opens the interactive config toggle