### PR TITLE
fix: prevent logging handler accumulation in gateway mode

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -306,19 +306,29 @@ class AIAgent:
 
         # Persistent error log -- always writes WARNING+ to ~/.hermes/logs/errors.log
         # so tool failures, API errors, etc. are inspectable after the fact.
-        from agent.redact import RedactingFormatter
-        _error_log_dir = Path.home() / ".hermes" / "logs"
-        _error_log_dir.mkdir(parents=True, exist_ok=True)
-        _error_log_path = _error_log_dir / "errors.log"
+        # In gateway mode, each incoming message creates a new AIAgent instance,
+        # while the root logger is process-global. Re-adding the same errors.log
+        # handler would cause each warning/error line to be written multiple times.
         from logging.handlers import RotatingFileHandler
-        _error_file_handler = RotatingFileHandler(
-            _error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,
+        root_logger = logging.getLogger()
+        error_log_dir = Path.home() / ".hermes" / "logs"
+        error_log_path = error_log_dir / "errors.log"
+        has_errors_log_handler = any(
+            isinstance(handler, RotatingFileHandler)
+            and Path(getattr(handler, "baseFilename", "")) == error_log_path
+            for handler in root_logger.handlers
         )
-        _error_file_handler.setLevel(logging.WARNING)
-        _error_file_handler.setFormatter(RedactingFormatter(
-            '%(asctime)s %(levelname)s %(name)s: %(message)s',
-        ))
-        logging.getLogger().addHandler(_error_file_handler)
+        if not has_errors_log_handler:
+            from agent.redact import RedactingFormatter
+            error_log_dir.mkdir(parents=True, exist_ok=True)
+            error_file_handler = RotatingFileHandler(
+                error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,
+            )
+            error_file_handler.setLevel(logging.WARNING)
+            error_file_handler.setFormatter(RedactingFormatter(
+                '%(asctime)s %(levelname)s %(name)s: %(message)s',
+            ))
+            root_logger.addHandler(error_file_handler)
 
         if self.verbose_logging:
             logging.basicConfig(


### PR DESCRIPTION
## Summary

`AIAgent.__init__()` unconditionally calls `logging.getLogger().addHandler(RotatingFileHandler(...errors.log...))`. In gateway mode, a new `AIAgent` is created per incoming message, so handlers accumulate linearly — after N messages, every WARNING+ log line is written N+1 times.

### Root Cause

The gateway already adds an `errors.log` handler at startup (`gateway/run.py:3242-3249`). Each subsequent `AIAgent` instance adds another one to the same root logger, and Python's logging module dispatches to all attached handlers.

### Fix

Guard the `addHandler` call by checking whether the root logger already has a `RotatingFileHandler` whose resolved `Path(baseFilename)` matches the exact `errors.log` path. If one exists, skip adding a duplicate. This avoids false positives from `endswith` matching similarly-named files.

One-file change in `run_agent.py`, net +10 lines.

### Impact

- **Gateway**: no more handler accumulation; startup handler is reused
- **CLI**: unchanged (single `AIAgent` per session, guard is a no-op)
- **Subagent delegation**: parent adds handler, child skips — correct