### PR TITLE
fix: sanitize chat payloads and provider precedence

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1142,8 +1142,8 @@ class HermesCLI:
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (
             provider
-            or os.getenv("HERMES_INFERENCE_PROVIDER")
             or CLI_CONFIG["model"].get("provider")
+            or os.getenv("HERMES_INFERENCE_PROVIDER")
             or "auto"
         )
         self._provider_source: Optional[str] = None

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -726,8 +726,8 @@ def cmd_model(args):
         config_provider = model_cfg.get("provider")
 
     effective_provider = (
-        os.getenv("HERMES_INFERENCE_PROVIDER")
-        or config_provider
+        config_provider
+        or os.getenv("HERMES_INFERENCE_PROVIDER")
         or "auto"
     )
     try:
@@ -2340,6 +2340,20 @@ For more help on a command:
         tools_command(args)
 
     tools_parser.set_defaults(func=cmd_tools)
+
+    # =========================================================================
+    # skills-config command
+    # =========================================================================
+    skills_parser = subparsers.add_parser(
+        "skills-config",
+        aliases=["skill-config"],
+        help="Configure which installed skills are enabled",
+        description="Interactive skill configuration — enable/disable individual installed skills."
+    )
+    def cmd_skills(args):
+        from hermes_cli.skills_config import skills_command
+        skills_command(args)
+    skills_parser.set_defaults(func=cmd_skills)
     # =========================================================================
     # sessions command
     # =========================================================================

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -33,14 +33,16 @@ def resolve_requested_provider(requested: Optional[str] = None) -> str:
     if requested and requested.strip():
         return requested.strip().lower()
 
-    env_provider = os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower()
-    if env_provider:
-        return env_provider
-
     model_cfg = _get_model_config()
     cfg_provider = model_cfg.get("provider")
     if isinstance(cfg_provider, str) and cfg_provider.strip():
         return cfg_provider.strip().lower()
+
+    # Prefer the persisted config selection over any stale shell/.env
+    # provider override so chat uses the endpoint the user last saved.
+    env_provider = os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower()
+    if env_provider:
+        return env_provider
 
     return "auto"
 

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -1,6 +1,6 @@
 """
 Skills configuration for Hermes Agent.
-`hermes skills` enters this module.
+`hermes skills-config` enters this module.
 
 Toggle individual skills or categories on/off, globally or per-platform.
 Config stored in ~/.hermes/config.yaml under:
@@ -127,9 +127,7 @@ def _toggle_by_category(skills: List[dict], disabled: Set[str]) -> Set[str]:
 # ─── Entry Point ──────────────────────────────────────────────────────────────
 
 def skills_command(args=None):
-    """Entry point for `hermes skills`."""
-    from hermes_cli.curses_ui import curses_checklist
-
+    """Entry point for `hermes skills-config`."""
     config = load_config()
     skills = _list_all_skills()
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2418,20 +2418,41 @@ class AIAgent:
 
             return kwargs
 
-        sanitized_messages = copy.deepcopy(api_messages)
-        for msg in sanitized_messages:
+        sanitized_messages = api_messages
+        needs_sanitization = False
+        for msg in api_messages:
             if not isinstance(msg, dict):
                 continue
-
-            # Codex-only replay state must not leak into strict chat-completions APIs.
-            msg.pop("codex_reasoning_items", None)
+            if "codex_reasoning_items" in msg:
+                needs_sanitization = True
+                break
 
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tool_call in tool_calls:
-                    if isinstance(tool_call, dict):
-                        tool_call.pop("call_id", None)
-                        tool_call.pop("response_item_id", None)
+                    if not isinstance(tool_call, dict):
+                        continue
+                    if "call_id" in tool_call or "response_item_id" in tool_call:
+                        needs_sanitization = True
+                        break
+                if needs_sanitization:
+                    break
+
+        if needs_sanitization:
+            sanitized_messages = copy.deepcopy(api_messages)
+            for msg in sanitized_messages:
+                if not isinstance(msg, dict):
+                    continue
+
+                # Codex-only replay state must not leak into strict chat-completions APIs.
+                msg.pop("codex_reasoning_items", None)
+
+                tool_calls = msg.get("tool_calls")
+                if isinstance(tool_calls, list):
+                    for tool_call in tool_calls:
+                        if isinstance(tool_call, dict):
+                            tool_call.pop("call_id", None)
+                            tool_call.pop("response_item_id", None)
 
         provider_preferences = {}
         if self.providers_allowed:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2418,6 +2418,21 @@ class AIAgent:
 
             return kwargs
 
+        sanitized_messages = copy.deepcopy(api_messages)
+        for msg in sanitized_messages:
+            if not isinstance(msg, dict):
+                continue
+
+            # Codex-only replay state must not leak into strict chat-completions APIs.
+            msg.pop("codex_reasoning_items", None)
+
+            tool_calls = msg.get("tool_calls")
+            if isinstance(tool_calls, list):
+                for tool_call in tool_calls:
+                    if isinstance(tool_call, dict):
+                        tool_call.pop("call_id", None)
+                        tool_call.pop("response_item_id", None)
+
         provider_preferences = {}
         if self.providers_allowed:
             provider_preferences["only"] = self.providers_allowed
@@ -2434,7 +2449,7 @@ class AIAgent:
 
         api_kwargs = {
             "model": self.model,
-            "messages": api_messages,
+            "messages": sanitized_messages,
             "tools": self.tools if self.tools else None,
             "timeout": 900.0,
         }

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -3,7 +3,7 @@
 import json
 import os
 from pathlib import Path
-from multiprocessing import Lock
+from threading import Lock
 from unittest.mock import patch, MagicMock
 
 import pytest

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -162,6 +162,22 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     assert shell.api_mode == "codex_responses"
 
 
+def test_cli_prefers_config_provider_over_stale_env_override(monkeypatch):
+    cli = _import_cli()
+
+    monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "openrouter")
+    config_copy = dict(cli.CLI_CONFIG)
+    model_copy = dict(config_copy.get("model", {}))
+    model_copy["provider"] = "custom"
+    model_copy["base_url"] = "https://api.fireworks.ai/inference/v1"
+    config_copy["model"] = model_copy
+    monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+
+    shell = cli.HermesCLI(model="fireworks/minimax-m2p5", compact=True, max_turns=1)
+
+    assert shell.requested_provider == "custom"
+
+
 def test_codex_provider_replaces_incompatible_default_model(monkeypatch):
     """When provider resolves to openai-codex and no model was explicitly
     chosen, the global config default (e.g. anthropic/claude-opus-4.6) must
@@ -303,3 +319,15 @@ def test_cmd_model_falls_back_to_auto_on_invalid_provider(monkeypatch, capsys):
     assert "Warning:" in output
     assert "falling back to auto provider detection" in output.lower()
     assert "No change." in output
+
+
+def test_main_help_builds_parser_without_duplicate_subcommands(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["hermes", "--help"])
+
+    try:
+        hermes_main.main()
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    output = capsys.readouterr().out
+    assert "skills-config" in output

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -95,6 +95,47 @@ class TestBuildApiKwargsOpenRouter:
         assert "instructions" not in kwargs
         assert "store" not in kwargs
 
+    def test_strips_codex_only_tool_call_fields_from_chat_messages(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openrouter")
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Checking now.",
+                "codex_reasoning_items": [
+                    {"type": "reasoning", "id": "rs_1", "encrypted_content": "blob"},
+                ],
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "call_id": "call_123",
+                        "response_item_id": "fc_123",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{\"command\":\"pwd\"}"},
+                        "extra_content": {"thought_signature": "opaque"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_123", "content": "/tmp"},
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assistant_msg = kwargs["messages"][1]
+        tool_call = assistant_msg["tool_calls"][0]
+
+        assert "codex_reasoning_items" not in assistant_msg
+        assert tool_call["id"] == "call_123"
+        assert tool_call["function"]["name"] == "terminal"
+        assert tool_call["extra_content"] == {"thought_signature": "opaque"}
+        assert "call_id" not in tool_call
+        assert "response_item_id" not in tool_call
+
+        # Original stored history must remain unchanged for Responses replay mode.
+        assert messages[1]["tool_calls"][0]["call_id"] == "call_123"
+        assert messages[1]["tool_calls"][0]["response_item_id"] == "fc_123"
+        assert "codex_reasoning_items" in messages[1]
+
 
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -168,6 +168,52 @@ class TestBuildApiKwargsCustomEndpoint:
         extra = kwargs.get("extra_body", {})
         assert "reasoning" not in extra
 
+    def test_fireworks_tool_call_payload_strips_codex_only_fields(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "custom",
+            base_url="https://api.fireworks.ai/inference/v1",
+        )
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Checking now.",
+                "codex_reasoning_items": [
+                    {"type": "reasoning", "id": "rs_1", "encrypted_content": "blob"},
+                ],
+                "tool_calls": [
+                    {
+                        "id": "call_fw_123",
+                        "call_id": "call_fw_123",
+                        "response_item_id": "fc_fw_123",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": "{\"command\":\"pwd\"}",
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_fw_123", "content": "/tmp"},
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assert kwargs["tools"][0]["function"]["name"] == "web_search"
+        assert "input" not in kwargs
+        assert kwargs.get("extra_body", {}) == {}
+
+        assistant_msg = kwargs["messages"][1]
+        tool_call = assistant_msg["tool_calls"][0]
+
+        assert "codex_reasoning_items" not in assistant_msg
+        assert tool_call["id"] == "call_fw_123"
+        assert tool_call["type"] == "function"
+        assert tool_call["function"]["name"] == "terminal"
+        assert "call_id" not in tool_call
+        assert "response_item_id" not in tool_call
+
 
 class TestBuildApiKwargsCodex:
     def test_uses_responses_api_format(self, monkeypatch):

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -204,3 +204,10 @@ def test_resolve_requested_provider_precedence(monkeypatch):
     monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "nous")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openai-codex"})
     assert rp.resolve_requested_provider("openrouter") == "openrouter"
+    assert rp.resolve_requested_provider() == "openai-codex"
+
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    assert rp.resolve_requested_provider() == "nous"
+
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    assert rp.resolve_requested_provider() == "auto"


### PR DESCRIPTION
Fixes #893

## Summary
This PR prevents Codex-only replay metadata from leaking into chat-completions requests and fixes provider precedence regressions in the CLI. It also replaces a multiprocessing lock in a checkpoint test so sandboxed CI runners do not fail on SemLock permissions.

## Changes
- sanitize outbound chat-completions messages by removing codex-only fields
- preserve original stored history for Codex Responses replay mode
- prefer saved config provider over stale environment override in CLI/provider resolution
- rename the skills command surface to skills-config in the touched branch changes
- switch checkpoint test lock usage from multiprocessing.Lock to threading.Lock

## Validation
- pytest -q tests/test_provider_parity.py
- pytest -q tests/test_batch_runner_checkpoint.py
- pytest -q tests/test_cli_provider_resolution.py tests/test_runtime_provider_resolution.py tests/test_batch_runner_checkpoint.py tests/test_provider_parity.py

## Notes
A full local suite run did not complete within the manual time caps used here, but the previously failing points were reproduced and fixed, and the focused touched-file test set passed.