### PR TITLE
fix(cron): pass session_db to AIAgent so cron messages are persisted

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -151,6 +151,15 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     from run_agent import AIAgent
     
+    # Initialize SQLite session store so cron job messages are persisted
+    # and discoverable via session_search (same pattern as gateway/run.py).
+    _session_db = None
+    try:
+        from hermes_state import SessionDB
+        _session_db = SessionDB()
+    except Exception as e:
+        logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
+    
     job_id = job["id"]
     job_name = job["name"]
     prompt = job["prompt"]
@@ -255,7 +264,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
             quiet_mode=True,
-            session_id=f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+            session_id=f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}",
+            session_db=_session_db,
         )
         
         result = agent.run_conversation(prompt)


### PR DESCRIPTION
## Problem

Cron jobs create `AIAgent` without passing `session_db`, so messages from cron runs (and their `delegate_task` subagents) are never written to the SQLite session store. This means `session_search` cannot find any cron job conversation history.

This is the same class of bug that was fixed for the gateway in 8aa531c (PR #105):

> **fix(gateway): Pass session_db to AIAgent, fixing session_search error**
> Root cause: gateway/run.py creates AIAgent without passing session_db=

The current state:

| Caller | `session_db` passed? | Messages persisted to SQLite? |
|--------|----------------------|-------------------------------|
| CLI (`cli.py`) | ✅ Yes | ✅ Yes |
| Gateway (`gateway/run.py`) | ✅ Yes (since #105) | ✅ Yes |
| **Cron (`cron/scheduler.py`)** | **❌ No** | **❌ No** |
| delegate_tool | Inherits from parent | Depends on parent |

Since delegate_task inherits `session_db` from its parent via `getattr(parent_agent, '_session_db', None)`, cron → delegate chains also lose persistence.

## Reproduction

1. Set up a cron job that runs a research task with `delegate_task` subagents
2. After the job completes, try `session_search` from Telegram or CLI
3. No cron session messages are found — only the session metadata exists in the JSON files on disk, but nothing in SQLite FTS5

## Fix

Initialize `SessionDB` in `run_job()` and pass it to `AIAgent`, following the identical pattern from `gateway/run.py`:

```python
_session_db = None
try:
    from hermes_state import SessionDB
    _session_db = SessionDB()
except Exception as e:
    logger.debug("SQLite session store not available: %s", e)

agent = AIAgent(
    ...,
    session_db=_session_db,
)
```

Minimal change — 11 lines added, 1 changed (trailing comma).