### PR TITLE
fix: add missing Responses API parameters for Codex provider

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2340,7 +2340,10 @@ class AIAgent:
                 "instructions": instructions,
                 "input": self._chat_messages_to_responses_input(payload_messages),
                 "tools": self._responses_tools(),
+                "tool_choice": "auto",
+                "parallel_tool_calls": True,
                 "store": False,
+                "prompt_cache_key": self.session_id,
             }
 
             if reasoning_enabled:

--- a/tests/test_run_agent_codex_responses.py
+++ b/tests/test_run_agent_codex_responses.py
@@ -235,6 +235,10 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert kwargs["tools"][0]["strict"] is False
     assert "function" not in kwargs["tools"][0]
     assert kwargs["store"] is False
+    assert kwargs["tool_choice"] == "auto"
+    assert kwargs["parallel_tool_calls"] is True
+    assert isinstance(kwargs["prompt_cache_key"], str)
+    assert len(kwargs["prompt_cache_key"]) > 0
     assert "timeout" not in kwargs
     assert "max_tokens" not in kwargs
     assert "extra_body" not in kwargs


### PR DESCRIPTION
## Summary

Adds three parameters to the Codex Responses API request that the official Codex CLI sends but we were missing:

| Parameter | Value | Why |
|-----------|-------|-----|
| `tool_choice` | `"auto"` | Enables proactive tool use. Without this, the model may not realize it should call tools — root cause of #747 (agent claims no shell access). |
| `parallel_tool_calls` | `true` | Allows the model to issue multiple tool calls per turn for efficiency. |
| `prompt_cache_key` | `session_id` | Enables server-side prompt caching across turns, reducing latency and cost. |

## Root cause analysis

Compared our Responses API integration against the [official Codex CLI codebase](https://github.com/openai/codex). The Codex CLI explicitly sets `tool_choice: "auto"` and `parallel_tool_calls: true` in every request ([codex-rs/core/src/client.rs](https://github.com/openai/codex/blob/main/codex-rs/core/src/client.rs)). We were omitting these, which likely caused the model to be less proactive about using function tools — manifesting as 'I don't have shell access' responses.

## Tests
- Updated existing `test_build_api_kwargs_codex` to verify all three new parameters

Refs #747