### PR TITLE
fix: ignore BrokenPipeError from console prints in gateway mode

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -20,6 +20,7 @@ Usage:
     response = agent.run_conversation("Tell me about the latest Python updates")
 """
 
+import builtins
 import copy
 import hashlib
 import json
@@ -32,6 +33,20 @@ import sys
 import time
 import threading
 from types import SimpleNamespace
+
+
+def print(*args, **kwargs):
+    """Best-effort console output for gateway/CLI contexts.
+
+    In gateway mode the agent may still emit progress/debug prints even with
+    quiet_mode=True. If stdout/stderr is detached or its pipe closes, a normal
+    print() raises BrokenPipeError and aborts the whole Telegram response.
+    Swallow that case so logging/output failures don't kill the agent turn.
+    """
+    try:
+        return builtins.print(*args, **kwargs)
+    except BrokenPipeError:
+        return None
 import uuid
 from typing import List, Dict, Any, Optional
 from openai import OpenAI


### PR DESCRIPTION
## Summary
- prevent gateway/Telegram conversations from failing when internal console prints raise `BrokenPipeError`
- this surfaced to users as the generic 'unexpected error' response

## Root cause
In gateway mode, `run_agent.py` can still emit debug/progress `print()` calls even with `quiet_mode=True`. If stdout/stderr is detached or its pipe closes, those prints raise `BrokenPipeError`, abort the turn, and `gateway/run.py` returns the generic error message to Telegram.

## Fix
- wrap module-level `print()` in `run_agent.py`
- delegate to `builtins.print()`
- swallow `BrokenPipeError` so best-effort console output cannot abort the conversation

## Validation
- `./venv/bin/python -m py_compile run_agent.py`
- restarted the local gateway and verified Telegram reconnects cleanly
- reproduced from logs that the previous failure path came from `BrokenPipeError` in `run_agent.py`
