### PR TITLE
feat: use Codex-style compaction prompt for context compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -103,22 +103,24 @@ class ContextCompressor:
             parts.append(f"[{role.upper()}]: {content}")
 
         content_to_summarize = "\n\n".join(parts)
-        prompt = f"""Summarize these conversation turns concisely. This summary will replace these turns in the conversation history.
-
-Write from a neutral perspective describing:
-1. What actions were taken (tool calls, searches, file operations)
-2. Key information or results obtained
-3. Important decisions or findings
-4. Relevant data, file names, or outputs
-
-Keep factual and informative. Target ~{self.summary_target_tokens} tokens.
-
----
-TURNS TO SUMMARIZE:
-{content_to_summarize}
----
-
-Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
+        prompt = (
+            "You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff "
+            "summary for the AI assistant that will resume this conversation.\n\n"
+            "Include:\n"
+            "- Current progress and key decisions made\n"
+            "- Important context, constraints, or user preferences discovered\n"
+            "- What remains to be done (clear next steps)\n"
+            "- Any critical data: file paths, variable names, URLs, error messages, "
+            "or code snippets needed to continue\n"
+            "- Tool calls made and their key results\n\n"
+            "Be concise, structured, and focused on helping the assistant seamlessly "
+            "continue the work without re-doing what's already been done.\n\n"
+            f"Target roughly {self.summary_target_tokens} tokens.\n\n"
+            "---\n"
+            f"TURNS TO SUMMARIZE:\n{content_to_summarize}\n"
+            "---\n\n"
+            'Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix.'
+        )
 
         # 1. Try the auxiliary model (cheap/fast)
         if self.client:


### PR DESCRIPTION
## Summary

Replaces the generic summarization prompt in `ContextCompressor._generate_summary()` with a task-oriented handoff prompt inspired by OpenAI's Codex CLI compaction flow (researched in #499).

## What exactly changes

**Before** — the prompt sent to the summarization model was:
```
Summarize these conversation turns concisely. This summary will replace
these turns in the conversation history.

Write from a neutral perspective describing:
1. What actions were taken (tool calls, searches, file operations)
2. Key information or results obtained
3. Important decisions or findings
4. Relevant data, file names, or outputs

Keep factual and informative. Target ~2500 tokens.
```

**After** — the new prompt is:
```
You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff
summary for the AI assistant that will resume this conversation.

Include:
- Current progress and key decisions made
- Important context, constraints, or user preferences discovered
- What remains to be done (clear next steps)
- Any critical data: file paths, variable names, URLs, error messages,
  or code snippets needed to continue
- Tool calls made and their key results

Be concise, structured, and focused on helping the assistant seamlessly
continue the work without re-doing what's already been done.

Target roughly 2500 tokens.
```

## Why this is better

The old prompt treated compression as generic text summarization. The new prompt frames it as a **handoff between LLMs** — the summarization model understands the output will be consumed by another model to continue the work. This produces summaries that better preserve:
- **Task continuity** — what was being done and what's left
- **Actionable context** — file paths, error messages, specific data
- **User intent** — preferences and constraints discovered during the conversation

## What does NOT change

- The compression algorithm itself (positional protection, role alternation, boundary alignment)
- The `[CONTEXT SUMMARY]:` prefix on inserted summaries
- The summarization model used (still auxiliary/Gemini Flash)
- The compression trigger logic (85% threshold)
- All existing tests pass unmodified

## File changed

- `agent/context_compressor.py` — prompt text in `_generate_summary()` only (18 insertions, 16 deletions)

Inspired by PR #776 by @kshitijk4poor and the research in #499.