### PR TITLE
feat: Codex-style handoff prefix for compressed context summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -17,6 +17,13 @@ from agent.model_metadata import (
 
 logger = logging.getLogger(__name__)
 
+SUMMARY_PREFIX = (
+    "[CONTEXT COMPACTION] An earlier part of this conversation was "
+    "summarized to preserve context space. Below is the summary — use it "
+    "to build on the work already done and avoid duplicating effort:"
+)
+LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
+
 
 class ContextCompressor:
     """Compresses conversation context when approaching the model's context limit.
@@ -166,9 +173,19 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 raise
 
         summary = response.choices[0].message.content.strip()
-        if not summary.startswith("[CONTEXT SUMMARY]:"):
-            summary = "[CONTEXT SUMMARY]: " + summary
-        return summary
+        return self._with_summary_prefix(summary)
+
+    @staticmethod
+    def _with_summary_prefix(summary: str) -> str:
+        """Normalize the summary prefix to the current standard.
+
+        Strips any legacy ``[CONTEXT SUMMARY]:`` prefix the model may have
+        produced and prepends the current ``SUMMARY_PREFIX`` handoff text.
+        """
+        text = (summary or "").strip()
+        if text.startswith(LEGACY_SUMMARY_PREFIX):
+            text = text[len(LEGACY_SUMMARY_PREFIX):].lstrip()
+        return f"{SUMMARY_PREFIX}\n{text}"
 
     def _get_fallback_client(self):
         """Try to build a fallback client from the main model's endpoint config.
@@ -338,7 +355,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         for i in range(compress_start):
             msg = messages[i].copy()
             if i == 0 and msg.get("role") == "system" and self.compression_count == 0:
-                msg["content"] = (msg.get("content") or "") + "\n\n[Note: Some earlier conversation turns may be summarized to preserve context space.]"
+                msg["content"] = (msg.get("content") or "") + "\n\n[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. Build on that summary rather than re-doing work.]"
             compressed.append(msg)
 
         if summary:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from agent.context_compressor import ContextCompressor
+from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
 
 
 @pytest.fixture()
@@ -141,7 +141,7 @@ class TestGenerateSummaryNoneContent:
 
         summary = c._generate_summary(messages)
         assert isinstance(summary, str)
-        assert "CONTEXT SUMMARY" in summary
+        assert summary.startswith(SUMMARY_PREFIX)
 
     def test_none_content_in_system_message_compress(self):
         """System message with content=None should not crash during compress."""
@@ -174,7 +174,7 @@ class TestCompressWithClient:
 
         # Should have summary message in the middle
         contents = [m.get("content", "") for m in result]
-        assert any("CONTEXT SUMMARY" in c for c in contents)
+        assert any(c.startswith(SUMMARY_PREFIX) for c in contents)
         assert len(result) < len(msgs)
 
     def test_summarization_does_not_split_tool_call_pairs(self):
@@ -246,7 +246,7 @@ class TestCompressWithClient:
             {"role": "assistant", "content": "msg 5"},
         ]
         result = c.compress(msgs)
-        summary_msg = [m for m in result if "CONTEXT SUMMARY" in (m.get("content") or "")]
+        summary_msg = [m for m in result if (m.get("content") or "").startswith(SUMMARY_PREFIX)]
         assert len(summary_msg) == 1
         assert summary_msg[0]["role"] == "user"
 
@@ -274,7 +274,7 @@ class TestCompressWithClient:
             {"role": "assistant", "content": "msg 7"},
         ]
         result = c.compress(msgs)
-        summary_msg = [m for m in result if "CONTEXT SUMMARY" in (m.get("content") or "")]
+        summary_msg = [m for m in result if (m.get("content") or "").startswith(SUMMARY_PREFIX)]
         assert len(summary_msg) == 1
         assert summary_msg[0]["role"] == "assistant"
 

--- a/tests/test_413_compression.py
+++ b/tests/test_413_compression.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent.context_compressor import SUMMARY_PREFIX
 from run_agent import AIAgent
 
 
@@ -335,7 +336,7 @@ class TestPreflightCompression:
             # Simulate compression reducing messages
             mock_compress.return_value = (
                 [
-                    {"role": "user", "content": "[CONTEXT SUMMARY]: Previous conversation"},
+                    {"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"},
                     {"role": "user", "content": "hello"},
                 ],
                 "new system prompt",


### PR DESCRIPTION
## Summary

Replaces the old `[CONTEXT SUMMARY]:` prefix on compressed summaries with a Codex-inspired handoff framing that tells the model what happened and how to use the summary.

## What exactly changes

**Before** — summaries were inserted as:
```
[CONTEXT SUMMARY]: The user asked about X. The assistant searched for Y...
```

**After** — summaries are inserted as:
```
[CONTEXT COMPACTION] An earlier part of this conversation was summarized
to preserve context space. Below is the summary — use it to build on
the work already done and avoid duplicating effort:

The user asked about X. The assistant searched for Y...
```

## Detailed changes

### `agent/context_compressor.py`

1. **New `SUMMARY_PREFIX` constant** (module-level) — the handoff text prepended to every summary
2. **New `LEGACY_SUMMARY_PREFIX` constant** — keeps `"[CONTEXT SUMMARY]:"` for backward compatibility detection
3. **New `_with_summary_prefix()` static method** — normalizes model output:
   - Strips any legacy `[CONTEXT SUMMARY]:` prefix the summarization model may have produced
   - Prepends the new `SUMMARY_PREFIX`
4. **`_call_summary_model()`** — now calls `_with_summary_prefix()` instead of manually checking/prepending `[CONTEXT SUMMARY]:`
5. **System message annotation** — the note appended to the system prompt on first compression updated from the generic `"[Note: Some earlier conversation turns may be summarized...]"` to `"[Note: Some earlier conversation turns have been compacted into a handoff summary... Build on that summary rather than re-doing work.]"`

### Test updates

- Tests now import and check against `SUMMARY_PREFIX` instead of hardcoded `"CONTEXT SUMMARY"` strings
- `tests/test_413_compression.py` mock return values updated to use the new prefix format
- All 31 existing tests pass unmodified in logic — only string matching updated

## What does NOT change

- The compression algorithm (positional protection, boundary alignment, middle-turn summarization)
- The role alternation logic (summary role still adapts to avoid consecutive same-role messages)
- The summarization model used or trigger thresholds
- The compression prompt sent to the summarization model (that's a separate PR)

## Why this is better

The old prefix gave the model zero context about what the summary block is. The new prefix:
- **Explains what happened** — context was compacted
- **Instructs the model** — build on prior work, don't duplicate effort
- **Has a detectable marker** — `[CONTEXT COMPACTION]` for programmatic detection

Inspired by PR #776 by @kshitijk4poor and the research in #499.