### PR TITLE
fix(slack): read thread_id from metadata for in-thread routing

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -160,8 +160,8 @@ class SlackAdapter(BasePlatformAdapter):
             # Reply in thread if thread_ts is available
             if reply_to:
                 kwargs["thread_ts"] = reply_to
-            elif metadata and metadata.get("thread_ts"):
-                kwargs["thread_ts"] = metadata["thread_ts"]
+            elif metadata and (metadata.get("thread_ts") or metadata.get("thread_id")):
+                kwargs["thread_ts"] = metadata.get("thread_ts") or metadata.get("thread_id")
 
             result = await self._app.client.chat_postMessage(**kwargs)
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -530,3 +530,83 @@ class TestMessageRouting:
         }
         await adapter._handle_slack_message(event)
         adapter.handle_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestSendThreading
+# ---------------------------------------------------------------------------
+
+class TestSendThreading:
+    """Verify that send() routes messages to the correct Slack thread."""
+
+    @pytest.mark.asyncio
+    async def test_send_threads_via_thread_id_metadata(self, adapter):
+        """Metadata with thread_id (from base adapter) should post in-thread."""
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "1111111111.111111"}
+        )
+
+        result = await adapter.send(
+            chat_id="C123",
+            content="tool progress",
+            metadata={"thread_id": "1111111111.111111"},
+        )
+
+        assert result.success
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["thread_ts"] == "1111111111.111111"
+
+    @pytest.mark.asyncio
+    async def test_send_threads_via_thread_ts_metadata(self, adapter):
+        """Metadata with thread_ts should still work as before."""
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "2222222222.222222"}
+        )
+
+        result = await adapter.send(
+            chat_id="C123",
+            content="status update",
+            metadata={"thread_ts": "2222222222.222222"},
+        )
+
+        assert result.success
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["thread_ts"] == "2222222222.222222"
+
+    @pytest.mark.asyncio
+    async def test_send_prefers_thread_ts_over_thread_id(self, adapter):
+        """When both keys are present, thread_ts takes precedence."""
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "3333333333.333333"}
+        )
+
+        result = await adapter.send(
+            chat_id="C123",
+            content="dual metadata",
+            metadata={
+                "thread_ts": "3333333333.333333",
+                "thread_id": "4444444444.444444",
+            },
+        )
+
+        assert result.success
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["thread_ts"] == "3333333333.333333"
+
+    @pytest.mark.asyncio
+    async def test_reply_to_takes_precedence_over_metadata(self, adapter):
+        """Explicit reply_to should win over metadata threading."""
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "5555555555.555555"}
+        )
+
+        result = await adapter.send(
+            chat_id="C123",
+            content="explicit reply",
+            reply_to="5555555555.555555",
+            metadata={"thread_id": "6666666666.666666"},
+        )
+
+        assert result.success
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["thread_ts"] == "5555555555.555555"


### PR DESCRIPTION
## Summary

Slack thread replies — progress messages, typing indicators, session hygiene
warnings, and other auxiliary sends from `_process_message_background()` — land
in the top-level DM window instead of the conversation thread.

### Root Cause

The base adapter and gateway construct thread metadata with a `thread_id` key:

- **`gateway/platforms/base.py:691`**: `_thread_metadata = {"thread_id": event.source.thread_id}`
- **`gateway/run.py`**: `_progress_metadata = {"thread_id": source.thread_id}`

But `SlackAdapter.send()` only checks for `thread_ts`:

- **`gateway/platforms/slack.py:163`**: `metadata.get("thread_ts")`

The value is correct — it's the original Slack `thread_ts`, stored as `thread_id`
in `MessageSource` at `slack.py:530`. The key name just doesn't match what
`send()` looks for.

The Telegram adapter already handles this correctly — `telegram.py:218` reads
`metadata.get("thread_id")`.

## Changes

- **`gateway/platforms/slack.py`**: Accept both `thread_ts` and `thread_id` from
  metadata in `send()`, preferring `thread_ts` when both are present. This aligns
  with the Telegram adapter's approach of reading the canonical `thread_id` key.
- **`tests/gateway/test_slack.py`**: Add `TestSendThreading` class with 4 tests:
  `thread_id`-only metadata, `thread_ts`-only metadata, both-keys precedence,
  and `reply_to` precedence over metadata.

## How to Test

1. Connect a Slack workspace
2. Start a threaded conversation with the bot
3. Send a message that triggers tool use (e.g., web search)
4. Verify progress messages appear **in the thread**, not the main DM window

Automated: `pytest tests/gateway/test_slack.py::TestSendThreading -v`

## Platforms Tested

- Slack (primary fix, live-verified)

## Related

- Supersedes the Slack threading portion of #857 and #851 (both closed without merge)

## Known Related Issue (not addressed here)

The Slack media methods (`send_image`, `send_document`, `send_video`,
`send_voice`, `send_image_file`) accept `**kwargs` from the base adapter but
don't extract `metadata` for threading. Media sent during threaded conversations
may land outside the thread. This is a separate issue affecting media method
implementations across adapters and should be addressed in a follow-up.