### PR TITLE
Improve Home Assistant adapter error logging

### DIFF
--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -122,7 +122,8 @@ class HomeAssistantAdapter(BasePlatformAdapter):
             return True
 
         except Exception as e:
-            logger.error("[%s] Failed to connect: %s", self.name, e)
+            # Include full stack trace so HA connection issues are easier to debug.
+            logger.error("[%s] Failed to connect: %s", self.name, e, exc_info=True)
             return False
 
     async def _ws_connect(self) -> bool:
@@ -210,7 +211,8 @@ class HomeAssistantAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 return
             except Exception as e:
-                logger.warning("[%s] WebSocket error: %s", self.name, e)
+                # Preserve the error details and stack trace during the main listen loop.
+                logger.warning("[%s] WebSocket error: %s", self.name, e, exc_info=True)
 
             if not self._running:
                 return
@@ -228,7 +230,8 @@ class HomeAssistantAdapter(BasePlatformAdapter):
                     backoff_idx = 0  # Reset on successful reconnect
                     logger.info("[%s] Reconnected", self.name)
             except Exception as e:
-                logger.warning("[%s] Reconnection failed: %s", self.name, e)
+                # Log reconnection failures with exc_info so flakiness is traceable.
+                logger.warning("[%s] Reconnection failed: %s", self.name, e, exc_info=True)
 
     async def _read_events(self) -> None:
         """Read events from WebSocket until disconnected."""


### PR DESCRIPTION
Improve observability for the Home Assistant WebSocket adapter.
Add exc_info=True to connection failures so HA setup issues include stack traces. Log WebSocket loop and reconnection errors with exc_info=True to make intermittent failures easier to debug.