### PR TITLE
fix(codex): drop unsupported fields instead of raising ValueError

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1803,10 +1803,14 @@ class AIAgent:
         elif "stream" in api_kwargs:
             raise ValueError("Codex Responses stream flag is only allowed in fallback streaming requests.")
 
+        # Silently drop fields that are valid for other providers but not
+        # supported by the Codex Responses API (e.g. parallel_tool_calls,
+        # prompt_cache_key, tool_choice injected by litellm or the caller).
         unexpected = sorted(key for key in api_kwargs.keys() if key not in allowed_keys)
         if unexpected:
-            raise ValueError(
-                f"Codex Responses request has unsupported field(s): {', '.join(unexpected)}."
+            logger.debug(
+                "Codex Responses: dropping unsupported field(s): %s",
+                ", ".join(unexpected),
             )
 
         return normalized


### PR DESCRIPTION
## Summary

Fixes #930

`hermes doctor` every Codex Responses request fails after 6 retries with:

ValueError: Codex Responses request has unsupported field(s): parallel_tool_calls, prompt_cache_key, tool_choice.


## Root Cause

`_preflight_codex_api_kwargs` validates incoming `api_kwargs` against an `allowed_keys` set and raises `ValueError` for any unexpected fields. These fields (`parallel_tool_calls`, `prompt_cache_key`, `tool_choice`) are injected by litellm or other callers for non-Codex providers — the user never adds them manually.

## Why the fix is safe

`_preflight_codex_api_kwargs` already builds a clean `normalized` dict containing only Codex-compatible fields. The unexpected fields **never reach the API** regardless. The `raise ValueError` was purely a strict validation check — replacing it with `logger.debug` drops the fields silently while keeping the normalized output identical.

before:

⚠️ API call failed (attempt 1/6): ValueError
Error: Codex Responses request has unsupported field(s): parallel_tool_calls, prompt_cache_key, tool_choice.
…
❌ Max retries (6) exceeded. Giving up.


After: Codex requests succeed normally. Dropped fields are logged at DEBUG level.
