### PR TITLE
feat(gateway): add /reasoning hot reload

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -557,6 +557,17 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.debug("Discord followup failed: %s", e)
 
+        @tree.command(name="reasoning", description="Show or change reasoning effort")
+        @discord.app_commands.describe(effort="Reasoning effort: xhigh, high, medium, low, minimal, or none.")
+        async def slash_reasoning(interaction: discord.Interaction, effort: str = ""):
+            await interaction.response.defer(ephemeral=True)
+            event = self._build_slash_event(interaction, f"/reasoning {effort}".strip())
+            await self.handle_message(event)
+            try:
+                await interaction.followup.send("Done~", ephemeral=True)
+            except Exception as e:
+                logger.debug("Discord followup failed: %s", e)
+
         @tree.command(name="personality", description="Set a personality")
         @discord.app_commands.describe(name="Personality name. Leave empty to list available.")
         async def slash_personality(interaction: discord.Interaction, name: str = ""):

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -554,7 +554,7 @@ class SlackAdapter(BasePlatformAdapter):
             "new": "/reset", "reset": "/reset",
             "status": "/status", "stop": "/stop",
             "help": "/help",
-            "model": "/model", "personality": "/personality",
+            "model": "/model", "reasoning": "/reasoning", "personality": "/personality",
             "retry": "/retry", "undo": "/undo",
         }
         first_word = text.split()[0] if text else ""

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -159,6 +159,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     BotCommand("new", "Start a new conversation"),
                     BotCommand("reset", "Reset conversation history"),
                     BotCommand("model", "Show or change the model"),
+                    BotCommand("reasoning", "Show or change reasoning effort"),
                     BotCommand("personality", "Set a personality"),
                     BotCommand("retry", "Retry your last message"),
                     BotCommand("undo", "Remove the last exchange"),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -363,23 +363,25 @@ class GatewayRunner:
 
     @staticmethod
     def _load_reasoning_config() -> dict | None:
-        """Load reasoning effort from config or env var.
-        
-        Checks HERMES_REASONING_EFFORT env var first, then agent.reasoning_effort
-        in config.yaml. Valid: "xhigh", "high", "medium", "low", "minimal", "none".
-        Returns None to use default (medium).
+        """Load reasoning effort from config with env fallback.
+
+        Checks agent.reasoning_effort in config.yaml first, then
+        HERMES_REASONING_EFFORT as a fallback. Valid: "xhigh", "high",
+        "medium", "low", "minimal", "none". Returns None to use default
+        (medium).
         """
-        effort = os.getenv("HERMES_REASONING_EFFORT", "")
+        effort = ""
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                effort = str(cfg.get("agent", {}).get("reasoning_effort", "") or "").strip()
+        except Exception:
+            pass
         if not effort:
-            try:
-                import yaml as _y
-                cfg_path = _hermes_home / "config.yaml"
-                if cfg_path.exists():
-                    with open(cfg_path, encoding="utf-8") as _f:
-                        cfg = _y.safe_load(_f) or {}
-                    effort = str(cfg.get("agent", {}).get("reasoning_effort", "") or "").strip()
-            except Exception:
-                pass
+            effort = os.getenv("HERMES_REASONING_EFFORT", "")
         if not effort:
             return None
         effort = effort.lower().strip()
@@ -812,7 +814,7 @@ class GatewayRunner:
         command = event.get_command()
         
         # Emit command:* hook for any recognized slash command
-        _known_commands = {"new", "reset", "help", "status", "stop", "model",
+        _known_commands = {"new", "reset", "help", "status", "stop", "model", "reasoning",
                           "personality", "retry", "undo", "sethome", "set-home",
                           "compress", "usage", "insights", "reload-mcp", "reload_mcp",
                           "update", "title", "resume", "provider", "rollback",
@@ -839,7 +841,10 @@ class GatewayRunner:
         
         if command == "model":
             return await self._handle_model_command(event)
-        
+
+        if command == "reasoning":
+            return await self._handle_reasoning_command(event)
+
         if command == "provider":
             return await self._handle_provider_command(event)
         
@@ -1502,6 +1507,7 @@ class GatewayRunner:
             "`/status` — Show session info",
             "`/stop` — Interrupt the running agent",
             "`/model [provider:model]` — Show/change model (or switch provider)",
+            "`/reasoning [effort]` — Show/change reasoning effort",
             "`/provider` — Show available providers and auth status",
             "`/personality [name]` — Set a personality",
             "`/retry` — Retry your last message",
@@ -1668,6 +1674,51 @@ class GatewayRunner:
         else:
             persist_note = "this session only — will revert on restart"
         return f"🤖 Model changed to `{new_model}` ({persist_note}){provider_note}{warning}\n_(takes effect on next message)_"
+
+    async def _handle_reasoning_command(self, event: MessageEvent) -> str:
+        """Handle /reasoning command - show or change reasoning effort."""
+        import yaml
+
+        args = event.get_command_args().strip().lower()
+        config_path = _hermes_home / "config.yaml"
+        valid = ("xhigh", "high", "medium", "low", "minimal", "none")
+
+        current_cfg = self._load_reasoning_config()
+        if current_cfg is None:
+            current = "medium"
+        elif current_cfg.get("enabled") is False:
+            current = "none"
+        else:
+            current = str(current_cfg.get("effort", "medium"))
+
+        if not args:
+            return (
+                f"🧠 **Current reasoning effort:** `{current}`\n\n"
+                "To change: `/reasoning xhigh|high|medium|low|minimal|none`"
+            )
+
+        if args not in valid:
+            return (
+                f"⚠️ Invalid reasoning effort: `{args}`\n\n"
+                "Use one of: `xhigh`, `high`, `medium`, `low`, `minimal`, `none`"
+            )
+
+        try:
+            user_config = {}
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+            if "agent" not in user_config or not isinstance(user_config["agent"], dict):
+                user_config["agent"] = {}
+            user_config["agent"]["reasoning_effort"] = args
+            with open(config_path, "w", encoding="utf-8") as f:
+                yaml.dump(user_config, f, default_flow_style=False, sort_keys=False)
+        except Exception as e:
+            return f"⚠️ Failed to save reasoning change: {e}"
+
+        self._reasoning_config = self._load_reasoning_config()
+
+        return f"🧠 Reasoning effort changed to `{args}` (saved to config)\n_(takes effect on next message)_"
 
     async def _handle_provider_command(self, event: MessageEvent) -> str:
         """Handle /provider command - show available providers."""
@@ -2058,6 +2109,8 @@ class GatewayRunner:
 
             pr = self._provider_routing
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            reasoning_config = self._load_reasoning_config()
+            self._reasoning_config = reasoning_config
 
             def run_sync():
                 agent = AIAgent(
@@ -2067,7 +2120,7 @@ class GatewayRunner:
                     quiet_mode=True,
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,
-                    reasoning_config=self._reasoning_config,
+                    reasoning_config=reasoning_config,
                     providers_allowed=pr.get("only"),
                     providers_ignored=pr.get("ignore"),
                     providers_order=pr.get("order"),
@@ -3120,6 +3173,8 @@ class GatewayRunner:
                 }
 
             pr = self._provider_routing
+            reasoning_config = self._load_reasoning_config()
+            self._reasoning_config = reasoning_config
             agent = AIAgent(
                 model=model,
                 **runtime_kwargs,
@@ -3129,7 +3184,7 @@ class GatewayRunner:
                 enabled_toolsets=enabled_toolsets,
                 ephemeral_system_prompt=combined_ephemeral or None,
                 prefill_messages=self._prefill_messages or None,
-                reasoning_config=self._reasoning_config,
+                reasoning_config=reasoning_config,
                 providers_allowed=pr.get("only"),
                 providers_ignored=pr.get("ignore"),
                 providers_order=pr.get("order"),

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -1,0 +1,194 @@
+"""Tests for gateway /reasoning command and hot reload behavior."""
+
+import asyncio
+import inspect
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/reasoning", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    """Build a MessageEvent for testing."""
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    """Create a bare GatewayRunner without calling __init__."""
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    return runner
+
+
+class _CapturingAgent:
+    """Fake agent that records init kwargs for assertions."""
+
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class TestReasoningCommand:
+    @pytest.mark.asyncio
+    async def test_reasoning_in_help_output(self):
+        runner = _make_runner()
+        event = _make_event(text="/help")
+
+        result = await runner._handle_help_command(event)
+
+        assert "/reasoning [effort]" in result
+
+    def test_reasoning_is_known_command(self):
+        source = inspect.getsource(gateway_run.GatewayRunner._handle_message)
+        assert '"reasoning"' in source
+
+    @pytest.mark.asyncio
+    async def test_handle_reasoning_command_updates_config_and_cache(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.delenv("HERMES_REASONING_EFFORT", raising=False)
+
+        runner = _make_runner()
+        runner._reasoning_config = {"enabled": True, "effort": "medium"}
+
+        result = await runner._handle_reasoning_command(_make_event("/reasoning low"))
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["agent"]["reasoning_effort"] == "low"
+        assert runner._reasoning_config == {"enabled": True, "effort": "low"}
+        assert "takes effect on next message" in result
+
+    def test_run_agent_reloads_reasoning_config_per_message(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("agent:\n  reasoning_effort: low\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+        monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "test-key",
+            },
+        )
+        monkeypatch.delenv("HERMES_REASONING_EFFORT", raising=False)
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = _CapturingAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+        _CapturingAgent.last_init = None
+        runner = _make_runner()
+        runner._reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        source = SessionSource(
+            platform=Platform.LOCAL,
+            chat_id="cli",
+            chat_name="CLI",
+            chat_type="dm",
+            user_id="user-1",
+        )
+
+        result = asyncio.run(
+            runner._run_agent(
+                message="ping",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="session-1",
+                session_key="agent:main:local:dm",
+            )
+        )
+
+        assert result["final_response"] == "ok"
+        assert _CapturingAgent.last_init is not None
+        assert _CapturingAgent.last_init["reasoning_config"] == {"enabled": True, "effort": "low"}
+
+    def test_run_agent_prefers_config_over_stale_reasoning_env(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("agent:\n  reasoning_effort: none\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+        monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "test-key",
+            },
+        )
+        monkeypatch.setenv("HERMES_REASONING_EFFORT", "low")
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = _CapturingAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+        _CapturingAgent.last_init = None
+        runner = _make_runner()
+
+        source = SessionSource(
+            platform=Platform.LOCAL,
+            chat_id="cli",
+            chat_name="CLI",
+            chat_type="dm",
+            user_id="user-1",
+        )
+
+        result = asyncio.run(
+            runner._run_agent(
+                message="ping",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="session-1",
+                session_key="agent:main:local:dm",
+            )
+        )
+
+        assert result["final_response"] == "ok"
+        assert _CapturingAgent.last_init is not None
+        assert _CapturingAgent.last_init["reasoning_config"] == {"enabled": False}


### PR DESCRIPTION
## What does this PR do?

Adds a gateway `/reasoning` command and makes reasoning changes apply on the next message without restarting the gateway.

## Related Issue

Closes #937

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `/reasoning [effort]` handling in `gateway/run.py` and include it in known commands and `/help` output.
- Persist `agent.reasoning_effort` to `config.yaml` from the gateway command.
- Reload reasoning config immediately before each `AIAgent(...)` construction in both normal gateway turns and background tasks so the next message uses the updated value.
- Treat `config.yaml` as the source of truth for gateway hot reload, with `HERMES_REASONING_EFFORT` only as a fallback.
- Expose `/reasoning` in Telegram, Slack, and Discord gateway entrypoints.
- Add regression coverage in `tests/gateway/test_reasoning_command.py` for the command, per-message reload, and stale env override behavior.

## How to Test

1. Start gateway on this branch and send `/reasoning low`.
2. Edit `~/.hermes/config.yaml` to set `agent.reasoning_effort: none` without restarting gateway.
3. Send `/reasoning` or another message and verify the updated reasoning setting is used on the next turn.
4. From the repository root, run:
   - `source .venv/bin/activate`
   - `python -m pytest -o addopts='' -q tests/gateway/test_reasoning_command.py tests/gateway/test_update_command.py -k 'reasoning or update_in_help_output or update_is_known_command'`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Manual gateway test: after `/reasoning low`, manually editing `config.yaml` to `none` takes effect on the next message without restarting the gateway.
- Targeted regression tests passed: `7 passed, 16 deselected`.
