### PR TITLE
refactor: split adapter and cli cleanup

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -63,7 +63,7 @@ def get_skin_tool_prefix() -> str:
 # Tool preview (one-line summary of a tool call's primary argument)
 # =========================================================================
 
-def build_tool_preview(tool_name: str, args: dict, max_len: int = 40) -> str:
+def build_tool_preview(tool_name: str, args: dict, max_len: int = 40) -> str | None:
     """Build a short preview of a tool call's primary argument for display."""
     if not args:
         return None

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -506,6 +506,18 @@ class DiscordAdapter(BasePlatformAdapter):
         # Discord markdown is fairly standard, no special escaping needed
         return content
     
+    async def _run_simple_slash(
+        self, interaction: discord.Interaction, command_text: str, followup_msg: str = "Done~",
+    ) -> None:
+        """Common handler for simple slash commands that dispatch a command string."""
+        await interaction.response.defer(ephemeral=True)
+        event = self._build_slash_event(interaction, command_text)
+        await self.handle_message(event)
+        try:
+            await interaction.followup.send(followup_msg, ephemeral=True)
+        except Exception as e:
+            logger.debug("Discord followup failed: %s", e)
+
     def _register_slash_commands(self) -> None:
         """Register Discord slash commands on the command tree."""
         if not self._client:
@@ -519,8 +531,6 @@ class DiscordAdapter(BasePlatformAdapter):
             await interaction.response.defer()
             event = self._build_slash_event(interaction, question)
             await self.handle_message(event)
-            # The response is sent via the normal send() flow
-            # Send a followup to close the interaction if needed
             try:
                 await interaction.followup.send("Processing complete~", ephemeral=True)
             except Exception as e:
@@ -528,188 +538,80 @@ class DiscordAdapter(BasePlatformAdapter):
 
         @tree.command(name="new", description="Start a new conversation")
         async def slash_new(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/reset")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("New conversation started~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/reset", "New conversation started~")
 
         @tree.command(name="reset", description="Reset your Hermes session")
         async def slash_reset(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/reset")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Session reset~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/reset", "Session reset~")
 
         @tree.command(name="model", description="Show or change the model")
         @discord.app_commands.describe(name="Model name (e.g. anthropic/claude-sonnet-4). Leave empty to see current.")
         async def slash_model(interaction: discord.Interaction, name: str = ""):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, f"/model {name}".strip())
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, f"/model {name}".strip())
 
         @tree.command(name="personality", description="Set a personality")
         @discord.app_commands.describe(name="Personality name. Leave empty to list available.")
         async def slash_personality(interaction: discord.Interaction, name: str = ""):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, f"/personality {name}".strip())
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, f"/personality {name}".strip())
 
         @tree.command(name="retry", description="Retry your last message")
         async def slash_retry(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/retry")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Retrying~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/retry", "Retrying~")
 
         @tree.command(name="undo", description="Remove the last exchange")
         async def slash_undo(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/undo")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/undo")
 
         @tree.command(name="status", description="Show Hermes session status")
         async def slash_status(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/status")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Status sent~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/status", "Status sent~")
 
         @tree.command(name="sethome", description="Set this chat as the home channel")
         async def slash_sethome(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/sethome")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/sethome")
 
         @tree.command(name="stop", description="Stop the running Hermes agent")
         async def slash_stop(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/stop")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Stop requested~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/stop", "Stop requested~")
 
         @tree.command(name="compress", description="Compress conversation context")
         async def slash_compress(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/compress")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/compress")
 
         @tree.command(name="title", description="Set or show the session title")
         @discord.app_commands.describe(name="Session title. Leave empty to show current.")
         async def slash_title(interaction: discord.Interaction, name: str = ""):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, f"/title {name}".strip())
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, f"/title {name}".strip())
 
         @tree.command(name="resume", description="Resume a previously-named session")
         @discord.app_commands.describe(name="Session name to resume. Leave empty to list sessions.")
         async def slash_resume(interaction: discord.Interaction, name: str = ""):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, f"/resume {name}".strip())
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, f"/resume {name}".strip())
 
         @tree.command(name="usage", description="Show token usage for this session")
         async def slash_usage(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/usage")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/usage")
 
         @tree.command(name="provider", description="Show available providers")
         async def slash_provider(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/provider")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/provider")
 
         @tree.command(name="help", description="Show available commands")
         async def slash_help(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/help")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/help")
 
         @tree.command(name="insights", description="Show usage insights and analytics")
         @discord.app_commands.describe(days="Number of days to analyze (default: 7)")
         async def slash_insights(interaction: discord.Interaction, days: int = 7):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, f"/insights {days}")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, f"/insights {days}")
 
         @tree.command(name="reload-mcp", description="Reload MCP servers from config")
         async def slash_reload_mcp(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/reload-mcp")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/reload-mcp")
 
         @tree.command(name="update", description="Update Hermes Agent to the latest version")
         async def slash_update(interaction: discord.Interaction):
-            await interaction.response.defer(ephemeral=True)
-            event = self._build_slash_event(interaction, "/update")
-            await self.handle_message(event)
-            try:
-                await interaction.followup.send("Update initiated~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
+            await self._run_simple_slash(interaction, "/update", "Update initiated~")
 
     def _build_slash_event(self, interaction: discord.Interaction, text: str) -> MessageEvent:
         """Build a MessageEvent from a Discord slash command interaction."""

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -245,6 +245,32 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def _send_file_attachment(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+    ) -> SendResult:
+        """Send a local file as a Discord attachment (shared by send_voice and send_image_file)."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        channel = self._client.get_channel(int(chat_id))
+        if not channel:
+            channel = await self._client.fetch_channel(int(chat_id))
+        if not channel:
+            return SendResult(success=False, error=f"Channel {chat_id} not found")
+
+        # Validate the file exists before constructing discord.File (which
+        # opens lazily and may not raise FileNotFoundError until send time).
+        fh = open(file_path, "rb")
+        file = discord.File(fh, filename=os.path.basename(file_path))
+        msg = await channel.send(
+            content=caption if caption else None,
+            file=file,
+        )
+        return SendResult(success=True, message_id=str(msg.id))
+
     async def send_voice(
         self,
         chat_id: str,
@@ -253,36 +279,14 @@ class DiscordAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
     ) -> SendResult:
         """Send audio as a Discord file attachment."""
-        if not self._client:
-            return SendResult(success=False, error="Not connected")
-        
         try:
-            import io
-            
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
-            
-            if not os.path.exists(audio_path):
-                return SendResult(success=False, error=f"Audio file not found: {audio_path}")
-            
-            # Determine filename from path
-            filename = os.path.basename(audio_path)
-            
-            with open(audio_path, "rb") as f:
-                file = discord.File(io.BytesIO(f.read()), filename=filename)
-                msg = await channel.send(
-                    content=caption if caption else None,
-                    file=file,
-                )
-                return SendResult(success=True, message_id=str(msg.id))
-        
-        except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send audio, falling back to base adapter: %s", self.name, e, exc_info=True)
+            return await self._send_file_attachment(chat_id, audio_path, caption)
+        except FileNotFoundError:
+            return SendResult(success=False, error=f"Audio file not found: {audio_path}")
+        except Exception as e:
+            print(f"[{self.name}] Failed to send audio: {e}")
             return await super().send_voice(chat_id, audio_path, caption, reply_to)
-    
+
     async def send_image_file(
         self,
         chat_id: str,
@@ -291,33 +295,12 @@ class DiscordAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
-        if not self._client:
-            return SendResult(success=False, error="Not connected")
-        
         try:
-            import io
-            
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
-            
-            if not os.path.exists(image_path):
-                return SendResult(success=False, error=f"Image file not found: {image_path}")
-            
-            filename = os.path.basename(image_path)
-            
-            with open(image_path, "rb") as f:
-                file = discord.File(io.BytesIO(f.read()), filename=filename)
-                msg = await channel.send(
-                    content=caption if caption else None,
-                    file=file,
-                )
-                return SendResult(success=True, message_id=str(msg.id))
-        
-        except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send local image, falling back to base adapter: %s", self.name, e, exc_info=True)
+            return await self._send_file_attachment(chat_id, image_path, caption)
+        except FileNotFoundError:
+            return SendResult(success=False, error=f"Image file not found: {image_path}")
+        except Exception as e:
+            print(f"[{self.name}] Failed to send local image: {e}")
             return await super().send_image_file(chat_id, image_path, caption, reply_to)
 
     async def send_image(

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -189,6 +189,30 @@ class SlackAdapter(BasePlatformAdapter):
         """Slack doesn't have a direct typing indicator API for bots."""
         pass
 
+    async def _upload_file(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+    ) -> SendResult:
+        """Upload a local file to Slack (shared by send_image_file and send_voice)."""
+        if not self._app:
+            return SendResult(success=False, error="Not connected")
+
+        # Validate file exists before attempting upload
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        result = await self._app.client.files_upload_v2(
+            channel=chat_id,
+            file=file_path,
+            filename=os.path.basename(file_path),
+            initial_comment=caption or "",
+            thread_ts=reply_to,
+        )
+        return SendResult(success=True, raw_response=result)
+
     async def send_image_file(
         self,
         chat_id: str,
@@ -197,23 +221,10 @@ class SlackAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
     ) -> SendResult:
         """Send a local image file to Slack by uploading it."""
-        if not self._app:
-            return SendResult(success=False, error="Not connected")
-
         try:
-            import os
-            if not os.path.exists(image_path):
-                return SendResult(success=False, error=f"Image file not found: {image_path}")
-
-            result = await self._app.client.files_upload_v2(
-                channel=chat_id,
-                file=image_path,
-                filename=os.path.basename(image_path),
-                initial_comment=caption or "",
-                thread_ts=reply_to,
-            )
-            return SendResult(success=True, raw_response=result)
-
+            return await self._upload_file(chat_id, image_path, caption, reply_to)
+        except FileNotFoundError:
+            return SendResult(success=False, error=f"Image file not found: {image_path}")
         except Exception as e:
             print(f"[{self.name}] Failed to send local image: {e}")
             return await super().send_image_file(chat_id, image_path, caption, reply_to)
@@ -260,19 +271,8 @@ class SlackAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
     ) -> SendResult:
         """Send an audio file to Slack."""
-        if not self._app:
-            return SendResult(success=False, error="Not connected")
-
         try:
-            result = await self._app.client.files_upload_v2(
-                channel=chat_id,
-                file=audio_path,
-                filename=os.path.basename(audio_path),
-                initial_comment=caption or "",
-                thread_ts=reply_to,
-            )
-            return SendResult(success=True, raw_response=result)
-
+            return await self._upload_file(chat_id, audio_path, caption, reply_to)
         except Exception as e:
             return SendResult(success=False, error=str(e))
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -312,10 +312,6 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         
         try:
-            import os
-            if not os.path.exists(audio_path):
-                return SendResult(success=False, error=f"Audio file not found: {audio_path}")
-            
             with open(audio_path, "rb") as audio_file:
                 # .ogg files -> send as voice (round playable bubble)
                 if audio_path.endswith(".ogg") or audio_path.endswith(".opus"):
@@ -338,6 +334,8 @@ class TelegramAdapter(BasePlatformAdapter):
                         message_thread_id=int(_audio_thread) if _audio_thread else None,
                     )
             return SendResult(success=True, message_id=str(msg.message_id))
+        except FileNotFoundError:
+            return SendResult(success=False, error=f"Audio file not found: {audio_path}")
         except Exception as e:
             logger.error(
                 "[%s] Failed to send Telegram voice/audio, falling back to base adapter: %s",
@@ -358,12 +356,8 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send a local image file natively as a Telegram photo."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
-        
+
         try:
-            import os
-            if not os.path.exists(image_path):
-                return SendResult(success=False, error=f"Image file not found: {image_path}")
-            
             with open(image_path, "rb") as image_file:
                 msg = await self._bot.send_photo(
                     chat_id=int(chat_id),
@@ -372,6 +366,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     reply_to_message_id=int(reply_to) if reply_to else None,
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
+        except FileNotFoundError:
+            return SendResult(success=False, error=f"Image file not found: {image_path}")
         except Exception as e:
             logger.error(
                 "[%s] Failed to send Telegram local image, falling back to base adapter: %s",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -50,11 +50,32 @@ os.environ.setdefault("MSWEA_GLOBAL_CONFIG_DIR", str(get_hermes_home()))
 os.environ.setdefault("MSWEA_SILENT_STARTUP", "1")
 
 import logging
+import time as _time
+from datetime import datetime
 
 from hermes_cli import __version__
 from hermes_constants import OPENROUTER_BASE_URL
 
 logger = logging.getLogger(__name__)
+
+
+def _relative_time(ts) -> str:
+    """Format a timestamp as relative time (e.g., '2h ago', 'yesterday')."""
+    if not ts:
+        return "?"
+    delta = _time.time() - ts
+    if delta < 60:
+        return "just now"
+    elif delta < 3600:
+        return f"{int(delta / 60)}m ago"
+    elif delta < 86400:
+        return f"{int(delta / 3600)}h ago"
+    elif delta < 172800:
+        return "yesterday"
+    elif delta < 604800:
+        return f"{int(delta / 86400)}d ago"
+    else:
+        return datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
 
 
 def _has_any_provider_configured() -> bool:
@@ -121,27 +142,8 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
     # Try curses-based picker first
     try:
         import curses
-        import time as _time
-        from datetime import datetime
 
         result_holder = [None]
-
-        def _relative_time(ts):
-            if not ts:
-                return "?"
-            delta = _time.time() - ts
-            if delta < 60:
-                return "just now"
-            elif delta < 3600:
-                return f"{int(delta / 60)}m ago"
-            elif delta < 86400:
-                return f"{int(delta / 3600)}h ago"
-            elif delta < 172800:
-                return "yesterday"
-            elif delta < 604800:
-                return f"{int(delta / 86400)}d ago"
-            else:
-                return datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
 
         def _format_row(s, max_x):
             """Format a session row for display."""
@@ -333,26 +335,6 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
         pass
 
     # Fallback: numbered list (Windows without curses, etc.)
-    import time as _time
-    from datetime import datetime
-
-    def _relative_time_fb(ts):
-        if not ts:
-            return "?"
-        delta = _time.time() - ts
-        if delta < 60:
-            return "just now"
-        elif delta < 3600:
-            return f"{int(delta / 60)}m ago"
-        elif delta < 86400:
-            return f"{int(delta / 3600)}h ago"
-        elif delta < 172800:
-            return "yesterday"
-        elif delta < 604800:
-            return f"{int(delta / 86400)}d ago"
-        else:
-            return datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
-
     print("\n  Browse sessions  (enter number to resume, q to cancel)\n")
     for i, s in enumerate(sessions):
         title = (s.get("title") or "").strip()
@@ -360,7 +342,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
         label = title or preview or s["id"]
         if len(label) > 50:
             label = label[:47] + "..."
-        last_active = _relative_time_fb(s.get("last_active"))
+        last_active = _relative_time(s.get("last_active"))
         src = s.get("source", "")[:6]
         print(f"  {i + 1:>3}. {label:<50}  {last_active:<10}  {src}")
 
@@ -2397,29 +2379,6 @@ For more help on a command:
             if not sessions:
                 print("No sessions found.")
                 return
-            from datetime import datetime
-            import time as _time
-
-            def _relative_time(ts):
-                """Format a timestamp as relative time (e.g., '2h ago', 'yesterday')."""
-                if not ts:
-                    return "?"
-                delta = _time.time() - ts
-                if delta < 60:
-                    return "just now"
-                elif delta < 3600:
-                    mins = int(delta / 60)
-                    return f"{mins}m ago"
-                elif delta < 86400:
-                    hours = int(delta / 3600)
-                    return f"{hours}h ago"
-                elif delta < 172800:
-                    return "yesterday"
-                elif delta < 604800:
-                    days = int(delta / 86400)
-                    return f"{days}d ago"
-                else:
-                    return datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
 
             has_titles = any(s.get("title") for s in sessions)
             if has_titles:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -267,8 +267,6 @@ class SessionDB:
         if not title:
             return None
 
-        import re
-
         # Remove ASCII control characters (0x00-0x1F, 0x7F) but keep
         # whitespace chars (\t=0x09, \n=0x0A, \r=0x0D) so they can be
         # normalized to spaces by the whitespace collapsing step below
@@ -373,7 +371,6 @@ class SessionDB:
         Strips any existing " #N" suffix to find the base name, then finds
         the highest existing number and increments.
         """
-        import re
         # Strip existing #N suffix to find the true base
         match = re.match(r'^(.*?) #(\d+)$', base_title)
         if match:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -67,6 +67,9 @@ from agent.auxiliary_client import get_vision_auxiliary_client, get_text_auxilia
 
 logger = logging.getLogger(__name__)
 
+# Standard PATH entries for environments with minimal PATH (e.g. systemd services)
+_SANE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 # ============================================================================
 # Configuration
 # ============================================================================
@@ -869,7 +872,6 @@ def _run_browser_command(
         
         browser_env = {**os.environ}
         # Ensure PATH includes standard dirs (systemd services may have minimal PATH)
-        _SANE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
         if "/usr/bin" not in browser_env.get("PATH", "").split(":"):
             browser_env["PATH"] = f"{browser_env.get('PATH', '')}:{_SANE_PATH}"
         browser_env["AGENT_BROWSER_SOCKET_DIR"] = task_socket_dir

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1608,9 +1608,18 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         return json.dumps(error_info, ensure_ascii=False)
 
 
+_last_screenshot_cleanup = 0.0
+
 def _cleanup_old_screenshots(screenshots_dir, max_age_hours=24):
-    """Remove browser screenshots older than max_age_hours to prevent disk bloat."""
-    import time
+    """Remove browser screenshots older than max_age_hours to prevent disk bloat.
+
+    Throttled to run at most once per hour to avoid per-call directory scans.
+    """
+    global _last_screenshot_cleanup
+    now = time.time()
+    if now - _last_screenshot_cleanup < 3600:
+        return
+    _last_screenshot_cleanup = now
     try:
         cutoff = time.time() - (max_age_hours * 3600)
         for f in screenshots_dir.glob("browser_screenshot_*.png"):


### PR DESCRIPTION
## Summary
- Split unrelated cleanup/refactor work out of #823 into an independent, reviewable PR.
- Deduplicate repeated helper logic across Discord/Slack/Telegram adapter flows.
- Consolidate small CLI/browser utility cleanups without changing doom-loop behavior.

## Scope
- Includes: `agent/display.py`, `gateway/platforms/{discord,slack,telegram}.py`, `hermes_cli/main.py`, `hermes_state.py`, `tools/browser_tool.py`
- Excludes: doom-loop detection changes in `run_agent.py` / `tests/test_run_agent.py`
- Excludes: vision logging/test fixes

## Related
- Refs #823

## Validation
- `python -m pytest tests/gateway/ -q`
- `python -m pytest tests/test_cli_init.py tests/hermes_cli/test_commands.py -q`