### PR TITLE
fix: clearer error when docker backend is unavailable

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,0 +1,64 @@
+import logging
+import subprocess
+
+import pytest
+
+from tools.environments import docker as docker_env
+
+
+def _make_dummy_env(**kwargs):
+    """Helper to construct DockerEnvironment with minimal required args."""
+    return docker_env.DockerEnvironment(
+        image=kwargs.get("image", "python:3.11"),
+        cwd=kwargs.get("cwd", "/root"),
+        timeout=kwargs.get("timeout", 60),
+        cpu=kwargs.get("cpu", 0),
+        memory=kwargs.get("memory", 0),
+        disk=kwargs.get("disk", 0),
+        persistent_filesystem=kwargs.get("persistent_filesystem", False),
+        task_id=kwargs.get("task_id", "test-task"),
+        volumes=kwargs.get("volumes", []),
+        network=kwargs.get("network", True),
+    )
+
+
+def test_ensure_docker_available_logs_and_raises_when_not_found(monkeypatch, caplog):
+    """When docker is missing from PATH, we should raise a clear error and log it."""
+
+    def _raise_not_found(*args, **kwargs):
+        raise FileNotFoundError("docker not found")
+
+    monkeypatch.setattr(docker_env, "subprocess", docker_env.subprocess)
+    monkeypatch.setattr(docker_env.subprocess, "run", _raise_not_found)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError) as excinfo:
+            _make_dummy_env()
+
+    # Error message should mention that docker is not in PATH
+    assert "Docker executable not found in PATH" in str(excinfo.value)
+    assert any(
+        "Docker backend selected but 'docker' executable was not found in PATH"
+        in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_ensure_docker_available_logs_and_raises_on_timeout(monkeypatch, caplog):
+    """When docker version times out, surface a helpful error instead of hanging."""
+
+    def _raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["docker", "version"], timeout=5)
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _raise_timeout)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError) as excinfo:
+            _make_dummy_env()
+
+    assert "Docker daemon is not responding" in str(excinfo.value)
+    assert any(
+        "docker version' timed out" in record.getMessage()
+        for record in caplog.records
+    )
+

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -43,6 +43,59 @@ _SECURITY_ARGS = [
 _storage_opt_ok: Optional[bool] = None  # cached result across instances
 
 
+def _ensure_docker_available() -> None:
+    """Best-effort check that the docker CLI is available before use.
+
+    This mirrors the gateway's behaviour of surfacing a clear, actionable
+    error when Docker is not installed or not in PATH, instead of failing
+    later with a low-level FileNotFoundError.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except FileNotFoundError:
+        logger.error(
+            "Docker backend selected but 'docker' executable was not found in PATH. "
+            "Install Docker Desktop and ensure 'docker' is available on the command line.",
+            exc_info=True,
+        )
+        raise RuntimeError(
+            "Docker executable not found in PATH. Install Docker and ensure "
+            "the 'docker' command is available."
+        )
+    except subprocess.TimeoutExpired:
+        logger.error(
+            "Docker backend selected but 'docker version' timed out. "
+            "The Docker daemon may not be running.",
+            exc_info=True,
+        )
+        raise RuntimeError(
+            "Docker daemon is not responding. Ensure Docker is running and try again."
+        )
+    except Exception:
+        logger.error(
+            "Unexpected error while checking Docker availability.",
+            exc_info=True,
+        )
+        raise
+    else:
+        if result.returncode != 0:
+            logger.error(
+                "Docker backend selected but 'docker version' failed "
+                "(exit code %d, stderr=%s)",
+                result.returncode,
+                result.stderr.strip(),
+            )
+            raise RuntimeError(
+                "Docker command is available but 'docker version' failed. "
+                "Check your Docker installation."
+            )
+
+
 class DockerEnvironment(BaseEnvironment):
     """Hardened Docker container execution with resource limits and persistence.
 
@@ -80,6 +133,10 @@ class DockerEnvironment(BaseEnvironment):
         if volumes is not None and not isinstance(volumes, list):
             logger.warning(f"docker_volumes config is not a list: {volumes!r}")
             volumes = []
+
+        # Fail fast if Docker is not available rather than surfacing a cryptic
+        # FileNotFoundError deep inside the mini-swe-agent stack.
+        _ensure_docker_available()
 
         from minisweagent.environments.docker import DockerEnvironment as _Docker
 


### PR DESCRIPTION
 When the Docker terminal backend is selected but Docker is not usable, the failure used to surface later as a low-level FileNotFoundError deep inside the mini-swe stack.

 This change adds a small preflight check in tools.environments.docker.DockerEnvironment:
 Call docker version once on construction and raise a clear RuntimeError if Docker is missing from PATH, the daemon is not responding, or docker version fails.

Log these failures with logger.error(..., exc_info=True) so stack traces are visible in logs.

New tests in tests/tools/test_docker_environment.py cover the “docker not found” and “docker version timeout” cases without requiring a real Docker daemon.