### PR TITLE
fix: remove invalid metadata kwarg from _keep_typing call

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -693,7 +693,7 @@ class BasePlatformAdapter(ABC):
         
         # Start continuous typing indicator (refreshes every 2 seconds)
         _thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
-        typing_task = asyncio.create_task(self._keep_typing(event.source.chat_id, metadata=_thread_metadata))
+        typing_task = asyncio.create_task(self._keep_typing(event.source.chat_id))
         
         try:
             # Call the handler (this can take a while with tool calls)


### PR DESCRIPTION
## Summary
- `_keep_typing()` in `BasePlatformAdapter` does not accept a `metadata` parameter
- The call at `base.py:696` was passing `metadata=_thread_metadata`, causing a `TypeError` crash whenever the gateway handled an incoming message
- Removed the invalid kwarg to fix the crash

## Test plan
- [x] Restarted gateway and sent a test message on Telegram
- [x] Gateway responded normally without `TypeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)