### PR TITLE
fix: add local STT fallback for gateway voice transcription

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -378,6 +378,11 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "HERMES_LOCAL_STT_COMMAND": {
+        "description": "Optional local speech-to-text fallback command template. Supports {input_path}, {output_dir}, and {language} placeholders.",
+        "prompt": "Local STT command template (optional)",
+        "category": "setting",
+    },
     "ELEVENLABS_API_KEY": {
         "description": "ElevenLabs API key for premium text-to-speech voices",
         "prompt": "ElevenLabs API key",

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1,0 +1,107 @@
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+from tools import transcription_tools
+
+
+def _write_dummy_audio(path: Path) -> None:
+    path.write_bytes(b"OggSdummy")
+
+
+def test_transcribe_audio_uses_openai_api_key_fallback_when_voice_tools_key_missing(monkeypatch, tmp_path):
+    audio_file = tmp_path / "sample.ogg"
+    _write_dummy_audio(audio_file)
+
+    monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
+
+    class FakeAPIError(Exception):
+        pass
+
+    class FakeAPIConnectionError(Exception):
+        pass
+
+    class FakeAPITimeoutError(Exception):
+        pass
+
+    class FakeOpenAI:
+        def __init__(self, api_key, base_url):
+            assert api_key == "openai-key"
+            assert base_url == "https://api.openai.com/v1"
+            self.audio = types.SimpleNamespace(
+                transcriptions=types.SimpleNamespace(
+                    create=lambda **kwargs: "hello from openai"
+                )
+            )
+
+    fake_openai_module = types.SimpleNamespace(
+        OpenAI=FakeOpenAI,
+        APIError=FakeAPIError,
+        APIConnectionError=FakeAPIConnectionError,
+        APITimeoutError=FakeAPITimeoutError,
+    )
+
+    with patch.dict(sys.modules, {"openai": fake_openai_module}):
+        result = transcription_tools.transcribe_audio(str(audio_file))
+
+    assert result["success"] is True
+    assert result["transcript"] == "hello from openai"
+
+
+def test_transcribe_audio_falls_back_to_local_command_when_openai_keys_missing(monkeypatch, tmp_path):
+    audio_file = tmp_path / "voice.ogg"
+    _write_dummy_audio(audio_file)
+
+    out_dir = tmp_path / "local-out"
+    out_dir.mkdir()
+
+    monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv(
+        "HERMES_LOCAL_STT_COMMAND",
+        "mlx-whisper-local --input {input_path} --output-dir {output_dir} --language {language}",
+    )
+    monkeypatch.setenv("HERMES_LOCAL_STT_LANGUAGE", "en")
+    monkeypatch.setattr(transcription_tools, "_find_ffmpeg_binary", lambda: "/usr/bin/ffmpeg")
+
+    @contextmanager
+    def fake_tempdir(prefix=None):
+        yield str(out_dir)
+
+    monkeypatch.setattr(transcription_tools.tempfile, "TemporaryDirectory", fake_tempdir)
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list):
+            # ffmpeg conversion step -> create the converted wav
+            Path(cmd[-1]).write_bytes(b"RIFF....WAVEfmt ")
+            return CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        (out_dir / "voice.txt").write_text("hello from local whisper\n")
+        return CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(transcription_tools.subprocess, "run", fake_run)
+
+    result = transcription_tools.transcribe_audio(str(audio_file))
+
+    assert result["success"] is True
+    assert result["transcript"] == "hello from local whisper"
+
+
+def test_transcribe_audio_reports_clear_error_when_no_backends_are_configured(monkeypatch, tmp_path):
+    audio_file = tmp_path / "sample.ogg"
+    _write_dummy_audio(audio_file)
+
+    monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
+
+    result = transcription_tools.transcribe_audio(str(audio_file))
+
+    assert result["success"] is False
+    assert "HERMES_LOCAL_STT_COMMAND" in result["error"]
+    assert "OPENAI_API_KEY" in result["error"]

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,16 +2,22 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription using OpenAI's Whisper API.
+Provides speech-to-text transcription using OpenAI's Whisper API, with an
+optional local command fallback for offline/local transcription workflows.
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, and Slack.
 
-Supported models:
-  - whisper-1        (cheapest, good quality)
-  - gpt-4o-mini-transcribe  (better quality, higher cost)
-  - gpt-4o-transcribe       (best quality, highest cost)
+Supported OpenAI input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg
 
-Supported input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg
+Environment variables:
+  - VOICE_TOOLS_OPENAI_KEY: Preferred OpenAI key for STT/TTS
+  - OPENAI_API_KEY: Fallback OpenAI key for STT when voice-specific key is unset
+  - HERMES_LOCAL_STT_COMMAND: Optional shell command template for local fallback.
+    Supported placeholders:
+      * {input_path}
+      * {output_dir}
+      * {language}
+  - HERMES_LOCAL_STT_LANGUAGE: Optional default language for local fallback
 
 Usage:
     from tools.transcription_tools import transcribe_audio
@@ -23,6 +29,10 @@ Usage:
 
 import logging
 import os
+import shlex
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 from typing import Optional, Dict, Any
 
@@ -31,20 +41,154 @@ logger = logging.getLogger(__name__)
 
 # Default STT model -- cheapest and widely available
 DEFAULT_STT_MODEL = "whisper-1"
+DEFAULT_LOCAL_STT_LANGUAGE = "en"
+LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
+LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 
 # Supported audio formats
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg"}
+
+# Formats typically safest to feed directly to local CLI pipelines
+LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 
 # Maximum file size (25MB - OpenAI limit)
 MAX_FILE_SIZE = 25 * 1024 * 1024
 
 
+def _resolve_openai_api_key() -> str:
+    """Prefer the voice-tools key, but fall back to the normal OpenAI key."""
+    return os.getenv("VOICE_TOOLS_OPENAI_KEY", "") or os.getenv("OPENAI_API_KEY", "")
+
+
+def _has_local_stt_command() -> bool:
+    return bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
+
+
+def _find_ffmpeg_binary() -> Optional[str]:
+    """Find ffmpeg, preferring the common Homebrew location on macOS."""
+    homebrew_ffmpeg = "/opt/homebrew/bin/ffmpeg"
+    if os.path.exists(homebrew_ffmpeg):
+        return homebrew_ffmpeg
+    return shutil.which("ffmpeg")
+
+
+def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], Optional[str]]:
+    """
+    Normalize audio for local STT when needed.
+
+    Returns:
+        (prepared_path, error)
+    """
+    audio_path = Path(file_path)
+    if audio_path.suffix.lower() in LOCAL_NATIVE_AUDIO_FORMATS:
+        return file_path, None
+
+    ffmpeg = _find_ffmpeg_binary()
+    if not ffmpeg:
+        return None, "Local STT fallback requires ffmpeg for non-WAV inputs, but ffmpeg was not found"
+
+    converted_path = os.path.join(work_dir, f"{audio_path.stem}.wav")
+    cmd = [ffmpeg, "-y", "-i", file_path, converted_path]
+
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        return converted_path, None
+    except subprocess.CalledProcessError as e:
+        details = e.stderr.strip() or e.stdout.strip() or str(e)
+        logger.error("ffmpeg conversion failed for %s: %s", file_path, details)
+        return None, f"Failed to convert audio for local STT: {details}"
+
+
+def _transcribe_audio_openai(file_path: str, model: str, api_key: str) -> Dict[str, Any]:
+    """Transcribe an audio file using OpenAI's Whisper API."""
+    try:
+        from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
+
+        client = OpenAI(api_key=api_key, base_url="https://api.openai.com/v1")
+
+        with open(file_path, "rb") as audio_file:
+            transcription = client.audio.transcriptions.create(
+                model=model,
+                file=audio_file,
+                response_format="text",
+            )
+
+        transcript_text = str(transcription).strip()
+        logger.info("Transcribed %s via OpenAI (%d chars)", Path(file_path).name, len(transcript_text))
+        return {"success": True, "transcript": transcript_text}
+
+    except PermissionError:
+        logger.error("Permission denied accessing file: %s", file_path, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except APIConnectionError as e:
+        logger.error("API connection error during transcription: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Connection error: {e}"}
+    except APITimeoutError as e:
+        logger.error("API timeout during transcription: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Request timeout: {e}"}
+    except APIError as e:
+        logger.error("OpenAI API error during transcription: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"API error: {e}"}
+    except Exception as e:
+        logger.error("Unexpected error during OpenAI transcription: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
+
+
+def _transcribe_audio_local(file_path: str) -> Dict[str, Any]:
+    """Run the configured local STT command template and read back a .txt transcript."""
+    command_template = os.getenv(LOCAL_STT_COMMAND_ENV, "").strip()
+    if not command_template:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"{LOCAL_STT_COMMAND_ENV} not configured",
+        }
+
+    language = os.getenv(LOCAL_STT_LANGUAGE_ENV, DEFAULT_LOCAL_STT_LANGUAGE)
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="hermes-local-stt-") as output_dir:
+            prepared_input, prep_error = _prepare_local_audio(file_path, output_dir)
+            if prep_error:
+                return {"success": False, "transcript": "", "error": prep_error}
+
+            command = command_template.format(
+                input_path=shlex.quote(prepared_input),
+                output_dir=shlex.quote(output_dir),
+                language=shlex.quote(language),
+            )
+            subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+
+            txt_files = sorted(Path(output_dir).glob("*.txt"))
+            if not txt_files:
+                return {
+                    "success": False,
+                    "transcript": "",
+                    "error": "Local STT command completed but did not produce a .txt transcript",
+                }
+
+            transcript_text = txt_files[0].read_text(encoding="utf-8").strip()
+            logger.info("Transcribed %s via local STT (%d chars)", Path(file_path).name, len(transcript_text))
+            return {"success": True, "transcript": transcript_text}
+
+    except KeyError as e:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Invalid {LOCAL_STT_COMMAND_ENV} template, missing placeholder: {e}",
+        }
+    except subprocess.CalledProcessError as e:
+        details = e.stderr.strip() or e.stdout.strip() or str(e)
+        logger.error("Local STT command failed for %s: %s", file_path, details)
+        return {"success": False, "transcript": "", "error": f"Local STT failed: {details}"}
+    except Exception as e:
+        logger.error("Unexpected error during local transcription: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}
+
+
 def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
     """
-    Transcribe an audio file using OpenAI's Whisper API.
-
-    This function calls the OpenAI Audio Transcriptions endpoint directly
-    (not via OpenRouter, since Whisper isn't available there).
+    Transcribe an audio file using OpenAI's Whisper API, with optional local fallback.
 
     Args:
         file_path: Absolute path to the audio file to transcribe.
@@ -56,16 +200,8 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
           - "transcript" (str): The transcribed text (empty on failure)
           - "error" (str, optional): Error message if success is False
     """
-    api_key = os.getenv("VOICE_TOOLS_OPENAI_KEY")
-    if not api_key:
-        return {
-            "success": False,
-            "transcript": "",
-            "error": "VOICE_TOOLS_OPENAI_KEY not set",
-        }
-
     audio_path = Path(file_path)
-    
+
     # Validate file exists
     if not audio_path.exists():
         return {
@@ -73,14 +209,14 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "transcript": "",
             "error": f"Audio file not found: {file_path}",
         }
-    
+
     if not audio_path.is_file():
         return {
             "success": False,
             "transcript": "",
             "error": f"Path is not a file: {file_path}",
         }
-    
+
     # Validate file extension
     if audio_path.suffix.lower() not in SUPPORTED_FORMATS:
         return {
@@ -88,7 +224,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "transcript": "",
             "error": f"Unsupported file format: {audio_path.suffix}. Supported formats: {', '.join(sorted(SUPPORTED_FORMATS))}",
         }
-    
+
     # Validate file size
     try:
         file_size = audio_path.stat().st_size
@@ -106,64 +242,35 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "error": f"Failed to access file: {e}",
         }
 
-    # Use provided model, or fall back to default
     if model is None:
         model = DEFAULT_STT_MODEL
 
-    try:
-        from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
+    api_key = _resolve_openai_api_key()
+    local_stt_configured = _has_local_stt_command()
 
-        client = OpenAI(api_key=api_key, base_url="https://api.openai.com/v1")
+    if api_key:
+        openai_result = _transcribe_audio_openai(file_path, model, api_key)
+        if openai_result["success"]:
+            return openai_result
+        if local_stt_configured:
+            local_result = _transcribe_audio_local(file_path)
+            if local_result["success"]:
+                return local_result
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"{openai_result['error']}; local fallback failed: {local_result['error']}",
+            }
+        return openai_result
 
-        with open(file_path, "rb") as audio_file:
-            transcription = client.audio.transcriptions.create(
-                model=model,
-                file=audio_file,
-                response_format="text",
-            )
+    if local_stt_configured:
+        return _transcribe_audio_local(file_path)
 
-        # The response is a plain string when response_format="text"
-        transcript_text = str(transcription).strip()
-
-        logger.info("Transcribed %s (%d chars)", audio_path.name, len(transcript_text))
-
-        return {
-            "success": True,
-            "transcript": transcript_text,
-        }
-
-    except PermissionError:
-        logger.error("Permission denied accessing file: %s", file_path, exc_info=True)
-        return {
-            "success": False,
-            "transcript": "",
-            "error": f"Permission denied: {file_path}",
-        }
-    except APIConnectionError as e:
-        logger.error("API connection error during transcription: %s", e, exc_info=True)
-        return {
-            "success": False,
-            "transcript": "",
-            "error": f"Connection error: {e}",
-        }
-    except APITimeoutError as e:
-        logger.error("API timeout during transcription: %s", e, exc_info=True)
-        return {
-            "success": False,
-            "transcript": "",
-            "error": f"Request timeout: {e}",
-        }
-    except APIError as e:
-        logger.error("OpenAI API error during transcription: %s", e, exc_info=True)
-        return {
-            "success": False,
-            "transcript": "",
-            "error": f"API error: {e}",
-        }
-    except Exception as e:
-        logger.error("Unexpected error during transcription: %s", e, exc_info=True)
-        return {
-            "success": False,
-            "transcript": "",
-            "error": f"Transcription failed: {e}",
-        }
+    return {
+        "success": False,
+        "transcript": "",
+        "error": (
+            "Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set, and "
+            f"{LOCAL_STT_COMMAND_ENV} is not configured"
+        ),
+    }

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -26,6 +26,7 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `HERMES_MODEL` | Preferred model name (checked before `LLM_MODEL`, used by gateway) |
 | `LLM_MODEL` | Default model name (fallback when not set in config.yaml) |
 | `VOICE_TOOLS_OPENAI_KEY` | OpenAI key for TTS and voice transcription (separate from custom endpoint) |
+| `HERMES_LOCAL_STT_COMMAND` | Optional local speech-to-text fallback command template with `{input_path}`, `{output_dir}`, `{language}` placeholders |
 | `HERMES_HOME` | Override Hermes config directory (default: `~/.hermes`) |
 
 ## Provider Auth (OAuth)

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -131,7 +131,7 @@ Group chat IDs are negative numbers (e.g., `-1001234567890`). Your personal DM c
 
 ### Incoming Voice (Speech-to-Text)
 
-Voice messages you send on Telegram are automatically transcribed using OpenAI's Whisper API and injected as text into the conversation. This requires `VOICE_TOOLS_OPENAI_KEY` in `~/.hermes/.env`.
+Voice messages you send on Telegram are automatically transcribed and injected as text into the conversation. Hermes will use OpenAI Whisper when `VOICE_TOOLS_OPENAI_KEY` is set, and can optionally fall back to a local command when `HERMES_LOCAL_STT_COMMAND` is configured in `~/.hermes/.env`. The local command template supports `{input_path}`, `{output_dir}`, and `{language}` placeholders.
 
 ### Outgoing Voice (Text-to-Speech)
 
@@ -173,7 +173,7 @@ Hermes Agent works in Telegram group chats with a few considerations:
 | Bot not responding at all | Verify `TELEGRAM_BOT_TOKEN` is correct. Check `hermes gateway` logs for errors. |
 | Bot responds with "unauthorized" | Your user ID is not in `TELEGRAM_ALLOWED_USERS`. Double-check with @userinfobot. |
 | Bot ignores group messages | Privacy mode is likely on. Disable it (Step 3) or make the bot a group admin. **Remember to remove and re-add the bot after changing privacy.** |
-| Voice messages not transcribed | Check that `VOICE_TOOLS_OPENAI_KEY` is set and valid in `~/.hermes/.env`. |
+| Voice messages not transcribed | Check that either `VOICE_TOOLS_OPENAI_KEY` is set and valid, or `HERMES_LOCAL_STT_COMMAND` is configured correctly in `~/.hermes/.env`. |
 | Voice replies are files, not bubbles | Install `ffmpeg` (needed for Edge TTS Opus conversion). |
 | Bot token revoked/invalid | Generate a new token via `/revoke` then `/newbot` or `/token` in BotFather. Update your `.env` file. |
 


### PR DESCRIPTION
## Summary
- let gateway voice transcription fall back to a local STT command when OpenAI voice credentials are unavailable
- accept OPENAI_API_KEY as a fallback for Whisper API calls when VOICE_TOOLS_OPENAI_KEY is unset
- document the new HERMES_LOCAL_STT_COMMAND env var and add regression tests

## Testing
- source venv/bin/activate && python -m pytest tests/tools/test_transcription_tools.py -q
- source venv/bin/activate && python -m pytest tests/tools/test_transcription_tools.py tests/gateway/test_platform_base.py -q
- live local self-test: generated an OGG clip with say + ffmpeg and verified tools.transcription_tools.transcribe_audio() succeeds via local MLX Whisper fallback
