### PR TITLE
Fix Codex request fields and allow OpenRouter key updates

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -880,7 +880,28 @@ def _model_flow_openrouter(config, current_model=""):
     from hermes_cli.config import get_env_value, save_env_value
 
     api_key = get_env_value("OPENROUTER_API_KEY")
-    if not api_key:
+    if api_key:
+        print(f"Current OpenRouter API key: {api_key[:8]}... (configured)")
+        try:
+            update = input("Update OpenRouter API key? [y/N]: ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return
+        if update in {"y", "yes"}:
+            try:
+                key = input("New OpenRouter API key (or Enter to keep current): ").strip()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                return
+            if key:
+                save_env_value("OPENROUTER_API_KEY", key)
+                api_key = key
+                print("API key updated.")
+                print()
+            else:
+                print("Keeping current OpenRouter API key.")
+                print()
+    else:
         print("No OpenRouter API key configured.")
         print("Get one at: https://openrouter.ai/keys")
         print()

--- a/run_agent.py
+++ b/run_agent.py
@@ -2340,10 +2340,7 @@ class AIAgent:
                 "instructions": instructions,
                 "input": self._chat_messages_to_responses_input(payload_messages),
                 "tools": self._responses_tools(),
-                "tool_choice": "auto",
-                "parallel_tool_calls": True,
                 "store": False,
-                "prompt_cache_key": self.session_id,
             }
 
             if reasoning_enabled:


### PR DESCRIPTION
  ## What does this PR do?

  Fixes two CLI/runtime bugs:

  1. `hermes model` (OpenRouter flow) now allows updating an already-configured `OPENROUTER_API_KEY`.
  2. Codex Responses requests no longer include unsupported fields (`tool_choice`, `parallel_tool_calls`,
  `prompt_cache_key`), which caused:
     `ValueError: Codex Responses request has unsupported field(s)...`

  This approach is correct because it preserves existing behavior while removing fields rejected by Codex and improving
  key-management UX in the model flow.

  ## Related Issue

  N/A (no issue filed)

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Updated [`hermes_cli/main.py`](hermes_cli/main.py)
    - In `_model_flow_openrouter`, when `OPENROUTER_API_KEY` already exists, prompt user to update it.
  - Updated [`run_agent.py`](run_agent.py)
    - In Codex Responses kwargs construction, removed unsupported fields:
      - `tool_choice`
      - `parallel_tool_calls`
      - `prompt_cache_key`

  ## How to Test

  1. Run `hermes model`, choose OpenRouter, confirm it now offers to update an existing API key.
  2. Set provider to Codex (`openai-codex`) and run `hermes chat -q "hi"`.
  3. Confirm the previous unsupported-field ValueError no longer occurs.

  ## Checklist

  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`,
  `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a
  duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [ ] I've run `pytest tests/ -q` and all tests pass
  - [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: WSL2 (Ubuntu) on Windows 11

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A)
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/
  NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A)

  ## Screenshots / Logs

  Before:
  - `ValueError: Codex Responses request has unsupported field(s): parallel_tool_calls, prompt_cache_key, tool_choice.`

  After:
  - Codex flow proceeds without that unsupported-field error.
  - OpenRouter model flow now prompts to update existing API key.