### PR TITLE
fix(agent): use atomic write in _save_session_log to prevent data loss on crash

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -26,6 +26,7 @@ import json
 import logging
 logger = logging.getLogger(__name__)
 import os
+import tempfile
 import random
 import re
 import sys
@@ -1228,8 +1229,17 @@ class AIAgent:
                 "messages": cleaned,
             }
 
-            with open(self.session_log_file, "w", encoding="utf-8") as f:
-                json.dump(entry, f, indent=2, ensure_ascii=False, default=str)
+            tmp_dir = str(self.session_log_file.parent) if hasattr(self.session_log_file, 'parent') else os.path.dirname(str(self.session_log_file))
+            fd, tmp_path = tempfile.mkstemp(dir=tmp_dir, suffix='.tmp', prefix='.session_')
+            try:
+                with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                    json.dump(entry, f, indent=2, ensure_ascii=False, default=str)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(tmp_path, str(self.session_log_file))
+            except:
+                os.unlink(tmp_path)
+                raise
 
         except Exception as e:
             if self.verbose_logging:


### PR DESCRIPTION
**What**
_save_session_log() uses bare open('w') which truncates the session log 
immediately. A crash or KeyboardInterrupt mid-write corrupts the file — 
json.load() fails with a decode error on next load.

**How It Works**
Write goes to a temp file first, then os.replace() swaps it atomically. 
Either the old log exists or the new one does — never truncated JSON.

Same pattern already used in save_jobs() in cron/jobs.py.

**Tests**
2726 tests pass (10 pre-existing failures on main unrelated to this change).