### PR TITLE
feat(skills): add native xint / xint-rs content intelligence skill

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -95,6 +95,7 @@ def _discover_tools():
         "tools.send_message_tool",
         "tools.honcho_tools",
         "tools.homeassistant_tool",
+        "tools.xint_tool",
     ]
     import importlib
     for mod_name in _modules:

--- a/skills/content/DESCRIPTION.md
+++ b/skills/content/DESCRIPTION.md
@@ -1,0 +1,3 @@
+---
+description: Content intelligence skills for social analytics, trend discovery, audience research, and writing pipeline inputs.
+---

--- a/skills/content/xint/SKILL.md
+++ b/skills/content/xint/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: xint
+description: Analyze X/Twitter accounts and posts using xint or xint-rs. Use for evidence-backed audience, engagement, and topic intelligence before writing.
+version: 1.0.0
+author: 0xNyk + Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [x, twitter, analytics, research, content-strategy, growth]
+    related_skills: [duckduckgo-search, writing-plans]
+---
+
+# xint / xint-rs (X Intelligence)
+
+Use this skill to extract factual engagement intelligence from X (Twitter) before writing content.
+
+Primary use cases:
+- Account-level performance reconnaissance
+- Topic/niche signal discovery
+- Viral post pattern mining
+- Input generation for article and launchpack workflows
+
+## Tool Choice
+
+Prefer `xint-rs` when available:
+- Faster (single Rust binary)
+- Good for repeated sweeps and larger sample windows
+
+Fallback to `xint` (Python) when:
+- You need parity with existing Python scripts
+- Rust binary is unavailable
+
+## Install
+
+### Option A: xint-rs (preferred)
+
+```bash
+# Clone and build
+cd /tmp
+git clone https://github.com/0xNyk/xint-rs.git
+cd xint-rs
+cargo build --release
+
+# Optional: install globally
+install -m 0755 target/release/xint-rs /usr/local/bin/xint-rs
+```
+
+Verify:
+```bash
+xint-rs --help
+```
+
+### Option B: xint (Python)
+
+```bash
+cd /tmp
+git clone https://github.com/0xNyk/xint.git
+cd xint
+python -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install -e .
+```
+
+Verify:
+```bash
+xint --help
+```
+
+## Standard Workflow (Hermes)
+
+1) Define the research target
+- account handle(s)
+- date window
+- post-count/sample window
+- success metric (impressions, likes, replies, bookmarks proxy, etc.)
+
+2) Collect raw intelligence with xint/xint-rs
+- run account/post analysis
+- save raw output to a timestamped artifact file
+
+3) Normalize into structured output
+- parse into JSON/CSV table: post_url, timestamp, format, topic, hooks, metrics
+
+4) Derive evidence-backed findings
+- top-performing themes
+- hook patterns
+- format distribution (thread, single post, media-rich)
+- recommended angles with explicit metric evidence
+
+5) Feed downstream systems
+- provide findings to writing workflows (e.g., x-article-factory)
+- preserve source links for traceability
+
+## Example Commands
+
+Note: exact flags may vary by version. Always check `--help` first.
+
+```bash
+# Inspect help to confirm available commands/flags
+xint-rs --help
+xint --help
+
+# Example pattern: analyze an account window
+# (replace with current syntax from --help)
+xint-rs analyze --handle 0xNyk --limit 200 --since 30d --format json > /tmp/xint-0xNyk.json
+
+# Python variant (replace flags to match installed version)
+xint analyze --handle 0xNyk --limit 200 --since 30d --format json > /tmp/xint-0xNyk.json
+```
+
+## Hermes Integration Pattern
+
+When invoked for content research, produce this output contract:
+
+1. Data quality check
+- command/version used
+- sample size
+- date range
+- any missing/partial fields
+
+2. Top findings (ranked)
+- each finding must cite at least 1 post URL and metric values
+
+3. Actionable recommendations
+- hooks to reuse
+- topic angles to test
+- format and posting cadence suggestions
+
+4. Machine-usable artifact
+- JSON or CSV path saved locally
+- compact markdown summary for human review
+
+## Evidence Gate (Required)
+
+Do NOT output unsupported claims.
+
+Every strategic claim must include:
+- source post/account URL
+- metric evidence
+- timeframe context
+
+If evidence is insufficient, explicitly say:
+- "insufficient evidence"
+- what is missing
+- what additional pull is needed
+
+## Pitfalls
+
+- X data freshness and API constraints can skew recency interpretation.
+- Small sample windows overfit to outliers.
+- Viral posts are not always transferable across niches.
+- Keep raw artifacts so conclusions remain auditable.
+
+## Suggested Artifact Naming
+
+```text
+research/xint/<handle>/<YYYY-MM-DD>/raw.json
+research/xint/<handle>/<YYYY-MM-DD>/normalized.csv
+research/xint/<handle>/<YYYY-MM-DD>/findings.md
+```

--- a/tests/tools/test_xint_tool.py
+++ b/tests/tools/test_xint_tool.py
@@ -1,0 +1,82 @@
+"""Tests for tools/xint_tool.py."""
+
+import json
+import subprocess
+from unittest.mock import Mock, patch
+
+from tools.xint_tool import (
+    check_xint_requirements,
+    xint_tool,
+    _find_xint_executable,
+    XINT_SCHEMA,
+)
+
+
+class TestExecutableResolution:
+    def test_prefers_xint_rs_in_auto_mode(self):
+        with patch("tools.xint_tool.shutil.which") as mock_which:
+            mock_which.side_effect = lambda name: {
+                "xint-rs": "/usr/local/bin/xint-rs",
+                "xint": "/usr/local/bin/xint",
+            }.get(name)
+            assert _find_xint_executable("auto") == "/usr/local/bin/xint-rs"
+
+    def test_falls_back_to_xint_when_rs_missing(self):
+        with patch("tools.xint_tool.shutil.which") as mock_which:
+            mock_which.side_effect = lambda name: {
+                "xint-rs": None,
+                "xint": "/usr/local/bin/xint",
+            }.get(name)
+            assert _find_xint_executable("auto") == "/usr/local/bin/xint"
+
+    def test_requirement_check_false_when_missing(self):
+        with patch("tools.xint_tool.shutil.which", return_value=None):
+            assert check_xint_requirements() is False
+
+
+class TestXintTool:
+    def test_returns_install_error_when_missing(self):
+        with patch("tools.xint_tool.shutil.which", return_value=None):
+            out = json.loads(xint_tool(action="help"))
+            assert out["success"] is False
+            assert "unavailable" in out["error"].lower()
+            assert "install_refs" in out
+
+    def test_executes_successfully(self):
+        completed = Mock()
+        completed.returncode = 0
+        completed.stdout = '{"ok":true}'
+        completed.stderr = ""
+
+        with patch("tools.xint_tool.shutil.which", side_effect=lambda n: "/usr/local/bin/xint-rs" if n == "xint-rs" else None), \
+             patch("tools.xint_tool.subprocess.run", return_value=completed) as mock_run:
+            out = json.loads(xint_tool(action="health", args=["--json"], parse_json=True))
+
+        assert out["success"] is True
+        assert out["exit_code"] == 0
+        assert out["parsed_json"] == {"ok": True}
+        mock_run.assert_called_once()
+        called_cmd = mock_run.call_args.kwargs
+        assert called_cmd["timeout"] == 120
+
+    def test_timeout_error(self):
+        with patch("tools.xint_tool.shutil.which", side_effect=lambda n: "/usr/local/bin/xint-rs" if n == "xint-rs" else None), \
+             patch("tools.xint_tool.subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=["xint-rs"], timeout=3)):
+            out = json.loads(xint_tool(action="search", timeout=3))
+
+        assert out["success"] is False
+        assert "timed out" in out["error"].lower()
+
+    def test_rejects_non_list_args(self):
+        with patch("tools.xint_tool.shutil.which", return_value="/usr/local/bin/xint-rs"):
+            out = json.loads(xint_tool(action="search", args="--json"))  # type: ignore[arg-type]
+            assert out["success"] is False
+            assert "array" in out["error"].lower()
+
+
+class TestXintSchema:
+    def test_schema_name(self):
+        assert XINT_SCHEMA["name"] == "xint"
+
+    def test_schema_requires_action(self):
+        assert "action" in XINT_SCHEMA["parameters"]["required"]

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -155,6 +155,13 @@ from .delegate_tool import (
     DELEGATE_TASK_SCHEMA,
 )
 
+# X intelligence CLI integration (xint-rs / xint)
+from .xint_tool import (
+    xint_tool,
+    check_xint_requirements,
+    XINT_SCHEMA,
+)
+
 # File tools have no external requirements - they use the terminal backend
 def check_file_requirements():
     """File tools only require terminal backend to be available."""
@@ -260,5 +267,9 @@ __all__ = [
     'delegate_task',
     'check_delegate_requirements',
     'DELEGATE_TASK_SCHEMA',
+    # X intelligence tool
+    'xint_tool',
+    'check_xint_requirements',
+    'XINT_SCHEMA',
 ]
 

--- a/tools/xint_tool.py
+++ b/tools/xint_tool.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Native xint/xint-rs tool integration.
+
+Provides an LLM-callable wrapper around xint-rs (preferred) or xint (fallback)
+for X/Twitter intelligence workflows.
+"""
+
+import json
+import logging
+import shutil
+import subprocess
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 120
+MAX_TIMEOUT_SECONDS = 600
+MAX_ARG_COUNT = 64
+MAX_ARG_LENGTH = 500
+MAX_STDIO_CHARS = 20_000
+
+
+def _find_xint_executable(prefer: str = "auto") -> Optional[str]:
+    """Resolve executable path by preference order."""
+    prefer = (prefer or "auto").strip().lower()
+
+    if prefer == "xint-rs":
+        return shutil.which("xint-rs")
+    if prefer == "xint":
+        return shutil.which("xint")
+
+    # auto
+    return shutil.which("xint-rs") or shutil.which("xint")
+
+
+def check_xint_requirements() -> bool:
+    """Tool is available when xint-rs or xint is installed in PATH."""
+    return _find_xint_executable("auto") is not None
+
+
+def _validate_args(action: str, args: Optional[List[str]]) -> Tuple[str, List[str], Optional[str]]:
+    """Validate and normalize action/args.
+
+    Returns: (normalized_action, normalized_args, error)
+    """
+    action = (action or "").strip()
+
+    if args is None:
+        args = []
+
+    if not isinstance(args, list):
+        return action, [], "args must be an array of strings"
+
+    if len(args) > MAX_ARG_COUNT:
+        return action, [], f"Too many args: {len(args)} (max {MAX_ARG_COUNT})"
+
+    normalized: List[str] = []
+    for i, arg in enumerate(args):
+        s = str(arg)
+        if len(s) > MAX_ARG_LENGTH:
+            return action, [], f"arg[{i}] too long (max {MAX_ARG_LENGTH} chars)"
+        if "\n" in s or "\r" in s or "\x00" in s:
+            return action, [], f"arg[{i}] contains forbidden control characters"
+        normalized.append(s)
+
+    if any(ch in action for ch in ["\n", "\r", "\x00"]):
+        return action, [], "action contains forbidden control characters"
+
+    return action, normalized, None
+
+
+def _truncate(text: str) -> Tuple[str, bool]:
+    if len(text) <= MAX_STDIO_CHARS:
+        return text, False
+    return text[:MAX_STDIO_CHARS] + "\n...[truncated]", True
+
+
+def xint_tool(
+    action: str,
+    args: Optional[List[str]] = None,
+    prefer: str = "auto",
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    parse_json: bool = False,
+    task_id: str = None,
+) -> str:
+    """Run xint-rs/xint and return structured execution output."""
+    action, args, err = _validate_args(action=action, args=args)
+    if err:
+        return json.dumps({"success": False, "error": err}, ensure_ascii=False)
+
+    executable = _find_xint_executable(prefer)
+    if not executable:
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    "xint tool unavailable: neither 'xint-rs' nor 'xint' was found in PATH. "
+                    "Install one of them first."
+                ),
+                "install_refs": [
+                    "https://github.com/0xNyk/xint-rs",
+                    "https://github.com/0xNyk/xint",
+                ],
+            },
+            ensure_ascii=False,
+        )
+
+    try:
+        timeout = int(timeout)
+    except Exception:
+        timeout = DEFAULT_TIMEOUT_SECONDS
+    timeout = max(1, min(timeout, MAX_TIMEOUT_SECONDS))
+
+    cmd = [executable]
+    if action:
+        cmd.append(action)
+    cmd.extend(args)
+
+    try:
+        completed = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as e:
+        stdout, stdout_truncated = _truncate((e.stdout or "") if isinstance(e.stdout, str) else "")
+        stderr, stderr_truncated = _truncate((e.stderr or "") if isinstance(e.stderr, str) else "")
+        return json.dumps(
+            {
+                "success": False,
+                "error": f"xint command timed out after {timeout}s",
+                "executable": executable,
+                "command": cmd,
+                "timeout_seconds": timeout,
+                "stdout": stdout,
+                "stderr": stderr,
+                "stdout_truncated": stdout_truncated,
+                "stderr_truncated": stderr_truncated,
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.exception("xint execution failed: %s", e)
+        return json.dumps(
+            {
+                "success": False,
+                "error": f"xint execution failed: {type(e).__name__}: {e}",
+                "executable": executable,
+                "command": cmd,
+            },
+            ensure_ascii=False,
+        )
+
+    stdout, stdout_truncated = _truncate(completed.stdout or "")
+    stderr, stderr_truncated = _truncate(completed.stderr or "")
+
+    parsed = None
+    parse_error = None
+    if parse_json:
+        try:
+            parsed = json.loads(completed.stdout or "")
+        except Exception as e:
+            parse_error = str(e)
+
+    result = {
+        "success": completed.returncode == 0,
+        "executable": executable,
+        "command": cmd,
+        "exit_code": completed.returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+        "stdout_truncated": stdout_truncated,
+        "stderr_truncated": stderr_truncated,
+    }
+    if parse_json:
+        result["parsed_json"] = parsed
+        if parse_error:
+            result["parse_error"] = parse_error
+
+    return json.dumps(result, ensure_ascii=False)
+
+
+XINT_SCHEMA = {
+    "name": "xint",
+    "description": "Run xint-rs (preferred) or xint (fallback) for X/Twitter intelligence tasks. Use this for account/post analytics and evidence-backed research pulls.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "description": "Subcommand to run (for example: search, profile, analyze, report, help)."
+            },
+            "args": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Additional CLI args as a list of strings, e.g. ['--handle', '0xNyk', '--limit', '100']."
+            },
+            "prefer": {
+                "type": "string",
+                "enum": ["auto", "xint-rs", "xint"],
+                "description": "Executable preference: auto tries xint-rs first then xint."
+            },
+            "timeout": {
+                "type": "integer",
+                "description": "Max seconds to wait for command completion (1-600)."
+            },
+            "parse_json": {
+                "type": "boolean",
+                "description": "If true, attempts to parse stdout as JSON and include parsed_json in the result."
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+from tools.registry import registry
+
+registry.register(
+    name="xint",
+    toolset="xint",
+    schema=XINT_SCHEMA,
+    handler=lambda args, **kw: xint_tool(
+        action=args.get("action", ""),
+        args=args.get("args"),
+        prefer=args.get("prefer", "auto"),
+        timeout=args.get("timeout", DEFAULT_TIMEOUT_SECONDS),
+        parse_json=bool(args.get("parse_json", False)),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_xint_requirements,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -64,6 +64,8 @@ _HERMES_CORE_TOOLS = [
     "query_user_context",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+    # X intelligence (gated on xint/xint-rs executable presence)
+    "xint",
 ]
 
 
@@ -199,6 +201,12 @@ TOOLSETS = {
     "homeassistant": {
         "description": "Home Assistant smart home control and monitoring",
         "tools": ["ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service"],
+        "includes": []
+    },
+
+    "xint": {
+        "description": "X/Twitter intelligence via xint-rs or xint CLI",
+        "tools": ["xint"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary
- add new built-in `xint` skill at `skills/content/xint/SKILL.md`
- add `skills/content/DESCRIPTION.md`
- add native `xint` tool integration (`tools/xint_tool.py`) for executing `xint-rs` (preferred) or `xint` (fallback)
- wire native tool into discovery + toolsets:
  - `model_tools.py` discovery import
  - `toolsets.py` new `xint` toolset + include in Hermes core tools
  - `tools/__init__.py` exports
- add unit tests for native tool behavior (`tests/tools/test_xint_tool.py`)

## Why
This ships both:
1) a reusable skill guide for X intelligence workflows, and
2) an actual callable native tool so the agent can run xint/xint-rs directly.

## Validation
- ✅ `source .venv/bin/activate && python -m pytest tests/tools/test_xint_tool.py tests/test_toolsets.py tests/test_model_tools.py -q` (40 passed)
- ✅ `source .venv/bin/activate && python -m pytest tests/agent/test_prompt_builder.py -q` (33 passed)
- ⚠️ `source .venv/bin/activate && python -m pytest tests/ -q` still has a pre-existing unrelated failure in this environment:
  - `tests/test_timezone.py::TestCronTimezone::test_get_due_jobs_handles_naive_timestamps`

## Notes
- native tool is availability-gated: it only appears when `xint-rs` or `xint` is in PATH
- command execution is argument-list based (no shell interpolation)
- outputs are structured JSON with exit code/stdout/stderr (+ optional stdout JSON parsing)
