### PR TITLE
feat: ACP server + cron timezone fix

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -168,16 +168,22 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
 
 
 def _ensure_aware(dt: datetime) -> datetime:
-    """Make a naive datetime tz-aware using the configured timezone.
+    """Return a timezone-aware datetime in Hermes configured timezone.
 
-    Handles backward compatibility: timestamps stored before timezone support
-    are naive (server-local).  We assume they were in the same timezone as
-    the current configuration so comparisons work without crashing.
+    Backward compatibility:
+    - Older stored timestamps may be naive.
+    - Naive values are interpreted as *system-local wall time* (the timezone
+      `datetime.now()` used when they were created), then converted to the
+      configured Hermes timezone.
+
+    This preserves relative ordering for legacy naive timestamps across
+    timezone changes and avoids false not-due results.
     """
+    target_tz = _hermes_now().tzinfo
     if dt.tzinfo is None:
-        tz = _hermes_now().tzinfo
-        return dt.replace(tzinfo=tz)
-    return dt
+        local_tz = datetime.now().astimezone().tzinfo
+        return dt.replace(tzinfo=local_tz).astimezone(target_tz)
+    return dt.astimezone(target_tz)
 
 
 def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None) -> Optional[str]:

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -249,6 +249,85 @@ class TestCronTimezone:
         due = get_due_jobs()
         assert len(due) == 1
 
+    def test_ensure_aware_naive_preserves_absolute_time(self):
+        """_ensure_aware must preserve the absolute instant for naive datetimes.
+
+        Regression: the old code used replace(tzinfo=hermes_tz) which shifted
+        absolute time when system-local tz != Hermes tz.  The fix interprets
+        naive values as system-local wall time, then converts.
+        """
+        from cron.jobs import _ensure_aware
+
+        os.environ["HERMES_TIMEZONE"] = "Asia/Kolkata"
+        hermes_time.reset_cache()
+
+        # Create a naive datetime — will be interpreted as system-local time
+        naive_dt = datetime(2026, 3, 11, 12, 0, 0)
+
+        result = _ensure_aware(naive_dt)
+
+        # The result should be in Kolkata tz
+        assert result.tzinfo is not None
+
+        # The UTC equivalent must match what we'd get by correctly interpreting
+        # the naive dt as system-local time first, then converting
+        system_tz = datetime.now().astimezone().tzinfo
+        expected_utc = naive_dt.replace(tzinfo=system_tz).astimezone(timezone.utc)
+        actual_utc = result.astimezone(timezone.utc)
+        assert actual_utc == expected_utc, (
+            f"Absolute time shifted: expected {expected_utc}, got {actual_utc}"
+        )
+
+    def test_ensure_aware_normalizes_aware_to_hermes_tz(self):
+        """Already-aware datetimes should be normalized to Hermes tz."""
+        from cron.jobs import _ensure_aware
+
+        os.environ["HERMES_TIMEZONE"] = "Asia/Kolkata"
+        hermes_time.reset_cache()
+
+        # Create an aware datetime in UTC
+        utc_dt = datetime(2026, 3, 11, 15, 0, 0, tzinfo=timezone.utc)
+        result = _ensure_aware(utc_dt)
+
+        # Must be in Hermes tz (Kolkata) but same absolute instant
+        kolkata = ZoneInfo("Asia/Kolkata")
+        assert result.utctimetuple()[:5] == (2026, 3, 11, 15, 0)
+        expected_local = utc_dt.astimezone(kolkata)
+        assert result == expected_local
+
+    def test_ensure_aware_due_job_not_skipped_when_system_ahead(self, tmp_path, monkeypatch):
+        """Reproduce the actual bug: system tz ahead of Hermes tz caused
+        overdue jobs to appear as not-yet-due.
+
+        Scenario: system is Asia/Kolkata (UTC+5:30), Hermes is UTC.
+        A naive timestamp from 5 minutes ago (local time) should still
+        be recognized as due after conversion.
+        """
+        import cron.jobs as jobs_module
+        monkeypatch.setattr(jobs_module, "CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr(jobs_module, "JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr(jobs_module, "OUTPUT_DIR", tmp_path / "cron" / "output")
+
+        os.environ["HERMES_TIMEZONE"] = "UTC"
+        hermes_time.reset_cache()
+
+        from cron.jobs import create_job, load_jobs, save_jobs, get_due_jobs
+
+        job = create_job(prompt="Bug repro", schedule="every 1h")
+        jobs = load_jobs()
+
+        # Simulate a naive timestamp that was written by datetime.now() on a
+        # system running in UTC+5:30 — 5 minutes in the past (local time)
+        naive_past = (datetime.now() - timedelta(minutes=5)).isoformat()
+        jobs[0]["next_run_at"] = naive_past
+        save_jobs(jobs)
+
+        # Must be recognized as due regardless of tz mismatch
+        due = get_due_jobs()
+        assert len(due) == 1, (
+            "Overdue job was skipped — _ensure_aware likely shifted absolute time"
+        )
+
     def test_create_job_stores_tz_aware_timestamps(self, tmp_path, monkeypatch):
         """New jobs store timezone-aware created_at and next_run_at."""
         import cron.jobs as jobs_module


### PR DESCRIPTION
## Two features in one PR

### 1. fix(cron): handle naive legacy timestamps in due-job checks
Cherry-picked from PR #807 by @0xNyk with 3 additional regression tests.

### 2. feat: ACP (Agent Client Protocol) server for editor integration
Based on PR #837 by @teknium1, with complete implementation of the prompt flow.

---

## ACP Implementation (~1200 lines)

Adds full ACP support, enabling hermes-agent to work as a coding agent inside **VS Code**, **Zed**, **JetBrains IDEs**, and any ACP-compatible editor.

### User Flow
```
1. hermes is already installed
2. pip install -e '.[acp]'
3. Install ACP Client extension in VS Code
4. Add to settings: point to acp_registry/ directory
5. Open ACP panel → Select hermes → Start chatting
```

### Architecture (`acp_adapter/`)

| File | Lines | Purpose |
|------|-------|---------|
| `server.py` | 280 | HermesACPAgent — all 15 Agent protocol methods |
| `session.py` | 120 | Thread-safe SessionManager with per-session AIAgent |
| `events.py` | 170 | Callback → ACP notification bridging |
| `tools.py` | 200 | Tool kind mapping (25+ tools) + content builders |
| `permissions.py` | 80 | Approval bridging → editor permission dialogs |
| `auth.py` | 26 | Provider credential detection |
| `entry.py` | 86 | CLI entry point |

### Key Features
- **Full prompt flow**: AIAgent runs in thread executor, streams tool events, thinking, and messages back in real-time
- **Tool events with kinds**: read/edit/execute/search/fetch/think mapped for 25+ hermes tools
- **Diff content** for file edits (patch, write_file)
- **Permission bridging**: dangerous commands → editor approval dialog
- **Session lifecycle**: new, load, resume, list, fork, cancel
- **Model switching** support
- **No modifications to run_agent.py** — works entirely through existing callback system

### Also includes
- `jupyter-live-kernel` skill for data science workflows
- `acp_registry/` with agent.json for editor auto-discovery
- `docs/acp-setup.md` setup guide (VS Code, Zed, JetBrains)
- `hermes acp` CLI subcommand

### What was fixed from the original PR #837
- Fixed broken imports in events.py (4 of 5 imported names didn't exist)
- Implemented prompt() (was a placeholder returning empty response)
- Made all Agent methods async (ACP SDK requires it)
- Added load_session/resume_session support
- Removed dead _acp_tool_bridge hook from run_agent.py
- Expanded TOOL_KIND_MAP from 7 to 25+ tools
- Added make_tool_call_id and build_tool_title functions
- Added result truncation for large tool outputs
- Added events.py tests (were completely missing)

## Tests
- 81 new ACP tests + 3 cron timezone regression tests
- Full suite: **3330 passed**, 16 skipped (2 pre-existing unrelated failures)

Fixes #806
Closes #807
Closes #837

Co-authored-by: 0xNyk <0xNyk@users.noreply.github.com>