### PR TITLE
fix(setup): persist provider when switching model endpoints

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -905,6 +905,7 @@ def _model_flow_openrouter(config, current_model=""):
         if get_env_value("OPENAI_BASE_URL"):
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
+        save_env_value("HERMES_INFERENCE_PROVIDER", "openrouter")
         _save_model_choice(selected)
 
         # Update config provider and deactivate any OAuth provider
@@ -987,6 +988,7 @@ def _model_flow_nous(config, current_model=""):
 
     selected = _prompt_model_selection(model_ids, current_model=current_model)
     if selected:
+        save_env_value("HERMES_INFERENCE_PROVIDER", "nous")
         _save_model_choice(selected)
         # Reactivate Nous as the provider and update config
         inference_url = creds.get("base_url", "")
@@ -1036,6 +1038,7 @@ def _model_flow_openai_codex(config, current_model=""):
 
     selected = _prompt_model_selection(codex_models, current_model=current_model)
     if selected:
+        save_env_value("HERMES_INFERENCE_PROVIDER", "openai-codex")
         _save_model_choice(selected)
         _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
         # Clear custom endpoint env vars that would otherwise override Codex.
@@ -1092,6 +1095,7 @@ def _model_flow_custom(config):
         save_env_value("OPENAI_API_KEY", api_key)
 
     if model_name:
+        save_env_value("HERMES_INFERENCE_PROVIDER", "custom")
         _save_model_choice(model_name)
 
         # Update config and deactivate any OAuth provider
@@ -1108,6 +1112,7 @@ def _model_flow_custom(config):
         print(f"Default model set to: {model_name} (via {effective_url})")
     else:
         if base_url or api_key:
+            save_env_value("HERMES_INFERENCE_PROVIDER", "custom")
             deactivate_provider()
         print("Endpoint saved. Use `/model` in chat or `hermes model` to set a model.")
 
@@ -1240,6 +1245,7 @@ def _model_flow_named_custom(config, provider_info):
         save_env_value("OPENAI_BASE_URL", base_url)
         if api_key:
             save_env_value("OPENAI_API_KEY", api_key)
+        save_env_value("HERMES_INFERENCE_PROVIDER", "custom")
         _save_model_choice(saved_model)
 
         cfg = load_config()
@@ -1314,6 +1320,7 @@ def _model_flow_named_custom(config, provider_info):
     save_env_value("OPENAI_BASE_URL", base_url)
     if api_key:
         save_env_value("OPENAI_API_KEY", api_key)
+    save_env_value("HERMES_INFERENCE_PROVIDER", "custom")
     _save_model_choice(model_name)
 
     cfg = load_config()
@@ -1427,6 +1434,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         if get_env_value("OPENAI_BASE_URL"):
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
+        save_env_value("HERMES_INFERENCE_PROVIDER", provider_id)
 
         _save_model_choice(selected)
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -888,10 +888,22 @@ def setup_model_provider(config: dict):
         _update_config_for_provider("minimax-cn", pconfig.inference_base_url)
 
     # else: provider_idx == 9 (Keep current) — only shown when a provider already exists
+    # Normalize "keep current" to an explicit provider so downstream logic
+    # (model list + env persistence) doesn't fall back to OpenRouter defaults.
+    if selected_provider is None:
+        if active_oauth and active_oauth in PROVIDER_REGISTRY:
+            selected_provider = active_oauth
+        elif existing_custom:
+            selected_provider = "custom"
+        elif existing_or:
+            selected_provider = "openrouter"
 
     # ── OpenRouter API Key for tools (if not already set) ──
     # Tools (vision, web, MoA) use OpenRouter independently of the main provider.
     # Prompt for OpenRouter key if not set and a non-OpenRouter provider was chosen.
+    if selected_provider in ("nous", "nous-api", "openai-codex", "openrouter", "custom", "zai", "kimi-coding", "minimax", "minimax-cn"):
+        save_env_value("HERMES_INFERENCE_PROVIDER", selected_provider)
+
     if selected_provider in ("nous", "nous-api", "openai-codex", "custom", "zai", "kimi-coding", "minimax", "minimax-cn") and not get_env_value("OPENROUTER_API_KEY"):
         print()
         print_header("OpenRouter API Key (for tools)")

--- a/tests/test_setup_model_provider.py
+++ b/tests/test_setup_model_provider.py
@@ -1,0 +1,106 @@
+"""Regression tests for interactive setup provider/model persistence."""
+
+from __future__ import annotations
+
+import yaml
+
+
+def _read_env(home):
+    env_path = home / ".env"
+    data = {}
+    if not env_path.exists():
+        return data
+    for line in env_path.read_text().splitlines():
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        data[k] = v
+    return data
+
+
+def test_setup_keep_current_custom_does_not_fall_through(tmp_path, monkeypatch):
+    """Selecting "Keep current" on a custom provider must remain custom."""
+    from hermes_cli.config import save_env_value
+    from hermes_cli.setup import setup_model_provider
+
+    home = tmp_path / "hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    # Existing custom endpoint + OR key (skip optional OpenRouter prompt).
+    save_env_value("OPENAI_BASE_URL", "https://example.invalid/v1")
+    save_env_value("OPENAI_API_KEY", "sk-custom")
+    save_env_value("OPENROUTER_API_KEY", "sk-or")
+
+    monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: None)
+    monkeypatch.setattr("hermes_cli.auth.detect_external_credentials", lambda: [])
+
+    calls = {"count": 0}
+
+    def fake_prompt_choice(_question, choices, default=0):
+        calls["count"] += 1
+        # First menu = provider menu. Pick "Keep current (...)".
+        if calls["count"] == 1:
+            return len(choices) - 1
+        raise AssertionError("Model menu should not appear for keep-current custom")
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: "")
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: False)
+
+    setup_model_provider({"model": "glm-5"})
+
+    env = _read_env(home)
+    assert env.get("HERMES_INFERENCE_PROVIDER") == "custom"
+    assert calls["count"] == 1
+
+
+def test_setup_switch_custom_to_codex_updates_provider(tmp_path, monkeypatch):
+    """Switching provider to OpenAI Codex must persist provider + clear custom URL."""
+    from hermes_cli.config import save_env_value
+    from hermes_cli.setup import setup_model_provider
+
+    home = tmp_path / "hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    # Start from custom endpoint state.
+    save_env_value("OPENAI_BASE_URL", "https://example.invalid/v1")
+    save_env_value("OPENAI_API_KEY", "sk-custom")
+    save_env_value("OPENROUTER_API_KEY", "sk-or")
+
+    monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: None)
+    monkeypatch.setattr("hermes_cli.auth.detect_external_credentials", lambda: [])
+    monkeypatch.setattr("hermes_cli.auth._login_openai_codex", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda: ["openai/gpt-5.3-codex", "openai/gpt-5-codex-mini"],
+    )
+
+    # 1st prompt_choice = provider (OpenAI Codex index), 2nd = model pick.
+    picks = iter([2, 0])
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: next(picks))
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: "")
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: False)
+
+    setup_model_provider({"model": "glm-5"})
+
+    env = _read_env(home)
+    assert env.get("HERMES_INFERENCE_PROVIDER") == "openai-codex"
+    assert env.get("OPENAI_BASE_URL", None) == ""
+
+    cfg = yaml.safe_load((home / "config.yaml").read_text()) or {}
+    model_cfg = cfg.get("model")
+    if isinstance(model_cfg, dict):
+        assert model_cfg.get("provider") == "openai-codex"
+        assert model_cfg.get("default") == "openai/gpt-5.3-codex"
+    else:
+        assert model_cfg == "openai/gpt-5.3-codex"


### PR DESCRIPTION
  ## What does this PR do?

  Fixes a provider-selection persistence bug in `hermes setup model`.

  Problem:
  - If a user had `custom` selected and then changed models/providers in setup, Hermes could keep
  `HERMES_INFERENCE_PROVIDER=custom`, causing runtime/provider mismatch.

  What this changes:
  - Normalizes `Keep current` to an explicit provider before model selection.
  - Persists `HERMES_INFERENCE_PROVIDER` in provider/model flows (including OpenAI Codex and custom endpoint flows).
  - Prevents setup from silently falling through to the wrong provider behavior.

  Why this approach:
  - Fixes the issue at the source (`setup model` flow) instead of requiring manual `.env` edits.

  ## Related Issue

  N/A (no issue opened)

  Fixes #

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Updated provider persistence and selection logic in:
    - `hermes_cli/setup.py`
    - `hermes_cli/main.py`
  - Added regression tests:
    - `tests/test_setup_model_provider.py`
      - `test_setup_keep_current_custom_does_not_fall_through`
      - `test_setup_switch_custom_to_codex_updates_provider`

  ## How to Test

  1. Start from a custom endpoint setup (`HERMES_INFERENCE_PROVIDER=custom`, `OPENAI_BASE_URL` set).
  2. Run `hermes setup model`, select **Login with OpenAI Codex**, choose a Codex model.
  3. Verify:
     - `HERMES_INFERENCE_PROVIDER=openai-codex`
     - `OPENAI_BASE_URL` is cleared
     - Hermes runs using Codex provider without custom-provider mismatch.

  ## Checklist

  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`,
  `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a
  duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [ ] I've run `pytest tests/ -q` and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Windows 11 (WSL2 Ubuntu)

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A)
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/
  NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A)

  ## Screenshots / Logs

  Targeted regression tests:
  - `pytest -q tests/test_setup_model_provider.py`
  - Result: `2 passed`