### PR TITLE
fix(config): atomic write for .env to prevent API key loss on crash

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -17,6 +17,7 @@ import platform
 import stat
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
 
@@ -958,8 +959,19 @@ def save_env_value(key: str, value: str):
             lines[-1] += "\n"
         lines.append(f"{key}={value}\n")
     
-    with open(env_path, 'w', **write_kw) as f:
-        f.writelines(lines)
+    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+    try:
+        with os.fdopen(fd, 'w', **write_kw) as f:
+            f.writelines(lines)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, env_path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
     _secure_file(env_path)
 
     # Restrict .env permissions to owner-only (contains API keys)


### PR DESCRIPTION
## Summary

Cherry-picked from PR #842 by @alireza78a, rebased onto current main with conflict resolution.

`save_env_value()` used bare `open('w')` which truncates `.env` immediately. A crash or OOM kill between truncation and the completed write silently wipes every credential in the file.

### Fix

Write now goes to a temp file in the same directory first (`tempfile.mkstemp`), then `os.replace()` swaps it atomically. Either the old `.env` exists or the new one does — never a truncated half-write. Same pattern already used in `save_jobs()` in `cron/jobs.py`.

### Conflict resolution

The PR was 165 commits behind main. The only conflict was that main had refactored the inline `os.chmod` into `_secure_file(env_path)`. Resolved by keeping the atomic write pattern AND the `_secure_file()` call.

### Tests

201 hermes_cli tests pass.

Closes #842

Co-authored-by: alireza78a <alireza78a@users.noreply.github.com>