### PR TITLE
fix: _SafeWriter for broken stdout + doctor MiniMax + vision logging

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -259,6 +259,7 @@ async def vision_analyze_tool(
         
         # Check auxiliary vision client availability
         if _aux_async_client is None or DEFAULT_VISION_MODEL is None:
+            logger.error("Vision analysis unavailable: no auxiliary vision model configured")
             return json.dumps({
                 "success": False,
                 "analysis": "Vision analysis unavailable: no auxiliary vision model configured. "


### PR DESCRIPTION
Three fixes:

## 1. _SafeWriter — guard all print() against OSError (Fixes #845)

When hermes-agent runs as a systemd service or headless daemon, stdout can become unavailable, causing `print()` to raise `OSError: [Errno 5]`. This crashes `run_conversation()` — especially via double-fault when the except handler also tries to print.

PR #858 attempted to fix this by wrapping 7 individual print() calls, but `run_conversation()` has **68 print() calls**, and the PR left adjacent prints in the same blocks unguarded.

**Our fix:** A transparent `_SafeWriter` wrapper installed once at the start of `run_conversation()`. It delegates all writes to the real stdout and silently catches OSError. Zero overhead when stdout is healthy, comprehensive coverage of all print calls including future ones.

- 6 tests covering: normal delegation, OSError catch on write/flush, print survival, installation in run_conversation, double-wrap prevention

## 2. Doctor MiniMax fix (Fixes #811)

Cherry-picked from PR #822 by @Bartok9. MiniMax providers now show `✓ (key configured)` instead of false HTTP 404.

## 3. Vision logging

Log an error when vision client is unavailable (previously silent). Inspired by PR #839 by @aydnOktay.

---

**Tests:** 3252 passed (2 pre-existing unrelated failures)