### PR TITLE
fix: make config set examples use placeholder syntax

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -763,7 +763,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                         print(f"  ✓ Saved {name}")
                     print()
             else:
-                print("  Set later with: hermes config set KEY VALUE")
+                print("  Set later with: hermes config set <key> <value>")
     
     # Check for missing config fields
     missing_config = get_missing_config_fields()
@@ -1138,7 +1138,7 @@ def show_config():
     print()
     print(color("─" * 60, Colors.DIM))
     print(color("  hermes config edit     # Edit config file", Colors.DIM))
-    print(color("  hermes config set KEY VALUE", Colors.DIM))
+    print(color("  hermes config set <key> <value>", Colors.DIM))
     print(color("  hermes setup           # Run setup wizard", Colors.DIM))
     print()
 
@@ -1264,7 +1264,7 @@ def config_command(args):
         key = getattr(args, 'key', None)
         value = getattr(args, 'value', None)
         if not key or not value:
-            print("Usage: hermes config set KEY VALUE")
+            print("Usage: hermes config set <key> <value>")
             print()
             print("Examples:")
             print("  hermes config set model anthropic/claude-sonnet-4")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -406,7 +406,7 @@ def _print_setup_summary(config: dict, hermes_home):
     print()
     print(f"   {color('hermes config', Colors.GREEN)}         View current settings")
     print(f"   {color('hermes config edit', Colors.GREEN)}    Open config in your editor")
-    print(f"   {color('hermes config set KEY VALUE', Colors.GREEN)}")
+    print(f"   {color('hermes config set <key> <value>', Colors.GREEN)}")
     print(f"                          Set a specific value")
     print()
     print(f"   Or edit the files directly:")

--- a/tests/hermes_cli/test_placeholder_usage.py
+++ b/tests/hermes_cli/test_placeholder_usage.py
@@ -1,0 +1,29 @@
+"""Tests for CLI placeholder text in config/setup output."""
+
+import os
+from argparse import Namespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import config_command
+from hermes_cli.setup import _print_setup_summary
+
+
+def test_config_set_usage_marks_placeholders(capsys):
+    args = Namespace(config_command="set", key=None, value=None)
+
+    with pytest.raises(SystemExit) as exc:
+        config_command(args)
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "Usage: hermes config set <key> <value>" in out
+
+
+def test_setup_summary_marks_placeholders(tmp_path, capsys):
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        _print_setup_summary({"tts": {"provider": "edge"}}, tmp_path)
+
+    out = capsys.readouterr().out
+    assert "hermes config set <key> <value>" in out


### PR DESCRIPTION
## Summary
- replace literal `KEY VALUE` examples with `<key> <value>` placeholders in the setup summary and config CLI output
- update the `config set` usage text so copy-paste examples no longer write a literal `KEY: VALUE` entry into config
- add focused CLI output tests covering the setup summary and missing-args usage path

## Testing
- `/opt/homebrew/bin/python3.11 -m pytest -o addopts='' tests/hermes_cli/test_config.py tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_placeholder_usage.py -q`

Closes #926
