### PR TITLE
fix: add exc_info=True to image generation error logging

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -209,7 +209,7 @@ def _upscale_image(image_url: str, original_prompt: str) -> Dict[str, Any]:
             return None
             
     except Exception as e:
-        logger.error("Error upscaling image: %s", e)
+        logger.error("Error upscaling image: %s", e, exc_info=True)
         return None
 
 
@@ -377,7 +377,7 @@ def image_generate_tool(
     except Exception as e:
         generation_time = (datetime.datetime.now() - start_time).total_seconds()
         error_msg = f"Error generating image: {str(e)}"
-        logger.error("%s", error_msg)
+        logger.error("%s", error_msg, exc_info=True)
         
         # Prepare error response - minimal format
         response_data = {


### PR DESCRIPTION
Cherry-picked from PR #868 by @aydnOktay (207 commits behind, applied manually).

Adds `exc_info=True` to two `logger.error()` calls in `tools/image_generation_tool.py` so error logs include full stack traces instead of just the message string. Matches the pattern established in commit 0fdeffe across the rest of the codebase.

Closes #868

Co-authored-by: aydnOktay <aydnOktay@users.noreply.github.com>