### PR TITLE
fix(doctor): treat configured honcho as available

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -53,6 +53,33 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
+def _honcho_is_configured_for_doctor() -> bool:
+    """Return True when Honcho is configured, even if this process has no active session."""
+    try:
+        from honcho_integration.client import HonchoClientConfig
+
+        cfg = HonchoClientConfig.from_global_config()
+        return bool(cfg.enabled and cfg.api_key)
+    except Exception:
+        return False
+
+
+def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
+    """Adjust runtime-gated tool availability for doctor diagnostics."""
+    if not _honcho_is_configured_for_doctor():
+        return available, unavailable
+
+    updated_available = list(available)
+    updated_unavailable = []
+    for item in unavailable:
+        if item.get("name") == "honcho":
+            if "honcho" not in updated_available:
+                updated_available.append("honcho")
+            continue
+        updated_unavailable.append(item)
+    return updated_available, updated_unavailable
+
+
 def check_ok(text: str, detail: str = ""):
     print(f"  {color('✓', Colors.GREEN)} {text}" + (f" {color(detail, Colors.DIM)}" if detail else ""))
 
@@ -582,6 +609,7 @@ def run_doctor(args):
         from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
         
         available, unavailable = check_tool_availability()
+        available, unavailable = _apply_doctor_tool_availability_overrides(available, unavailable)
         
         for tid in available:
             info = TOOLSET_REQUIREMENTS.get(tid, {})

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1,5 +1,8 @@
 """Tests for hermes doctor helpers."""
 
+from types import SimpleNamespace
+
+import hermes_cli.doctor as doctor
 from hermes_cli.doctor import _has_provider_env_config
 
 
@@ -15,3 +18,50 @@ class TestProviderEnvDetection:
     def test_returns_false_when_no_provider_settings(self):
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)
+
+
+class TestDoctorToolAvailabilityOverrides:
+    def test_marks_honcho_available_when_configured(self, monkeypatch):
+        monkeypatch.setattr(doctor, "_honcho_is_configured_for_doctor", lambda: True)
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [{"name": "honcho", "env_vars": [], "tools": ["query_user_context"]}],
+        )
+
+        assert available == ["honcho"]
+        assert unavailable == []
+
+    def test_leaves_honcho_unavailable_when_not_configured(self, monkeypatch):
+        monkeypatch.setattr(doctor, "_honcho_is_configured_for_doctor", lambda: False)
+
+        honcho_entry = {"name": "honcho", "env_vars": [], "tools": ["query_user_context"]}
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [honcho_entry],
+        )
+
+        assert available == []
+        assert unavailable == [honcho_entry]
+
+
+class TestHonchoDoctorConfigDetection:
+    def test_reports_configured_when_enabled_with_api_key(self, monkeypatch):
+        fake_config = SimpleNamespace(enabled=True, api_key="honcho-test-key")
+
+        monkeypatch.setattr(
+            "honcho_integration.client.HonchoClientConfig.from_global_config",
+            lambda: fake_config,
+        )
+
+        assert doctor._honcho_is_configured_for_doctor()
+
+    def test_reports_not_configured_without_api_key(self, monkeypatch):
+        fake_config = SimpleNamespace(enabled=True, api_key=None)
+
+        monkeypatch.setattr(
+            "honcho_integration.client.HonchoClientConfig.from_global_config",
+            lambda: fake_config,
+        )
+
+        assert not doctor._honcho_is_configured_for_doctor()


### PR DESCRIPTION
## What does this PR do?

This PR fixes a false negative in `hermes doctor` for Honcho.

Today, doctor reuses the runtime availability gate for the `honcho` toolset. That gate only becomes true after a live agent session has already initialized Honcho state and injected a session manager + session key. That is correct for runtime tool execution, but wrong for doctor diagnostics.

This change keeps runtime behavior unchanged and only adjusts doctor output:

- if Honcho is configured via `HonchoClientConfig.from_global_config()`
- and resolves to `enabled=True` with an API key present
- doctor treats `honcho` as available instead of reporting `system dependency not met`

This is the smallest correct fix because it changes the diagnostic interpretation without relaxing the actual runtime gate for `query_user_context`.

## Related Issue

Fixes #961

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/doctor.py` to add a doctor-specific Honcho config check based on `HonchoClientConfig.from_global_config()`.
- Updated `hermes_cli/doctor.py` to apply a doctor-only availability override for the `honcho` toolset after `check_tool_availability()` returns.
- Added regression tests in `tests/hermes_cli/test_doctor.py` for:
  - configured Honcho being promoted to available in doctor output
  - unconfigured Honcho remaining unavailable
  - Honcho config detection with and without an API key

## How to Test

1. From the repository root, configure Honcho with `enabled: true` and a valid API key in `~/.honcho/config.json`.
2. Run `hermes doctor` on `main` and observe `⚠ honcho (system dependency not met)`.
3. Check out this branch and run `hermes doctor` again.
4. Confirm that `honcho` is no longer misreported as a missing system dependency.
5. Run:
   - `source .venv/bin/activate`
   - `PYTHONPATH=. pytest -o addopts='' -q tests/hermes_cli/test_doctor.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] N/A: no user-facing documentation changes were required
- [x] N/A: no config keys changed, so `cli-config.yaml.example` did not require updates
- [x] N/A: no contributor workflow or architecture guide changes were required
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code was added
- [x] N/A: no tool descriptions/schemas were changed

## Screenshots / Logs

Targeted test result:

```shell
source .venv/bin/activate
PYTHONPATH=. pytest -o addopts='' -q tests/hermes_cli/test_doctor.py
.......                                                                  [100%]
7 passed in 0.06s
```