### PR TITLE
fix(patch): use regex to detect line-number prefix to prevent pipe char corruption

### DIFF
--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -359,7 +359,7 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     # Parse content (remove line numbers)
     current_lines = []
     for line in read_result.content.split('\n'):
-        if '|' in line:
+        if re.match(r'^\s*\d+\|', line):
             # Line format: "    123|content"
             parts = line.split('|', 1)
             if len(parts) == 2:


### PR DESCRIPTION
**What**
V4A patch apply uses `if '|' in line` to strip line-number prefixes from
file content. Any line containing `|` — Python bitwise ops, shell pipes,
SQL, Markdown tables — is split on the first `|` and the left side is
dropped. The file is rewritten with those lines corrupted, no error reported.

**How It Works**
Replaced the `'|' in line` check with `re.match(r'^\s*\d+\|', line)`.
This matches only the actual line-number prefix format (`   123|content`)
and leaves all other `|` characters untouched.

**Tests**
154 patch-related tests pass.