### PR TITLE
fix: handle MEDIA tags in send_message tool for native file delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -611,16 +611,16 @@ class BasePlatformAdapter(ABC):
         has_voice_tag = "[[audio_as_voice]]" in content
         cleaned = cleaned.replace("[[audio_as_voice]]", "")
         
-        # Extract MEDIA:<path> tags (path may contain spaces)
-        media_pattern = r'MEDIA:(\S+)'
+        # Extract MEDIA:<path> tags
+        media_pattern = r'MEDIA:\s*(\S+)'
         for match in re.finditer(media_pattern, content):
-            path = match.group(1).strip()
+            path = match.group(1).strip().rstrip('`"\',)}')
             if path:
                 media.append((path, has_voice_tag))
         
-        # Remove MEDIA tags from content
+        # Remove MEDIA tags from content (including surrounding backticks/quotes)
         if media:
-            cleaned = re.sub(media_pattern, '', cleaned)
+            cleaned = re.sub(r'[`"\']*MEDIA:\s*\S+[`"\']*', '', cleaned)
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
         
         return media, cleaned

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -15,6 +15,11 @@ logger = logging.getLogger(__name__)
 
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
 
+_IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
+_VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.3gp'}
+_AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
+_VOICE_EXTS = {'.ogg', '.opus'}
+
 
 SEND_MESSAGE_SCHEMA = {
     "name": "send_message",
@@ -195,12 +200,61 @@ async def _send_telegram(token, chat_id, message, thread_id=None):
     """Send via Telegram Bot API (one-shot, no polling needed)."""
     try:
         from telegram import Bot
+        from gateway.platforms.base import BasePlatformAdapter
         bot = Bot(token=token)
-        send_kwargs = {"chat_id": int(chat_id), "text": message}
+        int_chat_id = int(chat_id)
+        thread_kwargs = {}
         if thread_id is not None:
-            send_kwargs["message_thread_id"] = int(thread_id)
-        msg = await bot.send_message(**send_kwargs)
-        return {"success": True, "platform": "telegram", "chat_id": chat_id, "message_id": str(msg.message_id)}
+            thread_kwargs["message_thread_id"] = int(thread_id)
+
+        # Extract MEDIA:<path> tags and send files natively
+        media_files, cleaned = BasePlatformAdapter.extract_media(message)
+
+        last_msg = None
+        # Send text portion if any remains
+        if cleaned.strip():
+            last_msg = await bot.send_message(
+                chat_id=int_chat_id, text=cleaned, **thread_kwargs
+            )
+
+        # Send extracted media files
+        for media_path, is_voice in media_files:
+            if not os.path.exists(media_path):
+                logger.warning("Media file not found, skipping: %s", media_path)
+                continue
+            ext = os.path.splitext(media_path)[1].lower()
+            try:
+                with open(media_path, "rb") as f:
+                    if ext in _IMAGE_EXTS:
+                        last_msg = await bot.send_photo(
+                            chat_id=int_chat_id, photo=f, **thread_kwargs
+                        )
+                    elif ext in _VIDEO_EXTS:
+                        last_msg = await bot.send_video(
+                            chat_id=int_chat_id, video=f, **thread_kwargs
+                        )
+                    elif ext in _VOICE_EXTS and is_voice:
+                        last_msg = await bot.send_voice(
+                            chat_id=int_chat_id, voice=f, **thread_kwargs
+                        )
+                    elif ext in _AUDIO_EXTS:
+                        last_msg = await bot.send_audio(
+                            chat_id=int_chat_id, audio=f, **thread_kwargs
+                        )
+                    else:
+                        last_msg = await bot.send_document(
+                            chat_id=int_chat_id, document=f, **thread_kwargs
+                        )
+            except Exception as e:
+                logger.error("Failed to send media %s: %s", media_path, e)
+
+        # If no text and no media sent, send cleaned text as fallback
+        if last_msg is None:
+            last_msg = await bot.send_message(
+                chat_id=int_chat_id, text=cleaned if cleaned.strip() else message, **thread_kwargs
+            )
+
+        return {"success": True, "platform": "telegram", "chat_id": chat_id, "message_id": str(last_msg.message_id)}
     except ImportError:
         return {"error": "python-telegram-bot not installed. Run: pip install python-telegram-bot"}
     except Exception as e:


### PR DESCRIPTION
## What does this PR do?

The `send_message` tool's `_send_telegram()` function sent `MEDIA:<path>` tags as literal text instead of delivering actual files. When the agent used `send_message` (cross-channel messaging) rather than the gateway response pipeline, media files like images and voice clips were never extracted — users received raw `MEDIA:/tmp/file.png` text instead of the actual file.

**Root cause:** The `send_message` tool bypasses the gateway's `_process_message_background()` → `extract_media()` pipeline, so `MEDIA:` tags were passed through as plain text to `bot.send_message()`.

Also fixes `extract_media()` to handle LLM formatting variations (optional whitespace, surrounding backticks/quotes).

## Related Issue

N/A — discovered during manual testing of TTS voice delivery via `send_message` tool.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/send_message_tool.py`: extract `MEDIA:<path>` tags via `BasePlatformAdapter.extract_media()` and route files to native Telegram Bot API methods (`send_photo`, `send_video`, `send_voice`, `send_audio`, `send_document`) based on file extension
- `tools/send_message_tool.py`: add per-file error handling so one failure doesn't abort remaining media
- `tools/send_message_tool.py`: log warnings for missing media files instead of silently skipping
- `tools/send_message_tool.py`: use cleaned text (without MEDIA tags) in fallback to avoid leaking raw tags
- `tools/send_message_tool.py`: move extension constants to module level, add `_VOICE_EXTS` set matching gateway adapter's `.ogg/.opus`-only voice routing
- `gateway/platforms/base.py`: `extract_media()` handles optional whitespace after `MEDIA:` colon
- `gateway/platforms/base.py`: `extract_media()` strips surrounding backticks/quotes from paths
- `gateway/platforms/base.py`: cleanup regex updated to also remove surrounding quote characters

## How to Test

1. Start the gateway: `hermes gateway`
2. From a Telegram chat, ask the agent to generate a TTS voice clip (e.g. "say hello")
3. Verify the voice is delivered as a playable voice bubble, not as `MEDIA:/tmp/...` text
4. Test with image generation — verify images arrive as photos, not text tags
5. Run `pytest tests/tools/test_send_message_tool.py tests/gateway/test_platform_base.py -q` — all 51 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (trixie), Linux 6.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Manual test: generated TTS voice via `send_message` tool → delivered as playable Telegram voice bubble (previously sent as raw `MEDIA:/tmp/hermes_voice_test.ogg` text).