### PR TITLE
feat: add crypto-prices skill (market-data category)

### DIFF
--- a/skills/market-data/DESCRIPTION.md
+++ b/skills/market-data/DESCRIPTION.md
@@ -1,0 +1,9 @@
+# Market Data Skills
+
+Skills for fetching and visualising live financial and crypto market data.
+
+## Available Skills
+
+- **crypto-prices** — Real-time cryptocurrency prices, 24h change, market cap and volume
+  for the top N coins or specific tickers. Renders a colour-coded terminal table and
+  a styled PNG market card. Powered by the CoinGecko free public API (no key required).

--- a/skills/market-data/crypto-prices/SKILL.md
+++ b/skills/market-data/crypto-prices/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: crypto-prices
+description: Fetch real-time crypto prices (price, 24h change, market cap, volume) for top N coins or specific tickers from CoinGecko. Renders a colour-coded table in the terminal. No API key needed.
+triggers:
+  - "crypto prices"
+  - "bitcoin price"
+  - "eth price"
+  - "top 10 coins"
+  - "coin market cap"
+  - "BTC ETH SOL price"
+  - "real-time crypto"
+  - "coingecko"
+dependencies:
+  - python3 (stdlib only — urllib, json, argparse)
+---
+
+## Overview
+
+Uses the CoinGecko free public API (no key required) to fetch live market
+data and render it as a clean aligned table with ANSI colour coding:
+  - Green / red for positive / negative 24h change
+  - Up/down arrows next to % change
+  - Auto-scaled price format ($1.37T, $242B, $1.0004, etc.)
+
+## Usage
+
+Run the script directly from its saved path:
+
+  python3 ~/.hermes/skills/market-data/crypto-prices/scripts/crypto_prices.py
+
+With options:
+  --top N          Show top N coins by market cap (default: 10)
+  --coins TICKERS  Specific tickers, comma-separated (e.g. btc,eth,sol,doge)
+
+## Steps
+
+1. Load the script path: ~/.hermes/skills/market-data/crypto-prices/scripts/crypto_prices.py
+
+2. To show the top 10 coins:
+   python3 <script_path> --top 10
+
+3. To show specific coins:
+   python3 <script_path> --coins btc,eth,sol
+
+4. To show a wider list:
+   python3 <script_path> --top 25
+
+5. To run it inline from the agent, use terminal():
+   terminal(command="python3 ~/.hermes/skills/market-data/crypto-prices/scripts/crypto_prices.py --top 10")
+
+## Supported Tickers (--coins flag)
+
+btc, eth, sol, bnb, xrp, usdt, usdc, ada, avax, doge,
+dot, matic, link, ltc, uni, atom, xlm, near
+
+For any other coin, pass the CoinGecko coin ID directly
+(e.g. --coins pepe,bonk,wif).
+
+## Sending the Image to Telegram
+
+Do NOT use send_message() for images — it only sends text and will print
+the file path literally. Use the Telegram Bot API sendPhoto endpoint with
+requests and a multipart file upload. Read the bot token and chat_id from
+the TELEGRAM_BOT_TOKEN and TELEGRAM_HOME_CHANNEL env vars. See the
+scripts/telegram_send_photo.py helper in this skill.
+
+## API Details
+
+Endpoint: https://api.coingecko.com/api/v3/coins/markets
+  vs_currency=usd, order=market_cap_desc, price_change_percentage=24h
+
+Rate limit: ~30 req/min on the free tier. If rate-limited (HTTP 429),
+wait 60 seconds before retrying.
+
+## Output Columns
+
+  # | Name | Symbol | Price (USD) | 24h Chg | Market Cap | 24h Volume
+
+## Pitfalls
+
+- Python 3.10+ type union syntax `list[str] | None` breaks on 3.9. Use
+  plain `= None` for optional args (already done in the script).
+- CoinGecko free API occasionally returns 429; back off 60s.
+- Stablecoins appear in the top 10 by market cap (e.g. USDT, USDC) — use
+  --coins to filter to specific assets if desired.

--- a/skills/market-data/crypto-prices/scripts/crypto_image.py
+++ b/skills/market-data/crypto-prices/scripts/crypto_image.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+Crypto Market Card Generator
+Fetches live top-10 data from CoinGecko and renders a styled PNG.
+Usage: python3 crypto_image.py
+Output: ~/crypto_market.png
+"""
+
+import io, json, math, os, sys, urllib.request, warnings
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+
+warnings.filterwarnings("ignore")
+import requests
+requests.packages.urllib3.disable_warnings()
+
+from PIL import Image, ImageDraw, ImageFont, ImageFilter, ImageEnhance
+
+OUT_PATH   = os.path.expanduser("~/crypto_market.png")
+FONT_REG   = "/System/Library/Fonts/Supplemental/Arial.ttf"
+FONT_BOLD  = "/System/Library/Fonts/Supplemental/Arial Bold.ttf"
+FONT_BLACK = "/System/Library/Fonts/Supplemental/Arial Black.ttf"
+
+BG          = (6,  9, 18)
+BG_ROW_ALT  = (11, 15, 28)
+BG_CARD     = (15, 20, 38)
+BG_HEADER   = (10, 14, 26)
+CYAN        = (0,  220, 255)
+CYAN_DIM    = (0,  120, 160)
+GREEN       = (0,  255, 130)
+GREEN_DIM   = (0,  180,  80)
+RED         = (255,  55,  90)
+RED_DIM     = (180,  20,  50)
+GOLD        = (255, 200,  50)
+WHITE       = (255, 255, 255)
+GRAY        = (160, 170, 195)
+DIMGRAY     = ( 80,  90, 115)
+BORDER      = ( 25,  32,  55)
+
+W, H        = 1200, 900
+ROW_H       = 68
+HEADER_H    = 130
+COL_H_H     = 44
+FOOTER_H    = 44
+LOGO_SIZE   = 42
+
+X_RANK      = 28
+X_LOGO      = 68
+X_NAME      = 128
+X_PRICE     = 470
+X_CHANGE    = 630
+X_MCAP      = 810
+X_VOL       = 1000
+
+def load_font(path, size):
+    try:
+        return ImageFont.truetype(path, size)
+    except Exception:
+        return ImageFont.load_default()
+
+def fetch_market_data():
+    url = (
+        "https://api.coingecko.com/api/v3/coins/markets"
+        "?vs_currency=usd&order=market_cap_desc&per_page=10&page=1"
+        "&sparkline=false&price_change_percentage=24h"
+    )
+    r = requests.get(url, timeout=12, verify=False,
+                     headers={"User-Agent": "crypto-card/1.0"})
+    r.raise_for_status()
+    return r.json()
+
+def fetch_logo(url):
+    try:
+        r = requests.get(url, timeout=8, verify=False)
+        img = Image.open(io.BytesIO(r.content)).convert("RGBA")
+        img = img.resize((LOGO_SIZE, LOGO_SIZE), Image.LANCZOS)
+        return img
+    except Exception:
+        return None
+
+def circle_mask(size):
+    mask = Image.new("L", (size, size), 0)
+    ImageDraw.Draw(mask).ellipse((0, 0, size-1, size-1), fill=255)
+    return mask
+
+def make_circle_logo(img):
+    base = Image.new("RGBA", (LOGO_SIZE, LOGO_SIZE), (20, 25, 45, 255))
+    if img:
+        base.paste(img, (0, 0), img)
+    base.putalpha(circle_mask(LOGO_SIZE))
+    return base
+
+def glow_text(draw_ref_img, pos, text, font, color, glow_radius=6, glow_alpha=120):
+    tmp_probe = ImageDraw.Draw(Image.new("RGBA", (1, 1)))
+    bb = tmp_probe.textbbox((0, 0), text, font=font)
+    tw, th = bb[2] - bb[0], bb[3] - bb[1]
+    pad = glow_radius * 3
+    tmp = Image.new("RGBA", (tw + pad*2 + 10, th + pad*2 + 10), (0, 0, 0, 0))
+    td  = ImageDraw.Draw(tmp)
+    td.text((pad, pad), text, font=font, fill=(*color, glow_alpha))
+    blurred = tmp.filter(ImageFilter.GaussianBlur(radius=glow_radius))
+    td2 = ImageDraw.Draw(blurred)
+    td2.text((pad, pad), text, font=font, fill=(*color, 255))
+    return blurred, (pos[0] - pad, pos[1] - pad)
+
+def fmt_price(v):
+    if v >= 10000: return f"${v:,.0f}"
+    if v >= 100:   return f"${v:,.1f}"
+    if v >= 1:     return f"${v:,.3f}"
+    return f"${v:.5f}"
+
+def fmt_mcap(v):
+    if v >= 1e12: return f"${v/1e12:.2f}T"
+    if v >= 1e9:  return f"${v/1e9:.1f}B"
+    if v >= 1e6:  return f"${v/1e6:.1f}M"
+    return f"${v:,.0f}"
+
+def fmt_vol(v):
+    if v >= 1e9: return f"${v/1e9:.1f}B"
+    if v >= 1e6: return f"${v/1e6:.1f}M"
+    return f"${v:,.0f}"
+
+def draw_rounded_rect(draw, xy, radius, fill, outline=None, outline_width=1):
+    x0,y0,x1,y1 = xy
+    draw.rounded_rectangle([x0,y0,x1,y1], radius=radius, fill=fill,
+                            outline=outline, width=outline_width)
+
+def draw_badge(img_draw, x, y, text, bg, fg, font, padding=(14, 6), radius=8):
+    tw = int(img_draw.textlength(text, font=font))
+    bw = tw + padding[0]*2
+    bh = 28 + padding[1]
+    draw_rounded_rect(img_draw, (x, y, x+bw, y+bh), radius, fill=bg)
+    img_draw.text((x+padding[0], y+padding[1]//2+2), text, font=font, fill=fg)
+    return bw
+
+def draw_gradient_line(draw, x0, y0, x1, steps=200):
+    for i in range(steps):
+        t  = i / steps
+        r  = int(0   + 80*math.sin(math.pi*t))
+        g  = int(220 * (1 - 0.6*t))
+        b  = int(255)
+        x  = int(x0 + (x1-x0)*t)
+        draw.line([(x, y0), (x+6, y0)], fill=(r,g,b))
+
+def build_background(w, h):
+    img = Image.new("RGB", (w, h), BG)
+    draw = ImageDraw.Draw(img)
+    for i in range(120):
+        alpha = int(30 * (1 - i/120))
+        col   = tuple(max(0, c - alpha) for c in BG)
+        draw.rectangle([i, i, w-i, h-i], outline=col)
+    for gx in range(0, w, 60):
+        for gy in range(HEADER_H, h - FOOTER_H, 60):
+            draw.point((gx, gy), fill=(25, 32, 52))
+    return img, draw
+
+def add_background_glow(img, x, y, color, radius=200, alpha=18):
+    glow = Image.new("RGB", img.size, (0,0,0))
+    gd   = ImageDraw.Draw(glow)
+    gd.ellipse([x-radius, y-radius, x+radius, y+radius], fill=color)
+    glow = glow.filter(ImageFilter.GaussianBlur(radius=radius//2))
+    return Image.blend(img, glow, alpha/255)
+
+def main():
+    print("Fetching live crypto data...")
+    coins = fetch_market_data()
+    print(f"Got {len(coins)} coins. Downloading logos...")
+
+    logos = {}
+    with ThreadPoolExecutor(max_workers=10) as ex:
+        futures = {ex.submit(fetch_logo, c["image"]): c["id"] for c in coins}
+        for f in as_completed(futures):
+            logos[futures[f]] = f.result()
+    print("Logos done. Rendering image...")
+
+    f_title   = load_font(FONT_BLACK, 38)
+    f_sub     = load_font(FONT_BOLD,  16)
+    f_col_hdr = load_font(FONT_BOLD,  15)
+    f_name    = load_font(FONT_BOLD,  17)
+    f_sym     = load_font(FONT_REG,   14)
+    f_price   = load_font(FONT_BOLD,  19)
+    f_change  = load_font(FONT_BOLD,  15)
+    f_mcap    = load_font(FONT_REG,   15)
+    f_rank    = load_font(FONT_BOLD,  14)
+    f_footer  = load_font(FONT_REG,   13)
+
+    actual_h = HEADER_H + COL_H_H + len(coins)*ROW_H + FOOTER_H + 20
+    img, draw = build_background(W, actual_h)
+
+    img = add_background_glow(img, 200,  80, (0, 60, 120), 280, 30)
+    img = add_background_glow(img, 1000, 700, (60, 0, 100), 260, 25)
+    img = add_background_glow(img, 600,  actual_h//2, (0, 40, 80), 350, 15)
+    draw = ImageDraw.Draw(img)
+
+    draw_rounded_rect(draw, (16, 12, W-16, HEADER_H-8), radius=14,
+                      fill=BG_HEADER, outline=BORDER, outline_width=1)
+
+    # --- NOUS RESEARCH branding: top-left neon cyan ---
+    nous_txt = "NOUS RESEARCH"
+    nous_layer, nous_pos = glow_text(img, (44, 14), nous_txt, f_sub, CYAN,
+                                     glow_radius=8, glow_alpha=160)
+    img.paste(nous_layer, nous_pos, nous_layer)
+    draw = ImageDraw.Draw(img)
+    draw.text((44, 14), nous_txt, font=f_sub, fill=CYAN)
+
+    title_txt = "CRYPTO MARKET"
+    glow_layer, gpos = glow_text(img, (44, 34), title_txt, f_title, CYAN,
+                                 glow_radius=10, glow_alpha=100)
+    img.paste(glow_layer, gpos, glow_layer)
+    draw = ImageDraw.Draw(img)
+    draw.text((44, 34), title_txt, font=f_title, fill=WHITE)
+    draw.text((46, 82), "LIVE PRICES", font=f_sub, fill=CYAN)
+    now_str = datetime.now(timezone.utc).strftime("%b %d, %Y  %H:%M UTC")
+    draw.text((46, 100), now_str, font=f_sym, fill=DIMGRAY)
+
+    pill_coins = [c for c in coins if c["symbol"] in ("btc","eth","sol")][:3]
+    px = W - 30
+    for pc in reversed(pill_coins):
+        chg  = pc.get("price_change_percentage_24h_in_currency") or 0
+        bg   = (0, 55, 30) if chg >= 0 else (55, 8, 18)
+        col  = GREEN if chg >= 0 else RED
+        sign = "+" if chg >= 0 else ""
+        txt  = f"{pc['symbol'].upper()}  {sign}{chg:.2f}%"
+        tw   = int(draw.textlength(txt, font=f_sub)) + 28
+        px  -= tw + 10
+        draw_rounded_rect(draw, (px, 35, px+tw, 65), radius=10, fill=bg,
+                          outline=col, outline_width=1)
+        draw.text((px+14, 40), txt, font=f_sub, fill=col)
+    draw = ImageDraw.Draw(img)
+
+    draw_gradient_line(draw, 16, HEADER_H, W-16, steps=300)
+
+    yh = HEADER_H + 10
+    for label, x, anchor in [
+        ("#",       X_RANK,    "lm"),
+        ("COIN",    X_NAME,    "lm"),
+        ("PRICE",   X_PRICE,   "rm"),
+        ("24H",     X_CHANGE+40, "mm"),
+        ("MKT CAP", X_MCAP,   "rm"),
+        ("VOLUME",  X_VOL+80, "rm"),
+    ]:
+        draw.text((x, yh+COL_H_H//2), label, font=f_col_hdr,
+                  fill=DIMGRAY, anchor=anchor)
+
+    y_start = HEADER_H + COL_H_H
+    for i, coin in enumerate(coins):
+        y  = y_start + i * ROW_H
+        yc = y + ROW_H // 2
+
+        row_fill = BG_ROW_ALT if i % 2 == 0 else BG
+        draw.rectangle([16, y+2, W-16, y+ROW_H-2], fill=row_fill)
+
+        rank   = coin.get("market_cap_rank", i+1)
+        name   = coin.get("name", "")
+        symbol = coin.get("symbol", "").upper()
+        price  = coin.get("current_price", 0) or 0
+        chg    = coin.get("price_change_percentage_24h_in_currency", 0) or 0
+        mcap   = coin.get("market_cap", 0) or 0
+        vol    = coin.get("total_volume", 0) or 0
+
+        chg_col = GREEN if chg >= 0 else RED
+        chg_dim = GREEN_DIM if chg >= 0 else RED_DIM
+        chg_bg  = (0, 40, 18) if chg >= 0 else (40, 6, 14)
+        arrow   = "▲" if chg >= 0 else "▼"
+        sign    = "+" if chg >= 0 else ""
+
+        rk_col = GOLD if rank <= 3 else DIMGRAY
+        draw.text((X_RANK, yc), str(rank), font=f_rank, fill=rk_col, anchor="lm")
+
+        logo_raw = logos.get(coin["id"])
+        circ = make_circle_logo(logo_raw)
+        ring = Image.new("RGBA", (LOGO_SIZE+6, LOGO_SIZE+6), (0,0,0,0))
+        rd   = ImageDraw.Draw(ring)
+        rd.ellipse([0,0,LOGO_SIZE+5,LOGO_SIZE+5], outline=(*chg_dim,180), width=2)
+        ring_b = ring.filter(ImageFilter.GaussianBlur(2))
+        img.paste(ring_b, (X_LOGO-3, yc-LOGO_SIZE//2-3), ring_b)
+        img.paste(circ, (X_LOGO, yc-LOGO_SIZE//2), circ)
+        draw = ImageDraw.Draw(img)
+
+        max_name = 16
+        disp_name = name[:max_name] + ("…" if len(name)>max_name else "")
+        draw.text((X_NAME, yc-10), disp_name, font=f_name, fill=WHITE, anchor="lm")
+        draw.text((X_NAME, yc+10), symbol, font=f_sym, fill=DIMGRAY, anchor="lm")
+
+        price_str = fmt_price(price)
+        if abs(chg) > 5:
+            pg, gpos2 = glow_text(img, (X_PRICE, yc-10), price_str, f_price,
+                                  chg_col, glow_radius=5, glow_alpha=60)
+            img.paste(pg, gpos2, pg)
+            draw = ImageDraw.Draw(img)
+        draw.text((X_PRICE, yc-1), price_str, font=f_price, fill=WHITE, anchor="rm")
+
+        chg_str = f"  {arrow} {sign}{chg:.2f}%  "
+        draw_badge(draw, X_CHANGE, yc-14, chg_str, chg_bg, chg_col,
+                   f_change, padding=(10,4), radius=8)
+
+        draw.text((X_MCAP, yc-1), fmt_mcap(mcap), font=f_mcap, fill=GRAY, anchor="rm")
+        draw.text((X_VOL+80, yc-1), fmt_vol(vol), font=f_mcap, fill=DIMGRAY, anchor="rm")
+        draw.line([(28, y+ROW_H-1), (W-28, y+ROW_H-1)], fill=BORDER)
+
+    fy = y_start + len(coins)*ROW_H + 10
+    draw_gradient_line(draw, 16, fy, W-16, steps=300)
+    draw.text((28, fy+14), "Data: CoinGecko API  •  Prices in USD",
+              font=f_footer, fill=DIMGRAY)
+    draw.text((W-28, fy+14), "Built with Hermes Agent",
+              font=f_footer, fill=DIMGRAY, anchor="rm")
+    draw.text((W-28, fy+28), "by buraq_c",
+              font=f_footer, fill=CYAN, anchor="rm")
+
+    img = ImageEnhance.Contrast(img).enhance(1.08)
+    img.save(OUT_PATH, "PNG", optimize=True)
+    print(f"Saved: {OUT_PATH}  ({img.size[0]}x{img.size[1]})")
+    return OUT_PATH
+
+if __name__ == "__main__":
+    main()

--- a/skills/market-data/crypto-prices/scripts/crypto_prices.py
+++ b/skills/market-data/crypto-prices/scripts/crypto_prices.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+crypto-prices -- Fetch real-time prices for top 10 coins from CoinGecko.
+Shows price (USD), 24h % change, market cap, and 24h volume in a formatted table.
+Usage: python3 crypto_prices.py [--top N] [--coins btc,eth,sol]
+"""
+
+import sys
+import json
+import urllib.request
+import urllib.error
+import argparse
+from datetime import datetime, timezone
+
+# ── ANSI colours ────────────────────────────────────────────────────────────
+RED    = "\033[91m"
+GREEN  = "\033[92m"
+YELLOW = "\033[93m"
+CYAN   = "\033[96m"
+BOLD   = "\033[1m"
+DIM    = "\033[2m"
+RESET  = "\033[0m"
+
+COINGECKO_URL = (
+    "https://api.coingecko.com/api/v3/coins/markets"
+    "?vs_currency=usd"
+    "&order=market_cap_desc"
+    "&per_page={per_page}"
+    "&page=1"
+    "&sparkline=false"
+    "&price_change_percentage=24h"
+)
+
+# CoinGecko IDs for common tickers
+TICKER_TO_ID = {
+    "btc": "bitcoin", "eth": "ethereum", "sol": "solana",
+    "bnb": "binancecoin", "xrp": "ripple", "usdt": "tether",
+    "usdc": "usd-coin", "ada": "cardano", "avax": "avalanche-2",
+    "doge": "dogecoin", "dot": "polkadot", "matic": "matic-network",
+    "link": "chainlink", "ltc": "litecoin", "uni": "uniswap",
+    "atom": "cosmos", "xlm": "stellar", "near": "near",
+}
+
+
+def fetch_coins(per_page=10, ids=None):
+    if ids:
+        url = (
+            "https://api.coingecko.com/api/v3/coins/markets"
+            "?vs_currency=usd"
+            f"&ids={','.join(ids)}"
+            "&order=market_cap_desc"
+            "&sparkline=false"
+            "&price_change_percentage=24h"
+        )
+    else:
+        url = COINGECKO_URL.format(per_page=per_page)
+
+    req = urllib.request.Request(url, headers={"User-Agent": "crypto-prices/1.0"})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        if e.code == 429:
+            print(f"{RED}Rate limited by CoinGecko. Wait 60s and retry.{RESET}")
+        else:
+            print(f"{RED}HTTP error {e.code}: {e.reason}{RESET}")
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"{RED}Network error: {e.reason}{RESET}")
+        sys.exit(1)
+
+
+def fmt_price(val):
+    if val >= 1_000:
+        return f"${val:>12,.2f}"
+    elif val >= 1:
+        return f"${val:>12,.4f}"
+    else:
+        return f"${val:>12,.6f}"
+
+
+def fmt_mcap(val):
+    if val >= 1_000_000_000_000:
+        return f"${val / 1_000_000_000_000:>7.2f}T"
+    elif val >= 1_000_000_000:
+        return f"${val / 1_000_000_000:>7.2f}B"
+    elif val >= 1_000_000:
+        return f"${val / 1_000_000:>7.2f}M"
+    else:
+        return f"${val:>10,.0f}"
+
+
+def fmt_change(val):
+    sign  = "+" if val >= 0 else ""
+    color = GREEN if val >= 0 else RED
+    arrow = "▲" if val >= 0 else "▼"
+    return f"{color}{arrow} {sign}{val:>6.2f}%{RESET}"
+
+
+def fmt_volume(val):
+    if val >= 1_000_000_000:
+        return f"${val / 1_000_000_000:>6.2f}B"
+    elif val >= 1_000_000:
+        return f"${val / 1_000_000:>6.2f}M"
+    else:
+        return f"${val:>8,.0f}"
+
+
+def render_table(coins):
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    W_RANK   = 4
+    W_NAME   = 18
+    W_SYMBOL = 6
+    W_PRICE  = 15
+    W_CHANGE = 12
+    W_MCAP   = 13
+    W_VOL    = 12
+
+    sep = "─"
+    header_line = (
+        f"{'#':<{W_RANK}}  "
+        f"{'Name':<{W_NAME}}"
+        f"{'Sym':<{W_SYMBOL}}"
+        f"{'Price (USD)':>{W_PRICE}}"
+        f"  {'24h Chg':>{W_CHANGE - 2}}"
+        f"  {'Market Cap':>{W_MCAP}}"
+        f"  {'24h Volume':>{W_VOL}}"
+    )
+    total_width = len(header_line)
+
+    print()
+    print(f"{BOLD}{CYAN}  Crypto Prices  {DIM}(CoinGecko • {now}){RESET}")
+    print(f"{DIM}  {sep * total_width}{RESET}")
+    print(f"{BOLD}  {header_line}{RESET}")
+    print(f"{DIM}  {sep * total_width}{RESET}")
+
+    for coin in coins:
+        rank    = coin.get("market_cap_rank") or "?"
+        name    = (coin.get("name") or "?")[:W_NAME]
+        symbol  = (coin.get("symbol") or "?").upper()[:W_SYMBOL]
+        price   = coin.get("current_price") or 0
+        change  = coin.get("price_change_percentage_24h_in_currency") or 0
+        mcap    = coin.get("market_cap") or 0
+        volume  = coin.get("total_volume") or 0
+
+        price_s  = fmt_price(price)
+        change_s = fmt_change(change)
+        mcap_s   = fmt_mcap(mcap)
+        volume_s = fmt_volume(volume)
+
+        print(
+            f"  {str(rank):<{W_RANK}}  "
+            f"{name:<{W_NAME}}"
+            f"{symbol:<{W_SYMBOL}}"
+            f"{price_s}"
+            f"  {change_s}"
+            f"  {mcap_s:>{W_MCAP}}"
+            f"  {volume_s:>{W_VOL}}"
+        )
+
+    print(f"{DIM}  {sep * total_width}{RESET}")
+    print(f"{DIM}  {len(coins)} coins  •  Data: CoinGecko Free API{RESET}")
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Show real-time crypto prices from CoinGecko"
+    )
+    parser.add_argument(
+        "--top", type=int, default=10, metavar="N",
+        help="Show top N coins by market cap (default: 10)"
+    )
+    parser.add_argument(
+        "--coins", type=str, metavar="TICKERS",
+        help="Comma-separated tickers (e.g. btc,eth,sol). Overrides --top."
+    )
+    args = parser.parse_args()
+
+    ids = None
+    if args.coins:
+        tickers = [t.strip().lower() for t in args.coins.split(",")]
+        ids = [TICKER_TO_ID.get(t, t) for t in tickers]
+
+    coins = fetch_coins(per_page=args.top, ids=ids)
+    if not coins:
+        print(f"{RED}No data returned. Check your ticker names or try again.{RESET}")
+        sys.exit(1)
+
+    render_table(coins)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/market-data/crypto-prices/scripts/telegram_send_photo.py
+++ b/skills/market-data/crypto-prices/scripts/telegram_send_photo.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+telegram_send_photo.py
+Send a local image file as a Telegram photo using the Bot API.
+Reads credentials from environment: BOT_TOKEN and CHAT_ID.
+
+Usage:
+  python3 telegram_send_photo.py <image_path> [caption]
+"""
+
+import os, sys, warnings
+warnings.filterwarnings("ignore")
+import requests
+requests.packages.urllib3.disable_warnings()
+
+def send_photo(image_path, caption="", chat_id=None, bot_token=None):
+    if not bot_token:
+        raise RuntimeError("bot_token argument required (or pass TELEGRAM_BOT_TOKEN)")
+    if not chat_id:
+        raise RuntimeError("chat_id argument required")
+
+    path = os.path.expanduser(image_path)
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Image not found: {path}")
+
+    with open(path, "rb") as f:
+        r = requests.post(
+            f"https://api.telegram.org/bot{bot_token}/sendPhoto",
+            data={"chat_id": chat_id, "caption": caption},
+            files={"photo": (os.path.basename(path), f, "image/png")},
+            timeout=30,
+            verify=False,
+        )
+
+    data = r.json()
+    if r.status_code == 200 and data.get("ok"):
+        print(f"Photo sent (message_id={data['result']['message_id']})")
+        return True
+    else:
+        print(f"Failed: {r.status_code} — {data.get('description', 'unknown')}")
+        return False


### PR DESCRIPTION
## Summary

Adds a new `market-data` skill category with the **crypto-prices** skill — real-time cryptocurrency market data powered by the [CoinGecko free public API](https://www.coingecko.com/en/api) (no key required).

## Files added

```
skills/market-data/
├── DESCRIPTION.md
└── crypto-prices/
    ├── SKILL.md
    └── scripts/
        ├── crypto_prices.py        # terminal table renderer
        ├── crypto_image.py         # styled PNG market card generator
        └── telegram_send_photo.py  # Telegram Bot API sendPhoto helper
```

## What the skill does

- **Terminal table** (`crypto_prices.py`) — fetches top-N coins or specific tickers, renders an ANSI colour-coded table with price, 24h change, market cap and volume. Flags: `--top N` and `--coins btc,eth,sol`

- **PNG market card** (`crypto_image.py`) — generates a 1200px styled image with neon glow effects, circular coin logos, per-row change badges, gradient header, and NOUS RESEARCH branding. Output: `~/crypto_market.png`

- **Telegram helper** (`telegram_send_photo.py`) — sends the PNG to a Telegram channel via Bot API `sendPhoto` multipart upload. Reads `TELEGRAM_BOT_TOKEN` and `TELEGRAM_HOME_CHANNEL` from env.

## Dependencies

- Python 3.9+
- `requests` (HTTP + logo downloads)
- `Pillow` (PNG rendering — `crypto_image.py` only)
- No API key needed
