### PR TITLE
fix: clearer terminal backend requirement errors

### DIFF
--- a/tests/tools/test_terminal_requirements.py
+++ b/tests/tools/test_terminal_requirements.py
@@ -1,0 +1,77 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from tools.terminal_tool import check_terminal_requirements
+
+
+def _clear_terminal_env(monkeypatch):
+    """Helper to remove TERMINAL_* env vars that could affect tests."""
+    keys = [
+        "TERMINAL_ENV",
+        "TERMINAL_SSH_HOST",
+        "TERMINAL_SSH_USER",
+        "MODAL_TOKEN_ID",
+    ]
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_unknown_terminal_env_logs_error_and_returns_false(monkeypatch, caplog):
+    """Unknown TERMINAL_ENV should log a clear error and return False."""
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "unknown-backend")
+
+    with caplog.at_level(logging.ERROR):
+        ok = check_terminal_requirements()
+
+    assert ok is False
+    assert any(
+        "Unknown TERMINAL_ENV 'unknown-backend'" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_ssh_backend_without_host_or_user_logs_and_returns_false(monkeypatch, caplog):
+    """SSH backend requires both TERMINAL_SSH_HOST and TERMINAL_SSH_USER."""
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    # Leave TERMINAL_SSH_HOST / TERMINAL_SSH_USER unset on purpose
+
+    with caplog.at_level(logging.ERROR):
+        ok = check_terminal_requirements()
+
+    assert ok is False
+    assert any(
+        "SSH backend selected but TERMINAL_SSH_HOST and TERMINAL_SSH_USER" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_modal_backend_without_token_logs_and_returns_false(monkeypatch, caplog, tmp_path):
+    """Modal backend should surface a clear error when no token/config is present."""
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "modal")
+
+    # Ensure MODAL_TOKEN_ID is not set and ~/.modal.toml doesn't exist
+    monkeypatch.delenv("MODAL_TOKEN_ID", raising=False)
+
+    # Point HOME to a temp directory so Path.home()/.modal.toml is absent
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # On Windows, also set USERPROFILE which Path.home() may consult
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    with caplog.at_level(logging.ERROR):
+        ok = check_terminal_requirements()
+
+    assert ok is False
+    messages = [record.getMessage() for record in caplog.records]
+    # In environments without minisweagent installed, we at least expect a generic
+    # terminal requirements failure. When minisweagent is available, the more
+    # specific Modal configuration error should be logged.
+    assert any(
+        "Modal backend selected but no MODAL_TOKEN_ID environment variable" in m
+        for m in messages
+    ) or any("Terminal requirements check failed" in m for m in messages)
+

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1110,18 +1110,38 @@ def check_terminal_requirements() -> bool:
         elif env_type == "ssh":
             from tools.environments.ssh import SSHEnvironment
             # Check that host and user are configured
-            return bool(config.get("ssh_host")) and bool(config.get("ssh_user"))
+            if not config.get("ssh_host") or not config.get("ssh_user"):
+                logger.error(
+                    "SSH backend selected but TERMINAL_SSH_HOST and TERMINAL_SSH_USER "
+                    "are not both set. Configure both or switch TERMINAL_ENV to 'local'."
+                )
+                return False
+            return True
         elif env_type == "modal":
             from minisweagent.environments.extra.swerex_modal import SwerexModalEnvironment
             # Check for modal token
-            return os.getenv("MODAL_TOKEN_ID") is not None or Path.home().joinpath(".modal.toml").exists()
+            has_token = os.getenv("MODAL_TOKEN_ID") is not None
+            has_config = Path.home().joinpath(".modal.toml").exists()
+            if not (has_token or has_config):
+                logger.error(
+                    "Modal backend selected but no MODAL_TOKEN_ID environment variable "
+                    "or ~/.modal.toml config file was found. Configure Modal or choose "
+                    "a different TERMINAL_ENV."
+                )
+                return False
+            return True
         elif env_type == "daytona":
             from daytona import Daytona
             return os.getenv("DAYTONA_API_KEY") is not None
         else:
+            logger.error(
+                "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
+                "modal, daytona, ssh.",
+                env_type,
+            )
             return False
     except Exception as e:
-        logger.error("Terminal requirements check failed: %s", e)
+        logger.error("Terminal requirements check failed: %s", e, exc_info=True)
         return False
 
 


### PR DESCRIPTION
This PR improves preflight checks and error messages when selecting terminal backends.

Enhance check_terminal_requirements() in tools/terminal_tool.py to surface clearer, actionable errors for misconfigured backends:
SSH now logs and fails fast when TERMINAL_SSH_HOST or TERMINAL_SSH_USER are missing.
Modal now logs and fails when neither MODAL_TOKEN_ID nor ~/.modal.toml is present.
Unknown TERMINAL_ENV values are explicitly reported with the list of supported backends. Unexpected exceptions during requirement checks are logged with exc_info=True for easier debugging.
 Add tests/tools/test_terminal_requirements.py to cover SSH, Modal, and unknown-backend scenarios using caplog, without requiring real external services.