### PR TITLE
fix: resource leaks and crashes in long-running gateway

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -165,7 +165,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             else:
                 raise
 
-        summary = response.choices[0].message.content.strip()
+        summary = (response.choices[0].message.content or "").strip()
         if not summary.startswith("[CONTEXT SUMMARY]:"):
             summary = "[CONTEXT SUMMARY]: " + summary
         return summary

--- a/environments/agent_loop.py
+++ b/environments/agent_loop.py
@@ -39,7 +39,9 @@ def resize_tool_pool(max_workers: int):
     Safe to call before any tasks are submitted.
     """
     global _tool_executor
+    old_executor = _tool_executor
     _tool_executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+    old_executor.shutdown(wait=False)
     logger.info("Tool thread pool resized to %d workers", max_workers)
 
 logger = logging.getLogger(__name__)

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -159,7 +159,7 @@ class DeliveryRouter:
         
         # Always include local if configured
         if self.config.always_log_local:
-            local_key = (Platform.LOCAL, None)
+            local_key = (Platform.LOCAL, None, None)
             if local_key not in seen_platforms:
                 targets.append(DeliveryTarget(platform=Platform.LOCAL))
         

--- a/run_agent.py
+++ b/run_agent.py
@@ -25,6 +25,7 @@ import hashlib
 import json
 import logging
 logger = logging.getLogger(__name__)
+_error_handler_installed = False
 import os
 import random
 import re
@@ -353,19 +354,22 @@ class AIAgent:
 
         # Persistent error log -- always writes WARNING+ to ~/.hermes/logs/errors.log
         # so tool failures, API errors, etc. are inspectable after the fact.
-        from agent.redact import RedactingFormatter
-        _error_log_dir = Path.home() / ".hermes" / "logs"
-        _error_log_dir.mkdir(parents=True, exist_ok=True)
-        _error_log_path = _error_log_dir / "errors.log"
-        from logging.handlers import RotatingFileHandler
-        _error_file_handler = RotatingFileHandler(
-            _error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,
-        )
-        _error_file_handler.setLevel(logging.WARNING)
-        _error_file_handler.setFormatter(RedactingFormatter(
-            '%(asctime)s %(levelname)s %(name)s: %(message)s',
-        ))
-        logging.getLogger().addHandler(_error_file_handler)
+        global _error_handler_installed
+        if not _error_handler_installed:
+            from agent.redact import RedactingFormatter
+            _error_log_dir = Path.home() / ".hermes" / "logs"
+            _error_log_dir.mkdir(parents=True, exist_ok=True)
+            _error_log_path = _error_log_dir / "errors.log"
+            from logging.handlers import RotatingFileHandler
+            _error_file_handler = RotatingFileHandler(
+                _error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,
+            )
+            _error_file_handler.setLevel(logging.WARNING)
+            _error_file_handler.setFormatter(RedactingFormatter(
+                '%(asctime)s %(levelname)s %(name)s: %(message)s',
+            ))
+            logging.getLogger().addHandler(_error_file_handler)
+            _error_handler_installed = True
 
         if self.verbose_logging:
             logging.basicConfig(


### PR DESCRIPTION
Fixes #990

Four fixes for issues that compound in long-running gateway processes:

- **Log handler accumulation:** guard `RotatingFileHandler` addition with a module-level flag so it only runs once
- **Delivery dedup mismatch:** `(Platform.LOCAL, None)` → `(Platform.LOCAL, None, None)` to match the 3-tuple in `seen_platforms`
- **Context compressor crash:** `(content or "").strip()` to handle `None` API responses
- **Thread pool leak:** `shutdown(wait=False)` old executor before replacing in `resize_tool_pool()`