### PR TITLE
fix: email adapter IMAP UID tracking and SMTP TLS verification

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import smtplib
+import ssl
 import uuid
 from datetime import datetime
 from email.header import decode_header
@@ -212,7 +213,7 @@ class EmailAdapter(BasePlatformAdapter):
             imap.login(self._address, self._password)
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
-            status, data = imap.search(None, "ALL")
+            status, data = imap.uid("search", None, "ALL")
             if status == "OK" and data[0]:
                 for uid in data[0].split():
                     self._seen_uids.add(uid)
@@ -225,7 +226,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             # Test SMTP connection
             smtp = smtplib.SMTP(self._smtp_host, self._smtp_port)
-            smtp.starttls()
+            smtp.starttls(context=ssl.create_default_context())
             smtp.login(self._address, self._password)
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
@@ -277,7 +278,7 @@ class EmailAdapter(BasePlatformAdapter):
             imap.login(self._address, self._password)
             imap.select("INBOX")
 
-            status, data = imap.search(None, "UNSEEN")
+            status, data = imap.uid("search", None, "UNSEEN")
             if status != "OK" or not data[0]:
                 imap.logout()
                 return results
@@ -287,7 +288,7 @@ class EmailAdapter(BasePlatformAdapter):
                     continue
                 self._seen_uids.add(uid)
 
-                status, msg_data = imap.fetch(uid, "(RFC822)")
+                status, msg_data = imap.uid("fetch", uid, "(RFC822)")
                 if status != "OK":
                     continue
 
@@ -427,7 +428,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port)
-        smtp.starttls()
+        smtp.starttls(context=ssl.create_default_context())
         smtp.login(self._address, self._password)
         smtp.send_message(msg)
         smtp.quit()
@@ -515,7 +516,7 @@ class EmailAdapter(BasePlatformAdapter):
             msg.attach(part)
 
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port)
-        smtp.starttls()
+        smtp.starttls(context=ssl.create_default_context())
         smtp.login(self._address, self._password)
         smtp.send_message(msg)
         smtp.quit()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -797,7 +797,7 @@ class TestConnectDisconnect(unittest.TestCase):
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
-        mock_imap.search.return_value = ("OK", [b"1 2 3"])
+        mock_imap.uid.return_value = ("OK", [b"1 2 3"])
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
              patch("smtplib.SMTP") as mock_smtp:
@@ -831,7 +831,7 @@ class TestConnectDisconnect(unittest.TestCase):
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
-        mock_imap.search.return_value = ("OK", [b""])
+        mock_imap.uid.return_value = ("OK", [b""])
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
              patch("smtplib.SMTP", side_effect=Exception("SMTP down")):
@@ -877,8 +877,15 @@ class TestFetchNewMessages(unittest.TestCase):
         raw_email["Message-ID"] = "<msg@test.com>"
 
         mock_imap = MagicMock()
-        mock_imap.search.return_value = ("OK", [b"1 2 3"])
-        mock_imap.fetch.return_value = ("OK", [(b"3", raw_email.as_bytes())])
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1 2 3"])
+            if command == "fetch":
+                return ("OK", [(b"3", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
             results = adapter._fetch_new_messages()
@@ -893,7 +900,7 @@ class TestFetchNewMessages(unittest.TestCase):
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
-        mock_imap.search.return_value = ("OK", [b""])
+        mock_imap.uid.return_value = ("OK", [b""])
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
             results = adapter._fetch_new_messages()
@@ -919,8 +926,15 @@ class TestFetchNewMessages(unittest.TestCase):
         raw_email["Message-ID"] = "<msg@test.com>"
 
         mock_imap = MagicMock()
-        mock_imap.search.return_value = ("OK", [b"1"])
-        mock_imap.fetch.return_value = ("OK", [(b"1", raw_email.as_bytes())])
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
             results = adapter._fetch_new_messages()
@@ -963,8 +977,15 @@ class TestPollLoop(unittest.TestCase):
         raw_email["Message-ID"] = "<inbox@test.com>"
 
         mock_imap = MagicMock()
-        mock_imap.search.return_value = ("OK", [b"1"])
-        mock_imap.fetch.return_value = ("OK", [(b"1", raw_email.as_bytes())])
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
             asyncio.get_event_loop().run_until_complete(adapter._check_inbox())


### PR DESCRIPTION
Fixes #991

- **IMAP:** use `imap.uid("search", ...)` and `imap.uid("fetch", ...)` instead of `imap.search/fetch`. Sequence numbers shift on deletion, causing skipped or duplicate messages.
- **SMTP TLS:** pass `ssl.create_default_context()` to `starttls()` so the server certificate is verified. All three `starttls()` call sites fixed.