### PR TITLE
fix: backfill model on gateway sessions after agent runs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1434,10 +1434,11 @@ class GatewayRunner:
                         skip_db=agent_persisted,
                     )
             
-            # Update session with actual prompt token count from the agent
+            # Update session with actual prompt token count and model from the agent
             self.session_store.update_session(
                 session_entry.session_key,
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
+                model=agent_result.get("model"),
             )
             
             return response
@@ -3234,6 +3235,7 @@ class GatewayRunner:
                     "tools": tools_holder[0] or [],
                     "history_offset": len(agent_history),
                     "last_prompt_tokens": _last_prompt_toks,
+                    "model": agent_holder[0].model if agent_holder[0] else None,
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -3278,6 +3280,7 @@ class GatewayRunner:
                 "tools": tools_holder[0] or [],
                 "history_offset": len(agent_history),
                 "last_prompt_tokens": _last_prompt_toks,
+                "model": agent_holder[0].model if agent_holder[0] else None,
             }
         
         # Start progress message sender if enabled

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -559,6 +559,7 @@ class SessionStore:
         input_tokens: int = 0,
         output_tokens: int = 0,
         last_prompt_tokens: int = None,
+        model: str = None,
     ) -> None:
         """Update a session's metadata after an interaction."""
         self._ensure_loaded()
@@ -576,7 +577,8 @@ class SessionStore:
             if self._db:
                 try:
                     self._db.update_token_counts(
-                        entry.session_id, input_tokens, output_tokens
+                        entry.session_id, input_tokens, output_tokens,
+                        model=model,
                     )
                 except Exception as e:
                     logger.debug("Session DB operation failed: %s", e)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -227,15 +227,17 @@ class SessionDB:
         self._conn.commit()
 
     def update_token_counts(
-        self, session_id: str, input_tokens: int = 0, output_tokens: int = 0
+        self, session_id: str, input_tokens: int = 0, output_tokens: int = 0,
+        model: str = None,
     ) -> None:
-        """Increment token counters on a session."""
+        """Increment token counters and backfill model if not already set."""
         self._conn.execute(
             """UPDATE sessions SET
                input_tokens = input_tokens + ?,
-               output_tokens = output_tokens + ?
+               output_tokens = output_tokens + ?,
+               model = COALESCE(model, ?)
                WHERE id = ?""",
-            (input_tokens, output_tokens, session_id),
+            (input_tokens, output_tokens, model, session_id),
         )
         self._conn.commit()
 


### PR DESCRIPTION
Fixes #987

Gateway sessions have `model = NULL` because the row is created before `AIAgent` is constructed. After the agent responds, `update_session()` writes token counts but never fills in the model.

This threads `agent.model` through `_run_agent()`'s return dict into `update_session()` → `update_token_counts()`. The SQL uses `COALESCE(model, ?)` so it only fills NULL — never overwrites a model set at creation time (e.g. CLI sessions).

If the agent falls back to a different provider, `agent.model` is updated in-place by `_try_activate_fallback()`, so the recorded value reflects whichever model actually produced the response.

Tested on a live gateway across CLI and Telegram sessions.