### PR TITLE
fix: DeepSeek V3 parser drops tool calls when model returns multiple (#989)

### DIFF
--- a/environments/tool_call_parsers/deepseek_v3_parser.py
+++ b/environments/tool_call_parsers/deepseek_v3_parser.py
@@ -37,8 +37,9 @@ class DeepSeekV3ToolCallParser(ToolCallParser):
     START_TOKEN = "<｜tool▁calls▁begin｜>"
 
     # Regex captures: type, function_name, function_arguments
+    # Use non-greedy .*? to correctly match multiple tool calls
     PATTERN = re.compile(
-        r"<｜tool▁call▁begin｜>(?P<type>.*)<｜tool▁sep｜>(?P<function_name>.*)\n```json\n(?P<function_arguments>.*)\n```<｜tool▁call▁end｜>",
+        r"<｜tool▁call▁begin｜>(?P<type>.*?)<｜tool▁sep｜>(?P<function_name>.*?)\n```json\n(?P<function_arguments>.*?)\n```<｜tool▁call▁end｜>",
         re.DOTALL,
     )
 

--- a/tests/test_tool_call_parsers.py
+++ b/tests/test_tool_call_parsers.py
@@ -124,6 +124,104 @@ class TestHermesParser:
         # Either parse it successfully or return None
 
 
+# ─── DeepSeek V3 parser tests ───────────────────────────────────────────
+
+class TestDeepSeekV3Parser:
+    @pytest.fixture
+    def parser(self):
+        return get_parser("deepseek_v3")
+
+    def test_no_tool_call(self, parser):
+        text = "Hello, I can help you with that."
+        content, tool_calls = parser.parse(text)
+        assert content == text
+        assert tool_calls is None
+
+    def test_single_tool_call(self, parser):
+        text = (
+            '<｜tool▁calls▁begin｜>'
+            '<｜tool▁call▁begin｜>function<｜tool▁sep｜>terminal\n'
+            '```json\n{"command": "ls -la"}\n```'
+            '<｜tool▁call▁end｜>'
+            '<｜tool▁calls▁end｜>'
+        )
+        content, tool_calls = parser.parse(text)
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "terminal"
+
+    def test_multiple_tool_calls(self, parser):
+        """Regression test for issue #989: greedy regex dropped all but last tool call."""
+        text = (
+            'Let me run some commands.\n'
+            '<｜tool▁calls▁begin｜>'
+            '<｜tool▁call▁begin｜>function<｜tool▁sep｜>terminal\n'
+            '```json\n{"command": "ls"}\n```'
+            '<｜tool▁call▁end｜>'
+            '<｜tool▁call▁begin｜>function<｜tool▁sep｜>read_file\n'
+            '```json\n{"path": "test.py"}\n```'
+            '<｜tool▁call▁end｜>'
+            '<｜tool▁calls▁end｜>'
+        )
+        content, tool_calls = parser.parse(text)
+        assert tool_calls is not None
+        assert len(tool_calls) == 2, f"Expected 2 tool calls, got {len(tool_calls)}"
+        names = {tc.function.name for tc in tool_calls}
+        assert "terminal" in names
+        assert "read_file" in names
+
+    def test_three_tool_calls(self, parser):
+        """Ensure parser handles 3+ tool calls correctly."""
+        text = (
+            '<｜tool▁calls▁begin｜>'
+            '<｜tool▁call▁begin｜>function<｜tool▁sep｜>terminal\n'
+            '```json\n{"command": "echo 1"}\n```'
+            '<｜tool▁call▁end｜>'
+            '<｜tool▁call▁begin｜>function<｜tool▁sep｜>terminal\n'
+            '```json\n{"command": "echo 2"}\n```'
+            '<｜tool▁call▁end｜>'
+            '<｜tool▁call▁begin｜>function<｜tool▁sep｜>terminal\n'
+            '```json\n{"command": "echo 3"}\n```'
+            '<｜tool▁call▁end｜>'
+            '<｜tool▁calls▁end｜>'
+        )
+        content, tool_calls = parser.parse(text)
+        assert tool_calls is not None
+        assert len(tool_calls) == 3, f"Expected 3 tool calls, got {len(tool_calls)}"
+
+    def test_tool_call_ids_unique(self, parser):
+        """Each tool call should get a unique ID."""
+        text = (
+            '<｜tool▁calls▁begin｜>'
+            '<｜tool▁call▁begin｜>function<｜tool▁sep｜>terminal\n'
+            '```json\n{"command": "ls"}\n```'
+            '<｜tool▁call▁end｜>'
+            '<｜tool▁call▁begin｜>function<｜tool▁sep｜>terminal\n'
+            '```json\n{"command": "pwd"}\n```'
+            '<｜tool▁call▁end｜>'
+            '<｜tool▁calls▁end｜>'
+        )
+        _, tool_calls = parser.parse(text)
+        assert tool_calls is not None
+        ids = [tc.id for tc in tool_calls]
+        assert len(ids) == len(set(ids)), "Tool call IDs must be unique"
+
+    def test_content_before_tool_calls(self, parser):
+        """Text before tool calls should be preserved as content."""
+        text = (
+            'I will help you check that.\n'
+            '<｜tool▁calls▁begin｜>'
+            '<｜tool▁call▁begin｜>function<｜tool▁sep｜>terminal\n'
+            '```json\n{"command": "pwd"}\n```'
+            '<｜tool▁call▁end｜>'
+            '<｜tool▁calls▁end｜>'
+        )
+        content, tool_calls = parser.parse(text)
+        assert tool_calls is not None
+        assert content is not None
+        assert "help you" in content
+
+
 # ─── Parse result contract tests (applies to ALL parsers) ───────────────
 
 class TestParseResultContract:


### PR DESCRIPTION
## Problem

The regex in `DeepSeekV3ToolCallParser.PATTERN` used greedy `.*` with `re.DOTALL`. When the model returned multiple tool calls, `findall()` merged them into a single match — silently dropping all but the last one.

**Repro:** Any DeepSeek V3 response with 2+ tool calls → only the last tool call was parsed.

## Root Cause

`(?P<type>.*)` consumed across `<｜tool▁sep｜>` delimiters until the last occurrence.

## Fix

Changed `.*` to `.*?` (non-greedy) in all three capture groups.

Before: `1 match found` for 2 tool calls
After: `2 matches found` for 2 tool calls

## Tests Added

- Single tool call
- Multiple tool calls (2) - regression test for #989
- Three tool calls
- Unique tool call IDs
- Content preservation before tool calls

Closes #989