### PR TITLE
fix: GatewayConfig has no attribute 'get' when sending /start on Telegram (#973)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -158,6 +158,10 @@ class GatewayConfig:
     # Delivery settings
     always_log_local: bool = True  # Always save cron outputs to local files
     
+    # User-defined quick commands (bypass agent loop, no LLM call)
+    # Config example: quick_commands: {limits: {type: exec, command: "./limits.sh"}}
+    quick_commands: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -312,6 +316,11 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+
+            # Load quick_commands from config.yaml
+            qc = yaml_cfg.get("quick_commands")
+            if qc and isinstance(qc, dict):
+                config.quick_commands = qc
     except Exception:
         pass
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1008,7 +1008,7 @@ class GatewayRunner:
         
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
-            quick_commands = self.config.get("quick_commands", {})
+            quick_commands = getattr(self.config, "quick_commands", {})
             if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":


### PR DESCRIPTION
## Problem

Sending `/start` to the Telegram bot triggers an AttributeError:

```
[Telegram] Error handling message: 'GatewayConfig' object has no attribute 'get'
Traceback (most recent call last):
  File "gateway/run.py", line 917, in _handle_message
    quick_commands = self.config.get("quick_commands", {})
AttributeError: 'GatewayConfig' object has no attribute 'get'
```

## Root Cause

The quick_commands feature (commit 1404f84) was added to `gateway/run.py` but:
1. `GatewayConfig` dataclass didn't have a `quick_commands` field
2. Code used `self.config.get()` which doesn't work on dataclasses

Note: Commit bd2606a fixed this for CLI (`cli.py`), but the gateway (`run.py`) still had the bug.

## Fix

1. Added `quick_commands: Dict[str, Dict[str, Any]]` field to `GatewayConfig` dataclass
2. Load `quick_commands` from `config.yaml` in `load_gateway_config()`
3. Changed `self.config.get("quick_commands", {})` to `getattr(self.config, "quick_commands", {})`

Closes #973