### PR TITLE
feat: Add OPEN_AI_LLM_TIMEOUT environment variable for LLM timeout

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2350,7 +2350,7 @@ class AIAgent:
             "model": self.model,
             "messages": api_messages,
             "tools": self.tools if self.tools else None,
-            "timeout": 900.0,
+            "timeout": float(os.getenv("OPEN_AI_LLM_TIMEOUT", 900.0)),
         }
 
         if self.max_tokens is not None:


### PR DESCRIPTION
## Summary
- Adds `OPEN_AI_LLM_TIMEOUT` environment variable to configure LLM timeout
- Default is 900s (existing behavior) if not set
- Allows users to override when using local LLM providers like Ollama or LM Studio

## Changes
- `run_agent.py`: Changed hardcoded timeout to use `os.getenv("OPEN_AI_LLM_TIMEOUT", 900.0))`

## Testing
- Existing tests should pass (no behavior change when env var is not set)
- Can be tested by setting `OPEN_AI_LLM_TIMEOUT=1800` for 30-minute timeout

Closes #1010