### PR TITLE
fix: handle Responses-backed context compression summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -144,13 +144,23 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         return None
 
     def _call_summary_model(self, client, model: str, prompt: str) -> str:
-        """Make the actual LLM call to generate a summary. Raises on failure."""
+        """Make the actual LLM call to generate a summary. Raises on failure.
+
+        Prefer chat.completions for normal providers, but transparently fall back
+        to Responses API when the client/backend only supports Responses
+        semantics (notably Codex-like endpoints).
+        """
         kwargs = {
             "model": model,
             "messages": [{"role": "user", "content": prompt}],
             "temperature": 0.3,
             "timeout": 30.0,
         }
+
+        # If this client has no chat.completions surface, go straight to Responses.
+        if not hasattr(client, "chat") and hasattr(client, "responses"):
+            return self._call_summary_model_responses(client, model, prompt)
+
         # Most providers (OpenRouter, local models) use max_tokens.
         # Direct OpenAI with newer models (gpt-4o, o-series, gpt-5+)
         # requires max_completion_tokens instead.
@@ -158,10 +168,15 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             kwargs["max_tokens"] = self.summary_target_tokens * 2
             response = client.chat.completions.create(**kwargs)
         except Exception as first_err:
-            if "max_tokens" in str(first_err) or "unsupported_parameter" in str(first_err):
+            first_err_text = str(first_err)
+            if "max_tokens" in first_err_text or "unsupported_parameter" in first_err_text:
                 kwargs.pop("max_tokens", None)
                 kwargs["max_completion_tokens"] = self.summary_target_tokens * 2
                 response = client.chat.completions.create(**kwargs)
+            elif "Responses.stream() got an unexpected keyword argument 'stream'" in first_err_text:
+                # Some Responses-backed clients expose chat.completions but reject
+                # stream kwarg plumbing internally. Retry via Responses directly.
+                return self._call_summary_model_responses(client, model, prompt)
             else:
                 raise
 
@@ -170,16 +185,43 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             summary = "[CONTEXT SUMMARY]: " + summary
         return summary
 
+    def _call_summary_model_responses(self, client, model: str, prompt: str) -> str:
+        """Generate a summary using the Responses API client surface."""
+        response = client.responses.create(
+            model=model,
+            instructions="You are a helpful assistant.",
+            input=[{"role": "user", "content": [{"type": "input_text", "text": prompt}]}],
+            store=False,
+            timeout=30.0,
+        )
+
+        text_parts = []
+        for item in getattr(response, "output", []) or []:
+            if getattr(item, "type", None) != "message":
+                continue
+            for part in getattr(item, "content", []) or []:
+                if getattr(part, "type", None) in ("output_text", "text"):
+                    text_parts.append(getattr(part, "text", ""))
+
+        summary = "".join(text_parts).strip()
+        if not summary:
+            summary = (getattr(response, "output_text", "") or "").strip()
+        if not summary:
+            raise RuntimeError("Responses summary generation returned empty output")
+        if not summary.startswith("[CONTEXT SUMMARY]:"):
+            summary = "[CONTEXT SUMMARY]: " + summary
+        return summary
+
     def _get_fallback_client(self):
         """Try to build a fallback client from the main model's endpoint config.
 
         When the primary auxiliary client fails (e.g. stale OpenRouter key), this
-        creates a client using the user's active custom endpoint (OPENAI_BASE_URL)
-        so compression can still produce a real summary instead of a static string.
+        creates a client using the user's active endpoint so compression can still
+        produce a real summary.
 
         Returns (client, model) or (None, None).
         """
-        custom_base = os.getenv("OPENAI_BASE_URL")
+        custom_base = os.getenv("OPENAI_BASE_URL") or self.base_url
         custom_key = os.getenv("OPENAI_API_KEY")
         if not custom_base or not custom_key:
             return None, None

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,6 +1,7 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from agent.context_compressor import ContextCompressor
@@ -320,3 +321,51 @@ class TestCompressWithClient:
         for msg in result:
             if msg.get("role") == "tool" and msg.get("tool_call_id"):
                 assert msg["tool_call_id"] in called_ids
+
+
+class TestResponsesCompatibility:
+    def test_summary_uses_responses_when_chat_path_raises_stream_kwarg_error(self):
+        chat_client = MagicMock()
+        chat_client.chat.completions.create.side_effect = TypeError(
+            "Responses.stream() got an unexpected keyword argument 'stream'"
+        )
+
+        responses_output = [
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text="responses summary text")],
+            )
+        ]
+        chat_client.responses.create.return_value = SimpleNamespace(output=responses_output)
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000), \
+             patch("agent.context_compressor.get_text_auxiliary_client", return_value=(chat_client, "test-model")):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        summary = c._call_summary_model(chat_client, "test-model", "summarize this")
+        assert summary.startswith("[CONTEXT SUMMARY]:")
+        assert "responses summary text" in summary
+        assert chat_client.responses.create.call_count == 1
+
+    def test_generate_summary_falls_back_to_main_client_when_auxiliary_fails(self):
+        bad_aux_client = MagicMock()
+        bad_aux_client.chat.completions.create.side_effect = TypeError(
+            "Responses.stream() got an unexpected keyword argument 'stream'"
+        )
+        bad_aux_client.responses.create.side_effect = RuntimeError("aux failed")
+
+        fallback_client = MagicMock()
+        fallback_response = MagicMock()
+        fallback_response.choices = [MagicMock()]
+        fallback_response.choices[0].message.content = "[CONTEXT SUMMARY]: fallback worked"
+        fallback_client.chat.completions.create.return_value = fallback_response
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000), \
+             patch("agent.context_compressor.get_text_auxiliary_client", return_value=(bad_aux_client, "aux-model")):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        c._get_fallback_client = MagicMock(return_value=(fallback_client, "main-model"))
+
+        summary = c._generate_summary([{"role": "user", "content": "hello"}])
+        assert summary == "[CONTEXT SUMMARY]: fallback worked"
+        assert fallback_client.chat.completions.create.call_count == 1


### PR DESCRIPTION
## Summary
- add a Responses API summary path in agent/context_compressor.py when chat.completions fails with the Codex/Responses stream kwarg mismatch
- keep existing max_tokens -> max_completion_tokens retry behavior for standard chat completions
- broaden fallback client resolution to use the active runtime base URL when OPENAI_BASE_URL is unset
- add regression tests covering:
  - Responses-backed summary generation after "Responses.stream() got an unexpected keyword argument stream"
  - fallback to main client when auxiliary summary generation fails

## Validation
- python -m pytest -o addopts="" tests/agent/test_context_compressor.py -q
- python -m pytest -o addopts="" tests/test_run_agent_codex_responses.py -q

Closes #886