### PR TITLE
Add OPENAI_LLM_TIMEOUT env var for custom OpenAI-compatible provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -563,12 +563,13 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "setting",
     },
-    "HERMES_EPHEMERAL_SYSTEM_PROMPT": {
-        "description": "Ephemeral system prompt injected at API-call time (never persisted to sessions)",
-        "prompt": "Ephemeral system prompt",
+    "OPENAI_LLM_TIMEOUT": {
+        "description": "Timeout in seconds for LLM calls when using custom OpenAI-compatible provider",
+        "prompt": "LLM timeout for custom provider",
         "url": None,
         "password": False,
         "category": "setting",
+        "advanced": True,
     },
 }
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -563,6 +563,14 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "setting",
     },
+    "HERMES_EPHEMERAL_SYSTEM_PROMPT": {
+        "description": "Ephemeral system prompt injected at API-call time (never persisted to sessions)",
+        "prompt": "Ephemeral system prompt",
+        "url": None,
+        "password": False,
+        "category": "setting",
+
+    },
     "OPENAI_LLM_TIMEOUT": {
         "description": "Timeout in seconds for LLM calls when using custom OpenAI-compatible provider",
         "prompt": "LLM timeout for custom provider",

--- a/run_agent.py
+++ b/run_agent.py
@@ -2390,11 +2390,19 @@ class AIAgent:
         if self.provider_data_collection:
             provider_preferences["data_collection"] = self.provider_data_collection
 
+        # Determine timeout based on provider and environment variable
+        timeout = 900.0
+        if self.provider == "custom" and os.getenv("OPENAI_LLM_TIMEOUT"):
+            try:
+                timeout = float(os.getenv("OPENAI_LLM_TIMEOUT"))
+            except ValueError:
+                pass  # Keep default if invalid
+
         api_kwargs = {
             "model": self.model,
             "messages": api_messages,
             "tools": self.tools if self.tools else None,
-            "timeout": 900.0,
+            "timeout": timeout,
         }
 
         if self.max_tokens is not None:

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -490,12 +490,48 @@ class TestBuildApiKwargs:
         assert kwargs["messages"] is messages
         assert kwargs["timeout"] == 900.0
 
+    def test_timeout_custom_provider_with_env(self, agent, monkeypatch):
+        import os
+
+        monkeypatch.setenv("OPENAI_LLM_TIMEOUT", "120.0")
+        agent.provider = "custom"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["timeout"] == 120.0
+
+    def test_timeout_custom_provider_without_env(self, agent):
+        import os
+
+        os.environ.pop("OPENAI_LLM_TIMEOUT", None)
+        agent.provider = "custom"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["timeout"] == 900.0
+
+    def test_timeout_openrouter_ignores_env(self, agent, monkeypatch):
+        import os
+
+        monkeypatch.setenv("OPENAI_LLM_TIMEOUT", "120.0")
+        agent.provider = "openrouter"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["timeout"] == 900.0
+
+    def test_timeout_invalid_env_value(self, agent, monkeypatch):
+        import os
+
+        monkeypatch.setenv("OPENAI_LLM_TIMEOUT", "invalid")
+        agent.provider = "custom"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["timeout"] == 900.0
+
     def test_provider_preferences_injected(self, agent):
         agent.providers_allowed = ["Anthropic"]
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
+        assert "provider" in kwargs.get("extra_body", {})
         assert kwargs["extra_body"]["provider"]["only"] == ["Anthropic"]
-
     def test_reasoning_config_default_openrouter(self, agent):
         """Default reasoning config for OpenRouter should be medium."""
         messages = [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
## Summary

Adds support for `OPENAI_LLM_TIMEOUT` environment variable to control LLM timeout when using custom OpenAI-compatible providers.

This PR addresses issue #1010.

## Changes

### run_agent.py
- Modified `_build_api_kwargs()` method in `AIAgent` class (line 2624)
- Timeout now dynamically uses `OPENAI_LLM_TIMEOUT` env var when provider is "custom"
- Falls back to default 900 seconds for other providers or invalid env values

### tests/test_run_agent.py
Added comprehensive test coverage:
- `test_timeout_custom_provider_with_env`: Verifies custom timeout from env var
- `test_timeout_custom_provider_without_env`: Verifies default timeout when env not set
- `test_timeout_openrouter_ignores_env`: Confirms other providers ignore the env var
- `test_timeout_invalid_env_value`: Validates fallback to default on invalid values

### hermes_cli/config.py
Added `OPENAI_LLM_TIMEOUT` to `OPTIONAL_ENV_VARS` (line 576)
- Marked as advanced setting
- Documents purpose and usage

## Behavior

| Provider | OPENAI_LLM_TIMEOUT Set | Timeout Used |
|----------|------------------------|--------------|
| custom   | Yes                   | Env value    |
| custom   | No/Invalid            | 900 seconds  |
| Other    | Any                   | 900 seconds  |

## Testing

All tests passing:
- ✅ test_basic_kwargs
- ✅ test_timeout_custom_provider_with_env
- ✅ test_timeout_custom_provider_without_env
- ✅ test_timeout_openrouter_ignores_env
- ✅ test_timeout_invalid_env_value