### PR TITLE
fix: auto-enable systemd linger during gateway install on headless servers

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -188,6 +188,51 @@ StandardError=journal
 WantedBy=default.target
 """
 
+def _ensure_linger_enabled() -> None:
+    """Enable systemd linger for the current user if not already active.
+
+    Linger keeps user services alive after SSH logout.  Without it, the
+    gateway appears "active (running)" in systemctl but stops receiving
+    messages as soon as the terminal is closed.
+
+    Strategy:
+    1. Check whether linger is already enabled (fast path — no sudo needed).
+    2. If not, try ``loginctl enable-linger <user>`` — succeeds when the
+       process has CAP_SYS_ADMIN or the user has sudo-less loginctl access.
+    3. If that fails (no privileges), print a clear, actionable warning so
+       the user knows exactly what to run.
+    """
+    import getpass
+    username = getpass.getuser()
+
+    # Fast path: check linger state via the filesystem (no subprocess needed)
+    linger_file = Path(f"/var/lib/systemd/linger/{username}")
+    if linger_file.exists():
+        print("✓ Linger already enabled — gateway will persist after logout")
+        return
+
+    # Attempt to enable linger automatically
+    print("Enabling linger so the gateway survives SSH logout...")
+    result = subprocess.run(
+        ["loginctl", "enable-linger", username],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        print("✓ Linger enabled — gateway will persist after logout")
+    else:
+        # No privileges — print a clear, copy-pasteable warning
+        print()
+        print("⚠️  Linger not enabled — gateway will STOP when you close this terminal.")
+        print()
+        print("   On headless servers (VPS, cloud instances) you must run:")
+        print(f"     sudo loginctl enable-linger {username}")
+        print()
+        print("   Then restart the gateway:")
+        print("     systemctl --user restart hermes-gateway.service")
+        print()
+
+
 def systemd_install(force: bool = False):
     unit_path = get_systemd_unit_path()
     
@@ -211,8 +256,10 @@ def systemd_install(force: bool = False):
     print(f"  hermes gateway status             # Check status")
     print(f"  journalctl --user -u {SERVICE_NAME} -f  # View logs")
     print()
-    print("To enable lingering (keeps running after logout):")
-    print("  sudo loginctl enable-linger $USER")
+    # Auto-detect and enable linger for headless operation.
+    # Without linger, user services stop when the SSH session ends — even if
+    # systemctl shows "active (running)".  See: loginctl(1), systemd-logind(8).
+    _ensure_linger_enabled()
 
 def systemd_uninstall():
     subprocess.run(["systemctl", "--user", "stop", SERVICE_NAME], check=False)

--- a/tests/hermes_cli/test_gateway_linger.py
+++ b/tests/hermes_cli/test_gateway_linger.py
@@ -1,0 +1,76 @@
+"""Tests for _ensure_linger_enabled() — headless server linger detection."""
+import subprocess
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+
+def _get_fn():
+    from hermes_cli.gateway import _ensure_linger_enabled
+    return _ensure_linger_enabled
+
+
+class TestEnsureLingerEnabled:
+    def test_linger_already_enabled_via_file(self, tmp_path, capsys):
+        """If linger file exists, prints success and skips loginctl."""
+        linger_file = tmp_path / "testuser"
+        linger_file.touch()
+
+        with patch("hermes_cli.gateway.Path", side_effect=lambda p: Path(p).with_name(p.split("/")[-1])):
+            pass  # just verify the import works
+
+        fn = _get_fn()
+        with patch("getpass.getpass", return_value="testuser"), \
+             patch("getpass.getuser", return_value="testuser"), \
+             patch("hermes_cli.gateway.Path") as mock_path, \
+             patch("subprocess.run") as mock_run:
+            mock_linger = MagicMock()
+            mock_linger.exists.return_value = True
+            mock_path.return_value = mock_linger
+            fn()
+            mock_run.assert_not_called()
+
+        out = capsys.readouterr().out
+        assert "already enabled" in out
+
+    def test_linger_not_enabled_loginctl_succeeds(self, capsys):
+        """If linger file missing but loginctl succeeds, prints success."""
+        fn = _get_fn()
+        with patch("getpass.getuser", return_value="testuser"), \
+             patch("hermes_cli.gateway.Path") as mock_path, \
+             patch("subprocess.run") as mock_run:
+            mock_linger = MagicMock()
+            mock_linger.exists.return_value = False
+            mock_path.return_value = mock_linger
+            mock_run.return_value = MagicMock(returncode=0)
+            fn()
+
+        out = capsys.readouterr().out
+        assert "✓ Linger enabled" in out
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert "loginctl" in args
+        assert "enable-linger" in args
+        assert "testuser" in args
+
+    def test_linger_not_enabled_loginctl_fails_shows_warning(self, capsys):
+        """If loginctl fails (no sudo), prints clear actionable warning."""
+        fn = _get_fn()
+        with patch("getpass.getuser", return_value="testuser"), \
+             patch("hermes_cli.gateway.Path") as mock_path, \
+             patch("subprocess.run") as mock_run:
+            mock_linger = MagicMock()
+            mock_linger.exists.return_value = False
+            mock_path.return_value = mock_linger
+            mock_run.return_value = MagicMock(returncode=1, stderr="Permission denied")
+            fn()
+
+        out = capsys.readouterr().out
+        assert "sudo loginctl enable-linger testuser" in out
+        assert "STOP" in out
+
+    def test_linger_called_during_install(self):
+        """_ensure_linger_enabled is called inside systemd_install."""
+        import inspect
+        import hermes_cli.gateway as gw
+        src = inspect.getsource(gw.systemd_install)
+        assert "_ensure_linger_enabled" in src


### PR DESCRIPTION
Fixes #1005

## Problem

On headless servers, `hermes gateway install` sets up a user-level systemd service that stops when the SSH session ends — even though `systemctl --user status` shows `active (running)`. Root cause: user services require linger to survive logout.

## Solution (Option A + C from the issue)

New helper `_ensure_linger_enabled()` called at the end of `systemd_install()`:

1. **Fast path**: checks `/var/lib/systemd/linger/<user>` — no subprocess needed
2. **Auto-enable**: runs `loginctl enable-linger <user>` — succeeds when the process has sufficient privileges (e.g. running as root or sudo-less loginctl access)
3. **Fallback**: if loginctl fails, prints a clear, copy-pasteable warning:

```
⚠️  Linger not enabled — gateway will STOP when you close this terminal.

   On headless servers (VPS, cloud instances) you must run:
     sudo loginctl enable-linger <user>

   Then restart the gateway:
     systemctl --user restart hermes-gateway.service
```

## Out of scope
Option B (`--system` flag for system-level service) — can follow in a separate PR.

## Tests
4 new tests in `TestEnsureLingerEnabled`, 205 passed total.