### PR TITLE
fix: prevent log handler accumulation in AIAgent.__init__

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -358,14 +358,24 @@ class AIAgent:
         _error_log_dir.mkdir(parents=True, exist_ok=True)
         _error_log_path = _error_log_dir / "errors.log"
         from logging.handlers import RotatingFileHandler
-        _error_file_handler = RotatingFileHandler(
-            _error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,
+        
+        # Check if error file handler already exists to prevent accumulation
+        # when AIAgent is instantiated multiple times (e.g., gateway mode)
+        root_logger = logging.getLogger()
+        _has_error_handler = any(
+            isinstance(h, RotatingFileHandler) and 
+            getattr(h, 'baseFilename', '').endswith('errors.log')
+            for h in root_logger.handlers
         )
-        _error_file_handler.setLevel(logging.WARNING)
-        _error_file_handler.setFormatter(RedactingFormatter(
-            '%(asctime)s %(levelname)s %(name)s: %(message)s',
-        ))
-        logging.getLogger().addHandler(_error_file_handler)
+        if not _has_error_handler:
+            _error_file_handler = RotatingFileHandler(
+                _error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,
+            )
+            _error_file_handler.setLevel(logging.WARNING)
+            _error_file_handler.setFormatter(RedactingFormatter(
+                '%(asctime)s %(levelname)s %(name)s: %(message)s',
+            ))
+            root_logger.addHandler(_error_file_handler)
 
         if self.verbose_logging:
             logging.basicConfig(


### PR DESCRIPTION
## Problem

`AIAgent.__init__` appends a new `RotatingFileHandler` to the root logger on every instantiation without checking if one already exists. In gateway mode (new AIAgent per message), after N messages every log line is written N times to `errors.log`, degrading performance and causing log spam.

## Solution

Check for existing error file handlers before adding a new one:

```python
_has_error_handler = any(
    isinstance(h, RotatingFileHandler) and 
    getattr(h, 'baseFilename', '').endswith('errors.log')
    for h in root_logger.handlers
)
if not _has_error_handler:
    # ... add handler
```

## Testing

- Verified the check correctly identifies existing handlers by filename
- Minimal change, only affects the logging setup path

Fixes #990 (partial - addresses the log handler accumulation issue)