### PR TITLE
fix(cli): use angle brackets for config set placeholders

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -785,7 +785,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                         print(f"  ✓ Saved {name}")
                     print()
             else:
-                print("  Set later with: hermes config set KEY VALUE")
+                print("  Set later with: hermes config set <key> <value>")
     
     # Check for missing config fields
     missing_config = get_missing_config_fields()
@@ -1160,7 +1160,7 @@ def show_config():
     print()
     print(color("─" * 60, Colors.DIM))
     print(color("  hermes config edit     # Edit config file", Colors.DIM))
-    print(color("  hermes config set KEY VALUE", Colors.DIM))
+    print(color("  hermes config set <key> <value>", Colors.DIM))
     print(color("  hermes setup           # Run setup wizard", Colors.DIM))
     print()
 
@@ -1286,7 +1286,7 @@ def config_command(args):
         key = getattr(args, 'key', None)
         value = getattr(args, 'value', None)
         if not key or not value:
-            print("Usage: hermes config set KEY VALUE")
+            print("Usage: hermes config set <key> <value>")
             print()
             print("Examples:")
             print("  hermes config set model anthropic/claude-sonnet-4")
@@ -1401,7 +1401,7 @@ def config_command(args):
         print("Available commands:")
         print("  hermes config           Show current configuration")
         print("  hermes config edit      Open config in editor")
-        print("  hermes config set K V   Set a config value")
+        print("  hermes config set <key> <value>   Set a config value")
         print("  hermes config check     Check for missing/outdated config")
         print("  hermes config migrate   Update config with new options")
         print("  hermes config path      Show config file path")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -499,7 +499,7 @@ def _print_setup_summary(config: dict, hermes_home):
     print(
         f"   {color('hermes config edit', Colors.GREEN)}    Open config in your editor"
     )
-    print(f"   {color('hermes config set KEY VALUE', Colors.GREEN)}")
+    print(f"   {color('hermes config set <key> <value>', Colors.GREEN)}")
     print(f"                          Set a specific value")
     print()
     print(f"   Or edit the files directly:")


### PR DESCRIPTION
## Problem

The setup completion screen displays:
```
hermes config set KEY VALUE
```

Because `KEY` and `VALUE` look like valid literals, users who copy-paste this line end up with `KEY: VALUE` written to their `~/.hermes/config.yaml`.

## Solution

Changed to angle bracket convention:
```
hermes config set <key> <value>
```

This follows common CLI documentation patterns and clearly indicates these are placeholders.

## Changes

- `hermes_cli/config.py`: Updated 4 occurrences
- `hermes_cli/setup.py`: Updated 1 occurrence

Fixes #926