### PR TITLE
fix: prevent log handler accumulation in AIAgent.__init__

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -358,14 +358,24 @@ class AIAgent:
         _error_log_dir.mkdir(parents=True, exist_ok=True)
         _error_log_path = _error_log_dir / "errors.log"
         from logging.handlers import RotatingFileHandler
-        _error_file_handler = RotatingFileHandler(
-            _error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,
+        # Guard against duplicate handlers: in gateway mode a new AIAgent is
+        # created per message, so without this check every log line would be
+        # written N times after N messages (see #1025 / #990).
+        _root_logger = logging.getLogger()
+        _has_error_handler = any(
+            isinstance(h, RotatingFileHandler)
+            and getattr(h, "baseFilename", "").endswith("errors.log")
+            for h in _root_logger.handlers
         )
-        _error_file_handler.setLevel(logging.WARNING)
-        _error_file_handler.setFormatter(RedactingFormatter(
-            '%(asctime)s %(levelname)s %(name)s: %(message)s',
-        ))
-        logging.getLogger().addHandler(_error_file_handler)
+        if not _has_error_handler:
+            _error_file_handler = RotatingFileHandler(
+                _error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,
+            )
+            _error_file_handler.setLevel(logging.WARNING)
+            _error_file_handler.setFormatter(RedactingFormatter(
+                '%(asctime)s %(levelname)s %(name)s: %(message)s',
+            ))
+            _root_logger.addHandler(_error_file_handler)
 
         if self.verbose_logging:
             logging.basicConfig(


### PR DESCRIPTION
## Summary

- Add a guard in `AIAgent.__init__` to prevent duplicate `RotatingFileHandler` registration on the root logger
- In gateway mode, a new `AIAgent` is created per message — without this fix, after N messages every log line is written N times to `errors.log`

## Problem

`AIAgent.__init__` unconditionally appends a new `RotatingFileHandler` to the root logger. Since the root logger is global, repeated instantiations (e.g., one per gateway message) cause handler accumulation:

- After 100 messages: every WARNING+ log line is written 100 times
- Performance degrades linearly with message count
- `errors.log` fills up rapidly with duplicate entries

## Solution

Before adding the handler, check if one already exists by matching on both the handler type (`RotatingFileHandler`) and the target filename (`errors.log`):

```python
_has_error_handler = any(
    isinstance(h, RotatingFileHandler)
    and getattr(h, "baseFilename", "").endswith("errors.log")
    for h in _root_logger.handlers
)
if not _has_error_handler:
    # ... add handler
```

## Test Plan

- [ ] Verify syntax passes
- [ ] Create multiple `AIAgent` instances and confirm only one handler exists on root logger
- [ ] Gateway mode: send multiple messages and verify no duplicate log lines

Closes #1025
Fixes #990 (partial)