### PR TITLE
feat(stt): add local whisper.cpp transcription backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,9 +176,19 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # Contains full conversation history in trajectory format for debugging/replay
 
 # =============================================================================
-# VOICE TRANSCRIPTION & OPENAI TTS
+# SPEECH-TO-TEXT (STT)
 # =============================================================================
-# Required for voice message transcription (Whisper) and OpenAI TTS voices.
+# Hermes chooses speech-to-text from stt.provider in ~/.hermes/config.yaml.
+# Set HERMES_STT_PROVIDER=whispercpp only if you want to use local whisper.cpp.
+# These are optional .env overrides for the stt.whispercpp config values.
+# You can also set them in ~/.hermes/config.yaml instead.
+# HERMES_STT_PROVIDER=whispercpp
+# HERMES_STT_WHISPERCPP_BINARY_PATH=/home/me/whisper.cpp/build/bin/whisper-cli
+# HERMES_STT_WHISPERCPP_MODEL_PATH=/home/me/whisper.cpp/models/ggml-large-v3-turbo-q5_0.bin
+# HERMES_STT_WHISPERCPP_LANGUAGE=auto
+# HERMES_STT_WHISPERCPP_FFMPEG_PATH=ffmpeg
+
+# Required for OpenAI STT and OpenAI TTS voices.
 # Uses OpenAI's API directly (not via OpenRouter).
 # Named VOICE_TOOLS_OPENAI_KEY to avoid interference with OpenRouter.
 # Get at: https://platform.openai.com/api-keys

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -579,10 +579,16 @@ toolsets:
 # Voice Transcription (Speech-to-Text)
 # =============================================================================
 # Automatically transcribe voice messages on messaging platforms.
-# Requires OPENAI_API_KEY in .env (uses OpenAI Whisper API directly).
+# Provider is configurable. Use whisper.cpp only when you explicitly select it.
 stt:
   enabled: true
-  model: "whisper-1"  # whisper-1 (cheapest) | gpt-4o-mini-transcribe | gpt-4o-transcribe
+  provider: "openai"      # openai | whispercpp
+  model: "whisper-1"      # Used when provider=openai
+  whispercpp:
+    binary_path: ""       # Set when provider=whispercpp, e.g. /home/me/whisper.cpp/build/bin/whisper-cli
+    model_path: ""        # Set when provider=whispercpp to a ggml/gguf model file
+    language: "auto"      # "auto" for detection, or a language code like "en"
+    ffmpeg_path: "ffmpeg" # ffmpeg binary used to normalize input audio
 
 # =============================================================================
 # Response Pacing (Messaging Platforms)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2250,8 +2250,8 @@ class GatewayRunner:
         audio_paths: List[str],
     ) -> str:
         """
-        Auto-transcribe user voice/audio messages using OpenAI Whisper API
-        and prepend the transcript to the message text.
+        Auto-transcribe user voice/audio messages and prepend a lightweight
+        note to the message text before it reaches the agent.
 
         Args:
             user_text:   The user's original caption / message text.
@@ -2269,29 +2269,24 @@ class GatewayRunner:
                 logger.debug("Transcribing user voice: %s", path)
                 result = await asyncio.to_thread(transcribe_audio, path)
                 if result["success"]:
-                    transcript = result["transcript"]
-                    enriched_parts.append(
-                        f'[The user sent a voice message~ '
-                        f'Here\'s what they said: "{transcript}"]'
-                    )
-                else:
-                    error = result.get("error", "unknown error")
-                    if "OPENAI_API_KEY" in error or "VOICE_TOOLS_OPENAI_KEY" in error:
+                    transcript = str(result.get("transcript", "")).strip()
+                    if transcript:
                         enriched_parts.append(
-                            "[The user sent a voice message but I can't listen "
-                            "to it right now~ VOICE_TOOLS_OPENAI_KEY isn't set up yet "
-                            "(';w;') Let them know!]"
+                            "// Transcript of the user's audio message:\n"
+                            f"{transcript}"
                         )
                     else:
                         enriched_parts.append(
-                            "[The user sent a voice message but I had trouble "
-                            f"transcribing it~ ({error})]"
+                            "// The user sent an audio message that couldn't get transcribed"
                         )
+                else:
+                    enriched_parts.append(
+                        "// The user sent an audio message that couldn't get transcribed"
+                    )
             except Exception as e:
                 logger.error("Transcription error: %s", e)
                 enriched_parts.append(
-                    "[The user sent a voice message but something went wrong "
-                    "when I tried to listen to it~ Let them know!]"
+                    "// The user sent an audio message that couldn't get transcribed"
                 )
 
         if enriched_parts:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -89,6 +89,17 @@ DEFAULT_CONFIG = {
         "record_sessions": False,  # Auto-record browser sessions as WebM videos
     },
     
+    "web": {
+        "search": {
+            "provider": "firecrawl",  # firecrawl | brave | searxng | duckduckgo
+            "brave_api_key": "",
+            "searxng_url": "",
+        },
+        "extract": {
+            "provider": "firecrawl",  # firecrawl | trafilatura
+        },
+    },
+    
     "compression": {
         "enabled": True,
         "threshold": 0.85,
@@ -178,7 +189,7 @@ DEFAULT_CONFIG = {
     "command_allowlist": [],
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 5,
+    "_config_version": 6,
 }
 
 # =============================================================================
@@ -192,6 +203,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
     4: ["VOICE_TOOLS_OPENAI_KEY", "ELEVENLABS_API_KEY"],
     5: ["WHATSAPP_ENABLED", "WHATSAPP_MODE", "WHATSAPP_ALLOWED_USERS",
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
+    6: ["BRAVE_API_KEY", "SEARXNG_URL"],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -309,6 +321,22 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "tool",
         "advanced": True,
+    },
+    "BRAVE_API_KEY": {
+        "description": "Brave Search API key for web search",
+        "prompt": "Brave Search API key",
+        "url": "https://api.search.brave.com/",
+        "tools": ["web_search"],
+        "password": True,
+        "category": "tool",
+    },
+    "SEARXNG_URL": {
+        "description": "SearXNG instance URL for self-hosted web search",
+        "prompt": "SearXNG instance URL",
+        "url": None,
+        "tools": ["web_search"],
+        "password": False,
+        "category": "tool",
     },
     "BROWSERBASE_API_KEY": {
         "description": "Browserbase API key for cloud browser (optional — local browser works without this)",
@@ -627,6 +655,33 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 tz_display = config["timezone"] or "(server-local)"
                 print(f"  ✓ Added timezone to config.yaml: {tz_display}")
 
+    # ── Version 5 → 6: add web provider config ──
+    if current_ver < 6:
+        config = load_config()
+        raw_config = {}
+        config_path = get_config_path()
+        if config_path.exists():
+            try:
+                with open(config_path, encoding="utf-8") as f:
+                    raw_config = yaml.safe_load(f) or {}
+            except Exception:
+                raw_config = {}
+        if "web" not in raw_config:
+            config["web"] = {
+                "search": {
+                    "provider": "firecrawl",
+                    "brave_api_key": "",
+                    "searxng_url": "",
+                },
+                "extract": {
+                    "provider": "firecrawl",
+                },
+            }
+            results["config_added"].append("web")
+            save_config(config)
+            if not quiet:
+                print("  ✓ Added web provider configuration to config.yaml")
+
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")
     
@@ -935,6 +990,7 @@ def show_config():
         ("ANTHROPIC_API_KEY", "Anthropic"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
         ("FIRECRAWL_API_KEY", "Firecrawl"),
+        ("BRAVE_API_KEY", "Brave"),
         ("BROWSERBASE_API_KEY", "Browserbase"),
         ("FAL_KEY", "FAL"),
     ]
@@ -975,6 +1031,15 @@ def show_config():
         ssh_user = get_env_value('TERMINAL_SSH_USER')
         print(f"  SSH host:     {ssh_host or '(not set)'}")
         print(f"  SSH user:     {ssh_user or '(not set)'}")
+
+    # Web
+    print()
+    print(color("◆ Web", Colors.CYAN, Colors.BOLD))
+    web_cfg = config.get("web", {})
+    search_cfg = web_cfg.get("search", {})
+    extract_cfg = web_cfg.get("extract", {})
+    print(f"  Search:       {search_cfg.get('provider', 'firecrawl')}")
+    print(f"  Extract:      {extract_cfg.get('provider', 'firecrawl')}")
     
     # Timezone
     print()
@@ -1092,7 +1157,8 @@ def set_config_value(key: str, value: str):
     # Check if it's an API key (goes to .env)
     api_keys = [
         'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
-        'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL', 'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID',
+        'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL', 'BRAVE_API_KEY', 'SEARXNG_URL',
+        'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID',
         'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
         'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
         'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -136,7 +136,14 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
+        "provider": "openai",
         "model": "whisper-1",
+        "whispercpp": {
+            "binary_path": "",
+            "model_path": "",
+            "language": "auto",
+            "ffmpeg_path": "ffmpeg",
+        },
     },
     
     "human_delay": {
@@ -1012,6 +1019,26 @@ def show_config():
                 if mdl:
                     parts.append(f"model={mdl}")
                 print(f"  {label:12s}  {', '.join(parts)}")
+
+    # Speech-to-text
+    print()
+    print(color("◆ Speech-to-Text", Colors.CYAN, Colors.BOLD))
+    stt = config.get('stt', {})
+    stt_enabled = stt.get('enabled', True)
+    print(f"  Enabled:      {'yes' if stt_enabled else 'no'}")
+    if stt_enabled:
+        provider = stt.get('provider', DEFAULT_CONFIG['stt']['provider'])
+        print(f"  Provider:     {provider}")
+        stt_model = stt.get('model', '')
+        if stt_model:
+            print(f"  Model:        {stt_model}")
+        whispercpp = stt.get('whispercpp', {})
+        if provider in ('whispercpp', 'whisper.cpp', 'local'):
+            binary_path = whispercpp.get('binary_path', '') or '(auto-detect from PATH)'
+            model_path = whispercpp.get('model_path', '') or '(not set)'
+            print(f"  Binary:       {binary_path}")
+            print(f"  Model path:   {model_path}")
+            print(f"  Language:     {whispercpp.get('language', 'auto')}")
     
     # Messaging
     print()

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -53,6 +53,46 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
+def _get_stt_runtime_status():
+    """Inspect the effective speech-to-text configuration and prerequisites."""
+    try:
+        from tools.transcription_tools import (
+            DEFAULT_STT_PROVIDER,
+            WHISPERCPP_PROVIDER,
+            resolve_ffmpeg_binary,
+            resolve_stt_config,
+            resolve_whispercpp_binary,
+        )
+
+        stt_config = resolve_stt_config()
+        provider = str(stt_config.get("provider", DEFAULT_STT_PROVIDER) or DEFAULT_STT_PROVIDER).strip().lower()
+        whispercpp_cfg = stt_config.get("whispercpp", {})
+
+        binary_path = resolve_whispercpp_binary(stt_config) if provider == WHISPERCPP_PROVIDER else ""
+        ffmpeg_path = resolve_ffmpeg_binary(stt_config) if provider == WHISPERCPP_PROVIDER else ""
+        model_path_raw = str(whispercpp_cfg.get("model_path", "") or "").strip()
+        model_path = Path(os.path.expanduser(model_path_raw)) if model_path_raw else None
+
+        return {
+            "enabled": bool(stt_config.get("enabled", True)),
+            "provider": provider,
+            "binary_path": binary_path,
+            "binary_found": bool(binary_path),
+            "binary_configured": str(whispercpp_cfg.get("binary_path", "") or "").strip(),
+            "model_path": str(model_path) if model_path else "",
+            "model_found": bool(model_path and model_path.is_file()),
+            "ffmpeg_path": ffmpeg_path,
+            "ffmpeg_found": bool(ffmpeg_path),
+            "ffmpeg_configured": str(whispercpp_cfg.get("ffmpeg_path", "ffmpeg") or "ffmpeg").strip(),
+        }
+    except Exception as exc:
+        return {
+            "enabled": False,
+            "provider": "unknown",
+            "error": str(exc),
+        }
+
+
 def check_ok(text: str, detail: str = ""):
     print(f"  {color('✓', Colors.GREEN)} {text}" + (f" {color(detail, Colors.DIM)}" if detail else ""))
 
@@ -436,6 +476,48 @@ def run_doctor(args):
                     check_ok(f"{label} deps", f"({moderate} moderate vulnerability(ies))")
             except Exception:
                 pass
+
+    # =========================================================================
+    # Check: Speech-to-Text
+    # =========================================================================
+    print()
+    print(color("◆ Speech-to-Text", Colors.CYAN, Colors.BOLD))
+
+    stt_status = _get_stt_runtime_status()
+    if stt_status.get("error"):
+        check_warn("Could not inspect STT configuration", f"({stt_status['error']})")
+    elif not stt_status.get("enabled", True):
+        check_warn("Speech-to-text disabled")
+    elif stt_status.get("provider") == "whispercpp":
+        binary_label = stt_status.get("binary_path") or stt_status.get("binary_configured") or "(not configured)"
+        if stt_status.get("binary_found"):
+            check_ok("whisper.cpp binary", f"({binary_label})")
+        else:
+            check_fail("whisper.cpp binary", f"({binary_label})")
+            issues.append("Configure stt.whispercpp.binary_path or install whisper.cpp in PATH")
+
+        model_label = stt_status.get("model_path") or "(not configured)"
+        if stt_status.get("model_found"):
+            check_ok("whisper.cpp model", f"({model_label})")
+        else:
+            check_fail("whisper.cpp model", f"({model_label})")
+            issues.append("Configure stt.whispercpp.model_path to a local whisper.cpp model file")
+
+        ffmpeg_label = stt_status.get("ffmpeg_path") or stt_status.get("ffmpeg_configured") or "(not configured)"
+        if stt_status.get("ffmpeg_found"):
+            check_ok("ffmpeg", f"({ffmpeg_label})")
+        else:
+            check_fail("ffmpeg", f"({ffmpeg_label})")
+            issues.append("Install ffmpeg or configure stt.whispercpp.ffmpeg_path")
+    elif stt_status.get("provider") == "openai":
+        if os.getenv("VOICE_TOOLS_OPENAI_KEY"):
+            check_ok("OpenAI STT key", "(VOICE_TOOLS_OPENAI_KEY configured)")
+        else:
+            check_fail("OpenAI STT key", "(VOICE_TOOLS_OPENAI_KEY missing)")
+            issues.append("Set VOICE_TOOLS_OPENAI_KEY or switch stt.provider to whispercpp")
+    else:
+        check_warn("Unknown STT provider", f"({stt_status.get('provider', 'unknown')})")
+        issues.append(f"Set stt.provider to whispercpp or openai (current: {stt_status.get('provider', 'unknown')})")
 
     # =========================================================================
     # Check: API connectivity

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -147,23 +147,70 @@ TOOL_CATEGORIES = {
     },
     "web": {
         "name": "Web Search & Extract",
-        "setup_title": "Select Search Provider",
-        "setup_note": "A free DuckDuckGo search skill is also included — skip this if you don't need Firecrawl.",
+        "setup_note": "Firecrawl stays the default, but you can switch search and extract to cheaper providers.",
         "icon": "🔍",
-        "providers": [
+        "search_providers": [
             {
                 "name": "Firecrawl Cloud",
-                "tag": "Recommended - hosted service",
+                "tag": "Default - hosted service",
                 "env_vars": [
                     {"key": "FIRECRAWL_API_KEY", "prompt": "Firecrawl API key", "url": "https://firecrawl.dev"},
                 ],
+                "config_updates": {"web.search.provider": "firecrawl"},
             },
             {
                 "name": "Firecrawl Self-Hosted",
-                "tag": "Free - run your own instance",
+                "tag": "Default - run your own instance",
                 "env_vars": [
                     {"key": "FIRECRAWL_API_URL", "prompt": "Your Firecrawl instance URL (e.g., http://localhost:3002)"},
                 ],
+                "config_updates": {"web.search.provider": "firecrawl"},
+            },
+            {
+                "name": "Brave Search",
+                "tag": "API alternative",
+                "env_vars": [
+                    {"key": "BRAVE_API_KEY", "prompt": "Brave Search API key", "url": "https://api.search.brave.com/"},
+                ],
+                "config_updates": {"web.search.provider": "brave"},
+            },
+            {
+                "name": "SearXNG",
+                "tag": "Self-hosted metasearch",
+                "env_vars": [
+                    {"key": "SEARXNG_URL", "prompt": "SearXNG instance URL"},
+                ],
+                "config_updates": {"web.search.provider": "searxng"},
+            },
+            {
+                "name": "DuckDuckGo",
+                "tag": "Free via ddgs",
+                "env_vars": [],
+                "config_updates": {"web.search.provider": "duckduckgo"},
+            },
+        ],
+        "extract_providers": [
+            {
+                "name": "Firecrawl Cloud",
+                "tag": "Default - hosted service",
+                "env_vars": [
+                    {"key": "FIRECRAWL_API_KEY", "prompt": "Firecrawl API key", "url": "https://firecrawl.dev"},
+                ],
+                "config_updates": {"web.extract.provider": "firecrawl"},
+            },
+            {
+                "name": "Firecrawl Self-Hosted",
+                "tag": "Default - run your own instance",
+                "env_vars": [
+                    {"key": "FIRECRAWL_API_URL", "prompt": "Your Firecrawl instance URL (e.g., http://localhost:3002)"},
+                ],
+                "config_updates": {"web.extract.provider": "firecrawl"},
+            },
+            {
+                "name": "Trafilatura",
+                "tag": "Free static-page extraction",
+                "env_vars": [],
+                "config_updates": {"web.extract.provider": "trafilatura"},
             },
         ],
     },
@@ -347,6 +394,23 @@ def _toolset_has_keys(ts_key: str) -> bool:
     # Check TOOL_CATEGORIES first (provider-aware)
     cat = TOOL_CATEGORIES.get(ts_key)
     if cat:
+        if ts_key == "web":
+            config = load_config()
+            search_provider = config.get("web", {}).get("search", {}).get("provider", "firecrawl")
+            extract_provider = config.get("web", {}).get("extract", {}).get("provider", "firecrawl")
+
+            search_ok = (
+                search_provider == "duckduckgo"
+                or (search_provider == "firecrawl" and (get_env_value("FIRECRAWL_API_KEY") or get_env_value("FIRECRAWL_API_URL")))
+                or (search_provider == "brave" and get_env_value("BRAVE_API_KEY"))
+                or (search_provider == "searxng" and get_env_value("SEARXNG_URL"))
+            )
+            extract_ok = (
+                extract_provider == "trafilatura"
+                or (extract_provider == "firecrawl" and (get_env_value("FIRECRAWL_API_KEY") or get_env_value("FIRECRAWL_API_URL")))
+            )
+            return bool(search_ok and extract_ok)
+
         for provider in cat["providers"]:
             env_vars = provider.get("env_vars", [])
             if not env_vars:
@@ -580,8 +644,93 @@ def _configure_toolset(ts_key: str, config: dict):
         _configure_simple_requirements(ts_key)
 
 
+def _apply_config_updates(config: dict, updates: dict):
+    """Apply dotted config updates to the in-memory config dict."""
+    for dotted_key, value in (updates or {}).items():
+        parts = dotted_key.split(".")
+        current = config
+        for part in parts[:-1]:
+            if part not in current or not isinstance(current.get(part), dict):
+                current[part] = {}
+            current = current[part]
+        current[parts[-1]] = value
+
+
+def _provider_matches_updates(provider: dict, config: dict) -> bool:
+    """Check whether a provider matches current config state."""
+    updates = provider.get("config_updates", {})
+    if not updates:
+        return False
+    for dotted_key, expected in updates.items():
+        current = config
+        for part in dotted_key.split("."):
+            if not isinstance(current, dict) or part not in current:
+                return False
+            current = current[part]
+        if current != expected:
+            return False
+    return True
+
+
+def _provider_choice_label(provider: dict, config: dict) -> str:
+    """Render a provider label with configured state."""
+    tag = f" ({provider['tag']})" if provider.get("tag") else ""
+    configured = ""
+    env_vars = provider.get("env_vars", [])
+
+    if provider.get("tts_provider") and config.get("tts", {}).get("provider") == provider["tts_provider"]:
+        configured = " [active]"
+    elif provider.get("config_updates") and _provider_matches_updates(provider, config):
+        configured = " [active]"
+    elif env_vars and all(get_env_value(v["key"]) for v in env_vars):
+        configured = " [configured]"
+
+    return f"{provider['name']}{tag}{configured}"
+
+
+def _provider_default_idx(providers: list, config: dict) -> int:
+    """Pick the default menu index for the current provider."""
+    for i, provider in enumerate(providers):
+        if provider.get("tts_provider") and config.get("tts", {}).get("provider") == provider["tts_provider"]:
+            return i
+        if provider.get("config_updates") and _provider_matches_updates(provider, config):
+            return i
+        env_vars = provider.get("env_vars", [])
+        if env_vars and all(get_env_value(v["key"]) for v in env_vars):
+            return i
+    return 0
+
+
+def _configure_web_tool(config: dict, reconfigure: bool = False):
+    """Configure search and extract providers for the web toolset."""
+    cat = TOOL_CATEGORIES["web"]
+    print()
+    print(color(f"  --- {cat.get('icon', '')} {cat['name']} ---", Colors.CYAN))
+    if cat.get("setup_note"):
+        _print_info(f"  {cat['setup_note']}")
+    print()
+
+    search_providers = cat["search_providers"]
+    search_choices = [_provider_choice_label(provider, config) for provider in search_providers]
+    search_default = _provider_default_idx(search_providers, config)
+    search_idx = _prompt_choice("  Select search provider:", search_choices, search_default)
+    _reconfigure_provider(search_providers[search_idx], config) if reconfigure else _configure_provider(search_providers[search_idx], config)
+
+    print()
+
+    extract_providers = cat["extract_providers"]
+    extract_choices = [_provider_choice_label(provider, config) for provider in extract_providers]
+    extract_default = _provider_default_idx(extract_providers, config)
+    extract_idx = _prompt_choice("  Select extract provider:", extract_choices, extract_default)
+    _reconfigure_provider(extract_providers[extract_idx], config) if reconfigure else _configure_provider(extract_providers[extract_idx], config)
+
+
 def _configure_tool_category(ts_key: str, cat: dict, config: dict):
     """Configure a tool category with provider selection."""
+    if ts_key == "web":
+        _configure_web_tool(config, reconfigure=False)
+        return
+
     icon = cat.get("icon", "")
     name = cat["name"]
     providers = cat["providers"]
@@ -662,6 +811,8 @@ def _configure_provider(provider: dict, config: dict):
     # Set TTS provider in config if applicable
     if provider.get("tts_provider"):
         config.setdefault("tts", {})["provider"] = provider["tts_provider"]
+    if provider.get("config_updates"):
+        _apply_config_updates(config, provider["config_updates"])
 
     if not env_vars:
         _print_success(f"  {provider['name']} - no configuration needed!")
@@ -762,6 +913,10 @@ def _reconfigure_tool(config: dict):
 
 def _configure_tool_category_for_reconfig(ts_key: str, cat: dict, config: dict):
     """Reconfigure a tool category - provider selection + API key update."""
+    if ts_key == "web":
+        _configure_web_tool(config, reconfigure=True)
+        return
+
     icon = cat.get("icon", "")
     name = cat["name"]
     providers = cat["providers"]
@@ -811,6 +966,10 @@ def _reconfigure_provider(provider: dict, config: dict):
     if provider.get("tts_provider"):
         config.setdefault("tts", {})["provider"] = provider["tts_provider"]
         _print_success(f"  TTS provider set to: {provider['tts_provider']}")
+    if provider.get("config_updates"):
+        _apply_config_updates(config, provider["config_updates"])
+        for dotted_key, value in provider["config_updates"].items():
+            _print_success(f"  {dotted_key} set to: {value}")
 
     if not env_vars:
         _print_success(f"  {provider['name']} - no configuration needed!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,11 @@ dependencies = [
   "prompt_toolkit",
   # Tools
   "firecrawl-py",
+  "brave-search-python-client",
+  "ddgs",
   "fal-client",
+  "pyserxng",
+  "trafilatura",
   # Text-to-speech (Edge TTS is free, no API key needed)
   "edge-tts",
   # mini-swe-agent deps (terminal tool)

--- a/tests/gateway/test_run_transcription.py
+++ b/tests/gateway/test_run_transcription.py
@@ -1,0 +1,62 @@
+"""Tests for gateway transcription message enrichment."""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from gateway.run import GatewayRunner
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "tools" / "transcription_tools.py"
+SPEC = importlib.util.spec_from_file_location("test_transcription_tools_module", MODULE_PATH)
+tt = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(tt)
+
+
+def _install_fake_tools_package(monkeypatch):
+    tools_pkg = types.ModuleType("tools")
+    tools_pkg.transcription_tools = tt
+    monkeypatch.setitem(sys.modules, "tools", tools_pkg)
+    monkeypatch.setitem(sys.modules, "tools.transcription_tools", tt)
+
+
+class TestGatewayTranscriptionFormatting:
+    def test_successful_transcription_uses_lightweight_note(self, monkeypatch):
+        _install_fake_tools_package(monkeypatch)
+
+        def fake_transcribe_audio(_path):
+            return {"success": True, "transcript": "hello from audio"}
+
+        monkeypatch.setattr(tt, "transcribe_audio", fake_transcribe_audio)
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        result = asyncio.run(
+            runner._enrich_message_with_transcription(
+                "caption text",
+                ["/tmp/audio.ogg"],
+            )
+        )
+
+        assert "// Transcript of the user's audio message:" in result
+        assert "hello from audio" in result
+        assert result.endswith("caption text")
+
+    def test_failed_transcription_uses_single_failure_comment(self, monkeypatch):
+        _install_fake_tools_package(monkeypatch)
+
+        def fake_transcribe_audio(_path):
+            return {"success": False, "error": "whisper.cpp failed"}
+
+        monkeypatch.setattr(tt, "transcribe_audio", fake_transcribe_audio)
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        result = asyncio.run(
+            runner._enrich_message_with_transcription(
+                "",
+                ["/tmp/audio.ogg"],
+            )
+        )
+
+        assert result == "// The user sent an audio message that couldn't get transcribed"

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -44,6 +44,8 @@ class TestLoadConfigDefaults:
             assert config["max_turns"] == DEFAULT_CONFIG["max_turns"]
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
+            assert config["stt"]["provider"] == "openai"
+            assert config["stt"]["whispercpp"]["language"] == "auto"
 
 
 class TestSaveAndLoadRoundtrip:
@@ -66,3 +68,12 @@ class TestSaveAndLoadRoundtrip:
 
             reloaded = load_config()
             assert reloaded["terminal"]["timeout"] == 999
+
+    def test_stt_nested_defaults_preserved(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_config({"stt": {"provider": "whispercpp"}})
+
+            reloaded = load_config()
+            assert reloaded["stt"]["provider"] == "whispercpp"
+            assert reloaded["stt"]["whispercpp"]["language"] == "auto"
+            assert reloaded["stt"]["whispercpp"]["ffmpeg_path"] == "ffmpeg"

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1,6 +1,24 @@
 """Tests for hermes doctor helpers."""
 
-from hermes_cli.doctor import _has_provider_env_config
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from hermes_cli.doctor import _get_stt_runtime_status, _has_provider_env_config
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "tools" / "transcription_tools.py"
+SPEC = importlib.util.spec_from_file_location("test_transcription_tools_module", MODULE_PATH)
+tt = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(tt)
+
+
+def _install_fake_tools_package(monkeypatch):
+    tools_pkg = types.ModuleType("tools")
+    tools_pkg.transcription_tools = tt
+    monkeypatch.setitem(sys.modules, "tools", tools_pkg)
+    monkeypatch.setitem(sys.modules, "tools.transcription_tools", tt)
 
 
 class TestProviderEnvDetection:
@@ -15,3 +33,39 @@ class TestProviderEnvDetection:
     def test_returns_false_when_no_provider_settings(self):
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)
+
+
+class TestSttRuntimeStatus:
+    def test_reports_disabled_state(self, monkeypatch):
+        _install_fake_tools_package(monkeypatch)
+        monkeypatch.setattr(tt, "resolve_stt_config", lambda: {"enabled": False, "provider": "whispercpp", "whispercpp": {}})
+        status = _get_stt_runtime_status()
+        assert status["enabled"] is False
+
+    def test_reports_whispercpp_prerequisites(self, tmp_path, monkeypatch):
+        _install_fake_tools_package(monkeypatch)
+        model_path = tmp_path / "model.bin"
+        model_path.write_bytes(b"model")
+        monkeypatch.setattr(
+            tt,
+            "resolve_stt_config",
+            lambda: {
+                "enabled": True,
+                "provider": "whispercpp",
+                "whispercpp": {
+                    "binary_path": "/opt/whisper-cli",
+                    "model_path": str(model_path),
+                    "ffmpeg_path": "/usr/bin/ffmpeg",
+                },
+            },
+        )
+        monkeypatch.setattr(tt, "resolve_whispercpp_binary", lambda config=None: "/opt/whisper-cli")
+        monkeypatch.setattr(tt, "resolve_ffmpeg_binary", lambda config=None: "/usr/bin/ffmpeg")
+
+        status = _get_stt_runtime_status()
+
+        assert status["enabled"] is True
+        assert status["provider"] == "whispercpp"
+        assert status["binary_found"] is True
+        assert status["model_found"] is True
+        assert status["ffmpeg_found"] is True

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -115,3 +115,9 @@ class TestConfigYamlRouting:
         set_config_value("terminal.docker_image", "python:3.12")
         config = _read_config(_isolated_hermes_home)
         assert "python:3.12" in config
+
+    def test_stt_whispercpp_paths_go_to_config(self, _isolated_hermes_home):
+        set_config_value("stt.whispercpp.binary_path", "/opt/whisper.cpp/whisper-cli")
+        config = _read_config(_isolated_hermes_home)
+        assert "/opt/whisper.cpp/whisper-cli" in config
+        assert "WHISPERCPP" not in _read_env(_isolated_hermes_home)

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1,0 +1,110 @@
+"""Tests for local speech-to-text transcription helpers."""
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "tools" / "transcription_tools.py"
+SPEC = importlib.util.spec_from_file_location("test_transcription_tools_module", MODULE_PATH)
+tt = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(tt)
+
+
+def _write_audio_file(tmp_path: Path, suffix: str = ".ogg") -> Path:
+    audio_path = tmp_path / f"sample{suffix}"
+    audio_path.write_bytes(b"not-real-audio")
+    return audio_path
+
+
+def _stt_config(model_path: Path) -> dict:
+    return {
+        "enabled": True,
+        "provider": "whispercpp",
+        "model": "whisper-1",
+        "whispercpp": {
+            "binary_path": "/usr/bin/whisper-cli",
+            "model_path": str(model_path),
+            "language": "auto",
+            "ffmpeg_path": "/usr/bin/ffmpeg",
+        },
+    }
+
+
+class TestWhisperCppTranscription:
+    def test_transcribe_audio_success(self, tmp_path, monkeypatch):
+        audio_path = _write_audio_file(tmp_path)
+        model_path = tmp_path / "model.bin"
+        model_path.write_bytes(b"model")
+
+        monkeypatch.setattr(tt, "resolve_stt_config", lambda: _stt_config(model_path))
+        monkeypatch.setattr(tt, "resolve_whispercpp_binary", lambda config=None: "/usr/bin/whisper-cli")
+        monkeypatch.setattr(tt, "resolve_ffmpeg_binary", lambda config=None: "/usr/bin/ffmpeg")
+
+        def fake_run(command, capture_output=True, text=True):
+            if command[0] == "/usr/bin/ffmpeg":
+                return subprocess.CompletedProcess(command, 0, "", "")
+            output_base = Path(command[command.index("-of") + 1])
+            output_base.with_suffix(".txt").write_text("hello from local whisper\n", encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(tt.subprocess, "run", fake_run)
+
+        result = tt.transcribe_audio(str(audio_path))
+
+        assert result["success"] is True
+        assert result["provider"] == "whispercpp"
+        assert result["transcript"] == "hello from local whisper"
+
+    def test_transcribe_audio_missing_model(self, tmp_path, monkeypatch):
+        audio_path = _write_audio_file(tmp_path)
+        model_path = tmp_path / "missing-model.bin"
+
+        monkeypatch.setattr(tt, "resolve_stt_config", lambda: _stt_config(model_path))
+        monkeypatch.setattr(tt, "resolve_whispercpp_binary", lambda config=None: "/usr/bin/whisper-cli")
+        monkeypatch.setattr(tt, "resolve_ffmpeg_binary", lambda config=None: "/usr/bin/ffmpeg")
+
+        result = tt.transcribe_audio(str(audio_path))
+
+        assert result["success"] is False
+        assert "model not found" in result["error"]
+
+    def test_transcribe_audio_conversion_failure(self, tmp_path, monkeypatch):
+        audio_path = _write_audio_file(tmp_path)
+        model_path = tmp_path / "model.bin"
+        model_path.write_bytes(b"model")
+
+        monkeypatch.setattr(tt, "resolve_stt_config", lambda: _stt_config(model_path))
+        monkeypatch.setattr(tt, "resolve_whispercpp_binary", lambda config=None: "/usr/bin/whisper-cli")
+        monkeypatch.setattr(tt, "resolve_ffmpeg_binary", lambda config=None: "/usr/bin/ffmpeg")
+
+        def fake_run(command, capture_output=True, text=True):
+            if command[0] == "/usr/bin/ffmpeg":
+                return subprocess.CompletedProcess(command, 1, "", "bad input")
+            raise AssertionError("whisper.cpp should not run after ffmpeg conversion failure")
+
+        monkeypatch.setattr(tt.subprocess, "run", fake_run)
+
+        result = tt.transcribe_audio(str(audio_path))
+
+        assert result["success"] is False
+        assert "ffmpeg conversion failed" in result["error"]
+
+    def test_transcribe_audio_missing_transcript_output(self, tmp_path, monkeypatch):
+        audio_path = _write_audio_file(tmp_path)
+        model_path = tmp_path / "model.bin"
+        model_path.write_bytes(b"model")
+
+        monkeypatch.setattr(tt, "resolve_stt_config", lambda: _stt_config(model_path))
+        monkeypatch.setattr(tt, "resolve_whispercpp_binary", lambda config=None: "/usr/bin/whisper-cli")
+        monkeypatch.setattr(tt, "resolve_ffmpeg_binary", lambda config=None: "/usr/bin/ffmpeg")
+
+        def fake_run(command, capture_output=True, text=True):
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(tt.subprocess, "run", fake_run)
+
+        result = tt.transcribe_audio(str(audio_path))
+
+        assert result["success"] is False
+        assert "did not create transcript" in result["error"]

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1,114 +1,324 @@
 #!/usr/bin/env python3
 """
-Transcription Tools Module
+Transcription helpers for messaging platforms.
 
-Provides speech-to-text transcription using OpenAI's Whisper API.
-Used by the messaging gateway to automatically transcribe voice messages
-sent by users on Telegram, Discord, WhatsApp, and Slack.
-
-Supported models:
-  - whisper-1        (cheapest, good quality)
-  - gpt-4o-mini-transcribe  (better quality, higher cost)
-  - gpt-4o-transcribe       (best quality, highest cost)
-
-Supported input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg
-
-Usage:
-    from tools.transcription_tools import transcribe_audio
-
-    result = transcribe_audio("/path/to/audio.ogg")
-    if result["success"]:
-        print(result["transcript"])
+Speech-to-text is a gateway preprocessing step, not an agent tool call.
+Hermes chooses the backend from STT configuration, with OpenAI preserving the
+project's prior default behavior and local ``whisper.cpp`` available when
+explicitly configured.
 """
 
 import logging
 import os
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 from typing import Optional, Dict, Any
 
 logger = logging.getLogger(__name__)
 
 
-# Default STT model -- cheapest and widely available
+# Default STT provider/model.
+DEFAULT_STT_PROVIDER = "openai"
 DEFAULT_STT_MODEL = "whisper-1"
+DEFAULT_WHISPERCPP_LANGUAGE = "auto"
 
-# Supported audio formats
+# Supported input formats
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg"}
 
-# Maximum file size (25MB - OpenAI limit)
+# Maximum file size (25MB - OpenAI limit, also a sensible local default)
 MAX_FILE_SIZE = 25 * 1024 * 1024
 
+WHISPERCPP_PROVIDER_ALIASES = {"whispercpp", "whisper.cpp", "local"}
+OPENAI_PROVIDER_ALIASES = {"openai"}
+WHISPERCPP_PROVIDER = "whispercpp"
 
-def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
+
+def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge override values into base defaults."""
+    result = base.copy()
+    for key, value in override.items():
+        if isinstance(result.get(key), dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _default_stt_config() -> Dict[str, Any]:
+    return {
+        "enabled": True,
+        "provider": DEFAULT_STT_PROVIDER,
+        "model": DEFAULT_STT_MODEL,
+        "whispercpp": {
+            "binary_path": "",
+            "model_path": "",
+            "language": DEFAULT_WHISPERCPP_LANGUAGE,
+            "ffmpeg_path": "ffmpeg",
+        },
+    }
+
+
+def _normalize_provider(provider: str) -> str:
+    normalized = str(provider or DEFAULT_STT_PROVIDER).strip().lower()
+    if normalized in WHISPERCPP_PROVIDER_ALIASES:
+        return WHISPERCPP_PROVIDER
+    if normalized in OPENAI_PROVIDER_ALIASES:
+        return "openai"
+    return normalized
+
+
+def resolve_stt_config() -> Dict[str, Any]:
     """
-    Transcribe an audio file using OpenAI's Whisper API.
-
-    This function calls the OpenAI Audio Transcriptions endpoint directly
-    (not via OpenRouter, since Whisper isn't available there).
-
-    Args:
-        file_path: Absolute path to the audio file to transcribe.
-        model:     Whisper model to use. Defaults to config or "whisper-1".
-
-    Returns:
-        dict with keys:
-          - "success" (bool): Whether transcription succeeded
-          - "transcript" (str): The transcribed text (empty on failure)
-          - "error" (str, optional): Error message if success is False
+    Load the effective STT config from config.yaml plus optional env overrides.
     """
-    api_key = os.getenv("VOICE_TOOLS_OPENAI_KEY")
-    if not api_key:
-        return {
-            "success": False,
-            "transcript": "",
-            "error": "VOICE_TOOLS_OPENAI_KEY not set",
-        }
+    config = _default_stt_config()
 
+    try:
+        from hermes_cli.config import load_config
+
+        user_stt = load_config().get("stt", {})
+        if isinstance(user_stt, dict):
+            config = _deep_merge(config, user_stt)
+    except Exception as exc:
+        logger.debug("Failed to load Hermes STT config: %s", exc)
+
+    whispercpp_cfg = config.setdefault("whispercpp", {})
+    env_map = {
+        "enabled": os.getenv("HERMES_STT_ENABLED"),
+        "provider": os.getenv("HERMES_STT_PROVIDER"),
+        "model": os.getenv("HERMES_STT_MODEL"),
+    }
+    whisper_env_map = {
+        "binary_path": os.getenv("HERMES_STT_WHISPERCPP_BINARY_PATH"),
+        "model_path": os.getenv("HERMES_STT_WHISPERCPP_MODEL_PATH"),
+        "language": os.getenv("HERMES_STT_WHISPERCPP_LANGUAGE"),
+        "ffmpeg_path": os.getenv("HERMES_STT_WHISPERCPP_FFMPEG_PATH"),
+    }
+
+    enabled_override = env_map["enabled"]
+    if enabled_override is not None:
+        config["enabled"] = enabled_override.strip().lower() in {"1", "true", "yes", "on"}
+
+    for key in ("provider", "model"):
+        value = env_map[key]
+        if value:
+            config[key] = value.strip()
+
+    for key, value in whisper_env_map.items():
+        if value:
+            whispercpp_cfg[key] = value.strip()
+
+    config["provider"] = _normalize_provider(config.get("provider", DEFAULT_STT_PROVIDER))
+    whispercpp_cfg["language"] = str(
+        whispercpp_cfg.get("language", DEFAULT_WHISPERCPP_LANGUAGE) or DEFAULT_WHISPERCPP_LANGUAGE
+    ).strip() or DEFAULT_WHISPERCPP_LANGUAGE
+    whispercpp_cfg["ffmpeg_path"] = str(whispercpp_cfg.get("ffmpeg_path", "ffmpeg") or "ffmpeg").strip()
+    whispercpp_cfg["binary_path"] = str(whispercpp_cfg.get("binary_path", "") or "").strip()
+    whispercpp_cfg["model_path"] = str(whispercpp_cfg.get("model_path", "") or "").strip()
+    return config
+
+
+def resolve_whispercpp_binary(config: Optional[Dict[str, Any]] = None) -> str:
+    """Resolve the whisper.cpp executable from config or PATH."""
+    stt_config = config or resolve_stt_config()
+    whispercpp_cfg = stt_config.get("whispercpp", {})
+    binary_path = str(whispercpp_cfg.get("binary_path", "") or "").strip()
+
+    if binary_path:
+        expanded = os.path.expanduser(binary_path)
+        if os.path.isabs(expanded):
+            return expanded if Path(expanded).is_file() else ""
+        if Path(expanded).is_file():
+            return expanded
+        resolved = shutil.which(expanded)
+        return resolved or ""
+
+    for candidate in ("whisper-cli", "main"):
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+    return ""
+
+
+def resolve_ffmpeg_binary(config: Optional[Dict[str, Any]] = None) -> str:
+    """Resolve the ffmpeg executable from config or PATH."""
+    stt_config = config or resolve_stt_config()
+    ffmpeg_path = str(stt_config.get("whispercpp", {}).get("ffmpeg_path", "ffmpeg") or "ffmpeg").strip()
+    if not ffmpeg_path:
+        ffmpeg_path = "ffmpeg"
+    expanded = os.path.expanduser(ffmpeg_path)
+    if os.path.isabs(expanded):
+        return expanded if Path(expanded).is_file() else ""
+    if Path(expanded).is_file():
+        return expanded
+    return shutil.which(expanded) or ""
+
+
+def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
+    """Return an error dict if the input audio file is invalid."""
     audio_path = Path(file_path)
-    
-    # Validate file exists
+
     if not audio_path.exists():
         return {
             "success": False,
             "transcript": "",
             "error": f"Audio file not found: {file_path}",
         }
-    
+
     if not audio_path.is_file():
         return {
             "success": False,
             "transcript": "",
             "error": f"Path is not a file: {file_path}",
         }
-    
-    # Validate file extension
+
     if audio_path.suffix.lower() not in SUPPORTED_FORMATS:
         return {
             "success": False,
             "transcript": "",
-            "error": f"Unsupported file format: {audio_path.suffix}. Supported formats: {', '.join(sorted(SUPPORTED_FORMATS))}",
+            "error": (
+                f"Unsupported file format: {audio_path.suffix}. "
+                f"Supported formats: {', '.join(sorted(SUPPORTED_FORMATS))}"
+            ),
         }
-    
-    # Validate file size
+
     try:
         file_size = audio_path.stat().st_size
         if file_size > MAX_FILE_SIZE:
             return {
                 "success": False,
                 "transcript": "",
-                "error": f"File too large: {file_size / (1024*1024):.1f}MB (max {MAX_FILE_SIZE / (1024*1024)}MB)",
+                "error": (
+                    f"File too large: {file_size / (1024 * 1024):.1f}MB "
+                    f"(max {MAX_FILE_SIZE / (1024 * 1024)}MB)"
+                ),
             }
-    except OSError as e:
-        logger.error("Failed to get file size for %s: %s", file_path, e, exc_info=True)
+    except OSError as exc:
+        logger.error("Failed to get file size for %s: %s", file_path, exc, exc_info=True)
         return {
             "success": False,
             "transcript": "",
-            "error": f"Failed to access file: {e}",
+            "error": f"Failed to access file: {exc}",
         }
 
-    # Use provided model, or fall back to default
-    if model is None:
-        model = DEFAULT_STT_MODEL
+    return None
+
+
+def _format_failure(error: str) -> Dict[str, Any]:
+    return {
+        "success": False,
+        "transcript": "",
+        "error": error,
+    }
+
+
+def _convert_to_whispercpp_wav(input_path: str, output_path: str, ffmpeg_binary: str) -> None:
+    """Convert any supported audio input into mono 16 kHz WAV for whisper.cpp."""
+    result = subprocess.run(
+        [
+            ffmpeg_binary,
+            "-y",
+            "-loglevel",
+            "error",
+            "-i",
+            input_path,
+            "-ar",
+            "16000",
+            "-ac",
+            "1",
+            output_path,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip() or "unknown ffmpeg error"
+        raise RuntimeError(f"ffmpeg conversion failed: {detail}")
+
+
+def _transcribe_with_whispercpp(file_path: str, stt_config: Dict[str, Any]) -> Dict[str, Any]:
+    whispercpp_cfg = stt_config.get("whispercpp", {})
+    binary_path = resolve_whispercpp_binary(stt_config)
+    if not binary_path:
+        return _format_failure(
+            "whisper.cpp binary not found; set stt.whispercpp.binary_path or HERMES_STT_WHISPERCPP_BINARY_PATH"
+        )
+
+    model_path_raw = str(whispercpp_cfg.get("model_path", "") or "").strip()
+    if not model_path_raw:
+        return _format_failure(
+            "whisper.cpp model path not configured; set stt.whispercpp.model_path or HERMES_STT_WHISPERCPP_MODEL_PATH"
+        )
+
+    model_path = Path(os.path.expanduser(model_path_raw))
+    if not model_path.is_file():
+        return _format_failure(f"whisper.cpp model not found: {model_path}")
+
+    ffmpeg_binary = resolve_ffmpeg_binary(stt_config)
+    if not ffmpeg_binary:
+        return _format_failure(
+            "ffmpeg not found; install ffmpeg or set stt.whispercpp.ffmpeg_path"
+        )
+
+    language = str(whispercpp_cfg.get("language", DEFAULT_WHISPERCPP_LANGUAGE) or DEFAULT_WHISPERCPP_LANGUAGE).strip()
+    if not language:
+        language = DEFAULT_WHISPERCPP_LANGUAGE
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="hermes-stt-") as temp_dir:
+            temp_path = Path(temp_dir)
+            wav_path = temp_path / "input.wav"
+            output_base = temp_path / "transcript"
+            transcript_path = output_base.with_suffix(".txt")
+
+            _convert_to_whispercpp_wav(file_path, str(wav_path), ffmpeg_binary)
+
+            command = [
+                binary_path,
+                "-m",
+                str(model_path),
+                "-f",
+                str(wav_path),
+                "-of",
+                str(output_base),
+                "-otxt",
+                "-l",
+                language,
+            ]
+            result = subprocess.run(command, capture_output=True, text=True)
+            if result.returncode != 0:
+                detail = (result.stderr or result.stdout or "").strip() or "unknown whisper.cpp error"
+                return _format_failure(f"whisper.cpp failed: {detail}")
+
+            if not transcript_path.exists():
+                return _format_failure(f"whisper.cpp did not create transcript: {transcript_path}")
+
+            transcript_text = transcript_path.read_text(encoding="utf-8", errors="replace").strip()
+            if not transcript_text:
+                return _format_failure("whisper.cpp returned an empty transcript")
+
+            logger.info("Transcribed %s locally with whisper.cpp (%d chars)", Path(file_path).name, len(transcript_text))
+            return {
+                "success": True,
+                "transcript": transcript_text,
+                "provider": WHISPERCPP_PROVIDER,
+            }
+    except PermissionError:
+        logger.error("Permission denied accessing file: %s", file_path, exc_info=True)
+        return _format_failure(f"Permission denied: {file_path}")
+    except Exception as exc:
+        logger.error("Unexpected whisper.cpp transcription error: %s", exc, exc_info=True)
+        return _format_failure(f"Transcription failed: {exc}")
+
+
+def _transcribe_with_openai(file_path: str, model: str) -> Dict[str, Any]:
+    api_key = os.getenv("VOICE_TOOLS_OPENAI_KEY")
+    if not api_key:
+        return _format_failure("VOICE_TOOLS_OPENAI_KEY not set")
+
+    audio_path = Path(file_path)
 
     try:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
@@ -122,48 +332,56 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
                 response_format="text",
             )
 
-        # The response is a plain string when response_format="text"
         transcript_text = str(transcription).strip()
 
-        logger.info("Transcribed %s (%d chars)", audio_path.name, len(transcript_text))
+        logger.info("Transcribed %s with OpenAI (%d chars)", audio_path.name, len(transcript_text))
 
         return {
             "success": True,
             "transcript": transcript_text,
+            "provider": "openai",
         }
 
     except PermissionError:
         logger.error("Permission denied accessing file: %s", file_path, exc_info=True)
-        return {
-            "success": False,
-            "transcript": "",
-            "error": f"Permission denied: {file_path}",
-        }
+        return _format_failure(f"Permission denied: {file_path}")
     except APIConnectionError as e:
         logger.error("API connection error during transcription: %s", e, exc_info=True)
-        return {
-            "success": False,
-            "transcript": "",
-            "error": f"Connection error: {e}",
-        }
+        return _format_failure(f"Connection error: {e}")
     except APITimeoutError as e:
         logger.error("API timeout during transcription: %s", e, exc_info=True)
-        return {
-            "success": False,
-            "transcript": "",
-            "error": f"Request timeout: {e}",
-        }
+        return _format_failure(f"Request timeout: {e}")
     except APIError as e:
         logger.error("OpenAI API error during transcription: %s", e, exc_info=True)
-        return {
-            "success": False,
-            "transcript": "",
-            "error": f"API error: {e}",
-        }
+        return _format_failure(f"API error: {e}")
     except Exception as e:
         logger.error("Unexpected error during transcription: %s", e, exc_info=True)
-        return {
-            "success": False,
-            "transcript": "",
-            "error": f"Transcription failed: {e}",
-        }
+        return _format_failure(f"Transcription failed: {e}")
+
+
+def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Transcribe a local audio file using the configured STT provider.
+
+    Returns a dict with:
+      - success (bool)
+      - transcript (str)
+      - error (str, optional)
+      - provider (str, optional)
+    """
+    validation_error = _validate_audio_file(file_path)
+    if validation_error:
+        return validation_error
+
+    stt_config = resolve_stt_config()
+    if not stt_config.get("enabled", True):
+        return _format_failure("speech-to-text is disabled")
+
+    provider = _normalize_provider(stt_config.get("provider", DEFAULT_STT_PROVIDER))
+    chosen_model = model or stt_config.get("model") or DEFAULT_STT_MODEL
+
+    if provider == WHISPERCPP_PROVIDER:
+        return _transcribe_with_whispercpp(file_path, stt_config)
+    if provider == "openai":
+        return _transcribe_with_openai(file_path, chosen_model)
+    return _format_failure(f"Unsupported STT provider: {provider}")

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -45,6 +45,7 @@ import logging
 import os
 import re
 import asyncio
+from importlib import import_module
 from typing import List, Dict, Any, Optional
 from firecrawl import Firecrawl
 from openai import AsyncOpenAI
@@ -94,6 +95,320 @@ DEFAULT_SUMMARIZER_MODEL = (
 )
 
 _debug = DebugSession("web_tools", env_var="WEB_TOOLS_DEBUG")
+
+
+def _deep_merge_dict(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge override into base."""
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(merged.get(key), dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_dict(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _get_web_config() -> Dict[str, Any]:
+    """Load web provider config from config.yaml, falling back to env vars."""
+    config = {
+        "search": {
+            "provider": "firecrawl",
+            "brave_api_key": "",
+            "searxng_url": "",
+        },
+        "extract": {
+            "provider": "firecrawl",
+        },
+    }
+
+    try:
+        from hermes_cli.config import load_config
+        loaded = load_config().get("web", {})
+        if isinstance(loaded, dict):
+            config = _deep_merge_dict(config, loaded)
+    except Exception:
+        pass
+
+    search_cfg = config.setdefault("search", {})
+    extract_cfg = config.setdefault("extract", {})
+
+    search_cfg["provider"] = str(search_cfg.get("provider", "firecrawl") or "firecrawl").strip().lower()
+    extract_cfg["provider"] = str(extract_cfg.get("provider", "firecrawl") or "firecrawl").strip().lower()
+
+    if not search_cfg.get("brave_api_key"):
+        search_cfg["brave_api_key"] = os.getenv("BRAVE_API_KEY", "").strip()
+    if not search_cfg.get("searxng_url"):
+        search_cfg["searxng_url"] = os.getenv("SEARXNG_URL", "").strip()
+
+    return config
+
+
+def _import_optional_dependency(module_name: str):
+    """Import an optional dependency with a helpful error."""
+    try:
+        return import_module(module_name)
+    except ImportError as exc:
+        raise ImportError(
+            f"Optional dependency '{module_name}' is not installed."
+        ) from exc
+
+
+def _run_sync(coro):
+    """Run an async coroutine from sync code."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _normalize_search_result(
+    title: Any,
+    url: Any,
+    description: Any,
+    position: int,
+) -> Dict[str, Any]:
+    """Normalize provider-specific search results into Hermes shape."""
+    return {
+        "title": str(title or "").strip(),
+        "url": str(url or "").strip(),
+        "description": str(description or "").strip(),
+        "position": position,
+    }
+
+
+def _normalize_search_results(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Drop empty URLs and ensure sequential result positions."""
+    normalized = []
+    for result in results:
+        url = str(result.get("url", "") or "").strip()
+        if not url:
+            continue
+        normalized.append(
+            _normalize_search_result(
+                result.get("title", ""),
+                url,
+                result.get("description", ""),
+                len(normalized) + 1,
+            )
+        )
+    return normalized
+
+
+def _get_firecrawl_search_results(response: Any) -> List[Dict[str, Any]]:
+    """Convert Firecrawl search response objects into plain dicts."""
+    web_results: List[Dict[str, Any]] = []
+    if hasattr(response, "web"):
+        for result in response.web or []:
+            if hasattr(result, "model_dump"):
+                web_results.append(result.model_dump())
+            elif hasattr(result, "__dict__"):
+                web_results.append(result.__dict__)
+            elif isinstance(result, dict):
+                web_results.append(result)
+    elif hasattr(response, "model_dump"):
+        response_dict = response.model_dump()
+        if response_dict.get("web"):
+            web_results = response_dict["web"]
+    elif isinstance(response, dict) and response.get("web"):
+        web_results = response["web"]
+    return _normalize_search_results(web_results)
+
+
+def _search_firecrawl(query: str, limit: int) -> List[Dict[str, Any]]:
+    response = _get_firecrawl_client().search(query=query, limit=limit)
+    return _get_firecrawl_search_results(response)
+
+
+async def _search_brave_async(query: str, limit: int, api_key: str) -> List[Dict[str, Any]]:
+    brave_module = _import_optional_dependency("brave_search_python_client")
+    client = brave_module.BraveSearch(api_key=api_key)
+    response = await client.web(brave_module.WebSearchRequest(q=query, count=limit))
+    raw_results = []
+    if getattr(response, "web", None) and getattr(response.web, "results", None):
+        raw_results = [
+            _normalize_search_result(
+                getattr(result, "title", ""),
+                getattr(result, "url", ""),
+                getattr(result, "description", ""),
+                idx,
+            )
+            for idx, result in enumerate(response.web.results, start=1)
+        ]
+    return _normalize_search_results(raw_results)
+
+
+def _search_brave(query: str, limit: int, api_key: str) -> List[Dict[str, Any]]:
+    return _run_sync(_search_brave_async(query, limit, api_key))
+
+
+def _search_searxng(query: str, limit: int, base_url: str) -> List[Dict[str, Any]]:
+    searxng = _import_optional_dependency("pyserxng")
+    client = searxng.LocalSearXNGClient(base_url)
+    try:
+        results = client.search(query)
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    raw_results = []
+    for idx, result in enumerate(getattr(results, "results", [])[:limit], start=1):
+        raw_results.append(
+            _normalize_search_result(
+                getattr(result, "title", ""),
+                getattr(result, "url", ""),
+                getattr(result, "content", ""),
+                idx,
+            )
+        )
+    return _normalize_search_results(raw_results)
+
+
+def _search_duckduckgo(query: str, limit: int) -> List[Dict[str, Any]]:
+    ddgs_module = _import_optional_dependency("ddgs")
+    raw_results = ddgs_module.DDGS().text(query, max_results=limit)
+    normalized = []
+    for idx, result in enumerate(raw_results or [], start=1):
+        normalized.append(
+            _normalize_search_result(
+                result.get("title", ""),
+                result.get("href", "") or result.get("url", ""),
+                result.get("body", "") or result.get("description", ""),
+                idx,
+            )
+        )
+    return _normalize_search_results(normalized)
+
+
+def _extract_title_from_html(content: str) -> str:
+    """Best-effort title extraction for Trafilatura fallback."""
+    match = re.search(r"<title[^>]*>(.*?)</title>", content or "", flags=re.IGNORECASE | re.DOTALL)
+    if not match:
+        return ""
+    title = re.sub(r"\s+", " ", match.group(1)).strip()
+    return title
+
+
+def _get_firecrawl_formats(format: Optional[str]) -> List[str]:
+    if format == "markdown":
+        return ["markdown"]
+    if format == "html":
+        return ["html"]
+    return ["markdown", "html"]
+
+
+def _extract_single_firecrawl(url: str, format: Optional[str]) -> Dict[str, Any]:
+    formats = _get_firecrawl_formats(format)
+    scrape_result = _get_firecrawl_client().scrape(url=url, formats=formats)
+
+    metadata: Dict[str, Any] = {}
+    content_markdown = None
+    content_html = None
+
+    if hasattr(scrape_result, "model_dump"):
+        result_dict = scrape_result.model_dump()
+        content_markdown = result_dict.get("markdown")
+        content_html = result_dict.get("html")
+        metadata = result_dict.get("metadata", {})
+    elif hasattr(scrape_result, "__dict__"):
+        content_markdown = getattr(scrape_result, "markdown", None)
+        content_html = getattr(scrape_result, "html", None)
+        metadata_obj = getattr(scrape_result, "metadata", {})
+        if hasattr(metadata_obj, "model_dump"):
+            metadata = metadata_obj.model_dump()
+        elif hasattr(metadata_obj, "__dict__"):
+            metadata = metadata_obj.__dict__
+        elif isinstance(metadata_obj, dict):
+            metadata = metadata_obj
+    elif isinstance(scrape_result, dict):
+        content_markdown = scrape_result.get("markdown")
+        content_html = scrape_result.get("html")
+        metadata = scrape_result.get("metadata", {})
+
+    if not isinstance(metadata, dict):
+        if hasattr(metadata, "model_dump"):
+            metadata = metadata.model_dump()
+        elif hasattr(metadata, "__dict__"):
+            metadata = metadata.__dict__
+        else:
+            metadata = {}
+
+    title = metadata.get("title", "")
+    chosen_content = content_markdown if (format == "markdown" or (format is None and content_markdown)) else content_html or content_markdown or ""
+    return {
+        "url": metadata.get("sourceURL", url),
+        "title": title,
+        "content": chosen_content,
+        "raw_content": chosen_content,
+        "metadata": metadata,
+    }
+
+
+def _extract_single_trafilatura(url: str) -> Dict[str, Any]:
+    trafilatura = _import_optional_dependency("trafilatura")
+    downloaded = trafilatura.fetch_url(url)
+    if not downloaded:
+        raise ValueError("Unable to fetch content with trafilatura")
+
+    content = trafilatura.extract(
+        downloaded,
+        output_format="markdown",
+        include_links=True,
+        include_formatting=True,
+    ) or ""
+
+    return {
+        "url": url,
+        "title": _extract_title_from_html(downloaded),
+        "content": content,
+        "raw_content": content,
+        "metadata": {},
+    }
+
+
+def _is_firecrawl_available() -> bool:
+    return bool(os.getenv("FIRECRAWL_API_KEY") or os.getenv("FIRECRAWL_API_URL"))
+
+
+def _is_brave_available(web_cfg: Optional[Dict[str, Any]] = None) -> bool:
+    web_cfg = web_cfg or _get_web_config()
+    return bool(web_cfg.get("search", {}).get("brave_api_key"))
+
+
+def _is_searxng_available(web_cfg: Optional[Dict[str, Any]] = None) -> bool:
+    web_cfg = web_cfg or _get_web_config()
+    return bool(web_cfg.get("search", {}).get("searxng_url"))
+
+
+def _is_duckduckgo_available() -> bool:
+    try:
+        _import_optional_dependency("ddgs")
+        return True
+    except ImportError:
+        return False
+
+
+def _is_trafilatura_available() -> bool:
+    try:
+        _import_optional_dependency("trafilatura")
+        return True
+    except ImportError:
+        return False
+
+
+def _get_search_provider(web_cfg: Optional[Dict[str, Any]] = None) -> str:
+    web_cfg = web_cfg or _get_web_config()
+    return web_cfg.get("search", {}).get("provider", "firecrawl")
+
+
+def _get_extract_provider(web_cfg: Optional[Dict[str, Any]] = None) -> str:
+    web_cfg = web_cfg or _get_web_config()
+    return web_cfg.get("extract", {}).get("provider", "firecrawl")
 
 
 async def process_content_with_llm(
@@ -442,6 +757,28 @@ def clean_base64_images(text: str) -> str:
     return cleaned_text
 
 
+def _search_with_provider(query: str, limit: int) -> tuple[str, List[Dict[str, Any]]]:
+    """Dispatch search requests to the configured provider."""
+    web_cfg = _get_web_config()
+    provider = _get_search_provider(web_cfg)
+
+    if provider == "firecrawl":
+        return provider, _search_firecrawl(query, limit)
+    if provider == "brave":
+        api_key = web_cfg.get("search", {}).get("brave_api_key", "")
+        if not api_key:
+            raise ValueError("BRAVE_API_KEY is not configured")
+        return provider, _search_brave(query, limit, api_key)
+    if provider == "searxng":
+        base_url = web_cfg.get("search", {}).get("searxng_url", "")
+        if not base_url:
+            raise ValueError("SEARXNG_URL is not configured")
+        return provider, _search_searxng(query, limit, base_url)
+    if provider == "duckduckgo":
+        return provider, _search_duckduckgo(query, limit)
+    raise ValueError(f"Unsupported web search provider: {provider}")
+
+
 def web_search_tool(query: str, limit: int = 5) -> str:
     """
     Search the web for information using available search API backend.
@@ -481,6 +818,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             "query": query,
             "limit": limit
         },
+        "provider": None,
         "error": None,
         "results_count": 0,
         "original_response_size": 0,
@@ -493,43 +831,11 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             return json.dumps({"error": "Interrupted", "success": False})
 
         logger.info("Searching the web for: '%s' (limit: %d)", query, limit)
-        
-        response = _get_firecrawl_client().search(
-            query=query,
-            limit=limit
-        )
-        
-        # The response is a SearchData object with web, news, and images attributes
-        # When not scraping, the results are directly in these attributes
-        web_results = []
-        
-        # Check if response has web attribute (SearchData object)
-        if hasattr(response, 'web'):
-            # Response is a SearchData object with web attribute
-            if response.web:
-                # Convert each SearchResultWeb object to dict
-                for result in response.web:
-                    if hasattr(result, 'model_dump'):
-                        # Pydantic model - use model_dump
-                        web_results.append(result.model_dump())
-                    elif hasattr(result, '__dict__'):
-                        # Regular object - use __dict__
-                        web_results.append(result.__dict__)
-                    elif isinstance(result, dict):
-                        # Already a dict
-                        web_results.append(result)
-        elif hasattr(response, 'model_dump'):
-            # Response has model_dump method - use it to get dict
-            response_dict = response.model_dump()
-            if 'web' in response_dict and response_dict['web']:
-                web_results = response_dict['web']
-        elif isinstance(response, dict):
-            # Response is already a dictionary
-            if 'web' in response and response['web']:
-                web_results = response['web']
-        
+
+        provider, web_results = _search_with_provider(query, limit)
+        debug_call_data["provider"] = provider
         results_count = len(web_results)
-        logger.info("Found %d search results", results_count)
+        logger.info("Found %d search results using %s", results_count, provider)
         
         # Build response with just search metadata (URLs, titles, descriptions)
         response_data = {
@@ -562,6 +868,18 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         _debug.save()
         
         return json.dumps({"error": error_msg}, ensure_ascii=False)
+
+
+def _extract_single_url_with_provider(url: str, format: Optional[str]) -> tuple[str, Dict[str, Any]]:
+    """Dispatch extraction requests to the configured provider."""
+    web_cfg = _get_web_config()
+    provider = _get_extract_provider(web_cfg)
+
+    if provider == "firecrawl":
+        return provider, _extract_single_firecrawl(url, format)
+    if provider == "trafilatura":
+        return provider, _extract_single_trafilatura(url)
+    raise ValueError(f"Unsupported web extract provider: {provider}")
 
 
 async def web_extract_tool(
@@ -599,6 +917,7 @@ async def web_extract_tool(
             "model": model,
             "min_length": min_length
         },
+        "provider": None,
         "error": None,
         "pages_extracted": 0,
         "pages_processed_with_llm": 0,
@@ -609,17 +928,9 @@ async def web_extract_tool(
     }
     
     try:
-        logger.info("Extracting content from %d URL(s)", len(urls))
-        
-        # Determine requested formats for Firecrawl v2
-        formats: List[str] = []
-        if format == "markdown":
-            formats = ["markdown"]
-        elif format == "html":
-            formats = ["html"]
-        else:
-            # Default: request markdown for LLM-readiness and include html as backup
-            formats = ["markdown", "html"]
+        provider = _get_extract_provider()
+        debug_call_data["provider"] = provider
+        logger.info("Extracting content from %d URL(s) using %s", len(urls), provider)
         
         # Always use individual scraping for simplicity and reliability
         # Batch scraping adds complexity without much benefit for small numbers of URLs
@@ -633,68 +944,8 @@ async def web_extract_tool(
 
             try:
                 logger.info("Scraping: %s", url)
-                scrape_result = _get_firecrawl_client().scrape(
-                    url=url,
-                    formats=formats
-                )
-                
-                # Process the result - properly handle object serialization
-                metadata = {}
-                title = ""
-                content_markdown = None
-                content_html = None
-                
-                # Extract data from the scrape result
-                if hasattr(scrape_result, 'model_dump'):
-                    # Pydantic model - use model_dump to get dict
-                    result_dict = scrape_result.model_dump()
-                    content_markdown = result_dict.get('markdown')
-                    content_html = result_dict.get('html')
-                    metadata = result_dict.get('metadata', {})
-                elif hasattr(scrape_result, '__dict__'):
-                    # Regular object with attributes
-                    content_markdown = getattr(scrape_result, 'markdown', None)
-                    content_html = getattr(scrape_result, 'html', None)
-                    
-                    # Handle metadata - convert to dict if it's an object
-                    metadata_obj = getattr(scrape_result, 'metadata', {})
-                    if hasattr(metadata_obj, 'model_dump'):
-                        metadata = metadata_obj.model_dump()
-                    elif hasattr(metadata_obj, '__dict__'):
-                        metadata = metadata_obj.__dict__
-                    elif isinstance(metadata_obj, dict):
-                        metadata = metadata_obj
-                    else:
-                        metadata = {}
-                elif isinstance(scrape_result, dict):
-                    # Already a dictionary
-                    content_markdown = scrape_result.get('markdown')
-                    content_html = scrape_result.get('html')
-                    metadata = scrape_result.get('metadata', {})
-                
-                # Ensure metadata is a dict (not an object)
-                if not isinstance(metadata, dict):
-                    if hasattr(metadata, 'model_dump'):
-                        metadata = metadata.model_dump()
-                    elif hasattr(metadata, '__dict__'):
-                        metadata = metadata.__dict__
-                    else:
-                        metadata = {}
-                
-                # Get title from metadata
-                title = metadata.get("title", "")
-                
-                # Choose content based on requested format
-                chosen_content = content_markdown if (format == "markdown" or (format is None and content_markdown)) else content_html or content_markdown or ""
-                
-                results.append({
-                    "url": metadata.get("sourceURL", url),
-                    "title": title,
-                    "content": chosen_content,
-                    "raw_content": chosen_content,
-                    "metadata": metadata  # Now guaranteed to be a dict
-                })
-                
+                _, extracted = _extract_single_url_with_provider(url, format)
+                results.append(extracted)
             except Exception as scrape_err:
                 logger.debug("Scrape failed for %s: %s", url, scrape_err)
                 results.append({
@@ -1125,15 +1376,39 @@ async def web_crawl_tool(
         return json.dumps({"error": error_msg}, ensure_ascii=False)
 
 
-# Convenience function to check if API key is available
+# Convenience function to check if configured providers are available
 def check_firecrawl_api_key() -> bool:
     """
-    Check if the Firecrawl API key is available in environment variables.
+    Backward-compatible Firecrawl availability check.
     
     Returns:
-        bool: True if API key is set, False otherwise
+        bool: True if Firecrawl is configured, False otherwise
     """
-    return bool(os.getenv("FIRECRAWL_API_KEY"))
+    return _is_firecrawl_available()
+
+
+def check_web_search_available() -> bool:
+    """Check whether the configured search provider is usable."""
+    provider = _get_search_provider()
+    if provider == "firecrawl":
+        return _is_firecrawl_available()
+    if provider == "brave":
+        return _is_brave_available()
+    if provider == "searxng":
+        return _is_searxng_available()
+    if provider == "duckduckgo":
+        return _is_duckduckgo_available()
+    return False
+
+
+def check_web_extract_available() -> bool:
+    """Check whether the configured extract provider is usable."""
+    provider = _get_extract_provider()
+    if provider == "firecrawl":
+        return _is_firecrawl_available()
+    if provider == "trafilatura":
+        return _is_trafilatura_available()
+    return False
 
 
 def check_auxiliary_model() -> bool:
@@ -1271,8 +1546,8 @@ registry.register(
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
     handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=5),
-    check_fn=check_firecrawl_api_key,
-    requires_env=["FIRECRAWL_API_KEY"],
+    check_fn=check_web_search_available,
+    requires_env=[],
 )
 registry.register(
     name="web_extract",
@@ -1280,7 +1555,7 @@ registry.register(
     schema=WEB_EXTRACT_SCHEMA,
     handler=lambda args, **kw: web_extract_tool(
         args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
-    check_fn=check_firecrawl_api_key,
-    requires_env=["FIRECRAWL_API_KEY"],
+    check_fn=check_web_extract_available,
+    requires_env=[],
     is_async=True,
 )

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -25,7 +25,7 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `MINIMAX_CN_BASE_URL` | Override MiniMax China base URL (default: `https://api.minimaxi.com/v1`) |
 | `HERMES_MODEL` | Preferred model name (checked before `LLM_MODEL`, used by gateway) |
 | `LLM_MODEL` | Default model name (fallback when not set in config.yaml) |
-| `VOICE_TOOLS_OPENAI_KEY` | OpenAI key for TTS and voice transcription (separate from custom endpoint) |
+| `VOICE_TOOLS_OPENAI_KEY` | OpenAI key for OpenAI STT and OpenAI TTS (separate from custom endpoint) |
 | `HERMES_HOME` | Override Hermes config directory (default: `~/.hermes`) |
 
 ## Provider Auth (OAuth)
@@ -53,6 +53,20 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `TINKER_API_KEY` | RL training ([tinker-console.thinkingmachines.ai](https://tinker-console.thinkingmachines.ai/)) |
 | `WANDB_API_KEY` | RL training metrics ([wandb.ai](https://wandb.ai/)) |
 | `DAYTONA_API_KEY` | Daytona cloud sandboxes ([daytona.io](https://daytona.io/)) |
+
+## Speech-to-Text
+
+These variables are optional overrides for the `stt` section in `~/.hermes/config.yaml`.
+
+| Variable | Description |
+|----------|-------------|
+| `HERMES_STT_ENABLED` | Enable or disable speech-to-text preprocessing (`true`/`false`) |
+| `HERMES_STT_PROVIDER` | STT provider override: `openai` or `whispercpp` |
+| `HERMES_STT_MODEL` | OpenAI transcription model when `provider=openai` |
+| `HERMES_STT_WHISPERCPP_BINARY_PATH` | Path to the local `whisper.cpp` executable |
+| `HERMES_STT_WHISPERCPP_MODEL_PATH` | Path to the local `whisper.cpp` model file |
+| `HERMES_STT_WHISPERCPP_LANGUAGE` | Language override for `whisper.cpp` (`auto` by default) |
+| `HERMES_STT_WHISPERCPP_FFMPEG_PATH` | Path to the `ffmpeg` binary used to normalize input audio |
 
 ## Terminal Backend
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -627,10 +627,21 @@ display:
 
 ```yaml
 stt:
-  provider: "openai"           # STT provider
+  enabled: true
+  provider: "openai"           # openai | whispercpp
+  model: "whisper-1"           # Used when provider=openai
+  whispercpp:
+    binary_path: ""            # Used when provider=whispercpp
+    model_path: ""             # Used when provider=whispercpp
+    language: "auto"
+    ffmpeg_path: "ffmpeg"
 ```
 
-Requires `VOICE_TOOLS_OPENAI_KEY` in `.env` for OpenAI STT.
+Incoming messaging audio is transcribed as a workflow preprocessing step before the message reaches the agent.
+
+- `openai` uses `VOICE_TOOLS_OPENAI_KEY`.
+- `whispercpp` runs locally when you set `stt.provider: "whispercpp"` and configure `stt.whispercpp.binary_path` plus `stt.whispercpp.model_path`.
+- You can keep these settings in `~/.hermes/config.yaml` or override them with the `HERMES_STT_*` environment variables.
 
 ## Human Delay
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -210,7 +210,7 @@ Replace the ID with the actual channel ID (right-click → Copy Channel ID with 
 
 Hermes Agent supports Discord voice messages:
 
-- **Incoming voice messages** are automatically transcribed using Whisper (requires `VOICE_TOOLS_OPENAI_KEY` to be set in your environment).
+- **Incoming voice messages** are automatically transcribed using the shared STT workflow and whichever provider you configure in `stt.provider` (`openai` or `whispercpp`).
 - **Text-to-speech**: When TTS is enabled, the bot can send spoken responses as MP3 file attachments.
 
 ## Troubleshooting

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -221,7 +221,7 @@ Make sure the bot has been **invited to the channel** (`/invite @Hermes Agent`).
 
 Hermes supports voice on Slack:
 
-- **Incoming:** Voice/audio messages are automatically transcribed using Whisper (requires `VOICE_TOOLS_OPENAI_KEY`)
+- **Incoming:** Voice/audio messages are automatically transcribed using the shared STT workflow and whichever provider you configure in `stt.provider` (`openai` or `whispercpp`).
 - **Outgoing:** TTS responses are sent as audio file attachments
 
 ---

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -131,7 +131,7 @@ Group chat IDs are negative numbers (e.g., `-1001234567890`). Your personal DM c
 
 ### Incoming Voice (Speech-to-Text)
 
-Voice messages you send on Telegram are automatically transcribed using OpenAI's Whisper API and injected as text into the conversation. This requires `VOICE_TOOLS_OPENAI_KEY` in `~/.hermes/.env`.
+Voice messages you send on Telegram are automatically transcribed before they reach the agent. Hermes uses the configured STT provider from `~/.hermes/config.yaml`. If `stt.provider` is `whispercpp`, configure `stt.whispercpp.binary_path` and `stt.whispercpp.model_path`; if `stt.provider` is `openai`, set `VOICE_TOOLS_OPENAI_KEY`.
 
 ### Outgoing Voice (Text-to-Speech)
 
@@ -173,7 +173,7 @@ Hermes Agent works in Telegram group chats with a few considerations:
 | Bot not responding at all | Verify `TELEGRAM_BOT_TOKEN` is correct. Check `hermes gateway` logs for errors. |
 | Bot responds with "unauthorized" | Your user ID is not in `TELEGRAM_ALLOWED_USERS`. Double-check with @userinfobot. |
 | Bot ignores group messages | Privacy mode is likely on. Disable it (Step 3) or make the bot a group admin. **Remember to remove and re-add the bot after changing privacy.** |
-| Voice messages not transcribed | Check that `VOICE_TOOLS_OPENAI_KEY` is set and valid in `~/.hermes/.env`. |
+| Voice messages not transcribed | Check `stt.whispercpp.binary_path`, `stt.whispercpp.model_path`, and `ffmpeg` availability. If using OpenAI STT instead, verify `VOICE_TOOLS_OPENAI_KEY`. |
 | Voice replies are files, not bubbles | Install `ffmpeg` (needed for Edge TTS Opus conversion). |
 | Bot token revoked/invalid | Generate a new token via `/revoke` then `/newbot` or `/token` in BotFather. Update your `.env` file. |
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -158,7 +158,7 @@ with reconnection logic.
 
 Hermes supports voice on WhatsApp:
 
-- **Incoming:** Voice messages (`.ogg` opus) are automatically transcribed using Whisper (requires `VOICE_TOOLS_OPENAI_KEY`)
+- **Incoming:** Voice messages (`.ogg` opus) are automatically transcribed using the shared STT workflow and whichever provider you configure in `stt.provider` (`openai` or `whispercpp`).
 - **Outgoing:** TTS responses are sent as MP3 audio file attachments
 - Agent responses are prefixed with "⚕ **Hermes Agent**" for easy identification
 


### PR DESCRIPTION
## Summary

Add a local `whisper.cpp` speech-to-text backend for gateway audio transcription. Incoming voice and audio messages can now be transcribed locally when `stt.provider` is set to `whispercpp`, while the existing OpenAI STT path remains available via `stt.provider: openai`.

## Core Architecture

### `tools/transcription_tools.py`

`transcribe_audio(file_path, model=None)` is now a provider-dispatching STT entry point that:

- validates local audio input
- loads effective STT config from `config.yaml` plus `HERMES_STT_*` env overrides
- selects the backend from `stt.provider`
- routes to either `whispercpp` or `openai`
- returns structured success/error results without tool-style markup

### `whisper.cpp` backend

The local transcription flow includes:

- `ffmpeg` normalization to mono 16 kHz WAV
- execution of the configured local `whisper.cpp` binary
- reading generated transcript output
- cleanup of temporary artifacts
- explicit error reporting for missing binary, missing model, conversion failure, and missing output

## Config Surface

`config.yaml` now supports provider-driven STT:

```yaml
stt:
  enabled: true
  provider: "openai"   # openai | whispercpp
  model: "whisper-1"
  whispercpp:
    binary_path: ""
    model_path: ""
    language: "auto"
    ffmpeg_path: "ffmpeg"
```

Supported env overrides:

- `HERMES_STT_ENABLED`
- `HERMES_STT_PROVIDER`
- `HERMES_STT_MODEL`
- `HERMES_STT_WHISPERCPP_BINARY_PATH`
- `HERMES_STT_WHISPERCPP_MODEL_PATH`
- `HERMES_STT_WHISPERCPP_LANGUAGE`
- `HERMES_STT_WHISPERCPP_FFMPEG_PATH`

## Changes by Area

### Gateway workflow

`gateway/run.py`

- keeps transcription as internal preprocessing, not a model tool
- preserves shared audio handling across messaging platforms
- replaces the verbose injected wrapper with lightweight note formatting

Success format:

```text
// Transcript of the user's audio message:
<transcript>
```

Failure format:

```text
// The user sent an audio message that couldn't get transcribed
```

### CLI config

`hermes_cli/config.py`

- adds `stt.whispercpp.*` config support
- keeps OpenAI as the default provider unless `whispercpp` is explicitly selected
- updates config display to show whisper.cpp fields only when relevant

### Doctor

`hermes_cli/doctor.py`

Adds STT diagnostics for local transcription:

- whisper.cpp binary detection
- model file detection
- ffmpeg detection
- OpenAI key validation when `stt.provider` is `openai`

### Docs and examples

Updated:

- `.env.example`
- `cli-config.yaml.example`
- `website/docs/reference/environment-variables.md`
- `website/docs/user-guide/configuration.md`
- messaging docs for Telegram, Discord, Slack, WhatsApp

Docs now describe STT as provider-driven rather than saying local whisper.cpp is the default.

## Provider Behavior

### `openai`

- remains supported
- uses `VOICE_TOOLS_OPENAI_KEY`
- preserves prior default behavior

### `whispercpp`

- opt-in via `stt.provider: whispercpp`
- uses local binary/model paths from config or env overrides
- runs entirely as gateway preprocessing

## Test Results

Ran the targeted STT/config/gateway/doctor suite and all 44 tests passed.

This includes coverage for:

- local `whisper.cpp` transcription success/failure cases
- gateway transcript/failure note formatting
- STT config merging and config writes
- doctor checks for whisper.cpp binary/model/ffmpeg

Targeted test files:

- `tests/tools/test_transcription_tools.py`
- `tests/gateway/test_run_transcription.py`
- `tests/hermes_cli/test_config.py`
- `tests/hermes_cli/test_set_config_value.py`
- `tests/hermes_cli/test_doctor.py`

## Live Testing

- tested `hermes doctor` detection for:
  - whisper.cpp binary
  - local model path
  - ffmpeg
- verified config-driven STT setup with local whisper.cpp paths
- verified the targeted regression suite passes with both config and doctor updates
