### PR TITLE
fix(test): isolate codex provider tests from local env

### DIFF
--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -170,6 +170,8 @@ def test_codex_provider_replaces_incompatible_default_model(monkeypatch):
 
     monkeypatch.delenv("LLM_MODEL", raising=False)
     monkeypatch.delenv("OPENAI_MODEL", raising=False)
+    # Ensure local user config does not leak a model into the test
+    monkeypatch.setitem(cli.CLI_CONFIG, "model", {})
 
     def _runtime_resolve(**kwargs):
         return {
@@ -224,6 +226,11 @@ def test_codex_provider_uses_config_model(monkeypatch):
 
     monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
     monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    # Prevent live API call from overriding the config model
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.2-codex"],
+    )
 
     shell = cli.HermesCLI(compact=True, max_turns=1)
 

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -171,7 +171,10 @@ def test_codex_provider_replaces_incompatible_default_model(monkeypatch):
     monkeypatch.delenv("LLM_MODEL", raising=False)
     monkeypatch.delenv("OPENAI_MODEL", raising=False)
     # Ensure local user config does not leak a model into the test
-    monkeypatch.setitem(cli.CLI_CONFIG, "model", {})
+    monkeypatch.setitem(cli.CLI_CONFIG, "model", {
+        "default": "",
+        "base_url": "https://openrouter.ai/api/v1",
+    })
 
     def _runtime_resolve(**kwargs):
         return {


### PR DESCRIPTION
## Summary
- Codex provider resolution tests fail locally when real API keys are present (e.g. `OPENAI_API_KEY` in `~/.hermes/.env`)
- `test_codex_provider_uses_config_model`: `get_codex_model_ids()` hits live API which returns `gpt-5.2` (no `-codex` suffix) as first model, breaking `"codex" in shell.model` assertion
- `test_codex_provider_replaces_incompatible_default_model`: local `CLI_CONFIG` leaks user-configured model, making `_model_is_default` false

## Changes
- Mock `get_codex_model_ids` in `test_codex_provider_uses_config_model` to prevent live API call
- Clear `CLI_CONFIG["model"]` in `test_codex_provider_replaces_incompatible_default_model` to isolate from user config

## Test plan
- [x] `pytest tests/test_cli_provider_resolution.py` — 8/8 passed (was 1 failed before fix)
- [x] Full suite: 3437 passed, 0 failed