### PR TITLE
fix(vision): surface actual error reason instead of generic message

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -354,6 +354,7 @@ async def vision_analyze_tool(
         # Prepare error response
         result = {
             "success": False,
+            "error": error_msg,
             "analysis": analysis,
         }
         


### PR DESCRIPTION


## Problem

When `vision_analyze_tool` fails, the response only contained `success: false` and an `analysis` string with the error embedded in prose. The agent had no structured field to inspect the failure reason programmatically.

Fixes #1034

## Change

Add `"error": error_msg` to the failure response dict in `vision_analyze_tool`.

**Before:**
```json
{"success": false, "analysis": "There was a problem... Error: <reason>"}


After:

{"success": false, "error": "Error analyzing image: <reason>", "analysis": "..."}


The agent can now check result["error"] directly instead of parsing prose.
Note: provider fallback and retry are handled upstream by async_call_llm in auxiliary_client.py.
Tests
42 tests passing (test_vision_tools.py)