### PR TITLE
feat: allow custom endpoints to use responses api

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -33,6 +33,24 @@ def _get_model_config() -> Dict[str, Any]:
     return {}
 
 
+def _get_configured_api_mode(model_cfg: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    """Return an optional API mode override from env/config.
+
+    Allows advanced users to force custom OpenAI-compatible endpoints onto the
+    Responses API without hijacking the OpenAI Codex OAuth provider path.
+    """
+    candidate = os.getenv("HERMES_API_MODE", "").strip().lower()
+    if not candidate:
+        cfg = model_cfg if isinstance(model_cfg, dict) else _get_model_config()
+        raw_cfg_mode = cfg.get("api_mode")
+        if isinstance(raw_cfg_mode, str):
+            candidate = raw_cfg_mode.strip().lower()
+
+    if candidate in {"chat_completions", "codex_responses"}:
+        return candidate
+    return None
+
+
 def resolve_requested_provider(requested: Optional[str] = None) -> str:
     """Resolve provider request from explicit arg, config, then env."""
     if requested and requested.strip():
@@ -184,10 +202,11 @@ def _resolve_openrouter_runtime(
         )
 
     source = "explicit" if (explicit_api_key or explicit_base_url) else "env/config"
+    api_mode = _get_configured_api_mode(model_cfg) or "chat_completions"
 
     return {
         "provider": "openrouter",
-        "api_mode": "chat_completions",
+        "api_mode": api_mode,
         "base_url": base_url,
         "api_key": api_key,
         "source": source,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1318,7 +1318,7 @@ class AIAgent:
         error: Optional[Exception] = None,
     ) -> Optional[Path]:
         """
-        Dump a debug-friendly HTTP request record for chat.completions.create().
+        Dump a debug-friendly HTTP request record for the active inference API.
 
         Captures the request body from api_kwargs (excluding transport-only keys
         like timeout). Intended for debugging provider-side 4xx failures where
@@ -1335,13 +1335,14 @@ class AIAgent:
             except Exception as e:
                 logger.debug("Could not extract API key for debug dump: %s", e)
 
+            request_path = "/responses" if self.api_mode == "codex_responses" else "/chat/completions"
             dump_payload: Dict[str, Any] = {
                 "timestamp": datetime.now().isoformat(),
                 "session_id": self.session_id,
                 "reason": reason,
                 "request": {
                     "method": "POST",
-                    "url": f"{self.base_url.rstrip('/')}/chat/completions",
+                    "url": f"{self.base_url.rstrip('/')}{request_path}",
                     "headers": {
                         "Authorization": f"Bearer {self._mask_api_key_for_logs(api_key)}",
                         "Content-Type": "application/json",

--- a/tests/test_run_agent_codex_responses.py
+++ b/tests/test_run_agent_codex_responses.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import types
 from types import SimpleNamespace
@@ -242,6 +243,17 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert "timeout" not in kwargs
     assert "max_tokens" not in kwargs
     assert "extra_body" not in kwargs
+
+
+def test_dump_api_request_debug_uses_responses_url(monkeypatch, tmp_path):
+    agent = _build_agent(monkeypatch)
+    agent.base_url = "http://127.0.0.1:9208/v1"
+    agent.logs_dir = tmp_path
+
+    dump_file = agent._dump_api_request_debug(_codex_request_kwargs(), reason="preflight")
+
+    payload = json.loads(dump_file.read_text())
+    assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/responses"
 
 
 def test_run_codex_stream_retries_when_completed_event_missing(monkeypatch):

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -259,6 +259,46 @@ def test_named_custom_provider_does_not_shadow_builtin_provider(monkeypatch):
     assert resolved["requested_provider"] == "nous"
 
 
+def test_custom_endpoint_can_force_codex_responses_from_config(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "http://127.0.0.1:9208/v1",
+            "api_mode": "codex_responses",
+        },
+    )
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://127.0.0.1:9208/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-local-proxy")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("HERMES_API_MODE", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "http://127.0.0.1:9208/v1"
+    assert resolved["api_key"] == "sk-local-proxy"
+
+
+def test_env_can_override_custom_endpoint_api_mode(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://127.0.0.1:9208/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-local-proxy")
+    monkeypatch.setenv("HERMES_API_MODE", "codex_responses")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "http://127.0.0.1:9208/v1"
+
+
 def test_explicit_openrouter_skips_openai_base_url(monkeypatch):
     """When the user explicitly requests openrouter, OPENAI_BASE_URL
     (which may point to a custom endpoint) must not override the


### PR DESCRIPTION
## Summary
- allow custom OpenAI-compatible endpoints to opt into `codex_responses` via config or `HERMES_API_MODE`
- keep provider resolution and API key behavior unchanged while exposing `/v1/responses` for custom endpoints
- fix request debug dumps to show `/responses` when the active API mode is `codex_responses`
- add coverage for runtime provider api-mode overrides and responses-mode debug dump URLs

## Validation
- `/Users/langhuam/workspace/self/hermes-agent/venv/bin/pytest tests/test_runtime_provider_resolution.py tests/test_run_agent_codex_responses.py -q`
- `HERMES_DUMP_REQUESTS=1 HERMES_DUMP_REQUEST_STDOUT=1 hermes chat -Q -q "Reply with exactly OK."`
- verified runtime request dump uses `http://127.0.0.1:9208/v1/responses` with a custom endpoint configured in `~/.hermes/config.yaml`
