### PR TITLE
feat: phase 3 self-correction + handoff docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,34 @@ Hermes-Agent ensures caching remains valid throughout a conversation. **Do NOT i
 
 Cache-breaking forces dramatically higher costs. The ONLY time we alter context is during context compression.
 
+### Memory Governance (Anti-Bloat Defaults)
+When implementing or modifying memory behavior, follow these defaults to avoid drift and memory bloat:
+
+- **Source of truth split**
+  - Operational project/task state lives in workspace notes (e.g., Obsidian), not long-term profile memory.
+  - Hermes/Honcho long-term memory should store durable user preferences, stable behavior patterns, and high-value context only.
+  - Session/chat history is transient working memory.
+
+- **Write gate (default NOOP)** — only persist if all are true:
+  1. Durable beyond this session
+  2. Actionable for future responses/decisions
+  3. Explicitly user-confirmed or strongly validated
+
+- **Prefer UPDATE/DELETE over append-only ADD**
+  - Reconcile conflicting facts.
+  - Replace stale preferences.
+  - Prune low-value or obsolete entries.
+
+- **Conflict precedence**
+  1. Latest explicit user statement
+  2. Operational workspace state for project status
+  3. Long-term memory stores
+
+- **Consolidation cadence**
+  - Collect candidate memories during session.
+  - Consolidate/dedupe in background or end-of-session.
+  - Do periodic pruning to keep stores small and accurate.
+
 ### Working Directory Behavior
 - **CLI**: Uses current directory (`.` → `os.getcwd()`)
 - **Messaging**: Uses `MESSAGING_CWD` env var (default: home directory)
@@ -321,8 +349,8 @@ Rendering bugs in tmux/iTerm2 — ghosting on scroll. Use `curses` (stdlib) inst
 ### DO NOT use `\033[K` (ANSI erase-to-EOL) in spinner/display code
 Leaks as literal `?[K` text under `prompt_toolkit`'s `patch_stdout`. Use space-padding: `f"\r{line}{' ' * pad}"`.
 
-### `_last_resolved_tool_names` is a process-global in `model_tools.py`
-When subagents overwrite this global, `execute_code` calls after delegation may fail with missing tool imports. Known bug.
+### `execute_code` tool availability must remain session-scoped
+Pass `enabled_tools` explicitly from the caller context. Do not reintroduce process-global caches for resolved tool names in `model_tools.py`, or subagent/delegation paths can cross-contaminate.
 
 ### Tests must not write to `~/.hermes/`
 The `_isolate_hermes_home` autouse fixture in `tests/conftest.py` redirects `HERMES_HOME` to a temp dir. Never hardcode `~/.hermes/` paths in tests.

--- a/PHASE3_HANDOFF_NEXT_AGENT.md
+++ b/PHASE3_HANDOFF_NEXT_AGENT.md
@@ -1,0 +1,91 @@
+# Phase 3 Handoff (Clean Path for Next Agent)
+
+Last updated: 2026-03-12
+
+## 1) What is already done
+
+Phase 2 must-do cleanup + Phase 3 core implementation are landed in working tree:
+
+- Session-scoped tool resolution fix (global cache removed)
+  - `model_tools.py`
+- MCP coroutine cleanup fix (no unawaited coroutine leaks)
+  - `tools/mcp_tool.py`
+- Self-correction module and live-retry policy
+  - `agent/self_correction.py`
+  - `run_agent.py`
+- Regression tests for above
+  - `tests/test_model_tools.py`
+  - `tests/tools/test_mcp_tool.py`
+  - `tests/agent/test_self_correction.py`
+  - `tests/test_run_agent.py`
+
+Feature flags/policy now in `run_agent.py`:
+- `HERMES_SELF_CORRECTION_MODE=off|shadow|live` (default `shadow`)
+- `HERMES_SELF_CORRECTION_CONFIDENCE` (default `0.72`)
+- `HERMES_SELF_CORRECTION_MAX_RETRIES` (default `2`)
+- `HERMES_SELF_CORRECTION_SESSION_BUDGET` (default `20`)
+
+## 2) Validation baseline
+
+Recent full-suite result from current branch state:
+- 2926 passed, 5 skipped, 23 deselected
+
+Important local constraint:
+- On this machine, full suite can hit EMFILE with low fd limits.
+- Use: `ulimit -n 1024` before full test runs.
+
+## 3) Current repository state (for awareness)
+
+There are many modified/untracked files in the tree (not branch-clean yet), including:
+- Core files touched by this work: `run_agent.py`, `model_tools.py`, `tools/mcp_tool.py`, tests
+- Additional in-progress artifacts: `evals/`, `tools/safety_taxonomy.py`, gateway/tool-event test files, temp probe scripts (`tmp_honcho_*`), etc.
+
+Do not assume all diffs are Phase 3-specific. Filter by file list in section 1.
+
+## 4) Clean next objective (recommended)
+
+Complete Phase 3 handoff evidence artifact so Phase 4 can start from measured baseline.
+
+Target deliverable:
+- `Retry Outcome Report v1` generated from current event data and/or deterministic eval runs
+- Must include:
+  1. first-attempt vs post-retry success delta
+  2. retry cost/latency overhead
+  3. failure-signature recurrence summary
+  4. high-risk retry-policy compliance evidence (should be 100% blocked without re-approval)
+
+## 5) Suggested execution sequence for next agent
+
+1. Preflight
+   - `source .venv/bin/activate`
+   - `ulimit -n 1024`
+2. Verify Phase 3 core tests
+   - `python -m pytest tests/agent/test_self_correction.py -q`
+   - `python -m pytest tests/test_run_agent.py -q`
+   - `python -m pytest tests/test_model_tools.py tests/tools/test_mcp_tool.py -q`
+3. Implement/report path
+   - Add report generator (new module under `evals/` or extend `evals/harness.py`)
+   - Consume self_correction events (`shadow_critique`, `live_retry_attempt`, `live_retry_skipped`)
+   - Emit JSON artifact in `evals/reports/`
+4. Add tests for report correctness and schema stability
+5. Run targeted + full suite
+6. Prepare commit split:
+   - commit A: report generator + tests
+   - commit B: docs/handoff updates
+
+## 6) Guardrails to preserve
+
+- Prompt-caching invariants must remain intact.
+- No process-global tool-resolution cache reintroduction.
+- High-risk/side-effect tools must not auto-retry.
+- Keep `execute_code` session-scoped tool availability behavior.
+- Do not write tests that touch real `~/.hermes/`.
+
+## 7) Ready-to-paste kickoff prompt for next agent
+
+"Continue from `PHASE3_HANDOFF_NEXT_AGENT.md`. Treat Phase 3 core as implemented. Your goal is to deliver Retry Outcome Report v1 and get to a commit-ready checkpoint for Phase 4. Preserve prompt-cache invariants, keep retries bounded/flagged, and add tests proving report accuracy and high-risk retry compliance. Use `.venv`, set `ulimit -n 1024` before full-suite runs, and finish with explicit pass/fail against Phase 3 exit criteria."
+
+## 8) Companion docs added for clean relay
+
+- `START_HERE_NEXT_SESSION.md` — one-screen command block + kickoff text
+- `SESSION_CLOSE_CHECKLIST.md` — minimal closeout routine for reliable handoffs

--- a/SESSION_CLOSE_CHECKLIST.md
+++ b/SESSION_CLOSE_CHECKLIST.md
@@ -1,0 +1,51 @@
+# Session Close Checklist (Hermes Evolution Work)
+
+Purpose: leave a clean, low-friction handoff for the next session.
+
+## 1) Stabilize environment state
+
+1. Ensure venv is active for any final test command:
+   - `source .venv/bin/activate`
+2. If running broader tests, set file descriptor limit:
+   - `ulimit -n 1024`
+
+## 2) Validate current checkpoint
+
+Run at least targeted checks for touched areas:
+- `python -m pytest tests/agent/test_self_correction.py -q`
+- `python -m pytest tests/test_run_agent.py -q`
+- `python -m pytest tests/test_model_tools.py tests/tools/test_mcp_tool.py -q`
+
+If full-suite confidence is needed:
+- `python -m pytest tests/ -q`
+
+## 3) Preserve handoff clarity
+
+1. Confirm `PHASE3_HANDOFF_NEXT_AGENT.md` reflects:
+   - what is done
+   - what remains
+   - exact next deliverable
+2. Keep scope boundaries explicit (do not mix unrelated diffs into handoff notes).
+
+## 4) Record tree state
+
+Capture and review:
+- `git status --short`
+
+If there are many unrelated changes, note this explicitly in handoff docs and isolate the file list that matters for the next objective.
+
+## 5) Commit boundary readiness (if committing)
+
+Preferred split:
+- Commit A: feature/report code + tests
+- Commit B: docs/handoff updates
+
+If not committing yet, keep docs updated so next agent can proceed without reconstruction.
+
+## 6) Next-session launch pointer
+
+Use:
+- `START_HERE_NEXT_SESSION.md`
+
+And kickoff prompt:
+- "Continue from PHASE3_HANDOFF_NEXT_AGENT.md and execute it exactly."

--- a/START_HERE_NEXT_SESSION.md
+++ b/START_HERE_NEXT_SESSION.md
@@ -1,0 +1,31 @@
+# Start Here (Next Session Quickstart)
+
+Run from repo root.
+
+## Commands
+
+```bash
+source .venv/bin/activate
+ulimit -n 1024
+python -m pytest tests/agent/test_self_correction.py -q
+python -m pytest tests/test_run_agent.py -q
+python -m pytest tests/test_model_tools.py tests/tools/test_mcp_tool.py -q
+```
+
+Optional full-suite confidence pass:
+
+```bash
+python -m pytest tests/ -q
+```
+
+## Primary handoff doc
+
+- `PHASE3_HANDOFF_NEXT_AGENT.md`
+
+## Session close checklist
+
+- `SESSION_CLOSE_CHECKLIST.md`
+
+## Ready-to-paste kickoff prompt
+
+Continue from `PHASE3_HANDOFF_NEXT_AGENT.md`. Treat Phase 3 core as implemented. Your goal is to deliver Retry Outcome Report v1 and get to a commit-ready checkpoint for Phase 4. Preserve prompt-cache invariants, keep retries bounded/flagged, and add tests proving report accuracy and high-risk retry compliance. Use `.venv`, set `ulimit -n 1024` before full-suite runs, and finish with explicit pass/fail against Phase 3 exit criteria.

--- a/SUPER_AGENT_EVOLUTION_PLAN.diff
+++ b/SUPER_AGENT_EVOLUTION_PLAN.diff
@@ -1,0 +1,785 @@
+diff --git a/SUPER_AGENT_EVOLUTION_PLAN.md b/SUPER_AGENT_EVOLUTION_PLAN_REVIEWED.md
+index fed4589..a8391bf 100644
+--- a/SUPER_AGENT_EVOLUTION_PLAN.md
++++ b/SUPER_AGENT_EVOLUTION_PLAN_REVIEWED.md
+@@ -1,10 +1,16 @@
+-# Hermes Super-Agent Evolution Plan
++# Hermes Super-Agent Evolution Plan (Reviewed)
+ 
+ ## Purpose
+ 
+-This document defines a practical, phase-based roadmap for evolving Hermes from a capable assistant into an elite, reliable, self-improving agent system.
++This reviewed version keeps the original seven-phase roadmap intact while making it more implementation-oriented for the current Hermes codebase.
+ 
+-Planning constraints followed:
++Review goals:
++- Preserve the original intent, ordering, and north-star outcomes
++- Translate each phase into concrete changes against current Hermes modules
++- Add measurable exit criteria with metric definitions and sample sizes
++- Add explicit phase gates, no-go triggers, and updated risk controls
++
++Planning constraints preserved:
+ - No week-based planning
+ - Milestone and exit-criteria driven
+ - Emphasis on reliability, memory quality, eval rigor, and safe autonomy
+@@ -23,6 +29,47 @@ Build an agent that is:
+ 
+ ---
+ 
++## Current-Architecture Constraints To Preserve
++
++These are not optional. The reviewed plan assumes all implementation work respects them.
++
++- `run_agent.py` remains the single source of truth for the synchronous conversation loop and tool-call execution order.
++- Prompt-caching invariants must hold: the assembled system prompt stays stable within a session and is rebuilt only on compression boundaries governed by `agent/prompt_caching.py` and `run_agent.py`.
++- Agent-loop tools intercepted in `run_agent.py` (`todo`, `memory`, `session_search`, `delegate_task`) must not be silently rerouted through generic dispatch.
++- Delegated children in `tools/delegate_tool.py` must keep isolated context, bounded depth, and restricted tool access.
++- Persistent memory changes must not mutate the in-session prompt snapshot in `tools/memory_tool.py`.
++- Tests must continue to honor the isolated `HERMES_HOME` behavior in `tests/conftest.py`.
++
++---
++
++## Shared Instrumentation Required Before Any Phase Can Exit
++
++This is not a new phase. It is a cross-phase prerequisite for evidence-based gating.
++
++### Minimum instrumentation substrate
++
++Implement a small, durable event layer before declaring any phase complete. The simplest acceptable path is extending `hermes_state.py` with append-only event tables or writing versioned JSONL artifacts beside existing trajectories.
++
++Required event families:
++
++| Event family | Minimum fields | Primary code surfaces |
++|---|---|---|
++| Tool execution | `tool_name`, `toolset`, `success`, `error_type`, `retryable`, `latency_ms`, `session_id`, `task_id` | `run_agent.py`, `model_tools.py`, `tools/registry.py` |
++| Context/compression | `tokens_before`, `tokens_after`, `reason`, `summary_model`, `sanitizer_repairs` | `agent/context_compressor.py`, `run_agent.py` |
++| Memory | `candidate`, `target`, `write_decision`, `confidence`, `reconciliation_action`, `source` | `tools/memory_tool.py`, `run_agent.py` |
++| Delegation/routing | `route_selected`, `route_shadow`, `child_count`, `budget_used`, `model_selected` | `tools/delegate_tool.py`, `run_agent.py` |
++| Safety/audit | `risk_class`, `approval_required`, `approval_result`, `side_effect_type`, `rollback_artifact` | `tools/approval.py`, `tools/terminal_tool.py`, `tools/mcp_tool.py` |
++| Eval runs | `suite`, `task_id`, `commit`, `score`, `cost`, `duration`, `baseline_ref` | new `evals/` package or `batch_runner.py` extension |
++
++### Shared rules
++
++- No phase can claim success from anecdotal CLI usage alone.
++- All exit criteria below must be computed from versioned artifacts, not ad hoc notes.
++- Every phase needs a baseline snapshot before implementation starts.
++- Shadow-mode logging is preferred before behavior-changing rollouts.
++
++---
++
+ ## Operating Principles
+ 
+ ### 1) Stability before sophistication
+@@ -48,35 +95,52 @@ Any destructive, sensitive, or irreversible action requires explicit approval.
+ Harden core execution loops so Hermes is dependable under sustained use.
+ 
+ ### Why this phase matters
+-Most agent failures come from tool orchestration drift, weak error contracts, or context contamination—not lack of model capability.
+-
+-### Workstreams
+-
+-#### A. Tool contract hardening
+-- Standardize tool schema clarity (inputs, outputs, error shapes)
+-- Ensure handlers return actionable, structured errors
+-- Add explicit retryability signals (transient vs terminal failures)
+-
+-#### B. Prompt and context hygiene
+-- Keep system prefix stable and minimal
+-- Reduce duplicate tool output in conversation state
+-- Improve context compaction triggers and summaries
+-
+-#### C. Firecrawl reliability profile
+-- Define extraction presets (fast, balanced, deep)
+-- Add retry/backoff rules per endpoint type
+-- Standardize extraction post-processing for downstream use
++Most agent failures still come from tool orchestration drift, weak error contracts, or context contamination rather than raw model capability.
++
++### Primary implementation surfaces
++
++- `tools/registry.py`
++- `model_tools.py`
++- `run_agent.py`
++- `agent/prompt_builder.py`
++- `agent/prompt_caching.py`
++- `agent/context_compressor.py`
++- `tools/web_tools.py`
++- `tests/test_model_tools.py`
++- `tests/test_413_compression.py`
++- `tests/tools/`
++
++### Implementation tracks
++
++- Add a canonical tool result envelope in `tools/registry.py` for all tool handlers: `success`, `error`, `error_type`, `retryable`, `data`, `metrics`.
++- Add strict post-dispatch validation at the registry boundary so malformed tool outputs fail in tests instead of surfacing as ambiguous runtime strings.
++- Normalize pre-dispatch and post-dispatch error handling in `model_tools.py` and `run_agent.py::_execute_tool_calls()`.
++- Record tool latency, retryability, and error-class metrics at the agent-loop boundary rather than inside each tool ad hoc.
++- Tighten context hygiene in `agent/context_compressor.py`: dedupe repeated tool content, cap oversized tool results before reinjection, and count sanitizer repairs explicitly.
++- Convert Firecrawl reliability work in `tools/web_tools.py` into named presets with clear retry/backoff matrices and normalized extraction metadata.
+ 
+ ### Deliverables
++
+ - Tool Contract Spec v1
++- Canonical Tool Result Helper v1
+ - Context Hygiene Ruleset v1
+ - Firecrawl Preset Profiles v1
+-- Stability Regression Tests v1
++- Stability Regression Suite v1
+ 
+-### Exit criteria
+-- Core tool-call success rate >= 95%
+-- Context overflow/compression incidents reduced by >= 50%
+-- Firecrawl extraction retry rate < 10% on representative workloads
++### Measurable exit criteria
++
++- Tool-call success rate is at least `95%` across a representative suite of at least `300` core tool calls, excluding explicit user denials and unavailable toolsets.
++- At least `100%` of registered tools return the canonical result envelope in contract tests.
++- Context hard-failure incidents are reduced by at least `50%` from baseline across at least `50` long-running sessions.
++- Orphaned tool-call repair events are at or below `1%` of compression events.
++- Firecrawl requests requiring at least one retry are below `10%`, and terminal failures are below `3%`, on a fixed extraction corpus.
++
++### Phase gate
++
++- Baseline report exists with pre-change metrics for tool success, compression failures, and Firecrawl retries.
++- Contract tests cover every registered tool discovered by `model_tools._discover_tools()`.
++- Long-session regression suite passes with no prompt-cache invariant violations.
++- Go only if the canonical tool envelope is fully adopted; no-go if envelope adoption is partial or if compression failures rise versus baseline.
+ 
+ ---
+ 
+@@ -86,40 +150,55 @@ Most agent failures come from tool orchestration drift, weak error contracts, or
+ Transform memory from passive storage into operational leverage.
+ 
+ ### Why this phase matters
+-Compounding performance requires strong retrieval, contradiction handling, and high-signal persistence.
++Compounding performance requires strong retrieval, contradiction handling, and high-signal persistence, not just more stored text.
++
++### Primary implementation surfaces
++
++- `tools/memory_tool.py`
++- `tools/honcho_tools.py`
++- `tools/session_search_tool.py`
++- `run_agent.py` memory and Honcho integration paths
++- `hermes_state.py`
++- `agent/prompt_builder.py`
++- `agent/skill_commands.py`
++- `tests/tools/test_memory_tool.py`
++- new memory reconciliation tests
++
++### Implementation tracks
++
++- Formalize the current memory tiers instead of inventing new ones from scratch:
++  - Working memory: active messages, todo state, and task-local execution context in `run_agent.py`
++  - Episodic memory: session outcomes and searchable history in `hermes_state.py`
++  - Procedural memory: curated `MEMORY.md`, `USER.md`, Honcho-backed durable user context, and reusable skills
++- Add a write-gate scorer before persistence with explicit reasons for accept, reject, or defer.
++- Implement contradiction detection and reconciliation as a first-class operation instead of append-only growth.
++- Add one retrieval arbitration policy spanning curated memory, Honcho user modeling, and session search so the agent has a single precedence model.
++- Preserve prompt caching by routing mid-session retrieval updates through tool outputs or explicit session messages, never silent prompt mutation.
++- Add a skill-synthesis proposal flow that generates draft skills or runbooks for review instead of auto-promoting into `~/.hermes/skills/`.
++- Add pruning and consolidation routines with metrics for stale-entry removal, merge decisions, and contradiction cleanup.
+ 
+-### Workstreams
+-
+-#### A. Memory tiering architecture
+-- Working memory: per-task temporary state
+-- Episodic memory: session outcomes, failures, resolutions
+-- Procedural memory: reusable skills and runbooks
++### Deliverables
+ 
+-#### B. Write-gate policy
+-Persist only if all are true:
+-1. Durable beyond current session
+-2. Actionable for future responses
+-3. Explicitly confirmed or strongly validated
++- Memory Governance Spec v1
++- Retrieval and Reconciliation Engine v1
++- Memory Event Log Schema v1
++- Skill Synthesis Proposal Workflow v1
++- Memory Pruning and Consolidation Routine v1
+ 
+-#### C. Retrieval policy and conflict resolution
+-- Retrieve by intent + recency + relevance
+-- Detect and reconcile contradictory memories
+-- Prefer latest explicit user statements over stale entries
++### Measurable exit criteria
+ 
+-#### D. Skill synthesis loop
+-- Detect repeated workflows and failure-recovery patterns
+-- Auto-propose skill updates from successful multi-step tasks
++- On a repeated-task corpus of at least `30` paired tasks across at least `10` task types, median time-to-success improves by at least `30%`.
++- Explicit user correction rate on repeated task types decreases by at least `25%` from baseline.
++- Memory write precision is at least `90%` on an audited sample of at least `100` candidate writes.
++- Contradiction resolution accuracy is at least `90%` on a seeded reconciliation set of at least `50` conflict cases.
++- Procedural memory or skill reuse appears in at least `40%` of eligible repeated workflows without increasing prompt-cache invalidation incidents above zero.
+ 
+-### Deliverables
+-- Memory Governance Spec v1
+-- Retrieval/Reconciliation Engine v1
+-- Skill Synthesis Workflow v1
+-- Memory Pruning/Consolidation Routine v1
++### Phase gate
+ 
+-### Exit criteria
+-- Repeat-task completion time improves >= 30%
+-- User correction frequency decreases across repeated task types
+-- Skill reuse rate increases over successive sessions
++- Reconciliation tests cover duplicate, contradictory, stale, and ambiguous entries.
++- A before-and-after audit exists for memory growth, pruning rate, and correction rate.
++- Prompt-cache stability is explicitly verified across sessions with memory writes.
++- Go only if memory helps repeated tasks without increasing drift or mid-session prompt mutation; no-go if write precision or conflict resolution miss the thresholds above.
+ 
+ ---
+ 
+@@ -129,36 +208,47 @@ Persist only if all are true:
+ Enable Hermes to improve output quality within a session without retraining.
+ 
+ ### Why this phase matters
+-Iterative critique/revision can substantially improve task outcomes with minimal infrastructure overhead.
++Iterative critique and revision can improve outcomes materially, but only if retries are classified, bounded, and measured.
+ 
+-### Workstreams
++### Primary implementation surfaces
+ 
+-#### A. Attempt-Critique-Retry pipeline
+-- First attempt
+-- Structured self-critique pass
+-- Revised attempt with explicit fixes
++- `run_agent.py`
++- `agent/trajectory.py`
++- new `agent/self_correction.py` or equivalent helper module
++- `tests/test_run_agent.py`
++- new retry and critique tests
+ 
+-#### B. Failure signature logging
+-Capture:
+-- Failure class (reasoning, tool misuse, missing context, schema mismatch)
+-- Root cause hypothesis
+-- Effective correction strategy
++### Implementation tracks
+ 
+-#### C. Retry budgeting by risk class
+-- Low-risk tasks: up to 2-3 autonomous retries
+-- Medium-risk tasks: bounded retries + confidence threshold
+-- High-risk tasks: pause for approval before further action
++- Add a structured failure taxonomy covering reasoning failure, tool misuse, missing context, schema mismatch, provider failure, and unsafe-action block.
++- Start in shadow mode: record critique recommendations and likely retry actions without changing live responses.
++- Promote to bounded live retries only for low-risk and medium-risk classes with explicit budgets and confidence thresholds.
++- Log failure signatures and effective correction patterns into trajectories or dedicated event records.
++- Add tool-specific retry policies so transient provider/network failures are handled differently from logical errors.
++- Ensure high-risk or side-effecting actions never enter autonomous retry without renewed approval.
+ 
+ ### Deliverables
++
+ - Self-Correction Loop v1
+ - Failure Taxonomy v1
+ - Retry Budgeting Policy v1
+ - Critique Prompt Pack v1
++- Retry Outcome Report v1
++
++### Measurable exit criteria
+ 
+-### Exit criteria
+-- Final success within retry budget >= 90% on target workflows
+-- Reduction in repeated failure signatures over time
+-- Hallucination-induced tool misuse rate decreases continuously
++- On a target workflow set of at least `50` tasks, bounded retry increases final success rate by at least `10` percentage points versus first-attempt-only baseline.
++- Cost-per-success increases by no more than `20%` while achieving the success gain above.
++- Repeated failure-signature recurrence declines by at least `30%` across the same workflow set.
++- Hallucination-induced tool misuse is below `2%` of tool calls in the evaluated set.
++- High-risk tasks show `100%` compliance with approval-before-retry policy.
++
++### Phase gate
++
++- Shadow-mode report shows the critique signal is useful before live retries are enabled.
++- Retry policies are covered by tests for low-risk, medium-risk, and high-risk paths.
++- Live rollout stays behind a feature flag until the success-lift and cost ceilings are met.
++- Go only if retries improve success without materially increasing unsafe behavior or runaway cost; no-go if cost or tool misuse exceeds thresholds.
+ 
+ ---
+ 
+@@ -168,39 +258,51 @@ Capture:
+ Establish rigorous, repeatable measurements for agent capability growth.
+ 
+ ### Why this phase matters
+-Without eval discipline, improvements are anecdotal and regressions go unnoticed.
+-
+-### Workstreams
++Without eval discipline, improvements are anecdotal, regressions hide in noise, and later phases become ungovernable.
+ 
+-#### A. Multi-lane benchmark design
+-- Coding lane: SWE-bench style repo issue tasks
+-- Terminal lane: Terminal-Bench style command-line tasks
+-- Agent lane: GAIA-style multi-step tool reasoning tasks
++### Primary implementation surfaces
+ 
+-#### B. Grading architecture
+-- Deterministic checks (tests, exact outputs)
+-- Model-based rubric grading for qualitative outputs
+-- Human spot-checks for critical edge cases
++- `batch_runner.py`
++- `environments/hermes_base_env.py`
++- `environments/agent_loop.py`
++- `agent/trajectory.py`
++- `hermes_state.py`
++- `hermes_cli/main.py` or a dedicated eval CLI entrypoint
++- `tests/test_provider_parity.py`
++- new `evals/` package for tasks, graders, suites, and reports
+ 
+-#### C. Reliability metrics
+-- pass@k for exploration capability
+-- pass^k for repeated reliability
+-- Cost-per-success and time-to-success metrics
++### Implementation tracks
+ 
+-#### D. Regression controls
+-- Mandatory pre/post eval run for major changes
+-- Regression threshold alerts and rollback triggers
++- Define a versioned eval format for tasks, setup, expected outputs, graders, and cost/time budgets.
++- Use `batch_runner.py` for lightweight dataset sweeps and the existing `environments/` framework for scored agent-loop evaluations instead of building two parallel systems.
++- Build three lanes from the original plan: coding, terminal, and agentic multi-step tasks.
++- Prefer deterministic graders first; use model-based grading only for outputs that cannot be checked mechanically.
++- Create dev, regression, and holdout splits to reduce benchmark overfitting.
++- Persist eval artifacts per run: config, commit SHA, raw outputs, scores, latency, token usage, and failure signatures.
++- Add smoke-suite and full-suite entrypoints so local development can stay fast while release gates stay meaningful.
+ 
+ ### Deliverables
++
+ - Hermes Eval Harness v1
+ - Benchmark Task Suite v1
++- Grader Library v1
+ - Metrics Dashboard Spec v1
+ - Regression Policy v1
+ 
+-### Exit criteria
+-- Stable baseline established for each lane
+-- Automatic regression detection active
+-- Major merges gated by measured eval impact
++### Measurable exit criteria
++
++- Each eval lane has at least `25` versioned tasks with at least one locked holdout split.
++- At least `70%` of tasks across the full suite use deterministic grading.
++- Smoke suite completes unattended in under `30` minutes; full suite completes unattended in a documented, repeatable path.
++- Flake rate is below `5%` across two consecutive suite runs on the same commit.
++- Every major merge touching `run_agent.py`, `model_tools.py`, `tools/`, or `agent/` attaches a pre/post eval diff before promotion.
++
++### Phase gate
++
++- Baseline scorecards exist for all three lanes and are checked into versioned artifacts.
++- Holdout tasks are separated from day-to-day tuning tasks.
++- Regression thresholds are defined before the suite is used as a gate.
++- Go only when the eval harness is trusted enough to reject regressions; no-go if flakiness or grading ambiguity obscures signal.
+ 
+ ---
+ 
+@@ -210,39 +312,52 @@ Without eval discipline, improvements are anecdotal and regressions go unnoticed
+ Increase throughput and quality by decomposition, specialization, and model/tool routing.
+ 
+ ### Why this phase matters
+-Complex tasks benefit from manager-worker structures and specialized execution paths.
+-
+-### Workstreams
+-
+-#### A. Manager-worker orchestration
+-- Lead agent performs planning and task decomposition
+-- Subagents execute isolated workstreams
+-- Summarized outputs only return to main context
+-
+-#### B. Dynamic model routing
+-- Route low-risk routine tasks to low-cost models
+-- Route high-complexity reasoning to stronger models
+-- Use confidence + task class to choose execution path
+-
+-#### C. Tool routing heuristics
+-- Select direct tools for deterministic operations
+-- Escalate to browser/delegation only when necessary
+-- Minimize expensive tool calls via pre-check logic
+-
+-#### D. MCP capability expansion
+-- Add high-value external capabilities through controlled MCP integrations
+-- Define strict auth and permission boundaries
++Complex tasks benefit from manager-worker structures and specialized execution paths, but only when routing is auditable and state isolation is real.
++
++### Primary implementation surfaces
++
++- `tools/delegate_tool.py`
++- `cli.py`
++- `run_agent.py`
++- `model_tools.py`
++- `toolsets.py`
++- `agent/model_metadata.py`
++- `tools/mcp_tool.py`
++- `tools/mixture_of_agents_tool.py`
++- routing and delegation stress tests
++
++### Implementation tracks
++
++- Fix known shared-state hazards before scaling delegation, especially the process-global `_last_resolved_tool_names` path noted in `model_tools.py`.
++- Add explicit delegation budgets: child count, iteration budget share, latency ceiling, and return-summary size budget.
++- Introduce routing in shadow mode first: log recommended model/tool path before allowing policy-driven execution.
++- Add one central routing policy layer above the current CLI, agent-loop, delegation, and multi-model entry points so behavior stays explainable.
++- Classify tasks by complexity, risk, and determinism so routing is explainable rather than heuristic sprawl.
++- Keep parent context clean by enforcing summary-only child returns and size caps for delegated outputs.
++- Expand MCP integrations behind a checklist covering auth scope, side-effect classification, and audit support before tool exposure.
+ 
+ ### Deliverables
++
+ - Orchestration Topology v1
+ - Routing Policy Engine v1
+-- Cost/Latency Decision Table v1
++- Cost and Latency Decision Table v1
++- Delegation Budget Policy v1
+ - MCP Integration Checklist v1
+ 
+-### Exit criteria
+-- Throughput (completed tasks/session) improves >= 40%
+-- Cost per successful task declines while quality is maintained or improved
+-- No meaningful increase in context pollution or orchestration failures
++### Measurable exit criteria
++
++- On a complex-task corpus of at least `40` tasks, throughput improves by at least `40%` or median time-to-success improves by at least `25%`, while quality is non-inferior on eval scores.
++- Cost per successful task declines by at least `15%` relative to the non-routed baseline.
++- Delegated-task summaries keep parent-context growth within `10%` of the non-delegated baseline for comparable tasks.
++- Orchestration or routing failures do not increase above baseline error rates from Phase 1.
++- Cross-session or cross-agent toolset leakage incidents are reduced to zero in stress tests.
++
++### Phase gate
++
++- Shadow-mode routing report shows policy quality before live routing is enabled.
++- Delegation stress tests cover concurrency, interrupts, failures, and budget exhaustion.
++- The `_last_resolved_tool_names` global-state risk is retired or fully contained before enabling broader delegation.
++- Go only if routing improves cost or throughput without hurting reliability; no-go if orchestration failures or context pollution rise.
+ 
+ ---
+ 
+@@ -252,39 +367,52 @@ Complex tasks benefit from manager-worker structures and specialized execution p
+ Ensure capability growth remains aligned with user trust and operational safety.
+ 
+ ### Why this phase matters
+-Powerful autonomous behavior requires explicit guardrails and transparent audit trails.
+-
+-### Workstreams
++More autonomy without stronger approvals, provenance, and rollback support creates compounding operational risk.
++
++### Primary implementation surfaces
++
++- `tools/approval.py`
++- `tools/terminal_tool.py`
++- `tools/file_operations.py`
++- `tools/skills_guard.py`
++- `tools/mcp_tool.py`
++- `tools/memory_tool.py`
++- `tools/checkpoint_manager.py`
++- `agent/redact.py`
++- `hermes_state.py`
++- safety and adversarial test suites
++
++### Implementation tracks
++
++- Convert safety policy into an explicit action taxonomy: read-only, reversible side effect, irreversible side effect, sensitive data access, and policy-sensitive content.
++- Expand approval gating beyond shell danger patterns so MCP actions, browser actions, file mutations, and external side effects share one risk model.
++- Add provenance tagging for high-impact outputs: which tool ran, what was changed, what approval existed, and how to undo it.
++- Add secret and PII detection checks before memory persistence, external transmission, and artifact logging.
++- Store audit records in a queryable form rather than only console output.
++- Require rollback artifacts for automated file edits, external writes, or stateful integrations whenever rollback is possible.
+ 
+-#### A. Constitutional policy layer
+-- Define immutable constraints for unsafe categories
+-- Encode refusal and escalation behavior for policy-sensitive requests
++### Deliverables
+ 
+-#### B. High-risk action gating
+-Require explicit confirmation for:
+-- Destructive file/system operations
+-- Sensitive data handling
+-- External side effects with irreversible impact
++- Safety Policy Spec v1
++- Unified High-Risk Approval Gate v1
++- Data Governance Controls v1
++- Audit Trail Schema v1
++- Rollback Playbook v1
+ 
+-#### C. Data governance
+-- Source labeling and provenance tracking
+-- Secret/PII detection and redaction checks
+-- Memory boundary controls to prevent inappropriate persistence
++### Measurable exit criteria
+ 
+-#### D. Audit and rollback
+-- Log rationale and tool path for high-impact actions
+-- Keep recovery/rollback procedures for automated changes
++- Zero severity-1 unsafe autonomous actions on an adversarial validation set of at least `100` tasks.
++- `100%` of destructive, sensitive, or irreversible actions pass through approval or explicit policy denial paths.
++- `100%` of high-impact actions emit audit records with actor, rationale, tool path, and result.
++- Rollback drills succeed for `100%` of sampled reversible workflows in the validation set.
++- Memory and audit persistence show zero seeded-secret or seeded-PII leakage incidents in tests.
+ 
+-### Deliverables
+-- Safety Policy Spec v1
+-- High-Risk Approval Gate v1
+-- Data Governance Controls v1
+-- Audit Trail + Rollback Playbook v1
++### Phase gate
+ 
+-### Exit criteria
+-- Zero critical unsafe autonomous actions in validation set
+-- Complete auditability for high-impact operations
+-- Verified rollback path for all automated workflows
++- Adversarial and red-team report exists with severity rubric and reproducible cases.
++- Approval, audit, and rollback paths are exercised in automated tests, not only manual demos.
++- High-impact action coverage is measured by event logs, not inferred.
++- Go only if safety coverage is complete for the currently enabled capability surface; no-go if any high-impact path lacks auditability or rollback expectations.
+ 
+ ---
+ 
+@@ -294,112 +422,154 @@ Require explicit confirmation for:
+ Create a repeatable improvement loop that compounds with each cycle.
+ 
+ ### Why this phase matters
+-Elite performance requires ongoing adaptation and disciplined iteration.
++The end state is not a feature set. It is a disciplined operating system for improving Hermes without drifting on quality, cost, or safety.
+ 
+ ### Cycle template
+-1. Run eval harness
+-2. Identify top 3 bottlenecks by impact
+-3. Implement focused improvements (tooling/prompt/memory/skill/routing)
+-4. Re-run evals and compare deltas
+-5. Promote only positive-net changes
+-6. Archive lessons into skill and memory systems
++
++1. Run smoke and targeted eval suites
++2. Identify the top three bottlenecks by impact on success, correction burden, or cost
++3. Select one to three focused changes only
++4. Ship behind flags or shadow mode where appropriate
++5. Re-run evals and compare against baseline and holdout
++6. Promote only positive-net changes
++7. Archive lessons into skills, memory rules, routing policy, or test cases
++
++### Primary implementation surfaces
++
++- `evals/` results and reports
++- `batch_runner.py`
++- `agent/trajectory.py`
++- `agent/skill_commands.py`
++- `hermes_state.py`
++- versioned phase-gate and risk-review artifacts
+ 
+ ### Deliverables
++
+ - Evolution Cycle SOP v1
+ - Bottleneck Prioritization Rubric v1
+-- Change Promotion Criteria v1
++- Promotion Checklist v1
+ - Knowledge Capture Template v1
++- Risk Review Template v1
++
++### Measurable exit criteria
++
++- Three consecutive evolution cycles show non-regressing holdout scores and at least one improved primary metric per cycle.
++- Cost per successful outcome is stable or decreasing across the same three cycles.
++- Manual intervention rate decreases across the same three cycles on the tracked workflow set.
++- Every promoted change has a linked eval diff and risk-review record.
++
++### Phase gate
+ 
+-### Exit criteria
+-- Persistent upward trend in quality metrics
+-- Stable or reduced cost per outcome
+-- Decreasing need for manual intervention over time
++- Each cycle produces a single decision record: promote, hold, or revert.
++- Unresolved high-severity risks cannot remain open for more than two cycles without an explicit exception record.
++- Knowledge captured from one cycle must be traceable to later behavior changes, tests, or skill updates.
++- Go only if the loop keeps producing measurable gains; no-go if changes are being promoted without durable evidence.
+ 
+ ---
+ 
+-## Milestone Governance Framework
++## Phase Gate Framework
+ 
+-For each phase, enforce a phase gate with:
+-- Scope declaration
+-- Baseline metrics snapshot
+-- Implementation checklist completion
+-- Eval report (pre/post)
+-- Risk review
+-- Go / No-Go decision record
++Use the same evidence package for every phase so gate decisions stay comparable.
+ 
+-No phase advancement without gate approval.
++### Required gate packet
++
++- Scope declaration with exact files or modules touched
++- Baseline metrics snapshot taken before implementation
++- Implementation checklist with all required deliverables
++- Test report with named suites and pass/fail status
++- Eval diff report with pre/post metrics
++- Cost impact summary
++- Risk review with newly introduced and retired risks
++- Go or no-go decision record with rollback note
++
++### Default no-go triggers
++
++- Metrics improve on a dev subset but regress on holdout
++- Reliability, safety, or prompt-cache invariants regress
++- Success gains depend on hidden cost growth that exceeds stated thresholds
++- Feature behavior is enabled without shadow-mode evidence where shadow mode was feasible
+ 
+ ---
+ 
+ ## Cross-Phase Metric Stack
+ 
+ ### Reliability
++
+ - Tool success rate
+ - End-to-end task completion rate
+ - Retry-to-success ratio
++- Compression hard-failure rate
+ 
+ ### Quality
+-- Benchmark pass rates (lane-specific)
+-- Human-rated output quality
++
++- Benchmark pass rates by lane
++- Human-rated output quality on sampled tasks
+ - User correction frequency
++- Holdout non-regression score
+ 
+ ### Efficiency
++
+ - Time-to-success
+ - Cost-per-success
+ - Tokens-per-successful-task
++- Delegation overhead per successful task
+ 
+ ### Safety
++
+ - Unsafe action incidents
+ - Approval gate bypass incidents
+-- Data handling violations
++- Audit completeness rate
++- Secret and PII handling violations
+ 
+ ### Memory effectiveness
++
+ - Retrieval relevance score
+-- Contradiction resolution rate
++- Contradiction resolution accuracy
++- Memory write precision
+ - Skill reuse and impact score
+ 
+ ---
+ 
+-## Risk Register (Top Known Risks)
+-
+-1. Context bloat degrades reasoning quality
+-- Mitigation: stricter compaction + summarized tool returns
+-
+-2. Memory drift and contradiction accumulation
+-- Mitigation: reconciliation and pruning policies
+-
+-3. Benchmark overfitting
+-- Mitigation: rotating eval sets + blind holdout tasks
+-
+-4. Cost creep from over-delegation or excessive retries
+-- Mitigation: routing thresholds + retry budgets + cost dashboards
+-
+-5. Unsafe autonomy in edge cases
+-- Mitigation: strict high-risk approval gates + constitutional constraints
++## Risk Register (Updated)
++
++| ID | Risk | Likelihood | Impact | Early warning signal | Mitigation / contingency | Primary surfaces |
++|---|---|---|---|---|---|---|
++| R1 | Prompt-cache invalidation from mid-session prompt mutation | Medium | High | System prompt hash changes outside compression events | Assert prompt hash stability, route live updates through tool outputs, block silent prompt rebuilds | `run_agent.py`, `agent/prompt_builder.py`, `agent/prompt_caching.py`, `tools/memory_tool.py` |
++| R2 | Tool contract drift creates ambiguous runtime failures | High | High | Tool results fail JSON or envelope validation | Canonical result envelope, registry validation, contract tests for all tools | `tools/registry.py`, `model_tools.py`, `tests/tools/` |
++| R3 | Context bloat or tool-pair corruption degrades reasoning | High | High | Compression hard failures, orphaned tool repair count rises | Dedupe tool output, cap reinjected content, track sanitizer repairs, strengthen compression tests | `agent/context_compressor.py`, `run_agent.py` |
++| R4 | Memory drift, contradiction buildup, or over-persistence | High | High | User corrections rise on repeat tasks, contradiction count grows, memory size grows faster than reuse | Write-gate scoring, reconciliation, pruning, source-precedence rules | `tools/memory_tool.py`, `run_agent.py`, `hermes_state.py` |
++| R5 | Local memory and Honcho state diverge | Medium | High | Pending sync queue grows, conflicting facts appear between stores | Add sync-health metrics, write-ahead event log, clear precedence rules, repair job for drift | `run_agent.py` Honcho paths, `tools/memory_tool.py`, `tools/honcho_tools.py` |
++| R6 | Eval contamination or benchmark overfitting | Medium | High | Dev-suite gains do not reproduce on holdout | Locked holdout tasks, rotated eval subsets, regression gates based on holdout | new `evals/`, `batch_runner.py` |
++| R7 | Cost creep from retries, delegation, browser, or MCP overuse | High | Medium | Cost-per-success and average retries trend upward without quality gain | Shadow-mode routing, retry budgets, route-level cost dashboards, revert policies | `run_agent.py`, `tools/delegate_tool.py`, `tools/mcp_tool.py` |
++| R8 | Shared-state orchestration bugs under delegation | Medium | High | Cross-agent tool leakage, execute-code import failures, inconsistent enabled-tools sets | Remove or contain process-global state, add concurrency stress tests, per-agent routing state | `model_tools.py`, `tools/delegate_tool.py`, `run_agent.py` |
++| R9 | Safety coverage lags behind new capability surface | Medium | High | New tools or MCP integrations appear without approvals or audit support | Deny-by-default capability rollout, unified approval taxonomy, integration checklist | `tools/approval.py`, `tools/mcp_tool.py`, `tools/terminal_tool.py` |
++| R10 | Audit or rollback data is incomplete during real incidents | Medium | High | High-impact actions cannot be reconstructed after the fact | Queryable audit store, rollback artifact requirement, drill reversible workflows | `hermes_state.py`, `tools/approval.py`, `tools/terminal_tool.py`, `tools/checkpoint_manager.py` |
++| R11 | Observability gaps make phase gates anecdotal | Medium | Medium | Metrics require manual reconstruction from logs or memory | Mandatory event schema, versioned reports, no gate without baseline artifact | `hermes_state.py`, `agent/trajectory.py`, new `evals/` |
+ 
+ ---
+ 
+-## Immediate Execution Order (Recommended Default)
++## Immediate Execution Order (Retained, With Implementation Notes)
+ 
+-1. Phase 1 (stability and contracts)
+-2. Phase 4 foundations (baseline eval harness early)
+-3. Phase 2 (memory quality and retrieval)
+-4. Phase 3 (self-correction loops)
+-5. Phase 5 (scalable orchestration/routing)
+-6. Phase 6 (safety hardening)
+-7. Phase 7 (continuous compounding loop)
++1. Phase 1 core stability and contract normalization
++2. Phase 4 foundations early enough to establish baselines and regression visibility
++3. Phase 2 memory quality and retrieval discipline
++4. Phase 3 self-correction in shadow mode, then bounded live mode
++5. Phase 5 scalable orchestration and dynamic routing after state-isolation risks are retired
++6. Phase 6 safety hardening before broader autonomous rollout or new high-impact integrations
++7. Phase 7 continuous evolution loop as the standing operating cadence
+ 
+-Rationale:
+-- Establish reliability first
+-- Start measuring as early as possible
+-- Then improve memory and correction mechanisms
+-- Scale only after evidence and safety controls are in place
++### Practical sequencing notes
++
++- Start instrumentation work before closing Phase 1, or later gates will be weak.
++- Treat Phase 4 as an enabling layer, not a late-stage reporting exercise.
++- Start designing Phase 6 controls earlier than its formal gate if any new side-effecting capability is introduced in Phases 3 through 5.
+ 
+ ---
+ 
+ ## Source Spine (Primary References)
+ 
+ ### Hermes docs
++
+ - https://hermes-agent.nousresearch.com/docs/
+ - https://hermes-agent.nousresearch.com/docs/guides/tips/
+ - https://hermes-agent.nousresearch.com/docs/user-guide/features/memory
+@@ -407,6 +577,7 @@ Rationale:
+ - https://hermes-agent.nousresearch.com/docs/developer-guide/architecture
+ 
+ ### Agent engineering guidance
++
+ - https://www.anthropic.com/research/building-effective-agents
+ - https://www.anthropic.com/engineering/writing-tools-for-agents
+ - https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents
+@@ -415,6 +586,7 @@ Rationale:
+ - https://developers.openai.com/api/docs/guides/agent-evals/
+ 
+ ### Research foundations
++
+ - Voyager: https://arxiv.org/abs/2305.16291
+ - Reflexion: https://arxiv.org/abs/2303.11366
+ - Self-Refine: https://arxiv.org/abs/2303.17651
+@@ -424,10 +596,12 @@ Rationale:
+ - Memory survey: https://arxiv.org/abs/2512.13564
+ 
+ ### Benchmarks
++
+ - SWE-bench: https://www.swebench.com/SWE-bench/
+ - Terminal-Bench: https://www.tbench.ai/
+ 
+ ### Firecrawl docs
++
+ - Scrape endpoint: https://docs.firecrawl.dev/api-reference/endpoint/scrape
+ - Extract endpoint: https://docs.firecrawl.dev/api-reference/endpoint/extract
+ - Map endpoint: https://docs.firecrawl.dev/api-reference/endpoint/map
+@@ -437,10 +611,12 @@ Rationale:
+ 
+ ## Definition of Success
+ 
+-Hermes is considered “elite” when it demonstrates:
++Hermes is considered elite when it demonstrates:
++
+ - High reliability on real, tool-heavy tasks
+ - Persistent compounding gains from memory and skill systems
+ - Measurable benchmark improvement across lanes
+ - Controlled cost growth through routing
+ - Strong safety and audit guarantees
+ - Low user correction burden over time
++- A repeatable promotion process where improvements are evidenced, gated, and reversible

--- a/SUPER_AGENT_EVOLUTION_PLAN.md
+++ b/SUPER_AGENT_EVOLUTION_PLAN.md
@@ -1,0 +1,446 @@
+# Hermes Super-Agent Evolution Plan
+
+## Purpose
+
+This document defines a practical, phase-based roadmap for evolving Hermes from a capable assistant into an elite, reliable, self-improving agent system.
+
+Planning constraints followed:
+- No week-based planning
+- Milestone and exit-criteria driven
+- Emphasis on reliability, memory quality, eval rigor, and safe autonomy
+
+---
+
+## Strategic North Star
+
+Build an agent that is:
+1. Reliable under real tool-heavy workloads
+2. Memory-compounding across sessions
+3. Self-correcting on failures
+4. Measurably improving through benchmarked evals
+5. Cost-aware and routing-optimized
+6. Safe, auditable, and user-aligned
+
+---
+
+## Operating Principles
+
+### 1) Stability before sophistication
+Do not add advanced autonomy on top of brittle orchestration.
+
+### 2) Measured progress only
+No feature promotions without eval deltas.
+
+### 3) Memory quality over memory quantity
+Store durable, actionable, validated information only.
+
+### 4) Cost-performance balancing
+Use model/tool routing based on task complexity and risk.
+
+### 5) Human override for high-impact actions
+Any destructive, sensitive, or irreversible action requires explicit approval.
+
+---
+
+## Phase 1: Core Stability and Context Discipline
+
+### Objective
+Harden core execution loops so Hermes is dependable under sustained use.
+
+### Why this phase matters
+Most agent failures come from tool orchestration drift, weak error contracts, or context contamination—not lack of model capability.
+
+### Workstreams
+
+#### A. Tool contract hardening
+- Standardize tool schema clarity (inputs, outputs, error shapes)
+- Ensure handlers return actionable, structured errors
+- Add explicit retryability signals (transient vs terminal failures)
+
+#### B. Prompt and context hygiene
+- Keep system prefix stable and minimal
+- Reduce duplicate tool output in conversation state
+- Improve context compaction triggers and summaries
+
+#### C. Firecrawl reliability profile
+- Define extraction presets (fast, balanced, deep)
+- Add retry/backoff rules per endpoint type
+- Standardize extraction post-processing for downstream use
+
+### Deliverables
+- Tool Contract Spec v1
+- Context Hygiene Ruleset v1
+- Firecrawl Preset Profiles v1
+- Stability Regression Tests v1
+
+### Exit criteria
+- Core tool-call success rate >= 95%
+- Context overflow/compression incidents reduced by >= 50%
+- Firecrawl extraction retry rate < 10% on representative workloads
+
+---
+
+## Phase 2: Procedural Memory That Compounds Capability
+
+### Objective
+Transform memory from passive storage into operational leverage.
+
+### Why this phase matters
+Compounding performance requires strong retrieval, contradiction handling, and high-signal persistence.
+
+### Workstreams
+
+#### A. Memory tiering architecture
+- Working memory: per-task temporary state
+- Episodic memory: session outcomes, failures, resolutions
+- Procedural memory: reusable skills and runbooks
+
+#### B. Write-gate policy
+Persist only if all are true:
+1. Durable beyond current session
+2. Actionable for future responses
+3. Explicitly confirmed or strongly validated
+
+#### C. Retrieval policy and conflict resolution
+- Retrieve by intent + recency + relevance
+- Detect and reconcile contradictory memories
+- Prefer latest explicit user statements over stale entries
+
+#### D. Skill synthesis loop
+- Detect repeated workflows and failure-recovery patterns
+- Auto-propose skill updates from successful multi-step tasks
+
+### Deliverables
+- Memory Governance Spec v1
+- Retrieval/Reconciliation Engine v1
+- Skill Synthesis Workflow v1
+- Memory Pruning/Consolidation Routine v1
+
+### Exit criteria
+- Repeat-task completion time improves >= 30%
+- User correction frequency decreases across repeated task types
+- Skill reuse rate increases over successive sessions
+
+---
+
+## Phase 3: Self-Correction Loops (Reflexion + Self-Refine Pattern)
+
+### Objective
+Enable Hermes to improve output quality within a session without retraining.
+
+### Why this phase matters
+Iterative critique/revision can substantially improve task outcomes with minimal infrastructure overhead.
+
+### Workstreams
+
+#### A. Attempt-Critique-Retry pipeline
+- First attempt
+- Structured self-critique pass
+- Revised attempt with explicit fixes
+
+#### B. Failure signature logging
+Capture:
+- Failure class (reasoning, tool misuse, missing context, schema mismatch)
+- Root cause hypothesis
+- Effective correction strategy
+
+#### C. Retry budgeting by risk class
+- Low-risk tasks: up to 2-3 autonomous retries
+- Medium-risk tasks: bounded retries + confidence threshold
+- High-risk tasks: pause for approval before further action
+
+### Deliverables
+- Self-Correction Loop v1
+- Failure Taxonomy v1
+- Retry Budgeting Policy v1
+- Critique Prompt Pack v1
+
+### Exit criteria
+- Final success within retry budget >= 90% on target workflows
+- Reduction in repeated failure signatures over time
+- Hallucination-induced tool misuse rate decreases continuously
+
+---
+
+## Phase 4: Evaluation Harness and Evidence-Driven Improvement
+
+### Objective
+Establish rigorous, repeatable measurements for agent capability growth.
+
+### Why this phase matters
+Without eval discipline, improvements are anecdotal and regressions go unnoticed.
+
+### Workstreams
+
+#### A. Multi-lane benchmark design
+- Coding lane: SWE-bench style repo issue tasks
+- Terminal lane: Terminal-Bench style command-line tasks
+- Agent lane: GAIA-style multi-step tool reasoning tasks
+
+#### B. Grading architecture
+- Deterministic checks (tests, exact outputs)
+- Model-based rubric grading for qualitative outputs
+- Human spot-checks for critical edge cases
+
+#### C. Reliability metrics
+- pass@k for exploration capability
+- pass^k for repeated reliability
+- Cost-per-success and time-to-success metrics
+
+#### D. Regression controls
+- Mandatory pre/post eval run for major changes
+- Regression threshold alerts and rollback triggers
+
+### Deliverables
+- Hermes Eval Harness v1
+- Benchmark Task Suite v1
+- Metrics Dashboard Spec v1
+- Regression Policy v1
+
+### Exit criteria
+- Stable baseline established for each lane
+- Automatic regression detection active
+- Major merges gated by measured eval impact
+
+---
+
+## Phase 5: Scalable Orchestration and Dynamic Routing
+
+### Objective
+Increase throughput and quality by decomposition, specialization, and model/tool routing.
+
+### Why this phase matters
+Complex tasks benefit from manager-worker structures and specialized execution paths.
+
+### Workstreams
+
+#### A. Manager-worker orchestration
+- Lead agent performs planning and task decomposition
+- Subagents execute isolated workstreams
+- Summarized outputs only return to main context
+
+#### B. Dynamic model routing
+- Route low-risk routine tasks to low-cost models
+- Route high-complexity reasoning to stronger models
+- Use confidence + task class to choose execution path
+
+#### C. Tool routing heuristics
+- Select direct tools for deterministic operations
+- Escalate to browser/delegation only when necessary
+- Minimize expensive tool calls via pre-check logic
+
+#### D. MCP capability expansion
+- Add high-value external capabilities through controlled MCP integrations
+- Define strict auth and permission boundaries
+
+### Deliverables
+- Orchestration Topology v1
+- Routing Policy Engine v1
+- Cost/Latency Decision Table v1
+- MCP Integration Checklist v1
+
+### Exit criteria
+- Throughput (completed tasks/session) improves >= 40%
+- Cost per successful task declines while quality is maintained or improved
+- No meaningful increase in context pollution or orchestration failures
+
+---
+
+## Phase 6: Safety, Governance, and Auditability
+
+### Objective
+Ensure capability growth remains aligned with user trust and operational safety.
+
+### Why this phase matters
+Powerful autonomous behavior requires explicit guardrails and transparent audit trails.
+
+### Workstreams
+
+#### A. Constitutional policy layer
+- Define immutable constraints for unsafe categories
+- Encode refusal and escalation behavior for policy-sensitive requests
+
+#### B. High-risk action gating
+Require explicit confirmation for:
+- Destructive file/system operations
+- Sensitive data handling
+- External side effects with irreversible impact
+
+#### C. Data governance
+- Source labeling and provenance tracking
+- Secret/PII detection and redaction checks
+- Memory boundary controls to prevent inappropriate persistence
+
+#### D. Audit and rollback
+- Log rationale and tool path for high-impact actions
+- Keep recovery/rollback procedures for automated changes
+
+### Deliverables
+- Safety Policy Spec v1
+- High-Risk Approval Gate v1
+- Data Governance Controls v1
+- Audit Trail + Rollback Playbook v1
+
+### Exit criteria
+- Zero critical unsafe autonomous actions in validation set
+- Complete auditability for high-impact operations
+- Verified rollback path for all automated workflows
+
+---
+
+## Phase 7: Continuous Evolution Loop (Session-Based Cadence)
+
+### Objective
+Create a repeatable improvement loop that compounds with each cycle.
+
+### Why this phase matters
+Elite performance requires ongoing adaptation and disciplined iteration.
+
+### Cycle template
+1. Run eval harness
+2. Identify top 3 bottlenecks by impact
+3. Implement focused improvements (tooling/prompt/memory/skill/routing)
+4. Re-run evals and compare deltas
+5. Promote only positive-net changes
+6. Archive lessons into skill and memory systems
+
+### Deliverables
+- Evolution Cycle SOP v1
+- Bottleneck Prioritization Rubric v1
+- Change Promotion Criteria v1
+- Knowledge Capture Template v1
+
+### Exit criteria
+- Persistent upward trend in quality metrics
+- Stable or reduced cost per outcome
+- Decreasing need for manual intervention over time
+
+---
+
+## Milestone Governance Framework
+
+For each phase, enforce a phase gate with:
+- Scope declaration
+- Baseline metrics snapshot
+- Implementation checklist completion
+- Eval report (pre/post)
+- Risk review
+- Go / No-Go decision record
+
+No phase advancement without gate approval.
+
+---
+
+## Cross-Phase Metric Stack
+
+### Reliability
+- Tool success rate
+- End-to-end task completion rate
+- Retry-to-success ratio
+
+### Quality
+- Benchmark pass rates (lane-specific)
+- Human-rated output quality
+- User correction frequency
+
+### Efficiency
+- Time-to-success
+- Cost-per-success
+- Tokens-per-successful-task
+
+### Safety
+- Unsafe action incidents
+- Approval gate bypass incidents
+- Data handling violations
+
+### Memory effectiveness
+- Retrieval relevance score
+- Contradiction resolution rate
+- Skill reuse and impact score
+
+---
+
+## Risk Register (Top Known Risks)
+
+1. Context bloat degrades reasoning quality
+- Mitigation: stricter compaction + summarized tool returns
+
+2. Memory drift and contradiction accumulation
+- Mitigation: reconciliation and pruning policies
+
+3. Benchmark overfitting
+- Mitigation: rotating eval sets + blind holdout tasks
+
+4. Cost creep from over-delegation or excessive retries
+- Mitigation: routing thresholds + retry budgets + cost dashboards
+
+5. Unsafe autonomy in edge cases
+- Mitigation: strict high-risk approval gates + constitutional constraints
+
+---
+
+## Immediate Execution Order (Recommended Default)
+
+1. Phase 1 (stability and contracts)
+2. Phase 4 foundations (baseline eval harness early)
+3. Phase 2 (memory quality and retrieval)
+4. Phase 3 (self-correction loops)
+5. Phase 5 (scalable orchestration/routing)
+6. Phase 6 (safety hardening)
+7. Phase 7 (continuous compounding loop)
+
+Rationale:
+- Establish reliability first
+- Start measuring as early as possible
+- Then improve memory and correction mechanisms
+- Scale only after evidence and safety controls are in place
+
+---
+
+## Source Spine (Primary References)
+
+### Hermes docs
+- https://hermes-agent.nousresearch.com/docs/
+- https://hermes-agent.nousresearch.com/docs/guides/tips/
+- https://hermes-agent.nousresearch.com/docs/user-guide/features/memory
+- https://hermes-agent.nousresearch.com/docs/user-guide/features/skills
+- https://hermes-agent.nousresearch.com/docs/developer-guide/architecture
+
+### Agent engineering guidance
+- https://www.anthropic.com/research/building-effective-agents
+- https://www.anthropic.com/engineering/writing-tools-for-agents
+- https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents
+- https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents
+- https://openai.com/business/guides-and-resources/a-practical-guide-to-building-ai-agents/
+- https://developers.openai.com/api/docs/guides/agent-evals/
+
+### Research foundations
+- Voyager: https://arxiv.org/abs/2305.16291
+- Reflexion: https://arxiv.org/abs/2303.11366
+- Self-Refine: https://arxiv.org/abs/2303.17651
+- Toolformer: https://arxiv.org/abs/2302.04761
+- GAIA: https://arxiv.org/abs/2311.12983
+- Constitutional AI: https://arxiv.org/abs/2212.08073
+- Memory survey: https://arxiv.org/abs/2512.13564
+
+### Benchmarks
+- SWE-bench: https://www.swebench.com/SWE-bench/
+- Terminal-Bench: https://www.tbench.ai/
+
+### Firecrawl docs
+- Scrape endpoint: https://docs.firecrawl.dev/api-reference/endpoint/scrape
+- Extract endpoint: https://docs.firecrawl.dev/api-reference/endpoint/extract
+- Map endpoint: https://docs.firecrawl.dev/api-reference/endpoint/map
+- Extract feature: https://docs.firecrawl.dev/features/extract
+
+---
+
+## Definition of Success
+
+Hermes is considered “elite” when it demonstrates:
+- High reliability on real, tool-heavy tasks
+- Persistent compounding gains from memory and skill systems
+- Measurable benchmark improvement across lanes
+- Controlled cost growth through routing
+- Strong safety and audit guarantees
+- Low user correction burden over time

--- a/SUPER_AGENT_EVOLUTION_PLAN_REVIEWED.md
+++ b/SUPER_AGENT_EVOLUTION_PLAN_REVIEWED.md
@@ -1,0 +1,622 @@
+# Hermes Super-Agent Evolution Plan (Reviewed)
+
+## Purpose
+
+This reviewed version keeps the original seven-phase roadmap intact while making it more implementation-oriented for the current Hermes codebase.
+
+Review goals:
+- Preserve the original intent, ordering, and north-star outcomes
+- Translate each phase into concrete changes against current Hermes modules
+- Add measurable exit criteria with metric definitions and sample sizes
+- Add explicit phase gates, no-go triggers, and updated risk controls
+
+Planning constraints preserved:
+- No week-based planning
+- Milestone and exit-criteria driven
+- Emphasis on reliability, memory quality, eval rigor, and safe autonomy
+
+---
+
+## Strategic North Star
+
+Build an agent that is:
+1. Reliable under real tool-heavy workloads
+2. Memory-compounding across sessions
+3. Self-correcting on failures
+4. Measurably improving through benchmarked evals
+5. Cost-aware and routing-optimized
+6. Safe, auditable, and user-aligned
+
+---
+
+## Current-Architecture Constraints To Preserve
+
+These are not optional. The reviewed plan assumes all implementation work respects them.
+
+- `run_agent.py` remains the single source of truth for the synchronous conversation loop and tool-call execution order.
+- Prompt-caching invariants must hold: the assembled system prompt stays stable within a session and is rebuilt only on compression boundaries governed by `agent/prompt_caching.py` and `run_agent.py`.
+- Agent-loop tools intercepted in `run_agent.py` (`todo`, `memory`, `session_search`, `delegate_task`) must not be silently rerouted through generic dispatch.
+- Delegated children in `tools/delegate_tool.py` must keep isolated context, bounded depth, and restricted tool access.
+- Persistent memory changes must not mutate the in-session prompt snapshot in `tools/memory_tool.py`.
+- Tests must continue to honor the isolated `HERMES_HOME` behavior in `tests/conftest.py`.
+
+---
+
+## Shared Instrumentation Required Before Any Phase Can Exit
+
+This is not a new phase. It is a cross-phase prerequisite for evidence-based gating.
+
+### Minimum instrumentation substrate
+
+Implement a small, durable event layer before declaring any phase complete. The simplest acceptable path is extending `hermes_state.py` with append-only event tables or writing versioned JSONL artifacts beside existing trajectories.
+
+Required event families:
+
+| Event family | Minimum fields | Primary code surfaces |
+|---|---|---|
+| Tool execution | `tool_name`, `toolset`, `success`, `error_type`, `retryable`, `latency_ms`, `session_id`, `task_id` | `run_agent.py`, `model_tools.py`, `tools/registry.py` |
+| Context/compression | `tokens_before`, `tokens_after`, `reason`, `summary_model`, `sanitizer_repairs` | `agent/context_compressor.py`, `run_agent.py` |
+| Memory | `candidate`, `target`, `write_decision`, `confidence`, `reconciliation_action`, `source` | `tools/memory_tool.py`, `run_agent.py` |
+| Delegation/routing | `route_selected`, `route_shadow`, `child_count`, `budget_used`, `model_selected` | `tools/delegate_tool.py`, `run_agent.py` |
+| Safety/audit | `risk_class`, `approval_required`, `approval_result`, `side_effect_type`, `rollback_artifact` | `tools/approval.py`, `tools/terminal_tool.py`, `tools/mcp_tool.py` |
+| Eval runs | `suite`, `task_id`, `commit`, `score`, `cost`, `duration`, `baseline_ref` | new `evals/` package or `batch_runner.py` extension |
+
+### Shared rules
+
+- No phase can claim success from anecdotal CLI usage alone.
+- All exit criteria below must be computed from versioned artifacts, not ad hoc notes.
+- Every phase needs a baseline snapshot before implementation starts.
+- Shadow-mode logging is preferred before behavior-changing rollouts.
+
+---
+
+## Operating Principles
+
+### 1) Stability before sophistication
+Do not add advanced autonomy on top of brittle orchestration.
+
+### 2) Measured progress only
+No feature promotions without eval deltas.
+
+### 3) Memory quality over memory quantity
+Store durable, actionable, validated information only.
+
+### 4) Cost-performance balancing
+Use model/tool routing based on task complexity and risk.
+
+### 5) Human override for high-impact actions
+Any destructive, sensitive, or irreversible action requires explicit approval.
+
+---
+
+## Phase 1: Core Stability and Context Discipline
+
+### Objective
+Harden core execution loops so Hermes is dependable under sustained use.
+
+### Why this phase matters
+Most agent failures still come from tool orchestration drift, weak error contracts, or context contamination rather than raw model capability.
+
+### Primary implementation surfaces
+
+- `tools/registry.py`
+- `model_tools.py`
+- `run_agent.py`
+- `agent/prompt_builder.py`
+- `agent/prompt_caching.py`
+- `agent/context_compressor.py`
+- `tools/web_tools.py`
+- `tests/test_model_tools.py`
+- `tests/test_413_compression.py`
+- `tests/tools/`
+
+### Implementation tracks
+
+- Add a canonical tool result envelope in `tools/registry.py` for all tool handlers: `success`, `error`, `error_type`, `retryable`, `data`, `metrics`.
+- Add strict post-dispatch validation at the registry boundary so malformed tool outputs fail in tests instead of surfacing as ambiguous runtime strings.
+- Normalize pre-dispatch and post-dispatch error handling in `model_tools.py` and `run_agent.py::_execute_tool_calls()`.
+- Record tool latency, retryability, and error-class metrics at the agent-loop boundary rather than inside each tool ad hoc.
+- Tighten context hygiene in `agent/context_compressor.py`: dedupe repeated tool content, cap oversized tool results before reinjection, and count sanitizer repairs explicitly.
+- Convert Firecrawl reliability work in `tools/web_tools.py` into named presets with clear retry/backoff matrices and normalized extraction metadata.
+
+### Deliverables
+
+- Tool Contract Spec v1
+- Canonical Tool Result Helper v1
+- Context Hygiene Ruleset v1
+- Firecrawl Preset Profiles v1
+- Stability Regression Suite v1
+
+### Measurable exit criteria
+
+- Tool-call success rate is at least `95%` across a representative suite of at least `300` core tool calls, excluding explicit user denials and unavailable toolsets.
+- At least `100%` of registered tools return the canonical result envelope in contract tests.
+- Context hard-failure incidents are reduced by at least `50%` from baseline across at least `50` long-running sessions.
+- Orphaned tool-call repair events are at or below `1%` of compression events.
+- Firecrawl requests requiring at least one retry are below `10%`, and terminal failures are below `3%`, on a fixed extraction corpus.
+
+### Phase gate
+
+- Baseline report exists with pre-change metrics for tool success, compression failures, and Firecrawl retries.
+- Contract tests cover every registered tool discovered by `model_tools._discover_tools()`.
+- Long-session regression suite passes with no prompt-cache invariant violations.
+- Go only if the canonical tool envelope is fully adopted; no-go if envelope adoption is partial or if compression failures rise versus baseline.
+
+---
+
+## Phase 2: Procedural Memory That Compounds Capability
+
+### Objective
+Transform memory from passive storage into operational leverage.
+
+### Why this phase matters
+Compounding performance requires strong retrieval, contradiction handling, and high-signal persistence, not just more stored text.
+
+### Primary implementation surfaces
+
+- `tools/memory_tool.py`
+- `tools/honcho_tools.py`
+- `tools/session_search_tool.py`
+- `run_agent.py` memory and Honcho integration paths
+- `hermes_state.py`
+- `agent/prompt_builder.py`
+- `agent/skill_commands.py`
+- `tests/tools/test_memory_tool.py`
+- new memory reconciliation tests
+
+### Implementation tracks
+
+- Formalize the current memory tiers instead of inventing new ones from scratch:
+  - Working memory: active messages, todo state, and task-local execution context in `run_agent.py`
+  - Episodic memory: session outcomes and searchable history in `hermes_state.py`
+  - Procedural memory: curated `MEMORY.md`, `USER.md`, Honcho-backed durable user context, and reusable skills
+- Add a write-gate scorer before persistence with explicit reasons for accept, reject, or defer.
+- Implement contradiction detection and reconciliation as a first-class operation instead of append-only growth.
+- Add one retrieval arbitration policy spanning curated memory, Honcho user modeling, and session search so the agent has a single precedence model.
+- Preserve prompt caching by routing mid-session retrieval updates through tool outputs or explicit session messages, never silent prompt mutation.
+- Add a skill-synthesis proposal flow that generates draft skills or runbooks for review instead of auto-promoting into `~/.hermes/skills/`.
+- Add pruning and consolidation routines with metrics for stale-entry removal, merge decisions, and contradiction cleanup.
+
+### Deliverables
+
+- Memory Governance Spec v1
+- Retrieval and Reconciliation Engine v1
+- Memory Event Log Schema v1
+- Skill Synthesis Proposal Workflow v1
+- Memory Pruning and Consolidation Routine v1
+
+### Measurable exit criteria
+
+- On a repeated-task corpus of at least `30` paired tasks across at least `10` task types, median time-to-success improves by at least `30%`.
+- Explicit user correction rate on repeated task types decreases by at least `25%` from baseline.
+- Memory write precision is at least `90%` on an audited sample of at least `100` candidate writes.
+- Contradiction resolution accuracy is at least `90%` on a seeded reconciliation set of at least `50` conflict cases.
+- Procedural memory or skill reuse appears in at least `40%` of eligible repeated workflows without increasing prompt-cache invalidation incidents above zero.
+
+### Phase gate
+
+- Reconciliation tests cover duplicate, contradictory, stale, and ambiguous entries.
+- A before-and-after audit exists for memory growth, pruning rate, and correction rate.
+- Prompt-cache stability is explicitly verified across sessions with memory writes.
+- Go only if memory helps repeated tasks without increasing drift or mid-session prompt mutation; no-go if write precision or conflict resolution miss the thresholds above.
+
+---
+
+## Phase 3: Self-Correction Loops (Reflexion + Self-Refine Pattern)
+
+### Objective
+Enable Hermes to improve output quality within a session without retraining.
+
+### Why this phase matters
+Iterative critique and revision can improve outcomes materially, but only if retries are classified, bounded, and measured.
+
+### Primary implementation surfaces
+
+- `run_agent.py`
+- `agent/trajectory.py`
+- new `agent/self_correction.py` or equivalent helper module
+- `tests/test_run_agent.py`
+- new retry and critique tests
+
+### Implementation tracks
+
+- Add a structured failure taxonomy covering reasoning failure, tool misuse, missing context, schema mismatch, provider failure, and unsafe-action block.
+- Start in shadow mode: record critique recommendations and likely retry actions without changing live responses.
+- Promote to bounded live retries only for low-risk and medium-risk classes with explicit budgets and confidence thresholds.
+- Log failure signatures and effective correction patterns into trajectories or dedicated event records.
+- Add tool-specific retry policies so transient provider/network failures are handled differently from logical errors.
+- Ensure high-risk or side-effecting actions never enter autonomous retry without renewed approval.
+
+### Deliverables
+
+- Self-Correction Loop v1
+- Failure Taxonomy v1
+- Retry Budgeting Policy v1
+- Critique Prompt Pack v1
+- Retry Outcome Report v1
+
+### Measurable exit criteria
+
+- On a target workflow set of at least `50` tasks, bounded retry increases final success rate by at least `10` percentage points versus first-attempt-only baseline.
+- Cost-per-success increases by no more than `20%` while achieving the success gain above.
+- Repeated failure-signature recurrence declines by at least `30%` across the same workflow set.
+- Hallucination-induced tool misuse is below `2%` of tool calls in the evaluated set.
+- High-risk tasks show `100%` compliance with approval-before-retry policy.
+
+### Phase gate
+
+- Shadow-mode report shows the critique signal is useful before live retries are enabled.
+- Retry policies are covered by tests for low-risk, medium-risk, and high-risk paths.
+- Live rollout stays behind a feature flag until the success-lift and cost ceilings are met.
+- Go only if retries improve success without materially increasing unsafe behavior or runaway cost; no-go if cost or tool misuse exceeds thresholds.
+
+---
+
+## Phase 4: Evaluation Harness and Evidence-Driven Improvement
+
+### Objective
+Establish rigorous, repeatable measurements for agent capability growth.
+
+### Why this phase matters
+Without eval discipline, improvements are anecdotal, regressions hide in noise, and later phases become ungovernable.
+
+### Primary implementation surfaces
+
+- `batch_runner.py`
+- `environments/hermes_base_env.py`
+- `environments/agent_loop.py`
+- `agent/trajectory.py`
+- `hermes_state.py`
+- `hermes_cli/main.py` or a dedicated eval CLI entrypoint
+- `tests/test_provider_parity.py`
+- new `evals/` package for tasks, graders, suites, and reports
+
+### Implementation tracks
+
+- Define a versioned eval format for tasks, setup, expected outputs, graders, and cost/time budgets.
+- Use `batch_runner.py` for lightweight dataset sweeps and the existing `environments/` framework for scored agent-loop evaluations instead of building two parallel systems.
+- Build three lanes from the original plan: coding, terminal, and agentic multi-step tasks.
+- Prefer deterministic graders first; use model-based grading only for outputs that cannot be checked mechanically.
+- Create dev, regression, and holdout splits to reduce benchmark overfitting.
+- Persist eval artifacts per run: config, commit SHA, raw outputs, scores, latency, token usage, and failure signatures.
+- Add smoke-suite and full-suite entrypoints so local development can stay fast while release gates stay meaningful.
+
+### Deliverables
+
+- Hermes Eval Harness v1
+- Benchmark Task Suite v1
+- Grader Library v1
+- Metrics Dashboard Spec v1
+- Regression Policy v1
+
+### Measurable exit criteria
+
+- Each eval lane has at least `25` versioned tasks with at least one locked holdout split.
+- At least `70%` of tasks across the full suite use deterministic grading.
+- Smoke suite completes unattended in under `30` minutes; full suite completes unattended in a documented, repeatable path.
+- Flake rate is below `5%` across two consecutive suite runs on the same commit.
+- Every major merge touching `run_agent.py`, `model_tools.py`, `tools/`, or `agent/` attaches a pre/post eval diff before promotion.
+
+### Phase gate
+
+- Baseline scorecards exist for all three lanes and are checked into versioned artifacts.
+- Holdout tasks are separated from day-to-day tuning tasks.
+- Regression thresholds are defined before the suite is used as a gate.
+- Go only when the eval harness is trusted enough to reject regressions; no-go if flakiness or grading ambiguity obscures signal.
+
+---
+
+## Phase 5: Scalable Orchestration and Dynamic Routing
+
+### Objective
+Increase throughput and quality by decomposition, specialization, and model/tool routing.
+
+### Why this phase matters
+Complex tasks benefit from manager-worker structures and specialized execution paths, but only when routing is auditable and state isolation is real.
+
+### Primary implementation surfaces
+
+- `tools/delegate_tool.py`
+- `cli.py`
+- `run_agent.py`
+- `model_tools.py`
+- `toolsets.py`
+- `agent/model_metadata.py`
+- `tools/mcp_tool.py`
+- `tools/mixture_of_agents_tool.py`
+- routing and delegation stress tests
+
+### Implementation tracks
+
+- Fix known shared-state hazards before scaling delegation, especially the process-global `_last_resolved_tool_names` path noted in `model_tools.py`.
+- Add explicit delegation budgets: child count, iteration budget share, latency ceiling, and return-summary size budget.
+- Introduce routing in shadow mode first: log recommended model/tool path before allowing policy-driven execution.
+- Add one central routing policy layer above the current CLI, agent-loop, delegation, and multi-model entry points so behavior stays explainable.
+- Classify tasks by complexity, risk, and determinism so routing is explainable rather than heuristic sprawl.
+- Keep parent context clean by enforcing summary-only child returns and size caps for delegated outputs.
+- Expand MCP integrations behind a checklist covering auth scope, side-effect classification, and audit support before tool exposure.
+
+### Deliverables
+
+- Orchestration Topology v1
+- Routing Policy Engine v1
+- Cost and Latency Decision Table v1
+- Delegation Budget Policy v1
+- MCP Integration Checklist v1
+
+### Measurable exit criteria
+
+- On a complex-task corpus of at least `40` tasks, throughput improves by at least `40%` or median time-to-success improves by at least `25%`, while quality is non-inferior on eval scores.
+- Cost per successful task declines by at least `15%` relative to the non-routed baseline.
+- Delegated-task summaries keep parent-context growth within `10%` of the non-delegated baseline for comparable tasks.
+- Orchestration or routing failures do not increase above baseline error rates from Phase 1.
+- Cross-session or cross-agent toolset leakage incidents are reduced to zero in stress tests.
+
+### Phase gate
+
+- Shadow-mode routing report shows policy quality before live routing is enabled.
+- Delegation stress tests cover concurrency, interrupts, failures, and budget exhaustion.
+- The `_last_resolved_tool_names` global-state risk is retired or fully contained before enabling broader delegation.
+- Go only if routing improves cost or throughput without hurting reliability; no-go if orchestration failures or context pollution rise.
+
+---
+
+## Phase 6: Safety, Governance, and Auditability
+
+### Objective
+Ensure capability growth remains aligned with user trust and operational safety.
+
+### Why this phase matters
+More autonomy without stronger approvals, provenance, and rollback support creates compounding operational risk.
+
+### Primary implementation surfaces
+
+- `tools/approval.py`
+- `tools/terminal_tool.py`
+- `tools/file_operations.py`
+- `tools/skills_guard.py`
+- `tools/mcp_tool.py`
+- `tools/memory_tool.py`
+- `tools/checkpoint_manager.py`
+- `agent/redact.py`
+- `hermes_state.py`
+- safety and adversarial test suites
+
+### Implementation tracks
+
+- Convert safety policy into an explicit action taxonomy: read-only, reversible side effect, irreversible side effect, sensitive data access, and policy-sensitive content.
+- Expand approval gating beyond shell danger patterns so MCP actions, browser actions, file mutations, and external side effects share one risk model.
+- Add provenance tagging for high-impact outputs: which tool ran, what was changed, what approval existed, and how to undo it.
+- Add secret and PII detection checks before memory persistence, external transmission, and artifact logging.
+- Store audit records in a queryable form rather than only console output.
+- Require rollback artifacts for automated file edits, external writes, or stateful integrations whenever rollback is possible.
+
+### Deliverables
+
+- Safety Policy Spec v1
+- Unified High-Risk Approval Gate v1
+- Data Governance Controls v1
+- Audit Trail Schema v1
+- Rollback Playbook v1
+
+### Measurable exit criteria
+
+- Zero severity-1 unsafe autonomous actions on an adversarial validation set of at least `100` tasks.
+- `100%` of destructive, sensitive, or irreversible actions pass through approval or explicit policy denial paths.
+- `100%` of high-impact actions emit audit records with actor, rationale, tool path, and result.
+- Rollback drills succeed for `100%` of sampled reversible workflows in the validation set.
+- Memory and audit persistence show zero seeded-secret or seeded-PII leakage incidents in tests.
+
+### Phase gate
+
+- Adversarial and red-team report exists with severity rubric and reproducible cases.
+- Approval, audit, and rollback paths are exercised in automated tests, not only manual demos.
+- High-impact action coverage is measured by event logs, not inferred.
+- Go only if safety coverage is complete for the currently enabled capability surface; no-go if any high-impact path lacks auditability or rollback expectations.
+
+---
+
+## Phase 7: Continuous Evolution Loop (Session-Based Cadence)
+
+### Objective
+Create a repeatable improvement loop that compounds with each cycle.
+
+### Why this phase matters
+The end state is not a feature set. It is a disciplined operating system for improving Hermes without drifting on quality, cost, or safety.
+
+### Cycle template
+
+1. Run smoke and targeted eval suites
+2. Identify the top three bottlenecks by impact on success, correction burden, or cost
+3. Select one to three focused changes only
+4. Ship behind flags or shadow mode where appropriate
+5. Re-run evals and compare against baseline and holdout
+6. Promote only positive-net changes
+7. Archive lessons into skills, memory rules, routing policy, or test cases
+
+### Primary implementation surfaces
+
+- `evals/` results and reports
+- `batch_runner.py`
+- `agent/trajectory.py`
+- `agent/skill_commands.py`
+- `hermes_state.py`
+- versioned phase-gate and risk-review artifacts
+
+### Deliverables
+
+- Evolution Cycle SOP v1
+- Bottleneck Prioritization Rubric v1
+- Promotion Checklist v1
+- Knowledge Capture Template v1
+- Risk Review Template v1
+
+### Measurable exit criteria
+
+- Three consecutive evolution cycles show non-regressing holdout scores and at least one improved primary metric per cycle.
+- Cost per successful outcome is stable or decreasing across the same three cycles.
+- Manual intervention rate decreases across the same three cycles on the tracked workflow set.
+- Every promoted change has a linked eval diff and risk-review record.
+
+### Phase gate
+
+- Each cycle produces a single decision record: promote, hold, or revert.
+- Unresolved high-severity risks cannot remain open for more than two cycles without an explicit exception record.
+- Knowledge captured from one cycle must be traceable to later behavior changes, tests, or skill updates.
+- Go only if the loop keeps producing measurable gains; no-go if changes are being promoted without durable evidence.
+
+---
+
+## Phase Gate Framework
+
+Use the same evidence package for every phase so gate decisions stay comparable.
+
+### Required gate packet
+
+- Scope declaration with exact files or modules touched
+- Baseline metrics snapshot taken before implementation
+- Implementation checklist with all required deliverables
+- Test report with named suites and pass/fail status
+- Eval diff report with pre/post metrics
+- Cost impact summary
+- Risk review with newly introduced and retired risks
+- Go or no-go decision record with rollback note
+
+### Default no-go triggers
+
+- Metrics improve on a dev subset but regress on holdout
+- Reliability, safety, or prompt-cache invariants regress
+- Success gains depend on hidden cost growth that exceeds stated thresholds
+- Feature behavior is enabled without shadow-mode evidence where shadow mode was feasible
+
+---
+
+## Cross-Phase Metric Stack
+
+### Reliability
+
+- Tool success rate
+- End-to-end task completion rate
+- Retry-to-success ratio
+- Compression hard-failure rate
+
+### Quality
+
+- Benchmark pass rates by lane
+- Human-rated output quality on sampled tasks
+- User correction frequency
+- Holdout non-regression score
+
+### Efficiency
+
+- Time-to-success
+- Cost-per-success
+- Tokens-per-successful-task
+- Delegation overhead per successful task
+
+### Safety
+
+- Unsafe action incidents
+- Approval gate bypass incidents
+- Audit completeness rate
+- Secret and PII handling violations
+
+### Memory effectiveness
+
+- Retrieval relevance score
+- Contradiction resolution accuracy
+- Memory write precision
+- Skill reuse and impact score
+
+---
+
+## Risk Register (Updated)
+
+| ID | Risk | Likelihood | Impact | Early warning signal | Mitigation / contingency | Primary surfaces |
+|---|---|---|---|---|---|---|
+| R1 | Prompt-cache invalidation from mid-session prompt mutation | Medium | High | System prompt hash changes outside compression events | Assert prompt hash stability, route live updates through tool outputs, block silent prompt rebuilds | `run_agent.py`, `agent/prompt_builder.py`, `agent/prompt_caching.py`, `tools/memory_tool.py` |
+| R2 | Tool contract drift creates ambiguous runtime failures | High | High | Tool results fail JSON or envelope validation | Canonical result envelope, registry validation, contract tests for all tools | `tools/registry.py`, `model_tools.py`, `tests/tools/` |
+| R3 | Context bloat or tool-pair corruption degrades reasoning | High | High | Compression hard failures, orphaned tool repair count rises | Dedupe tool output, cap reinjected content, track sanitizer repairs, strengthen compression tests | `agent/context_compressor.py`, `run_agent.py` |
+| R4 | Memory drift, contradiction buildup, or over-persistence | High | High | User corrections rise on repeat tasks, contradiction count grows, memory size grows faster than reuse | Write-gate scoring, reconciliation, pruning, source-precedence rules | `tools/memory_tool.py`, `run_agent.py`, `hermes_state.py` |
+| R5 | Local memory and Honcho state diverge | Medium | High | Pending sync queue grows, conflicting facts appear between stores | Add sync-health metrics, write-ahead event log, clear precedence rules, repair job for drift | `run_agent.py` Honcho paths, `tools/memory_tool.py`, `tools/honcho_tools.py` |
+| R6 | Eval contamination or benchmark overfitting | Medium | High | Dev-suite gains do not reproduce on holdout | Locked holdout tasks, rotated eval subsets, regression gates based on holdout | new `evals/`, `batch_runner.py` |
+| R7 | Cost creep from retries, delegation, browser, or MCP overuse | High | Medium | Cost-per-success and average retries trend upward without quality gain | Shadow-mode routing, retry budgets, route-level cost dashboards, revert policies | `run_agent.py`, `tools/delegate_tool.py`, `tools/mcp_tool.py` |
+| R8 | Shared-state orchestration bugs under delegation | Medium | High | Cross-agent tool leakage, execute-code import failures, inconsistent enabled-tools sets | Remove or contain process-global state, add concurrency stress tests, per-agent routing state | `model_tools.py`, `tools/delegate_tool.py`, `run_agent.py` |
+| R9 | Safety coverage lags behind new capability surface | Medium | High | New tools or MCP integrations appear without approvals or audit support | Deny-by-default capability rollout, unified approval taxonomy, integration checklist | `tools/approval.py`, `tools/mcp_tool.py`, `tools/terminal_tool.py` |
+| R10 | Audit or rollback data is incomplete during real incidents | Medium | High | High-impact actions cannot be reconstructed after the fact | Queryable audit store, rollback artifact requirement, drill reversible workflows | `hermes_state.py`, `tools/approval.py`, `tools/terminal_tool.py`, `tools/checkpoint_manager.py` |
+| R11 | Observability gaps make phase gates anecdotal | Medium | Medium | Metrics require manual reconstruction from logs or memory | Mandatory event schema, versioned reports, no gate without baseline artifact | `hermes_state.py`, `agent/trajectory.py`, new `evals/` |
+
+---
+
+## Immediate Execution Order (Retained, With Implementation Notes)
+
+1. Phase 1 core stability and contract normalization
+2. Phase 4 foundations early enough to establish baselines and regression visibility
+3. Phase 2 memory quality and retrieval discipline
+4. Phase 3 self-correction in shadow mode, then bounded live mode
+5. Phase 5 scalable orchestration and dynamic routing after state-isolation risks are retired
+6. Phase 6 safety hardening before broader autonomous rollout or new high-impact integrations
+7. Phase 7 continuous evolution loop as the standing operating cadence
+
+### Practical sequencing notes
+
+- Start instrumentation work before closing Phase 1, or later gates will be weak.
+- Treat Phase 4 as an enabling layer, not a late-stage reporting exercise.
+- Start designing Phase 6 controls earlier than its formal gate if any new side-effecting capability is introduced in Phases 3 through 5.
+
+---
+
+## Source Spine (Primary References)
+
+### Hermes docs
+
+- https://hermes-agent.nousresearch.com/docs/
+- https://hermes-agent.nousresearch.com/docs/guides/tips/
+- https://hermes-agent.nousresearch.com/docs/user-guide/features/memory
+- https://hermes-agent.nousresearch.com/docs/user-guide/features/skills
+- https://hermes-agent.nousresearch.com/docs/developer-guide/architecture
+
+### Agent engineering guidance
+
+- https://www.anthropic.com/research/building-effective-agents
+- https://www.anthropic.com/engineering/writing-tools-for-agents
+- https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents
+- https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents
+- https://openai.com/business/guides-and-resources/a-practical-guide-to-building-ai-agents/
+- https://developers.openai.com/api/docs/guides/agent-evals/
+
+### Research foundations
+
+- Voyager: https://arxiv.org/abs/2305.16291
+- Reflexion: https://arxiv.org/abs/2303.11366
+- Self-Refine: https://arxiv.org/abs/2303.17651
+- Toolformer: https://arxiv.org/abs/2302.04761
+- GAIA: https://arxiv.org/abs/2311.12983
+- Constitutional AI: https://arxiv.org/abs/2212.08073
+- Memory survey: https://arxiv.org/abs/2512.13564
+
+### Benchmarks
+
+- SWE-bench: https://www.swebench.com/SWE-bench/
+- Terminal-Bench: https://www.tbench.ai/
+
+### Firecrawl docs
+
+- Scrape endpoint: https://docs.firecrawl.dev/api-reference/endpoint/scrape
+- Extract endpoint: https://docs.firecrawl.dev/api-reference/endpoint/extract
+- Map endpoint: https://docs.firecrawl.dev/api-reference/endpoint/map
+- Extract feature: https://docs.firecrawl.dev/features/extract
+
+---
+
+## Definition of Success
+
+Hermes is considered elite when it demonstrates:
+
+- High reliability on real, tool-heavy tasks
+- Persistent compounding gains from memory and skill systems
+- Measurable benchmark improvement across lanes
+- Controlled cost growth through routing
+- Strong safety and audit guarantees
+- Low user correction burden over time
+- A repeatable promotion process where improvements are evidenced, gated, and reversible

--- a/agent/self_correction.py
+++ b/agent/self_correction.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class FailureAssessment:
+    failure_class: str
+    confidence: float
+    recommendation: str
+    retryable: bool
+
+
+@dataclass
+class RetryPolicy:
+    max_retries: int
+    backoff_seconds: list[float]
+    reason: str
+
+
+def classify_failure(
+    *,
+    tool_name: str,
+    error_type: Optional[str],
+    error_summary: Optional[str],
+    retryable_hint: bool,
+) -> FailureAssessment:
+    """Classify a tool failure into the super-agent failure taxonomy."""
+    summary = (error_summary or "").lower()
+    etype = (error_type or "").lower()
+
+    if "reasoning" in summary or "halluc" in summary or "reasoning" in etype:
+        return FailureAssessment(
+            failure_class="reasoning_failure",
+            confidence=0.74,
+            recommendation="Reframe objective and constraints, then regenerate the plan before retry.",
+            retryable=False,
+        )
+
+    if retryable_hint or "timeout" in summary or "rate" in summary or "connection" in summary:
+        return FailureAssessment(
+            failure_class="provider_failure",
+            confidence=0.8,
+            recommendation="Retry with backoff and preserve prior reasoning state.",
+            retryable=True,
+        )
+
+    if "json" in summary or "schema" in summary or "invalid" in summary:
+        return FailureAssessment(
+            failure_class="schema_mismatch",
+            confidence=0.78,
+            recommendation="Ask model to repair tool args/schema before reissuing call.",
+            retryable=True,
+        )
+
+    if tool_name in {"terminal", "patch", "write_file"} and ("permission" in summary or "denied" in summary):
+        return FailureAssessment(
+            failure_class="unsafe_action_block",
+            confidence=0.82,
+            recommendation="Request explicit approval before retrying side-effecting action.",
+            retryable=False,
+        )
+
+    if "missing" in summary or "not found" in summary:
+        return FailureAssessment(
+            failure_class="missing_context",
+            confidence=0.7,
+            recommendation="Gather required context/input, then retry once.",
+            retryable=True,
+        )
+
+    return FailureAssessment(
+        failure_class="tool_misuse",
+        confidence=0.6,
+        recommendation="Use tool-specific correction prompt and require argument sanity-check.",
+        retryable=True,
+    )
+
+
+def get_retry_policy(*, tool_name: str, failure: FailureAssessment) -> RetryPolicy:
+    """Return tool-aware retry policy for bounded live retries."""
+    provider_tool = tool_name.startswith("web_") or tool_name.startswith("browser_") or tool_name.startswith("mcp")
+
+    if failure.failure_class == "provider_failure" and failure.retryable:
+        if provider_tool:
+            return RetryPolicy(max_retries=2, backoff_seconds=[0.2, 0.5], reason="provider_backoff")
+        return RetryPolicy(max_retries=1, backoff_seconds=[0.25], reason="single_transient_retry")
+
+    if failure.failure_class == "schema_mismatch" and failure.retryable:
+        return RetryPolicy(max_retries=1, backoff_seconds=[0.0], reason="schema_repair_retry")
+
+    if failure.failure_class == "missing_context" and failure.retryable:
+        return RetryPolicy(max_retries=1, backoff_seconds=[0.0], reason="context_retry")
+
+    return RetryPolicy(max_retries=0, backoff_seconds=[], reason=f"{failure.failure_class}_non_retry")
+
+
+def build_shadow_critique_event(
+    *,
+    tool_name: str,
+    error_type: Optional[str],
+    error_summary: Optional[str],
+    retryable_hint: bool,
+) -> Dict[str, Any]:
+    """Build a shadow-mode critique payload without changing live behavior."""
+    assessment = classify_failure(
+        tool_name=tool_name,
+        error_type=error_type,
+        error_summary=error_summary,
+        retryable_hint=retryable_hint,
+    )
+    return {
+        "tool_name": tool_name,
+        "failure_class": assessment.failure_class,
+        "confidence": assessment.confidence,
+        "recommendation": assessment.recommendation,
+        "retryable": assessment.retryable,
+        "shadow_mode": True,
+    }

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -638,8 +638,16 @@ delegation:
 # Config: ~/.honcho/config.json (shared with Claude Code, Cursor, etc.)
 # API key: HONCHO_API_KEY in ~/.hermes/.env or ~/.honcho/config.json
 #
-# Hermes-specific overrides (optional — most config comes from ~/.honcho/config.json):
-# honcho: {}
+# Hermes-specific runtime overrides (optional — most config comes from ~/.honcho/config.json):
+# honcho:
+#   fail_open: true        # Keep replying if Honcho is down; queue sync for retry
+#   retry_attempts: 2      # Additional retries per Honcho prefetch/sync call
+#   tool_events:
+#     enabled: true        # Sync compact structured tool events into Honcho
+#     max_result_chars: 240  # Clip per-event result preview to control token overhead
+#   max_pending_sync: 200         # Bound queued user/assistant turn sync backlog
+#   max_pending_tool_events: 400  # Bound queued tool-event backlog
+#   flush_batch_size: 25          # Replay at most this many queued items per cycle
 
 # =============================================================================
 # Display

--- a/cli.py
+++ b/cli.py
@@ -2036,8 +2036,328 @@ class HermesCLI:
         print("  -- Session --")
         print(f"  Started:     {self.session_start.strftime('%Y-%m-%d %H:%M:%S')}")
         print(f"  Config File: {config_path} {config_status}")
+        if self.agent and hasattr(self.agent, "get_honcho_status"):
+            hstatus = self.agent.get_honcho_status()
+            print()
+            print("  -- Honcho Runtime --")
+            print(f"  Enabled:      {hstatus.get('enabled')}")
+            print(f"  Session Key:  {hstatus.get('session_key') or '-'}")
+            print(f"  Mode:         {'fail-open' if hstatus.get('fail_open') else 'strict'}")
+            print(f"  Retries:      {hstatus.get('retry_attempts')}")
+            print(f"  Tool Events:  {hstatus.get('tool_events_enabled')}")
+            print(f"  Queue:        sync={hstatus.get('pending_sync', 0)}/{hstatus.get('max_pending_sync', '-')}, tool_events={hstatus.get('pending_tool_events', 0)}/{hstatus.get('max_pending_tool_events', '-')} (batch={hstatus.get('flush_batch_size', '-')})")
         print()
-    
+
+    def _handle_honcho_command(self, cmd: str) -> None:
+        """Handle /honcho status and runtime controls."""
+        if not self.agent or not hasattr(self.agent, "get_honcho_status"):
+            print("  Honcho runtime is unavailable (agent not initialized yet).")
+            print("  Send one message first, then run /honcho.")
+            return
+
+        parts = cmd.strip().split()
+        subcmd = parts[1].lower() if len(parts) > 1 else "status"
+
+        if subcmd in {"status", "show"}:
+            status = self.agent.get_honcho_status()
+            mode = "fail-open" if status.get("fail_open") else "strict"
+            telemetry = status.get("telemetry") or {}
+            print("\n  -- Honcho Runtime --")
+            print(f"  Enabled:      {status.get('enabled')}")
+            print(f"  Session Key:  {status.get('session_key') or '-'}")
+            print(f"  Mode:         {mode}")
+            print(f"  Retries:      {status.get('retry_attempts')}")
+            print(f"  Tool Events:  {status.get('tool_events_enabled')}")
+            print(f"  Queue:        sync={status.get('pending_sync', 0)}/{status.get('max_pending_sync', '-')}, tool_events={status.get('pending_tool_events', 0)}/{status.get('max_pending_tool_events', '-')} (batch={status.get('flush_batch_size', '-')})")
+            print(f"  Dropped:      sync={telemetry.get('dropped_sync', 0)}, tool_events={telemetry.get('dropped_tool_events', 0)}")
+            print(f"  Last Error:   {status.get('last_error') or '-'}")
+            print()
+            return
+
+        if subcmd in {"flush", "drain"}:
+            if not hasattr(self.agent, "flush_honcho_queues"):
+                print("  This agent runtime does not support manual Honcho flush yet.")
+                return
+            status = self.agent.flush_honcho_queues()
+            print(
+                "  Honcho flush complete: "
+                f"replayed sync={status.get('flushed_sync', 0)}, "
+                f"tool_events={status.get('flushed_tool_events', 0)}; "
+                f"pending sync={status.get('pending_sync', 0)}, "
+                f"tool_events={status.get('pending_tool_events', 0)}"
+            )
+            return
+
+        if subcmd in {"strict", "fail-open", "fail_open"}:
+            fail_open = subcmd != "strict"
+            status = self.agent.set_honcho_runtime_mode(fail_open=fail_open)
+            save_config_value("honcho.fail_open", fail_open)
+            mode = "fail-open" if status.get("fail_open") else "strict"
+            print(f"  Honcho mode set to {mode} (saved).")
+            return
+
+        if subcmd in {"retries", "retry"}:
+            if len(parts) < 3:
+                print("  Usage: /honcho retries <count>")
+                return
+            try:
+                retry_attempts = max(0, int(parts[2]))
+            except ValueError:
+                print("  Retry count must be an integer >= 0.")
+                return
+            status = self.agent.set_honcho_runtime_mode(retry_attempts=retry_attempts)
+            save_config_value("honcho.retry_attempts", retry_attempts)
+            print(f"  Honcho retries set to {status.get('retry_attempts')} (saved).")
+            return
+
+        if subcmd in {"tool-events", "tool_events"}:
+            if len(parts) < 3:
+                print("  Usage: /honcho tool-events <on|off>")
+                return
+            enabled = parts[2].lower() in {"on", "true", "1", "yes", "enable", "enabled"}
+            status = self.agent.set_honcho_runtime_mode(tool_events_enabled=enabled)
+            save_config_value("honcho.tool_events.enabled", enabled)
+            state = "enabled" if status.get("tool_events_enabled") else "disabled"
+            print(f"  Honcho tool events {state} (saved).")
+            return
+
+        print("  Usage:")
+        print("    /honcho                  # Show runtime status")
+        print("    /honcho strict           # Disable fail-open (strict mode)")
+        print("    /honcho fail-open        # Enable fail-open mode")
+        print("    /honcho retries <count>  # Set retry attempts")
+        print("    /honcho tool-events on|off")
+        print("    /honcho flush            # Replay one batch of queued writes now")
+
+    def _handle_tool_events_command(self, cmd: str) -> None:
+        """Handle /tool-events with optional filters, stats, and JSON export."""
+        parts = cmd.strip().split()
+        tokens = parts[1:]
+
+        limit = 10
+        tool_name = None
+        errors_only = False
+        retryable_only = False
+        bucket_by = "tool"  # tool | window
+        window_size = 5
+        json_requested = False
+        export_requested = False
+        stats_requested = False
+        output_mode = "text"  # text | json | export | stats | stats_json
+
+        for token in tokens:
+            lower = token.lower()
+            if lower.isdigit():
+                limit = max(1, min(200, int(lower)))
+            elif lower in {"errors", "error", "errors-only", "failed", "failures"}:
+                errors_only = True
+            elif lower in {"retryable", "retry"}:
+                retryable_only = True
+            elif lower in {"json", "--json"}:
+                json_requested = True
+            elif lower == "export":
+                export_requested = True
+            elif lower in {"stats", "summary"}:
+                stats_requested = True
+            elif lower.startswith("tool="):
+                tool_name = token.split("=", 1)[1].strip()
+            elif lower.startswith("tool:"):
+                tool_name = token.split(":", 1)[1].strip()
+            elif lower.startswith("bucket=") or lower.startswith("group="):
+                bucket_value = token.split("=", 1)[1].strip().lower()
+                if bucket_value in {"tool", "tools", "by_tool"}:
+                    bucket_by = "tool"
+                elif bucket_value in {"window", "windows", "chunk", "chunks"}:
+                    bucket_by = "window"
+                else:
+                    print("  Usage: /tool-events [limit] [errors] [retryable] [tool=<name>] [stats] [bucket=tool|window] [window=<n>] [json|export]")
+                    return
+            elif lower.startswith("window="):
+                try:
+                    window_size = max(1, min(200, int(token.split("=", 1)[1].strip())))
+                except ValueError:
+                    print("  Usage: /tool-events [limit] [errors] [retryable] [tool=<name>] [stats] [bucket=tool|window] [window=<n>] [json|export]")
+                    return
+            else:
+                print("  Usage: /tool-events [limit] [errors] [retryable] [tool=<name>] [stats] [bucket=tool|window] [window=<n>] [json|export]")
+                return
+
+        if stats_requested and export_requested:
+            print("  Usage: /tool-events [limit] [errors] [retryable] [tool=<name>] [stats] [bucket=tool|window] [window=<n>] [json|export]")
+            return
+
+        if stats_requested:
+            output_mode = "stats_json" if json_requested else "stats"
+        elif export_requested:
+            output_mode = "export"
+        elif json_requested:
+            output_mode = "json"
+
+        if tool_name == "":
+            tool_name = None
+
+        events = []
+        requested_ok = False if errors_only else None
+        requested_retryable = True if retryable_only else None
+
+        if self.agent and hasattr(self.agent, "get_recent_tool_execution_events"):
+            try:
+                events = self.agent.get_recent_tool_execution_events(
+                    limit=limit,
+                    tool_name=tool_name,
+                    ok=requested_ok,
+                    retryable=requested_retryable,
+                )
+            except TypeError:
+                # Backward compatibility if an older agent object is injected.
+                events = self.agent.get_recent_tool_execution_events(limit=limit)
+            except Exception as err:
+                print(f"  Failed to load live tool events: {err}")
+
+        if not events and getattr(self, "_session_db", None):
+            try:
+                events = self._session_db.get_recent_tool_execution_events(
+                    self.session_id,
+                    limit=limit,
+                    tool_name=tool_name,
+                    success=requested_ok,
+                    retryable=requested_retryable,
+                )
+            except TypeError:
+                events = self._session_db.get_recent_tool_execution_events(self.session_id, limit=limit)
+            except Exception as err:
+                print(f"  Failed to load persisted tool events: {err}")
+
+        normalized_events = []
+        for event in events:
+            ok_value = event.get("ok")
+            if ok_value is None:
+                ok_value = bool(event.get("success"))
+
+            ts = event.get("ts")
+            if not ts and event.get("timestamp"):
+                try:
+                    ts = datetime.fromtimestamp(float(event["timestamp"])).strftime("%Y-%m-%dT%H:%M:%SZ")
+                except (TypeError, ValueError, OSError):
+                    ts = "-"
+
+            normalized_events.append(
+                {
+                    "ts": ts or "-",
+                    "tool": event.get("tool") or event.get("tool_name") or "unknown",
+                    "tool_call_id": event.get("tool_call_id") or "-",
+                    "duration_ms": event.get("duration_ms"),
+                    "ok": bool(ok_value),
+                    "envelope": bool(event.get("envelope", False)),
+                    "retryable": bool(event.get("retryable", False)),
+                    "error_type": event.get("error_type"),
+                    "error_summary": event.get("error_summary") or "",
+                    "args_preview": event.get("args_preview"),
+                    "result_preview": event.get("result_preview"),
+                }
+            )
+
+        if not normalized_events:
+            print("  Tool event inspection unavailable or no matching events captured yet.")
+            return
+
+        if output_mode in {"stats", "stats_json"}:
+            def _nearest_rank_percentile(values: list[int], percentile: float) -> int:
+                if not values:
+                    return 0
+                rank = max(1, int(round((percentile / 100.0) * len(values))))
+                rank = min(len(values), rank)
+                return values[rank - 1]
+
+            def _stats_row(bucket_label: str, bucket_events: list[dict[str, Any]]) -> dict[str, Any]:
+                total = len(bucket_events)
+                failures = sum(1 for e in bucket_events if not e.get("ok"))
+                error_rate = (failures / total) * 100.0 if total else 0.0
+                durations = sorted(
+                    int(e["duration_ms"])
+                    for e in bucket_events
+                    if isinstance(e.get("duration_ms"), int)
+                )
+                p50 = _nearest_rank_percentile(durations, 50) if durations else None
+                p95 = _nearest_rank_percentile(durations, 95) if durations else None
+                return {
+                    "bucket": bucket_label,
+                    "count": total,
+                    "errors": failures,
+                    "error_rate_pct": round(error_rate, 1),
+                    "p50_ms": p50,
+                    "p95_ms": p95,
+                }
+
+            stats_rows: list[dict[str, Any]] = []
+            if bucket_by == "window":
+                for start in range(0, len(normalized_events), max(1, window_size)):
+                    chunk = normalized_events[start : start + max(1, window_size)]
+                    bucket_label = f"latest_{start + 1}_{start + len(chunk)}"
+                    stats_rows.append(_stats_row(bucket_label, chunk))
+            else:
+                grouped: dict[str, list[dict[str, Any]]] = {}
+                for event in normalized_events:
+                    grouped.setdefault(event["tool"], []).append(event)
+                for tool, events_for_tool in sorted(grouped.items(), key=lambda kv: (-len(kv[1]), kv[0])):
+                    stats_rows.append(_stats_row(tool, events_for_tool))
+
+            if output_mode == "stats_json":
+                stats_payload = {
+                    "mode": "stats",
+                    "bucket_by": bucket_by,
+                    "window_size": window_size if bucket_by == "window" else None,
+                    "total_events": len(normalized_events),
+                    "buckets": stats_rows,
+                }
+                print(json.dumps(stats_payload, indent=2, ensure_ascii=False))
+                return
+
+            print(f"\n  -- Tool Event Stats (latest {len(normalized_events)}) --")
+            for row in stats_rows:
+                p50 = f"{row['p50_ms']}ms" if isinstance(row.get("p50_ms"), int) else "-"
+                p95 = f"{row['p95_ms']}ms" if isinstance(row.get("p95_ms"), int) else "-"
+                print(
+                    f"  - bucket={row['bucket']}: count={row['count']} "
+                    f"errors={row['errors']} ({row['error_rate_pct']:.1f}%) "
+                    f"p50={p50} p95={p95}"
+                )
+            return
+
+        if output_mode in {"json", "export"}:
+            payload = json.dumps(normalized_events, indent=2, ensure_ascii=False)
+            if output_mode == "json":
+                print(payload)
+                return
+
+            session_label = getattr(self, "session_id", "session") or "session"
+            safe_session_label = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in session_label)
+            ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+            out_path = Path.cwd() / f"tool-events-{safe_session_label}-{ts}.json"
+            out_path.write_text(payload, encoding="utf-8")
+            print(f"  Exported {len(normalized_events)} tool events to: {out_path}")
+            return
+
+        print(f"\n  -- Tool Execution Events (latest {len(normalized_events)}) --")
+        for idx, event in enumerate(normalized_events, start=1):
+            status = "ok" if event["ok"] else "error"
+            duration = event.get("duration_ms")
+            duration_str = f"{duration}ms" if isinstance(duration, int) else "-"
+            summary = event.get("error_summary") or ""
+            suffix = f" — {summary}" if summary else ""
+            print(
+                f"  {idx:>2}. [{status}] {event['tool']} ({duration_str}) "
+                f"id={event['tool_call_id']} @ {event['ts']}{suffix}"
+            )
+
+        latest_failure = next((event for event in normalized_events if not event.get("ok")), None)
+        if latest_failure:
+            tool_value = latest_failure.get("tool") or "unknown"
+            args_value = latest_failure.get("args_preview") or "{}"
+            print("\n  Last failure replay hint:")
+            print(f"    /tool-events errors retryable tool={tool_value}")
+            print(f"    args={args_value}")
+
     def show_history(self):
         """Display conversation history."""
         if not self.conversation_history:
@@ -2503,6 +2823,10 @@ class HermesCLI:
             self.show_toolsets()
         elif cmd_lower == "/config":
             self.show_config()
+        elif cmd_lower.startswith("/honcho"):
+            self._handle_honcho_command(cmd_original)
+        elif cmd_lower.startswith("/tool-events"):
+            self._handle_tool_events_command(cmd_original)
         elif cmd_lower == "/clear":
             # Flush memories before clearing
             if self.agent and self.conversation_history:

--- a/evals/EVOLUTION_CYCLE_SOP.md
+++ b/evals/EVOLUTION_CYCLE_SOP.md
@@ -1,0 +1,11 @@
+# Evolution Cycle SOP v1
+
+1) Run smoke suite (`evals/suites/smoke_v1.json`) and targeted regressions.
+2) Identify top three bottlenecks by impact on success/cost/manual correction burden.
+3) Select up to three scoped changes.
+4) Ship behind flags or shadow mode when behavior-changing.
+5) Re-run evals against baseline + holdout.
+6) Promote only net-positive changes.
+7) Capture lessons in memory/skills/tests.
+
+Decision record required each cycle: PROMOTE | HOLD | REVERT.

--- a/evals/REGRESSION_POLICY.md
+++ b/evals/REGRESSION_POLICY.md
@@ -1,0 +1,11 @@
+# Regression Policy v1
+
+Promotion gate:
+- Run smoke suite on every major change.
+- Run full suite before promotion.
+- Reject promotion on holdout regression.
+- Require pre/post diff for run_agent.py, model_tools.py, agent/, tools/ edits.
+
+Flake control:
+- Same-commit rerun required when pass rate delta > 5%.
+- Prefer deterministic graders; model-graded tasks must include rationale artifacts.

--- a/evals/RISK_REVIEW_TEMPLATE.md
+++ b/evals/RISK_REVIEW_TEMPLATE.md
@@ -1,0 +1,21 @@
+# Risk Review Template
+
+Change:
+Baseline ref:
+Eval diff ref:
+
+Risks introduced:
+- 
+
+Risks retired:
+- 
+
+Prompt-cache invariant check:
+- [ ] No mid-session prompt mutation
+
+Safety check:
+- [ ] High-impact actions audited
+- [ ] Approval gate coverage unchanged or improved
+
+Decision:
+- PROMOTE / HOLD / REVERT

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,5 @@
+"""Evaluation harness package for Hermes super-agent evolution."""
+
+from .harness import EvalHarness, EvalTask, EvalResult, EvalSuite
+
+__all__ = ["EvalHarness", "EvalTask", "EvalResult", "EvalSuite"]

--- a/evals/harness.py
+++ b/evals/harness.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+
+@dataclass
+class EvalTask:
+    task_id: str
+    lane: str
+    prompt: str
+    expected: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class EvalResult:
+    task_id: str
+    lane: str
+    passed: bool
+    score: float
+    duration_s: float
+    output: str
+    failure_signature: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class EvalSuite:
+    suite: str
+    version: str
+    tasks: List[EvalTask]
+    holdout_task_ids: List[str]
+
+
+class EvalHarness:
+    """Versioned eval harness for coding/terminal/agentic lanes.
+
+    This is intentionally lightweight and deterministic-first. Callers provide
+    a ``runner`` callback that executes a task prompt and returns output text.
+    """
+
+    def __init__(self, *, suite_name: str, commit: str = "unknown") -> None:
+        self.suite_name = suite_name
+        self.commit = commit
+
+    @staticmethod
+    def load_suite(path: str | Path) -> EvalSuite:
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+        tasks = [
+            EvalTask(
+                task_id=t["task_id"],
+                lane=t["lane"],
+                prompt=t["prompt"],
+                expected=t.get("expected"),
+                metadata=t.get("metadata") or {},
+            )
+            for t in raw.get("tasks", [])
+        ]
+        return EvalSuite(
+            suite=raw.get("suite", "unknown"),
+            version=str(raw.get("version", "v1")),
+            tasks=tasks,
+            holdout_task_ids=list(raw.get("holdout_task_ids", [])),
+        )
+
+    @staticmethod
+    def deterministic_grade(task: EvalTask, output: str) -> tuple[bool, float, Optional[str]]:
+        expected = (task.expected or "").strip()
+        if not expected:
+            # No deterministic target -> treat as informational lane task.
+            return True, 1.0, None
+
+        passed = expected.lower() in (output or "").lower()
+        if passed:
+            return True, 1.0, None
+        return False, 0.0, f"missing_expected:{expected[:60]}"
+
+    def run_suite(
+        self,
+        suite: EvalSuite,
+        *,
+        runner: Callable[[EvalTask], str],
+        output_dir: str | Path,
+    ) -> Dict[str, Any]:
+        started = time.time()
+        results: List[EvalResult] = []
+
+        for task in suite.tasks:
+            task_started = time.time()
+            output = runner(task)
+            passed, score, failure_signature = self.deterministic_grade(task, output)
+            results.append(
+                EvalResult(
+                    task_id=task.task_id,
+                    lane=task.lane,
+                    passed=passed,
+                    score=score,
+                    duration_s=round(time.time() - task_started, 4),
+                    output=output,
+                    failure_signature=failure_signature,
+                    metadata=task.metadata or {},
+                )
+            )
+
+        total = len(results)
+        passed_count = sum(1 for r in results if r.passed)
+        lane_scores: Dict[str, List[float]] = {}
+        for row in results:
+            lane_scores.setdefault(row.lane, []).append(row.score)
+
+        by_lane = {
+            lane: {
+                "count": len(scores),
+                "avg_score": round(sum(scores) / len(scores), 4) if scores else 0.0,
+            }
+            for lane, scores in lane_scores.items()
+        }
+
+        report = {
+            "suite": suite.suite,
+            "version": suite.version,
+            "commit": self.commit,
+            "harness": self.suite_name,
+            "duration_s": round(time.time() - started, 4),
+            "summary": {
+                "total": total,
+                "passed": passed_count,
+                "pass_rate": round((passed_count / total), 4) if total else 0.0,
+            },
+            "by_lane": by_lane,
+            "holdout_task_ids": suite.holdout_task_ids,
+            "results": [asdict(r) for r in results],
+        }
+
+        out_path = Path(output_dir)
+        out_path.mkdir(parents=True, exist_ok=True)
+        stamp = int(time.time())
+        report_file = out_path / f"{suite.suite}_report_{stamp}.json"
+        report_file.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+        report["report_file"] = str(report_file)
+        return report

--- a/evals/suites/smoke_v1.json
+++ b/evals/suites/smoke_v1.json
@@ -1,0 +1,25 @@
+{
+  "suite": "smoke",
+  "version": "v1",
+  "holdout_task_ids": ["agentic-1"],
+  "tasks": [
+    {
+      "task_id": "coding-1",
+      "lane": "coding",
+      "prompt": "Return the word FIXED",
+      "expected": "FIXED"
+    },
+    {
+      "task_id": "terminal-1",
+      "lane": "terminal",
+      "prompt": "Return READY and include shell-safe guidance",
+      "expected": "READY"
+    },
+    {
+      "task_id": "agentic-1",
+      "lane": "agentic",
+      "prompt": "Summarize a two-step plan and include PLAN",
+      "expected": "PLAN"
+    }
+  ]
+}

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -620,16 +620,26 @@ class BasePlatformAdapter(ABC):
         
         return media, cleaned
     
-    async def _keep_typing(self, chat_id: str, interval: float = 2.0) -> None:
+    async def _keep_typing(
+        self,
+        chat_id: str,
+        interval: float = 2.0,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """
         Continuously send typing indicator until cancelled.
-        
+
         Telegram/Discord typing status expires after ~5 seconds, so we refresh every 2
         to recover quickly after progress messages interrupt it.
         """
         try:
             while True:
-                await self.send_typing(chat_id)
+                try:
+                    # Newer adapters accept metadata (e.g., Telegram thread_id),
+                    # older ones don't. Try metadata first, then fall back.
+                    await self.send_typing(chat_id, metadata=metadata)  # type: ignore[misc]
+                except TypeError:
+                    await self.send_typing(chat_id)
                 await asyncio.sleep(interval)
         except asyncio.CancelledError:
             pass  # Normal cancellation when handler completes

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -806,7 +806,8 @@ class GatewayRunner:
         _known_commands = {"new", "reset", "help", "status", "stop", "model",
                           "personality", "retry", "undo", "sethome", "set-home",
                           "compress", "usage", "insights", "reload-mcp", "reload_mcp",
-                          "update", "title", "resume", "provider", "rollback"}
+                          "update", "title", "resume", "provider", "rollback",
+                          "tool-events", "tool_events"}
         if command and command in _known_commands:
             await self.hooks.emit(f"command:{command}", {
                 "platform": source.platform.value if source.platform else "",
@@ -868,6 +869,9 @@ class GatewayRunner:
 
         if command == "rollback":
             return await self._handle_rollback_command(event)
+
+        if command in ("tool-events", "tool_events"):
+            return await self._handle_tool_events_command(event)
         
         # Skill slash commands: /skill-name loads the skill and sends to agent
         if command:
@@ -1419,6 +1423,197 @@ class GatewayRunner:
         else:
             return "No active task to stop."
     
+    async def _handle_tool_events_command(self, event: MessageEvent) -> str:
+        """Handle /tool-events with optional filters, stats, and JSON output."""
+        source = event.source
+        session_entry = self.session_store.get_or_create_session(source)
+
+        args = event.get_command_args().strip()
+        tokens = args.split() if args else []
+
+        limit = 10
+        tool_name = None
+        errors_only = False
+        retryable_only = False
+        bucket_by = "tool"  # tool | window
+        window_size = 5
+        json_requested = False
+        stats_requested = False
+        output_mode = "text"  # text | json | stats | stats_json
+
+        for token in tokens:
+            lower = token.lower()
+            if lower.isdigit():
+                limit = max(1, min(50, int(lower)))
+            elif lower in {"errors", "error", "errors-only", "failed", "failures"}:
+                errors_only = True
+            elif lower in {"retryable", "retry"}:
+                retryable_only = True
+            elif lower in {"json", "--json", "export"}:
+                json_requested = True
+            elif lower in {"stats", "summary"}:
+                stats_requested = True
+            elif lower.startswith("tool="):
+                tool_name = token.split("=", 1)[1].strip()
+            elif lower.startswith("tool:"):
+                tool_name = token.split(":", 1)[1].strip()
+            elif lower.startswith("bucket=") or lower.startswith("group="):
+                bucket_value = token.split("=", 1)[1].strip().lower()
+                if bucket_value in {"tool", "tools", "by_tool"}:
+                    bucket_by = "tool"
+                elif bucket_value in {"window", "windows", "chunk", "chunks"}:
+                    bucket_by = "window"
+                else:
+                    return "Usage: `/tool-events [limit] [errors] [retryable] [tool=<name>] [stats] [bucket=tool|window] [window=<n>] [json]`"
+            elif lower.startswith("window="):
+                try:
+                    window_size = max(1, min(50, int(token.split("=", 1)[1].strip())))
+                except ValueError:
+                    return "Usage: `/tool-events [limit] [errors] [retryable] [tool=<name>] [stats] [bucket=tool|window] [window=<n>] [json]`"
+            else:
+                return "Usage: `/tool-events [limit] [errors] [retryable] [tool=<name>] [stats] [bucket=tool|window] [window=<n>] [json]`"
+
+        if stats_requested:
+            output_mode = "stats_json" if json_requested else "stats"
+        elif json_requested:
+            output_mode = "json"
+
+        if tool_name == "":
+            tool_name = None
+
+        if not self._session_db:
+            return "Tool event inspection is unavailable: session database disabled."
+
+        success_filter = False if errors_only else None
+        retryable_filter = True if retryable_only else None
+
+        try:
+            events = self._session_db.get_recent_tool_execution_events(
+                session_entry.session_id,
+                limit=limit,
+                tool_name=tool_name,
+                success=success_filter,
+                retryable=retryable_filter,
+            )
+        except Exception as e:
+            logger.debug("Failed to load tool events for %s: %s", session_entry.session_id, e)
+            return "Failed to load tool events for this session."
+
+        if not events:
+            return "No matching tool execution events recorded yet for this session."
+
+        normalized_events = []
+        for item in events:
+            normalized_events.append(
+                {
+                    "ts": item.get("timestamp"),
+                    "tool": item.get("tool_name", "unknown"),
+                    "tool_call_id": item.get("tool_call_id") or "-",
+                    "duration_ms": item.get("duration_ms"),
+                    "ok": bool(item.get("success")),
+                    "envelope": bool(item.get("envelope")),
+                    "retryable": bool(item.get("retryable")),
+                    "error_type": item.get("error_type"),
+                    "error_summary": item.get("error_summary") or "",
+                    "args_preview": item.get("args_preview"),
+                    "result_preview": item.get("result_preview"),
+                }
+            )
+
+        if output_mode in {"stats", "stats_json"}:
+            def _nearest_rank_percentile(values: list[int], percentile: float) -> int:
+                if not values:
+                    return 0
+                rank = max(1, int(round((percentile / 100.0) * len(values))))
+                rank = min(len(values), rank)
+                return values[rank - 1]
+
+            def _stats_row(bucket_label: str, bucket_events: List[Dict[str, Any]]) -> Dict[str, Any]:
+                total = len(bucket_events)
+                failures = sum(1 for event in bucket_events if not event.get("ok"))
+                error_rate = (failures / total) * 100.0 if total else 0.0
+                durations = sorted(
+                    int(event["duration_ms"])
+                    for event in bucket_events
+                    if isinstance(event.get("duration_ms"), int)
+                )
+                p50 = _nearest_rank_percentile(durations, 50) if durations else None
+                p95 = _nearest_rank_percentile(durations, 95) if durations else None
+                return {
+                    "bucket": bucket_label,
+                    "count": total,
+                    "errors": failures,
+                    "error_rate_pct": round(error_rate, 1),
+                    "p50_ms": p50,
+                    "p95_ms": p95,
+                }
+
+            stats_rows: List[Dict[str, Any]] = []
+            if bucket_by == "window":
+                for start in range(0, len(normalized_events), max(1, window_size)):
+                    chunk = normalized_events[start : start + max(1, window_size)]
+                    bucket_label = f"latest_{start + 1}_{start + len(chunk)}"
+                    stats_rows.append(_stats_row(bucket_label, chunk))
+            else:
+                grouped: Dict[str, List[Dict[str, Any]]] = {}
+                for item in normalized_events:
+                    grouped.setdefault(item.get("tool", "unknown"), []).append(item)
+                for tool, events_for_tool in sorted(grouped.items(), key=lambda kv: (-len(kv[1]), kv[0])):
+                    stats_rows.append(_stats_row(tool, events_for_tool))
+
+            if output_mode == "stats_json":
+                import json
+
+                stats_payload = {
+                    "mode": "stats",
+                    "bucket_by": bucket_by,
+                    "window_size": window_size if bucket_by == "window" else None,
+                    "total_events": len(normalized_events),
+                    "buckets": stats_rows,
+                }
+                return json.dumps(stats_payload, indent=2, ensure_ascii=False)
+
+            lines = [f"🧮 Tool Event Stats (latest {len(normalized_events)})", ""]
+            for row in stats_rows:
+                p50 = f"{row['p50_ms']}ms" if isinstance(row.get("p50_ms"), int) else "-"
+                p95 = f"{row['p95_ms']}ms" if isinstance(row.get("p95_ms"), int) else "-"
+                lines.append(
+                    f"• bucket={row['bucket']}: count={row['count']} "
+                    f"errors={row['errors']} ({row['error_rate_pct']:.1f}%) p50={p50} p95={p95}"
+                )
+            return "\n".join(lines)
+
+        if output_mode == "json":
+            import json
+
+            return json.dumps(normalized_events, indent=2, ensure_ascii=False)
+
+        lines = [f"🧰 Recent Tool Events (latest {len(normalized_events)})", ""]
+        for item in normalized_events:
+            status = "✅" if item.get("ok") else "❌"
+            tool = item.get("tool", "unknown")
+            duration = item.get("duration_ms")
+            duration_str = f"{duration}ms" if isinstance(duration, int) else "-"
+            call_id = item.get("tool_call_id") or "-"
+            summary = item.get("error_summary") or ""
+            suffix = f" — {summary}" if summary else ""
+            lines.append(f"{status} {tool} ({duration_str}) id={call_id}{suffix}")
+
+        latest_failure = next((item for item in normalized_events if not item.get("ok")), None)
+        if latest_failure:
+            tool_value = latest_failure.get("tool") or "unknown"
+            args_value = latest_failure.get("args_preview") or "{}"
+            lines.extend(
+                [
+                    "",
+                    "🧩 Last failure replay hint:",
+                    f"/tool-events errors retryable tool={tool_value}",
+                    f"args={args_value}",
+                ]
+            )
+
+        return "\n".join(lines)
+
     async def _handle_help_command(self, event: MessageEvent) -> str:
         """Handle /help command - list available commands."""
         lines = [
@@ -1439,6 +1634,7 @@ class GatewayRunner:
             "`/usage` — Show token usage for this session",
             "`/insights [days]` — Show usage insights and analytics",
             "`/rollback [number]` — List or restore filesystem checkpoints",
+            "`/tool-events [limit] [errors] [retryable] [tool=<name>] [stats] [bucket=tool|window] [window=<n>] [json]` — Show recent tool execution events", 
             "`/reload-mcp` — Reload MCP servers from config",
             "`/update` — Update Hermes Agent to the latest version",
             "`/help` — Show this message",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -29,6 +29,8 @@ COMMANDS = {
     "/undo": "Remove the last user/assistant exchange",
     "/save": "Save the current conversation",
     "/config": "Show current configuration",
+    "/honcho": "Show or change Honcho runtime mode (status/strict/fail-open/retries)",
+    "/tool-events": "Inspect recent tool execution events for this session",
     "/cron": "Manage scheduled tasks (list, add, remove)",
     "/skills": "Search, install, inspect, or manage skills from online registries",
     "/platforms": "Show gateway/messaging platform status",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -170,9 +170,23 @@ DEFAULT_CONFIG = {
     "prefill_messages_file": "",
     
     # Honcho AI-native memory -- reads ~/.honcho/config.json as single source of truth.
-    # This section is only needed for hermes-specific overrides; everything else
-    # (apiKey, workspace, peerName, sessions, enabled) comes from the global config.
-    "honcho": {},
+    # This section is only needed for hermes-specific runtime behavior overrides.
+    "honcho": {
+        # Fail-open default: keep responding if Honcho is unavailable; queue/retry sync.
+        "fail_open": True,
+        # Additional retries for Honcho prefetch/sync operations (initial try + retries).
+        "retry_attempts": 2,
+        # Optional toolchain behavior telemetry synced into Honcho as assistant events.
+        "tool_events": {
+            "enabled": True,
+            "max_result_chars": 240,
+        },
+        # Backlog guardrails for fail-open queueing during Honcho outages.
+        "max_pending_sync": 200,
+        "max_pending_tool_events": 400,
+        # Max queued records to replay per turn/flush cycle.
+        "flush_batch_size": 25,
+    },
 
     # IANA timezone (e.g. "Asia/Kolkata", "America/New_York").
     # Empty string means use server-local time.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -25,7 +25,7 @@ from typing import Dict, Any, List, Optional
 
 DEFAULT_DB_PATH = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 6
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -64,10 +64,42 @@ CREATE TABLE IF NOT EXISTS messages (
     finish_reason TEXT
 );
 
+CREATE TABLE IF NOT EXISTS tool_execution_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    tool_name TEXT NOT NULL,
+    tool_call_id TEXT,
+    duration_ms INTEGER,
+    success INTEGER NOT NULL,
+    args_preview TEXT,
+    result_preview TEXT,
+    envelope INTEGER,
+    retryable INTEGER,
+    error_type TEXT,
+    error_summary TEXT,
+    timestamp REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS agent_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    family TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    task_id TEXT,
+    success INTEGER,
+    latency_ms INTEGER,
+    risk_class TEXT,
+    payload_json TEXT,
+    timestamp REAL NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_tool_events_session ON tool_execution_events(session_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_events_session ON agent_events(session_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_events_family ON agent_events(family, timestamp DESC);
 """
 
 FTS_SQL = """
@@ -152,6 +184,65 @@ class SessionDB:
                 except sqlite3.OperationalError:
                     pass  # Index already exists
                 cursor.execute("UPDATE schema_version SET version = 4")
+            if current_version < 5:
+                # v5: durable tool execution event table + session index
+                try:
+                    cursor.execute(
+                        """CREATE TABLE IF NOT EXISTS tool_execution_events (
+                            id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            session_id TEXT NOT NULL REFERENCES sessions(id),
+                            tool_name TEXT NOT NULL,
+                            tool_call_id TEXT,
+                            duration_ms INTEGER,
+                            success INTEGER NOT NULL,
+                            args_preview TEXT,
+                            result_preview TEXT,
+                            envelope INTEGER,
+                            retryable INTEGER,
+                            error_type TEXT,
+                            error_summary TEXT,
+                            timestamp REAL NOT NULL
+                        )"""
+                    )
+                except sqlite3.OperationalError:
+                    pass
+                try:
+                    cursor.execute(
+                        "CREATE INDEX IF NOT EXISTS idx_tool_events_session "
+                        "ON tool_execution_events(session_id, timestamp DESC)"
+                    )
+                except sqlite3.OperationalError:
+                    pass
+                cursor.execute("UPDATE schema_version SET version = 5")
+                current_version = 5
+            if current_version < 6:
+                # v6: generic cross-phase agent event log
+                try:
+                    cursor.execute(
+                        """CREATE TABLE IF NOT EXISTS agent_events (
+                            id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            session_id TEXT NOT NULL REFERENCES sessions(id),
+                            family TEXT NOT NULL,
+                            event_type TEXT NOT NULL,
+                            task_id TEXT,
+                            success INTEGER,
+                            latency_ms INTEGER,
+                            risk_class TEXT,
+                            payload_json TEXT,
+                            timestamp REAL NOT NULL
+                        )"""
+                    )
+                except sqlite3.OperationalError:
+                    pass
+                for idx_sql in (
+                    "CREATE INDEX IF NOT EXISTS idx_agent_events_session ON agent_events(session_id, timestamp DESC)",
+                    "CREATE INDEX IF NOT EXISTS idx_agent_events_family ON agent_events(family, timestamp DESC)",
+                ):
+                    try:
+                        cursor.execute(idx_sql)
+                    except sqlite3.OperationalError:
+                        pass
+                cursor.execute("UPDATE schema_version SET version = 6")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -510,6 +601,174 @@ class SessionDB:
 
         self._conn.commit()
         return msg_id
+
+    def append_tool_execution_event(
+        self,
+        session_id: str,
+        tool_name: str,
+        tool_call_id: str = None,
+        duration_ms: int = None,
+        success: bool = True,
+        args_preview: str = None,
+        result_preview: str = None,
+        envelope: bool = False,
+        retryable: bool = False,
+        error_type: str = None,
+        error_summary: str = None,
+    ) -> int:
+        """Append a normalized tool execution event for a session."""
+        cursor = self._conn.execute(
+            """INSERT INTO tool_execution_events (
+                session_id, tool_name, tool_call_id, duration_ms, success,
+                args_preview, result_preview, envelope, retryable, error_type,
+                error_summary, timestamp
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                session_id,
+                tool_name,
+                tool_call_id,
+                duration_ms,
+                1 if success else 0,
+                args_preview,
+                result_preview,
+                1 if envelope else 0,
+                1 if retryable else 0,
+                error_type,
+                error_summary,
+                time.time(),
+            ),
+        )
+        event_id = cursor.lastrowid
+        self._conn.commit()
+        return event_id
+
+    def get_recent_tool_execution_events(
+        self,
+        session_id: str,
+        limit: int = 20,
+        *,
+        tool_name: Optional[str] = None,
+        success: Optional[bool] = None,
+        retryable: Optional[bool] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return newest-first tool execution events for a specific session.
+
+        Optional filters are combined with AND semantics.
+        """
+        size = max(1, int(limit or 20))
+
+        where_clauses = ["session_id = ?"]
+        params: list[Any] = [session_id]
+
+        if tool_name:
+            where_clauses.append("tool_name = ?")
+            params.append(str(tool_name))
+        if success is not None:
+            where_clauses.append("success = ?")
+            params.append(1 if success else 0)
+        if retryable is not None:
+            where_clauses.append("retryable = ?")
+            params.append(1 if retryable else 0)
+
+        where_sql = " AND ".join(where_clauses)
+        params.append(size)
+
+        cursor = self._conn.execute(
+            f"""SELECT * FROM tool_execution_events
+               WHERE {where_sql}
+               ORDER BY timestamp DESC, id DESC
+               LIMIT ?""",
+            tuple(params),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+    def append_agent_event(
+        self,
+        session_id: str,
+        family: str,
+        event_type: str,
+        *,
+        task_id: str = None,
+        success: Optional[bool] = None,
+        latency_ms: int = None,
+        risk_class: str = None,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> int:
+        """Append a cross-phase agent event record.
+
+        ``payload`` is persisted as JSON for forward-compatible schema evolution.
+        """
+        payload_json = None
+        if payload is not None:
+            payload_json = json.dumps(payload, ensure_ascii=False, default=str)
+
+        cursor = self._conn.execute(
+            """INSERT INTO agent_events (
+                session_id, family, event_type, task_id, success, latency_ms,
+                risk_class, payload_json, timestamp
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                session_id,
+                str(family),
+                str(event_type),
+                task_id,
+                None if success is None else (1 if success else 0),
+                None if latency_ms is None else int(latency_ms),
+                risk_class,
+                payload_json,
+                time.time(),
+            ),
+        )
+        event_id = cursor.lastrowid
+        self._conn.commit()
+        return event_id
+
+    def get_recent_agent_events(
+        self,
+        session_id: str,
+        limit: int = 50,
+        *,
+        family: Optional[str] = None,
+        event_type: Optional[str] = None,
+        success: Optional[bool] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return newest-first cross-phase agent events for a session."""
+        size = max(1, int(limit or 50))
+        where_clauses = ["session_id = ?"]
+        params: list[Any] = [session_id]
+
+        if family:
+            where_clauses.append("family = ?")
+            params.append(str(family))
+        if event_type:
+            where_clauses.append("event_type = ?")
+            params.append(str(event_type))
+        if success is not None:
+            where_clauses.append("success = ?")
+            params.append(1 if success else 0)
+
+        params.append(size)
+        cursor = self._conn.execute(
+            f"""SELECT * FROM agent_events
+               WHERE {' AND '.join(where_clauses)}
+               ORDER BY timestamp DESC, id DESC
+               LIMIT ?""",
+            tuple(params),
+        )
+
+        rows: List[Dict[str, Any]] = []
+        for row in cursor.fetchall():
+            item = dict(row)
+            raw_payload = item.get("payload_json")
+            if raw_payload:
+                try:
+                    item["payload"] = json.loads(raw_payload)
+                except (json.JSONDecodeError, TypeError):
+                    item["payload"] = raw_payload
+            else:
+                item["payload"] = None
+            rows.append(item)
+        return rows
 
     def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages for a session, ordered by timestamp."""

--- a/honcho_integration/session.py
+++ b/honcho_integration/session.py
@@ -127,8 +127,11 @@ class HonchoSessionManager:
 
         # Configure peer observation settings
         from honcho.session import SessionPeerConfig
-        user_config = SessionPeerConfig(observe_me=True, observe_others=True)
-        ai_config = SessionPeerConfig(observe_me=False, observe_others=True)
+        # Docs-aligned defaults for a stateful assistant profile:
+        # - user peer observes itself only
+        # - assistant peer observes both user and itself
+        user_config = SessionPeerConfig(observe_me=True, observe_others=False)
+        ai_config = SessionPeerConfig(observe_me=True, observe_others=True)
 
         session.add_peers([(user_peer, user_config), (assistant_peer, ai_config)])
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -26,7 +26,7 @@ import os
 import logging
 from typing import Dict, Any, List, Optional, Tuple
 
-from tools.registry import registry
+from tools.registry import registry, make_tool_result
 from toolsets import resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
@@ -122,9 +122,8 @@ TOOL_TO_TOOLSET_MAP: Dict[str, str] = registry.get_tool_to_toolset_map()
 
 TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
 
-# Resolved tool names from the last get_tool_definitions() call.
-# Used by code_execution_tool to know which tools are available in this session.
-_last_resolved_tool_names: List[str] = []
+# NOTE: keep tool selection session-scoped via explicit ``enabled_tools`` arguments.
+# Do not cache resolved tool names in process-global mutable state.
 
 
 # =============================================================================
@@ -244,9 +243,6 @@ def get_tool_definitions(
         else:
             print("🛠️  No tools selected (all filtered out or unavailable)")
 
-    global _last_resolved_tool_names
-    _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
-
     return filtered_tools
 
 
@@ -276,22 +272,30 @@ def handle_function_call(
         function_args: Arguments for the function.
         task_id: Unique identifier for terminal/browser session isolation.
         user_task: The user's original task (for browser_snapshot context).
-        enabled_tools: Tool names enabled for this session.  When provided,
+        enabled_tools: Tool names enabled for this session. When provided,
                        execute_code uses this list to determine which sandbox
-                       tools to generate.  Falls back to the process-global
-                       ``_last_resolved_tool_names`` for backward compat.
+                       tools to generate. If omitted, it falls back to the
+                       full registry tool list (no process-global cache).
 
     Returns:
         Function result as a JSON string.
     """
     try:
         if function_name in _AGENT_LOOP_TOOLS:
-            return json.dumps({"error": f"{function_name} must be handled by the agent loop"})
+            return make_tool_result(
+                success=False,
+                error=f"{function_name} must be handled by the agent loop",
+                error_type="AgentLoopDispatchError",
+                retryable=False,
+                data=None,
+                metrics={"tool_name": function_name, "duration_ms": 0},
+            )
 
         if function_name == "execute_code":
-            # Prefer the caller-provided list so subagents can't overwrite
-            # the parent's tool set via the process-global.
-            sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
+            # Prefer caller-provided enabled_tools. If omitted, default to the
+            # full registry set instead of the process-global cache to avoid
+            # cross-agent/state leakage.
+            sandbox_enabled = enabled_tools if enabled_tools is not None else registry.get_all_tool_names()
             return registry.dispatch(
                 function_name, function_args,
                 task_id=task_id,
@@ -307,7 +311,14 @@ def handle_function_call(
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"
         logger.error(error_msg)
-        return json.dumps({"error": error_msg}, ensure_ascii=False)
+        return make_tool_result(
+            success=False,
+            error=error_msg,
+            error_type=type(e).__name__,
+            retryable=False,
+            data=None,
+            metrics={"tool_name": function_name, "duration_ms": 0},
+        )
 
 
 # =============================================================================

--- a/run_agent.py
+++ b/run_agent.py
@@ -36,7 +36,7 @@ import uuid
 from typing import List, Dict, Any, Optional
 from openai import OpenAI
 import fire
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback
@@ -545,7 +545,81 @@ class AIAgent:
         # Reads ~/.honcho/config.json as the single source of truth.
         self._honcho = None  # HonchoSessionManager | None
         self._honcho_session_key = honcho_session_key
+        self._honcho_fail_open = True
+        self._honcho_retry_attempts = 2  # Retries after the initial attempt
+        self._honcho_tool_events_enabled = True
+        self._honcho_tool_events_max_result_chars = 240
+        self._honcho_max_pending_sync = 200
+        self._honcho_max_pending_tool_events = 400
+        self._honcho_flush_batch_size = 25
+        self._pending_honcho_sync: list[dict[str, str]] = []
+        self._pending_honcho_tool_events: list[str] = []
+        self._turn_honcho_context = ""
+        self._turn_honcho_context_baked = False
+        self._honcho_last_prefetch_chars = 0
+        self._honcho_last_error = ""
+        self._honcho_telemetry = {
+            "prefetch_attempts": 0,
+            "prefetch_success": 0,
+            "prefetch_failures": 0,
+            "sync_attempts": 0,
+            "sync_success": 0,
+            "sync_failures": 0,
+            "tool_event_attempts": 0,
+            "tool_event_success": 0,
+            "tool_event_failures": 0,
+            "queued_sync": 0,
+            "queued_tool_events": 0,
+            "replayed_sync": 0,
+            "replayed_tool_events": 0,
+            "dropped_sync": 0,
+            "dropped_tool_events": 0,
+            "flush_cycles": 0,
+        }
+
+        # Local tool-execution event substrate (independent of Honcho).
+        # Keeps a bounded rolling window for debugging/evaluation hooks.
+        self._tool_execution_events: list[dict[str, Any]] = []
+        self._max_tool_execution_events = 500
+        self._agent_events: list[dict[str, Any]] = []
+        self._max_agent_events = 1000
+        self._delegation_budget = {
+            "max_child_count": 3,
+            "max_summary_chars": 12000,
+            "max_iterations": 50,
+        }
+
+        self._self_correction_policy = {
+            "mode": str(os.getenv("HERMES_SELF_CORRECTION_MODE", "shadow")).strip().lower(),
+            "confidence_threshold": float(os.getenv("HERMES_SELF_CORRECTION_CONFIDENCE", "0.72")),
+            "max_live_retries_per_call": max(0, int(os.getenv("HERMES_SELF_CORRECTION_MAX_RETRIES", "2"))),
+            "session_retry_budget": max(0, int(os.getenv("HERMES_SELF_CORRECTION_SESSION_BUDGET", "20"))),
+        }
+        if self._self_correction_policy["mode"] not in {"off", "shadow", "live"}:
+            self._self_correction_policy["mode"] = "shadow"
+        self._self_correction_retries_remaining = int(self._self_correction_policy["session_retry_budget"])
+
         if not skip_memory:
+            try:
+                from hermes_cli.config import load_config as _load_honcho_config
+                _honcho_cfg = _load_honcho_config().get("honcho", {})
+                self._honcho_fail_open = bool(_honcho_cfg.get("fail_open", True))
+                self._honcho_retry_attempts = max(0, int(_honcho_cfg.get("retry_attempts", 2)))
+                _tool_events_cfg = _honcho_cfg.get("tool_events", {}) or {}
+                self._honcho_tool_events_enabled = bool(_tool_events_cfg.get("enabled", True))
+                self._honcho_tool_events_max_result_chars = max(
+                    80,
+                    int(_tool_events_cfg.get("max_result_chars", 240)),
+                )
+                self._honcho_max_pending_sync = max(1, int(_honcho_cfg.get("max_pending_sync", 200)))
+                self._honcho_max_pending_tool_events = max(
+                    1,
+                    int(_honcho_cfg.get("max_pending_tool_events", 400)),
+                )
+                self._honcho_flush_batch_size = max(1, int(_honcho_cfg.get("flush_batch_size", 25)))
+            except Exception:
+                pass
+
             try:
                 from honcho_integration.client import HonchoClientConfig, get_honcho_client
                 hcfg = HonchoClientConfig.from_global_config()
@@ -569,8 +643,8 @@ class AIAgent:
                     from tools.honcho_tools import set_session_context
                     set_session_context(self._honcho, self._honcho_session_key)
                     logger.info(
-                        "Honcho active (session: %s, user: %s, workspace: %s)",
-                        self._honcho_session_key, hcfg.peer_name, hcfg.workspace_id,
+                        "Honcho active (session: %s, user: %s, workspace: %s, fail_open=%s)",
+                        self._honcho_session_key, hcfg.peer_name, hcfg.workspace_id, self._honcho_fail_open,
                     )
                 else:
                     if not hcfg.enabled:
@@ -1317,6 +1391,499 @@ class AIAgent:
 
     # ── Honcho integration helpers ──
 
+    def _honcho_call_with_retry(self, operation, action_name: str):
+        """Run a Honcho operation with bounded retries and fail-open semantics."""
+        attempts = self._honcho_retry_attempts + 1
+        last_error = None
+        for attempt in range(1, attempts + 1):
+            try:
+                return operation()
+            except Exception as e:
+                last_error = e
+                if attempt < attempts:
+                    wait_s = min(0.25 * attempt, 1.0)
+                    logger.debug(
+                        "Honcho %s attempt %d/%d failed: %s (retrying in %.2fs)",
+                        action_name,
+                        attempt,
+                        attempts,
+                        e,
+                        wait_s,
+                    )
+                    time.sleep(wait_s)
+                else:
+                    logger.debug("Honcho %s failed after %d attempts: %s", action_name, attempts, e)
+        if self._honcho_fail_open:
+            return None
+        raise RuntimeError(f"Honcho {action_name} failed: {last_error}")
+
+    def _honcho_preview(self, value: Any, max_chars: int = 200) -> str:
+        """Return a compact single-line preview for Honcho event payloads."""
+        if value is None:
+            return ""
+        if isinstance(value, (dict, list, tuple)):
+            try:
+                rendered = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+            except Exception:
+                rendered = str(value)
+        else:
+            rendered = str(value)
+
+        rendered = " ".join(rendered.split())
+        if len(rendered) > max_chars:
+            return rendered[: max_chars - 3] + "..."
+        return rendered
+
+    @staticmethod
+    def _parse_canonical_tool_envelope(function_name: str, function_result: str) -> dict[str, Any] | None:
+        """Parse canonical tool envelopes produced by tools.registry.dispatch.
+
+        Returns ``None`` for non-canonical payloads to preserve backward
+        compatibility with legacy tool outputs.
+        """
+        if not isinstance(function_result, str) or not function_result.strip():
+            return None
+
+        try:
+            parsed = json.loads(function_result)
+        except (TypeError, ValueError):
+            return None
+
+        if not isinstance(parsed, dict):
+            return None
+
+        required_keys = {"success", "error", "error_type", "retryable", "data", "metrics"}
+        if not required_keys.issubset(parsed.keys()):
+            return None
+
+        metrics = parsed.get("metrics")
+        if not isinstance(metrics, dict):
+            return None
+        if metrics.get("tool_name") != function_name:
+            return None
+        if not isinstance(metrics.get("duration_ms"), (int, float)):
+            return None
+
+        return parsed
+
+    def _maybe_apply_live_retry(
+        self,
+        *,
+        function_name: str,
+        function_args: dict[str, Any],
+        effective_task_id: str,
+        tool_call_id: str,
+        function_result: str,
+        tool_duration: float,
+        envelope: dict[str, Any] | None,
+        is_error_result: bool,
+        error_summary: str,
+    ) -> tuple[str, float, dict[str, Any] | None, bool, str]:
+        """Apply bounded live retries for low/medium risk tool failures."""
+        if not is_error_result:
+            return function_result, tool_duration, envelope, is_error_result, error_summary
+
+        mode = str(self._self_correction_policy.get("mode", "shadow")).lower()
+        if mode != "live" or self._interrupt_requested:
+            return function_result, tool_duration, envelope, is_error_result, error_summary
+
+        try:
+            from agent.self_correction import classify_failure, get_retry_policy
+        except Exception:
+            return function_result, tool_duration, envelope, is_error_result, error_summary
+
+        risk_class = self._classify_tool_risk(function_name)
+        retryable_hint = bool(envelope.get("retryable")) if envelope else False
+        error_type = envelope.get("error_type") if envelope else None
+        assessment = classify_failure(
+            tool_name=function_name,
+            error_type=error_type,
+            error_summary=error_summary,
+            retryable_hint=retryable_hint,
+        )
+
+        if risk_class == "high":
+            self._record_agent_event(
+                family="self_correction",
+                event_type="live_retry_skipped",
+                task_id=tool_call_id,
+                success=False,
+                latency_ms=int(max(0.0, tool_duration) * 1000),
+                risk_class=risk_class,
+                payload={
+                    "tool_name": function_name,
+                    "failure_class": assessment.failure_class,
+                    "reason": "high_risk",
+                },
+            )
+            return function_result, tool_duration, envelope, is_error_result, error_summary
+
+        confidence_threshold = float(self._self_correction_policy.get("confidence_threshold", 0.72))
+        if float(assessment.confidence) < confidence_threshold:
+            self._record_agent_event(
+                family="self_correction",
+                event_type="live_retry_skipped",
+                task_id=tool_call_id,
+                success=False,
+                latency_ms=int(max(0.0, tool_duration) * 1000),
+                risk_class=risk_class,
+                payload={
+                    "tool_name": function_name,
+                    "failure_class": assessment.failure_class,
+                    "reason": "confidence_below_threshold",
+                    "confidence": assessment.confidence,
+                    "confidence_threshold": confidence_threshold,
+                },
+            )
+            return function_result, tool_duration, envelope, is_error_result, error_summary
+
+        retry_policy = get_retry_policy(tool_name=function_name, failure=assessment)
+        max_live_retries = int(self._self_correction_policy.get("max_live_retries_per_call", 2))
+        retries_to_attempt = min(
+            max(0, retry_policy.max_retries),
+            max(0, max_live_retries),
+            max(0, int(self._self_correction_retries_remaining)),
+        )
+
+        if retries_to_attempt <= 0:
+            self._record_agent_event(
+                family="self_correction",
+                event_type="live_retry_skipped",
+                task_id=tool_call_id,
+                success=False,
+                latency_ms=int(max(0.0, tool_duration) * 1000),
+                risk_class=risk_class,
+                payload={
+                    "tool_name": function_name,
+                    "failure_class": assessment.failure_class,
+                    "reason": "retry_budget_or_policy_exhausted",
+                    "policy_reason": retry_policy.reason,
+                    "retries_remaining": int(self._self_correction_retries_remaining),
+                },
+            )
+            return function_result, tool_duration, envelope, is_error_result, error_summary
+
+        current_result = function_result
+        current_duration = tool_duration
+        current_envelope = envelope
+        current_is_error = is_error_result
+        current_error_summary = error_summary
+
+        for retry_idx in range(retries_to_attempt):
+            if self._interrupt_requested:
+                break
+
+            wait_s = 0.0
+            if retry_idx < len(retry_policy.backoff_seconds):
+                wait_s = max(0.0, float(retry_policy.backoff_seconds[retry_idx]))
+            if wait_s > 0:
+                time.sleep(wait_s)
+
+            attempt_start = time.time()
+            try:
+                retry_result = handle_function_call(
+                    function_name,
+                    function_args,
+                    effective_task_id,
+                    enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                )
+            except Exception as retry_error:
+                retry_result = f"Error executing tool '{function_name}': {retry_error}"
+                logger.error("live retry handle_function_call raised for %s: %s", function_name, retry_error, exc_info=True)
+
+            attempt_duration = max(0.0, time.time() - attempt_start)
+            attempt_envelope = self._parse_canonical_tool_envelope(function_name, retry_result)
+            if attempt_envelope:
+                try:
+                    attempt_duration = max(0.0, float(attempt_envelope["metrics"].get("duration_ms", 0)) / 1000.0)
+                except (TypeError, ValueError, KeyError, AttributeError):
+                    pass
+                attempt_is_error = attempt_envelope.get("success") is False
+                attempt_error_summary = str(attempt_envelope.get("error") or "")
+            else:
+                attempt_is_error, attempt_error_summary = _detect_tool_failure(function_name, retry_result)
+
+            self._self_correction_retries_remaining = max(0, int(self._self_correction_retries_remaining) - 1)
+            self._record_agent_event(
+                family="self_correction",
+                event_type="live_retry_attempt",
+                task_id=tool_call_id,
+                success=not attempt_is_error,
+                latency_ms=int(max(0.0, attempt_duration) * 1000),
+                risk_class=risk_class,
+                payload={
+                    "tool_name": function_name,
+                    "attempt": retry_idx + 1,
+                    "max_attempts": retries_to_attempt,
+                    "failure_class": assessment.failure_class,
+                    "policy_reason": retry_policy.reason,
+                    "retries_remaining": int(self._self_correction_retries_remaining),
+                },
+            )
+
+            current_result = retry_result
+            current_duration = attempt_duration
+            current_envelope = attempt_envelope
+            current_is_error = attempt_is_error
+            current_error_summary = attempt_error_summary
+
+            if not attempt_is_error:
+                break
+
+            next_retryable = bool(attempt_envelope.get("retryable")) if attempt_envelope else False
+            next_error_type = attempt_envelope.get("error_type") if attempt_envelope else None
+            assessment = classify_failure(
+                tool_name=function_name,
+                error_type=next_error_type,
+                error_summary=attempt_error_summary,
+                retryable_hint=next_retryable,
+            )
+            if not assessment.retryable:
+                break
+
+        return current_result, current_duration, current_envelope, current_is_error, current_error_summary
+
+    def _record_tool_execution_event(
+        self,
+        *,
+        function_name: str,
+        tool_call_id: str,
+        function_args: dict[str, Any],
+        function_result: str,
+        tool_duration: float,
+        envelope: dict[str, Any] | None,
+        is_error_result: bool,
+        error_summary: str,
+    ) -> None:
+        """Append a bounded local execution-event record for tooling/evals."""
+        event = {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+            "tool": function_name,
+            "tool_call_id": tool_call_id,
+            "duration_ms": int(max(0.0, tool_duration) * 1000),
+            "ok": not is_error_result,
+            "error_summary": self._honcho_preview(error_summary, max_chars=240) if is_error_result else "",
+            "args_preview": self._honcho_preview(function_args, max_chars=240),
+            "result_preview": self._honcho_preview(function_result, max_chars=240),
+            "envelope": bool(envelope),
+        }
+
+        if envelope:
+            event["retryable"] = bool(envelope.get("retryable", False))
+            event["error_type"] = envelope.get("error_type")
+
+        self._tool_execution_events.append(event)
+        cap = max(1, int(self._max_tool_execution_events or 500))
+        if len(self._tool_execution_events) > cap:
+            del self._tool_execution_events[: len(self._tool_execution_events) - cap]
+
+        if self._session_db and hasattr(self._session_db, "append_tool_execution_event"):
+            try:
+                self._session_db.append_tool_execution_event(
+                    session_id=self.session_id,
+                    tool_name=function_name,
+                    tool_call_id=tool_call_id,
+                    duration_ms=event["duration_ms"],
+                    success=event["ok"],
+                    args_preview=event.get("args_preview"),
+                    result_preview=event.get("result_preview"),
+                    envelope=event.get("envelope", False),
+                    retryable=event.get("retryable", False),
+                    error_type=event.get("error_type"),
+                    error_summary=event.get("error_summary"),
+                )
+            except Exception as db_err:
+                logger.debug("Session DB append_tool_execution_event failed: %s", db_err)
+
+        self._record_agent_event(
+            family="tool_execution",
+            event_type="tool_call",
+            task_id=tool_call_id,
+            success=event.get("ok"),
+            latency_ms=event.get("duration_ms"),
+            risk_class=self._classify_tool_risk(function_name),
+            payload={
+                "tool_name": function_name,
+                "retryable": bool(event.get("retryable", False)),
+                "error_type": event.get("error_type"),
+            },
+        )
+
+        if not event.get("ok"):
+            try:
+                from agent.self_correction import build_shadow_critique_event
+
+                critique_payload = build_shadow_critique_event(
+                    tool_name=function_name,
+                    error_type=event.get("error_type"),
+                    error_summary=event.get("error_summary"),
+                    retryable_hint=bool(event.get("retryable", False)),
+                )
+                self._record_agent_event(
+                    family="self_correction",
+                    event_type="shadow_critique",
+                    task_id=tool_call_id,
+                    success=False,
+                    latency_ms=event.get("duration_ms"),
+                    risk_class=self._classify_tool_risk(function_name),
+                    payload=critique_payload,
+                )
+            except Exception as critique_err:
+                logger.debug("Shadow critique generation failed: %s", critique_err)
+
+    @staticmethod
+    def _classify_tool_risk(function_name: str) -> str:
+        """Classify tool side-effect risk for audit event tagging."""
+        try:
+            from tools.safety_taxonomy import classify_tool_action
+
+            return classify_tool_action(function_name).risk_class
+        except Exception:
+            return "low"
+
+    def _record_agent_event(
+        self,
+        *,
+        family: str,
+        event_type: str,
+        task_id: str | None = None,
+        success: bool | None = None,
+        latency_ms: int | None = None,
+        risk_class: str | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        """Append a bounded in-memory + sqlite agent event record."""
+        event = {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+            "family": family,
+            "event_type": event_type,
+            "task_id": task_id,
+            "success": success,
+            "latency_ms": latency_ms,
+            "risk_class": risk_class,
+            "payload": payload or {},
+        }
+        self._agent_events.append(event)
+        cap = max(1, int(self._max_agent_events or 1000))
+        if len(self._agent_events) > cap:
+            del self._agent_events[: len(self._agent_events) - cap]
+
+        if self._session_db and hasattr(self._session_db, "append_agent_event"):
+            try:
+                self._session_db.append_agent_event(
+                    session_id=self.session_id,
+                    family=family,
+                    event_type=event_type,
+                    task_id=task_id,
+                    success=success,
+                    latency_ms=latency_ms,
+                    risk_class=risk_class,
+                    payload=payload,
+                )
+            except Exception as db_err:
+                logger.debug("Session DB append_agent_event failed: %s", db_err)
+
+    def get_recent_agent_events(
+        self,
+        limit: int = 50,
+        *,
+        family: Optional[str] = None,
+        event_type: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        """Return newest-first in-memory agent events with optional filters."""
+        size = max(1, int(limit or 50))
+        events = list(reversed(self._agent_events))
+        if family:
+            events = [e for e in events if (e.get("family") or "") == family]
+        if event_type:
+            events = [e for e in events if (e.get("event_type") or "") == event_type]
+        return events[:size]
+
+    def get_recent_tool_execution_events(
+        self,
+        limit: int = 50,
+        *,
+        tool_name: Optional[str] = None,
+        ok: Optional[bool] = None,
+        retryable: Optional[bool] = None,
+    ) -> list[dict[str, Any]]:
+        """Return newest-first local tool execution events with optional filters."""
+        size = max(1, int(limit or 50))
+        events = list(reversed(self._tool_execution_events))
+
+        if tool_name:
+            events = [e for e in events if (e.get("tool") or "") == tool_name]
+        if ok is not None:
+            events = [e for e in events if bool(e.get("ok")) == bool(ok)]
+        if retryable is not None:
+            events = [e for e in events if bool(e.get("retryable", False)) == bool(retryable)]
+
+        return events[:size]
+
+    def _honcho_enqueue_with_cap(
+        self,
+        queue: list[Any],
+        item: Any,
+        *,
+        max_size: int,
+        dropped_metric_key: str,
+        queue_name: str,
+    ) -> None:
+        """Append to a bounded queue, dropping oldest entries when full."""
+        if max_size <= 0:
+            return
+        dropped = max(0, len(queue) - max_size + 1)
+        if dropped:
+            del queue[:dropped]
+            self._honcho_telemetry[dropped_metric_key] += dropped
+            logger.warning(
+                "Honcho %s queue full; dropped %d oldest item(s) to stay within cap=%d",
+                queue_name,
+                dropped,
+                max_size,
+            )
+        queue.append(item)
+
+    def _honcho_flush_pending_sync(self) -> None:
+        """Best-effort replay of failed sync payloads from earlier turns."""
+        if not self._honcho or not self._honcho_session_key or not self._pending_honcho_sync:
+            return
+
+        self._honcho_telemetry["flush_cycles"] += 1
+        limit = max(1, self._honcho_flush_batch_size)
+        replay_slice = self._pending_honcho_sync[:limit]
+        still_pending = []
+        for payload in replay_slice:
+            synced = self._honcho_sync(payload["user"], payload["assistant"], queue_on_failure=False)
+            if not synced:
+                still_pending.append(payload)
+
+        replayed = len(replay_slice) - len(still_pending)
+        if replayed:
+            self._honcho_telemetry["replayed_sync"] += replayed
+            logger.info("Replayed %d queued Honcho sync payload(s)", replayed)
+        self._pending_honcho_sync = still_pending + self._pending_honcho_sync[limit:]
+
+    def _honcho_flush_pending_tool_events(self) -> None:
+        """Best-effort replay of queued Honcho tool events from earlier turns."""
+        if not self._honcho or not self._honcho_session_key or not self._pending_honcho_tool_events:
+            return
+
+        self._honcho_telemetry["flush_cycles"] += 1
+        limit = max(1, self._honcho_flush_batch_size)
+        replay_slice = self._pending_honcho_tool_events[:limit]
+        still_pending = []
+        for event_message in replay_slice:
+            synced = self._honcho_sync_tool_event(event_message, queue_on_failure=False)
+            if not synced:
+                still_pending.append(event_message)
+
+        replayed = len(replay_slice) - len(still_pending)
+        if replayed:
+            self._honcho_telemetry["replayed_tool_events"] += replayed
+            logger.info("Replayed %d queued Honcho tool event(s)", replayed)
+        self._pending_honcho_tool_events = still_pending + self._pending_honcho_tool_events[limit:]
+
     def _honcho_prefetch(self, user_message: str) -> str:
         """Fetch user context from Honcho for system prompt injection.
 
@@ -1324,9 +1891,15 @@ class AIAgent:
         """
         if not self._honcho or not self._honcho_session_key:
             return ""
+
+        def _fetch():
+            return self._honcho.get_prefetch_context(self._honcho_session_key, user_message)
+
+        self._honcho_telemetry["prefetch_attempts"] += 1
         try:
-            ctx = self._honcho.get_prefetch_context(self._honcho_session_key, user_message)
+            ctx = self._honcho_call_with_retry(_fetch, "prefetch")
             if not ctx:
+                self._honcho_telemetry["prefetch_failures"] += 1
                 return ""
             parts = []
             rep = ctx.get("representation", "")
@@ -1336,9 +1909,15 @@ class AIAgent:
             if card:
                 parts.append(card)
             if not parts:
+                self._honcho_telemetry["prefetch_failures"] += 1
                 return ""
-            return "# Honcho User Context\n" + "\n\n".join(parts)
+            rendered = "# Honcho User Context\n" + "\n\n".join(parts)
+            self._honcho_last_prefetch_chars = len(rendered)
+            self._honcho_telemetry["prefetch_success"] += 1
+            return rendered
         except Exception as e:
+            self._honcho_last_error = f"prefetch: {e}"
+            self._honcho_telemetry["prefetch_failures"] += 1
             logger.debug("Honcho prefetch failed (non-fatal): %s", e)
             return ""
 
@@ -1363,17 +1942,178 @@ class AIAgent:
             logger.debug("Honcho user observation failed: %s", e)
             return json.dumps({"success": False, "error": f"Honcho save failed: {e}"})
 
-    def _honcho_sync(self, user_content: str, assistant_content: str) -> None:
-        """Sync the user/assistant message pair to Honcho."""
+    def _honcho_sync(
+        self,
+        user_content: str,
+        assistant_content: str,
+        queue_on_failure: bool = True,
+    ) -> bool:
+        """Sync the user/assistant message pair to Honcho.
+
+        Returns True when synced, False when deferred/failure.
+        """
         if not self._honcho or not self._honcho_session_key:
-            return
-        try:
+            return False
+
+        def _sync_once():
             session = self._honcho.get_or_create(self._honcho_session_key)
             session.add_message("user", user_content)
             session.add_message("assistant", assistant_content)
             self._honcho.save(session)
+            return True
+
+        self._honcho_telemetry["sync_attempts"] += 1
+        try:
+            synced = bool(self._honcho_call_with_retry(_sync_once, "sync"))
+            if synced:
+                self._honcho_telemetry["sync_success"] += 1
+                return True
         except Exception as e:
-            logger.debug("Honcho sync failed (non-fatal): %s", e)
+            self._honcho_last_error = f"sync: {e}"
+            logger.debug("Honcho sync failed in strict mode: %s", e)
+            if not self._honcho_fail_open:
+                raise
+
+        self._honcho_telemetry["sync_failures"] += 1
+        if queue_on_failure and user_content and assistant_content:
+            self._honcho_enqueue_with_cap(
+                self._pending_honcho_sync,
+                {"user": user_content, "assistant": assistant_content},
+                max_size=self._honcho_max_pending_sync,
+                dropped_metric_key="dropped_sync",
+                queue_name="sync",
+            )
+            self._honcho_telemetry["queued_sync"] += 1
+            logger.debug("Queued Honcho sync payload for retry (%d pending)", len(self._pending_honcho_sync))
+        return False
+
+    def _honcho_build_tool_event(
+        self,
+        function_name: str,
+        function_args: dict[str, Any],
+        function_result: str,
+        tool_duration: float,
+        is_error_result: bool,
+        error_summary: str = "",
+    ) -> str:
+        """Encode a compact structured tool event for Honcho ingestion."""
+        event = {
+            "event": "tool_call",
+            "tool": function_name,
+            "ok": not is_error_result,
+            "duration_ms": int(max(0.0, tool_duration) * 1000),
+            "args_preview": self._honcho_preview(function_args, max_chars=180),
+        }
+        if is_error_result:
+            event["error_preview"] = self._honcho_preview(error_summary or function_result, max_chars=220)
+        else:
+            event["result_preview"] = self._honcho_preview(
+                function_result,
+                max_chars=self._honcho_tool_events_max_result_chars,
+            )
+        return "[tool_event] " + json.dumps(event, ensure_ascii=False, separators=(",", ":"))
+
+    def _honcho_sync_tool_event(self, event_message: str, queue_on_failure: bool = True) -> bool:
+        """Sync a structured tool event to Honcho as assistant-side behavior context."""
+        if (
+            not self._honcho
+            or not self._honcho_session_key
+            or not self._honcho_tool_events_enabled
+            or not event_message
+        ):
+            return False
+
+        def _sync_once():
+            session = self._honcho.get_or_create(self._honcho_session_key)
+            session.add_message("assistant", event_message)
+            self._honcho.save(session)
+            return True
+
+        self._honcho_telemetry["tool_event_attempts"] += 1
+        try:
+            synced = bool(self._honcho_call_with_retry(_sync_once, "tool_event"))
+            if synced:
+                self._honcho_telemetry["tool_event_success"] += 1
+                return True
+        except Exception as e:
+            self._honcho_last_error = f"tool_event: {e}"
+            logger.debug("Honcho tool-event sync failed in strict mode: %s", e)
+            if not self._honcho_fail_open:
+                raise
+
+        self._honcho_telemetry["tool_event_failures"] += 1
+        if queue_on_failure:
+            self._honcho_enqueue_with_cap(
+                self._pending_honcho_tool_events,
+                event_message,
+                max_size=self._honcho_max_pending_tool_events,
+                dropped_metric_key="dropped_tool_events",
+                queue_name="tool_event",
+            )
+            self._honcho_telemetry["queued_tool_events"] += 1
+            logger.debug(
+                "Queued Honcho tool event for retry (%d pending)",
+                len(self._pending_honcho_tool_events),
+            )
+        return False
+
+    def flush_honcho_queues(self) -> dict[str, Any]:
+        """Force one best-effort flush cycle for pending Honcho queues."""
+        before_sync = len(self._pending_honcho_sync)
+        before_tool = len(self._pending_honcho_tool_events)
+        try:
+            self._honcho_flush_pending_sync()
+            self._honcho_flush_pending_tool_events()
+        except Exception as e:
+            self._honcho_last_error = f"flush: {e}"
+            logger.debug("Honcho manual queue flush failed (non-fatal): %s", e)
+        status = self.get_honcho_status()
+        status["flushed_sync"] = max(0, before_sync - status.get("pending_sync", 0))
+        status["flushed_tool_events"] = max(0, before_tool - status.get("pending_tool_events", 0))
+        return status
+
+    def get_honcho_status(self) -> dict[str, Any]:
+        """Return Honcho runtime/health snapshot for observability surfaces."""
+        return {
+            "enabled": bool(self._honcho),
+            "session_key": self._honcho_session_key,
+            "fail_open": self._honcho_fail_open,
+            "retry_attempts": self._honcho_retry_attempts,
+            "tool_events_enabled": self._honcho_tool_events_enabled,
+            "max_pending_sync": self._honcho_max_pending_sync,
+            "max_pending_tool_events": self._honcho_max_pending_tool_events,
+            "flush_batch_size": self._honcho_flush_batch_size,
+            "pending_sync": len(self._pending_honcho_sync),
+            "pending_tool_events": len(self._pending_honcho_tool_events),
+            "last_prefetch_chars": self._honcho_last_prefetch_chars,
+            "last_error": self._honcho_last_error,
+            "telemetry": dict(self._honcho_telemetry),
+        }
+
+    def set_honcho_runtime_mode(
+        self,
+        *,
+        fail_open: bool | None = None,
+        retry_attempts: int | None = None,
+        tool_events_enabled: bool | None = None,
+    ) -> dict[str, Any]:
+        """Adjust Honcho runtime behavior without restarting the agent."""
+        if fail_open is not None:
+            self._honcho_fail_open = bool(fail_open)
+        if retry_attempts is not None:
+            self._honcho_retry_attempts = max(0, int(retry_attempts))
+        if tool_events_enabled is not None:
+            self._honcho_tool_events_enabled = bool(tool_events_enabled)
+        return self.get_honcho_status()
+
+    def _compose_effective_system_prompt(self, active_system_prompt: str | None) -> str:
+        """Compose per-call system prompt with ephemeral and turn-scoped Honcho context."""
+        effective_system = active_system_prompt or ""
+        if self.ephemeral_system_prompt:
+            effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+        if self._turn_honcho_context and not self._turn_honcho_context_baked:
+            effective_system = (effective_system + "\n\n" + self._turn_honcho_context).strip()
+        return effective_system
 
     def _build_system_prompt(self, system_message: str = None) -> str:
         """
@@ -2660,6 +3400,20 @@ class AIAgent:
 
         compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
 
+        self._record_agent_event(
+            family="context_compression",
+            event_type="compression",
+            task_id=self.session_id,
+            success=True,
+            risk_class="low",
+            payload={
+                "messages_before": len(messages),
+                "messages_after": len(compressed),
+                "reason": "threshold_exceeded",
+                "summary_model": getattr(self.context_compressor, "summary_model_override", None),
+            },
+        )
+
         todo_snapshot = self._todo_store.format_for_injection()
         if todo_snapshot:
             compressed.append({"role": "user", "content": todo_snapshot})
@@ -2795,6 +3549,28 @@ class AIAgent:
                 # Also send user observations to Honcho when active
                 if self._honcho and target == "user" and function_args.get("action") == "add":
                     self._honcho_save_user_observation(function_args.get("content", ""))
+
+                try:
+                    _memory_result = json.loads(function_result) if isinstance(function_result, str) else {}
+                except Exception:
+                    _memory_result = {}
+                _write_gate = _memory_result.get("write_gate") if isinstance(_memory_result, dict) else None
+                self._record_agent_event(
+                    family="memory",
+                    event_type="write_gate",
+                    task_id=tool_call.id,
+                    success=_memory_result.get("success") if isinstance(_memory_result, dict) else None,
+                    latency_ms=int(max(0.0, time.time() - tool_start_time) * 1000),
+                    risk_class="medium",
+                    payload={
+                        "target": target,
+                        "action": function_args.get("action"),
+                        "write_decision": (_memory_result.get("write_decision") if isinstance(_memory_result, dict) else None)
+                        or (_write_gate.get("decision") if isinstance(_write_gate, dict) else None),
+                        "confidence": _write_gate.get("confidence") if isinstance(_write_gate, dict) else None,
+                        "reconciliation_action": _memory_result.get("reconciliation_action") if isinstance(_memory_result, dict) else None,
+                    },
+                )
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
                     print(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
@@ -2811,36 +3587,88 @@ class AIAgent:
             elif function_name == "delegate_task":
                 from tools.delegate_tool import delegate_task as _delegate_task
                 tasks_arg = function_args.get("tasks")
-                if tasks_arg and isinstance(tasks_arg, list):
-                    spinner_label = f"🔀 delegating {len(tasks_arg)} tasks"
-                else:
-                    goal_preview = (function_args.get("goal") or "")[:30]
-                    spinner_label = f"🔀 {goal_preview}" if goal_preview else "🔀 delegating"
-                spinner = None
-                if self.quiet_mode:
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
-                    spinner = KawaiiSpinner(f"{face} {spinner_label}", spinner_type='dots')
-                    spinner.start()
-                self._delegate_spinner = spinner
-                _delegate_result = None
-                try:
-                    function_result = _delegate_task(
-                        goal=function_args.get("goal"),
-                        context=function_args.get("context"),
-                        toolsets=function_args.get("toolsets"),
-                        tasks=tasks_arg,
-                        max_iterations=function_args.get("max_iterations"),
-                        parent_agent=self,
+                requested_children = len(tasks_arg) if isinstance(tasks_arg, list) else 1
+                max_children = int(self._delegation_budget.get("max_child_count", 3))
+                if requested_children > max_children:
+                    function_result = json.dumps({
+                        "success": False,
+                        "error": f"Delegation budget exceeded: requested {requested_children} child tasks (max {max_children}).",
+                        "error_type": "DelegationBudgetExceeded",
+                        "retryable": False,
+                        "data": {
+                            "requested_children": requested_children,
+                            "max_child_count": max_children,
+                        },
+                        "metrics": {"tool_name": "delegate_task", "duration_ms": 0},
+                    })
+                    self._record_agent_event(
+                        family="delegation",
+                        event_type="budget_check",
+                        task_id=tool_call.id,
+                        success=False,
+                        latency_ms=0,
+                        risk_class="medium",
+                        payload={
+                            "requested_children": requested_children,
+                            "max_child_count": max_children,
+                            "reason": "child_count_exceeded",
+                        },
                     )
-                    _delegate_result = function_result
-                finally:
-                    self._delegate_spinner = None
                     tool_duration = time.time() - tool_start_time
-                    cute_msg = _get_cute_tool_message_impl('delegate_task', function_args, tool_duration, result=_delegate_result)
-                    if spinner:
-                        spinner.stop(cute_msg)
-                    elif self.quiet_mode:
-                        print(f"  {cute_msg}")
+                    if self.quiet_mode:
+                        print(f"  {_get_cute_tool_message_impl('delegate_task', function_args, tool_duration, result=function_result)}")
+                    envelope = self._parse_canonical_tool_envelope(function_name, function_result)
+                    result_preview = function_result[:200] if len(function_result) > 200 else function_result
+                    _is_error_result = True
+                    _tool_error_summary = "Delegation budget exceeded"
+                    # Continue to standard post-processing path below.
+                else:
+                    if tasks_arg and isinstance(tasks_arg, list):
+                        spinner_label = f"🔀 delegating {len(tasks_arg)} tasks"
+                    else:
+                        goal_preview = (function_args.get("goal") or "")[:30]
+                        spinner_label = f"🔀 {goal_preview}" if goal_preview else "🔀 delegating"
+                    spinner = None
+                    if self.quiet_mode:
+                        face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                        spinner = KawaiiSpinner(f"{face} {spinner_label}", spinner_type='dots')
+                        spinner.start()
+                    self._delegate_spinner = spinner
+                    _delegate_result = None
+                    try:
+                        function_result = _delegate_task(
+                            goal=function_args.get("goal"),
+                            context=function_args.get("context"),
+                            toolsets=function_args.get("toolsets"),
+                            tasks=tasks_arg,
+                            max_iterations=min(
+                                int(function_args.get("max_iterations") or self._delegation_budget.get("max_iterations", 50)),
+                                int(self._delegation_budget.get("max_iterations", 50)),
+                            ),
+                            parent_agent=self,
+                        )
+                        _delegate_result = function_result
+                        self._record_agent_event(
+                            family="delegation",
+                            event_type="budget_check",
+                            task_id=tool_call.id,
+                            success=True,
+                            latency_ms=int(max(0.0, time.time() - tool_start_time) * 1000),
+                            risk_class="medium",
+                            payload={
+                                "requested_children": requested_children,
+                                "max_child_count": max_children,
+                                "reason": "within_budget",
+                            },
+                        )
+                    finally:
+                        self._delegate_spinner = None
+                        tool_duration = time.time() - tool_start_time
+                        cute_msg = _get_cute_tool_message_impl('delegate_task', function_args, tool_duration, result=_delegate_result)
+                        if spinner:
+                            spinner.stop(cute_msg)
+                        elif self.quiet_mode:
+                            print(f"  {cute_msg}")
             elif self.quiet_mode:
                 face = random.choice(KawaiiSpinner.KAWAII_WAITING)
                 tool_emoji_map = {
@@ -2890,13 +3718,70 @@ class AIAgent:
                     logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
                 tool_duration = time.time() - tool_start_time
 
+            envelope = self._parse_canonical_tool_envelope(function_name, function_result)
+            if envelope:
+                try:
+                    tool_duration = max(0.0, float(envelope["metrics"].get("duration_ms", 0)) / 1000.0)
+                except (TypeError, ValueError, KeyError, AttributeError):
+                    pass
+
             result_preview = function_result[:200] if len(function_result) > 200 else function_result
 
             # Log tool errors to the persistent error log so [error] tags
             # in the UI always have a corresponding detailed entry on disk.
-            _is_error_result, _ = _detect_tool_failure(function_name, function_result)
+            if envelope:
+                _is_error_result = envelope.get("success") is False
+                _tool_error_summary = str(envelope.get("error") or "")
+            else:
+                _is_error_result, _tool_error_summary = _detect_tool_failure(function_name, function_result)
+
             if _is_error_result:
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
+
+            (
+                function_result,
+                tool_duration,
+                envelope,
+                _is_error_result,
+                _tool_error_summary,
+            ) = self._maybe_apply_live_retry(
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=tool_call.id,
+                function_result=function_result,
+                tool_duration=tool_duration,
+                envelope=envelope,
+                is_error_result=_is_error_result,
+                error_summary=_tool_error_summary,
+            )
+
+            result_preview = function_result[:200] if len(function_result) > 200 else function_result
+
+            self._record_tool_execution_event(
+                function_name=function_name,
+                tool_call_id=tool_call.id,
+                function_args=function_args,
+                function_result=function_result,
+                tool_duration=tool_duration,
+                envelope=envelope,
+                is_error_result=_is_error_result,
+                error_summary=_tool_error_summary,
+            )
+
+            if self._honcho and self._honcho_tool_events_enabled:
+                try:
+                    event_message = self._honcho_build_tool_event(
+                        function_name=function_name,
+                        function_args=function_args,
+                        function_result=function_result,
+                        tool_duration=tool_duration,
+                        is_error_result=_is_error_result,
+                        error_summary=_tool_error_summary,
+                    )
+                    self._honcho_sync_tool_event(event_message)
+                except Exception as event_err:
+                    logger.debug("Honcho tool-event capture failed (non-fatal): %s", event_err)
 
             if self.verbose_logging:
                 logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
@@ -2965,9 +3850,7 @@ class AIAgent:
                     api_msg.pop(internal_field, None)
                 api_messages.append(api_msg)
 
-            effective_system = self._cached_system_prompt or ""
-            if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+            effective_system = self._compose_effective_system_prompt(self._cached_system_prompt)
             if effective_system:
                 api_messages = [{"role": "system", "content": effective_system}] + api_messages
             if self.prefill_messages:
@@ -3153,16 +4036,20 @@ class AIAgent:
             )
             self._iters_since_skill = 0
 
-        # Honcho prefetch: retrieve user context for system prompt injection.
-        # Only on the FIRST turn of a session (empty history).  On subsequent
-        # turns the model already has all prior context in its conversation
-        # history, and the Honcho context is baked into the stored system
-        # prompt — re-fetching it would change the system message and break
-        # Anthropic prompt caching.
-        self._honcho_context = ""
-        if self._honcho and self._honcho_session_key and not conversation_history:
+        # Honcho-first preflight: always try to flush queued writes and prefetch
+        # fresh user context each turn. Context is baked only when building a new
+        # session prompt; otherwise it's injected ephemerally for this turn.
+        self._turn_honcho_context = ""
+        self._turn_honcho_context_baked = False
+        if self._honcho and self._honcho_session_key:
             try:
-                self._honcho_context = self._honcho_prefetch(user_message)
+                self._honcho_flush_pending_sync()
+                self._honcho_flush_pending_tool_events()
+            except Exception as e:
+                logger.debug("Honcho queued flush failed (non-fatal): %s", e)
+
+            try:
+                self._turn_honcho_context = self._honcho_prefetch(original_user_message)
             except Exception as e:
                 logger.debug("Honcho prefetch failed (non-fatal): %s", e)
 
@@ -3202,12 +4089,13 @@ class AIAgent:
             else:
                 # First turn of a new session — build from scratch.
                 self._cached_system_prompt = self._build_system_prompt(system_message)
-                # Bake Honcho context into the prompt so it's stable for
-                # the entire session (not re-fetched per turn).
-                if self._honcho_context:
+                # Bake this turn's Honcho context into the initial prompt snapshot.
+                # Later turns still prefetch context and inject it ephemerally.
+                if self._turn_honcho_context:
                     self._cached_system_prompt = (
-                        self._cached_system_prompt + "\n\n" + self._honcho_context
+                        self._cached_system_prompt + "\n\n" + self._turn_honcho_context
                     ).strip()
+                    self._turn_honcho_context_baked = True
                 # Store the system prompt snapshot in SQLite
                 if self._session_db:
                     try:
@@ -3340,16 +4228,11 @@ class AIAgent:
                 # The signature field helps maintain reasoning continuity
                 api_messages.append(api_msg)
 
-            # Build the final system message: cached prompt + ephemeral system prompt.
-            # The ephemeral part is appended here (not baked into the cached prompt)
-            # so it stays out of the session DB and logs.
-            # Note: Honcho context is baked into _cached_system_prompt on the first
-            # turn and stored in the session DB, so it does NOT need to be injected
-            # here.  This keeps the system message identical across all turns in a
-            # session, maximizing Anthropic prompt cache hits.
-            effective_system = active_system_prompt or ""
-            if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+            # Build final system message from:
+            # 1) cached session system prompt snapshot,
+            # 2) optional ephemeral system prompt,
+            # 3) turn-scoped Honcho context (when not already baked this turn).
+            effective_system = self._compose_effective_system_prompt(active_system_prompt)
             if effective_system:
                 api_messages = [{"role": "system", "content": effective_system}] + api_messages
 
@@ -4303,7 +5186,8 @@ class AIAgent:
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
-                                "error": "Model generated only think blocks with no actual response after 3 retries"
+                                "error": "Model generated only think blocks with no actual response after 3 retries",
+                                "honcho": self.get_honcho_status(),
                             }
                     
                     # Reset retry counter on successful content
@@ -4438,6 +5322,7 @@ class AIAgent:
             "completed": completed,
             "partial": False,  # True only when stopped due to invalid tool calls
             "interrupted": interrupted,
+            "honcho": self.get_honcho_status(),
         }
         
         # Include interrupt message if one triggered the interrupt

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -66,7 +66,6 @@
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -91,7 +90,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -108,7 +106,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -131,7 +128,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -154,7 +150,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -171,7 +166,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -188,7 +182,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -205,7 +198,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -222,7 +214,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -239,7 +230,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -256,7 +246,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -273,7 +262,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -290,7 +278,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -307,7 +294,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -324,7 +310,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -347,7 +332,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -370,7 +354,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -393,7 +376,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -416,7 +398,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -439,7 +420,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -462,7 +442,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -485,7 +464,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -505,7 +483,6 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -528,7 +505,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -548,7 +524,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -568,7 +543,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -955,7 +929,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1312,6 +1285,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -1797,7 +1771,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/tests/agent/test_self_correction.py
+++ b/tests/agent/test_self_correction.py
@@ -1,0 +1,62 @@
+from agent.self_correction import (
+    build_shadow_critique_event,
+    classify_failure,
+    get_retry_policy,
+)
+
+
+def test_classify_provider_failure_from_retryable_timeout():
+    result = classify_failure(
+        tool_name="web_extract",
+        error_type="TimeoutError",
+        error_summary="request timeout from upstream",
+        retryable_hint=True,
+    )
+    assert result.failure_class == "provider_failure"
+    assert result.retryable is True
+
+
+def test_classify_unsafe_action_block_for_permission_denied():
+    result = classify_failure(
+        tool_name="terminal",
+        error_type="PermissionError",
+        error_summary="permission denied writing /etc/hosts",
+        retryable_hint=False,
+    )
+    assert result.failure_class == "unsafe_action_block"
+    assert result.retryable is False
+
+
+def test_build_shadow_critique_event_contains_recommendation():
+    payload = build_shadow_critique_event(
+        tool_name="browser_click",
+        error_type="ToolExecutionError",
+        error_summary="element not found",
+        retryable_hint=False,
+    )
+    assert payload["shadow_mode"] is True
+    assert payload["failure_class"] in {"missing_context", "tool_misuse"}
+    assert isinstance(payload["recommendation"], str) and payload["recommendation"]
+
+
+def test_retry_policy_provider_tool_gets_two_retries():
+    failure = classify_failure(
+        tool_name="web_extract",
+        error_type="TimeoutError",
+        error_summary="connection timeout",
+        retryable_hint=True,
+    )
+    policy = get_retry_policy(tool_name="web_extract", failure=failure)
+    assert policy.max_retries == 2
+    assert policy.reason == "provider_backoff"
+
+
+def test_retry_policy_unsafe_block_has_zero_retries():
+    failure = classify_failure(
+        tool_name="write_file",
+        error_type="PermissionError",
+        error_summary="permission denied",
+        retryable_hint=False,
+    )
+    policy = get_retry_policy(tool_name="write_file", failure=failure)
+    assert policy.max_retries == 0

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -97,7 +97,7 @@ class TestTelegramSendImageFile:
         mock_msg.message_id = 42
         adapter._bot.send_photo = AsyncMock(return_value=mock_msg)
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             adapter.send_image_file(chat_id="12345", image_path=str(img))
         )
         assert result.success
@@ -110,7 +110,7 @@ class TestTelegramSendImageFile:
 
     def test_returns_error_when_file_missing(self, adapter):
         """send_image_file should return error for nonexistent file."""
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             adapter.send_image_file(chat_id="12345", image_path="/nonexistent/image.png")
         )
         assert not result.success
@@ -119,7 +119,7 @@ class TestTelegramSendImageFile:
     def test_returns_error_when_not_connected(self, adapter):
         """send_image_file should return error when bot is None."""
         adapter._bot = None
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             adapter.send_image_file(chat_id="12345", image_path="/tmp/img.png")
         )
         assert not result.success
@@ -135,7 +135,7 @@ class TestTelegramSendImageFile:
         adapter._bot.send_photo = AsyncMock(return_value=mock_msg)
 
         long_caption = "A" * 2000
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             adapter.send_image_file(chat_id="12345", image_path=str(img), caption=long_caption)
         )
 
@@ -187,7 +187,7 @@ class TestDiscordSendImageFile:
         mock_channel.send = AsyncMock(return_value=mock_msg)
         adapter._client.get_channel = MagicMock(return_value=mock_channel)
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             adapter.send_image_file(chat_id="67890", image_path=str(img))
         )
         assert result.success
@@ -195,7 +195,7 @@ class TestDiscordSendImageFile:
         mock_channel.send.assert_awaited_once()
 
     def test_returns_error_when_file_missing(self, adapter):
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             adapter.send_image_file(chat_id="67890", image_path="/nonexistent.png")
         )
         assert not result.success
@@ -203,7 +203,7 @@ class TestDiscordSendImageFile:
 
     def test_returns_error_when_not_connected(self, adapter):
         adapter._client = None
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             adapter.send_image_file(chat_id="67890", image_path="/tmp/img.png")
         )
         assert not result.success
@@ -213,7 +213,7 @@ class TestDiscordSendImageFile:
         adapter._client.get_channel = MagicMock(return_value=None)
         adapter._client.fetch_channel = AsyncMock(return_value=None)
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             adapter.send_image_file(chat_id="99999", image_path="/tmp/img.png")
         )
         assert not result.success
@@ -256,7 +256,7 @@ class TestSlackSendImageFile:
         mock_result = MagicMock()
         adapter._app.client.files_upload_v2 = AsyncMock(return_value=mock_result)
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             adapter.send_image_file(chat_id="C12345", image_path=str(img))
         )
         assert result.success
@@ -268,7 +268,7 @@ class TestSlackSendImageFile:
         assert call_kwargs["channel"] == "C12345"
 
     def test_returns_error_when_file_missing(self, adapter):
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             adapter.send_image_file(chat_id="C12345", image_path="/nonexistent.png")
         )
         assert not result.success
@@ -276,7 +276,7 @@ class TestSlackSendImageFile:
 
     def test_returns_error_when_not_connected(self, adapter):
         adapter._app = None
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             adapter.send_image_file(chat_id="C12345", image_path="/tmp/img.png")
         )
         assert not result.success

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -130,7 +130,7 @@ class TestAppMentionHandler:
              patch.object(_slack_mod, "AsyncSocketModeHandler", return_value=MagicMock()), \
              patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-fake"}), \
              patch("asyncio.create_task"):
-            asyncio.get_event_loop().run_until_complete(adapter.connect())
+            asyncio.run(adapter.connect())
 
         assert "message" in registered_events
         assert "app_mention" in registered_events

--- a/tests/gateway/test_tool_events_command.py
+++ b/tests/gateway/test_tool_events_command.py
@@ -1,0 +1,184 @@
+"""Tests for gateway /tool-events command parsing and output."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text: str = "/tool-events") -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(session_db=None):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = session_db
+    entry = MagicMock()
+    entry.session_id = "session-1"
+    entry.session_key = "telegram:u1:c1"
+    store = MagicMock()
+    store.get_or_create_session.return_value = entry
+    runner.session_store = store
+    return runner
+
+
+class TestGatewayToolEventsCommand:
+    @pytest.mark.asyncio
+    async def test_unavailable_without_session_db(self):
+        runner = _make_runner(session_db=None)
+        result = await runner._handle_tool_events_command(_make_event("/tool-events"))
+        assert "unavailable" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_passes_filters_to_session_db(self):
+        db = MagicMock()
+        db.get_recent_tool_execution_events.return_value = [
+            {
+                "tool_name": "browser_click",
+                "tool_call_id": "c2",
+                "duration_ms": 45,
+                "success": 0,
+                "retryable": 1,
+                "error_summary": "missing ref",
+            }
+        ]
+        runner = _make_runner(session_db=db)
+
+        result = await runner._handle_tool_events_command(
+            _make_event("/tool-events 7 errors retryable tool=browser_click")
+        )
+
+        db.get_recent_tool_execution_events.assert_called_once_with(
+            "session-1",
+            limit=7,
+            tool_name="browser_click",
+            success=False,
+            retryable=True,
+        )
+        assert "browser_click" in result
+        assert "missing ref" in result
+
+    @pytest.mark.asyncio
+    async def test_json_mode_returns_json_payload(self):
+        db = MagicMock()
+        db.get_recent_tool_execution_events.return_value = [
+            {
+                "timestamp": 1710000000.0,
+                "tool_name": "web_search",
+                "tool_call_id": "c1",
+                "duration_ms": 12,
+                "success": 1,
+                "retryable": 0,
+                "envelope": 1,
+                "error_type": None,
+                "error_summary": "",
+            }
+        ]
+        runner = _make_runner(session_db=db)
+
+        result = await runner._handle_tool_events_command(_make_event("/tool-events json 1"))
+        parsed = json.loads(result)
+        assert parsed[0]["tool"] == "web_search"
+        assert parsed[0]["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_stats_mode_shows_percentiles_and_error_rate(self):
+        db = MagicMock()
+        db.get_recent_tool_execution_events.return_value = [
+            {"timestamp": 1710000005.0, "tool_name": "browser_click", "duration_ms": 10, "success": 0},
+            {"timestamp": 1710000004.0, "tool_name": "browser_click", "duration_ms": 40, "success": 1},
+            {"timestamp": 1710000003.0, "tool_name": "web_search", "duration_ms": 50, "success": 1},
+            {"timestamp": 1710000002.0, "tool_name": "web_search", "duration_ms": 30, "success": 1},
+            {"timestamp": 1710000001.0, "tool_name": "web_search", "duration_ms": 20, "success": 0},
+        ]
+        runner = _make_runner(session_db=db)
+
+        result = await runner._handle_tool_events_command(_make_event("/tool-events stats 20"))
+
+        assert "Tool Event Stats" in result
+        assert "web_search" in result
+        assert "browser_click" in result
+        assert "33.3%" in result
+        assert "50.0%" in result
+        assert "p50=30ms" in result
+        assert "p95=50ms" in result
+
+    @pytest.mark.asyncio
+    async def test_stats_json_mode_returns_machine_readable_payload(self):
+        db = MagicMock()
+        db.get_recent_tool_execution_events.return_value = [
+            {"timestamp": 1710000005.0, "tool_name": "browser_click", "duration_ms": 10, "success": 0},
+            {"timestamp": 1710000004.0, "tool_name": "browser_click", "duration_ms": 40, "success": 1},
+            {"timestamp": 1710000003.0, "tool_name": "web_search", "duration_ms": 50, "success": 1},
+        ]
+        runner = _make_runner(session_db=db)
+
+        result = await runner._handle_tool_events_command(_make_event("/tool-events stats json 20"))
+        parsed = json.loads(result)
+        assert parsed["mode"] == "stats"
+        assert parsed["bucket_by"] == "tool"
+        assert parsed["total_events"] == 3
+        assert parsed["buckets"][0]["count"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_stats_mode_supports_window_bucketing(self):
+        db = MagicMock()
+        db.get_recent_tool_execution_events.return_value = [
+            {"timestamp": 1710000006.0, "tool_name": "browser_click", "duration_ms": 12, "success": 1},
+            {"timestamp": 1710000005.0, "tool_name": "browser_click", "duration_ms": 10, "success": 0},
+            {"timestamp": 1710000004.0, "tool_name": "browser_click", "duration_ms": 40, "success": 1},
+            {"timestamp": 1710000003.0, "tool_name": "web_search", "duration_ms": 50, "success": 1},
+            {"timestamp": 1710000002.0, "tool_name": "web_search", "duration_ms": 30, "success": 1},
+            {"timestamp": 1710000001.0, "tool_name": "web_search", "duration_ms": 20, "success": 0},
+        ]
+        runner = _make_runner(session_db=db)
+
+        result = await runner._handle_tool_events_command(_make_event("/tool-events stats bucket=window window=2 20"))
+
+        assert "bucket=latest_1_2" in result
+        assert "bucket=latest_3_4" in result
+        assert "bucket=latest_5_6" in result
+
+    @pytest.mark.asyncio
+    async def test_text_mode_includes_last_failure_replay_hint(self):
+        db = MagicMock()
+        db.get_recent_tool_execution_events.return_value = [
+            {
+                "timestamp": 1710000002.0,
+                "tool_name": "web_search",
+                "tool_call_id": "ok-1",
+                "duration_ms": 8,
+                "success": 1,
+                "args_preview": '{"query":"ok"}',
+                "error_summary": "",
+            },
+            {
+                "timestamp": 1710000001.0,
+                "tool_name": "browser_click",
+                "tool_call_id": "err-1",
+                "duration_ms": 12,
+                "success": 0,
+                "args_preview": '{"ref":"@e9"}',
+                "error_summary": "missing ref",
+            },
+        ]
+        runner = _make_runner(session_db=db)
+
+        result = await runner._handle_tool_events_command(_make_event("/tool-events 5"))
+
+        assert "Last failure replay hint" in result
+        assert "browser_click" in result
+        assert "tool=browser_click" in result
+        assert 'args={"ref":"@e9"}' in result

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -12,7 +12,7 @@ EXPECTED_COMMANDS = {
     "/personality", "/clear", "/history", "/new", "/reset", "/retry",
     "/undo", "/save", "/config", "/cron", "/skills", "/platforms",
     "/verbose", "/compress", "/title", "/usage", "/insights", "/paste",
-    "/reload-mcp", "/rollback", "/skin", "/quit",
+    "/reload-mcp", "/rollback", "/skin", "/honcho", "/tool-events", "/quit",
 }
 
 

--- a/tests/test_cli_honcho_command.py
+++ b/tests/test_cli_honcho_command.py
@@ -1,0 +1,100 @@
+"""Tests for the `/honcho` slash command in the interactive CLI."""
+
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+class TestHonchoCommand:
+    def _make_cli(self):
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        cli_obj.agent = MagicMock()
+        cli_obj.agent.get_honcho_status.return_value = {
+            "enabled": True,
+            "session_key": "telegram:123",
+            "fail_open": True,
+            "retry_attempts": 2,
+            "tool_events_enabled": True,
+            "max_pending_sync": 200,
+            "max_pending_tool_events": 400,
+            "flush_batch_size": 25,
+            "pending_sync": 0,
+            "pending_tool_events": 0,
+            "last_error": "",
+            "telemetry": {"dropped_sync": 0, "dropped_tool_events": 0},
+        }
+        cli_obj.console = MagicMock()
+        return cli_obj
+
+    def test_honcho_status(self, capsys):
+        cli_obj = self._make_cli()
+
+        cli_obj.process_command("/honcho")
+
+        output = capsys.readouterr().out
+        assert "Honcho Runtime" in output
+        assert "telegram:123" in output
+
+    def test_honcho_strict_updates_runtime_and_config(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.agent.set_honcho_runtime_mode.return_value = {
+            "fail_open": False,
+            "retry_attempts": 2,
+            "tool_events_enabled": True,
+        }
+
+        with patch("cli.save_config_value", return_value=True) as save_mock:
+            cli_obj.process_command("/honcho strict")
+
+        cli_obj.agent.set_honcho_runtime_mode.assert_called_once_with(fail_open=False)
+        save_mock.assert_called_once_with("honcho.fail_open", False)
+        output = capsys.readouterr().out
+        assert "strict" in output.lower()
+
+    def test_honcho_retries_updates_runtime_and_config(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.agent.set_honcho_runtime_mode.return_value = {
+            "retry_attempts": 5,
+            "tool_events_enabled": True,
+            "fail_open": True,
+        }
+
+        with patch("cli.save_config_value", return_value=True) as save_mock:
+            cli_obj.process_command("/honcho retries 5")
+
+        cli_obj.agent.set_honcho_runtime_mode.assert_called_once_with(retry_attempts=5)
+        save_mock.assert_called_once_with("honcho.retry_attempts", 5)
+        output = capsys.readouterr().out
+        assert "retries set to 5" in output.lower()
+
+    def test_honcho_tool_events_toggle(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.agent.set_honcho_runtime_mode.return_value = {
+            "tool_events_enabled": False,
+            "retry_attempts": 2,
+            "fail_open": True,
+        }
+
+        with patch("cli.save_config_value", return_value=True) as save_mock:
+            cli_obj.process_command("/honcho tool-events off")
+
+        cli_obj.agent.set_honcho_runtime_mode.assert_called_once_with(tool_events_enabled=False)
+        save_mock.assert_called_once_with("honcho.tool_events.enabled", False)
+        output = capsys.readouterr().out
+        assert "disabled" in output.lower()
+
+    def test_honcho_flush_runs_manual_queue_replay(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.agent.flush_honcho_queues.return_value = {
+            "flushed_sync": 2,
+            "flushed_tool_events": 3,
+            "pending_sync": 1,
+            "pending_tool_events": 0,
+        }
+
+        cli_obj.process_command("/honcho flush")
+
+        cli_obj.agent.flush_honcho_queues.assert_called_once_with()
+        output = capsys.readouterr().out
+        assert "flush complete" in output.lower()
+        assert "replayed sync=2" in output.lower()

--- a/tests/test_cli_tool_events_command.py
+++ b/tests/test_cli_tool_events_command.py
@@ -1,0 +1,208 @@
+"""Tests for the `/tool-events` slash command in the interactive CLI."""
+
+import json
+from unittest.mock import MagicMock
+
+from cli import HermesCLI
+
+
+class TestToolEventsCommand:
+    def _make_cli(self):
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        cli_obj.agent = MagicMock()
+        cli_obj.console = MagicMock()
+        cli_obj.session_id = "session-123"
+        cli_obj._session_db = None
+        return cli_obj
+
+    def test_tool_events_shows_recent_events(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.agent.get_recent_tool_execution_events.return_value = [
+            {
+                "ts": "2026-03-12T00:00:00Z",
+                "tool": "web_search",
+                "tool_call_id": "c1",
+                "duration_ms": 88,
+                "ok": True,
+                "envelope": True,
+                "retryable": False,
+                "error_type": None,
+                "error_summary": "",
+            }
+        ]
+
+        cli_obj.process_command("/tool-events 5")
+
+        cli_obj.agent.get_recent_tool_execution_events.assert_called_once_with(
+            limit=5,
+            tool_name=None,
+            ok=None,
+            retryable=None,
+        )
+        output = capsys.readouterr().out
+        assert "Tool Execution Events" in output
+        assert "web_search" in output
+        assert "88ms" in output
+
+    def test_tool_events_supports_filters(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.agent.get_recent_tool_execution_events.return_value = [
+            {
+                "ts": "2026-03-12T00:00:01Z",
+                "tool": "browser_click",
+                "tool_call_id": "c2",
+                "duration_ms": 23,
+                "ok": False,
+                "retryable": True,
+                "error_summary": "missing ref",
+            }
+        ]
+
+        cli_obj.process_command("/tool-events 7 errors retryable tool=browser_click")
+
+        cli_obj.agent.get_recent_tool_execution_events.assert_called_once_with(
+            limit=7,
+            tool_name="browser_click",
+            ok=False,
+            retryable=True,
+        )
+        output = capsys.readouterr().out
+        assert "browser_click" in output
+        assert "missing ref" in output
+
+    def test_tool_events_json_output(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.agent.get_recent_tool_execution_events.return_value = [
+            {
+                "ts": "2026-03-12T00:00:02Z",
+                "tool": "web_search",
+                "tool_call_id": "c3",
+                "duration_ms": 12,
+                "ok": True,
+            }
+        ]
+
+        cli_obj.process_command("/tool-events json 1")
+
+        output = capsys.readouterr().out
+        parsed = json.loads(output)
+        assert parsed[0]["tool"] == "web_search"
+
+    def test_tool_events_export_writes_json_file(self, tmp_path, capsys, monkeypatch):
+        cli_obj = self._make_cli()
+        cli_obj.agent.get_recent_tool_execution_events.return_value = [
+            {
+                "ts": "2026-03-12T00:00:03Z",
+                "tool": "web_search",
+                "tool_call_id": "c4",
+                "duration_ms": 9,
+                "ok": True,
+            }
+        ]
+
+        monkeypatch.chdir(tmp_path)
+        cli_obj.process_command("/tool-events export 1")
+
+        output = capsys.readouterr().out
+        assert "Exported 1 tool events" in output
+        exported_files = list(tmp_path.glob("tool-events-*.json"))
+        assert len(exported_files) == 1
+        parsed = json.loads(exported_files[0].read_text(encoding="utf-8"))
+        assert parsed[0]["tool_call_id"] == "c4"
+
+    def test_tool_events_stats_mode_shows_percentiles_and_error_rate(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.agent.get_recent_tool_execution_events.return_value = [
+            {"ts": "2026-03-12T00:00:05Z", "tool": "browser_click", "tool_call_id": "c5", "duration_ms": 10, "ok": False},
+            {"ts": "2026-03-12T00:00:04Z", "tool": "browser_click", "tool_call_id": "c4", "duration_ms": 40, "ok": True},
+            {"ts": "2026-03-12T00:00:03Z", "tool": "web_search", "tool_call_id": "c3", "duration_ms": 50, "ok": True},
+            {"ts": "2026-03-12T00:00:02Z", "tool": "web_search", "tool_call_id": "c2", "duration_ms": 30, "ok": True},
+            {"ts": "2026-03-12T00:00:01Z", "tool": "web_search", "tool_call_id": "c1", "duration_ms": 20, "ok": False},
+        ]
+
+        cli_obj.process_command("/tool-events stats 20")
+
+        output = capsys.readouterr().out
+        assert "Tool Event Stats" in output
+        assert "web_search" in output
+        assert "browser_click" in output
+        assert "33.3%" in output  # web_search error rate (1/3 failed)
+        assert "50.0%" in output  # browser_click error rate (1/2 failed)
+        assert "p50=30ms" in output
+        assert "p95=50ms" in output
+
+    def test_tool_events_stats_json_output_is_machine_readable(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.agent.get_recent_tool_execution_events.return_value = [
+            {"ts": "2026-03-12T00:00:05Z", "tool": "browser_click", "tool_call_id": "c5", "duration_ms": 10, "ok": False},
+            {"ts": "2026-03-12T00:00:04Z", "tool": "browser_click", "tool_call_id": "c4", "duration_ms": 40, "ok": True},
+            {"ts": "2026-03-12T00:00:03Z", "tool": "web_search", "tool_call_id": "c3", "duration_ms": 50, "ok": True},
+        ]
+
+        cli_obj.process_command("/tool-events stats json 10")
+
+        output = capsys.readouterr().out
+        parsed = json.loads(output)
+        assert parsed["mode"] == "stats"
+        assert parsed["bucket_by"] == "tool"
+        assert parsed["total_events"] == 3
+        assert parsed["buckets"][0]["count"] >= 1
+
+    def test_tool_events_stats_window_bucketing(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.agent.get_recent_tool_execution_events.return_value = [
+            {"ts": "2026-03-12T00:00:06Z", "tool": "browser_click", "tool_call_id": "c6", "duration_ms": 12, "ok": True},
+            {"ts": "2026-03-12T00:00:05Z", "tool": "browser_click", "tool_call_id": "c5", "duration_ms": 10, "ok": False},
+            {"ts": "2026-03-12T00:00:04Z", "tool": "browser_click", "tool_call_id": "c4", "duration_ms": 40, "ok": True},
+            {"ts": "2026-03-12T00:00:03Z", "tool": "web_search", "tool_call_id": "c3", "duration_ms": 50, "ok": True},
+            {"ts": "2026-03-12T00:00:02Z", "tool": "web_search", "tool_call_id": "c2", "duration_ms": 30, "ok": True},
+            {"ts": "2026-03-12T00:00:01Z", "tool": "web_search", "tool_call_id": "c1", "duration_ms": 20, "ok": False},
+        ]
+
+        cli_obj.process_command("/tool-events stats bucket=window window=2 20")
+
+        output = capsys.readouterr().out
+        assert "bucket=latest_1_2" in output
+        assert "bucket=latest_3_4" in output
+        assert "bucket=latest_5_6" in output
+
+    def test_tool_events_shows_last_failure_replay_hint(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.agent.get_recent_tool_execution_events.return_value = [
+            {
+                "ts": "2026-03-12T00:00:02Z",
+                "tool": "web_search",
+                "tool_call_id": "ok-1",
+                "duration_ms": 8,
+                "ok": True,
+                "args_preview": '{"query":"ok"}',
+            },
+            {
+                "ts": "2026-03-12T00:00:01Z",
+                "tool": "browser_click",
+                "tool_call_id": "err-1",
+                "duration_ms": 12,
+                "ok": False,
+                "error_summary": "missing ref",
+                "args_preview": '{"ref":"@e9"}',
+            },
+        ]
+
+        cli_obj.process_command("/tool-events 5")
+
+        output = capsys.readouterr().out
+        assert "Last failure replay hint" in output
+        assert "browser_click" in output
+        assert "tool=browser_click" in output
+        assert "args={\"ref\":\"@e9\"}" in output
+
+    def test_tool_events_without_agent_support_prints_guidance(self, capsys):
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        cli_obj.agent = None
+        cli_obj.console = MagicMock()
+        cli_obj._session_db = None
+
+        cli_obj.process_command("/tool-events")
+
+        output = capsys.readouterr().out
+        assert "unavailable" in output.lower()

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+from evals.harness import EvalHarness, EvalTask
+
+
+def test_load_suite_parses_tasks(tmp_path):
+    suite_file = tmp_path / "suite.json"
+    suite_file.write_text(
+        json.dumps(
+            {
+                "suite": "smoke",
+                "version": "v1",
+                "holdout_task_ids": ["t2"],
+                "tasks": [
+                    {"task_id": "t1", "lane": "coding", "prompt": "Say OK", "expected": "OK"},
+                    {"task_id": "t2", "lane": "agentic", "prompt": "Say PLAN", "expected": "PLAN"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    suite = EvalHarness.load_suite(suite_file)
+    assert suite.suite == "smoke"
+    assert suite.version == "v1"
+    assert len(suite.tasks) == 2
+    assert suite.holdout_task_ids == ["t2"]
+
+
+def test_run_suite_writes_report(tmp_path):
+    harness = EvalHarness(suite_name="hermes-eval", commit="abc123")
+    suite = EvalHarness.load_suite("evals/suites/smoke_v1.json")
+
+    def runner(task: EvalTask) -> str:
+        if task.task_id == "terminal-1":
+            return "READY with shell-safe guidance"
+        if task.task_id == "coding-1":
+            return "FIXED"
+        return "PLAN with two steps"
+
+    report = harness.run_suite(suite, runner=runner, output_dir=tmp_path)
+
+    assert report["summary"]["total"] == 3
+    assert report["summary"]["passed"] == 3
+    assert report["summary"]["pass_rate"] == 1.0
+
+    report_file = Path(report["report_file"])
+    assert report_file.exists()
+    loaded = json.loads(report_file.read_text(encoding="utf-8"))
+    assert loaded["commit"] == "abc123"
+    assert loaded["by_lane"]["coding"]["avg_score"] == 1.0
+
+
+def test_deterministic_grade_flags_missing_expected():
+    task = EvalTask(task_id="t1", lane="coding", prompt="x", expected="PASS")
+    passed, score, signature = EvalHarness.deterministic_grade(task, "output without marker")
+    assert passed is False
+    assert score == 0.0
+    assert signature == "missing_expected:PASS"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4,7 +4,7 @@ import time
 import pytest
 from pathlib import Path
 
-from hermes_state import SessionDB
+from hermes_state import SCHEMA_VERSION, SessionDB
 
 
 @pytest.fixture()
@@ -167,6 +167,159 @@ class TestMessageStorage:
 # =========================================================================
 # FTS5 search
 # =========================================================================
+
+class TestToolExecutionEvents:
+    def test_append_and_get_recent_tool_execution_events(self, db):
+        db.create_session(session_id="s1", source="cli")
+
+        db.append_tool_execution_event(
+            session_id="s1",
+            tool_name="web_search",
+            tool_call_id="call_1",
+            duration_ms=123,
+            success=True,
+            args_preview='{"query":"agents"}',
+            result_preview='{"hits":3}',
+            envelope=True,
+            retryable=False,
+            error_type=None,
+            error_summary="",
+        )
+        db.append_tool_execution_event(
+            session_id="s1",
+            tool_name="browser_click",
+            tool_call_id="call_2",
+            duration_ms=45,
+            success=False,
+            args_preview='{"ref":"@e2"}',
+            result_preview='{"error":"not found"}',
+            envelope=True,
+            retryable=True,
+            error_type="ToolExecutionError",
+            error_summary="not found",
+        )
+
+        events = db.get_recent_tool_execution_events("s1", limit=10)
+        assert len(events) == 2
+
+        newest = events[0]
+        assert newest["tool_name"] == "browser_click"
+        assert newest["tool_call_id"] == "call_2"
+        assert newest["success"] == 0
+        assert newest["retryable"] == 1
+        assert newest["error_type"] == "ToolExecutionError"
+
+        older = events[1]
+        assert older["tool_name"] == "web_search"
+        assert older["duration_ms"] == 123
+
+    def test_get_recent_tool_execution_events_is_scoped_to_session(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.create_session(session_id="s2", source="telegram")
+
+        db.append_tool_execution_event(
+            session_id="s1",
+            tool_name="web_search",
+            tool_call_id="c1",
+            duration_ms=10,
+            success=True,
+        )
+        db.append_tool_execution_event(
+            session_id="s2",
+            tool_name="browser_click",
+            tool_call_id="c2",
+            duration_ms=20,
+            success=False,
+        )
+
+        s1_events = db.get_recent_tool_execution_events("s1")
+        assert len(s1_events) == 1
+        assert s1_events[0]["tool_name"] == "web_search"
+
+    def test_get_recent_tool_execution_events_supports_filters(self, db):
+        db.create_session(session_id="s1", source="cli")
+
+        db.append_tool_execution_event(
+            session_id="s1",
+            tool_name="web_search",
+            tool_call_id="ok_1",
+            duration_ms=12,
+            success=True,
+            retryable=False,
+        )
+        db.append_tool_execution_event(
+            session_id="s1",
+            tool_name="browser_click",
+            tool_call_id="err_1",
+            duration_ms=34,
+            success=False,
+            retryable=True,
+            error_summary="missing ref",
+        )
+
+        errors = db.get_recent_tool_execution_events("s1", success=False)
+        assert len(errors) == 1
+        assert errors[0]["tool_name"] == "browser_click"
+
+        retryable = db.get_recent_tool_execution_events("s1", retryable=True)
+        assert len(retryable) == 1
+        assert retryable[0]["tool_call_id"] == "err_1"
+
+        browser_only = db.get_recent_tool_execution_events("s1", tool_name="browser_click")
+        assert len(browser_only) == 1
+        assert browser_only[0]["success"] == 0
+
+
+class TestAgentEvents:
+    def test_append_and_get_recent_agent_events(self, db):
+        db.create_session(session_id="s1", source="cli")
+
+        db.append_agent_event(
+            session_id="s1",
+            family="memory",
+            event_type="write_gate",
+            task_id="t1",
+            success=True,
+            latency_ms=12,
+            risk_class="low",
+            payload={"decision": "accept", "confidence": 0.91},
+        )
+        db.append_agent_event(
+            session_id="s1",
+            family="delegation",
+            event_type="budget_check",
+            task_id="t2",
+            success=False,
+            latency_ms=2,
+            risk_class="medium",
+            payload={"reason": "child_count_exceeded"},
+        )
+
+        events = db.get_recent_agent_events("s1", limit=10)
+        assert len(events) == 2
+        assert events[0]["family"] == "delegation"
+        assert events[0]["success"] == 0
+        assert events[0]["payload"]["reason"] == "child_count_exceeded"
+        assert events[1]["family"] == "memory"
+        assert events[1]["payload"]["decision"] == "accept"
+
+    def test_agent_event_filters(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_agent_event("s1", "memory", "write_gate", success=True, payload={"decision": "accept"})
+        db.append_agent_event("s1", "memory", "write_gate", success=False, payload={"decision": "reject"})
+        db.append_agent_event("s1", "safety", "approval", success=True, payload={"result": "granted"})
+
+        memory_events = db.get_recent_agent_events("s1", family="memory")
+        assert len(memory_events) == 2
+
+        rejected = db.get_recent_agent_events("s1", family="memory", success=False)
+        assert len(rejected) == 1
+        assert rejected[0]["payload"]["decision"] == "reject"
+
+        approval = db.get_recent_agent_events("s1", event_type="approval")
+        assert len(approval) == 1
+        assert approval[0]["family"] == "safety"
+
 
 class TestFTS5Search:
     def test_search_finds_content(self, db):
@@ -625,7 +778,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 4
+        assert version == SCHEMA_VERSION
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -681,12 +834,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v4
+        # Open with SessionDB — should migrate to latest schema
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 4
+        assert cursor.fetchone()[0] == SCHEMA_VERSION
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -3,6 +3,7 @@
 import json
 import pytest
 
+import model_tools
 from model_tools import (
     handle_function_call,
     get_all_tool_names,
@@ -18,25 +19,47 @@ from model_tools import (
 # =========================================================================
 
 class TestHandleFunctionCall:
-    def test_agent_loop_tool_returns_error(self):
+    def test_agent_loop_tool_returns_canonical_error_envelope(self):
         for tool_name in _AGENT_LOOP_TOOLS:
             result = json.loads(handle_function_call(tool_name, {}))
-            assert "error" in result
+            assert result["success"] is False
             assert "agent loop" in result["error"].lower()
+            assert result["error_type"] == "AgentLoopDispatchError"
+            assert result["retryable"] is False
+            assert result["data"] is None
+            assert result["metrics"]["tool_name"] == tool_name
 
     def test_unknown_tool_returns_error(self):
         result = json.loads(handle_function_call("totally_fake_tool_xyz", {}))
         assert "error" in result
         assert "totally_fake_tool_xyz" in result["error"]
 
-    def test_exception_returns_json_error(self):
+    def test_exception_returns_canonical_json_error_envelope(self):
         # Even if something goes wrong, should return valid JSON
         result = handle_function_call("web_search", None)  # None args may cause issues
         parsed = json.loads(result)
         assert isinstance(parsed, dict)
+        assert parsed["success"] is False
         assert "error" in parsed
         assert len(parsed["error"]) > 0
+        assert parsed["retryable"] is False
+        assert parsed["metrics"]["tool_name"] == "web_search"
         assert "error" in parsed["error"].lower() or "failed" in parsed["error"].lower()
+
+    def test_execute_code_without_enabled_tools_uses_registry_tool_list(self, monkeypatch):
+        captured = {}
+
+        def _fake_dispatch(name, args, **kwargs):
+            captured["name"] = name
+            captured["kwargs"] = kwargs
+            return json.dumps({"success": True, "data": {"ok": True}})
+
+        monkeypatch.setattr(model_tools.registry, "dispatch", _fake_dispatch)
+
+        result = json.loads(handle_function_call("execute_code", {"code": "print('hi')"}))
+        assert result["success"] is True
+        assert captured["name"] == "execute_code"
+        assert captured["kwargs"]["enabled_tools"] == model_tools.registry.get_all_tool_names()
 
 
 # =========================================================================

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -648,6 +648,234 @@ class TestExecuteToolCalls:
         assert len(messages[0]["content"]) < 150_000
         assert "Truncated" in messages[0]["content"]
 
+    def test_canonical_envelope_metrics_feed_local_execution_event(self, agent):
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"agents"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        canonical_result = json.dumps({
+            "success": True,
+            "error": None,
+            "error_type": None,
+            "retryable": False,
+            "data": {"hits": 3},
+            "metrics": {"tool_name": "web_search", "duration_ms": 321},
+        })
+
+        with patch("run_agent.handle_function_call", return_value=canonical_result):
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        event = agent.get_recent_tool_execution_events(limit=1)[0]
+        assert event["tool"] == "web_search"
+        assert event["tool_call_id"] == "c1"
+        assert event["envelope"] is True
+        assert event["duration_ms"] == 321
+        assert event["ok"] is True
+
+    def test_canonical_envelope_failure_sets_error_summary(self, agent):
+        tc = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        canonical_result = json.dumps({
+            "success": False,
+            "error": "upstream timeout",
+            "error_type": "TimeoutError",
+            "retryable": True,
+            "data": None,
+            "metrics": {"tool_name": "web_search", "duration_ms": 55},
+        })
+
+        with patch("run_agent.handle_function_call", return_value=canonical_result):
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        event = agent.get_recent_tool_execution_events(limit=1)[0]
+        assert event["ok"] is False
+        assert event["error_summary"] == "upstream timeout"
+        assert event["retryable"] is True
+        assert event["error_type"] == "TimeoutError"
+
+        critiques = agent.get_recent_agent_events(limit=5, family="self_correction")
+        assert len(critiques) >= 1
+        assert critiques[0]["event_type"] == "shadow_critique"
+        assert critiques[0]["payload"]["failure_class"] == "provider_failure"
+
+    def test_tool_execution_event_persisted_to_session_db_when_available(self, agent):
+        tc = _mock_tool_call(name="web_search", arguments='{"query":"abc"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        mock_db = MagicMock()
+        agent._session_db = mock_db
+
+        canonical_result = json.dumps({
+            "success": True,
+            "error": None,
+            "error_type": None,
+            "retryable": False,
+            "data": {"hits": 1},
+            "metrics": {"tool_name": "web_search", "duration_ms": 87},
+        })
+
+        with patch("run_agent.handle_function_call", return_value=canonical_result):
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        mock_db.append_tool_execution_event.assert_called_once()
+        kwargs = mock_db.append_tool_execution_event.call_args.kwargs
+        assert kwargs["session_id"] == agent.session_id
+        assert kwargs["tool_name"] == "web_search"
+        assert kwargs["tool_call_id"] == "c1"
+        assert kwargs["duration_ms"] == 87
+        assert kwargs["success"] is True
+
+    def test_get_recent_tool_execution_events_supports_filters(self, agent):
+        agent._tool_execution_events = [
+            {
+                "ts": "2026-03-12T00:00:00Z",
+                "tool": "web_search",
+                "tool_call_id": "c1",
+                "duration_ms": 11,
+                "ok": True,
+                "retryable": False,
+            },
+            {
+                "ts": "2026-03-12T00:00:01Z",
+                "tool": "browser_click",
+                "tool_call_id": "c2",
+                "duration_ms": 22,
+                "ok": False,
+                "retryable": True,
+            },
+        ]
+
+        errors = agent.get_recent_tool_execution_events(limit=10, ok=False)
+        assert len(errors) == 1
+        assert errors[0]["tool"] == "browser_click"
+
+        retryable = agent.get_recent_tool_execution_events(limit=10, retryable=True)
+        assert len(retryable) == 1
+        assert retryable[0]["tool_call_id"] == "c2"
+
+        web = agent.get_recent_tool_execution_events(limit=10, tool_name="web_search")
+        assert len(web) == 1
+        assert web[0]["ok"] is True
+
+    def test_tool_execution_also_records_agent_event(self, agent):
+        tc = _mock_tool_call(name="terminal", arguments='{"command":"pwd"}', call_id="c-risk")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        canonical_result = json.dumps({
+            "success": True,
+            "error": None,
+            "error_type": None,
+            "retryable": False,
+            "data": {"output": "/tmp"},
+            "metrics": {"tool_name": "terminal", "duration_ms": 33},
+        })
+
+        with patch("run_agent.handle_function_call", return_value=canonical_result):
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        events = agent.get_recent_agent_events(limit=5, family="tool_execution")
+        assert len(events) >= 1
+        assert events[0]["event_type"] == "tool_call"
+        assert events[0]["risk_class"] == "high"
+        assert events[0]["payload"]["tool_name"] == "terminal"
+
+    def test_record_agent_event_persists_to_session_db(self, agent):
+        mock_db = MagicMock()
+        agent._session_db = mock_db
+
+        agent._record_agent_event(
+            family="memory",
+            event_type="write_gate",
+            task_id="t1",
+            success=True,
+            latency_ms=9,
+            risk_class="medium",
+            payload={"decision": "accept"},
+        )
+
+        mock_db.append_agent_event.assert_called_once()
+        kwargs = mock_db.append_agent_event.call_args.kwargs
+        assert kwargs["family"] == "memory"
+        assert kwargs["event_type"] == "write_gate"
+        assert kwargs["payload"]["decision"] == "accept"
+
+    def test_delegate_budget_blocks_excess_child_count(self, agent):
+        tc = _mock_tool_call(
+            name="delegate_task",
+            arguments=json.dumps({"tasks": [{"goal": "a"}, {"goal": "b"}, {"goal": "c"}, {"goal": "d"}]}),
+            call_id="c-delegate",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        with patch("tools.delegate_tool.delegate_task") as delegate_mock:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        delegate_mock.assert_not_called()
+        assert len(messages) == 1
+        payload = json.loads(messages[0]["content"])
+        assert payload["success"] is False
+        assert payload["error_type"] == "DelegationBudgetExceeded"
+
+    def test_live_retry_retries_low_risk_provider_failure(self, agent):
+        agent._self_correction_policy["mode"] = "live"
+
+        first = json.dumps({
+            "success": False,
+            "error": "upstream timeout",
+            "error_type": "TimeoutError",
+            "retryable": True,
+            "data": None,
+            "metrics": {"tool_name": "web_search", "duration_ms": 40},
+        })
+        second = json.dumps({
+            "success": True,
+            "error": None,
+            "error_type": None,
+            "retryable": False,
+            "data": {"hits": 2},
+            "metrics": {"tool_name": "web_search", "duration_ms": 28},
+        })
+        tc = _mock_tool_call(name="web_search", arguments='{"query":"retry me"}', call_id="c-retry")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        with patch("run_agent.handle_function_call", side_effect=[first, second]) as handler:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert handler.call_count == 2
+        payload = json.loads(messages[0]["content"])
+        assert payload["success"] is True
+
+        retries = agent.get_recent_agent_events(limit=5, family="self_correction")
+        assert any(e["event_type"] == "live_retry_attempt" for e in retries)
+
+    def test_live_retry_does_not_retry_high_risk_tools(self, agent):
+        agent._self_correction_policy["mode"] = "live"
+
+        failed_terminal = json.dumps({
+            "success": False,
+            "error": "connection timeout",
+            "error_type": "TimeoutError",
+            "retryable": True,
+            "data": None,
+            "metrics": {"tool_name": "terminal", "duration_ms": 45},
+        })
+        tc = _mock_tool_call(name="terminal", arguments='{"command":"pwd"}', call_id="c-risk-retry")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        with patch("run_agent.handle_function_call", return_value=failed_terminal) as handler:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        assert handler.call_count == 1
+        critiques = agent.get_recent_agent_events(limit=8, family="self_correction")
+        assert any(
+            e["event_type"] == "live_retry_skipped" and e["payload"].get("reason") == "high_risk"
+            for e in critiques
+        )
+
 
 class TestHandleMaxIterations:
     def test_returns_summary(self, agent):
@@ -1177,34 +1405,208 @@ class TestSystemPromptStability:
         assert "Hermes Agent" in agent._cached_system_prompt
 
     def test_honcho_context_baked_into_prompt_on_first_turn(self, agent):
-        """Honcho context should be baked into _cached_system_prompt on
-        the first turn, not injected separately per API call."""
-        agent._honcho_context = "User prefers Python over JavaScript."
+        """Honcho context should be baked into _cached_system_prompt on first-turn prompt build."""
+        agent._turn_honcho_context = "User prefers Python over JavaScript."
+        agent._turn_honcho_context_baked = False
         agent._cached_system_prompt = None
 
         # Simulate first turn: build fresh and bake in Honcho
         agent._cached_system_prompt = agent._build_system_prompt()
-        if agent._honcho_context:
+        if agent._turn_honcho_context:
             agent._cached_system_prompt = (
-                agent._cached_system_prompt + "\n\n" + agent._honcho_context
+                agent._cached_system_prompt + "\n\n" + agent._turn_honcho_context
             ).strip()
+            agent._turn_honcho_context_baked = True
 
         assert "User prefers Python over JavaScript" in agent._cached_system_prompt
+        assert agent._turn_honcho_context_baked is True
 
-    def test_honcho_prefetch_skipped_on_continuing_session(self):
-        """Honcho prefetch should not be called when conversation_history
-        is non-empty (continuing session)."""
-        conversation_history = [
-            {"role": "user", "content": "hello"},
-            {"role": "assistant", "content": "hi there"},
+    def test_compose_effective_system_injects_turn_honcho_context_when_not_baked(self, agent):
+        agent.ephemeral_system_prompt = "Ephemeral guidance"
+        agent._turn_honcho_context = "Fresh Honcho context"
+        agent._turn_honcho_context_baked = False
+
+        effective = agent._compose_effective_system_prompt("Base system")
+
+        assert "Base system" in effective
+        assert "Ephemeral guidance" in effective
+        assert "Fresh Honcho context" in effective
+
+    def test_compose_effective_system_skips_turn_honcho_context_when_baked(self, agent):
+        agent._turn_honcho_context = "Fresh Honcho context"
+        agent._turn_honcho_context_baked = True
+
+        effective = agent._compose_effective_system_prompt("Base system")
+
+        assert effective == "Base system"
+
+    def test_honcho_sync_queues_when_fail_open_and_sync_fails(self, agent):
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "telegram:123"
+        agent._honcho_fail_open = True
+        agent._honcho_retry_attempts = 0
+        agent._pending_honcho_sync = []
+
+        def _always_fail():
+            raise RuntimeError("boom")
+
+        agent._honcho.get_or_create.side_effect = _always_fail
+
+        synced = agent._honcho_sync("u", "a")
+
+        assert synced is False
+        assert len(agent._pending_honcho_sync) == 1
+        assert agent._pending_honcho_sync[0] == {"user": "u", "assistant": "a"}
+
+    def test_honcho_flush_pending_sync_replays_and_clears_queue(self, agent):
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "telegram:123"
+        agent._pending_honcho_sync = [{"user": "u1", "assistant": "a1"}]
+
+        with patch.object(agent, "_honcho_sync", return_value=True) as sync_mock:
+            agent._honcho_flush_pending_sync()
+
+        sync_mock.assert_called_once_with("u1", "a1", queue_on_failure=False)
+        assert agent._pending_honcho_sync == []
+
+    def test_honcho_sync_tool_event_queues_when_fail_open(self, agent):
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "telegram:123"
+        agent._honcho_fail_open = True
+        agent._honcho_retry_attempts = 0
+        agent._honcho_tool_events_enabled = True
+        agent._pending_honcho_tool_events = []
+
+        agent._honcho.get_or_create.side_effect = RuntimeError("boom")
+
+        synced = agent._honcho_sync_tool_event("[tool_event] {}")
+
+        assert synced is False
+        assert len(agent._pending_honcho_tool_events) == 1
+
+    def test_honcho_flush_pending_tool_events_replays_and_clears_queue(self, agent):
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "telegram:123"
+        agent._pending_honcho_tool_events = ["[tool_event] {}"]
+
+        with patch.object(agent, "_honcho_sync_tool_event", return_value=True) as sync_mock:
+            agent._honcho_flush_pending_tool_events()
+
+        sync_mock.assert_called_once_with("[tool_event] {}", queue_on_failure=False)
+        assert agent._pending_honcho_tool_events == []
+
+    def test_honcho_sync_queue_respects_cap_and_drops_oldest(self, agent):
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "telegram:123"
+        agent._honcho_fail_open = True
+        agent._honcho_retry_attempts = 0
+        agent._honcho_max_pending_sync = 2
+        agent._pending_honcho_sync = []
+        agent._honcho.get_or_create.side_effect = RuntimeError("boom")
+
+        agent._honcho_sync("u1", "a1")
+        agent._honcho_sync("u2", "a2")
+        agent._honcho_sync("u3", "a3")
+
+        assert agent._pending_honcho_sync == [
+            {"user": "u2", "assistant": "a2"},
+            {"user": "u3", "assistant": "a3"},
+        ]
+        assert agent._honcho_telemetry["dropped_sync"] == 1
+
+    def test_honcho_tool_event_queue_respects_cap_and_drops_oldest(self, agent):
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "telegram:123"
+        agent._honcho_fail_open = True
+        agent._honcho_retry_attempts = 0
+        agent._honcho_tool_events_enabled = True
+        agent._honcho_max_pending_tool_events = 2
+        agent._pending_honcho_tool_events = []
+        agent._honcho.get_or_create.side_effect = RuntimeError("boom")
+
+        agent._honcho_sync_tool_event("e1")
+        agent._honcho_sync_tool_event("e2")
+        agent._honcho_sync_tool_event("e3")
+
+        assert agent._pending_honcho_tool_events == ["e2", "e3"]
+        assert agent._honcho_telemetry["dropped_tool_events"] == 1
+
+    def test_honcho_flush_respects_batch_size(self, agent):
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "telegram:123"
+        agent._honcho_flush_batch_size = 1
+        agent._pending_honcho_sync = [
+            {"user": "u1", "assistant": "a1"},
+            {"user": "u2", "assistant": "a2"},
         ]
 
-        # The guard: `not conversation_history` is False when history exists
-        should_prefetch = not conversation_history
-        assert should_prefetch is False
+        with patch.object(agent, "_honcho_sync", return_value=True) as sync_mock:
+            agent._honcho_flush_pending_sync()
 
-    def test_honcho_prefetch_runs_on_first_turn(self):
-        """Honcho prefetch should run when conversation_history is empty."""
-        conversation_history = []
-        should_prefetch = not conversation_history
-        assert should_prefetch is True
+        sync_mock.assert_called_once_with("u1", "a1", queue_on_failure=False)
+        assert agent._pending_honcho_sync == [{"user": "u2", "assistant": "a2"}]
+
+    def test_honcho_status_snapshot_includes_runtime_fields(self, agent):
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "telegram:123"
+        agent._honcho_fail_open = False
+        agent._honcho_retry_attempts = 5
+        agent._honcho_tool_events_enabled = True
+        agent._honcho_max_pending_sync = 8
+        agent._honcho_max_pending_tool_events = 9
+        agent._honcho_flush_batch_size = 3
+        agent._pending_honcho_sync = [{"user": "u", "assistant": "a"}]
+        agent._pending_honcho_tool_events = ["[tool_event] {}"]
+        agent._honcho_last_prefetch_chars = 77
+        agent._honcho_last_error = "sync: boom"
+
+        status = agent.get_honcho_status()
+
+        assert status["enabled"] is True
+        assert status["session_key"] == "telegram:123"
+        assert status["fail_open"] is False
+        assert status["retry_attempts"] == 5
+        assert status["tool_events_enabled"] is True
+        assert status["max_pending_sync"] == 8
+        assert status["max_pending_tool_events"] == 9
+        assert status["flush_batch_size"] == 3
+        assert status["pending_sync"] == 1
+        assert status["pending_tool_events"] == 1
+        assert status["last_prefetch_chars"] == 77
+        assert status["last_error"] == "sync: boom"
+
+    def test_flush_honcho_queues_reports_replayed_counts(self, agent):
+        agent._pending_honcho_sync = [{"user": "u1", "assistant": "a1"}]
+        agent._pending_honcho_tool_events = ["e1", "e2"]
+
+        def _flush_sync():
+            agent._pending_honcho_sync = []
+
+        def _flush_tool_events():
+            agent._pending_honcho_tool_events = ["e2"]
+
+        with patch.object(agent, "_honcho_flush_pending_sync", side_effect=_flush_sync), patch.object(
+            agent,
+            "_honcho_flush_pending_tool_events",
+            side_effect=_flush_tool_events,
+        ):
+            status = agent.flush_honcho_queues()
+
+        assert status["flushed_sync"] == 1
+        assert status["flushed_tool_events"] == 1
+        assert status["pending_sync"] == 0
+        assert status["pending_tool_events"] == 1
+
+    def test_set_honcho_runtime_mode_updates_settings(self, agent):
+        status = agent.set_honcho_runtime_mode(
+            fail_open=False,
+            retry_attempts=4,
+            tool_events_enabled=False,
+        )
+
+        assert agent._honcho_fail_open is False
+        assert agent._honcho_retry_attempts == 4
+        assert agent._honcho_tool_events_enabled is False
+        assert status["fail_open"] is False
+        assert status["retry_attempts"] == 4
+        assert status["tool_events_enabled"] is False

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -243,6 +243,30 @@ class TestToolHandler:
         finally:
             _servers.pop("test_srv", None)
 
+    def test_closes_coroutine_when_loop_dispatch_raises(self, recwarn):
+        import gc
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=_make_call_result("ok", is_error=False))
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "greet", 120)
+            with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=RuntimeError("loop down")):
+                result = json.loads(handler({"name": "world"}))
+            assert "error" in result
+            assert "loop down" in result["error"]
+
+            gc.collect()
+            assert not any(
+                "was never awaited" in str(w.message)
+                for w in recwarn
+            )
+        finally:
+            _servers.pop("test_srv", None)
+
 
 # ---------------------------------------------------------------------------
 # Tool registration (discovery + register)

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -116,6 +116,11 @@ class TestMemoryStoreAdd:
         assert result["success"] is False
         assert "Blocked" in result["error"]
 
+    def test_write_gate_rejects_trivial_entry(self, store):
+        result = store.add("memory", "ok")
+        assert result["success"] is False
+        assert result["write_gate"]["decision"] == "reject"
+
 
 class TestMemoryStoreReplace:
     def test_replace_entry(self, store):
@@ -240,3 +245,9 @@ class TestMemoryToolDispatcher:
     def test_remove_requires_old_text(self, store):
         result = json.loads(memory_tool(action="remove", store=store))
         assert result["success"] is False
+
+    def test_consolidate_action(self, store):
+        store.add("memory", "python project")
+        result = json.loads(memory_tool(action="consolidate", target="memory", store=store))
+        assert result["success"] is True
+        assert result["reconciliation_action"] == "dedupe_prune"

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -23,7 +23,13 @@ class TestRegisterAndDispatch:
             handler=_dummy_handler,
         )
         result = json.loads(reg.dispatch("alpha", {}))
-        assert result == {"ok": True}
+        assert result["success"] is True
+        assert result["error"] is None
+        assert result["error_type"] is None
+        assert result["retryable"] is False
+        assert result["data"] == {"ok": True}
+        assert result["metrics"]["tool_name"] == "alpha"
+        assert isinstance(result["metrics"]["duration_ms"], int)
 
     def test_dispatch_passes_args(self):
         reg = ToolRegistry()
@@ -33,7 +39,50 @@ class TestRegisterAndDispatch:
 
         reg.register(name="echo", toolset="core", schema=_make_schema("echo"), handler=echo_handler)
         result = json.loads(reg.dispatch("echo", {"msg": "hi"}))
-        assert result == {"msg": "hi"}
+        assert result["success"] is True
+        assert result["data"] == {"msg": "hi"}
+
+
+class TestAsyncDispatch:
+    def test_async_handler_result_is_normalized(self):
+        reg = ToolRegistry()
+
+        async def async_handler(args, **kw):
+            return json.dumps({"value": args.get("x", 0)})
+
+        reg.register(
+            name="async_echo",
+            toolset="core",
+            schema=_make_schema("async_echo"),
+            handler=async_handler,
+            is_async=True,
+        )
+        result = json.loads(reg.dispatch("async_echo", {"x": 7}))
+
+        assert result["success"] is True
+        assert result["data"] == {"value": 7}
+        assert result["metrics"]["tool_name"] == "async_echo"
+        assert isinstance(result["metrics"]["duration_ms"], int)
+
+    def test_async_handler_exception_returns_error_envelope(self):
+        reg = ToolRegistry()
+
+        async def failing_async_handler(args, **kw):
+            raise ValueError("async boom")
+
+        reg.register(
+            name="async_fail",
+            toolset="core",
+            schema=_make_schema("async_fail"),
+            handler=failing_async_handler,
+            is_async=True,
+        )
+        result = json.loads(reg.dispatch("async_fail", {}))
+
+        assert result["success"] is False
+        assert result["error_type"] == "ValueError"
+        assert "async boom" in result["error"]
+        assert result["metrics"]["tool_name"] == "async_fail"
 
 
 class TestGetDefinitions:
@@ -73,8 +122,10 @@ class TestUnknownToolDispatch:
     def test_returns_error_json(self):
         reg = ToolRegistry()
         result = json.loads(reg.dispatch("nonexistent", {}))
-        assert "error" in result
+        assert result["success"] is False
         assert "Unknown tool" in result["error"]
+        assert result["error_type"] == "UnknownToolError"
+        assert result["metrics"]["tool_name"] == "nonexistent"
 
 
 class TestToolsetAvailability:
@@ -117,8 +168,83 @@ class TestToolsetAvailability:
 
         reg.register(name="bad", toolset="s", schema=_make_schema(), handler=bad_handler)
         result = json.loads(reg.dispatch("bad", {}))
-        assert "error" in result
+        assert result["success"] is False
         assert "RuntimeError" in result["error"]
+        assert result["error_type"] == "RuntimeError"
+        assert result["metrics"]["tool_name"] == "bad"
+        assert isinstance(result["metrics"]["duration_ms"], int)
+
+    def test_malformed_envelope_is_sanitized(self):
+        reg = ToolRegistry()
+
+        def malformed_handler(args, **kw):
+            return json.dumps({
+                "success": "false",
+                "error": {"message": "bad"},
+                "error_type": 404,
+                "retryable": "yes",
+                "metrics": "bad metrics",
+                "path": "/tmp/result.txt",
+            })
+
+        reg.register(name="sanitize", toolset="s", schema=_make_schema(), handler=malformed_handler)
+        result = json.loads(reg.dispatch("sanitize", {}))
+
+        assert result == {
+            "success": False,
+            "error": '{"message": "bad"}',
+            "error_type": "404",
+            "retryable": True,
+            "data": {"path": "/tmp/result.txt"},
+            "metrics": {
+                "tool_name": "sanitize",
+                "duration_ms": result["metrics"]["duration_ms"],
+            },
+        }
+        assert isinstance(result["metrics"]["duration_ms"], int)
+
+    def test_single_error_key_payload_is_wrapped_as_plain_data(self):
+        reg = ToolRegistry()
+
+        def error_payload_handler(args, **kw):
+            return json.dumps({"error": "plain data"})
+
+        reg.register(name="error_payload", toolset="s", schema=_make_schema(), handler=error_payload_handler)
+        result = json.loads(reg.dispatch("error_payload", {}))
+
+        assert result["success"] is True
+        assert result["error"] is None
+        assert result["error_type"] is None
+        assert result["retryable"] is False
+        assert result["data"] == {"error": "plain data"}
+        assert result["metrics"]["tool_name"] == "error_payload"
+
+    def test_scalar_data_envelope_preserves_extras(self):
+        reg = ToolRegistry()
+
+        def scalar_data_handler(args, **kw):
+            return json.dumps({
+                "success": True,
+                "data": "saved",
+                "path": "/tmp/result.txt",
+                "bytes": 42,
+            })
+
+        reg.register(name="scalar_data", toolset="s", schema=_make_schema(), handler=scalar_data_handler)
+        result = json.loads(reg.dispatch("scalar_data", {}))
+
+        assert result["success"] is True
+        assert result["data"] == {
+            "value": "saved",
+            "path": "/tmp/result.txt",
+            "bytes": 42,
+        }
+
+    def test_unknown_bool_strings_use_default(self):
+        reg = ToolRegistry()
+
+        assert reg._coerce_bool("maybe", default=False) is False
+        assert reg._coerce_bool("maybe", default=True) is True
 
 
 class TestCheckFnExceptionHandling:

--- a/tests/tools/test_safety_taxonomy.py
+++ b/tests/tools/test_safety_taxonomy.py
@@ -1,0 +1,21 @@
+from tools.safety_taxonomy import classify_tool_action
+
+
+def test_classify_read_only_tool():
+    c = classify_tool_action("read_file")
+    assert c.risk_class == "low"
+    assert c.action_type == "read_only"
+    assert c.approval_required is False
+
+
+def test_classify_reversible_tool_requires_approval():
+    c = classify_tool_action("patch")
+    assert c.risk_class == "medium"
+    assert c.approval_required is True
+    assert c.rollback_expected is True
+
+
+def test_classify_irreversible_tool_is_high_risk():
+    c = classify_tool_action("terminal")
+    assert c.risk_class == "high"
+    assert c.action_type == "irreversible_side_effect"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -797,6 +797,21 @@ def _run_on_mcp_loop(coro, timeout: float = 30):
     return future.result(timeout=timeout)
 
 
+def _run_on_mcp_loop_safe(coro, timeout: float = 30):
+    """Run coro on MCP loop and always close the coroutine object.
+
+    This avoids unawaited-coroutine warnings when tests monkeypatch
+    ``_run_on_mcp_loop`` and do not drive the coroutine.
+    """
+    try:
+        return _run_on_mcp_loop(coro, timeout=timeout)
+    finally:
+        try:
+            coro.close()
+        except Exception:
+            pass
+
+
 # ---------------------------------------------------------------------------
 # Config loading
 # ---------------------------------------------------------------------------
@@ -881,8 +896,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     parts.append(block.text)
             return json.dumps({"result": "\n".join(parts) if parts else ""})
 
+        coro = _call()
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop_safe(coro, timeout=tool_timeout)
         except Exception as exc:
             logger.error(
                 "MCP tool %s/%s call failed: %s",
@@ -924,8 +940,9 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
                 resources.append(entry)
             return json.dumps({"resources": resources})
 
+        coro = _call()
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop_safe(coro, timeout=tool_timeout)
         except Exception as exc:
             logger.error(
                 "MCP %s/list_resources failed: %s", server_name, exc,
@@ -966,8 +983,9 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
                     parts.append(f"[binary data, {len(block.blob)} bytes]")
             return json.dumps({"result": "\n".join(parts) if parts else ""})
 
+        coro = _call()
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop_safe(coro, timeout=tool_timeout)
         except Exception as exc:
             logger.error(
                 "MCP %s/read_resource failed: %s", server_name, exc,
@@ -1013,8 +1031,9 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
                 prompts.append(entry)
             return json.dumps({"prompts": prompts})
 
+        coro = _call()
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop_safe(coro, timeout=tool_timeout)
         except Exception as exc:
             logger.error(
                 "MCP %s/list_prompts failed: %s", server_name, exc,
@@ -1066,8 +1085,9 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
                 resp["description"] = result.description
             return json.dumps(resp)
 
+        coro = _call()
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop_safe(coro, timeout=tool_timeout)
         except Exception as exc:
             logger.error(
                 "MCP %s/get_prompt failed: %s", server_name, exc,

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -151,6 +151,70 @@ class MemoryStore:
             return self.user_char_limit
         return self.memory_char_limit
 
+    @staticmethod
+    def _score_write_candidate(target: str, content: str) -> Dict[str, Any]:
+        """Score whether a candidate write is durable/actionable enough to persist."""
+        text = (content or "").strip()
+        lowered = text.lower()
+        reasons: List[str] = []
+
+        trivial_exact = {
+            "ok", "okay", "thanks", "thank you", "noted", "cool", "sounds good",
+            "test", "tmp", "temporary", "todo", "later",
+        }
+        if lowered in trivial_exact:
+            return {
+                "decision": "reject",
+                "confidence": 0.95,
+                "reasons": ["candidate appears trivial/ephemeral"],
+                "target": target,
+            }
+
+        score = 0.2
+        if len(text) >= 16:
+            score += 0.2
+            reasons.append("sufficient detail length")
+        if re.search(r"\b(prefer|always|never|workflow|habit|style|timezone|tool|project|environment|role|name:|uses|wants)\b", lowered):
+            score += 0.3
+            reasons.append("contains durable preference/context signal")
+        if re.search(r"[:;]|\b(v\d+|python\s*\d|darwin|linux|macos|windows)\b", lowered):
+            score += 0.2
+            reasons.append("contains operationally actionable detail")
+        if len(text.split()) >= 2:
+            score += 0.15
+
+        decision = "accept" if score >= 0.45 else "defer"
+        confidence = min(0.99, max(0.05, score))
+        if decision == "defer" and not reasons:
+            reasons.append("low-signal entry; consider consolidating instead of appending")
+
+        return {
+            "decision": decision,
+            "confidence": round(confidence, 2),
+            "reasons": reasons,
+            "target": target,
+        }
+
+    def _find_potential_contradictions(self, target: str, content: str) -> List[str]:
+        """Return previews of likely contradictory entries for reconciliation flow."""
+        entries = self._entries_for(target)
+        lowered = content.lower()
+        conflicts: List[str] = []
+
+        polarity_pairs = ((" always ", " never "), ("enabled", "disabled"), ("prefers", "avoids"))
+        padded = f" {lowered} "
+        for entry in entries:
+            entry_lower = entry.lower()
+            for positive, negative in polarity_pairs:
+                if positive in padded and negative.strip() in entry_lower:
+                    conflicts.append(entry)
+                    break
+                if negative in padded and positive.strip() in entry_lower:
+                    conflicts.append(entry)
+                    break
+
+        return conflicts[:5]
+
     def add(self, target: str, content: str) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
         content = content.strip()
@@ -162,12 +226,24 @@ class MemoryStore:
         if scan_error:
             return {"success": False, "error": scan_error}
 
+        write_gate = self._score_write_candidate(target, content)
+        if write_gate.get("decision") == "reject":
+            return {
+                "success": False,
+                "error": "Write rejected by memory governance gate.",
+                "write_gate": write_gate,
+            }
+
         entries = self._entries_for(target)
         limit = self._char_limit(target)
+        potential_conflicts = self._find_potential_contradictions(target, content)
 
         # Reject exact duplicates
         if content in entries:
-            return self._success_response(target, "Entry already exists (no duplicate added).")
+            resp = self._success_response(target, "Entry already exists (no duplicate added).")
+            resp["write_gate"] = write_gate
+            resp["write_decision"] = "dedupe_noop"
+            return resp
 
         # Calculate what the new total would be
         new_entries = entries + [content]
@@ -184,13 +260,22 @@ class MemoryStore:
                 ),
                 "current_entries": entries,
                 "usage": f"{current:,}/{limit:,}",
+                "write_gate": write_gate,
             }
 
         entries.append(content)
         self._set_entries(target, entries)
         self.save_to_disk(target)
 
-        return self._success_response(target, "Entry added.")
+        resp = self._success_response(target, "Entry added.")
+        resp["write_gate"] = write_gate
+        resp["write_decision"] = write_gate.get("decision", "accept")
+        if potential_conflicts:
+            resp["reconciliation_action"] = "review_conflicts"
+            resp["potential_conflicts"] = [
+                c[:120] + ("..." if len(c) > 120 else "") for c in potential_conflicts
+            ]
+        return resp
 
     def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
         """Find entry containing old_text substring, replace it with new_content."""
@@ -277,6 +362,21 @@ class MemoryStore:
         self.save_to_disk(target)
 
         return self._success_response(target, "Entry removed.")
+
+    def consolidate(self, target: str) -> Dict[str, Any]:
+        """Prune exact duplicates/empty entries and persist compacted memory."""
+        entries = [e.strip() for e in self._entries_for(target) if (e or "").strip()]
+        before = len(entries)
+        deduped = list(dict.fromkeys(entries))
+        removed = max(0, before - len(deduped))
+
+        self._set_entries(target, deduped)
+        self.save_to_disk(target)
+
+        resp = self._success_response(target, "Memory consolidated.")
+        resp["removed_entries"] = removed
+        resp["reconciliation_action"] = "dedupe_prune"
+        return resp
 
     def format_for_system_prompt(self, target: str) -> Optional[str]:
         """
@@ -417,8 +517,11 @@ def memory_tool(
             return json.dumps({"success": False, "error": "old_text is required for 'remove' action."}, ensure_ascii=False)
         result = store.remove(target, old_text)
 
+    elif action == "consolidate":
+        result = store.consolidate(target)
+
     else:
-        return json.dumps({"success": False, "error": f"Unknown action '{action}'. Use: add, replace, remove"}, ensure_ascii=False)
+        return json.dumps({"success": False, "error": f"Unknown action '{action}'. Use: add, replace, remove, consolidate"}, ensure_ascii=False)
 
     return json.dumps(result, ensure_ascii=False)
 
@@ -459,7 +562,7 @@ MEMORY_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["add", "replace", "remove"],
+                "enum": ["add", "replace", "remove", "consolidate"],
                 "description": "The action to perform."
             },
             "target": {

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -16,9 +16,35 @@ Import chain (circular-import safe):
 
 import json
 import logging
+import time
 from typing import Any, Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
+
+_TOOL_RESULT_KEYS = ("success", "error", "error_type", "retryable", "data", "metrics")
+_TOOL_RESULT_KEY_SET = set(_TOOL_RESULT_KEYS)
+_TOOL_RESULT_SIGNAL_KEYS = {"success", "error", "error_type", "retryable"}
+
+
+def make_tool_result(
+    *,
+    success: bool,
+    error: Optional[str] = None,
+    error_type: Optional[str] = None,
+    retryable: bool = False,
+    data: Any = None,
+    metrics: Optional[dict] = None,
+) -> str:
+    """Return the canonical JSON tool result envelope."""
+    envelope = {
+        "success": bool(success),
+        "error": error if error is None else str(error),
+        "error_type": error_type if error_type is None else str(error_type),
+        "retryable": bool(retryable),
+        "data": data,
+        "metrics": metrics if isinstance(metrics, dict) else {},
+    }
+    return json.dumps(envelope, ensure_ascii=False, default=str)
 
 
 class ToolEntry:
@@ -109,24 +135,184 @@ class ToolRegistry:
     # Dispatch
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _maybe_parse_json(value: Any) -> Any:
+        """Best-effort JSON decode for handler outputs."""
+        if isinstance(value, (bytes, bytearray)):
+            value = value.decode("utf-8", errors="replace")
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except (TypeError, ValueError):
+                return value
+        return value
+
+    @staticmethod
+    def _stringify_field(value: Any) -> Optional[str]:
+        """Normalize error-like fields into strings or None."""
+        if value is None or value == "":
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (dict, list)):
+            return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+        return str(value)
+
+    @staticmethod
+    def _coerce_bool(value: Any, default: bool = False) -> bool:
+        """Normalize bool-like values without relying on raw truthiness alone."""
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "y", "on"}:
+                return True
+            if normalized in {"0", "false", "no", "n", "off", ""}:
+                return False
+            return default
+        return bool(value)
+
+    @staticmethod
+    def _sanitize_metrics(metrics: Any, tool_name: str, duration_ms: int) -> dict:
+        """Force metrics into a dict and stamp canonical dispatch metadata."""
+        normalized = {}
+        if isinstance(metrics, dict):
+            normalized = {str(key): value for key, value in metrics.items()}
+        normalized["tool_name"] = tool_name
+        normalized["duration_ms"] = max(0, int(duration_ms))
+        return normalized
+
+    @staticmethod
+    def _looks_like_envelope(payload: Any) -> bool:
+        """Detect existing success/error-style tool payloads."""
+        if not isinstance(payload, dict):
+            return False
+        signal_count = len(_TOOL_RESULT_SIGNAL_KEYS.intersection(payload))
+        return "success" in payload or signal_count >= 2
+
+    @staticmethod
+    def _merge_data_with_extras(data: Any, extras: dict) -> Any:
+        """Preserve extra payload keys alongside canonical ``data``."""
+        if not extras:
+            return data
+        if isinstance(data, dict):
+            merged = dict(data)
+            for key, value in extras.items():
+                merged.setdefault(key, value)
+            return merged
+
+        wrapped = {"value": data}
+        for key, value in extras.items():
+            if key not in wrapped:
+                wrapped[key] = value
+                continue
+            suffix = 2
+            conflict_key = f"extra_{key}"
+            while conflict_key in wrapped:
+                conflict_key = f"extra_{key}_{suffix}"
+                suffix += 1
+            wrapped[conflict_key] = value
+        return wrapped
+
+    def validate_tool_result_envelope(self, payload: Any, *, tool_name: str, duration_ms: int) -> dict:
+        """Sanitize arbitrary handler output into the canonical tool envelope."""
+        parsed = self._maybe_parse_json(payload)
+        metrics = self._sanitize_metrics(None, tool_name, duration_ms)
+
+        if not self._looks_like_envelope(parsed):
+            return {
+                "success": True,
+                "error": None,
+                "error_type": None,
+                "retryable": False,
+                "data": parsed,
+                "metrics": metrics,
+            }
+
+        extras = {key: value for key, value in parsed.items() if key not in _TOOL_RESULT_KEY_SET}
+        error = self._stringify_field(parsed.get("error"))
+        error_type = self._stringify_field(parsed.get("error_type"))
+
+        raw_success = parsed.get("success")
+        success_default = error is None
+        if raw_success is None:
+            success = success_default
+        else:
+            success = self._coerce_bool(raw_success, default=success_default)
+
+        data = parsed.get("data")
+        if "data" not in parsed and extras:
+            data = extras
+        elif "data" in parsed and extras:
+            data = self._merge_data_with_extras(data, extras)
+
+        retryable = self._coerce_bool(parsed.get("retryable"), default=False)
+        metrics = self._sanitize_metrics(parsed.get("metrics"), tool_name, duration_ms)
+
+        if success:
+            error = None
+            error_type = None
+            retryable = False
+        else:
+            error = error or "Tool reported failure."
+
+        return {
+            "success": success,
+            "error": error,
+            "error_type": error_type,
+            "retryable": retryable,
+            "data": data,
+            "metrics": metrics,
+        }
+
     def dispatch(self, name: str, args: dict, **kwargs) -> str:
         """Execute a tool handler by name.
 
         * Async handlers are bridged automatically via ``_run_async()``.
-        * All exceptions are caught and returned as ``{"error": "..."}``
-          for consistent error format.
+        * All outputs are normalized into the canonical tool result envelope.
+        * All exceptions are caught and returned as a JSON string for
+          backward-compatible callers.
         """
         entry = self._tools.get(name)
         if not entry:
-            return json.dumps({"error": f"Unknown tool: {name}"})
+            return make_tool_result(
+                success=False,
+                error=f"Unknown tool: {name}",
+                error_type="UnknownToolError",
+                retryable=False,
+                data=None,
+                metrics=self._sanitize_metrics(None, name, 0),
+            )
+
+        started_at = time.perf_counter()
         try:
             if entry.is_async:
                 from model_tools import _run_async
-                return _run_async(entry.handler(args, **kwargs))
-            return entry.handler(args, **kwargs)
+
+                raw_result = _run_async(entry.handler(args, **kwargs))
+            else:
+                raw_result = entry.handler(args, **kwargs)
+
+            duration_ms = round((time.perf_counter() - started_at) * 1000)
+            normalized = self.validate_tool_result_envelope(
+                raw_result,
+                tool_name=name,
+                duration_ms=duration_ms,
+            )
+            return make_tool_result(**normalized)
         except Exception as e:
             logger.exception("Tool %s dispatch error: %s", name, e)
-            return json.dumps({"error": f"Tool execution failed: {type(e).__name__}: {e}"})
+            duration_ms = round((time.perf_counter() - started_at) * 1000)
+            return make_tool_result(
+                success=False,
+                error=f"Tool execution failed: {type(e).__name__}: {e}",
+                error_type=type(e).__name__,
+                retryable=False,
+                data=None,
+                metrics=self._sanitize_metrics(None, name, duration_ms),
+            )
 
     # ------------------------------------------------------------------
     # Query helpers  (replace redundant dicts in model_tools.py)

--- a/tools/safety_taxonomy.py
+++ b/tools/safety_taxonomy.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SafetyClassification:
+    risk_class: str
+    action_type: str
+    approval_required: bool
+    rollback_expected: bool
+
+
+_READ_ONLY = {
+    "read_file", "search_files", "web_search", "web_extract", "browser_snapshot", "session_search", "list_cronjobs"
+}
+_REVERSIBLE = {
+    "patch", "write_file", "remove_cronjob", "memory", "todo"
+}
+_IRREVERSIBLE = {
+    "terminal", "schedule_cronjob", "send_message", "mcp_call_tool", "skill_manage"
+}
+
+
+def classify_tool_action(tool_name: str) -> SafetyClassification:
+    if tool_name in _READ_ONLY:
+        return SafetyClassification("low", "read_only", False, False)
+    if tool_name in _REVERSIBLE:
+        return SafetyClassification("medium", "reversible_side_effect", True, True)
+    if tool_name in _IRREVERSIBLE:
+        return SafetyClassification("high", "irreversible_side_effect", True, False)
+    if tool_name.startswith("browser_"):
+        return SafetyClassification("medium", "external_interaction", False, False)
+    return SafetyClassification("low", "unknown", False, False)


### PR DESCRIPTION
Includes commits 90df37e and adc009c.\n\n- Phase 3 bounded live self-correction retries (shadow default, risk/confidence gates, per-session budgets)\n- Guardrail + handoff docs updates\n- Cleanup: retire process-global tool-name cache and MCP coroutine cleanup regressions already covered in included commits/tests\n\nPlease review as a Phase 3 checkpoint before Phase 4 eval harness work.