### PR TITLE
feat: add Tlon (Urbit) messaging platform adapter

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -139,6 +139,14 @@ PLATFORM_HINTS = {
         "is preserved for threading. Do not include greetings or sign-offs unless "
         "contextually appropriate."
     ),
+    "tlon": (
+        "You are on Tlon, a decentralized messaging platform built on Urbit. "
+        "Users are identified by ship names (patps) like ~sampel-palnet. "
+        "You can use basic markdown formatting. When mentioning users, use their "
+        "full ship name with the ~ prefix. You can send images by including "
+        "image URLs in markdown format ![alt](url). In group channels, users "
+        "mention you with your ship name to get your attention."
+    ),
     "cli": (
         "You are a CLI AI Agent. Try not to use markdown but simple text "
         "renderable inside a terminal."

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -104,6 +104,7 @@ def _deliver_result(job: dict, content: str) -> None:
         "whatsapp": Platform.WHATSAPP,
         "signal": Platform.SIGNAL,
         "email": Platform.EMAIL,
+        "tlon": Platform.TLON,
     }
     platform = platform_map.get(platform_name.lower())
     if not platform:

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -61,7 +61,7 @@ def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
     # Telegram, WhatsApp & Signal can't enumerate chats -- pull from session history
-    for plat_name in ("telegram", "whatsapp", "signal", "email"):
+    for plat_name in ("telegram", "whatsapp", "signal", "email", "tlon"):
         if plat_name not in platforms:
             platforms[plat_name] = _build_from_sessions(plat_name)
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -29,6 +29,7 @@ class Platform(Enum):
     SIGNAL = "signal"
     HOMEASSISTANT = "homeassistant"
     EMAIL = "email"
+    TLON = "tlon"
 
 
 @dataclass
@@ -456,6 +457,26 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 platform=Platform.EMAIL,
                 chat_id=email_home,
                 name=os.getenv("EMAIL_HOME_ADDRESS_NAME", "Home"),
+            )
+
+    # Tlon (Urbit)
+    tlon_url = os.getenv("TLON_SHIP_URL")
+    tlon_name = os.getenv("TLON_SHIP_NAME")
+    tlon_code = os.getenv("TLON_SHIP_CODE")
+    if all([tlon_url, tlon_name, tlon_code]):
+        if Platform.TLON not in config.platforms:
+            config.platforms[Platform.TLON] = PlatformConfig()
+        config.platforms[Platform.TLON].enabled = True
+        config.platforms[Platform.TLON].extra.update({
+            "ship_url": tlon_url,
+            "ship_name": tlon_name,
+        })
+        tlon_home = os.getenv("TLON_HOME_CHANNEL")
+        if tlon_home:
+            config.platforms[Platform.TLON].home_channel = HomeChannel(
+                platform=Platform.TLON,
+                chat_id=tlon_home,
+                name=os.getenv("TLON_HOME_CHANNEL_NAME", "Home"),
             )
 
     # Session settings

--- a/gateway/platforms/tlon.py
+++ b/gateway/platforms/tlon.py
@@ -1,0 +1,1261 @@
+"""
+Tlon (Urbit) platform adapter for Hermes Gateway.
+
+Connects to a Tlon ship via Eyre HTTP API:
+- Authenticates with ship +code
+- Subscribes to channel messages (channels /v2) and DMs (chat /v3) via SSE
+- Sends messages back via pokes
+
+Requires: aiohttp (pip install aiohttp)
+
+Environment variables:
+  TLON_SHIP_URL    - Ship URL (e.g. https://sampel-palnet.tlon.network)
+  TLON_SHIP_NAME   - Ship name (e.g. ~sampel-palnet)
+  TLON_SHIP_CODE   - Ship +code for authentication
+  TLON_CHANNELS    - Comma-separated channel nests to monitor (e.g. chat/~host/channel)
+  TLON_DM_ALLOWLIST - Comma-separated ships allowed to DM (empty = all allowed)
+  TLON_HOME_CHANNEL - Default channel for cron delivery
+  TLON_ALLOWED_USERS - Comma-separated ships allowed to interact
+  TLON_ALLOW_ALL_USERS - Set to "true" to allow all users (default: false)
+  TLON_AUTO_DISCOVER - Set to "true" to auto-discover all group channels
+"""
+
+import asyncio
+import json
+import logging
+import os
+import re
+import time
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    cache_image_from_bytes,
+)
+
+# Maximum message length for Tlon (generous - Tlon handles long messages well)
+MAX_MESSAGE_LENGTH = 10000
+
+
+def check_tlon_requirements() -> bool:
+    """Check if aiohttp is available for HTTP/SSE communication."""
+    try:
+        import aiohttp
+        return True
+    except ImportError:
+        logger.warning("Tlon adapter requires aiohttp. Install with: pip install aiohttp")
+        return False
+
+
+def _normalize_ship(ship: str) -> str:
+    """Normalize a ship name to include ~ prefix."""
+    ship = ship.strip()
+    if ship and not ship.startswith("~"):
+        ship = "~" + ship
+    return ship
+
+
+def _parse_channel_nest(nest: str) -> Optional[Dict[str, str]]:
+    """Parse a channel nest like 'chat/~host/channel-name'."""
+    parts = nest.split("/", 2)
+    if len(parts) != 3:
+        return None
+    return {
+        "type": parts[0],       # chat, heap, diary
+        "host": parts[1],       # ~host-ship
+        "name": parts[2],       # channel-name
+    }
+
+
+def _extract_message_text(content: Any) -> str:
+    """
+    Extract plain text from Tlon's story/content format.
+
+    Tlon messages use a 'story' format: an array of blocks.
+    Each block is either:
+      - {"inline": [...]} with text strings, links, mentions, etc.
+      - {"block": {"image": {...}}} for images
+      - {"block": {"cite": {...}}} for quotes
+    """
+    if not content:
+        return ""
+
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                # Inline block: {"inline": [...]}
+                if "inline" in block:
+                    for inline in block["inline"]:
+                        if isinstance(inline, str):
+                            parts.append(inline)
+                        elif isinstance(inline, dict):
+                            # Bold, italic, etc.
+                            if "bold" in inline:
+                                parts.append(_extract_inline_text(inline["bold"]))
+                            elif "italics" in inline:
+                                parts.append(_extract_inline_text(inline["italics"]))
+                            elif "strike" in inline:
+                                parts.append(_extract_inline_text(inline["strike"]))
+                            elif "blockquote" in inline:
+                                parts.append(_extract_inline_text(inline["blockquote"]))
+                            elif "inline-code" in inline:
+                                parts.append(inline["inline-code"])
+                            elif "code" in inline:
+                                parts.append(inline["code"])
+                            elif "link" in inline:
+                                link = inline["link"]
+                                href = link.get("href", "")
+                                link_content = link.get("content", href)
+                                parts.append(link_content if link_content else href)
+                            elif "ship" in inline:
+                                parts.append(_normalize_ship(inline["ship"]))
+                            elif "break" in inline:
+                                parts.append("\n")
+                            elif "tag" in inline:
+                                parts.append(f"#{inline['tag']}")
+                # Block types
+                elif "block" in block:
+                    b = block["block"]
+                    if isinstance(b, dict):
+                        if "image" in b:
+                            img = b["image"]
+                            alt = img.get("alt", "")
+                            src = img.get("src", "")
+                            parts.append(f"[image: {alt or src}]")
+                        elif "cite" in b:
+                            parts.append("[quoted message]")
+                        elif "code" in b:
+                            code = b["code"]
+                            lang = code.get("lang", "")
+                            body = code.get("code", "")
+                            parts.append(f"```{lang}\n{body}\n```")
+        return " ".join(p for p in parts if p).strip()
+
+    return str(content)
+
+
+def _extract_inline_text(inlines: Any) -> str:
+    """Recursively extract text from inline content."""
+    if isinstance(inlines, str):
+        return inlines
+    if isinstance(inlines, list):
+        parts = []
+        for item in inlines:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                if "ship" in item:
+                    parts.append(_normalize_ship(item["ship"]))
+                elif "link" in item:
+                    parts.append(item["link"].get("content", item["link"].get("href", "")))
+                elif "bold" in item:
+                    parts.append(_extract_inline_text(item["bold"]))
+                elif "italics" in item:
+                    parts.append(_extract_inline_text(item["italics"]))
+                elif "inline-code" in item:
+                    parts.append(item["inline-code"])
+                elif "break" in item:
+                    parts.append("\n")
+        return "".join(parts)
+    return ""
+
+
+def _text_to_story(text: str) -> list:
+    """
+    Convert plain text/markdown to Tlon's story format.
+
+    Returns a list of story blocks suitable for use as post content.
+    """
+    # Simple conversion: wrap text as inline blocks, split on double newlines
+    # for paragraph breaks
+    blocks = []
+    paragraphs = text.split("\n\n")
+    for i, para in enumerate(paragraphs):
+        if not para.strip():
+            continue
+        # Convert each paragraph to an inline block
+        inlines = []
+        # Handle @mentions (ship names)
+        parts = re.split(r'(~[a-z][\w-]*)', para)
+        for part in parts:
+            if re.match(r'^~[a-z][\w-]*$', part):
+                inlines.append({"ship": part.lstrip("~")})
+            elif part:
+                inlines.append(part)
+        if inlines:
+            blocks.append({"inline": inlines})
+        # Add line break between paragraphs (except after last)
+        if i < len(paragraphs) - 1:
+            blocks.append({"inline": [{"break": None}]})
+    if not blocks:
+        blocks = [{"inline": [""]}]
+    return blocks
+
+
+def _da_from_unix(unix_ms: int) -> str:
+    """
+    Convert Unix timestamp (ms) to Urbit @da format (dot-separated @ud).
+
+    This produces an @ud-formatted bigint suitable for post IDs.
+    The Urbit epoch is ~292 billion years before Unix epoch.
+    """
+    # Urbit @da epoch offset from Unix epoch (in milliseconds)
+    # ~2000.1.1 in Unix = 946684800000 ms
+    # But we need the actual @da conversion...
+    # For message IDs, Tlon uses the timestamp as a bigint @ud
+    # We just need a unique, monotonically increasing number
+    return str(unix_ms)
+
+
+class TlonSSEClient:
+    """
+    Manages an Eyre SSE channel for subscribing to Tlon events.
+
+    Handles:
+    - Authentication via POST /~/login
+    - Channel creation via PUT /~/channel/{id}
+    - SSE event streaming via GET /~/channel/{id}
+    - Event acknowledgement
+    - Reconnection with exponential backoff
+    """
+
+    def __init__(
+        self,
+        url: str,
+        code: str,
+        ship: str,
+        *,
+        auto_reconnect: bool = True,
+        max_reconnect_attempts: int = 10,
+        reconnect_delay: float = 1.0,
+        max_reconnect_delay: float = 30.0,
+    ):
+        self.url = url.rstrip("/")
+        self.code = code
+        self.ship = _normalize_ship(ship)
+        self.auto_reconnect = auto_reconnect
+        self.max_reconnect_attempts = max_reconnect_attempts
+        self.reconnect_delay = reconnect_delay
+        self.max_reconnect_delay = max_reconnect_delay
+
+        self.cookie: Optional[str] = None
+        self.channel_id: Optional[str] = None
+        self.channel_url: Optional[str] = None
+        self._session: Optional[Any] = None  # aiohttp.ClientSession
+        self._sse_task: Optional[asyncio.Task] = None
+        self._aborted = False
+        self._connected = False
+        self._reconnect_attempts = 0
+        self._action_counter = 0
+
+        # Subscription tracking
+        self._subscriptions: List[Dict[str, Any]] = []
+        self._event_handlers: Dict[int, Dict[str, Any]] = {}
+
+        # Event ack tracking
+        self._last_heard_event_id = -1
+        self._last_acked_event_id = -1
+        self._ack_threshold = 20
+
+    async def authenticate(self) -> str:
+        """Authenticate with the ship and return the cookie."""
+        import aiohttp
+
+        if not self._session:
+            self._session = aiohttp.ClientSession()
+
+        async with self._session.post(
+            f"{self.url}/~/login",
+            data={"password": self.code},
+            allow_redirects=False,
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as resp:
+            if resp.status not in (200, 204, 302, 303, 307):
+                raise ConnectionError(f"Auth failed: HTTP {resp.status}")
+            cookie = resp.headers.get("set-cookie", "")
+            if not cookie:
+                # Try from cookies jar
+                for c in self._session.cookie_jar:
+                    if c.key.startswith("urbauth"):
+                        cookie = f"{c.key}={c.value}"
+                        break
+            if not cookie:
+                raise ConnectionError("No auth cookie received")
+            self.cookie = cookie
+            logger.info("[tlon] Authenticated as %s", self.ship)
+            return cookie
+
+    async def _new_channel_id(self) -> str:
+        """Generate a new unique channel ID."""
+        ts = int(time.time())
+        uid = uuid.uuid4().hex[:8]
+        return f"{ts}-{uid}"
+
+    def _next_action_id(self) -> int:
+        """Get the next action ID for channel operations."""
+        self._action_counter += 1
+        return self._action_counter
+
+    async def subscribe(
+        self,
+        app: str,
+        path: str,
+        on_event: Optional[Any] = None,
+        on_error: Optional[Any] = None,
+        on_quit: Optional[Any] = None,
+    ) -> int:
+        """
+        Subscribe to a Gall agent path.
+
+        Returns the subscription ID.
+        """
+        sub_id = self._next_action_id()
+        sub = {
+            "id": sub_id,
+            "action": "subscribe",
+            "ship": self.ship.lstrip("~"),
+            "app": app,
+            "path": path,
+        }
+        self._subscriptions.append(sub)
+        self._event_handlers[sub_id] = {
+            "event": on_event,
+            "err": on_error,
+            "quit": on_quit,
+        }
+
+        # If already connected, send subscription immediately
+        if self._connected:
+            await self._send_actions([sub])
+
+        return sub_id
+
+    async def _send_actions(self, actions: List[Dict[str, Any]]) -> None:
+        """Send actions to the Eyre channel."""
+        import aiohttp
+
+        headers = {"Content-Type": "application/json"}
+        if self.cookie:
+            headers["Cookie"] = self.cookie
+
+        async with self._session.put(
+            self.channel_url,
+            json=actions,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as resp:
+            if resp.status not in (200, 204):
+                text = await resp.text()
+                raise ConnectionError(
+                    f"Channel action failed: HTTP {resp.status} - {text[:200]}"
+                )
+
+    async def connect(self) -> None:
+        """
+        Create the Eyre channel with initial subscriptions and start
+        the SSE event stream.
+        """
+        self.channel_id = await self._new_channel_id()
+        self.channel_url = f"{self.url}/~/channel/{self.channel_id}"
+
+        # Create channel with all pending subscriptions
+        if self._subscriptions:
+            await self._send_actions(self._subscriptions)
+
+        # Start SSE stream
+        await self._open_stream()
+        self._connected = True
+        self._reconnect_attempts = 0
+        logger.info("[tlon] SSE connected on channel %s", self.channel_id)
+
+    async def _open_stream(self) -> None:
+        """Open the SSE GET stream."""
+        import aiohttp
+
+        headers = {
+            "Accept": "text/event-stream",
+        }
+        if self.cookie:
+            headers["Cookie"] = self.cookie
+
+        self._sse_task = asyncio.create_task(self._stream_loop(headers))
+
+    async def _stream_loop(self, headers: Dict[str, str]) -> None:
+        """Read the SSE stream and dispatch events."""
+        import aiohttp
+
+        try:
+            async with self._session.get(
+                self.channel_url,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(
+                    total=None,  # No total timeout for SSE
+                    sock_read=None,  # No read timeout
+                    connect=60,
+                ),
+            ) as resp:
+                if resp.status != 200:
+                    raise ConnectionError(f"SSE stream failed: HTTP {resp.status}")
+
+                buffer = ""
+                async for chunk in resp.content.iter_any():
+                    if self._aborted:
+                        break
+                    buffer += chunk.decode("utf-8", errors="replace")
+
+                    while "\n\n" in buffer:
+                        event_data, buffer = buffer.split("\n\n", 1)
+                        await self._process_event(event_data)
+
+        except asyncio.CancelledError:
+            return
+        except Exception as e:
+            if not self._aborted:
+                logger.error("[tlon] SSE stream error: %s", e)
+                self._connected = False
+                if self.auto_reconnect:
+                    await self._attempt_reconnect()
+
+    async def _process_event(self, event_data: str) -> None:
+        """Parse and dispatch a single SSE event."""
+        lines = event_data.split("\n")
+        data = None
+        event_id = None
+
+        for line in lines:
+            if line.startswith("id: "):
+                try:
+                    event_id = int(line[4:])
+                except ValueError:
+                    pass
+            elif line.startswith("data: "):
+                data = line[6:]
+
+        if not data:
+            return
+
+        # Track and ack events
+        if event_id is not None and event_id > self._last_heard_event_id:
+            self._last_heard_event_id = event_id
+            if event_id - self._last_acked_event_id > self._ack_threshold:
+                asyncio.create_task(self._ack(event_id))
+
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError:
+            logger.debug("[tlon] Non-JSON SSE data: %s", data[:100])
+            return
+
+        # Handle quit events (agent kicked us)
+        if parsed.get("response") == "quit":
+            sub_id = parsed.get("id")
+            if sub_id and sub_id in self._event_handlers:
+                handler = self._event_handlers[sub_id]
+                if handler.get("quit"):
+                    handler["quit"]()
+                # Auto-resubscribe
+                asyncio.create_task(self._resubscribe(sub_id))
+            return
+
+        # Dispatch to handlers
+        sub_id = parsed.get("id")
+        event_json = parsed.get("json")
+
+        if sub_id and sub_id in self._event_handlers:
+            handler = self._event_handlers[sub_id]
+            if handler.get("event") and event_json is not None:
+                try:
+                    await handler["event"](event_json)
+                except Exception as e:
+                    logger.error("[tlon] Event handler error: %s", e)
+        elif event_json is not None:
+            # Broadcast to all handlers
+            for handler in self._event_handlers.values():
+                if handler.get("event"):
+                    try:
+                        await handler["event"](event_json)
+                    except Exception as e:
+                        logger.error("[tlon] Broadcast handler error: %s", e)
+
+    async def _ack(self, event_id: int) -> None:
+        """Acknowledge events up to event_id."""
+        self._last_acked_event_id = event_id
+        try:
+            await self._send_actions([{
+                "id": self._next_action_id(),
+                "action": "ack",
+                "event-id": event_id,
+            }])
+        except Exception as e:
+            logger.debug("[tlon] Ack failed: %s", e)
+
+    async def _resubscribe(self, old_sub_id: int) -> None:
+        """Re-subscribe after a quit event."""
+        old_sub = None
+        for sub in self._subscriptions:
+            if sub["id"] == old_sub_id:
+                old_sub = sub
+                break
+        if not old_sub:
+            return
+
+        handlers = self._event_handlers.get(old_sub_id)
+        if not handlers:
+            return
+
+        for attempt in range(5):
+            delay = min(2.0 * (2 ** attempt), 30.0)
+            logger.info("[tlon] Resubscribing to %s%s in %.0fs...",
+                       old_sub["app"], old_sub["path"], delay)
+            await asyncio.sleep(delay)
+
+            if self._aborted or not self._connected:
+                return
+
+            try:
+                new_id = self._next_action_id()
+                new_sub = {**old_sub, "id": new_id}
+                self._subscriptions.append(new_sub)
+                self._event_handlers[new_id] = handlers
+                del self._event_handlers[old_sub_id]
+                await self._send_actions([new_sub])
+                logger.info("[tlon] Resubscribed to %s%s", old_sub["app"], old_sub["path"])
+                return
+            except Exception as e:
+                logger.error("[tlon] Resubscribe failed: %s", e)
+
+    async def _attempt_reconnect(self) -> None:
+        """Reconnect with exponential backoff."""
+        if self._aborted:
+            return
+
+        while self._reconnect_attempts < self.max_reconnect_attempts:
+            self._reconnect_attempts += 1
+            delay = min(
+                self.reconnect_delay * (2 ** (self._reconnect_attempts - 1)),
+                self.max_reconnect_delay,
+            )
+            logger.info("[tlon] Reconnecting in %.1fs (attempt %d/%d)...",
+                       delay, self._reconnect_attempts, self.max_reconnect_attempts)
+            await asyncio.sleep(delay)
+
+            if self._aborted:
+                return
+
+            try:
+                # Re-authenticate
+                await self.authenticate()
+                # New channel
+                self.channel_id = await self._new_channel_id()
+                self.channel_url = f"{self.url}/~/channel/{self.channel_id}"
+                # Reconnect
+                await self.connect()
+                logger.info("[tlon] Reconnected successfully!")
+                return
+            except Exception as e:
+                logger.error("[tlon] Reconnect failed: %s", e)
+
+        # Reset and keep trying
+        logger.warning("[tlon] Max reconnect attempts reached, resetting counter...")
+        await asyncio.sleep(10)
+        self._reconnect_attempts = 0
+        await self._attempt_reconnect()
+
+    async def poke(self, app: str, mark: str, json_data: Any) -> None:
+        """Send a poke to a Gall agent."""
+        action = {
+            "id": self._next_action_id(),
+            "action": "poke",
+            "ship": self.ship.lstrip("~"),
+            "app": app,
+            "mark": mark,
+            "json": json_data,
+        }
+        await self._send_actions([action])
+
+    async def scry(self, path: str) -> Any:
+        """Scry a path and return the JSON response."""
+        import aiohttp
+
+        headers = {}
+        if self.cookie:
+            headers["Cookie"] = self.cookie
+
+        full_path = path if path.endswith(".json") else f"{path}.json"
+        async with self._session.get(
+            f"{self.url}{full_path}",
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as resp:
+            if resp.status != 200:
+                text = await resp.text()
+                raise Exception(f"Scry failed: HTTP {resp.status} - {text[:200]}")
+            return await resp.json()
+
+    async def close(self) -> None:
+        """Close the SSE connection and clean up."""
+        self._aborted = True
+        self._connected = False
+
+        if self._sse_task:
+            self._sse_task.cancel()
+            try:
+                await self._sse_task
+            except asyncio.CancelledError:
+                pass
+
+        # Try to clean up the Eyre channel
+        if self._session and self.channel_url:
+            try:
+                # Unsubscribe
+                unsubs = [
+                    {"id": sub["id"], "action": "unsubscribe", "subscription": sub["id"]}
+                    for sub in self._subscriptions
+                ]
+                if unsubs:
+                    await self._send_actions(unsubs)
+            except Exception:
+                pass
+
+            try:
+                headers = {}
+                if self.cookie:
+                    headers["Cookie"] = self.cookie
+                await self._session.delete(
+                    self.channel_url,
+                    headers=headers,
+                    timeout=5,
+                )
+            except Exception:
+                pass
+
+        if self._session:
+            await self._session.close()
+            self._session = None
+
+
+class TlonAdapter(BasePlatformAdapter):
+    """
+    Hermes Gateway adapter for Tlon (Urbit).
+
+    Connects to a Tlon ship and monitors channels + DMs for messages,
+    dispatching them to the Hermes agent session store.
+    """
+
+    MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.TLON)
+
+        # Read config from env vars (following Hermes convention)
+        self.ship_url = os.getenv("TLON_SHIP_URL", "").rstrip("/")
+        self.ship_name = _normalize_ship(os.getenv("TLON_SHIP_NAME", ""))
+        self.ship_code = os.getenv("TLON_SHIP_CODE", "")
+
+        # Channels to monitor
+        channels_str = os.getenv("TLON_CHANNELS", "")
+        self.monitored_channels: Set[str] = set(
+            ch.strip() for ch in channels_str.split(",") if ch.strip()
+        )
+
+        # DM allowlist
+        dm_str = os.getenv("TLON_DM_ALLOWLIST", "")
+        self.dm_allowlist: Set[str] = set(
+            _normalize_ship(s) for s in dm_str.split(",") if s.strip()
+        )
+
+        # User allowlist (for authorization)
+        users_str = os.getenv("TLON_ALLOWED_USERS", "")
+        self.allowed_users: Set[str] = set(
+            _normalize_ship(s) for s in users_str.split(",") if s.strip()
+        )
+        self.allow_all = os.getenv("TLON_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
+
+        # Auto-discover channels
+        self.auto_discover = os.getenv("TLON_AUTO_DISCOVER", "").lower() in ("true", "1", "yes")
+
+        # SSE client
+        self._sse: Optional[TlonSSEClient] = None
+
+        # Dedup tracker
+        self._processed_ids: Set[str] = set()
+        self._max_processed = 2000
+
+        # Bot nickname cache
+        self._bot_nickname: Optional[str] = None
+
+    async def connect(self) -> bool:
+        """Connect to the Tlon ship and start listening."""
+        if not self.ship_url or not self.ship_name or not self.ship_code:
+            logger.error("[tlon] Missing config: TLON_SHIP_URL, TLON_SHIP_NAME, TLON_SHIP_CODE")
+            return False
+
+        try:
+            self._sse = TlonSSEClient(
+                url=self.ship_url,
+                code=self.ship_code,
+                ship=self.ship_name,
+            )
+
+            # Authenticate
+            await self._sse.authenticate()
+
+            # Fetch bot profile for nickname
+            try:
+                profile = await self._sse.scry("/contacts/v1/self.json")
+                if profile and isinstance(profile, dict):
+                    self._bot_nickname = profile.get("nickname", {}).get("value")
+                    if self._bot_nickname:
+                        logger.info("[tlon] Bot nickname: %s", self._bot_nickname)
+            except Exception as e:
+                logger.debug("[tlon] Could not fetch self profile: %s", e)
+
+            # Auto-discover channels from groups
+            if self.auto_discover:
+                try:
+                    discovered = await self._discover_channels()
+                    self.monitored_channels.update(discovered)
+                    logger.info("[tlon] Auto-discovered %d channel(s)", len(discovered))
+                except Exception as e:
+                    logger.warning("[tlon] Auto-discovery failed: %s", e)
+
+            if self.monitored_channels:
+                logger.info("[tlon] Monitoring %d channel(s): %s",
+                           len(self.monitored_channels),
+                           ", ".join(sorted(self.monitored_channels)))
+            else:
+                logger.info("[tlon] No group channels configured (DMs only)")
+
+            # Subscribe to channels firehose (/v2) for group messages
+            await self._sse.subscribe(
+                app="channels",
+                path="/v2",
+                on_event=self._handle_channel_event,
+                on_error=lambda e: logger.error("[tlon] Channels error: %s", e),
+                on_quit=lambda: logger.info("[tlon] Channels quit received"),
+            )
+
+            # Subscribe to chat firehose (/v3) for DMs
+            await self._sse.subscribe(
+                app="chat",
+                path="/v3",
+                on_event=self._handle_dm_event,
+                on_error=lambda e: logger.error("[tlon] Chat error: %s", e),
+                on_quit=lambda: logger.info("[tlon] Chat quit received"),
+            )
+
+            # Connect and start streaming
+            await self._sse.connect()
+
+            self._running = True
+            logger.info("[tlon] Connected and listening!")
+            return True
+
+        except Exception as e:
+            logger.error("[tlon] Connection failed: %s", e)
+            return False
+
+    async def disconnect(self) -> None:
+        """Disconnect from the Tlon ship."""
+        self._running = False
+        if self._sse:
+            await self._sse.close()
+            self._sse = None
+        logger.info("[tlon] Disconnected")
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """
+        Send a message to a Tlon channel or DM.
+
+        chat_id: channel nest (e.g. "chat/~host/channel") or ship name for DMs
+        """
+        if not self._sse or not self._sse._connected:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            sent_at = int(time.time() * 1000)
+            story = _text_to_story(content)
+
+            if chat_id.startswith("~"):
+                # DM
+                await self._send_dm(chat_id, story, sent_at, reply_to)
+            else:
+                # Channel post
+                await self._send_channel_post(chat_id, story, sent_at, reply_to)
+
+            msg_id = f"{self.ship_name}/{sent_at}"
+            return SendResult(success=True, message_id=msg_id)
+
+        except Exception as e:
+            logger.error("[tlon] Send failed: %s", e)
+            return SendResult(success=False, error=str(e))
+
+    async def _send_dm(
+        self,
+        to_ship: str,
+        story: list,
+        sent_at: int,
+        reply_to: Optional[str] = None,
+    ) -> None:
+        """Send a DM via %chat poke."""
+        to_ship = _normalize_ship(to_ship)
+
+        if reply_to:
+            # Reply to a specific message in a DM thread
+            await self._sse.poke(
+                app="chat",
+                mark="chat-action",
+                json_data={
+                    "ship": to_ship.lstrip("~"),
+                    "diff": {
+                        "reply": {
+                            "id": reply_to,
+                            "delta": {
+                                "add": {
+                                    "memo": {
+                                        "content": story,
+                                        "author": self.ship_name.lstrip("~"),
+                                        "sent": sent_at,
+                                    }
+                                }
+                            },
+                        }
+                    },
+                },
+            )
+        else:
+            await self._sse.poke(
+                app="chat",
+                mark="chat-action",
+                json_data={
+                    "ship": to_ship.lstrip("~"),
+                    "diff": {
+                        "add": {
+                            "essay": {
+                                "content": story,
+                                "author": self.ship_name.lstrip("~"),
+                                "sent": sent_at,
+                            }
+                        }
+                    },
+                },
+            )
+
+    async def _send_channel_post(
+        self,
+        nest: str,
+        story: list,
+        sent_at: int,
+        reply_to: Optional[str] = None,
+    ) -> None:
+        """Send a post to a channel (chat, heap, diary)."""
+        if reply_to:
+            await self._sse.poke(
+                app="channels",
+                mark="channel-action",
+                json_data={
+                    "channel": {
+                        "nest": nest,
+                        "action": {
+                            "post": {
+                                "reply": {
+                                    "id": reply_to,
+                                    "delta": {
+                                        "add": {
+                                            "memo": {
+                                                "content": story,
+                                                "author": self.ship_name.lstrip("~"),
+                                                "sent": sent_at,
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+            )
+        else:
+            await self._sse.poke(
+                app="channels",
+                mark="channel-action",
+                json_data={
+                    "channel": {
+                        "nest": nest,
+                        "action": {
+                            "post": {
+                                "add": {
+                                    "essay": {
+                                        "content": story,
+                                        "author": self.ship_name.lstrip("~"),
+                                        "sent": sent_at,
+                                    }
+                                }
+                            }
+                        },
+                    }
+                },
+            )
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+    ) -> SendResult:
+        """Send an image as a Tlon story block with optional caption."""
+        story = []
+        if caption:
+            story.extend(_text_to_story(caption))
+        # Add image block
+        story.append({
+            "block": {
+                "image": {
+                    "src": image_url,
+                    "alt": caption or "",
+                    "width": 0,
+                    "height": 0,
+                }
+            }
+        })
+
+        sent_at = int(time.time() * 1000)
+        try:
+            if chat_id.startswith("~"):
+                await self._send_dm(chat_id, story, sent_at, reply_to)
+            else:
+                await self._send_channel_post(chat_id, story, sent_at, reply_to)
+            return SendResult(success=True, message_id=f"{self.ship_name}/{sent_at}")
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Get info about a chat/channel."""
+        if chat_id.startswith("~"):
+            return {
+                "name": chat_id,
+                "type": "dm",
+                "chat_id": chat_id,
+            }
+        parsed = _parse_channel_nest(chat_id)
+        return {
+            "name": parsed["name"] if parsed else chat_id,
+            "type": "group",
+            "chat_id": chat_id,
+        }
+
+    def _is_bot_mentioned(self, text: str) -> bool:
+        """Check if the bot is mentioned in the text."""
+        text_lower = text.lower()
+        # Check ship name mention
+        if self.ship_name.lower() in text_lower:
+            return True
+        # Check nickname mention
+        if self._bot_nickname and self._bot_nickname.lower() in text_lower:
+            return True
+        return False
+
+    def _strip_bot_mention(self, text: str) -> str:
+        """Remove bot mentions from text."""
+        # Remove ship name
+        text = re.sub(
+            re.escape(self.ship_name),
+            "",
+            text,
+            flags=re.IGNORECASE,
+        ).strip()
+        # Remove nickname if set
+        if self._bot_nickname:
+            text = re.sub(
+                re.escape(self._bot_nickname),
+                "",
+                text,
+                flags=re.IGNORECASE,
+            ).strip()
+        return text
+
+    def _mark_processed(self, msg_id: str) -> bool:
+        """
+        Mark a message ID as processed. Returns True if this is new,
+        False if already processed (duplicate).
+        """
+        if msg_id in self._processed_ids:
+            return False
+        self._processed_ids.add(msg_id)
+        # Trim old entries
+        if len(self._processed_ids) > self._max_processed:
+            # Remove oldest entries (set doesn't preserve order, but this is fine
+            # for dedup purposes - we just prevent unbounded growth)
+            excess = len(self._processed_ids) - self._max_processed
+            to_remove = list(self._processed_ids)[:excess]
+            for item in to_remove:
+                self._processed_ids.discard(item)
+        return True
+
+    async def _discover_channels(self) -> Set[str]:
+        """Discover channels from groups the bot is a member of."""
+        channels: Set[str] = set()
+        try:
+            # Scry all groups
+            groups = await self._sse.scry("/groups/v1/groups.json")
+            if not isinstance(groups, dict):
+                return channels
+
+            for group_flag, group_data in groups.items():
+                if not isinstance(group_data, dict):
+                    continue
+                group_channels = group_data.get("channels", {})
+                if not isinstance(group_channels, dict):
+                    continue
+                for nest in group_channels:
+                    # Only monitor chat and heap channels
+                    if nest.startswith("chat/") or nest.startswith("heap/"):
+                        channels.add(nest)
+        except Exception as e:
+            logger.debug("[tlon] Channel discovery scry failed: %s", e)
+        return channels
+
+    async def _handle_channel_event(self, event: Any) -> None:
+        """Handle a channels firehose (/v2) event."""
+        try:
+            if not isinstance(event, dict):
+                return
+
+            nest = event.get("nest")
+            if not nest:
+                return
+
+            # Auto-watch channels from firehose
+            if nest not in self.monitored_channels:
+                if self.auto_discover and (nest.startswith("chat/") or nest.startswith("heap/")):
+                    self.monitored_channels.add(nest)
+                    logger.info("[tlon] Auto-watching channel: %s", nest)
+                else:
+                    return
+
+            response = event.get("response")
+            if not response:
+                return
+
+            # Extract post content (new posts and replies)
+            essay = (response.get("post", {})
+                     .get("r-post", {})
+                     .get("set", {})
+                     .get("essay"))
+            memo = (response.get("post", {})
+                    .get("r-post", {})
+                    .get("reply", {})
+                    .get("r-reply", {})
+                    .get("set", {})
+                    .get("memo"))
+
+            content = memo or essay
+            if not content:
+                return
+
+            is_thread_reply = bool(memo)
+            msg_id = (
+                response.get("post", {}).get("r-post", {}).get("reply", {}).get("id")
+                if is_thread_reply
+                else response.get("post", {}).get("id")
+            )
+
+            if not msg_id or not self._mark_processed(str(msg_id)):
+                return
+
+            sender = _normalize_ship(content.get("author", ""))
+            if not sender or sender == self.ship_name:
+                return
+
+            text = _extract_message_text(content.get("content"))
+            if not text.strip():
+                return
+
+            # In group channels, only respond to mentions
+            if not self._is_bot_mentioned(text):
+                return
+
+            # Check user authorization
+            if not self._is_user_allowed(sender):
+                logger.info("[tlon] Unauthorized user %s in %s", sender, nest)
+                return
+
+            # Strip bot mention from text
+            clean_text = self._strip_bot_mention(text)
+
+            # Get parent ID for thread context
+            seal = (
+                response.get("post", {}).get("r-post", {}).get("reply", {})
+                .get("r-reply", {}).get("set", {}).get("seal")
+                if is_thread_reply
+                else response.get("post", {}).get("r-post", {}).get("set", {}).get("seal")
+            )
+            parent_id = None
+            if seal:
+                parent_id = seal.get("parent-id") or seal.get("parent")
+
+            # Build message event
+            parsed = _parse_channel_nest(nest)
+            source = self.build_source(
+                chat_id=nest,
+                chat_name=parsed["name"] if parsed else nest,
+                chat_type="group",
+                user_id=sender,
+                user_name=sender,
+                thread_id=str(parent_id) if parent_id else None,
+            )
+
+            event_obj = MessageEvent(
+                text=clean_text,
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id=str(msg_id),
+                reply_to_message_id=str(parent_id) if parent_id else None,
+                timestamp=datetime.fromtimestamp(
+                    content.get("sent", time.time() * 1000) / 1000
+                ),
+            )
+
+            await self.handle_message(event_obj)
+
+        except Exception as e:
+            logger.error("[tlon] Channel event error: %s", e, exc_info=True)
+
+    async def _handle_dm_event(self, event: Any) -> None:
+        """Handle a chat firehose (/v3) event."""
+        try:
+            # Handle DM invite arrays
+            if isinstance(event, list):
+                for invite in event:
+                    ship = _normalize_ship(invite.get("ship", ""))
+                    if ship and self._is_user_allowed(ship):
+                        try:
+                            await self._sse.poke(
+                                app="chat",
+                                mark="chat-dm-rsvp",
+                                json_data={"ship": ship.lstrip("~"), "ok": True},
+                            )
+                            logger.info("[tlon] Auto-accepted DM invite from %s", ship)
+                        except Exception as e:
+                            logger.error("[tlon] Failed to accept DM from %s: %s", ship, e)
+                return
+
+            if not isinstance(event, dict):
+                return
+
+            if "whom" not in event or "response" not in event:
+                return
+
+            whom = event["whom"]
+            msg_id = event.get("id")
+            response = event["response"]
+
+            # Extract message content
+            essay = response.get("add", {}).get("essay") if isinstance(response.get("add"), dict) else None
+            dm_reply_memo = None
+            dm_reply = response.get("reply")
+            if isinstance(dm_reply, dict):
+                dm_reply_memo = (dm_reply.get("delta", {})
+                                .get("add", {})
+                                .get("memo"))
+
+            content = essay or dm_reply_memo
+            if not content:
+                return
+
+            is_thread_reply = bool(dm_reply_memo)
+            effective_id = msg_id
+            if is_thread_reply and dm_reply:
+                effective_id = dm_reply.get("id") or dm_reply.get("delta", {}).get("add", {}).get("id") or msg_id
+
+            if not effective_id or not self._mark_processed(str(effective_id)):
+                return
+
+            sender = _normalize_ship(content.get("author", ""))
+            # Extract DM partner from whom field
+            partner = _normalize_ship(whom) if isinstance(whom, str) else ""
+
+            # Use partner for routing, author for identity
+            effective_sender = partner or sender
+            if not effective_sender or effective_sender == self.ship_name:
+                return
+
+            text = _extract_message_text(content.get("content"))
+            if not text.strip():
+                return
+
+            # Check DM authorization
+            if not self._is_user_allowed(effective_sender):
+                logger.info("[tlon] Unauthorized DM from %s", effective_sender)
+                return
+
+            # Build message event
+            source = self.build_source(
+                chat_id=effective_sender,
+                chat_name=effective_sender,
+                chat_type="dm",
+                user_id=effective_sender,
+                user_name=effective_sender,
+                thread_id=str(msg_id) if is_thread_reply else None,
+            )
+
+            event_obj = MessageEvent(
+                text=text,
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id=str(effective_id),
+                reply_to_message_id=str(msg_id) if is_thread_reply else None,
+                timestamp=datetime.fromtimestamp(
+                    content.get("sent", time.time() * 1000) / 1000
+                ),
+            )
+
+            await self.handle_message(event_obj)
+
+        except Exception as e:
+            logger.error("[tlon] DM event error: %s", e, exc_info=True)
+
+    def _is_user_allowed(self, ship: str) -> bool:
+        """Check if a ship is authorized to interact with the bot."""
+        # Global allow-all
+        global_allow = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
+        if global_allow or self.allow_all:
+            return True
+
+        # Check global allowlist
+        global_users = os.getenv("GATEWAY_ALLOWED_USERS", "")
+        if global_users:
+            allowed = set(_normalize_ship(s) for s in global_users.split(",") if s.strip())
+            if ship in allowed:
+                return True
+
+        # Check Tlon-specific allowlist
+        if self.allowed_users and ship in self.allowed_users:
+            return True
+
+        # If no allowlists configured at all, deny
+        if not self.allowed_users and not global_users:
+            return False
+
+        return False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8,7 +8,7 @@ This module provides:
 Usage:
     # Start the gateway
     python -m gateway.run
-    
+
     # Or from CLI
     python cli.py --gateway
 """
@@ -43,18 +43,18 @@ if _env_path.exists():
 load_dotenv()
 
 # Bridge config.yaml values into the environment so os.getenv() picks them up.
-# config.yaml is authoritative for terminal settings — overrides .env.
+# config.yaml is authoritative for terminal settings - overrides .env.
 _config_path = _hermes_home / 'config.yaml'
 if _config_path.exists():
     try:
         import yaml as _yaml
         with open(_config_path, encoding="utf-8") as _f:
             _cfg = _yaml.safe_load(_f) or {}
-        # Top-level simple values (fallback only — don't override .env)
+        # Top-level simple values (fallback only - don't override .env)
         for _key, _val in _cfg.items():
             if isinstance(_val, (str, int, float, bool)) and _key not in os.environ:
                 os.environ[_key] = str(_val)
-        # Terminal config is nested — bridge to TERMINAL_* env vars.
+        # Terminal config is nested - bridge to TERMINAL_* env vars.
         # config.yaml overrides .env for these since it's the documented config path.
         _terminal_cfg = _cfg.get("terminal", {})
         if _terminal_cfg and isinstance(_terminal_cfg, dict):
@@ -188,7 +188,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
 
 
 def _resolve_gateway_model() -> str:
-    """Read model from env/config — mirrors the resolution in _run_agent_sync.
+    """Read model from env/config - mirrors the resolution in _run_agent_sync.
 
     Without this, temporary AIAgent instances (memory flush, /compress) fall
     back to the hardcoded default ("anthropic/claude-opus-4.6") which fails
@@ -214,11 +214,11 @@ def _resolve_gateway_model() -> str:
 class GatewayRunner:
     """
     Main gateway controller.
-    
+
     Manages the lifecycle of all platform adapters and routes
     messages to/from the agent.
     """
-    
+
     def __init__(self, config: Optional[GatewayConfig] = None):
         self.config = config or load_gateway_config()
         self.adapters: Dict[Platform, BasePlatformAdapter] = {}
@@ -240,16 +240,16 @@ class GatewayRunner:
         self.delivery_router = DeliveryRouter(self.config)
         self._running = False
         self._shutdown_event = asyncio.Event()
-        
+
         # Track running agents per session for interrupt support
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
-        
+
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str}
         self._pending_approvals: Dict[str, Dict[str, str]] = {}
-        
+
         # Initialize session database for session_search tool support
         self._session_db = None
         try:
@@ -257,19 +257,19 @@ class GatewayRunner:
             self._session_db = SessionDB()
         except Exception as e:
             logger.debug("SQLite session store not available: %s", e)
-        
+
         # DM pairing store for code-based user authorization
         from gateway.pairing import PairingStore
         self.pairing_store = PairingStore()
-        
+
         # Event hook system
         from gateway.hooks import HookRegistry
         self.hooks = HookRegistry()
-    
+
     def _flush_memories_for_session(self, old_session_id: str):
         """Prompt the agent to save memories/skills before context is lost.
 
-        Synchronous worker — meant to be called via run_in_executor from
+        Synchronous worker - meant to be called via run_in_executor from
         an async context so it doesn't block the event loop.
         """
         try:
@@ -282,7 +282,7 @@ class GatewayRunner:
             if not runtime_kwargs.get("api_key"):
                 return
 
-            # Resolve model from config — AIAgent's default is OpenRouter-
+            # Resolve model from config - AIAgent's default is OpenRouter-
             # formatted ("anthropic/claude-opus-4.6") which fails when the
             # active provider is openai-codex.
             model = _resolve_gateway_model()
@@ -313,7 +313,7 @@ class GatewayRunner:
                 "(user profile or your notes) that would be useful in future sessions.\n"
                 "2. If you discovered a reusable workflow or solved a non-trivial "
                 "problem, consider saving it as a skill.\n"
-                "3. If nothing is worth saving, that's fine — just skip.\n\n"
+                "3. If nothing is worth saving, that's fine - just skip.\n\n"
                 "Do NOT respond to the user. Just use the memory and skill_manage "
                 "tools if needed, then stop.]"
             )
@@ -330,11 +330,11 @@ class GatewayRunner:
         """Run the sync memory flush in a thread pool so it won't block the event loop."""
         loop = asyncio.get_event_loop()
         await loop.run_in_executor(None, self._flush_memories_for_session, old_session_id)
-    
+
     @staticmethod
     def _load_prefill_messages() -> List[Dict[str, Any]]:
         """Load ephemeral prefill messages from config or env var.
-        
+
         Checks HERMES_PREFILL_MESSAGES_FILE env var first, then falls back to
         the prefill_messages_file key in ~/.hermes/config.yaml.
         Relative paths are resolved from ~/.hermes/.
@@ -373,7 +373,7 @@ class GatewayRunner:
     @staticmethod
     def _load_ephemeral_system_prompt() -> str:
         """Load ephemeral system prompt from config or env var.
-        
+
         Checks HERMES_EPHEMERAL_SYSTEM_PROMPT env var first, then falls back to
         agent.system_prompt in ~/.hermes/config.yaml.
         """
@@ -394,7 +394,7 @@ class GatewayRunner:
     @staticmethod
     def _load_reasoning_config() -> dict | None:
         """Load reasoning effort from config or env var.
-        
+
         Checks HERMES_REASONING_EFFORT env var first, then agent.reasoning_effort
         in config.yaml. Valid: "xhigh", "high", "medium", "low", "minimal", "none".
         Returns None to use default (medium).
@@ -426,10 +426,10 @@ class GatewayRunner:
         """Load background process notification mode from config or env var.
 
         Modes:
-          - ``all``    — push running-output updates *and* the final message (default)
-          - ``result`` — only the final completion message (regardless of exit code)
-          - ``error``  — only the final message when exit code is non-zero
-          - ``off``    — no watcher messages at all
+          - ``all``    - push running-output updates *and* the final message (default)
+          - ``result`` - only the final completion message (regardless of exit code)
+          - ``error``  - only the final message when exit code is non-zero
+          - ``off``    - no watcher messages at all
         """
         mode = os.getenv("HERMES_BACKGROUND_NOTIFICATIONS", "")
         if not mode:
@@ -493,12 +493,12 @@ class GatewayRunner:
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
-        
+
         Returns True if at least one adapter connected successfully.
         """
         logger.info("Starting Hermes Gateway...")
         logger.info("Session storage: %s", self.config.sessions_dir)
-        
+
         # Warn if no user allowlists are configured and open access is not opted in
         _any_allowlist = any(
             os.getenv(v)
@@ -513,10 +513,10 @@ class GatewayRunner:
                 "Set GATEWAY_ALLOW_ALL_USERS=true in ~/.hermes/.env to allow open access, "
                 "or configure platform allowlists (e.g., TELEGRAM_ALLOWED_USERS=your_id)."
             )
-        
+
         # Discover and load event hooks
         self.hooks.discover_and_load()
-        
+
         # Recover background processes from checkpoint (crash recovery)
         try:
             from tools.process_registry import process_registry
@@ -525,22 +525,22 @@ class GatewayRunner:
                 logger.info("Recovered %s background process(es) from previous run", recovered)
         except Exception as e:
             logger.warning("Process checkpoint recovery: %s", e)
-        
+
         connected_count = 0
-        
+
         # Initialize and connect each configured platform
         for platform, platform_config in self.config.platforms.items():
             if not platform_config.enabled:
                 continue
-            
+
             adapter = self._create_adapter(platform, platform_config)
             if not adapter:
                 logger.warning("No adapter available for %s", platform.value)
                 continue
-            
+
             # Set up message handler
             adapter.set_message_handler(self._handle_message)
-            
+
             # Try to connect
             logger.info("Connecting to %s...", platform.value)
             try:
@@ -553,16 +553,16 @@ class GatewayRunner:
                     logger.warning("✗ %s failed to connect", platform.value)
             except Exception as e:
                 logger.error("✗ %s error: %s", platform.value, e)
-        
+
         if connected_count == 0:
             logger.warning("No messaging platforms connected.")
             logger.info("Gateway will continue running for cron job execution.")
-        
+
         # Update delivery router with adapters
         self.delivery_router.adapters = self.adapters
-        
+
         self._running = True
-        
+
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)
         if hook_count:
@@ -570,10 +570,10 @@ class GatewayRunner:
         await self.hooks.emit("gateway:startup", {
             "platforms": [p.value for p in self.adapters.keys()],
         })
-        
+
         if connected_count > 0:
             logger.info("Gateway running with %s platform(s)", connected_count)
-        
+
         # Build initial channel directory for send_message name resolution
         try:
             from gateway.channel_directory import build_channel_directory
@@ -582,7 +582,7 @@ class GatewayRunner:
             logger.info("Channel directory built: %d target(s)", ch_count)
         except Exception as e:
             logger.warning("Channel directory build failed: %s", e)
-        
+
         # Check if we're restarting after a /update command
         await self._send_update_notification()
 
@@ -590,12 +590,12 @@ class GatewayRunner:
         asyncio.create_task(self._session_expiry_watcher())
 
         logger.info("Press Ctrl+C to stop")
-        
+
         return True
-    
+
     async def _session_expiry_watcher(self, interval: int = 300):
         """Background task that proactively flushes memories for expired sessions.
-        
+
         Runs every `interval` seconds (default 5 min).  For each session that
         has expired according to its reset policy, flushes memories in a thread
         pool and marks the session so it won't be flushed again.
@@ -603,7 +603,7 @@ class GatewayRunner:
         This means memories are already saved by the time the user sends their
         next message, so there's no blocking delay.
         """
-        await asyncio.sleep(60)  # initial delay — let the gateway fully start
+        await asyncio.sleep(60)  # initial delay - let the gateway fully start
         while self._running:
             try:
                 self.session_store._ensure_loaded()
@@ -612,7 +612,7 @@ class GatewayRunner:
                         continue  # already flushed this session
                     if not self.session_store._is_session_expired(entry):
                         continue  # session still active
-                    # Session has expired — flush memories in the background
+                    # Session has expired - flush memories in the background
                     logger.info(
                         "Session %s expired (key=%s), flushing memories proactively",
                         entry.session_id, key,
@@ -634,29 +634,29 @@ class GatewayRunner:
         """Stop the gateway and disconnect all adapters."""
         logger.info("Stopping gateway...")
         self._running = False
-        
+
         for platform, adapter in self.adapters.items():
             try:
                 await adapter.disconnect()
                 logger.info("✓ %s disconnected", platform.value)
             except Exception as e:
                 logger.error("✗ %s disconnect error: %s", platform.value, e)
-        
+
         self.adapters.clear()
         self._shutdown_event.set()
-        
+
         from gateway.status import remove_pid_file
         remove_pid_file()
-        
+
         logger.info("Gateway stopped")
-    
+
     async def wait_for_shutdown(self) -> None:
         """Wait for shutdown signal."""
         await self._shutdown_event.wait()
-    
+
     def _create_adapter(
-        self, 
-        platform: Platform, 
+        self,
+        platform: Platform,
         config: Any
     ) -> Optional[BasePlatformAdapter]:
         """Create the appropriate adapter for a platform."""
@@ -666,21 +666,21 @@ class GatewayRunner:
                 logger.warning("Telegram: python-telegram-bot not installed")
                 return None
             return TelegramAdapter(config)
-        
+
         elif platform == Platform.DISCORD:
             from gateway.platforms.discord import DiscordAdapter, check_discord_requirements
             if not check_discord_requirements():
                 logger.warning("Discord: discord.py not installed")
                 return None
             return DiscordAdapter(config)
-        
+
         elif platform == Platform.WHATSAPP:
             from gateway.platforms.whatsapp import WhatsAppAdapter, check_whatsapp_requirements
             if not check_whatsapp_requirements():
                 logger.warning("WhatsApp: Node.js not installed or bridge not configured")
                 return None
             return WhatsAppAdapter(config)
-        
+
         elif platform == Platform.SLACK:
             from gateway.platforms.slack import SlackAdapter, check_slack_requirements
             if not check_slack_requirements():
@@ -709,12 +709,19 @@ class GatewayRunner:
                 return None
             return EmailAdapter(config)
 
+        elif platform == Platform.TLON:
+            from gateway.platforms.tlon import TlonAdapter, check_tlon_requirements
+            if not check_tlon_requirements():
+                logger.warning("Tlon: aiohttp not installed or TLON_SHIP_URL/NAME/CODE not set")
+                return None
+            return TlonAdapter(config)
+
         return None
-    
+
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
         Check if a user is authorized to use the bot.
-        
+
         Checks in order:
         1. Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
         2. Environment variable allowlists (TELEGRAM_ALLOWED_USERS, etc.)
@@ -739,6 +746,7 @@ class GatewayRunner:
             Platform.SLACK: "SLACK_ALLOWED_USERS",
             Platform.SIGNAL: "SIGNAL_ALLOWED_USERS",
             Platform.EMAIL: "EMAIL_ALLOWED_USERS",
+            Platform.TLON: "TLON_ALLOWED_USERS",
         }
         platform_allow_all_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",
@@ -747,6 +755,7 @@ class GatewayRunner:
             Platform.SLACK: "SLACK_ALLOW_ALL_USERS",
             Platform.SIGNAL: "SIGNAL_ALLOW_ALL_USERS",
             Platform.EMAIL: "EMAIL_ALLOW_ALL_USERS",
+            Platform.TLON: "TLON_ALLOW_ALL_USERS",
         }
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
@@ -774,16 +783,16 @@ class GatewayRunner:
         if global_allowlist:
             allowed_ids.update(uid.strip() for uid in global_allowlist.split(",") if uid.strip())
 
-        # WhatsApp JIDs have @s.whatsapp.net suffix — strip it for comparison
+        # WhatsApp JIDs have @s.whatsapp.net suffix - strip it for comparison
         check_ids = {user_id}
         if "@" in user_id:
             check_ids.add(user_id.split("@")[0])
         return bool(check_ids & allowed_ids)
-    
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
-        
+
         This is the core message processing pipeline:
         1. Check user authorization
         2. Check for commands (/new, /reset, etc.)
@@ -794,7 +803,7 @@ class GatewayRunner:
         7. Return response
         """
         source = event.source
-        
+
         # Check if user is authorized
         if not self._is_user_authorized(source):
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
@@ -823,7 +832,7 @@ class GatewayRunner:
                             "Please try again later!"
                         )
             return None
-        
+
         # PRIORITY: If an agent is already running for this session, interrupt it
         # immediately. This is before command parsing to minimize latency -- the
         # user's "stop" message reaches the agent as fast as possible.
@@ -837,10 +846,10 @@ class GatewayRunner:
             else:
                 self._pending_messages[_quick_key] = event.text
             return None
-        
+
         # Check for commands
         command = event.get_command()
-        
+
         # Emit command:* hook for any recognized slash command
         _known_commands = {"new", "reset", "help", "status", "stop", "model",
                           "personality", "retry", "undo", "sethome", "set-home",
@@ -854,34 +863,34 @@ class GatewayRunner:
                 "command": command,
                 "args": event.get_command_args().strip(),
             })
-        
+
         if command in ["new", "reset"]:
             return await self._handle_reset_command(event)
-        
+
         if command == "help":
             return await self._handle_help_command(event)
-        
+
         if command == "status":
             return await self._handle_status_command(event)
-        
+
         if command == "stop":
             return await self._handle_stop_command(event)
-        
+
         if command == "model":
             return await self._handle_model_command(event)
-        
+
         if command == "provider":
             return await self._handle_provider_command(event)
-        
+
         if command == "personality":
             return await self._handle_personality_command(event)
-        
+
         if command == "retry":
             return await self._handle_retry_command(event)
-        
+
         if command == "undo":
             return await self._handle_undo_command(event)
-        
+
         if command in ["sethome", "set-home"]:
             return await self._handle_set_home_command(event)
 
@@ -911,7 +920,7 @@ class GatewayRunner:
 
         if command == "background":
             return await self._handle_background_command(event)
-        
+
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
             quick_commands = self.config.get("quick_commands", {})
@@ -952,7 +961,7 @@ class GatewayRunner:
                         # Fall through to normal message processing with skill content
             except Exception as e:
                 logger.debug("Skill command check failed (non-fatal): %s", e)
-        
+
         # Check for pending exec approval responses
         session_key_preview = build_session_key(source)
         if session_key_preview in self._pending_approvals:
@@ -971,11 +980,11 @@ class GatewayRunner:
                 self._pending_approvals.pop(session_key_preview)
                 return "❌ Command denied."
             # If it's not clearly an approval/denial, fall through to normal processing
-        
+
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
-        
+
         # Emit session:start for new or auto-reset sessions
         _is_new_session = (
             session_entry.created_at == session_entry.updated_at
@@ -988,16 +997,16 @@ class GatewayRunner:
                 "session_id": session_entry.session_id,
                 "session_key": session_key,
             })
-        
+
         # Build session context
         context = build_session_context(source, self.config, session_entry)
-        
+
         # Set environment variables for tools
         self._set_session_env(context)
-        
+
         # Build the context prompt to inject
         context_prompt = build_session_context_prompt(context)
-        
+
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).
         if getattr(session_entry, 'was_auto_reset', False):
@@ -1007,17 +1016,17 @@ class GatewayRunner:
                 + context_prompt
             )
             session_entry.was_auto_reset = False
-        
+
         # Load conversation history from transcript
         history = self.session_store.load_transcript(session_entry.session_id)
-        
+
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
         #
         # Long-lived gateway sessions can accumulate enough history that
         # every new message rehydrates an oversized transcript, causing
         # repeated truncation/context failures.  Detect this early and
-        # compress proactively — before the agent even starts.  (#628)
+        # compress proactively - before the agent even starts.  (#628)
         #
         # Token source priority:
         # 1. Actual API-reported prompt_tokens from the last turn
@@ -1032,7 +1041,7 @@ class GatewayRunner:
                 get_model_context_length,
             )
 
-            # Read model + compression config from config.yaml — same
+            # Read model + compression config from config.yaml - same
             # source of truth the agent itself uses.
             _hyg_model = "anthropic/claude-sonnet-4.6"
             _hyg_threshold_pct = 0.85
@@ -1100,7 +1109,7 @@ class GatewayRunner:
 
                 if _needs_compress:
                     logger.info(
-                        "Session hygiene: %s messages, ~%s tokens (%s) — auto-compressing "
+                        "Session hygiene: %s messages, ~%s tokens (%s) - auto-compressing "
                         "(threshold: %s%% of %s = %s tokens)",
                         _msg_count, f"{_approx_tokens:,}", _token_source,
                         int(_hyg_threshold_pct * 100),
@@ -1155,7 +1164,7 @@ class GatewayRunner:
                                 self.session_store.rewrite_transcript(
                                     session_entry.session_id, _compressed
                                 )
-                                # Reset stored token count — transcript was rewritten
+                                # Reset stored token count - transcript was rewritten
                                 session_entry.last_prompt_tokens = 0
                                 history = _compressed
                                 _new_count = len(_compressed)
@@ -1183,11 +1192,11 @@ class GatewayRunner:
                                     except Exception:
                                         pass
 
-                                # Still too large after compression — warn user
+                                # Still too large after compression - warn user
                                 if _new_tokens >= _warn_token_threshold:
                                     logger.warning(
                                         "Session hygiene: still ~%s tokens after "
-                                        "compression — suggesting /reset",
+                                        "compression - suggesting /reset",
                                         f"{_new_tokens:,}",
                                     )
                                     if _hyg_adapter:
@@ -1234,7 +1243,7 @@ class GatewayRunner:
                 "Briefly introduce yourself and mention that /help shows available commands. "
                 "Keep the introduction concise -- one or two sentences max.]"
             )
-        
+
         # One-time prompt if no home channel is set for this platform
         if not history and source.platform and source.platform != Platform.LOCAL:
             platform_name = source.platform.value
@@ -1250,7 +1259,7 @@ class GatewayRunner:
                         f"Type /sethome to make this chat your home channel, "
                         f"or ignore to skip."
                     )
-        
+
         # -----------------------------------------------------------------
         # Auto-analyze images sent by the user
         #
@@ -1279,7 +1288,7 @@ class GatewayRunner:
                 message_text = await self._enrich_message_with_vision(
                     message_text, image_paths
                 )
-        
+
         # -----------------------------------------------------------------
         # Auto-transcribe voice/audio messages sent by the user
         # -----------------------------------------------------------------
@@ -1339,7 +1348,7 @@ class GatewayRunner:
                 "message": message_text[:500],
             }
             await self.hooks.emit("agent:start", hook_ctx)
-            
+
             # Run the agent
             agent_result = await self._run_agent(
                 message=message_text,
@@ -1349,16 +1358,16 @@ class GatewayRunner:
                 session_id=session_entry.session_id,
                 session_key=session_key
             )
-            
+
             response = agent_result.get("final_response", "")
             agent_messages = agent_result.get("messages", [])
-            
+
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
                 **hook_ctx,
                 "response": (response or "")[:500],
             })
-            
+
             # Check for pending process watchers (check_interval on background processes)
             try:
                 from tools.process_registry import process_registry
@@ -1376,13 +1385,13 @@ class GatewayRunner:
                     self._pending_approvals[session_key] = pending
             except Exception as e:
                 logger.debug("Failed to check pending approvals: %s", e)
-            
+
             # Save the full conversation to the transcript, including tool calls.
             # This preserves the complete agent loop (tool_calls, tool results,
             # intermediate reasoning) so sessions can be resumed with full context
             # and transcripts are useful for debugging and training data.
             ts = datetime.now().isoformat()
-            
+
             # If this is a fresh session (no history), write the full tool
             # definitions as the first entry so the transcript is self-describing
             # -- the same list of dicts sent as tools=[...] in the API request.
@@ -1398,14 +1407,14 @@ class GatewayRunner:
                         "timestamp": ts,
                     }
                 )
-            
+
             # Find only the NEW messages from this turn (skip history we loaded).
             # Use the filtered history length (history_offset) that was actually
             # passed to the agent, not len(history) which includes session_meta
             # entries that were stripped before the agent saw them.
             history_len = agent_result.get("history_offset", len(history))
             new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []
-            
+
             # If no new messages found (edge case), fall back to simple user/assistant
             if not new_messages:
                 self.session_store.append_to_transcript(
@@ -1433,15 +1442,15 @@ class GatewayRunner:
                         session_entry.session_id, entry,
                         skip_db=agent_persisted,
                     )
-            
+
             # Update session with actual prompt token count from the agent
             self.session_store.update_session(
                 session_entry.session_key,
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
             )
-            
+
             return response
-            
+
         except Exception as e:
             logger.exception("Agent error in session %s", session_key)
             return (
@@ -1452,14 +1461,14 @@ class GatewayRunner:
         finally:
             # Clear session env
             self._clear_session_env()
-    
+
     async def _handle_reset_command(self, event: MessageEvent) -> str:
         """Handle /new or /reset command."""
         source = event.source
-        
+
         # Get existing session key
         session_key = self.session_store._generate_session_key(source)
-        
+
         # Flush memories in the background (fire-and-forget) so the user
         # gets the "Session reset!" response immediately.
         try:
@@ -1468,35 +1477,35 @@ class GatewayRunner:
                 asyncio.create_task(self._async_flush_memories(old_entry.session_id))
         except Exception as e:
             logger.debug("Gateway memory flush on reset failed: %s", e)
-        
+
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
-        
+
         # Emit session:reset hook
         await self.hooks.emit("session:reset", {
             "platform": source.platform.value if source.platform else "",
             "user_id": source.user_id,
             "session_key": session_key,
         })
-        
+
         if new_entry:
             return "✨ Session reset! I've started fresh with no memory of our previous conversation."
         else:
             # No existing session, just create one
             self.session_store.get_or_create_session(source, force_new=True)
             return "✨ New session started!"
-    
+
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
-        
+
         connected_platforms = [p.value for p in self.adapters.keys()]
-        
+
         # Check if there's an active agent
         session_key = session_entry.session_key
         is_running = session_key in self._running_agents
-        
+
         lines = [
             "📊 **Hermes Gateway Status**",
             "",
@@ -1508,46 +1517,46 @@ class GatewayRunner:
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",
         ]
-        
+
         return "\n".join(lines)
-    
+
     async def _handle_stop_command(self, event: MessageEvent) -> str:
         """Handle /stop command - interrupt a running agent."""
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
-        
+
         if session_key in self._running_agents:
             agent = self._running_agents[session_key]
             agent.interrupt()
             return "⚡ Stopping the current task... The agent will finish its current step and respond."
         else:
             return "No active task to stop."
-    
+
     async def _handle_help_command(self, event: MessageEvent) -> str:
         """Handle /help command - list available commands."""
         lines = [
             "📖 **Hermes Commands**\n",
-            "`/new` — Start a new conversation",
-            "`/reset` — Reset conversation history",
-            "`/status` — Show session info",
-            "`/stop` — Interrupt the running agent",
-            "`/model [provider:model]` — Show/change model (or switch provider)",
-            "`/provider` — Show available providers and auth status",
-            "`/personality [name]` — Set a personality",
-            "`/retry` — Retry your last message",
-            "`/undo` — Remove the last exchange",
-            "`/sethome` — Set this chat as the home channel",
-            "`/compress` — Compress conversation context",
-            "`/title [name]` — Set or show the session title",
-            "`/resume [name]` — Resume a previously-named session",
-            "`/usage` — Show token usage for this session",
-            "`/insights [days]` — Show usage insights and analytics",
-            "`/rollback [number]` — List or restore filesystem checkpoints",
-            "`/background <prompt>` — Run a prompt in a separate background session",
-            "`/reload-mcp` — Reload MCP servers from config",
-            "`/update` — Update Hermes Agent to the latest version",
-            "`/help` — Show this message",
+            "`/new` - Start a new conversation",
+            "`/reset` - Reset conversation history",
+            "`/status` - Show session info",
+            "`/stop` - Interrupt the running agent",
+            "`/model [provider:model]` - Show/change model (or switch provider)",
+            "`/provider` - Show available providers and auth status",
+            "`/personality [name]` - Set a personality",
+            "`/retry` - Retry your last message",
+            "`/undo` - Remove the last exchange",
+            "`/sethome` - Set this chat as the home channel",
+            "`/compress` - Compress conversation context",
+            "`/title [name]` - Set or show the session title",
+            "`/resume [name]` - Resume a previously-named session",
+            "`/usage` - Show token usage for this session",
+            "`/insights [days]` - Show usage insights and analytics",
+            "`/rollback [number]` - List or restore filesystem checkpoints",
+            "`/background <prompt>` - Run a prompt in a separate background session",
+            "`/reload-mcp` - Reload MCP servers from config",
+            "`/update` - Update Hermes Agent to the latest version",
+            "`/help` - Show this message",
         ]
         try:
             from agent.skill_commands import get_skill_commands
@@ -1555,11 +1564,11 @@ class GatewayRunner:
             if skill_cmds:
                 lines.append(f"\n⚡ **Skill Commands** ({len(skill_cmds)} installed):")
                 for cmd in sorted(skill_cmds):
-                    lines.append(f"`{cmd}` — {skill_cmds[cmd]['description']}")
+                    lines.append(f"`{cmd}` - {skill_cmds[cmd]['description']}")
         except Exception:
             pass
         return "\n".join(lines)
-    
+
     async def _handle_model_command(self, event: MessageEvent) -> str:
         """Handle /model command - show or change the current model."""
         import yaml
@@ -1600,7 +1609,7 @@ class GatewayRunner:
                 current_provider = "openrouter"
 
         # Detect custom endpoint: provider resolved to openrouter but a custom
-        # base URL is configured — the user set up a custom endpoint.
+        # base URL is configured - the user set up a custom endpoint.
         if current_provider == "openrouter" and os.getenv("OPENAI_BASE_URL", "").strip():
             current_provider = "custom"
 
@@ -1697,7 +1706,7 @@ class GatewayRunner:
         if validation.get("persist"):
             persist_note = "saved to config"
         else:
-            persist_note = "this session only — will revert on restart"
+            persist_note = "this session only - will revert on restart"
         return f"🤖 Model changed to `{new_model}` ({persist_note}){provider_note}{warning}\n_(takes effect on next message)_"
 
     async def _handle_provider_command(self, event: MessageEvent) -> str:
@@ -1747,13 +1756,13 @@ class GatewayRunner:
             marker = " ← active" if p["id"] == current_provider else ""
             auth = "✅" if p["authenticated"] else "❌"
             aliases = f"  _(also: {', '.join(p['aliases'])})_" if p["aliases"] else ""
-            lines.append(f"{auth} `{p['id']}` — {p['label']}{aliases}{marker}")
+            lines.append(f"{auth} `{p['id']}` - {p['label']}{aliases}{marker}")
 
         lines.append("")
         lines.append("Switch: `/model provider:model-name`")
         lines.append("Setup: `hermes setup`")
         return "\n".join(lines)
-    
+
     async def _handle_personality_command(self, event: MessageEvent) -> str:
         """Handle /personality command - list or set a personality."""
         import yaml
@@ -1778,13 +1787,13 @@ class GatewayRunner:
 
         if not args:
             lines = ["🎭 **Available Personalities**\n"]
-            lines.append("• `none` — (no personality overlay)")
+            lines.append("• `none` - (no personality overlay)")
             for name, prompt in personalities.items():
                 if isinstance(prompt, dict):
                     preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
                 else:
                     preview = prompt[:50] + "..." if len(prompt) > 50 else prompt
-                lines.append(f"• `{name}` — {preview}")
+                lines.append(f"• `{name}` - {preview}")
             lines.append(f"\nUsage: `/personality <name>`")
             return "\n".join(lines)
 
@@ -1808,7 +1817,7 @@ class GatewayRunner:
             except Exception as e:
                 return f"⚠️ Failed to save personality change: {e}"
             self._ephemeral_system_prompt = ""
-            return "🎭 Personality cleared — using base agent behavior.\n_(takes effect on next message)_"
+            return "🎭 Personality cleared - using base agent behavior.\n_(takes effect on next message)_"
         elif args in personalities:
             new_prompt = _resolve_prompt(personalities[args])
 
@@ -1829,13 +1838,13 @@ class GatewayRunner:
 
         available = "`none`, " + ", ".join(f"`{n}`" for n in personalities.keys())
         return f"Unknown personality: `{args}`\n\nAvailable: {available}"
-    
+
     async def _handle_retry_command(self, event: MessageEvent) -> str:
         """Handle /retry command - re-send the last user message."""
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
         history = self.session_store.load_transcript(session_entry.session_id)
-        
+
         # Find the last user message
         last_user_msg = None
         last_user_idx = None
@@ -1844,16 +1853,16 @@ class GatewayRunner:
                 last_user_msg = history[i].get("content", "")
                 last_user_idx = i
                 break
-        
+
         if not last_user_msg:
             return "No previous message to retry."
-        
+
         # Truncate history to before the last user message and persist
         truncated = history[:last_user_idx]
         self.session_store.rewrite_transcript(session_entry.session_id, truncated)
-        # Reset stored token count — transcript was truncated
+        # Reset stored token count - transcript was truncated
         session_entry.last_prompt_tokens = 0
-        
+
         # Re-send by creating a fake text event with the old message
         retry_event = MessageEvent(
             text=last_user_msg,
@@ -1861,44 +1870,44 @@ class GatewayRunner:
             source=source,
             raw_message=event.raw_message,
         )
-        
+
         # Let the normal message handler process it
         return await self._handle_message(retry_event)
-    
+
     async def _handle_undo_command(self, event: MessageEvent) -> str:
         """Handle /undo command - remove the last user/assistant exchange."""
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
         history = self.session_store.load_transcript(session_entry.session_id)
-        
+
         # Find the last user message and remove everything from it onward
         last_user_idx = None
         for i in range(len(history) - 1, -1, -1):
             if history[i].get("role") == "user":
                 last_user_idx = i
                 break
-        
+
         if last_user_idx is None:
             return "Nothing to undo."
-        
+
         removed_msg = history[last_user_idx].get("content", "")
         removed_count = len(history) - last_user_idx
         self.session_store.rewrite_transcript(session_entry.session_id, history[:last_user_idx])
-        # Reset stored token count — transcript was truncated
+        # Reset stored token count - transcript was truncated
         session_entry.last_prompt_tokens = 0
-        
+
         preview = removed_msg[:40] + "..." if len(removed_msg) > 40 else removed_msg
         return f"↩️ Undid {removed_count} message(s).\nRemoved: \"{preview}\""
-    
+
     async def _handle_set_home_command(self, event: MessageEvent) -> str:
         """Handle /sethome command -- set the current chat as the platform's home channel."""
         source = event.source
         platform_name = source.platform.value if source.platform else "unknown"
         chat_id = source.chat_id
         chat_name = source.chat_name or chat_id
-        
+
         env_key = f"{platform_name.upper()}_HOME_CHANNEL"
-        
+
         # Save to config.yaml
         try:
             import yaml
@@ -1914,14 +1923,14 @@ class GatewayRunner:
             os.environ[env_key] = str(chat_id)
         except Exception as e:
             return f"Failed to save home channel: {e}"
-        
+
         return (
             f"✅ Home channel set to **{chat_name}** (ID: {chat_id}).\n"
             f"Cron jobs and cross-platform messages will be delivered here."
         )
-    
+
     async def _handle_rollback_command(self, event: MessageEvent) -> str:
-        """Handle /rollback command — list or restore filesystem checkpoints."""
+        """Handle /rollback command - list or restore filesystem checkpoints."""
         from tools.checkpoint_manager import CheckpointManager, format_checkpoint_list
 
         # Read checkpoint config from config.yaml
@@ -1980,7 +1989,7 @@ class GatewayRunner:
         return f"❌ {result['error']}"
 
     async def _handle_background_command(self, event: MessageEvent) -> str:
-        """Handle /background <prompt> — run a prompt in a separate background session.
+        """Handle /background <prompt> - run a prompt in a separate background session.
 
         Spawns a new AIAgent in a background thread with its own session.
         When it completes, sends the result back to the same chat without
@@ -1992,7 +2001,7 @@ class GatewayRunner:
                 "Usage: /background <prompt>\n"
                 "Example: /background Summarize the top HN stories today\n\n"
                 "Runs the prompt in a separate session. "
-                "You can keep chatting — the result will appear here when done."
+                "You can keep chatting - the result will appear here when done."
             )
 
         source = event.source
@@ -2004,7 +2013,7 @@ class GatewayRunner:
         )
 
         preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
-        return f'🔄 Background task started: "{preview}"\nTask ID: {task_id}\nYou can keep chatting — results will appear when done.'
+        return f'🔄 Background task started: "{preview}"\nTask ID: {task_id}\nYou can keep chatting - results will appear when done.'
 
     async def _run_background_task(
         self, prompt: str, source: "SessionSource", task_id: str
@@ -2042,6 +2051,7 @@ class GatewayRunner:
                 Platform.SIGNAL: "hermes-signal",
                 Platform.HOMEASSISTANT: "hermes-homeassistant",
                 Platform.EMAIL: "hermes-email",
+                Platform.TLON: "hermes-tlon",
             }
             platform_toolsets_config = {}
             try:
@@ -2063,6 +2073,7 @@ class GatewayRunner:
                 Platform.SIGNAL: "signal",
                 Platform.HOMEASSISTANT: "homeassistant",
                 Platform.EMAIL: "email",
+                Platform.TLON: "tlon",
             }.get(source.platform, "telegram")
 
             config_toolsets = platform_toolsets_config.get(platform_config_key)
@@ -2214,7 +2225,7 @@ class GatewayRunner:
             )
 
             self.session_store.rewrite_transcript(session_entry.session_id, compressed)
-            # Reset stored token count — transcript changed, old value is stale
+            # Reset stored token count - transcript changed, old value is stale
             self.session_store.update_session(
                 session_entry.session_key, last_prompt_tokens=0,
             )
@@ -2230,7 +2241,7 @@ class GatewayRunner:
             return f"Compression failed: {e}"
 
     async def _handle_title_command(self, event: MessageEvent) -> str:
-        """Handle /title command — set or show the current session's title."""
+        """Handle /title command - set or show the current session's title."""
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
         session_id = session_entry.session_id
@@ -2264,7 +2275,7 @@ class GatewayRunner:
                 return "No title set. Usage: `/title My Session Name`"
 
     async def _handle_resume_command(self, event: MessageEvent) -> str:
-        """Handle /resume command — switch to a previously-named session."""
+        """Handle /resume command - switch to a previously-named session."""
         if not self._session_db:
             return "Session database not available."
 
@@ -2290,7 +2301,7 @@ class GatewayRunner:
                 for s in titled[:10]:
                     title = s["title"]
                     preview = s.get("preview", "")[:40]
-                    preview_part = f" — _{preview}_" if preview else ""
+                    preview_part = f" - _{preview}_" if preview else ""
                     lines.append(f"• **{title}**{preview_part}")
                 lines.append("\nUsage: `/resume <session name>`")
                 return "\n".join(lines)
@@ -2491,7 +2502,7 @@ class GatewayRunner:
             return f"❌ MCP reload failed: {e}"
 
     async def _handle_update_command(self, event: MessageEvent) -> str:
-        """Handle /update command — update Hermes Agent to the latest version.
+        """Handle /update command - update Hermes Agent to the latest version.
 
         Spawns ``hermes update`` in a separate systemd scope so it survives the
         gateway restart that ``hermes update`` triggers at the end.  A marker
@@ -2507,7 +2518,7 @@ class GatewayRunner:
         git_dir = project_root / '.git'
 
         if not git_dir.exists():
-            return "✗ Not a git repository — cannot update."
+            return "✗ Not a git repository - cannot update."
 
         hermes_bin = shutil.which("hermes")
         if not hermes_bin:
@@ -2584,9 +2595,9 @@ class GatewayRunner:
                     # Truncate if too long for a single message
                     if len(output) > 3500:
                         output = "…" + output[-3500:]
-                    msg = f"✅ Hermes update finished — gateway restarted.\n\n```\n{output}\n```"
+                    msg = f"✅ Hermes update finished - gateway restarted.\n\n```\n{output}\n```"
                 else:
-                    msg = "✅ Hermes update finished — gateway restarted successfully."
+                    msg = "✅ Hermes update finished - gateway restarted successfully."
                 await adapter.send(chat_id, msg)
                 logger.info("Sent post-update notification to %s:%s", platform_str, chat_id)
         except Exception as e:
@@ -2601,13 +2612,13 @@ class GatewayRunner:
         os.environ["HERMES_SESSION_CHAT_ID"] = context.source.chat_id
         if context.source.chat_name:
             os.environ["HERMES_SESSION_CHAT_NAME"] = context.source.chat_name
-    
+
     def _clear_session_env(self) -> None:
         """Clear session environment variables."""
         for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME"]:
             if var in os.environ:
                 del os.environ[var]
-    
+
     async def _enrich_message_with_vision(
         self,
         user_text: str,
@@ -2741,10 +2752,10 @@ class GatewayRunner:
         Auto-removes when the process exits or is killed.
 
         Notification mode (from ``display.background_process_notifications``):
-          - ``all``    — running-output updates + final message
-          - ``result`` — final completion message only
-          - ``error``  — final message only when exit code != 0
-          - ``off``    — no messages at all
+          - ``all``    - running-output updates + final message
+          - ``result`` - final completion message only
+          - ``error``  - final message only when exit code != 0
+          - ``off``    - no messages at all
         """
         from tools.process_registry import process_registry
 
@@ -2836,19 +2847,19 @@ class GatewayRunner:
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
-        
+
         Returns the full result dict from run_conversation, including:
           - "final_response": str (the text to send back)
           - "messages": list (full conversation including tool calls)
           - "api_calls": int
           - "completed": bool
-        
+
         This is run in a thread pool to not block the event loop.
         Supports interruption via new messages.
         """
         from run_agent import AIAgent
         import queue
-        
+
         # Determine toolset based on platform.
         # Check config.yaml for per-platform overrides, fallback to hardcoded defaults.
         default_toolset_map = {
@@ -2860,8 +2871,9 @@ class GatewayRunner:
             Platform.SIGNAL: "hermes-signal",
             Platform.HOMEASSISTANT: "hermes-homeassistant",
             Platform.EMAIL: "hermes-email",
+            Platform.TLON: "hermes-tlon",
         }
-        
+
         # Try to load platform_toolsets from config
         platform_toolsets_config = {}
         try:
@@ -2873,7 +2885,7 @@ class GatewayRunner:
                 platform_toolsets_config = user_config.get("platform_toolsets", {})
         except Exception as e:
             logger.debug("Could not load platform_toolsets config: %s", e)
-        
+
         # Map platform enum to config key
         platform_config_key = {
             Platform.LOCAL: "cli",
@@ -2884,8 +2896,9 @@ class GatewayRunner:
             Platform.SIGNAL: "signal",
             Platform.HOMEASSISTANT: "homeassistant",
             Platform.EMAIL: "email",
+            Platform.TLON: "tlon",
         }.get(source.platform, "telegram")
-        
+
         # Use config override if present (list of toolsets), otherwise hardcoded default
         config_toolsets = platform_toolsets_config.get(platform_config_key)
         if config_toolsets and isinstance(config_toolsets, list):
@@ -2893,7 +2906,7 @@ class GatewayRunner:
         else:
             default_toolset = default_toolset_map.get(source.platform, "hermes-telegram")
             enabled_toolsets = [default_toolset]
-        
+
         # Tool progress mode from config.yaml: "all", "new", "verbose", "off"
         # Falls back to env vars for backward compatibility
         _progress_cfg = {}
@@ -2912,21 +2925,21 @@ class GatewayRunner:
             or "all"
         )
         tool_progress_enabled = progress_mode != "off"
-        
+
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if tool_progress_enabled else None
         last_tool = [None]  # Mutable container for tracking in closure
-        
+
         def progress_callback(tool_name: str, preview: str = None, args: dict = None):
             """Callback invoked by agent when a tool is called."""
             if not progress_queue:
                 return
-            
+
             # "new" mode: only report when tool changes
             if progress_mode == "new" and tool_name == last_tool[0]:
                 return
             last_tool[0] = tool_name
-            
+
             # Build progress message with primary argument preview
             tool_emojis = {
                 "terminal": "💻",
@@ -2969,7 +2982,7 @@ class GatewayRunner:
                 "skill_manage": "📝",
             }
             emoji = tool_emojis.get(tool_name, "⚙️")
-            
+
             # Verbose mode: show detailed arguments
             if progress_mode == "verbose" and args:
                 import json as _json
@@ -2979,7 +2992,7 @@ class GatewayRunner:
                 msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
                 progress_queue.put(msg)
                 return
-            
+
             if preview:
                 # Truncate preview to keep messages clean
                 if len(preview) > 80:
@@ -2987,9 +3000,9 @@ class GatewayRunner:
                 msg = f"{emoji} {tool_name}: \"{preview}\""
             else:
                 msg = f"{emoji} {tool_name}..."
-            
+
             progress_queue.put(msg)
-        
+
         # Background task to send progress messages
         # Accumulates tool lines into a single message that gets edited
         _progress_metadata = {"thread_id": source.thread_id} if source.thread_id else None
@@ -3020,7 +3033,7 @@ class GatewayRunner:
                             content=full_text,
                         )
                         if not result.success:
-                            # Platform doesn't support editing — stop trying,
+                            # Platform doesn't support editing - stop trying,
                             # send just this new line as a separate message
                             can_edit = False
                             await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
@@ -3064,12 +3077,12 @@ class GatewayRunner:
                 except Exception as e:
                     logger.error("Progress message error: %s", e)
                     await asyncio.sleep(1)
-        
+
         # We need to share the agent instance for interrupt support
         agent_holder = [None]  # Mutable container for the agent instance
         result_holder = [None]  # Mutable container for the result
         tools_holder = [None]   # Mutable container for the tool definitions
-        
+
         # Bridge sync step_callback → async hooks.emit for agent:step events
         _loop_for_step = asyncio.get_event_loop()
         _hooks_ref = self.hooks
@@ -3096,11 +3109,11 @@ class GatewayRunner:
 
             # Read from env var or use default (same as CLI)
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
-            
+
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
-            
+
             # Combine platform context with user-configured ephemeral system prompt
             combined_ephemeral = context_prompt or ""
             if self._ephemeral_system_prompt:
@@ -3152,12 +3165,12 @@ class GatewayRunner:
                 session_db=self._session_db,
                 fallback_model=self._fallback_model,
             )
-            
+
             # Store agent reference for interrupt support
             agent_holder[0] = agent
             # Capture the full tool definitions for transcript logging
             tools_holder[0] = agent.tools if hasattr(agent, 'tools') else None
-            
+
             # Convert history to agent format.
             # Two cases:
             #   1. Normal path (from transcript): simple {role, content, timestamp} dicts
@@ -3171,22 +3184,22 @@ class GatewayRunner:
                 role = msg.get("role")
                 if not role:
                     continue
-                
+
                 # Skip metadata entries (tool definitions, session info)
                 # -- these are for transcript logging, not for the LLM
                 if role in ("session_meta",):
                     continue
-                
+
                 # Skip system messages -- the agent rebuilds its own system prompt
                 if role == "system":
                     continue
-                
+
                 # Rich agent messages (tool_calls, tool results) must be passed
                 # through intact so the API sees valid assistant→tool sequences
                 has_tool_calls = "tool_calls" in msg
                 has_tool_call_id = "tool_call_id" in msg
                 is_tool_message = role == "tool"
-                
+
                 if has_tool_calls or has_tool_call_id or is_tool_message:
                     clean_msg = {k: v for k, v in msg.items() if k != "timestamp"}
                     agent_history.append(clean_msg)
@@ -3199,7 +3212,7 @@ class GatewayRunner:
                             mirror_src = msg.get("mirror_source", "another session")
                             content = f"[Delivered from {mirror_src}] {content}"
                         agent_history.append({"role": role, "content": content})
-            
+
             # Collect MEDIA paths already in history so we can exclude them
             # from the current turn's extraction. This is compression-safe:
             # even if the message list shrinks, we know which paths are old.
@@ -3212,10 +3225,10 @@ class GatewayRunner:
                             _p = _match.group(1).strip().rstrip('",}')
                             if _p:
                                 _history_media_paths.add(_p)
-            
+
             result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
             result_holder[0] = result
-            
+
             # Return final response, or a message if something went wrong
             final_response = result.get("final_response")
 
@@ -3235,7 +3248,7 @@ class GatewayRunner:
                     "history_offset": len(agent_history),
                     "last_prompt_tokens": _last_prompt_toks,
                 }
-            
+
             # Scan tool results for MEDIA:<path> tags that need to be delivered
             # as native audio/file attachments.  The TTS tool embeds MEDIA: tags
             # in its JSON response, but the model's final text reply usually
@@ -3259,7 +3272,7 @@ class GatewayRunner:
                                     media_tags.append(f"MEDIA:{path}")
                             if "[[audio_as_voice]]" in content:
                                 has_voice_directive = True
-                
+
                 if media_tags:
                     seen = set()
                     unique_tags = []
@@ -3270,7 +3283,7 @@ class GatewayRunner:
                     if has_voice_directive:
                         unique_tags.insert(0, "[[audio_as_voice]]")
                     final_response = final_response + "\n" + "\n".join(unique_tags)
-            
+
             return {
                 "final_response": final_response,
                 "messages": result_holder[0].get("messages", []) if result_holder[0] else [],
@@ -3279,12 +3292,12 @@ class GatewayRunner:
                 "history_offset": len(agent_history),
                 "last_prompt_tokens": _last_prompt_toks,
             }
-        
+
         # Start progress message sender if enabled
         progress_task = None
         if tool_progress_enabled:
             progress_task = asyncio.create_task(send_progress_messages())
-        
+
         # Track this agent as running for this session (for interrupt support)
         # We do this in a callback after the agent is created
         async def track_agent():
@@ -3293,15 +3306,15 @@ class GatewayRunner:
                 await asyncio.sleep(0.05)
             if session_key:
                 self._running_agents[session_key] = agent_holder[0]
-        
+
         tracking_task = asyncio.create_task(track_agent())
-        
+
         # Monitor for interrupts from the adapter (new messages arriving)
         async def monitor_for_interrupt():
             adapter = self.adapters.get(source.platform)
             if not adapter:
                 return
-            
+
             chat_id = source.chat_id
             while True:
                 await asyncio.sleep(0.2)  # Check every 200ms
@@ -3314,18 +3327,18 @@ class GatewayRunner:
                         logger.debug("Interrupt detected from adapter, signaling agent...")
                         agent.interrupt(pending_text)
                         break
-        
+
         interrupt_monitor = asyncio.create_task(monitor_for_interrupt())
-        
+
         try:
             # Run in thread pool to not block
             loop = asyncio.get_event_loop()
             response = await loop.run_in_executor(None, run_sync)
-            
+
             # Check if we were interrupted and have a pending message
             result = result_holder[0]
             adapter = self.adapters.get(source.platform)
-            
+
             # Get pending message from adapter if interrupted
             pending = None
             if result and result.get("interrupted") and adapter:
@@ -3334,20 +3347,20 @@ class GatewayRunner:
                     pending = pending_event.text
                 elif result.get("interrupt_message"):
                     pending = result.get("interrupt_message")
-            
+
             if pending:
                 logger.debug("Processing interrupted message: '%s...'", pending[:40])
-                
+
                 # Clear the adapter's interrupt event so the next _run_agent call
                 # doesn't immediately re-trigger the interrupt before the new agent
                 # even makes its first API call (this was causing an infinite loop).
                 if adapter and hasattr(adapter, '_active_sessions') and source.chat_id in adapter._active_sessions:
                     adapter._active_sessions[source.chat_id].clear()
-                
-                # Don't send the interrupted response to the user — it's just noise
+
+                # Don't send the interrupted response to the user - it's just noise
                 # like "Operation interrupted." They already know they sent a new
                 # message, so go straight to processing it.
-                
+
                 # Now process the pending message with updated history
                 updated_history = result.get("messages", history)
                 return await self._run_agent(
@@ -3363,12 +3376,12 @@ class GatewayRunner:
             if progress_task:
                 progress_task.cancel()
             interrupt_monitor.cancel()
-            
+
             # Clean up tracking
             tracking_task.cancel()
             if session_key and session_key in self._running_agents:
                 del self._running_agents[session_key]
-            
+
             # Wait for cancelled tasks
             for task in [progress_task, interrupt_monitor, tracking_task]:
                 if task:
@@ -3376,14 +3389,14 @@ class GatewayRunner:
                         await task
                     except asyncio.CancelledError:
                         pass
-        
+
         return response
 
 
 def _start_cron_ticker(stop_event: threading.Event, adapters=None, interval: int = 60):
     """
     Background thread that ticks the cron scheduler at a regular interval.
-    
+
     Runs inside the gateway process so cronjobs fire automatically without
     needing a separate `hermes cron daemon` or system cron entry.
 
@@ -3393,8 +3406,8 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, interval: int
     from cron.scheduler import tick as cron_tick
     from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
 
-    IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
-    CHANNEL_DIR_EVERY = 5    # ticks — every 5 minutes
+    IMAGE_CACHE_EVERY = 60   # ticks - once per hour at default 60s interval
+    CHANNEL_DIR_EVERY = 5    # ticks - every 5 minutes
 
     logger.info("Cron ticker started (interval=%ds)", interval)
     tick_count = 0
@@ -3434,11 +3447,11 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, interval: int
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False) -> bool:
     """
     Start the gateway and run until interrupted.
-    
+
     This is the main entry point for running the gateway.
     Returns True if the gateway ran successfully, False if it failed to start.
     A False return causes a non-zero exit code so systemd can auto-restart.
-    
+
     Args:
         config: Optional gateway configuration override.
         replace: If True, kill any existing gateway instance before starting.
@@ -3477,7 +3490,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 except (ProcessLookupError, PermissionError):
                     break  # Process is gone
             else:
-                # Still alive after 10s — force kill
+                # Still alive after 10s - force kill
                 logger.warning(
                     "Old gateway (PID %d) did not exit after SIGTERM, sending SIGKILL.",
                     existing_pid,
@@ -3534,29 +3547,29 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     logging.getLogger().addHandler(error_handler)
 
     runner = GatewayRunner(config)
-    
+
     # Set up signal handlers
     def signal_handler():
         asyncio.create_task(runner.stop())
-    
+
     loop = asyncio.get_event_loop()
     for sig in (signal.SIGINT, signal.SIGTERM):
         try:
             loop.add_signal_handler(sig, signal_handler)
         except NotImplementedError:
             pass
-    
+
     # Start the gateway
     success = await runner.start()
     if not success:
         return False
-    
+
     # Write PID file so CLI can detect gateway is running
     import atexit
     from gateway.status import write_pid_file, remove_pid_file
     write_pid_file()
     atexit.register(remove_pid_file)
-    
+
     # Start background cron ticker so scheduled jobs fire automatically
     cron_stop = threading.Event()
     cron_thread = threading.Thread(
@@ -3567,10 +3580,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         name="cron-ticker",
     )
     cron_thread.start()
-    
+
     # Wait for shutdown
     await runner.wait_for_shutdown()
-    
+
     # Stop cron ticker cleanly
     cron_stop.set()
     cron_thread.join(timeout=5)
@@ -3588,20 +3601,20 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 def main():
     """CLI entry point for the gateway."""
     import argparse
-    
+
     parser = argparse.ArgumentParser(description="Hermes Gateway - Multi-platform messaging")
     parser.add_argument("--config", "-c", help="Path to gateway config file")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
-    
+
     args = parser.parse_args()
-    
+
     config = None
     if args.config:
         import json
         with open(args.config, encoding="utf-8") as f:
             data = json.load(f)
             config = GatewayConfig.from_dict(data)
-    
+
     # Run the gateway - exit with code 1 if no platforms connected,
     # so systemd Restart=on-failure will retry on transient errors (e.g. DNS)
     success = asyncio.run(start_gateway(config))

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -544,6 +544,31 @@ _PLATFORMS = [
              "help": "Only emails from these addresses will be processed."},
         ],
     },
+    {
+        "key": "tlon",
+        "label": "Tlon (Urbit)",
+        "emoji": "⛵",
+        "token_var": "TLON_SHIP_URL",
+        "setup_instructions": [
+            "1. You need a running Urbit ship with Tlon installed",
+            "2. Get your ship's URL (e.g., https://sampel-palnet.tlon.network)",
+            "3. Get your ship's +code from the Dojo: +code",
+            "4. Your ship name is the @p (e.g., ~sampel-palnet)",
+        ],
+        "vars": [
+            {"name": "TLON_SHIP_URL", "prompt": "Ship URL", "password": False,
+             "help": "The URL of your Urbit ship (e.g., https://sampel-palnet.tlon.network)."},
+            {"name": "TLON_SHIP_NAME", "prompt": "Ship name (@p)", "password": False,
+             "help": "Your ship's @p identifier (e.g., ~sampel-palnet)."},
+            {"name": "TLON_SHIP_CODE", "prompt": "Ship +code", "password": True,
+             "help": "The +code for authentication (run +code in your ship's Dojo)."},
+            {"name": "TLON_CHANNELS", "prompt": "Channels to monitor (comma-separated, optional)", "password": False,
+             "help": "Channel nests to watch (e.g., chat/~host/channel-name). Leave empty for DMs only."},
+            {"name": "TLON_ALLOWED_USERS", "prompt": "Allowed ships (comma-separated)", "password": False,
+             "is_allowlist": True,
+             "help": "Only these ships can interact with the bot (e.g., ~malmur-halmex,~zod)."},
+        ],
+    },
 ]
 
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -209,6 +209,7 @@ def show_status(args):
         "Signal": ("SIGNAL_HTTP_URL", "SIGNAL_HOME_CHANNEL"),
         "Slack": ("SLACK_BOT_TOKEN", None),
         "Email": ("EMAIL_ADDRESS", "EMAIL_HOME_ADDRESS"),
+        "Tlon": ("TLON_SHIP_URL", "TLON_HOME_CHANNEL"),
     }
     
     for name, (token_var, home_var) in platforms.items():

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -8,6 +8,7 @@ human-friendly channel names to IDs. Works in both CLI and gateway contexts.
 import json
 import logging
 import os
+import uuid
 import re
 import time
 
@@ -120,6 +121,7 @@ def _handle_send(args):
         "whatsapp": Platform.WHATSAPP,
         "signal": Platform.SIGNAL,
         "email": Platform.EMAIL,
+        "tlon": Platform.TLON,
     }
     platform = platform_map.get(platform_name)
     if not platform:
@@ -188,6 +190,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None)
         return await _send_signal(pconfig.extra, chat_id, message)
     elif platform == Platform.EMAIL:
         return await _send_email(pconfig.extra, chat_id, message)
+    elif platform == Platform.TLON:
+        return await _send_tlon(pconfig.extra, chat_id, message)
     return {"error": f"Direct sending not yet implemented for {platform.value}"}
 
 
@@ -315,6 +319,119 @@ async def _send_email(extra, chat_id, message):
         return {"error": f"Email send failed: {e}"}
 
 
+async def _send_tlon(extra, chat_id, message):
+    """Send via Tlon ship HTTP API (one-shot poke)."""
+    import aiohttp
+    import time as _time
+
+    ship_url = extra.get("ship_url") or os.getenv("TLON_SHIP_URL", "")
+    ship_name = extra.get("ship_name") or os.getenv("TLON_SHIP_NAME", "")
+    ship_code = os.getenv("TLON_SHIP_CODE", "")
+
+    if not all([ship_url, ship_name, ship_code]):
+        return {"error": "Tlon not configured (TLON_SHIP_URL, TLON_SHIP_NAME, TLON_SHIP_CODE)"}
+
+    ship_url = ship_url.rstrip("/")
+    if ship_name and not ship_name.startswith("~"):
+        ship_name = "~" + ship_name
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            # Authenticate
+            async with session.post(
+                f"{ship_url}/~/login",
+                data={"password": ship_code},
+                allow_redirects=False,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as auth_resp:
+                cookie = None
+                for c in session.cookie_jar:
+                    if c.key.startswith("urbauth"):
+                        cookie = f"{c.key}={c.value}"
+                        break
+                if not cookie:
+                    return {"error": "Tlon authentication failed"}
+
+            # Build story content
+            from gateway.platforms.tlon import _text_to_story
+            story = _text_to_story(message)
+            sent_at = int(_time.time() * 1000)
+
+            # Create channel and poke
+            channel_id = f"{int(_time.time())}-send-{uuid.uuid4().hex[:6]}"
+            channel_url = f"{ship_url}/~/channel/{channel_id}"
+            headers = {"Content-Type": "application/json", "Cookie": cookie}
+
+            if chat_id.startswith("~"):
+                # DM
+                action = {
+                    "id": 1,
+                    "action": "poke",
+                    "ship": ship_name.lstrip("~"),
+                    "app": "chat",
+                    "mark": "chat-action",
+                    "json": {
+                        "ship": chat_id.lstrip("~"),
+                        "diff": {
+                            "add": {
+                                "essay": {
+                                    "content": story,
+                                    "author": ship_name.lstrip("~"),
+                                    "sent": sent_at,
+                                }
+                            }
+                        },
+                    },
+                }
+            else:
+                # Channel post
+                action = {
+                    "id": 1,
+                    "action": "poke",
+                    "ship": ship_name.lstrip("~"),
+                    "app": "channels",
+                    "mark": "channel-action",
+                    "json": {
+                        "channel": {
+                            "nest": chat_id,
+                            "action": {
+                                "post": {
+                                    "add": {
+                                        "essay": {
+                                            "content": story,
+                                            "author": ship_name.lstrip("~"),
+                                            "sent": sent_at,
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+
+            async with session.put(
+                channel_url,
+                json=[action],
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status not in (200, 204):
+                    text = await resp.text()
+                    return {"error": f"Tlon send failed: HTTP {resp.status} - {text[:200]}"}
+
+            # Clean up channel
+            try:
+                async with session.delete(channel_url, headers=headers, timeout=5):
+                    pass
+            except Exception:
+                pass
+
+            return {"success": True, "message_id": f"{ship_name}/{sent_at}"}
+
+    except Exception as e:
+        return {"error": f"Tlon send failed: {e}"}
+
+
 def _check_send_message():
     """Gate send_message on gateway running (always available on messaging platforms)."""
     platform = os.getenv("HERMES_SESSION_PLATFORM", "")
@@ -325,6 +442,114 @@ def _check_send_message():
         return is_gateway_running()
     except Exception:
         return False
+
+
+async def _send_tlon(extra, chat_id, message):
+    """Send via Tlon (Urbit) ship HTTP API (one-shot, no SSE needed)."""
+    try:
+        import aiohttp
+        ship_url = extra.get("ship_url") or os.getenv("TLON_SHIP_URL", "")
+        ship_name = os.getenv("TLON_SHIP_NAME", "")
+        ship_code = os.getenv("TLON_SHIP_CODE", "")
+        if not all([ship_url, ship_name, ship_code]):
+            return {"error": "Tlon not configured (TLON_SHIP_URL/NAME/CODE required)"}
+
+        ship_url = ship_url.rstrip("/")
+        # Normalize ship
+        if ship_name and not ship_name.startswith("~"):
+            ship_name = "~" + ship_name
+
+        async with aiohttp.ClientSession() as session:
+            # Authenticate
+            async with session.post(
+                f"{ship_url}/~/login",
+                data={"password": ship_code},
+                allow_redirects=False,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                if resp.status not in (200, 204, 302, 303, 307):
+                    return {"error": f"Tlon auth failed: HTTP {resp.status}"}
+                cookie = resp.headers.get("set-cookie", "")
+                if not cookie:
+                    for c in session.cookie_jar:
+                        if c.key.startswith("urbauth"):
+                            cookie = f"{c.key}={c.value}"
+                            break
+
+            # Create channel and poke
+            import time, uuid
+            channel_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+            channel_url = f"{ship_url}/~/channel/{channel_id}"
+
+            sent_at = int(time.time() * 1000)
+            story = [{"inline": [message]}]
+            bare_ship = ship_name.lstrip("~")
+
+            # Determine if DM or channel post
+            if chat_id.startswith("~"):
+                poke_data = {
+                    "id": 1,
+                    "action": "poke",
+                    "ship": bare_ship,
+                    "app": "chat",
+                    "mark": "chat-action",
+                    "json": {
+                        "ship": chat_id.lstrip("~"),
+                        "diff": {
+                            "add": {
+                                "essay": {
+                                    "content": story,
+                                    "author": bare_ship,
+                                    "sent": sent_at,
+                                }
+                            }
+                        },
+                    },
+                }
+            else:
+                poke_data = {
+                    "id": 1,
+                    "action": "poke",
+                    "ship": bare_ship,
+                    "app": "channels",
+                    "mark": "channel-action",
+                    "json": {
+                        "channel": {
+                            "nest": chat_id,
+                            "action": {
+                                "post": {
+                                    "add": {
+                                        "essay": {
+                                            "content": story,
+                                            "author": bare_ship,
+                                            "sent": sent_at,
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+
+            headers = {"Content-Type": "application/json"}
+            if cookie:
+                headers["Cookie"] = cookie
+
+            async with session.put(
+                channel_url,
+                json=[poke_data],
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status not in (200, 204):
+                    text = await resp.text()
+                    return {"error": f"Tlon send failed: HTTP {resp.status} - {text[:200]}"}
+
+            return {"success": True, "platform": "tlon", "chat_id": chat_id}
+    except ImportError:
+        return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+    except Exception as e:
+        return {"error": f"Tlon send error: {str(e)}"}
 
 
 # --- Registry ---

--- a/toolsets.py
+++ b/toolsets.py
@@ -273,10 +273,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-tlon": {
+        "description": "Tlon bot toolset - decentralized Urbit messaging (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-tlon"]
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a full Tlon (Urbit) messaging platform adapter to the Hermes gateway, enabling bots to connect to ships on the Tlon network.

### What's included

**Core adapter** (`gateway/platforms/tlon.py` — 1,261 lines):
- `TlonSSEClient`: Low-level Eyre HTTP API client — auth, channel management, SSE streaming, poke, scry, auto-reconnect with exponential backoff
- `TlonAdapter(BasePlatformAdapter)`: High-level adapter — connects to ship, monitors group channels + DMs, sends messages/images, auto-discovers channels

**Integration touchpoints** (8 additional files):
- `gateway/config.py`: `Platform.TLON` enum + env var config
- `tools/send_message_tool.py`: Standalone Tlon send (one-shot poke)
- `hermes_cli/gateway.py`: Setup wizard entry
- `toolsets.py`: `hermes-tlon` toolset
- `agent/prompt_builder.py`: Tlon platform hints
- `cron/scheduler.py`: Tlon delivery support
- `hermes_cli/status.py`: Status display

### How it works

1. Auth via `POST /~/login` with ship +code → urbauth cookie
2. Subscribe to channels firehose (`/v2`) and DMs (`/v3`) via SSE
3. Listen for @mentions in group channels + all DMs
4. Route inbound → Hermes session store → AI agent
5. Send responses via pokes (`channel-action` / `chat-action`)
6. Auto-reconnect with exponential backoff

### Config env vars

```
TLON_SHIP_URL, TLON_SHIP_NAME, TLON_SHIP_CODE
TLON_CHANNELS, TLON_DM_ALLOWLIST, TLON_AUTO_DISCOVER
TLON_HOME_CHANNEL, TLON_ALLOWED_USERS, TLON_ALLOW_ALL_USERS
```

### Deps: aiohttp (already in requirements)

### Testing status
- ✅ Auth, SSE, channel send/receive, auto-reconnect
- ⚠️ DM mark format fixed but needs more live testing
