### PR TITLE
fix: exclude Coding Plan-only models from Moonshot model selection

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1352,6 +1352,12 @@ _PROVIDER_MODELS = {
         "kimi-k2-turbo-preview",
         "kimi-k2-0905-preview",
     ],
+    "moonshot": [
+        "kimi-k2.5",
+        "kimi-k2-thinking",
+        "kimi-k2-turbo-preview",
+        "kimi-k2-0905-preview",
+    ],
     "minimax": [
         "MiniMax-M2.5",
         "MiniMax-M2.5-highspeed",
@@ -1433,8 +1439,8 @@ def _model_flow_kimi(config, current_model=""):
             "kimi-k2-thinking-turbo",
         ]
     else:
-        # Legacy Moonshot models
-        model_list = _PROVIDER_MODELS.get(provider_id, [])
+        # Legacy Moonshot models (excludes Coding Plan-only models)
+        model_list = _PROVIDER_MODELS.get("moonshot", [])
 
     if model_list:
         selected = _prompt_model_selection(model_list, current_model=current_model)

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -426,3 +426,30 @@ class TestKimiCodeCredentialAutoDetect:
         monkeypatch.setenv("GLM_API_KEY", "sk-kimi-looks-like-kimi-but-isnt")
         creds = resolve_api_key_provider_credentials("zai")
         assert creds["base_url"] == "https://api.z.ai/api/paas/v4"
+
+
+# =============================================================================
+# Kimi / Moonshot model list isolation tests
+# =============================================================================
+
+class TestKimiMoonshotModelListIsolation:
+    """Moonshot (legacy) users must not see Coding Plan-only models."""
+
+    def test_moonshot_list_excludes_coding_plan_only_models(self):
+        from hermes_cli.main import _PROVIDER_MODELS
+        moonshot_models = _PROVIDER_MODELS["moonshot"]
+        coding_plan_only = {"kimi-for-coding", "kimi-k2-thinking-turbo"}
+        leaked = set(moonshot_models) & coding_plan_only
+        assert not leaked, f"Moonshot list contains Coding Plan-only models: {leaked}"
+
+    def test_moonshot_list_contains_shared_models(self):
+        from hermes_cli.main import _PROVIDER_MODELS
+        moonshot_models = _PROVIDER_MODELS["moonshot"]
+        assert "kimi-k2.5" in moonshot_models
+        assert "kimi-k2-thinking" in moonshot_models
+
+    def test_coding_plan_list_contains_plan_specific_models(self):
+        from hermes_cli.main import _PROVIDER_MODELS
+        coding_models = _PROVIDER_MODELS["kimi-coding"]
+        assert "kimi-for-coding" in coding_models
+        assert "kimi-k2-thinking-turbo" in coding_models


### PR DESCRIPTION
## Summary
- Moonshot (legacy key) users are shown `kimi-for-coding` and `kimi-k2-thinking-turbo` in the model selection menu, but these models only work on the Coding Plan endpoint (`api.kimi.com/coding/v1`)
- Selecting them against the Moonshot endpoint (`api.moonshot.ai/v1`) results in API errors
- Root cause: `_model_flow_kimi()` uses `_PROVIDER_MODELS["kimi-coding"]` (all 6 models) for both Coding Plan and Moonshot users

## Changes
- Add separate `"moonshot"` list in `_PROVIDER_MODELS` with only Moonshot-compatible models (`kimi-k2.5`, `kimi-k2-thinking`, `kimi-k2-turbo-preview`, `kimi-k2-0905-preview`)
- Update the Moonshot branch in `_model_flow_kimi()` to use `_PROVIDER_MODELS["moonshot"]` instead of `_PROVIDER_MODELS[provider_id]`
- Add 3 tests verifying model list isolation between Coding Plan and Moonshot

## Proof

```python
# Before fix: Moonshot users see Coding Plan-only models
_PROVIDER_MODELS["kimi-coding"]
# → ['kimi-for-coding', 'kimi-k2.5', 'kimi-k2-thinking',
#    'kimi-k2-thinking-turbo', 'kimi-k2-turbo-preview', 'kimi-k2-0905-preview']
#    ^^^^^^^^^^^^^^^^  Coding Plan only  ^^^^^^^^^^^^^^^^^^

# After fix: Moonshot users only see compatible models
_PROVIDER_MODELS["moonshot"]
# → ['kimi-k2.5', 'kimi-k2-thinking', 'kimi-k2-turbo-preview', 'kimi-k2-0905-preview']
```

## Test plan
- [x] `pytest tests/test_api_key_providers.py` — 65/65 passed
- [x] Moonshot list excludes `kimi-for-coding` and `kimi-k2-thinking-turbo`
- [x] Moonshot list contains shared models (`kimi-k2.5`, `kimi-k2-thinking`)
- [x] Coding Plan list still contains plan-specific models