### PR TITLE
fix(gateway): fall back to sys.executable -m hermes_cli.main when hermes not on PATH

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -157,6 +157,33 @@ def _resolve_runtime_agent_kwargs() -> dict:
     }
 
 
+def _resolve_hermes_bin():
+    """Resolve the hermes executable path.
+
+    Tries in order:
+    1. ``shutil.which("hermes")`` -- standard PATH lookup.
+    2. ``sys.executable -m hermes_cli.main`` -- works when Hermes is launched
+       via a venv or module invocation where the ``hermes`` symlink is not on
+       PATH for the gateway process.
+
+    Returns the command string to use, or None if neither works.
+    """
+    import shutil
+    hermes_bin = shutil.which("hermes")
+    if hermes_bin:
+        return hermes_bin
+
+    # Fallback: use the current Python interpreter with -m hermes_cli.main
+    try:
+        import importlib.util
+        if importlib.util.find_spec("hermes_cli") is not None:
+            return f"{sys.executable} -m hermes_cli.main"
+    except Exception:
+        pass
+
+    return None
+
+
 class GatewayRunner:
     """
     Main gateway controller.
@@ -1980,9 +2007,14 @@ class GatewayRunner:
         if not git_dir.exists():
             return "✗ Not a git repository — cannot update."
 
-        hermes_bin = shutil.which("hermes")
+        hermes_bin = _resolve_hermes_bin()
         if not hermes_bin:
-            return "✗ `hermes` command not found on PATH."
+            return (
+                "✗ Could not locate the `hermes` command. "
+                "Hermes is running, but the update command could not find the "
+                "executable on PATH or via the current Python interpreter. "
+                "Try running `hermes update` manually in your terminal."
+            )
 
         # Write marker so the restarted gateway can notify this chat
         pending_path = _hermes_home / ".update_pending.json"

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -87,7 +87,7 @@ class TestHandleUpdateCommand:
 
     @pytest.mark.asyncio
     async def test_no_hermes_binary(self, tmp_path):
-        """Returns error when hermes is not on PATH."""
+        """Returns error when hermes is not on PATH and hermes_cli is not importable."""
         runner = _make_runner()
         event = _make_event()
 
@@ -101,10 +101,79 @@ class TestHandleUpdateCommand:
 
         with patch("gateway.run._hermes_home", tmp_path), \
              patch("gateway.run.__file__", fake_file), \
-             patch("shutil.which", return_value=None):
+             patch("shutil.which", return_value=None), \
+             patch("importlib.util.find_spec", return_value=None):
             result = await runner._handle_update_command(event)
 
-        assert "not found on PATH" in result
+        assert "Could not locate" in result
+        assert "hermes update" in result
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_sys_executable(self, tmp_path):
+        """Falls back to sys.executable -m hermes_cli.main when hermes not on PATH."""
+        runner = _make_runner()
+        event = _make_event()
+
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / ".git").mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        mock_popen = MagicMock()
+        fake_spec = MagicMock()
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("shutil.which", return_value=None), \
+             patch("importlib.util.find_spec", return_value=fake_spec), \
+             patch("subprocess.Popen", mock_popen):
+            result = await runner._handle_update_command(event)
+
+        assert "Starting Hermes update" in result
+        call_args = mock_popen.call_args[0][0]
+        # The update_cmd uses sys.executable -m hermes_cli.main
+        joined = " ".join(call_args) if isinstance(call_args, list) else call_args
+        assert "hermes_cli.main" in joined or "bash" in call_args[0]
+
+    @pytest.mark.asyncio
+    async def test_resolve_hermes_bin_prefers_which(self, tmp_path):
+        """_resolve_hermes_bin returns shutil.which result when available."""
+        from gateway.run import _resolve_hermes_bin
+
+        with patch("shutil.which", return_value="/custom/path/hermes"):
+            result = _resolve_hermes_bin()
+
+        assert result == "/custom/path/hermes"
+
+    @pytest.mark.asyncio
+    async def test_resolve_hermes_bin_fallback(self):
+        """_resolve_hermes_bin falls back to sys.executable when which fails."""
+        import sys
+        from gateway.run import _resolve_hermes_bin
+
+        fake_spec = MagicMock()
+        with patch("shutil.which", return_value=None), \
+             patch("importlib.util.find_spec", return_value=fake_spec):
+            result = _resolve_hermes_bin()
+
+        assert result is not None
+        assert sys.executable in result
+        assert "hermes_cli.main" in result
+
+    @pytest.mark.asyncio
+    async def test_resolve_hermes_bin_returns_none_when_both_fail(self):
+        """_resolve_hermes_bin returns None when both strategies fail."""
+        from gateway.run import _resolve_hermes_bin
+
+        with patch("shutil.which", return_value=None), \
+             patch("importlib.util.find_spec", return_value=None):
+            result = _resolve_hermes_bin()
+
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_writes_pending_marker(self, tmp_path):


### PR DESCRIPTION
Fixes #1049

## Problem
`/update` hard-failed with `✗ `hermes` command not found on PATH.` even when Hermes was already running. This happens in setups where Hermes is launched via a venv or module invocation and the `hermes` symlink is not on PATH for the gateway process.

## Fix
Extracts a `_resolve_hermes_bin()` helper that tries two strategies in order:
1. `shutil.which("hermes")` — standard PATH lookup (existing behavior)
2. `sys.executable -m hermes_cli.main` — fallback when `hermes_cli` is importable but the symlink is missing from PATH

If both fail, returns a clear error message explaining that the problem is path resolution, not Hermes availability, and suggests running `hermes update` manually.

## Changes
- `gateway/run.py`: add `_resolve_hermes_bin()` helper, use it in `_handle_update_command`
- `tests/gateway/test_update_command.py`: update existing test + add 4 new tests covering fallback behavior