### PR TITLE
fix(gateway): enforce chat_id isolation for all DM sessions

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -298,17 +298,18 @@ class SessionEntry:
 def build_session_key(source: SessionSource) -> str:
     """Build a deterministic session key from a message source.
 
-    This is the single source of truth for session key construction.
-    WhatsApp DMs include chat_id (multi-user), other DMs do not (single owner).
+    Always isolate sessions by chat_id, regardless of platform or chat_type.
     """
     platform = source.platform.value
-    if source.chat_type == "dm":
-        if platform == "whatsapp" and source.chat_id:
-            return f"agent:main:{platform}:dm:{source.chat_id}"
-        return f"agent:main:{platform}:dm"
-    if source.thread_id:
-        return f"agent:main:{platform}:{source.chat_type}:{source.chat_id}:{source.thread_id}"
-    return f"agent:main:{platform}:{source.chat_type}:{source.chat_id}"
+    
+    # Always isolate sessions by chat_id, regardless of platform or chat_type
+    if source.chat_id:
+        if source.thread_id:
+            return f"agent:main:{platform}:{source.chat_type}:{source.chat_id}:{source.thread_id}"
+        return f"agent:main:{platform}:{source.chat_type}:{source.chat_id}"
+        
+    # Fallback only if chat_id is somehow missing
+    return f"agent:main:{platform}:{source.chat_type}"
 
 
 class SessionStore:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -348,15 +348,15 @@ class TestWhatsAppDMSessionKeyConsistency:
         )
         assert store._generate_session_key(source) == build_session_key(source)
 
-    def test_telegram_dm_omits_chat_id(self):
-        """Non-WhatsApp DMs should still omit chat_id (single owner DM)."""
+    def test_telegram_dm_includes_chat_id(self):
+        """Non-WhatsApp DMs should also include chat_id to separate users."""
         source = SessionSource(
             platform=Platform.TELEGRAM,
             chat_id="99",
             chat_type="dm",
         )
         key = build_session_key(source)
-        assert key == "agent:main:telegram:dm"
+        assert key == "agent:main:telegram:dm:99"
 
     def test_discord_group_includes_chat_id(self):
         """Group/channel keys include chat_type and chat_id."""


### PR DESCRIPTION
## What does this PR do?

Fixes a critical privacy and context-bleeding bug in the platform gateway. 
Previously, `build_session_key()` hardcoded `whatsapp` as the only platform that uses `chat_id` for DMs. This caused all Direct Messages from platforms like Telegram and Discord to fall back to a single global session key (`agent:main:<platform>:dm`), merging completely different users into the same shared agent context/memory. 
This PR simplifies the logic to universally isolate sessions by `chat_id` across all platforms whenever a `chat_id` is present, while maintaining fallback behavior and thread grouping.

## Related Issue

[Bug]: Telegram and Discord DMs share a single global session (Context Bleeding) #1056

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`gateway/session.py`**: Updated `build_session_key()` to check for `source.chat_id` generically instead of strictly requiring `platform == "whatsapp"`.
- **`tests/gateway/test_session.py`**: Updated `TestWhatsAppDMSessionKeyConsistency` to verify that Telegram DMs correctly include the `chat_id` in the generated session key (renamed `test_telegram_dm_omits_chat_id` to `test_telegram_dm_includes_chat_id`).

## How to Test

1. Start the Hermes agent with the Telegram (or Discord) gateway enabled.
2. Send a Direct Message to the bot from Account A.
3. Send a Direct Message to the bot from Account B.
4. Verify in the console logs or `~/.hermes/sessions/sessions.json` that two distinct session keys are created (e.g., `agent:main:telegram:dm:<Account_A_ID>` and `agent:main:telegram:dm:<Account_B_ID>`) rather than a single shared `agent:main:telegram:dm`.
5. Run `python -m pytest tests/gateway/test_session.py` to ensure the updated unit tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```text
============================= test session starts ==============================
platform darwin -- Python 3.11.6, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/xxx/hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
created: 8/8 workers
8 workers [37 items]
.....................................                                    [100%]
============================== 37 passed in 1.07s ==============================