### PR TITLE
fix: strip call_id/response_item_id from tool_calls for Mistral compatibility

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2530,6 +2530,31 @@ class AIAgent:
 
         return msg
 
+    @staticmethod
+    def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:
+        """Strip Codex Responses API fields from tool_calls for strict providers.
+
+        Providers like Mistral strictly validate the Chat Completions schema
+        and reject unknown fields (call_id, response_item_id) with 422.
+        These fields are preserved in the internal message history — this
+        method only modifies the outgoing API copy.
+
+        Creates new tool_call dicts rather than mutating in-place, so the
+        original messages list retains call_id/response_item_id for Codex
+        Responses API compatibility (e.g. if the session falls back to a
+        Codex provider later).
+        """
+        tool_calls = api_msg.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            return api_msg
+        _STRIP_KEYS = {"call_id", "response_item_id"}
+        api_msg["tool_calls"] = [
+            {k: v for k, v in tc.items() if k not in _STRIP_KEYS}
+            if isinstance(tc, dict) else tc
+            for tc in tool_calls
+        ]
+        return api_msg
+
     def flush_memories(self, messages: list = None, min_turns: int = None):
         """Give the model one turn to persist memories before context is lost.
 
@@ -2567,6 +2592,7 @@ class AIAgent:
 
         try:
             # Build API messages for the flush call
+            _is_strict_api = "api.mistral.ai" in self.base_url.lower()
             api_messages = []
             for msg in messages:
                 api_msg = msg.copy()
@@ -2577,6 +2603,8 @@ class AIAgent:
                 api_msg.pop("reasoning", None)
                 api_msg.pop("finish_reason", None)
                 api_msg.pop("_flush_sentinel", None)
+                if _is_strict_api:
+                    self._sanitize_tool_calls_for_strict_api(api_msg)
                 api_messages.append(api_msg)
 
             if self._cached_system_prompt:
@@ -3042,11 +3070,14 @@ class AIAgent:
         try:
             # Build API messages, stripping internal-only fields
             # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
+            _is_strict_api = "api.mistral.ai" in self.base_url.lower()
             api_messages = []
             for msg in messages:
                 api_msg = msg.copy()
                 for internal_field in ("reasoning", "finish_reason"):
                     api_msg.pop(internal_field, None)
+                if _is_strict_api:
+                    self._sanitize_tool_calls_for_strict_api(api_msg)
                 api_messages.append(api_msg)
 
             effective_system = self._cached_system_prompt or ""
@@ -3425,6 +3456,12 @@ class AIAgent:
                 # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
                 if "finish_reason" in api_msg:
                     api_msg.pop("finish_reason")
+                # Strip Codex Responses API fields (call_id, response_item_id) for
+                # strict providers like Mistral that reject unknown fields with 422.
+                # Uses new dicts so the internal messages list retains the fields
+                # for Codex Responses compatibility.
+                if "api.mistral.ai" in self.base_url.lower():
+                    self._sanitize_tool_calls_for_strict_api(api_msg)
                 # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
                 # The signature field helps maintain reasoning continuity
                 api_messages.append(api_msg)


### PR DESCRIPTION
## Summary

Mistral's API strictly validates the Chat Completions schema and rejects unknown fields (`call_id`, `response_item_id`) with 422 "Extra inputs are not permitted". These fields are added by `_build_assistant_message()` for Codex Responses API support but are not part of the Chat Completions spec.

## Approach

Unlike PR #864 which stripped these fields unconditionally (and mutated originals via shallow copy), this fix:

1. **Only strips when targeting Mistral** — checks for `api.mistral.ai` in `self.base_url`
2. **Creates new tool_call dicts** via dict comprehension instead of `tc.pop()` — avoids mutating the shared objects from `msg.copy()` (shallow copy)
3. **Preserves fields in internal message history** — so `_chat_messages_to_responses_input()` can still read `call_id`/`response_item_id` if the session falls back to a Codex provider mid-conversation

## Changes

- Added `_sanitize_tool_calls_for_strict_api()` static method that builds new tool_call dicts without the Codex-specific fields
- Applied in all 3 API message building locations:
  - Main conversation loop (`run_conversation`)
  - `_handle_max_iterations()`
  - `flush_memories()`

## Why not merge PR #864

PR #864 had several issues:
- Ran an autoformatter on the entire 5000-line `run_agent.py` (+1526/-758 lines of noise)
- Reverted the centralized provider router from PR #1003 (merge conflict resolution against stale branch)
- Stripped `call_id`/`response_item_id` unconditionally for ALL providers, not just Mistral
- Used `tc.pop()` on shallow-copied dicts, permanently destroying the fields from internal message history

This PR cherry-picks the valid fix idea with proper scoping.

## Related

- PR #864 by @unmodeled-tyler — identified the issue
- Issue #134 — original Mistral 422 error report
- PR #253 — earlier fix for `finish_reason` stripping

Co-authored-by: unmodeled-tyler <unmodeled.tyler@proton.me>