### PR TITLE
fix: add missing json import at module level in gateway/run.py

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import asyncio
+import json
 import logging
 import os
 import re

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1,5 +1,9 @@
 """Tests for gateway configuration management."""
 
+import ast
+import json
+from pathlib import Path
+
 from gateway.config import (
     GatewayConfig,
     HomeChannel,
@@ -101,3 +105,53 @@ class TestGatewayConfigRoundtrip:
         assert Platform.TELEGRAM in restored.platforms
         assert restored.platforms[Platform.TELEGRAM].token == "tok"
         assert restored.reset_triggers == ["/new"]
+
+
+# =========================================================================
+# Config bridging (gateway/run.py module-level yaml->env bridge)
+# =========================================================================
+
+
+class TestConfigBridgeJsonImport:
+    """json.dumps is called at module level in gateway/run.py for list config
+    values (e.g. docker_volumes). json must be imported at module scope."""
+
+    def test_json_imported_at_module_level(self):
+        run_py = Path(__file__).parent.parent.parent / "gateway" / "run.py"
+        with open(run_py) as f:
+            tree = ast.parse(f.read())
+
+        json_imported = False
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "json":
+                        json_imported = True
+            elif isinstance(node, ast.ImportFrom) and node.module == "json":
+                json_imported = True
+
+        assert json_imported, (
+            "json must be imported at module level in gateway/run.py — "
+            "line 85 calls json.dumps() during config bridging"
+        )
+
+    def test_list_config_value_serialized_to_json(self):
+        terminal_cfg = {"docker_volumes": ["/home:/workspace", "/data:/data"]}
+        env_map = {"docker_volumes": "TERMINAL_DOCKER_VOLUMES"}
+
+        result_env = {}
+        for cfg_key, env_var in env_map.items():
+            if cfg_key in terminal_cfg:
+                val = terminal_cfg[cfg_key]
+                if isinstance(val, list):
+                    result_env[env_var] = json.dumps(val)
+                else:
+                    result_env[env_var] = str(val)
+
+        assert result_env["TERMINAL_DOCKER_VOLUMES"] == json.dumps(
+            ["/home:/workspace", "/data:/data"]
+        )
+        assert json.loads(result_env["TERMINAL_DOCKER_VOLUMES"]) == [
+            "/home:/workspace",
+            "/data:/data",
+        ]


### PR DESCRIPTION
## Summary

- `gateway/run.py` line 85 calls `json.dumps()` during module-level config bridging (terminal config with list values like `docker_volumes`), but `json` was never imported at module scope
- This causes `NameError: name 'json' is not defined` on gateway startup for any user with list-valued terminal config in `config.yaml`

## Reproduction

Add a list value to terminal config in `~/.hermes/config.yaml`:
```yaml
terminal:
  docker_volumes:
    - "/home/user:/workspace"
```
Then import `gateway.run` — crashes immediately with `NameError`.

## Fix

Add `import json` to the module-level imports (line 17).

## Test plan

- [x] AST test verifies `json` is imported at module scope in `gateway/run.py`
- [x] Test verifies list config values are correctly JSON-serialized
- [x] Test fails without the fix, passes with it