### PR TITLE
fix: use getattr instead of dict .get() on GatewayConfig dataclass

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -932,7 +932,7 @@ class GatewayRunner:
         
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
-            quick_commands = self.config.get("quick_commands", {})
+            quick_commands = getattr(self.config, "quick_commands", {})
             if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -67,6 +67,43 @@ class TestGetConnectedPlatforms:
         assert config.get_connected_platforms() == []
 
 
+# =========================================================================
+# Quick commands: GatewayConfig has no .get() method
+# =========================================================================
+
+
+class TestQuickCommandsAccess:
+    """GatewayConfig is a dataclass, not a dict. Accessing quick_commands
+    via config.get() raises AttributeError. The gateway must use getattr()."""
+
+    def test_config_has_no_get_method(self):
+        config = GatewayConfig()
+        assert not hasattr(config, "get"), (
+            "GatewayConfig is a dataclass and should not have a dict-like get()"
+        )
+
+    def test_getattr_returns_default_for_missing_attr(self):
+        config = GatewayConfig()
+        result = getattr(config, "quick_commands", {})
+        assert result == {}
+
+    def test_gateway_uses_getattr_not_dict_get(self):
+        """gateway/run.py must use getattr(self.config, 'quick_commands', {})
+        instead of self.config.get('quick_commands', {})."""
+        import ast
+        from pathlib import Path
+
+        run_py = Path(__file__).parent.parent.parent / "gateway" / "run.py"
+        with open(run_py) as f:
+            source = f.read()
+
+        # Must NOT contain config.get("quick_commands"
+        assert 'self.config.get("quick_commands"' not in source, (
+            "gateway/run.py still uses self.config.get() which crashes — "
+            "GatewayConfig is a dataclass, use getattr() instead"
+        )
+
+
 class TestSessionResetPolicy:
     def test_roundtrip(self):
         policy = SessionResetPolicy(mode="idle", at_hour=6, idle_minutes=120)

--- a/tests/test_quick_commands.py
+++ b/tests/test_quick_commands.py
@@ -93,28 +93,29 @@ class TestGatewayQuickCommands:
         event.source.chat_id = "123"
         return event
 
-    @pytest.mark.asyncio
-    async def test_exec_command_returns_output(self):
+    def _make_runner(self, quick_commands):
+        """Create a GatewayRunner with quick_commands configured via a
+        namespace object that supports getattr (matching real GatewayConfig)."""
+        from types import SimpleNamespace
         from gateway.run import GatewayRunner
         runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = {"quick_commands": {"limits": {"type": "exec", "command": "echo ok"}}}
+        runner.config = SimpleNamespace(quick_commands=quick_commands)
         runner._running_agents = {}
         runner._pending_messages = {}
+        runner._pending_approvals = {}
         runner._is_user_authorized = MagicMock(return_value=True)
+        return runner
 
+    @pytest.mark.asyncio
+    async def test_exec_command_returns_output(self):
+        runner = self._make_runner({"limits": {"type": "exec", "command": "echo ok"}})
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
 
     @pytest.mark.asyncio
     async def test_unsupported_type_returns_error(self):
-        from gateway.run import GatewayRunner
-        runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = {"quick_commands": {"bad": {"type": "prompt", "command": "echo hi"}}}
-        runner._running_agents = {}
-        runner._pending_messages = {}
-        runner._is_user_authorized = MagicMock(return_value=True)
-
+        runner = self._make_runner({"bad": {"type": "prompt", "command": "echo hi"}})
         event = self._make_event("bad")
         result = await runner._handle_message(event)
         assert result is not None
@@ -122,14 +123,8 @@ class TestGatewayQuickCommands:
 
     @pytest.mark.asyncio
     async def test_timeout_returns_error(self):
-        from gateway.run import GatewayRunner
         import asyncio
-        runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = {"quick_commands": {"slow": {"type": "exec", "command": "sleep 100"}}}
-        runner._running_agents = {}
-        runner._pending_messages = {}
-        runner._is_user_authorized = MagicMock(return_value=True)
-
+        runner = self._make_runner({"slow": {"type": "exec", "command": "sleep 100"}})
         event = self._make_event("slow")
         with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
             result = await runner._handle_message(event)


### PR DESCRIPTION
## Summary

- `gateway/run.py` line 935 calls `self.config.get("quick_commands", {})` but `self.config` is a `GatewayConfig` **dataclass**, not a dict — dataclasses have no `.get()` method
- In production, every unrecognized slash command hits this path and raises `AttributeError`, which is silently caught by the outer try/except — preventing skill commands from ever being reached
- Existing tests didn't catch this because they mocked `runner.config` as a raw dict instead of using the real dataclass type

## Reproduction

```python
from gateway.config import GatewayConfig
config = GatewayConfig()
config.get("quick_commands", {})  # AttributeError!
```

## Fix

- Replace `self.config.get(...)` with `getattr(self.config, ..., {})` 
- Fix `TestGatewayQuickCommands` to use `SimpleNamespace` (matching real `GatewayConfig` behavior) instead of a raw dict, and add missing `_pending_approvals` mock

## Test plan

- [x] 3 new tests verify `GatewayConfig` has no `.get()`, `getattr` works, and source uses `getattr`
- [x] Gateway quick command tests updated to reflect real config type
- [x] All 22 config + quick command tests pass