### PR TITLE
fix(test): remove stale build_system_prompt patch from interrupt test

### DIFF
--- a/tests/test_real_interrupt_subagent.py
+++ b/tests/test_real_interrupt_subagent.py
@@ -93,31 +93,29 @@ class TestRealSubagentInterrupt(unittest.TestCase):
                     mock_client.close = MagicMock()
                     MockOpenAI.return_value = mock_client
 
-                    # Also need to patch the system prompt builder
-                    with patch('run_agent.build_system_prompt', return_value="You are a test agent"):
-                        # Signal when child starts
-                        original_run = AIAgent.run_conversation
+                    # Signal when child starts
+                    original_run = AIAgent.run_conversation
 
-                        def patched_run(self_agent, *args, **kwargs):
-                            child_started.set()
-                            return original_run(self_agent, *args, **kwargs)
+                    def patched_run(self_agent, *args, **kwargs):
+                        child_started.set()
+                        return original_run(self_agent, *args, **kwargs)
 
-                        with patch.object(AIAgent, 'run_conversation', patched_run):
-                            result = _run_single_child(
-                                task_index=0,
-                                goal="Test task",
-                                context=None,
-                                toolsets=["terminal"],
-                                model="test/model",
-                                max_iterations=5,
-                                parent_agent=parent,
-                                task_count=1,
-                                override_provider="test",
-                                override_base_url="http://localhost:1",
-                                override_api_key="test",
-                                override_api_mode="chat_completions",
-                            )
-                            result_holder[0] = result
+                    with patch.object(AIAgent, 'run_conversation', patched_run):
+                        result = _run_single_child(
+                            task_index=0,
+                            goal="Test task",
+                            context=None,
+                            toolsets=["terminal"],
+                            model="test/model",
+                            max_iterations=5,
+                            parent_agent=parent,
+                            task_count=1,
+                            override_provider="test",
+                            override_base_url="http://localhost:1",
+                            override_api_key="test",
+                            override_api_mode="chat_completions",
+                        )
+                        result_holder[0] = result
             except Exception as e:
                 import traceback
                 traceback.print_exc()


### PR DESCRIPTION
## Summary

`tests/test_real_interrupt_subagent.py` patches `run_agent.build_system_prompt` which was removed in a prior refactor. System prompt is now handled via `ephemeral_system_prompt` parameter in `AIAgent.__init__`. The stale patch causes `AttributeError` on **every CI run across all PRs**.

## Fix

Remove the unnecessary `with patch('run_agent.build_system_prompt', ...)` wrapper. The test works correctly without it.

## Test plan

- [x] `test_interrupt_child_during_api_call` passes (was failing on every CI run)