### PR TITLE
fix: register web_crawl tool that was never wired to the registry

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -132,7 +132,7 @@ _last_resolved_tool_names: List[str] = []
 # =============================================================================
 
 _LEGACY_TOOLSET_MAP = {
-    "web_tools": ["web_search", "web_extract"],
+    "web_tools": ["web_search", "web_extract", "web_crawl"],
     "terminal_tools": ["terminal"],
     "vision_tools": ["vision_analyze"],
     "moa_tools": ["mixture_of_agents"],

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -28,7 +28,7 @@ class TestGetToolset:
 class TestResolveToolset:
     def test_leaf_toolset(self):
         tools = resolve_toolset("web")
-        assert set(tools) == {"web_search", "web_extract"}
+        assert set(tools) == {"web_search", "web_extract", "web_crawl"}
 
     def test_composite_toolset(self):
         tools = resolve_toolset("debugging")
@@ -92,7 +92,7 @@ class TestGetToolsetInfo:
         info = get_toolset_info("web")
         assert info["name"] == "web"
         assert info["is_composite"] is False
-        assert info["tool_count"] == 2
+        assert info["tool_count"] == 3
 
     def test_composite(self):
         info = get_toolset_info("debugging")

--- a/tests/tools/test_web_crawl.py
+++ b/tests/tools/test_web_crawl.py
@@ -1,0 +1,246 @@
+"""Tests for web_crawl tool registration and schema."""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+import json
+
+
+class TestWebCrawlRegistration:
+    """Verify web_crawl is properly registered in the tool system."""
+
+    def test_tool_registered_in_registry(self):
+        from tools.registry import registry
+        from tools import web_tools  # noqa: F401
+        assert "web_crawl" in registry._tools
+
+    def test_tool_metadata(self):
+        from tools.registry import registry
+        from tools import web_tools  # noqa: F401
+        tool = registry._tools["web_crawl"]
+        assert tool.toolset == "web"
+        assert tool.is_async is True
+        assert "FIRECRAWL_API_KEY" in tool.requires_env
+
+    def test_tool_schema_has_required_fields(self):
+        from tools.web_tools import WEB_CRAWL_SCHEMA
+        assert WEB_CRAWL_SCHEMA["name"] == "web_crawl"
+        assert "url" in WEB_CRAWL_SCHEMA["parameters"]["properties"]
+        assert "url" in WEB_CRAWL_SCHEMA["parameters"]["required"]
+
+    def test_tool_schema_optional_fields(self):
+        from tools.web_tools import WEB_CRAWL_SCHEMA
+        props = WEB_CRAWL_SCHEMA["parameters"]["properties"]
+        assert "instructions" in props
+        assert "depth" in props
+        assert props["depth"]["enum"] == ["basic", "advanced"]
+
+
+class TestWebCrawlInToolset:
+    """Verify web_crawl is included in the web toolset."""
+
+    def test_web_toolset_includes_crawl(self):
+        from toolsets import TOOLSETS
+        assert "web_crawl" in TOOLSETS["web"]["tools"]
+
+    def test_legacy_map_includes_crawl(self):
+        from model_tools import _LEGACY_TOOLSET_MAP
+        assert "web_crawl" in _LEGACY_TOOLSET_MAP["web_tools"]
+
+
+def _make_mock_page(markdown, source_url, title, status_code=200):
+    """Helper: create a mock Firecrawl Document with model_dump support."""
+    page = MagicMock()
+    page.model_dump.return_value = {
+        "markdown": markdown,
+        "metadata": {
+            "sourceURL": source_url,
+            "title": title,
+            "statusCode": status_code,
+        },
+    }
+    return page
+
+
+def _make_crawl_result(pages, status="completed"):
+    """Helper: create a mock CrawlJob object."""
+    crawl = MagicMock()
+    crawl.data = pages
+    crawl.status = status
+    return crawl
+
+
+class TestWebCrawlHandler:
+    """Test the crawl handler dispatches correctly."""
+
+    @pytest.mark.asyncio
+    async def test_crawl_adds_https_prefix(self):
+        """URL without protocol should get https:// prepended."""
+        with patch("tools.web_tools._get_firecrawl_client") as mock_client:
+            mock_client.return_value.crawl.return_value = _make_crawl_result([])
+
+            from tools.web_tools import web_crawl_tool
+            await web_crawl_tool("example.com", use_llm_processing=False)
+
+            call_kwargs = mock_client.return_value.crawl.call_args[1]
+            assert call_kwargs["url"] == "https://example.com"
+
+    @pytest.mark.asyncio
+    async def test_crawl_preserves_http_prefix(self):
+        """URL with http:// should NOT be changed to https://."""
+        with patch("tools.web_tools._get_firecrawl_client") as mock_client:
+            mock_client.return_value.crawl.return_value = _make_crawl_result([])
+
+            from tools.web_tools import web_crawl_tool
+            await web_crawl_tool("http://example.com", use_llm_processing=False)
+
+            call_kwargs = mock_client.return_value.crawl.call_args[1]
+            assert call_kwargs["url"] == "http://example.com"
+
+    @pytest.mark.asyncio
+    async def test_crawl_params_passed_to_firecrawl(self):
+        """Firecrawl client should receive limit=20 and markdown format."""
+        with patch("tools.web_tools._get_firecrawl_client") as mock_client:
+            mock_client.return_value.crawl.return_value = _make_crawl_result([])
+
+            from tools.web_tools import web_crawl_tool
+            await web_crawl_tool("https://example.com", use_llm_processing=False)
+
+            call_kwargs = mock_client.return_value.crawl.call_args[1]
+            assert call_kwargs["limit"] == 20
+            assert call_kwargs["scrape_options"]["formats"] == ["markdown"]
+
+    @pytest.mark.asyncio
+    async def test_crawl_returns_trimmed_fields(self):
+        """Response should only contain title, content, error per page (url stripped)."""
+        page = _make_mock_page("# Hello", "https://example.com/page1", "Hello Page")
+        with patch("tools.web_tools._get_firecrawl_client") as mock_client:
+            mock_client.return_value.crawl.return_value = _make_crawl_result([page])
+
+            from tools.web_tools import web_crawl_tool
+            result = await web_crawl_tool("https://example.com", use_llm_processing=False)
+            data = json.loads(result)
+
+            entry = data["results"][0]
+            assert set(entry.keys()) == {"title", "content", "error"}
+            assert entry["title"] == "Hello Page"
+            assert entry["content"] == "# Hello"
+
+    @pytest.mark.asyncio
+    async def test_crawl_multiple_pages(self):
+        """Multiple crawled pages should all appear in results."""
+        pages = [
+            _make_mock_page("Page 1 content", "https://a.com/1", "Page 1"),
+            _make_mock_page("Page 2 content", "https://a.com/2", "Page 2"),
+            _make_mock_page("Page 3 content", "https://a.com/3", "Page 3"),
+        ]
+        with patch("tools.web_tools._get_firecrawl_client") as mock_client:
+            mock_client.return_value.crawl.return_value = _make_crawl_result(pages)
+
+            from tools.web_tools import web_crawl_tool
+            result = await web_crawl_tool("https://a.com", use_llm_processing=False)
+            data = json.loads(result)
+
+            assert len(data["results"]) == 3
+            titles = [r["title"] for r in data["results"]]
+            assert titles == ["Page 1", "Page 2", "Page 3"]
+
+    @pytest.mark.asyncio
+    async def test_crawl_empty_results(self):
+        """Crawl with no pages should return empty results list."""
+        with patch("tools.web_tools._get_firecrawl_client") as mock_client:
+            mock_client.return_value.crawl.return_value = _make_crawl_result([])
+
+            from tools.web_tools import web_crawl_tool
+            result = await web_crawl_tool("https://example.com", use_llm_processing=False)
+            data = json.loads(result)
+
+            assert data["results"] == []
+
+    @pytest.mark.asyncio
+    async def test_crawl_dict_item_type(self):
+        """Items returned as plain dicts (not Pydantic models) should work."""
+        dict_item = {
+            "markdown": "# Dict Page",
+            "metadata": {
+                "sourceURL": "https://example.com/dict",
+                "title": "Dict Title",
+            },
+        }
+        mock_crawl = MagicMock()
+        # data returns dicts, not objects with model_dump
+        mock_crawl.data = [dict_item]
+        mock_crawl.status = "completed"
+
+        with patch("tools.web_tools._get_firecrawl_client") as mock_client:
+            mock_client.return_value.crawl.return_value = mock_crawl
+
+            from tools.web_tools import web_crawl_tool
+            result = await web_crawl_tool("https://example.com", use_llm_processing=False)
+            data = json.loads(result)
+
+            assert len(data["results"]) == 1
+            assert data["results"][0]["title"] == "Dict Title"
+            assert data["results"][0]["content"] == "# Dict Page"
+
+    @pytest.mark.asyncio
+    async def test_crawl_strips_base64_images(self):
+        """Base64 encoded images in content should be replaced with placeholders."""
+        markdown_with_b64 = (
+            "# Page\n"
+            "![img](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEA"
+            "AAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJ"
+            "RU5ErkJggg==)\n"
+            "Some text after"
+        )
+        page = _make_mock_page(markdown_with_b64, "https://example.com", "B64 Test")
+        with patch("tools.web_tools._get_firecrawl_client") as mock_client:
+            mock_client.return_value.crawl.return_value = _make_crawl_result([page])
+
+            from tools.web_tools import web_crawl_tool
+            result = await web_crawl_tool("https://example.com", use_llm_processing=False)
+
+            # The raw base64 string should NOT be in the output
+            assert "iVBORw0KGgo" not in result
+            # But the surrounding text should remain
+            assert "Some text after" in result
+
+    @pytest.mark.asyncio
+    async def test_crawl_error_returns_error_json(self):
+        """Exception from Firecrawl should return error JSON, not raise."""
+        with patch("tools.web_tools._get_firecrawl_client", side_effect=Exception("Connection refused")):
+            from tools.web_tools import web_crawl_tool
+            result = await web_crawl_tool("https://example.com")
+            data = json.loads(result)
+
+            assert "error" in data
+            assert "Connection refused" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_crawl_interrupted_returns_early(self):
+        """If interrupted before crawl starts, return immediately."""
+        with patch("tools.interrupt.is_interrupted", return_value=True):
+            from tools.web_tools import web_crawl_tool
+            result = await web_crawl_tool("https://example.com")
+            data = json.loads(result)
+
+            assert data["success"] is False
+            assert "Interrupted" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_crawl_with_llm_processing(self):
+        """When use_llm_processing=True (default), process_content_with_llm is called per page."""
+        page = _make_mock_page(
+            "x" * 6000,  # content longer than default min_length
+            "https://example.com/long",
+            "Long Page",
+        )
+        with patch("tools.web_tools._get_firecrawl_client") as mock_client, \
+             patch("tools.web_tools.process_content_with_llm", new_callable=AsyncMock) as mock_llm:
+            mock_client.return_value.crawl.return_value = _make_crawl_result([page])
+            mock_llm.return_value = "## Summarized content"
+
+            from tools.web_tools import web_crawl_tool
+            result = await web_crawl_tool("https://example.com", use_llm_processing=True)
+            data = json.loads(result)
+
+            mock_llm.assert_called_once()
+            assert data["results"][0]["content"] == "## Summarized content"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1251,6 +1251,35 @@ WEB_EXTRACT_SCHEMA = {
     }
 }
 
+WEB_CRAWL_SCHEMA = {
+    "name": "web_crawl",
+    "description": (
+        "Crawl an entire website starting from a URL. Discovers pages via sitemaps and links, "
+        "then returns their content as markdown. Use this when you need information spread across "
+        "multiple pages of a site (e.g. documentation, blog archives). "
+        "Returns up to 20 pages by default. For single pages, use web_extract instead."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "The starting URL to crawl (e.g. 'docs.example.com' or 'https://example.com/docs')"
+            },
+            "instructions": {
+                "type": "string",
+                "description": "Optional instructions for what to focus on during crawling"
+            },
+            "depth": {
+                "type": "string",
+                "enum": ["basic", "advanced"],
+                "description": "Crawl depth: 'basic' (default, up to 20 pages) or 'advanced' (deeper crawl)"
+            }
+        },
+        "required": ["url"]
+    }
+}
+
 registry.register(
     name="web_search",
     toolset="web",
@@ -1265,6 +1294,19 @@ registry.register(
     schema=WEB_EXTRACT_SCHEMA,
     handler=lambda args, **kw: web_extract_tool(
         args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
+    check_fn=check_firecrawl_api_key,
+    requires_env=["FIRECRAWL_API_KEY"],
+    is_async=True,
+)
+registry.register(
+    name="web_crawl",
+    toolset="web",
+    schema=WEB_CRAWL_SCHEMA,
+    handler=lambda args, **kw: web_crawl_tool(
+        args.get("url", ""),
+        instructions=args.get("instructions"),
+        depth=args.get("depth", "basic"),
+    ),
     check_fn=check_firecrawl_api_key,
     requires_env=["FIRECRAWL_API_KEY"],
     is_async=True,

--- a/toolsets.py
+++ b/toolsets.py
@@ -72,8 +72,8 @@ _HERMES_CORE_TOOLS = [
 TOOLSETS = {
     # Basic toolsets - individual tool categories
     "web": {
-        "description": "Web research and content extraction tools",
-        "tools": ["web_search", "web_extract"],
+        "description": "Web research, content extraction, and site crawling tools",
+        "tools": ["web_search", "web_extract", "web_crawl"],
         "includes": []  # No other toolsets included
     },
     


### PR DESCRIPTION
## Summary
- The `web_crawl_tool` function (~280 lines) existed in `tools/web_tools.py` but was never registered via `registry.register()`, so the agent could not discover or use it.
- Added `WEB_CRAWL_SCHEMA` and `registry.register()` call for `web_crawl`
- Added `web_crawl` to `TOOLSETS["web"]` in `toolsets.py` and `_LEGACY_TOOLSET_MAP` in `model_tools.py`
- Added 17 tests covering registration, schema validation, URL handling, crawl params, response trimming, multi-page results, dict item types, base64 image cleanup, error handling, interrupt, and LLM processing

## Test plan
- [x] 17 unit tests pass (`pytest tests/tools/test_web_crawl.py`)
- [x] Tool appears in `get_tool_definitions(enabled_toolsets=["web"])` output
- [x] Verified real crawl against `docs.firecrawl.dev` — 20 pages returned with markdown content