### PR TITLE
fix: add metadata param to base send_image/send_animation

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -428,10 +428,11 @@ class BasePlatformAdapter(ABC):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """
         Send an image natively via the platform API.
-        
+
         Override in subclasses to send images as proper attachments
         instead of plain-text URLs. Default falls back to sending the
         URL as a text message.
@@ -439,22 +440,23 @@ class BasePlatformAdapter(ABC):
         # Fallback: send URL as text (subclasses override for native images)
         text = f"{caption}\n{image_url}" if caption else image_url
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
-    
+
     async def send_animation(
         self,
         chat_id: str,
         animation_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """
         Send an animated GIF natively via the platform API.
-        
+
         Override in subclasses to send GIFs as proper animations
         (e.g., Telegram send_animation) so they auto-play inline.
         Default falls back to send_image.
         """
-        return await self.send_image(chat_id=chat_id, image_url=animation_url, caption=caption, reply_to=reply_to)
+        return await self.send_image(chat_id=chat_id, image_url=animation_url, caption=caption, reply_to=reply_to, metadata=metadata)
     
     @staticmethod
     def _is_animation_url(url: str) -> bool:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -3,10 +3,13 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    SendResult,
 )
 
 
@@ -368,3 +371,68 @@ class TestGetHumanDelay:
         with patch.dict(os.environ, env):
             delay = BasePlatformAdapter._get_human_delay()
             assert 0.1 <= delay <= 0.2
+
+
+# ---------------------------------------------------------------------------
+# send_image / send_animation — metadata kwarg acceptance
+# ---------------------------------------------------------------------------
+
+
+class TestSendImageMetadataKwarg:
+    """Bug: base.py _send_response_parts calls send_image(metadata=...) and
+    send_animation(metadata=...) but the base class signatures don't accept
+    a ``metadata`` parameter.  Any platform that falls back to the default
+    implementation (Discord, Slack, WhatsApp, Email) gets a TypeError."""
+
+    def _adapter(self):
+        class StubAdapter(BasePlatformAdapter):
+            async def connect(self): return True
+            async def disconnect(self): pass
+            async def send(self, *a, **kw):
+                return SendResult(success=True, message_id="1")
+            async def get_chat_info(self, *a): return {}
+
+        from gateway.config import Platform, PlatformConfig
+        config = PlatformConfig(enabled=True, token="test")
+        return StubAdapter(config=config, platform=Platform.DISCORD)
+
+    @pytest.mark.asyncio
+    async def test_send_image_accepts_metadata_kwarg(self):
+        adapter = self._adapter()
+        result = await adapter.send_image(
+            chat_id="123",
+            image_url="https://example.com/img.png",
+            caption="test",
+            metadata={"thread_id": "456"},
+        )
+        assert result.success
+
+    @pytest.mark.asyncio
+    async def test_send_animation_accepts_metadata_kwarg(self):
+        adapter = self._adapter()
+        result = await adapter.send_animation(
+            chat_id="123",
+            animation_url="https://example.com/anim.gif",
+            caption="test",
+            metadata={"thread_id": "456"},
+        )
+        assert result.success
+
+    @pytest.mark.asyncio
+    async def test_send_image_works_without_metadata(self):
+        """Existing callers that don't pass metadata must still work."""
+        adapter = self._adapter()
+        result = await adapter.send_image(
+            chat_id="123",
+            image_url="https://example.com/img.png",
+        )
+        assert result.success
+
+    @pytest.mark.asyncio
+    async def test_send_animation_works_without_metadata(self):
+        adapter = self._adapter()
+        result = await adapter.send_animation(
+            chat_id="123",
+            animation_url="https://example.com/anim.gif",
+        )
+        assert result.success


### PR DESCRIPTION
## Summary
- `_send_response_parts()` in `base.py` calls `send_image(metadata=...)` and `send_animation(metadata=...)` to pass thread context (e.g. Telegram topic thread IDs)
- The base class signatures for these methods don't accept a `metadata` parameter
- Any platform that doesn't override them (Discord, Slack, WhatsApp, Email) crashes with `TypeError: send_image() got an unexpected keyword argument 'metadata'`
- Adds `metadata: Optional[Dict[str, Any]] = None` to both base class method signatures
- `send_animation` base impl forwards `metadata` to `send_image` for consistency

## Test plan
- [x] `test_send_image_accepts_metadata_kwarg` — proves the bug (TypeError before fix)
- [x] `test_send_animation_accepts_metadata_kwarg` — proves the bug for animations
- [x] `test_send_image_works_without_metadata` — backwards compatibility
- [x] `test_send_animation_works_without_metadata` — backwards compatibility
- [x] All 53 tests in `test_platform_base.py` pass