### PR TITLE
fix: escape parens/braces in fork bomb regex pattern

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -401,3 +401,20 @@ class TestViewFullCommand:
         # After first 'v', is_truncated becomes False, so second 'v' -> deny
         assert result == "deny"
 
+
+class TestForkBombDetection:
+    """The fork bomb regex must match the classic :(){ :|:& };: pattern."""
+
+    def test_classic_fork_bomb(self):
+        dangerous, key, desc = detect_dangerous_command(":(){ :|:& };:")
+        assert dangerous is True, "classic fork bomb not detected"
+        assert "fork bomb" in desc.lower()
+
+    def test_fork_bomb_with_spaces(self):
+        dangerous, key, desc = detect_dangerous_command(":()  {  : | :&  } ; :")
+        assert dangerous is True, "fork bomb with extra spaces not detected"
+
+    def test_colon_in_safe_command_not_flagged(self):
+        dangerous, key, desc = detect_dangerous_command("echo hello:world")
+        assert dangerous is False
+

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -38,7 +38,7 @@ DANGEROUS_PATTERNS = [
     (r'\bsystemctl\s+(stop|disable|mask)\b', "stop/disable system service"),
     (r'\bkill\s+-9\s+-1\b', "kill all processes"),
     (r'\bpkill\s+-9\b', "force kill processes"),
-    (r':()\s*{\s*:\s*\|\s*:&\s*}\s*;:', "fork bomb"),
+    (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
     (r'\b(bash|sh|zsh)\s+-c\s+', "shell command via -c flag"),
     (r'\b(python[23]?|perl|ruby|node)\s+-[ec]\s+', "script execution via -e/-c flag"),
     (r'\b(curl|wget)\b.*\|\s*(ba)?sh\b', "pipe remote content to shell"),


### PR DESCRIPTION
## Summary
- The fork bomb regex `:()\s*{\s*:\s*\|\s*:&\s*}\s*;:` uses `()` as an empty capture group and unescaped `{}`, so it never matches the classic fork bomb `:(){ :|:& };:`
- Fixed to `:\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:` with properly escaped literal characters
- Also added flexible `\s*` spacing between `:` and `&`, and between `;` and trailing `:`

## Test plan
- [x] `test_classic_fork_bomb` — proves the bug (`:(){ :|:& };:` not detected before fix)
- [x] `test_fork_bomb_with_spaces` — whitespace variant also caught
- [x] `test_colon_in_safe_command_not_flagged` — no false positives
- [x] All 63 tests in `test_approval.py` pass (zero regressions)