### PR TITLE
fix: handle dict tool call arguments from llama.cpp/Ollama backends

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4276,6 +4276,10 @@ class AIAgent:
                     invalid_json_args = []
                     for tc in assistant_message.tool_calls:
                         args = tc.function.arguments
+                        # Handle dict/list returned by some backends (llama.cpp, Ollama)
+                        if isinstance(args, (dict, list)):
+                            tc.function.arguments = json.dumps(args)
+                            continue
                         # Treat empty/whitespace strings as empty object
                         if not args or not args.strip():
                             tc.function.arguments = "{}"


### PR DESCRIPTION
This PR adds an `isinstance(args, (dict, list))` check to normalize to JSON string before the `.strip()` call — matching the existing pattern already used for `assistant_message.content` at line ~4114.

## Related Issue

Fixes #1071

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: Added `isinstance(args, (dict, list))` guard before `.strip()` call (~line 4278)

## How to Test

1. Start `llama-server` with a tool-calling model (e.g. Qwen)
2. Configure hermes to use `http://localhost:8080/v1` as OpenAI-compatible backend
3. Give the agent a task that triggers tool calls
4. Confirm no `AttributeError: 'dict' object has no attribute 'strip'`

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit follows Conventional Commits
- [x] No duplicate PRs
- [x] Only changes related to this fix
- [x] Tested on Ubuntu 24.04 / WSL2 — N/A (reported fix, verified locally)