### PR TITLE
fix: guard RotatingFileHandler to prevent leak on repeated AIAgent init

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -355,19 +355,26 @@ class AIAgent:
 
         # Persistent error log -- always writes WARNING+ to ~/.hermes/logs/errors.log
         # so tool failures, API errors, etc. are inspectable after the fact.
-        from agent.redact import RedactingFormatter
-        _error_log_dir = Path.home() / ".hermes" / "logs"
-        _error_log_dir.mkdir(parents=True, exist_ok=True)
-        _error_log_path = _error_log_dir / "errors.log"
+        # Guard: only add the handler once (delegate children create new AIAgent
+        # instances, which would otherwise leak duplicate handlers).
         from logging.handlers import RotatingFileHandler
-        _error_file_handler = RotatingFileHandler(
-            _error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,
+        _root = logging.getLogger()
+        _has_error_handler = any(
+            isinstance(h, RotatingFileHandler) for h in _root.handlers
         )
-        _error_file_handler.setLevel(logging.WARNING)
-        _error_file_handler.setFormatter(RedactingFormatter(
-            '%(asctime)s %(levelname)s %(name)s: %(message)s',
-        ))
-        logging.getLogger().addHandler(_error_file_handler)
+        if not _has_error_handler:
+            from agent.redact import RedactingFormatter
+            _error_log_dir = Path.home() / ".hermes" / "logs"
+            _error_log_dir.mkdir(parents=True, exist_ok=True)
+            _error_log_path = _error_log_dir / "errors.log"
+            _error_file_handler = RotatingFileHandler(
+                _error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,
+            )
+            _error_file_handler.setLevel(logging.WARNING)
+            _error_file_handler.setFormatter(RedactingFormatter(
+                '%(asctime)s %(levelname)s %(name)s: %(message)s',
+            ))
+            _root.addHandler(_error_file_handler)
 
         if self.verbose_logging:
             logging.basicConfig(

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1363,3 +1363,41 @@ class TestSafeWriter:
         # Still just one layer
         wrapped.write("test")
         assert inner.getvalue() == "test"
+
+
+# ---------------------------------------------------------------------------
+# RotatingFileHandler leak — Bug F
+# ---------------------------------------------------------------------------
+
+
+class TestRotatingFileHandlerLeak:
+    """Each AIAgent() adds a RotatingFileHandler to the root logger.
+    Creating multiple agents (e.g. delegate children) leaks handlers."""
+
+    def test_multiple_agents_do_not_duplicate_file_handlers(self):
+        import logging
+        from logging.handlers import RotatingFileHandler
+
+        root = logging.getLogger()
+        # Count existing RotatingFileHandlers before creating agents
+        before = sum(1 for h in root.handlers if isinstance(h, RotatingFileHandler))
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            for _ in range(3):
+                AIAgent(
+                    api_key="test-key-1234567890",
+                    quiet_mode=True,
+                    skip_context_files=True,
+                    skip_memory=True,
+                )
+
+        after = sum(1 for h in root.handlers if isinstance(h, RotatingFileHandler))
+        added = after - before
+        assert added <= 1, (
+            f"Creating 3 agents added {added} RotatingFileHandlers "
+            f"(expected at most 1)"
+        )


### PR DESCRIPTION
## Summary
- Each `AIAgent.__init__` unconditionally adds a `RotatingFileHandler` to the root logger
- Delegate children create new `AIAgent` instances, so each delegation leaks another handler
- Over time the root logger accumulates duplicate handlers, writing every log line N times
- Added an `isinstance` guard to only attach the handler if one doesn't already exist
- Safe in both CLI mode (first agent adds, children skip) and gateway mode (gateway already adds its own handler to the same file)

## Test plan
- [x] `test_multiple_agents_do_not_duplicate_file_handlers` — creates 3 agents, asserts at most 1 handler added (was 3 before fix)
- [x] All 107 tests in `test_run_agent.py` pass (zero regressions)