### PR TITLE
fix: add browser_console to browser toolset and core tools list

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -142,7 +142,7 @@ _LEGACY_TOOLSET_MAP = {
         "browser_navigate", "browser_snapshot", "browser_click",
         "browser_type", "browser_scroll", "browser_back",
         "browser_press", "browser_close", "browser_get_images",
-        "browser_vision"
+        "browser_vision", "browser_console"
     ],
     "cronjob_tools": ["schedule_cronjob", "list_cronjobs", "remove_cronjob"],
     "rl_tools": [

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -117,6 +117,27 @@ class TestBrowserConsoleSchema:
         assert props["clear"]["type"] == "boolean"
 
 
+class TestBrowserConsoleToolsetWiring:
+    """browser_console must be reachable via toolset resolution."""
+
+    def test_in_browser_toolset(self):
+        from toolsets import TOOLSETS
+        assert "browser_console" in TOOLSETS["browser"]["tools"]
+
+    def test_in_hermes_core_tools(self):
+        from toolsets import _HERMES_CORE_TOOLS
+        assert "browser_console" in _HERMES_CORE_TOOLS
+
+    def test_in_legacy_toolset_map(self):
+        from model_tools import _LEGACY_TOOLSET_MAP
+        assert "browser_console" in _LEGACY_TOOLSET_MAP["browser_tools"]
+
+    def test_in_registry(self):
+        from tools.registry import registry
+        from tools import browser_tool  # noqa: F401
+        assert "browser_console" in registry._tools
+
+
 # ── browser_vision annotate ──────────────────────────────────────────
 
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -45,7 +45,7 @@ _HERMES_CORE_TOOLS = [
     "browser_navigate", "browser_snapshot", "browser_click",
     "browser_type", "browser_scroll", "browser_back",
     "browser_press", "browser_close", "browser_get_images",
-    "browser_vision",
+    "browser_vision", "browser_console",
     # Text-to-speech
     "text_to_speech",
     # Planning & memory
@@ -119,7 +119,7 @@ TOOLSETS = {
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_close", "browser_get_images",
-            "browser_vision", "web_search"
+            "browser_vision", "browser_console", "web_search"
         ],
         "includes": []
     },


### PR DESCRIPTION
## Summary
- `browser_console` was registered in the tool registry (`tools/browser_tool.py:1906`) but missing from all toolset definitions, so the agent could never discover or use it
- Added `browser_console` to `TOOLSETS["browser"]`, `_HERMES_CORE_TOOLS`, and `_LEGACY_TOOLSET_MAP["browser_tools"]`
- Added 4 wiring tests verifying the tool is present in all required locations

## Test plan
- [x] 25 existing + new browser_console tests pass
- [x] Verified `browser_console` now appears in `get_tool_definitions(enabled_toolsets=["browser"])` output (was missing before)