### PR TITLE
fix(security): harden terminal safety and sandbox file writes

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -41,6 +41,20 @@ class TestDetectDangerousSudo:
         assert key is not None
         assert "pipe" in desc.lower() or "shell" in desc.lower()
 
+    def test_shell_via_lc_flag(self):
+        """bash -lc should be treated as dangerous just like bash -c."""
+        is_dangerous, key, desc = detect_dangerous_command("bash -lc 'echo pwned'")
+        assert is_dangerous is True
+        assert key is not None
+        assert "shell" in desc.lower() or "-lc" in desc
+
+    def test_shell_via_lc_with_newline(self):
+        """Multi-line bash -lc invocations must still be detected."""
+        cmd = "bash -lc \\\n'echo pwned'"
+        is_dangerous, key, desc = detect_dangerous_command(cmd)
+        assert is_dangerous is True
+        assert key is not None
+
 
 class TestDetectSqlPatterns:
     def test_drop_table(self):

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -1,0 +1,54 @@
+"""Tests for file write safety and HERMES_WRITE_SAFE_ROOT sandboxing."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tools.file_operations import _is_write_denied
+
+
+class TestStaticDenyList:
+    """Basic sanity checks for the static write deny list."""
+
+    def test_temp_file_not_denied_by_default(self, tmp_path: Path):
+        target = tmp_path / "regular.txt"
+        # By default, arbitrary temp files should not be denied by the static list.
+        assert _is_write_denied(str(target)) is False
+
+
+class TestSafeWriteRoot:
+    """HERMES_WRITE_SAFE_ROOT should sandbox writes to a specific subtree."""
+
+    def test_writes_inside_safe_root_are_allowed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        safe_root = tmp_path / "workspace"
+        child = safe_root / "subdir" / "file.txt"
+
+        # Simulate a workspace directory
+        os.makedirs(child.parent, exist_ok=True)
+
+        # Point safe root at the workspace
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        # Writes inside the safe root (including nested dirs) are allowed
+        assert _is_write_denied(str(child)) is False
+
+    def test_writes_outside_safe_root_are_denied(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        safe_root = tmp_path / "workspace"
+        outside = tmp_path / "other" / "file.txt"
+
+        os.makedirs(safe_root, exist_ok=True)
+        os.makedirs(outside.parent, exist_ok=True)
+
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        # Any path outside the configured safe root must be denied
+        assert _is_write_denied(str(outside)) is True
+
+    def test_safe_root_env_ignores_empty_value(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        target = tmp_path / "regular.txt"
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", "")
+
+        # Empty env var should behave as if the feature is disabled
+        assert _is_write_denied(str(target)) is False
+

--- a/tests/tools/test_yolo_mode.py
+++ b/tests/tools/test_yolo_mode.py
@@ -45,6 +45,7 @@ class TestYoloMode:
         dangerous_commands = [
             "rm -rf /",
             "chmod 777 /etc/passwd",
+            "bash -lc 'echo pwned'",
             "mkfs.ext4 /dev/sda1",
             "dd if=/dev/zero of=/dev/sda",
             "DROP TABLE users",

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -39,7 +39,10 @@ DANGEROUS_PATTERNS = [
     (r'\bkill\s+-9\s+-1\b', "kill all processes"),
     (r'\bpkill\s+-9\b', "force kill processes"),
     (r':()\s*{\s*:\s*\|\s*:&\s*}\s*;:', "fork bomb"),
-    (r'\b(bash|sh|zsh)\s+-c\s+', "shell command via -c flag"),
+    # Any shell invocation that executes an inline command string via -c or -lc
+    # (including common variants like `bash -lc 'cmd'`) is treated as dangerous
+    # because it often wraps complex one-liners and remote payloads.
+    (r'\b(bash|sh|zsh|ksh)\s+-[^\s]*c(\s+|$)', "shell command via -c/-lc flag"),
     (r'\b(python[23]?|perl|ruby|node)\s+-[ec]\s+', "script execution via -e/-c flag"),
     (r'\b(curl|wget)\b.*\|\s*(ba)?sh\b', "pipe remote content to shell"),
     (r'\b(bash|sh|zsh|ksh)\s+<\s*<?\s*\(\s*(curl|wget)\b', "execute remote script via process substitution"),

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -75,14 +75,50 @@ WRITE_DENIED_PREFIXES = [
 ]
 
 
+def _get_safe_write_root() -> Optional[str]:
+    """
+    Return the optional safety root for writes.
+
+    When HERMES_WRITE_SAFE_ROOT is set, all write/patch operations are
+    constrained to that directory tree. Any attempt to write outside this
+    root is denied, even if the target path is not on the static deny list.
+
+    This is opt-in hardening for users who want to sandbox the agent's file
+    writes to a specific workspace directory (e.g., a project checkout).
+    """
+    root = os.getenv("HERMES_WRITE_SAFE_ROOT") or ""
+    if not root:
+        return None
+    try:
+        return os.path.realpath(os.path.expanduser(root))
+    except Exception:
+        return None
+
+
 def _is_write_denied(path: str) -> bool:
     """Return True if path is on the write deny list."""
     resolved = os.path.realpath(os.path.expanduser(path))
+
+    # 1) Static deny list: high‑value credential and system files/directories
     if resolved in WRITE_DENIED_PATHS:
         return True
     for prefix in WRITE_DENIED_PREFIXES:
         if resolved.startswith(prefix):
             return True
+
+    # 2) Optional safety root: sandbox writes to a configured subtree.
+    #
+    # When HERMES_WRITE_SAFE_ROOT is set, any write outside that directory
+    # tree is denied. This is especially useful for messaging/gateway
+    # deployments where you want to ensure the agent only touches a checkout
+    # directory and never the rest of the filesystem.
+    safe_root = _get_safe_write_root()
+    if safe_root:
+        # Allow writes to the root itself and any descendants; everything
+        # else is rejected.
+        if not (resolved == safe_root or resolved.startswith(safe_root + os.sep)):
+            return True
+
     return False
 
 


### PR DESCRIPTION
## What does this PR do?

This PR hardens Hermes Agent’s terminal and filesystem safety in two ways:

1. **Dangerous command detection**: expands the approval system to treat all `bash|sh|zsh|ksh -...c` invocations (including `bash -lc`) as dangerous inline shell execution, closing common RCE patterns that were not previously caught explicitly.  
2. **File write sandboxing**: adds an optional `HERMES_WRITE_SAFE_ROOT` guard that constrains all `write_file`/`patch` operations to a configured directory tree, denying writes outside that subtree even if they are not on the static deny list. This gives operators a simple way to sandbox file writes to a workspace checkout, especially in gateway/messaging deployments.

This approach builds on the existing approval and write‑deny mechanisms, keeps behavior backwards‑compatible by default (safe root is opt‑in), and adds tests to prevent regressions.

## Related Issue

Fixes #  <!-- optional: put issue number here if you create one -->

## Type of Change

<!-- Check the ones that apply. -->

- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- **`tools/approval.py`**
  - Generalized the dangerous shell pattern to treat any `bash|sh|zsh|ksh -[... ]c` invocation (including `bash -lc`) as “shell command via -c/-lc flag”.

- **`tools/file_operations.py`**
  - Introduced `_get_safe_write_root()` helper that resolves `HERMES_WRITE_SAFE_ROOT`.
  - Extended `_is_write_denied()` to:
    - First apply the existing static deny list and prefixes.
    - Then, when `HERMES_WRITE_SAFE_ROOT` is set, deny any write/patch whose resolved path is **outside** the configured safe root subtree.

- **`tests/tools/test_approval.py`**
  - Added regression tests for:
    - `bash -lc 'echo pwned'` being detected as dangerous.
    - A multiline `bash -lc` command still being caught by the detector.

- **`tests/tools/test_yolo_mode.py`**
  - Extended YOLO‑mode tests to include `bash -lc 'echo pwned'` in the list of dangerous commands, ensuring `HERMES_YOLO_MODE` consistently bypasses all dangerous patterns (including the new one) as designed.

- **`tests/tools/test_file_write_safety.py`** (new)
  - Added tests for write safety:
    - Verifies that arbitrary temp files are not denied by the static deny list by default.
    - Verifies that, when `HERMES_WRITE_SAFE_ROOT` is set, writes **inside** the safe root are allowed and writes **outside** are denied.
    - Verifies that an empty `HERMES_WRITE_SAFE_ROOT` behaves as “feature disabled”.

## How to Test

1. **Run targeted tests** (after activating your virtualenv):

   pytest tests/tools/test_approval.py tests/tools/test_yolo_mode.py tests/tools/test_file_write_safety.py -q
   