### PR TITLE
feat: add website blocklist enforcement for web/browser tools

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -208,6 +208,14 @@ def load_cli_config() -> Dict[str, Any]:
             "show_reasoning": False,
             "skin": "default",
         },
+        "security": {
+            "redact_secrets": True,
+            "website_blocklist": {
+                "enabled": True,
+                "domains": [],
+                "shared_files": [],
+            },
+        },
         "clarify": {
             "timeout": 120,  # Seconds to wait for a clarify answer before auto-proceeding
         },

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -238,6 +238,15 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
     },
 
+    "security": {
+        "redact_secrets": True,
+        "website_blocklist": {
+            "enabled": True,
+            "domains": [],
+            "shared_files": [],
+        },
+    },
+
     # Permanently allowed dangerous command patterns (added via "always" approval)
     "command_allowlist": [],
     # User-defined quick commands that bypass the agent loop (type: exec only)

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from tools.website_policy import check_website_access, load_website_blocklist
+from tools.website_policy import WebsitePolicyError, check_website_access, load_website_blocklist
 
 
 def test_load_website_blocklist_merges_config_and_shared_file(tmp_path):
@@ -93,6 +93,40 @@ def test_default_config_exposes_website_blocklist_shape():
     assert website_blocklist["shared_files"] == []
 
 
+def test_load_website_blocklist_raises_clean_error_for_malformed_yaml(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("security: [oops\n", encoding="utf-8")
+
+    with pytest.raises(WebsitePolicyError, match="Invalid config YAML"):
+        load_website_blocklist(config_path)
+
+
+def test_check_website_access_uses_dynamic_hermes_home(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "domains": ["dynamic.example"],
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    blocked = check_website_access("https://dynamic.example/path")
+
+    assert blocked is not None
+    assert blocked["rule"] == "dynamic.example"
+
+
 def test_browser_navigate_returns_policy_block(monkeypatch):
     from tools import browser_tool
 
@@ -116,6 +150,33 @@ def test_browser_navigate_returns_policy_block(monkeypatch):
 
     assert result["success"] is False
     assert result["blocked_by_policy"]["rule"] == "blocked.test"
+
+
+def test_browser_navigate_returns_clean_policy_error_for_missing_shared_file(monkeypatch, tmp_path):
+    from tools import browser_tool
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "shared_files": ["missing-blocklist.txt"],
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(browser_tool, "check_website_access", lambda url: check_website_access(url, config_path=config_path))
+
+    result = json.loads(browser_tool.browser_navigate("https://allowed.test"))
+
+    assert result["success"] is False
+    assert "Website policy error" in result["error"]
 
 
 @pytest.mark.asyncio
@@ -143,3 +204,19 @@ async def test_web_extract_short_circuits_blocked_url(monkeypatch):
 
     assert result["results"][0]["url"] == "https://blocked.test"
     assert "Blocked by website policy" in result["results"][0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_web_extract_returns_clean_policy_error_for_malformed_config(monkeypatch, tmp_path):
+    from tools import web_tools
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("security: [oops\n", encoding="utf-8")
+
+    monkeypatch.setattr(web_tools, "check_website_access", lambda url: check_website_access(url, config_path=config_path))
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    result = json.loads(await web_tools.web_extract_tool(["https://allowed.test"], use_llm_processing=False))
+
+    assert result["results"][0]["url"] == "https://allowed.test"
+    assert "Website policy error" in result["results"][0]["error"]

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -145,6 +145,52 @@ def test_load_website_blocklist_raises_clean_error_for_invalid_shared_files_type
         load_website_blocklist(config_path)
 
 
+def test_load_website_blocklist_raises_clean_error_for_invalid_security_type(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"security": []}, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(WebsitePolicyError, match="security must be a mapping"):
+        load_website_blocklist(config_path)
+
+
+def test_load_website_blocklist_raises_clean_error_for_invalid_website_blocklist_type(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": "block everything",
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WebsitePolicyError, match="security.website_blocklist must be a mapping"):
+        load_website_blocklist(config_path)
+
+
+def test_load_website_blocklist_raises_clean_error_for_invalid_enabled_type(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": "false",
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WebsitePolicyError, match="security.website_blocklist.enabled must be a boolean"):
+        load_website_blocklist(config_path)
+
+
 def test_load_website_blocklist_raises_clean_error_for_malformed_yaml(tmp_path):
     config_path = tmp_path / "config.yaml"
     config_path.write_text("security: [oops\n", encoding="utf-8")

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -81,6 +81,7 @@ def test_check_website_access_supports_wildcard_subdomains_only(tmp_path):
     )
 
     assert check_website_access("https://a.tracking.example", config_path=config_path) is not None
+    assert check_website_access("https://www.tracking.example", config_path=config_path) is not None
     assert check_website_access("https://tracking.example", config_path=config_path) is None
 
 
@@ -149,6 +150,35 @@ def test_load_website_blocklist_raises_clean_error_for_malformed_yaml(tmp_path):
     config_path.write_text("security: [oops\n", encoding="utf-8")
 
     with pytest.raises(WebsitePolicyError, match="Invalid config YAML"):
+        load_website_blocklist(config_path)
+
+
+def test_load_website_blocklist_wraps_shared_file_read_errors(tmp_path, monkeypatch):
+    shared = tmp_path / "community-blocklist.txt"
+    shared.write_text("example.org\n", encoding="utf-8")
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "shared_files": [str(shared)],
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    def failing_read_text(self, *args, **kwargs):
+        raise PermissionError("no permission")
+
+    monkeypatch.setattr(Path, "read_text", failing_read_text)
+
+    with pytest.raises(WebsitePolicyError, match="Failed to read shared blocklist file"):
         load_website_blocklist(config_path)
 
 

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -345,7 +345,10 @@ def test_browser_navigate_blocks_redirected_final_url(monkeypatch):
             }
         pytest.fail(f"unexpected URL checked: {url}")
 
+    cleanup_calls = []
+
     monkeypatch.setattr(browser_tool, "check_website_access", fake_check)
+    monkeypatch.setattr(browser_tool, "cleanup_browser", lambda task_id=None: cleanup_calls.append(task_id))
     monkeypatch.setattr(browser_tool, "_get_session_info", lambda task_id: {"_first_nav": False})
     monkeypatch.setattr(browser_tool, "_run_browser_command", lambda *args, **kwargs: {
         "success": True,
@@ -357,6 +360,7 @@ def test_browser_navigate_blocks_redirected_final_url(monkeypatch):
     assert result["success"] is False
     assert result["url"] == "https://blocked.test/final"
     assert result["blocked_by_policy"]["rule"] == "blocked.test"
+    assert cleanup_calls == ["default"]
 
 
 @pytest.mark.asyncio
@@ -436,4 +440,72 @@ async def test_web_extract_blocks_redirected_final_url(monkeypatch):
 
     assert result["results"][0]["url"] == "https://blocked.test/final"
     assert result["results"][0]["content"] == ""
+    assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"
+
+
+@pytest.mark.asyncio
+async def test_web_crawl_short_circuits_blocked_url(monkeypatch):
+    from tools import web_tools
+
+    monkeypatch.setattr(
+        web_tools,
+        "check_website_access",
+        lambda url: {
+            "host": "blocked.test",
+            "rule": "blocked.test",
+            "source": "config",
+            "message": "Blocked by website policy",
+        },
+    )
+    monkeypatch.setattr(
+        web_tools,
+        "_get_firecrawl_client",
+        lambda: pytest.fail("firecrawl should not run for blocked crawl URL"),
+    )
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    result = json.loads(await web_tools.web_crawl_tool("https://blocked.test", use_llm_processing=False))
+
+    assert result["results"][0]["url"] == "https://blocked.test"
+    assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"
+
+
+@pytest.mark.asyncio
+async def test_web_crawl_blocks_redirected_final_url(monkeypatch):
+    from tools import web_tools
+
+    def fake_check(url):
+        if url == "https://allowed.test":
+            return None
+        if url == "https://blocked.test/final":
+            return {
+                "host": "blocked.test",
+                "rule": "blocked.test",
+                "source": "config",
+                "message": "Blocked by website policy",
+            }
+        pytest.fail(f"unexpected URL checked: {url}")
+
+    class FakeCrawlClient:
+        def crawl(self, url, **kwargs):
+            return {
+                "data": [
+                    {
+                        "markdown": "secret crawl content",
+                        "metadata": {
+                            "title": "Redirected crawl page",
+                            "sourceURL": "https://blocked.test/final",
+                        },
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(web_tools, "check_website_access", fake_check)
+    monkeypatch.setattr(web_tools, "_get_firecrawl_client", lambda: FakeCrawlClient())
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    result = json.loads(await web_tools.web_crawl_tool("https://allowed.test", use_llm_processing=False))
+
+    assert result["results"][0]["content"] == ""
+    assert result["results"][0]["error"] == "Blocked by website policy"
     assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -93,6 +93,57 @@ def test_default_config_exposes_website_blocklist_shape():
     assert website_blocklist["shared_files"] == []
 
 
+def test_load_website_blocklist_uses_enabled_default_when_section_missing(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"display": {"tool_progress": "all"}}, sort_keys=False), encoding="utf-8")
+
+    policy = load_website_blocklist(config_path)
+
+    assert policy == {"enabled": True, "rules": []}
+
+
+def test_load_website_blocklist_raises_clean_error_for_invalid_domains_type(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "domains": "example.com",
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WebsitePolicyError, match="security.website_blocklist.domains must be a list"):
+        load_website_blocklist(config_path)
+
+
+def test_load_website_blocklist_raises_clean_error_for_invalid_shared_files_type(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "shared_files": "community-blocklist.txt",
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WebsitePolicyError, match="security.website_blocklist.shared_files must be a list"):
+        load_website_blocklist(config_path)
+
+
 def test_load_website_blocklist_raises_clean_error_for_malformed_yaml(tmp_path):
     config_path = tmp_path / "config.yaml"
     config_path.write_text("security: [oops\n", encoding="utf-8")

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -1,0 +1,145 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tools.website_policy import check_website_access, load_website_blocklist
+
+
+def test_load_website_blocklist_merges_config_and_shared_file(tmp_path):
+    shared = tmp_path / "community-blocklist.txt"
+    shared.write_text("# comment\nexample.org\nsub.bad.net\n", encoding="utf-8")
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "domains": ["example.com", "https://www.evil.test/path"],
+                        "shared_files": [str(shared)],
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    policy = load_website_blocklist(config_path)
+
+    assert policy["enabled"] is True
+    assert {rule["pattern"] for rule in policy["rules"]} == {
+        "example.com",
+        "evil.test",
+        "example.org",
+        "sub.bad.net",
+    }
+
+
+def test_check_website_access_matches_parent_domain_subdomains(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "domains": ["example.com"],
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    blocked = check_website_access("https://docs.example.com/page", config_path=config_path)
+
+    assert blocked is not None
+    assert blocked["host"] == "docs.example.com"
+    assert blocked["rule"] == "example.com"
+
+
+def test_check_website_access_supports_wildcard_subdomains_only(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "domains": ["*.tracking.example"],
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    assert check_website_access("https://a.tracking.example", config_path=config_path) is not None
+    assert check_website_access("https://tracking.example", config_path=config_path) is None
+
+
+def test_default_config_exposes_website_blocklist_shape():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    website_blocklist = DEFAULT_CONFIG["security"]["website_blocklist"]
+    assert website_blocklist["enabled"] is True
+    assert website_blocklist["domains"] == []
+    assert website_blocklist["shared_files"] == []
+
+
+def test_browser_navigate_returns_policy_block(monkeypatch):
+    from tools import browser_tool
+
+    monkeypatch.setattr(
+        browser_tool,
+        "check_website_access",
+        lambda url: {
+            "host": "blocked.test",
+            "rule": "blocked.test",
+            "source": "config",
+            "message": "Blocked by website policy",
+        },
+    )
+    monkeypatch.setattr(
+        browser_tool,
+        "_run_browser_command",
+        lambda *args, **kwargs: pytest.fail("browser command should not run for blocked URL"),
+    )
+
+    result = json.loads(browser_tool.browser_navigate("https://blocked.test"))
+
+    assert result["success"] is False
+    assert result["blocked_by_policy"]["rule"] == "blocked.test"
+
+
+@pytest.mark.asyncio
+async def test_web_extract_short_circuits_blocked_url(monkeypatch):
+    from tools import web_tools
+
+    monkeypatch.setattr(
+        web_tools,
+        "check_website_access",
+        lambda url: {
+            "host": "blocked.test",
+            "rule": "blocked.test",
+            "source": "config",
+            "message": "Blocked by website policy",
+        },
+    )
+    monkeypatch.setattr(
+        web_tools,
+        "_get_firecrawl_client",
+        lambda: pytest.fail("firecrawl should not run for blocked URL"),
+    )
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    result = json.loads(await web_tools.web_extract_tool(["https://blocked.test"], use_llm_processing=False))
+
+    assert result["results"][0]["url"] == "https://blocked.test"
+    assert "Blocked by website policy" in result["results"][0]["error"]

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -145,6 +145,14 @@ def test_load_website_blocklist_raises_clean_error_for_invalid_shared_files_type
         load_website_blocklist(config_path)
 
 
+def test_load_website_blocklist_raises_clean_error_for_invalid_top_level_config_type(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(["not", "a", "mapping"], sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(WebsitePolicyError, match="config root must be a mapping"):
+        load_website_blocklist(config_path)
+
+
 def test_load_website_blocklist_raises_clean_error_for_invalid_security_type(tmp_path):
     config_path = tmp_path / "config.yaml"
     config_path.write_text(yaml.safe_dump({"security": []}, sort_keys=False), encoding="utf-8")

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -363,6 +363,93 @@ def test_browser_navigate_blocks_redirected_final_url(monkeypatch):
     assert cleanup_calls == ["default"]
 
 
+def test_browser_click_blocks_redirected_final_url(monkeypatch):
+    from tools import browser_tool
+
+    def fake_check(url):
+        if url == "https://blocked.test/after-click":
+            return {
+                "host": "blocked.test",
+                "rule": "blocked.test",
+                "source": "config",
+                "message": "Blocked by website policy",
+            }
+        return None
+
+    cleanup_calls = []
+
+    monkeypatch.setattr(browser_tool, "check_website_access", fake_check)
+    monkeypatch.setattr(browser_tool, "cleanup_browser", lambda task_id=None: cleanup_calls.append(task_id))
+    monkeypatch.setattr(browser_tool, "_run_browser_command", lambda *args, **kwargs: {
+        "success": True,
+        "data": {"url": "https://blocked.test/after-click"},
+    })
+
+    result = json.loads(browser_tool.browser_click("@e5"))
+
+    assert result["success"] is False
+    assert result["blocked_by_policy"]["rule"] == "blocked.test"
+    assert cleanup_calls == ["default"]
+
+
+def test_browser_back_blocks_redirected_final_url(monkeypatch):
+    from tools import browser_tool
+
+    def fake_check(url):
+        if url == "https://blocked.test/from-history":
+            return {
+                "host": "blocked.test",
+                "rule": "blocked.test",
+                "source": "config",
+                "message": "Blocked by website policy",
+            }
+        return None
+
+    cleanup_calls = []
+
+    monkeypatch.setattr(browser_tool, "check_website_access", fake_check)
+    monkeypatch.setattr(browser_tool, "cleanup_browser", lambda task_id=None: cleanup_calls.append(task_id))
+    monkeypatch.setattr(browser_tool, "_run_browser_command", lambda *args, **kwargs: {
+        "success": True,
+        "data": {"url": "https://blocked.test/from-history"},
+    })
+
+    result = json.loads(browser_tool.browser_back())
+
+    assert result["success"] is False
+    assert result["blocked_by_policy"]["rule"] == "blocked.test"
+    assert cleanup_calls == ["default"]
+
+
+def test_browser_press_blocks_redirected_final_url(monkeypatch):
+    from tools import browser_tool
+
+    def fake_check(url):
+        if url == "https://blocked.test/from-press":
+            return {
+                "host": "blocked.test",
+                "rule": "blocked.test",
+                "source": "config",
+                "message": "Blocked by website policy",
+            }
+        return None
+
+    cleanup_calls = []
+
+    monkeypatch.setattr(browser_tool, "check_website_access", fake_check)
+    monkeypatch.setattr(browser_tool, "cleanup_browser", lambda task_id=None: cleanup_calls.append(task_id))
+    monkeypatch.setattr(browser_tool, "_run_browser_command", lambda *args, **kwargs: {
+        "success": True,
+        "data": {"url": "https://blocked.test/from-press"},
+    })
+
+    result = json.loads(browser_tool.browser_press("Enter"))
+
+    assert result["success"] is False
+    assert result["blocked_by_policy"]["rule"] == "blocked.test"
+    assert cleanup_calls == ["default"]
+
+
 @pytest.mark.asyncio
 async def test_web_extract_short_circuits_blocked_url(monkeypatch):
     from tools import web_tools

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -254,6 +254,30 @@ def test_check_website_access_uses_dynamic_hermes_home(monkeypatch, tmp_path):
     assert blocked["rule"] == "dynamic.example"
 
 
+def test_check_website_access_blocks_scheme_less_urls(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "domains": ["blocked.test"],
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    blocked = check_website_access("www.blocked.test/path", config_path=config_path)
+
+    assert blocked is not None
+    assert blocked["host"] == "www.blocked.test"
+    assert blocked["rule"] == "blocked.test"
+
+
 def test_browser_navigate_returns_policy_block(monkeypatch):
     from tools import browser_tool
 
@@ -306,6 +330,35 @@ def test_browser_navigate_returns_clean_policy_error_for_missing_shared_file(mon
     assert "Website policy error" in result["error"]
 
 
+def test_browser_navigate_blocks_redirected_final_url(monkeypatch):
+    from tools import browser_tool
+
+    def fake_check(url):
+        if url == "https://allowed.test":
+            return None
+        if url == "https://blocked.test/final":
+            return {
+                "host": "blocked.test",
+                "rule": "blocked.test",
+                "source": "config",
+                "message": "Blocked by website policy",
+            }
+        pytest.fail(f"unexpected URL checked: {url}")
+
+    monkeypatch.setattr(browser_tool, "check_website_access", fake_check)
+    monkeypatch.setattr(browser_tool, "_get_session_info", lambda task_id: {"_first_nav": False})
+    monkeypatch.setattr(browser_tool, "_run_browser_command", lambda *args, **kwargs: {
+        "success": True,
+        "data": {"title": "Redirected", "url": "https://blocked.test/final"},
+    })
+
+    result = json.loads(browser_tool.browser_navigate("https://allowed.test"))
+
+    assert result["success"] is False
+    assert result["url"] == "https://blocked.test/final"
+    assert result["blocked_by_policy"]["rule"] == "blocked.test"
+
+
 @pytest.mark.asyncio
 async def test_web_extract_short_circuits_blocked_url(monkeypatch):
     from tools import web_tools
@@ -347,3 +400,40 @@ async def test_web_extract_returns_clean_policy_error_for_malformed_config(monke
 
     assert result["results"][0]["url"] == "https://allowed.test"
     assert "Website policy error" in result["results"][0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_web_extract_blocks_redirected_final_url(monkeypatch):
+    from tools import web_tools
+
+    def fake_check(url):
+        if url == "https://allowed.test":
+            return None
+        if url == "https://blocked.test/final":
+            return {
+                "host": "blocked.test",
+                "rule": "blocked.test",
+                "source": "config",
+                "message": "Blocked by website policy",
+            }
+        pytest.fail(f"unexpected URL checked: {url}")
+
+    class FakeFirecrawlClient:
+        def scrape(self, url, formats):
+            return {
+                "markdown": "secret content",
+                "metadata": {
+                    "title": "Redirected",
+                    "sourceURL": "https://blocked.test/final",
+                },
+            }
+
+    monkeypatch.setattr(web_tools, "check_website_access", fake_check)
+    monkeypatch.setattr(web_tools, "_get_firecrawl_client", lambda: FakeFirecrawlClient())
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    result = json.loads(await web_tools.web_extract_tool(["https://allowed.test"], use_llm_processing=False))
+
+    assert result["results"][0]["url"] == "https://blocked.test/final"
+    assert result["results"][0]["content"] == ""
+    assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1038,6 +1038,10 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             }, ensure_ascii=False)
 
         if final_blocked:
+            try:
+                cleanup_browser(effective_task_id)
+            except Exception as cleanup_err:
+                logger.warning("Failed to clean up blocked browser session for task %s: %s", effective_task_id, cleanup_err)
             return json.dumps({
                 "success": False,
                 "url": final_url,

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1027,6 +1027,27 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         data = result.get("data", {})
         title = data.get("title", "")
         final_url = data.get("url", url)
+
+        try:
+            final_blocked = check_website_access(final_url)
+        except WebsitePolicyError as policy_err:
+            return json.dumps({
+                "success": False,
+                "url": final_url,
+                "error": f"Website policy error: {policy_err}"
+            }, ensure_ascii=False)
+
+        if final_blocked:
+            return json.dumps({
+                "success": False,
+                "url": final_url,
+                "error": final_blocked["message"],
+                "blocked_by_policy": {
+                    "host": final_blocked["host"],
+                    "rule": final_blocked["rule"],
+                    "source": final_blocked["source"],
+                },
+            }, ensure_ascii=False)
         
         response = {
             "success": True,

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -979,6 +979,53 @@ def _truncate_snapshot(snapshot_text: str, max_chars: int = 8000) -> str:
 # Browser Tool Functions
 # ============================================================================
 
+def _blocked_browser_response(blocked: Dict[str, str], url: Optional[str] = None) -> str:
+    response: Dict[str, Any] = {
+        "success": False,
+        "error": blocked["message"],
+        "blocked_by_policy": {
+            "host": blocked["host"],
+            "rule": blocked["rule"],
+            "source": blocked["source"],
+        },
+    }
+    if url:
+        response["url"] = url
+    return json.dumps(response, ensure_ascii=False)
+
+
+def _enforce_post_action_policy(result: Dict[str, Any], task_id: str) -> Optional[str]:
+    if not result.get("success"):
+        return None
+
+    data = result.get("data", {}) or {}
+    current_url = data.get("url")
+    if not current_url:
+        return None
+
+    try:
+        blocked = check_website_access(current_url)
+    except WebsitePolicyError as policy_err:
+        try:
+            cleanup_browser(task_id)
+        except Exception as cleanup_err:
+            logger.warning("Failed to clean up browser session after policy error for task %s: %s", task_id, cleanup_err)
+        return json.dumps({
+            "success": False,
+            "url": current_url,
+            "error": f"Website policy error: {policy_err}"
+        }, ensure_ascii=False)
+
+    if blocked:
+        try:
+            cleanup_browser(task_id)
+        except Exception as cleanup_err:
+            logger.warning("Failed to clean up blocked browser session for task %s: %s", task_id, cleanup_err)
+        return _blocked_browser_response(blocked, current_url)
+
+    return None
+
+
 def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     """
     Navigate to a URL in the browser.
@@ -1028,30 +1075,9 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         title = data.get("title", "")
         final_url = data.get("url", url)
 
-        try:
-            final_blocked = check_website_access(final_url)
-        except WebsitePolicyError as policy_err:
-            return json.dumps({
-                "success": False,
-                "url": final_url,
-                "error": f"Website policy error: {policy_err}"
-            }, ensure_ascii=False)
-
-        if final_blocked:
-            try:
-                cleanup_browser(effective_task_id)
-            except Exception as cleanup_err:
-                logger.warning("Failed to clean up blocked browser session for task %s: %s", effective_task_id, cleanup_err)
-            return json.dumps({
-                "success": False,
-                "url": final_url,
-                "error": final_blocked["message"],
-                "blocked_by_policy": {
-                    "host": final_blocked["host"],
-                    "rule": final_blocked["rule"],
-                    "source": final_blocked["source"],
-                },
-            }, ensure_ascii=False)
+        post_action_error = _enforce_post_action_policy(result, effective_task_id)
+        if post_action_error:
+            return post_action_error
         
         response = {
             "success": True,
@@ -1164,6 +1190,10 @@ def browser_click(ref: str, task_id: Optional[str] = None) -> str:
         ref = f"@{ref}"
     
     result = _run_browser_command(effective_task_id, "click", [ref])
+
+    post_action_error = _enforce_post_action_policy(result, effective_task_id)
+    if post_action_error:
+        return post_action_error
     
     if result.get("success"):
         return json.dumps({
@@ -1257,6 +1287,10 @@ def browser_back(task_id: Optional[str] = None) -> str:
     """
     effective_task_id = task_id or "default"
     result = _run_browser_command(effective_task_id, "back", [])
+
+    post_action_error = _enforce_post_action_policy(result, effective_task_id)
+    if post_action_error:
+        return post_action_error
     
     if result.get("success"):
         data = result.get("data", {})
@@ -1284,6 +1318,10 @@ def browser_press(key: str, task_id: Optional[str] = None) -> str:
     """
     effective_task_id = task_id or "default"
     result = _run_browser_command(effective_task_id, "press", [key])
+
+    post_action_error = _enforce_post_action_policy(result, effective_task_id)
+    if post_action_error:
+        return post_action_error
     
     if result.get("success"):
         return json.dumps({

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -64,6 +64,7 @@ import requests
 from typing import Dict, Any, Optional, List
 from pathlib import Path
 from agent.auxiliary_client import call_llm
+from tools.website_policy import WebsitePolicyError, check_website_access
 
 logger = logging.getLogger(__name__)
 
@@ -989,6 +990,25 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     Returns:
         JSON string with navigation result (includes stealth features info on first nav)
     """
+    try:
+        blocked = check_website_access(url)
+    except WebsitePolicyError as policy_err:
+        return json.dumps({
+            "success": False,
+            "error": f"Website policy error: {policy_err}"
+        }, ensure_ascii=False)
+
+    if blocked:
+        return json.dumps({
+            "success": False,
+            "error": blocked["message"],
+            "blocked_by_policy": {
+                "host": blocked["host"],
+                "rule": blocked["rule"],
+                "source": blocked["source"],
+            },
+        }, ensure_ascii=False)
+
     effective_task_id = task_id or "default"
     
     # Get session info to check if this is a new session

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -935,6 +935,36 @@ async def web_crawl_tool(
         instructions_text = f" with instructions: '{instructions}'" if instructions else ""
         logger.info("Crawling %s%s", url, instructions_text)
         
+        try:
+            blocked = check_website_access(url)
+        except WebsitePolicyError as policy_err:
+            error_msg = f"Website policy error: {policy_err}"
+            logger.warning("%s", error_msg)
+            return json.dumps({
+                "results": [{
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": error_msg,
+                }]
+            }, ensure_ascii=False)
+
+        if blocked:
+            logger.info("Blocked web_crawl for %s by rule %s", blocked["host"], blocked["rule"])
+            return json.dumps({
+                "results": [{
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": blocked["message"],
+                    "blocked_by_policy": {
+                        "host": blocked["host"],
+                        "rule": blocked["rule"],
+                        "source": blocked["source"],
+                    },
+                }]
+            }, ensure_ascii=False)
+
         # Use Firecrawl's v2 crawl functionality
         # Docs: https://docs.firecrawl.dev/features/crawl
         # The crawl() method automatically waits for completion and returns all data
@@ -1039,6 +1069,38 @@ async def web_crawl_tool(
             # Extract URL and title from metadata
             page_url = metadata.get("sourceURL", metadata.get("url", "Unknown URL"))
             title = metadata.get("title", "")
+
+            try:
+                final_blocked = check_website_access(page_url)
+            except WebsitePolicyError as policy_err:
+                error_msg = f"Website policy error: {policy_err}"
+                logger.warning("%s", error_msg)
+                pages.append({
+                    "url": page_url,
+                    "title": title,
+                    "content": "",
+                    "raw_content": "",
+                    "metadata": metadata,
+                    "error": error_msg,
+                })
+                continue
+
+            if final_blocked:
+                logger.info("Blocked crawled page %s by rule %s", final_blocked["host"], final_blocked["rule"])
+                pages.append({
+                    "url": page_url,
+                    "title": title,
+                    "content": "",
+                    "raw_content": "",
+                    "metadata": metadata,
+                    "error": final_blocked["message"],
+                    "blocked_by_policy": {
+                        "host": final_blocked["host"],
+                        "rule": final_blocked["rule"],
+                        "source": final_blocked["source"],
+                    },
+                })
+                continue
             
             # Choose content (prefer markdown)
             content = content_markdown or content_html or ""
@@ -1135,9 +1197,11 @@ async def web_crawl_tool(
         # Trim output to minimal fields per entry: title, content, error
         trimmed_results = [
             {
+                "url": r.get("url", ""),
                 "title": r.get("title", ""),
                 "content": r.get("content", ""),
-                "error": r.get("error")
+                "error": r.get("error"),
+                **({"blocked_by_policy": r["blocked_by_policy"]} if "blocked_by_policy" in r else {}),
             }
             for r in response.get("results", [])
         ]

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -699,12 +699,45 @@ async def web_extract_tool(
                 
                 # Get title from metadata
                 title = metadata.get("title", "")
+                final_url = metadata.get("sourceURL", url)
+
+                try:
+                    final_blocked = check_website_access(final_url)
+                except WebsitePolicyError as policy_err:
+                    error_msg = f"Website policy error: {policy_err}"
+                    logger.warning("%s", error_msg)
+                    results.append({
+                        "url": final_url,
+                        "title": title,
+                        "content": "",
+                        "raw_content": "",
+                        "metadata": metadata,
+                        "error": error_msg,
+                    })
+                    continue
+
+                if final_blocked:
+                    logger.info("Blocked redirected web_extract for %s by rule %s", final_blocked["host"], final_blocked["rule"])
+                    results.append({
+                        "url": final_url,
+                        "title": title,
+                        "content": "",
+                        "raw_content": "",
+                        "metadata": metadata,
+                        "error": final_blocked["message"],
+                        "blocked_by_policy": {
+                            "host": final_blocked["host"],
+                            "rule": final_blocked["rule"],
+                            "source": final_blocked["source"],
+                        },
+                    })
+                    continue
                 
                 # Choose content based on requested format
                 chosen_content = content_markdown if (format == "markdown" or (format is None and content_markdown)) else content_html or content_markdown or ""
                 
                 results.append({
-                    "url": metadata.get("sourceURL", url),
+                    "url": final_url,
                     "title": title,
                     "content": chosen_content,
                     "raw_content": chosen_content,
@@ -809,6 +842,7 @@ async def web_extract_tool(
                 "title": r.get("title", ""),
                 "content": r.get("content", ""),
                 "error": r.get("error"),
+                **({"blocked_by_policy": r["blocked_by_policy"]} if "blocked_by_policy" in r else {}),
             }
             for r in response.get("results", [])
         ]

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -49,6 +49,7 @@ from typing import List, Dict, Any, Optional
 from firecrawl import Firecrawl
 from agent.auxiliary_client import async_call_llm
 from tools.debug_helpers import DebugSession
+from tools.website_policy import WebsitePolicyError, check_website_access
 
 logger = logging.getLogger(__name__)
 
@@ -614,6 +615,36 @@ async def web_extract_tool(
         for url in urls:
             if _is_interrupted():
                 results.append({"url": url, "error": "Interrupted", "title": ""})
+                continue
+
+            try:
+                blocked = check_website_access(url)
+            except WebsitePolicyError as policy_err:
+                error_msg = f"Website policy error: {policy_err}"
+                logger.warning("%s", error_msg)
+                results.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": error_msg,
+                })
+                continue
+
+            if blocked:
+                logger.info("Blocked web_extract for %s by rule %s", blocked["host"], blocked["rule"])
+                results.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": blocked["message"],
+                    "blocked_by_policy": {
+                        "host": blocked["host"],
+                        "rule": blocked["rule"],
+                        "source": blocked["source"],
+                    },
+                })
                 continue
 
             try:

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -91,13 +91,13 @@ def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
     if security is None:
         security = {}
     if not isinstance(security, dict):
-        return dict(_DEFAULT_WEBSITE_BLOCKLIST)
+        raise WebsitePolicyError("security must be a mapping")
 
     website_blocklist = security.get("website_blocklist", {})
     if website_blocklist is None:
         website_blocklist = {}
     if not isinstance(website_blocklist, dict):
-        return dict(_DEFAULT_WEBSITE_BLOCKLIST)
+        raise WebsitePolicyError("security.website_blocklist must be a mapping")
 
     policy = dict(_DEFAULT_WEBSITE_BLOCKLIST)
     policy.update(website_blocklist)
@@ -116,7 +116,10 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
     if not isinstance(raw_shared_files, list):
         raise WebsitePolicyError("security.website_blocklist.shared_files must be a list")
 
-    enabled = bool(policy.get("enabled", True))
+    enabled = policy.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise WebsitePolicyError("security.website_blocklist.enabled must be a boolean")
+
     rules: List[Dict[str, str]] = []
     seen: set[Tuple[str, str]] = set()
 

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -7,17 +7,21 @@ tools can enforce URL policy without pulling in the heavier CLI config stack.
 
 from __future__ import annotations
 
+import fnmatch
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
-import fnmatch
-import os
 
 import yaml
 
 
-_DEFAULT_HERMES_HOME = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
-_DEFAULT_CONFIG_PATH = _DEFAULT_HERMES_HOME / "config.yaml"
+def _get_hermes_home() -> Path:
+    return Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+
+
+def _get_default_config_path() -> Path:
+    return _get_hermes_home() / "config.yaml"
 
 
 class WebsitePolicyError(Exception):
@@ -63,11 +67,17 @@ def _iter_blocklist_file_rules(path: Path) -> List[str]:
     return rules
 
 
-def _load_policy_config(config_path: Path = _DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
+def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
+    config_path = config_path or _get_default_config_path()
     if not config_path.exists():
         return {}
-    with open(config_path, encoding="utf-8") as f:
-        config = yaml.safe_load(f) or {}
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            config = yaml.safe_load(f) or {}
+    except yaml.YAMLError as exc:
+        raise WebsitePolicyError(f"Invalid config YAML at {config_path}: {exc}") from exc
+    except OSError as exc:
+        raise WebsitePolicyError(f"Failed to read config file {config_path}: {exc}") from exc
     security = config.get("security", {})
     if not isinstance(security, dict):
         return {}
@@ -77,7 +87,8 @@ def _load_policy_config(config_path: Path = _DEFAULT_CONFIG_PATH) -> Dict[str, A
     return website_blocklist
 
 
-def load_website_blocklist(config_path: Path = _DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
+def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]:
+    config_path = config_path or _get_default_config_path()
     policy = _load_policy_config(config_path)
     if not policy:
         return {"enabled": False, "rules": []}
@@ -97,7 +108,7 @@ def load_website_blocklist(config_path: Path = _DEFAULT_CONFIG_PATH) -> Dict[str
             continue
         path = Path(shared_file).expanduser()
         if not path.is_absolute():
-            path = (_DEFAULT_HERMES_HOME / path).resolve()
+            path = (_get_hermes_home() / path).resolve()
         for normalized in _iter_blocklist_file_rules(path):
             key = (str(path), normalized)
             if key in seen:
@@ -116,7 +127,7 @@ def _match_host_against_rule(host: str, pattern: str) -> bool:
     return host == pattern or host.endswith(f".{pattern}")
 
 
-def check_website_access(url: str, config_path: Path = _DEFAULT_CONFIG_PATH) -> Optional[Dict[str, str]]:
+def check_website_access(url: str, config_path: Optional[Path] = None) -> Optional[Dict[str, str]]:
     parsed = urlparse(url)
     host = _normalize_host(parsed.hostname or parsed.netloc)
     if not host:

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -16,6 +16,13 @@ from urllib.parse import urlparse
 import yaml
 
 
+_DEFAULT_WEBSITE_BLOCKLIST = {
+    "enabled": True,
+    "domains": [],
+    "shared_files": [],
+}
+
+
 def _get_hermes_home() -> Path:
     return Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
 
@@ -70,7 +77,7 @@ def _iter_blocklist_file_rules(path: Path) -> List[str]:
 def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
     config_path = config_path or _get_default_config_path()
     if not config_path.exists():
-        return {}
+        return dict(_DEFAULT_WEBSITE_BLOCKLIST)
     try:
         with open(config_path, encoding="utf-8") as f:
             config = yaml.safe_load(f) or {}
@@ -78,32 +85,49 @@ def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
         raise WebsitePolicyError(f"Invalid config YAML at {config_path}: {exc}") from exc
     except OSError as exc:
         raise WebsitePolicyError(f"Failed to read config file {config_path}: {exc}") from exc
+    if not isinstance(config, dict):
+        return dict(_DEFAULT_WEBSITE_BLOCKLIST)
+
     security = config.get("security", {})
+    if security is None:
+        security = {}
     if not isinstance(security, dict):
-        return {}
+        return dict(_DEFAULT_WEBSITE_BLOCKLIST)
+
     website_blocklist = security.get("website_blocklist", {})
+    if website_blocklist is None:
+        website_blocklist = {}
     if not isinstance(website_blocklist, dict):
-        return {}
-    return website_blocklist
+        return dict(_DEFAULT_WEBSITE_BLOCKLIST)
+
+    policy = dict(_DEFAULT_WEBSITE_BLOCKLIST)
+    policy.update(website_blocklist)
+    return policy
 
 
 def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]:
     config_path = config_path or _get_default_config_path()
     policy = _load_policy_config(config_path)
-    if not policy:
-        return {"enabled": False, "rules": []}
+
+    raw_domains = policy.get("domains", []) or []
+    if not isinstance(raw_domains, list):
+        raise WebsitePolicyError("security.website_blocklist.domains must be a list")
+
+    raw_shared_files = policy.get("shared_files", []) or []
+    if not isinstance(raw_shared_files, list):
+        raise WebsitePolicyError("security.website_blocklist.shared_files must be a list")
 
     enabled = bool(policy.get("enabled", True))
     rules: List[Dict[str, str]] = []
     seen: set[Tuple[str, str]] = set()
 
-    for raw_rule in policy.get("domains", []) or []:
+    for raw_rule in raw_domains:
         normalized = _normalize_rule(raw_rule)
         if normalized and ("config", normalized) not in seen:
             rules.append({"pattern": normalized, "source": "config"})
             seen.add(("config", normalized))
 
-    for shared_file in policy.get("shared_files", []) or []:
+    for shared_file in raw_shared_files:
         if not isinstance(shared_file, str) or not shared_file.strip():
             continue
         path = Path(shared_file).expanduser()

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -36,10 +36,7 @@ class WebsitePolicyError(Exception):
 
 
 def _normalize_host(host: str) -> str:
-    host = (host or "").strip().lower().rstrip(".")
-    if host.startswith("www."):
-        host = host[4:]
-    return host
+    return (host or "").strip().lower().rstrip(".")
 
 
 def _normalize_rule(rule: Any) -> Optional[str]:
@@ -60,8 +57,10 @@ def _normalize_rule(rule: Any) -> Optional[str]:
 def _iter_blocklist_file_rules(path: Path) -> List[str]:
     try:
         raw = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        raise WebsitePolicyError(f"Shared blocklist file not found: {path}")
+    except FileNotFoundError as exc:
+        raise WebsitePolicyError(f"Shared blocklist file not found: {path}") from exc
+    except (OSError, UnicodeDecodeError) as exc:
+        raise WebsitePolicyError(f"Failed to read shared blocklist file {path}: {exc}") from exc
 
     rules: List[str] = []
     for line in raw.splitlines():

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -1,0 +1,142 @@
+"""Website access policy helpers for URL-capable tools.
+
+This module loads a user-managed website blocklist from ~/.hermes/config.yaml
+and optional shared list files. It is intentionally lightweight so web/browser
+tools can enforce URL policy without pulling in the heavier CLI config stack.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+import fnmatch
+import os
+
+import yaml
+
+
+_DEFAULT_HERMES_HOME = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+_DEFAULT_CONFIG_PATH = _DEFAULT_HERMES_HOME / "config.yaml"
+
+
+class WebsitePolicyError(Exception):
+    """Raised when a website policy file is malformed."""
+
+
+def _normalize_host(host: str) -> str:
+    host = (host or "").strip().lower().rstrip(".")
+    if host.startswith("www."):
+        host = host[4:]
+    return host
+
+
+def _normalize_rule(rule: Any) -> Optional[str]:
+    if not isinstance(rule, str):
+        return None
+    value = rule.strip().lower()
+    if not value or value.startswith("#"):
+        return None
+    if "://" in value:
+        parsed = urlparse(value)
+        value = parsed.netloc or parsed.path
+    value = value.split("/", 1)[0].strip().rstrip(".")
+    if value.startswith("www."):
+        value = value[4:]
+    return value or None
+
+
+def _iter_blocklist_file_rules(path: Path) -> List[str]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise WebsitePolicyError(f"Shared blocklist file not found: {path}")
+
+    rules: List[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        normalized = _normalize_rule(stripped)
+        if normalized:
+            rules.append(normalized)
+    return rules
+
+
+def _load_policy_config(config_path: Path = _DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
+    if not config_path.exists():
+        return {}
+    with open(config_path, encoding="utf-8") as f:
+        config = yaml.safe_load(f) or {}
+    security = config.get("security", {})
+    if not isinstance(security, dict):
+        return {}
+    website_blocklist = security.get("website_blocklist", {})
+    if not isinstance(website_blocklist, dict):
+        return {}
+    return website_blocklist
+
+
+def load_website_blocklist(config_path: Path = _DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
+    policy = _load_policy_config(config_path)
+    if not policy:
+        return {"enabled": False, "rules": []}
+
+    enabled = bool(policy.get("enabled", True))
+    rules: List[Dict[str, str]] = []
+    seen: set[Tuple[str, str]] = set()
+
+    for raw_rule in policy.get("domains", []) or []:
+        normalized = _normalize_rule(raw_rule)
+        if normalized and ("config", normalized) not in seen:
+            rules.append({"pattern": normalized, "source": "config"})
+            seen.add(("config", normalized))
+
+    for shared_file in policy.get("shared_files", []) or []:
+        if not isinstance(shared_file, str) or not shared_file.strip():
+            continue
+        path = Path(shared_file).expanduser()
+        if not path.is_absolute():
+            path = (_DEFAULT_HERMES_HOME / path).resolve()
+        for normalized in _iter_blocklist_file_rules(path):
+            key = (str(path), normalized)
+            if key in seen:
+                continue
+            rules.append({"pattern": normalized, "source": str(path)})
+            seen.add(key)
+
+    return {"enabled": enabled, "rules": rules}
+
+
+def _match_host_against_rule(host: str, pattern: str) -> bool:
+    if not host or not pattern:
+        return False
+    if pattern.startswith("*."):
+        return fnmatch.fnmatch(host, pattern)
+    return host == pattern or host.endswith(f".{pattern}")
+
+
+def check_website_access(url: str, config_path: Path = _DEFAULT_CONFIG_PATH) -> Optional[Dict[str, str]]:
+    parsed = urlparse(url)
+    host = _normalize_host(parsed.hostname or parsed.netloc)
+    if not host:
+        return None
+
+    policy = load_website_blocklist(config_path)
+    if not policy.get("enabled"):
+        return None
+
+    for rule in policy.get("rules", []):
+        pattern = rule.get("pattern", "")
+        if _match_host_against_rule(host, pattern):
+            return {
+                "url": url,
+                "host": host,
+                "rule": pattern,
+                "source": rule.get("source", "config"),
+                "message": (
+                    f"Blocked by website policy: '{host}' matched rule '{pattern}'"
+                    f" from {rule.get('source', 'config')}"
+                ),
+            }
+    return None

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -85,7 +85,7 @@ def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
     except OSError as exc:
         raise WebsitePolicyError(f"Failed to read config file {config_path}: {exc}") from exc
     if not isinstance(config, dict):
-        return dict(_DEFAULT_WEBSITE_BLOCKLIST)
+        raise WebsitePolicyError("config root must be a mapping")
 
     security = config.get("security", {})
     if security is None:

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -153,9 +153,23 @@ def _match_host_against_rule(host: str, pattern: str) -> bool:
     return host == pattern or host.endswith(f".{pattern}")
 
 
-def check_website_access(url: str, config_path: Optional[Path] = None) -> Optional[Dict[str, str]]:
+def _extract_host_from_urlish(url: str) -> str:
     parsed = urlparse(url)
     host = _normalize_host(parsed.hostname or parsed.netloc)
+    if host:
+        return host
+
+    if "://" not in url:
+        schemeless = urlparse(f"//{url}")
+        host = _normalize_host(schemeless.hostname or schemeless.netloc)
+        if host:
+            return host
+
+    return ""
+
+
+def check_website_access(url: str, config_path: Optional[Path] = None) -> Optional[Dict[str, str]]:
+    host = _extract_host_from_urlish(url)
     if not host:
         return None
 


### PR DESCRIPTION
## Summary

Add first-class website blocklist enforcement for Hermes URL-capable browser/web tools.

This implements the MVP direction in #1064 with runtime policy enforcement rather than prompt-level guardrails, so user-managed website policy can change without touching prompt assembly, toolset resolution, or cache-sensitive session state.

## Problem

Hermes previously had no shared user-managed way to block domains across URL-capable tools.

That left a few gaps:
- `web_extract` could fetch user-blocked domains
- browser navigation/actions could open blocked domains
- there was no shared-file-backed mechanism for maintaining reusable community/team blocklists
- malformed policy config could degrade into unclear behavior instead of producing explicit policy errors

## What Changed

### Website policy helper
Added `tools/website_policy.py`.

Core behavior:
- loads `security.website_blocklist` from `~/.hermes/config.yaml`
- supports local `domains` rules and `shared_files` imports
- normalizes:
  - exact domains
  - full URLs
  - scheme-less URL-ish inputs like `example.com/path`
  - wildcard subdomain rules like `*.tracking.example`
- returns structured block metadata: `host`, `rule`, `source`
- raises `WebsitePolicyError` for malformed policy config instead of silently failing open

Validated config/type cases include:
- non-mapping config root
- non-mapping `security`
- non-mapping `security.website_blocklist`
- non-list `domains`
- non-list `shared_files`
- non-boolean `enabled`
- malformed YAML
- shared blocklist file read failures

### Tool enforcement
Added enforcement in the URL-capable runtime paths touched by this PR:

- `web_extract`
  - checks requested URLs before scraping
  - re-checks resolved/final URLs before returning content
- `web_crawl`
  - checks the initial crawl URL before starting
  - re-checks each crawled page URL before returning content
- `browser_navigate`
  - checks requested URLs before opening pages
  - re-checks the resolved/final URL after navigation
  - closes the browser session if navigation lands on a blocked destination
- browser actions that can land on a new page
  - `browser_click`
  - `browser_back`
  - `browser_press`
  - each re-checks the resulting URL and closes the browser session if the action lands on a blocked destination

Blocked responses return structured `blocked_by_policy` metadata so the agent can explain exactly what was denied and why.

### Config surface
Added the default config shape in both config loaders:
- `cli.py`
- `hermes_cli/config.py`

```yaml
security:
  redact_secrets: true
  website_blocklist:
    enabled: true
    domains: []
    shared_files: []
```

## Architecture Notes

This is enforced at tool runtime rather than via prompt injection.

That keeps it aligned with Hermes cache-safety constraints:
- no past-context mutation
- no mid-conversation toolset changes
- no memory/system-prompt rebuilds

Policy changes affect future tool calls, but do not alter the active prompt/session framing.

### Redirect semantics
- direct blocked URLs are denied before the tool performs work
- redirected/final destinations are re-checked as soon as the tool/backend exposes the resolved target URL
- browser sessions are cleaned up when a navigation/action lands on a blocked destination so later browser actions do not continue on the blocked page

## Changes by Area

### `tools/website_policy.py`
- shared policy loading + normalization
- config/type validation
- host matching for exact and wildcard rules
- scheme-less URL host extraction

### `tools/web_tools.py`
- `web_extract` policy enforcement
- `web_crawl` policy enforcement
- final URL re-checks
- structured blocked result passthrough in trimmed responses

### `tools/browser_tool.py`
- pre-navigation policy enforcement
- post-navigation/post-action destination re-checks
- browser session cleanup on blocked landings

### Config
- default `security.website_blocklist` shape in both config loaders

### Tests
Expanded `tests/tools/test_website_policy.py` to cover:
- config/default shape
- malformed config/type handling
- shared blocklist files
- wildcard behavior
- dynamic `HERMES_HOME`
- scheme-less URL blocking
- browser blocked navigation/action flows
- browser cleanup on blocked destinations
- `web_extract` blocked/redirected flows
- `web_crawl` blocked/redirected flows

## Test Results

Passed:
- `source venv/bin/activate && pytest -o addopts='' tests/tools/test_website_policy.py -q`
- `source venv/bin/activate && pytest -o addopts='' tests/tools/ -q`

Current results:
- `26 passed` in `tests/tools/test_website_policy.py`
- `1136 passed, 132 skipped, 1 warning` in `tests/tools/ -q`

## Issue

Closes #1064
