### PR TITLE
fix(agent): skip reasoning extra_body for models that don't support it

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2413,7 +2413,17 @@ class AIAgent:
         _is_nous = "nousresearch" in self.base_url.lower()
 
         _is_mistral = "api.mistral.ai" in self.base_url.lower()
-        if (_is_openrouter or _is_nous) and not _is_mistral:
+        # Only send reasoning extra_body to providers/models known to support it.
+        # Sending unsupported fields (e.g. to MiniMax, Nvidia) causes 400 errors.
+        _REASONING_MODEL_PREFIXES = (
+            "deepseek/", "anthropic/", "openai/", "x-ai/",
+            "google/gemini-2", "qwen/qwen3",
+        )
+        _model_supports_reasoning = (
+            _is_nous
+            or any(self.model.lower().startswith(p) for p in _REASONING_MODEL_PREFIXES)
+        )
+        if (_is_openrouter or _is_nous) and not _is_mistral and _model_supports_reasoning:
             if self.reasoning_config is not None:
                 rc = dict(self.reasoning_config)
                 # Nous Portal requires reasoning enabled — don't send
@@ -3106,7 +3116,15 @@ class AIAgent:
             summary_extra_body = {}
             _is_openrouter = "openrouter" in self.base_url.lower()
             _is_nous = "nousresearch" in self.base_url.lower()
-            if _is_openrouter or _is_nous:
+            _REASONING_MODEL_PREFIXES = (
+                "deepseek/", "anthropic/", "openai/", "x-ai/",
+                "google/gemini-2", "qwen/qwen3",
+            )
+            _model_supports_reasoning = (
+                _is_nous
+                or any(self.model.lower().startswith(p) for p in _REASONING_MODEL_PREFIXES)
+            )
+            if (_is_openrouter or _is_nous) and _model_supports_reasoning:
                 if self.reasoning_config is not None:
                     summary_extra_body["reasoning"] = self.reasoning_config
                 else:


### PR DESCRIPTION
## Problem

Sending `reasoning` in `extra_body` to models that don't support it (MiniMax, Nvidia, etc.) via OpenRouter causes a `400 BadRequestError`, making it impossible to use these models.

Fixes #1083

## Root Cause

`_build_api_kwargs` unconditionally sends `reasoning` extra_body to all OpenRouter and Nous requests. OpenRouter forwards this field to the upstream provider, and models that don't implement the reasoning extension reject the request with 400.

## Fix

Only send `reasoning` extra_body when the model slug starts with a known reasoning-capable prefix:
- `deepseek/`, `anthropic/`, `openai/`, `x-ai/`
- `google/gemini-2`, `qwen/qwen3`
- Nous Portal (always supports reasoning)

Applied to both:
- Main API call path (`_build_api_kwargs`)
- Conversation summary path

## Tests
3062 tests passing
