### PR TITLE
docs: add audio tools troubleshooting for tts and transcription

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1535,6 +1535,19 @@ class AIAgent:
         if self._memory_store:
             self._memory_store.load_from_disk()
 
+
+# ---------------------------------------------------------------------------
+# Backwards-compat helper for tests / older callsites
+# ---------------------------------------------------------------------------
+def build_system_prompt(agent: "AIAgent", system_message: str | None = None) -> str:
+    """
+    Backwards-compatible wrapper for AIAgent._build_system_prompt.
+
+    Some tests patch `run_agent.build_system_prompt` directly; this thin
+    helper keeps that surface area while delegating to the instance method.
+    """
+    return agent._build_system_prompt(system_message=system_message)
+
     def _responses_tools(self, tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
         """Convert chat-completions tool schemas to Responses function-tool schemas."""
         source_tools = tools if tools is not None else self.tools

--- a/run_agent.py
+++ b/run_agent.py
@@ -1535,19 +1535,6 @@ class AIAgent:
         if self._memory_store:
             self._memory_store.load_from_disk()
 
-
-# ---------------------------------------------------------------------------
-# Backwards-compat helper for tests / older callsites
-# ---------------------------------------------------------------------------
-def build_system_prompt(agent: "AIAgent", system_message: str | None = None) -> str:
-    """
-    Backwards-compatible wrapper for AIAgent._build_system_prompt.
-
-    Some tests patch `run_agent.build_system_prompt` directly; this thin
-    helper keeps that surface area while delegating to the instance method.
-    """
-    return agent._build_system_prompt(system_message=system_message)
-
     def _responses_tools(self, tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
         """Convert chat-completions tool schemas to Responses function-tool schemas."""
         source_tools = tools if tools is not None else self.tools

--- a/website/docs/user-guide/features/audio-troubleshooting.md
+++ b/website/docs/user-guide/features/audio-troubleshooting.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 10
+title: "Audio Tools Troubleshooting"
+description: "Diagnose and fix common issues with text-to-speech and transcription"
+---
+
+# Audio Tools Troubleshooting
+
+This page collects the most common issues users hit when configuring **text-to-speech (TTS)** and **voice transcription (STT)**, and how to fix them quickly.
+
+## Quick Checklist
+
+- **Virtualenv activated?**
+  - Always activate `.venv` before running Hermes or `pytest`:
+    ```bash
+    source .venv/bin/activate
+    ```
+  - On Windows PowerShell:
+    ```powershell
+    .venv\Scripts\Activate.ps1
+    ```
+
+- **API keys configured?**
+  - TTS:
+    - ElevenLabs: `ELEVENLABS_API_KEY`
+    - OpenAI: `VOICE_TOOLS_OPENAI_KEY`
+  - Transcription:
+    - OpenAI: `VOICE_TOOLS_OPENAI_KEY`
+
+- **System dependencies installed?**
+  - Telegram voice bubbles with Edge TTS require `ffmpeg`.
+
+## TTS: No Audio or Empty Files
+
+If Hermes reports success but the audio file is missing or zero bytes:
+
+- Make sure at least one TTS provider is correctly installed and configured.
+- For **Edge TTS**:
+  - Install the Python package:
+    ```bash
+    uv pip install edge-tts
+    ```
+  - If you are using Telegram and want voice bubbles, install `ffmpeg` so MP3 output can be converted to Opus/OGG.
+
+Hermes logs the final file path and size when TTS succeeds. If you still see `0 bytes`, check the logs for provider-specific errors.
+
+## TTS: Provider-Specific Failures
+
+- **ElevenLabs**
+  - Symptom: immediate failure with a configuration or dependency error.
+  - Fixes:
+    - Set `ELEVENLABS_API_KEY` in `~/.hermes/.env`.
+    - Verify `voice_id` and `model_id` under the `tts.elevenlabs` section of `config.yaml`.
+
+- **OpenAI TTS**
+  - Symptom: API error when generating speech.
+  - Fixes:
+    - Set `VOICE_TOOLS_OPENAI_KEY` in `~/.hermes/.env`.
+    - Check that your account has access to the configured TTS model.
+
+## Transcription: Requests Failing
+
+Transcription uses OpenAI’s audio API directly.
+
+- Symptom: Hermes returns an error mentioning `VOICE_TOOLS_OPENAI_KEY` or `API error`.
+- Fixes:
+  - Set `VOICE_TOOLS_OPENAI_KEY` and ensure it matches your OpenAI account.
+  - Keep files under the 25MB limit and in one of the supported formats (`.mp3`, `.ogg`, `.wav`, etc.).
+
+## Where to Look in Logs
+
+Hermes captures detailed error logs (including stack traces) for both TTS and transcription when something goes wrong. If basic fixes do not help:
+
+- Check the main Hermes error log file documented in the **Logs & Diagnostics** section.
+- Look for entries tagged with the TTS or transcription module names, which include full exception details to help you or maintainers debug further.
+

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -67,6 +67,26 @@ Without ffmpeg, Edge TTS audio is sent as a regular audio file (playable, but sh
 If you want voice bubbles without installing ffmpeg, switch to the OpenAI or ElevenLabs provider.
 :::
 
+### Common TTS Issues
+
+- **Edge TTS selected but no audio or empty file**
+  - Check that the `edge-tts` package is installed in your virtualenv:
+    ```bash
+    source .venv/bin/activate
+    uv pip install edge-tts
+    ```
+  - If you're using Telegram and want voice bubbles, install `ffmpeg` as shown above. Without it, Hermes falls back to MP3 and sends a regular audio attachment.
+
+- **ElevenLabs provider selected but calls fail immediately**
+  - Ensure `ELEVENLABS_API_KEY` is set in `~/.hermes/.env` or your shell environment.
+  - Verify that the configured `voice_id` and `model_id` match values available in your ElevenLabs account.
+
+- **OpenAI TTS selected but you get an API error**
+  - Confirm `VOICE_TOOLS_OPENAI_KEY` is set and valid.
+  - Double-check that the model in your config (for example `gpt-4o-mini-tts`) is available to your account.
+
+Hermes logs detailed TTS errors (including stack traces) to the error log directory; see the **Logs** section in the user guide if you need to dig deeper.
+
 ## Voice Message Transcription
 
 Voice messages sent on Telegram, Discord, WhatsApp, or Slack are automatically transcribed and injected as text into the conversation. The agent sees the transcript as normal text.


### PR DESCRIPTION
> This PR adds more complete documentation and troubleshooting guidance for audio tools (TTS + transcription), going beyond a few-line tweak while remaining low-risk.
>
> - Extend website/docs/user-guide/features/tts.md with a “Common TTS Issues” section covering:
> - Edge TTS producing no audio / empty files and how to install edge-tts and ffmpeg.
> - ElevenLabs configuration failures and required ELEVENLABS_API_KEY, voice_id, and model_id.
> - OpenAI TTS API errors with VOICE_TOOLS_OPENAI_KEY and model availability.
> - Add a new page website/docs/user-guide/features/audio-troubleshooting.md that:
> - Provides a quick checklist (venv activation, API keys, system deps).
> - Documents common TTS failure modes per provider and how to fix them.
> - Covers transcription (STT) failures, file size/format limits, and VOICE_TOOLS_OPENAI_KEY.
> - Explains where to look in logs for detailed TTS/STT error information.