### PR TITLE
fix(gateway): harden Discord allowlist auth with username fallback

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -892,7 +892,9 @@ class DiscordAdapter(BasePlatformAdapter):
             chat_name=chat_name,
             chat_type=chat_type,
             user_id=str(message.author.id),
-            user_name=message.author.display_name,
+            # Use canonical Discord username (not mutable server nickname)
+            # for authorization fallback matching.
+            user_name=message.author.name,
             thread_id=thread_id,
             chat_topic=chat_topic,
         )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -783,17 +783,31 @@ class GatewayRunner:
             return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
 
         # Check if user is in any allowlist
-        allowed_ids = set()
+        allowed_entries = set()
         if platform_allowlist:
-            allowed_ids.update(uid.strip() for uid in platform_allowlist.split(",") if uid.strip())
+            allowed_entries.update(uid.strip() for uid in platform_allowlist.split(",") if uid.strip())
         if global_allowlist:
-            allowed_ids.update(uid.strip() for uid in global_allowlist.split(",") if uid.strip())
+            allowed_entries.update(uid.strip() for uid in global_allowlist.split(",") if uid.strip())
 
-        # WhatsApp JIDs have @s.whatsapp.net suffix — strip it for comparison
+        # First pass: ID-based matching
+        # WhatsApp JIDs have @s.whatsapp.net suffix — strip it for comparison.
         check_ids = {user_id}
         if "@" in user_id:
             check_ids.add(user_id.split("@")[0])
-        return bool(check_ids & allowed_ids)
+        if check_ids & allowed_entries:
+            return True
+
+        # Second pass: username-based matching (case-insensitive).
+        # This supports configs like DISCORD_ALLOWED_USERS=alice,bob without
+        # requiring member-intent username->ID resolution to succeed first.
+        user_name = (source.user_name or "").strip()
+        if user_name:
+            normalized_user_name = user_name.lower().lstrip("@")
+            normalized_entries = {entry.lower().lstrip("@") for entry in allowed_entries}
+            if normalized_user_name in normalized_entries:
+                return True
+
+        return False
     
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """

--- a/tests/gateway/test_gateway_authorization.py
+++ b/tests/gateway/test_gateway_authorization.py
@@ -1,0 +1,49 @@
+"""Tests for GatewayRunner user authorization behavior."""
+
+from unittest.mock import MagicMock, patch
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner() -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    return runner
+
+
+def _make_discord_source(user_id: str = "507191144904654858", user_name: str = "treeindustries") -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="1049724380118261770",
+        chat_type="group",
+        user_id=user_id,
+        user_name=user_name,
+    )
+
+
+def test_authorizes_discord_user_by_id_allowlist():
+    runner = _make_runner()
+    source = _make_discord_source()
+
+    with patch.dict("os.environ", {"DISCORD_ALLOWED_USERS": "507191144904654858"}, clear=True):
+        assert runner._is_user_authorized(source) is True
+
+
+def test_authorizes_discord_user_by_username_allowlist_case_insensitive():
+    runner = _make_runner()
+    source = _make_discord_source(user_name="TreeIndustries")
+
+    with patch.dict("os.environ", {"DISCORD_ALLOWED_USERS": "JJTREE,@treeindustries"}, clear=True):
+        assert runner._is_user_authorized(source) is True
+
+
+def test_denies_discord_user_when_not_in_allowlist():
+    runner = _make_runner()
+    source = _make_discord_source(user_name="treeindustries")
+
+    with patch.dict("os.environ", {"DISCORD_ALLOWED_USERS": "somebodyelse,123"}, clear=True):
+        assert runner._is_user_authorized(source) is False


### PR DESCRIPTION
## Summary
This PR fixes a gateway auth edge case where Discord users configured by username in DISCORD_ALLOWED_USERS could be rejected if username-to-ID resolution did not complete.

### Root cause
GatewayRunner._is_user_authorized() primarily matched allowlist entries against source.user_id (and JID variants). For Discord, this could fail when operators used usernames in DISCORD_ALLOWED_USERS and runtime username-to-ID resolution was unavailable or delayed.

### Changes
- Keep existing ID/JID allowlist matching as the primary path.
- Add a second, explicit username fallback path:
  - case-insensitive matching
  - @username normalization
- For Discord SessionSource, use canonical message.author.name for user_name (instead of mutable display nickname), so username fallback is stable.
- Add focused gateway authorization regression tests.

## Why this is safe
- No relaxation of existing ID checks; this only adds a fallback when ID checks fail.
- Username fallback only compares against explicit allowlist entries.
- Existing auth order (allow-all flags, pairing approvals, allowlists) is preserved.

## Tests
- Added: tests/gateway/test_gateway_authorization.py
  - authorizes by ID allowlist
  - authorizes by username allowlist (case-insensitive + @ support)
  - denies when user is not in allowlist
- Ran gateway suite:
  - python -m pytest tests/gateway -q
  - result: passing (with pre-existing unrelated warnings)

## Files changed
- gateway/run.py
- gateway/platforms/discord.py
- tests/gateway/test_gateway_authorization.py
