### PR TITLE
fix: eliminate execute_code progress spam on gateway platforms

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -63,6 +63,11 @@ def get_skin_tool_prefix() -> str:
 # Tool preview (one-line summary of a tool call's primary argument)
 # =========================================================================
 
+def _oneline(text: str) -> str:
+    """Collapse whitespace (including newlines) to single spaces."""
+    return " ".join(text.split())
+
+
 def build_tool_preview(tool_name: str, args: dict, max_len: int = 40) -> str:
     """Build a short preview of a tool call's primary argument for display."""
     if not args:
@@ -89,7 +94,7 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int = 40) -> str:
         if sid:
             parts.append(sid[:16])
         if data:
-            parts.append(f'"{data[:20]}"')
+            parts.append(f'"{_oneline(data[:20])}"')
         if timeout_val and action == "wait":
             parts.append(f"{timeout_val}s")
         return " ".join(parts) if parts else None
@@ -105,24 +110,24 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int = 40) -> str:
             return f"planning {len(todos_arg)} task(s)"
 
     if tool_name == "session_search":
-        query = args.get("query", "")
+        query = _oneline(args.get("query", ""))
         return f"recall: \"{query[:25]}{'...' if len(query) > 25 else ''}\""
 
     if tool_name == "memory":
         action = args.get("action", "")
         target = args.get("target", "")
         if action == "add":
-            content = args.get("content", "")
+            content = _oneline(args.get("content", ""))
             return f"+{target}: \"{content[:25]}{'...' if len(content) > 25 else ''}\""
         elif action == "replace":
-            return f"~{target}: \"{args.get('old_text', '')[:20]}\""
+            return f"~{target}: \"{_oneline(args.get('old_text', '')[:20])}\""
         elif action == "remove":
-            return f"-{target}: \"{args.get('old_text', '')[:20]}\""
+            return f"-{target}: \"{_oneline(args.get('old_text', '')[:20])}\""
         return action
 
     if tool_name == "send_message":
         target = args.get("target", "?")
-        msg = args.get("message", "")
+        msg = _oneline(args.get("message", ""))
         if len(msg) > 20:
             msg = msg[:17] + "..."
         return f"to {target}: \"{msg}\""
@@ -156,7 +161,7 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int = 40) -> str:
     if isinstance(value, list):
         value = value[0] if value else ""
 
-    preview = str(value).strip()
+    preview = _oneline(str(value))
     if not preview:
         return None
     if len(preview) > max_len:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2916,6 +2916,8 @@ class GatewayRunner:
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if tool_progress_enabled else None
         last_tool = [None]  # Mutable container for tracking in closure
+        last_progress_msg = [None]  # Track last message for dedup
+        repeat_count = [0]  # How many times the same message repeated
         
         def progress_callback(tool_name: str, preview: str = None, args: dict = None):
             """Callback invoked by agent when a tool is called."""
@@ -2988,6 +2990,18 @@ class GatewayRunner:
             else:
                 msg = f"{emoji} {tool_name}..."
             
+            # Dedup: collapse consecutive identical progress messages.
+            # Common with execute_code where models iterate with the same
+            # code (same boilerplate imports → identical previews).
+            if msg == last_progress_msg[0]:
+                repeat_count[0] += 1
+                # Update the last line in progress_lines with a counter
+                # via a special "dedup" queue message.
+                progress_queue.put(("__dedup__", msg, repeat_count[0]))
+                return
+            last_progress_msg[0] = msg
+            repeat_count[0] = 0
+            
             progress_queue.put(msg)
         
         # Background task to send progress messages
@@ -3008,8 +3022,17 @@ class GatewayRunner:
 
             while True:
                 try:
-                    msg = progress_queue.get_nowait()
-                    progress_lines.append(msg)
+                    raw = progress_queue.get_nowait()
+                    
+                    # Handle dedup messages: update last line with repeat counter
+                    if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
+                        _, base_msg, count = raw
+                        if progress_lines:
+                            progress_lines[-1] = f"{base_msg} (×{count + 1})"
+                        msg = progress_lines[-1] if progress_lines else base_msg
+                    else:
+                        msg = raw
+                        progress_lines.append(msg)
 
                     if can_edit and progress_msg_id is not None:
                         # Try to edit the existing progress message
@@ -3045,8 +3068,13 @@ class GatewayRunner:
                     # Drain remaining queued messages
                     while not progress_queue.empty():
                         try:
-                            msg = progress_queue.get_nowait()
-                            progress_lines.append(msg)
+                            raw = progress_queue.get_nowait()
+                            if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
+                                _, base_msg, count = raw
+                                if progress_lines:
+                                    progress_lines[-1] = f"{base_msg} (×{count + 1})"
+                            else:
+                                progress_lines.append(raw)
                         except Exception:
                             break
                     # Final edit with all remaining tools (only if editing works)


### PR DESCRIPTION
## Problem

On Telegram/Discord/etc., execute_code tool calls produce massive visual spam — a single message bubble fills with 17+ identical lines like:

```
🐍 execute_code: "import os
print("=== Current Director..."
🐍 execute_code: "import os
print("=== Current Director..."
(repeat 17 times)
```

This happens because of two independent issues:

### Issue 1: Newlines in previews

`build_tool_preview()` preserves \n characters from execute_code's `code` argument. A preview like `import os\nprint("...")` renders as **2 visual lines** per progress entry on messaging platforms. Other tools (terminal, web_search, etc.) never have newlines in their primary argument, so they don't exhibit this.

### Issue 2: No deduplication of identical messages

In "all" mode (the default), every tool call gets a progress line — even when identical to the previous one. When models iterate with execute_code using the same boilerplate code (common pattern: `import os\nprint(...)`), each call produces an identical progress line. 9 calls × 2 visual lines each = 18 lines of identical spam.

## Fixes

### 1. Collapse whitespace in `build_tool_preview()` (`agent/display.py`)

```python
preview = " ".join(preview.split())
```

Newlines and tabs become spaces. Now: `import os print("=== Current Dir..."` — one clean line.

### 2. Dedup consecutive identical progress messages (`gateway/run.py`)

Track the last progress message. When the same message appears consecutively, collapse it with a repeat counter instead of adding a new line:

**Before:** 9 identical lines  
**After:** `🐍 execute_code: "import os print("=== Cur..." (×9)`

The dedup works by sending a special `(__dedup__, msg, count)` tuple through the progress queue. The `send_progress_messages` async loop updates the last line in-place and re-edits the Telegram message.

## Testing

- 3205 tests pass, 0 new failures
- Verified preview collapsing works: `import os\nprint(...)` → `import os print(...)` (single line, 0 newlines)