### PR TITLE
fix(google-oauth): bypass PKCE for headless token exchange

### DIFF
--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -142,41 +142,55 @@ def store_client_secret(path: str):
 
 
 def get_auth_url():
-    """Print the OAuth authorization URL. User visits this in a browser."""
+    """Print the OAuth authorization URL. User visits this in a browser.
+
+    Builds the URL manually without PKCE parameters so the token exchange
+    in exchange_auth_code() can succeed on headless systems where the Flow
+    object is no longer in memory.
+    """
     if not CLIENT_SECRET_PATH.exists():
         print("ERROR: No client secret stored. Run --client-secret first.")
         sys.exit(1)
 
-    _ensure_deps()
-    from google_auth_oauthlib.flow import Flow
+    try:
+        client_data = json.loads(CLIENT_SECRET_PATH.read_text())
+    except Exception as e:
+        print(f"ERROR: Could not read client secret: {e}")
+        sys.exit(1)
 
-    flow = Flow.from_client_secrets_file(
-        str(CLIENT_SECRET_PATH),
-        scopes=SCOPES,
-        redirect_uri=REDIRECT_URI,
-    )
-    auth_url, _ = flow.authorization_url(
-        access_type="offline",
-        prompt="consent",
-    )
+    client_info = client_data.get("installed") or client_data.get("web")
+    if not client_info:
+        print("ERROR: Unrecognized client secret format.")
+        sys.exit(1)
+
+    client_id = client_info["client_id"]
+    auth_uri = client_info.get("auth_uri", "https://accounts.google.com/o/oauth2/auth")
+
+    import urllib.parse
+    params = {
+        "client_id": client_id,
+        "redirect_uri": REDIRECT_URI,
+        "response_type": "code",
+        "scope": " ".join(SCOPES),
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    auth_url = auth_uri + "?" + urllib.parse.urlencode(params)
     # Print just the URL so the agent can extract it cleanly
     print(auth_url)
 
 
 def exchange_auth_code(code: str):
-    """Exchange the authorization code for a token and save it."""
+    """Exchange the authorization code for a token and save it.
+
+    Uses a direct HTTP token exchange without PKCE so it works on headless
+    systems where the Flow object that generated the auth URL is no longer
+    available.  Desktop OAuth clients are not required to use PKCE, and
+    Google's token endpoint accepts non-PKCE requests for installed apps.
+    """
     if not CLIENT_SECRET_PATH.exists():
         print("ERROR: No client secret stored. Run --client-secret first.")
         sys.exit(1)
-
-    _ensure_deps()
-    from google_auth_oauthlib.flow import Flow
-
-    flow = Flow.from_client_secrets_file(
-        str(CLIENT_SECRET_PATH),
-        scopes=SCOPES,
-        redirect_uri=REDIRECT_URI,
-    )
 
     # The code might come as a full redirect URL or just the code itself
     if code.startswith("http"):
@@ -190,14 +204,64 @@ def exchange_auth_code(code: str):
         code = params["code"][0]
 
     try:
-        flow.fetch_token(code=code)
+        client_data = json.loads(CLIENT_SECRET_PATH.read_text())
+    except Exception as e:
+        print(f"ERROR: Could not read client secret: {e}")
+        sys.exit(1)
+
+    # Support both "installed" and "web" client secret formats
+    client_info = client_data.get("installed") or client_data.get("web")
+    if not client_info:
+        print("ERROR: Unrecognized client secret format.")
+        sys.exit(1)
+
+    client_id = client_info["client_id"]
+    client_secret = client_info["client_secret"]
+    token_uri = client_info.get("token_uri", "https://oauth2.googleapis.com/token")
+
+    # Direct token exchange — no PKCE verifier needed.
+    # This avoids the "Missing code verifier" error on headless systems where
+    # the Flow object that held the verifier is no longer in memory.
+    import urllib.parse
+    import urllib.request
+
+    post_data = urllib.parse.urlencode({
+        "code": code,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "redirect_uri": REDIRECT_URI,
+        "grant_type": "authorization_code",
+    }).encode()
+
+    try:
+        req = urllib.request.Request(
+            token_uri,
+            data=post_data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req) as resp:
+            token_data = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"ERROR: Token exchange failed: {e} — {body}")
+        print("The code may have expired. Run --auth-url to get a fresh URL.")
+        sys.exit(1)
     except Exception as e:
         print(f"ERROR: Token exchange failed: {e}")
         print("The code may have expired. Run --auth-url to get a fresh URL.")
         sys.exit(1)
 
-    creds = flow.credentials
-    TOKEN_PATH.write_text(creds.to_json())
+    # Build a credentials JSON compatible with google.oauth2.credentials.Credentials
+    creds_data = {
+        "token": token_data.get("access_token"),
+        "refresh_token": token_data.get("refresh_token"),
+        "token_uri": token_uri,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "scopes": SCOPES,
+    }
+    TOKEN_PATH.write_text(json.dumps(creds_data, indent=2))
     print(f"OK: Authenticated. Token saved to {TOKEN_PATH}")
 
 

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -1,0 +1,247 @@
+"""Tests for Google Workspace OAuth setup script.
+
+Focuses on exchange_auth_code() — specifically that it uses a direct HTTP
+token exchange without PKCE so it works on headless systems.
+"""
+
+import json
+import sys
+import unittest.mock
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+def _make_client_secret(tmp_path) -> Path:
+    """Write a minimal client_secret.json and return its path."""
+    data = {
+        "installed": {
+            "client_id": "test-client-id",
+            "client_secret": "test-client-secret",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "redirect_uris": ["http://localhost"],
+        }
+    }
+    p = tmp_path / "google_client_secret.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+def _make_token_response() -> dict:
+    return {
+        "access_token": "ya29.test-access-token",
+        "refresh_token": "1//test-refresh-token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+
+
+# ---------------------------------------------------------------------------
+# exchange_auth_code
+# ---------------------------------------------------------------------------
+
+class TestExchangeAuthCode:
+
+    def _run(self, tmp_path, code, token_response=None, http_error=None):
+        """Import and call exchange_auth_code with mocked HTTP and paths."""
+        import importlib, types
+
+        # Dynamically import the setup module from its file path
+        spec = importlib.util.spec_from_file_location(
+            "setup",
+            Path(__file__).parent.parent.parent
+            / "skills/productivity/google-workspace/scripts/setup.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        # Patch TOKEN_PATH and CLIENT_SECRET_PATH
+        client_secret_path = _make_client_secret(tmp_path)
+        token_path = tmp_path / "google_token.json"
+
+        import urllib.error
+
+        if http_error:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = b'{"error": "invalid_grant"}'
+            urlopen_side_effect = urllib.error.HTTPError(
+                url="https://oauth2.googleapis.com/token",
+                code=400,
+                msg="Bad Request",
+                hdrs={},
+                fp=MagicMock(read=lambda: b'{"error": "invalid_grant"}'),
+            )
+        else:
+            resp_body = json.dumps(token_response or _make_token_response()).encode()
+            mock_response = MagicMock()
+            mock_response.read.return_value = resp_body
+            mock_response.__enter__ = lambda s: s
+            mock_response.__exit__ = MagicMock(return_value=False)
+            urlopen_side_effect = mock_response
+
+        with patch.object(mod, "TOKEN_PATH", token_path), \
+             patch.object(mod, "CLIENT_SECRET_PATH", client_secret_path), \
+             patch("urllib.request.urlopen",
+                   side_effect=[urlopen_side_effect] if http_error else None,
+                   return_value=urlopen_side_effect if not http_error else None):
+            if http_error:
+                with pytest.raises(SystemExit):
+                    mod.exchange_auth_code(code)
+                return None, token_path
+            else:
+                mod.exchange_auth_code(code)
+                return token_path.read_text(), token_path
+
+    def test_plain_code_produces_token_file(self, tmp_path):
+        """A plain auth code results in a saved token file."""
+        token_json, token_path = self._run(tmp_path, "4/test-auth-code")
+        assert token_path.exists()
+        data = json.loads(token_json)
+        assert data["token"] == "ya29.test-access-token"
+        assert data["refresh_token"] == "1//test-refresh-token"
+        assert data["client_id"] == "test-client-id"
+        assert data["client_secret"] == "test-client-secret"
+
+    def test_url_code_is_extracted(self, tmp_path):
+        """A full redirect URL has the code extracted from query params."""
+        url_code = "http://localhost:1/?code=4/extracted-code&scope=gmail"
+        token_json, token_path = self._run(tmp_path, url_code)
+        assert token_path.exists()
+        data = json.loads(token_json)
+        assert data["token"] == "ya29.test-access-token"
+
+    def test_no_pkce_in_request(self, tmp_path):
+        """The token request does not include code_verifier or code_challenge."""
+        import urllib.request as _urllib_request
+
+        spec = __import__("importlib").util.spec_from_file_location(
+            "setup2",
+            Path(__file__).parent.parent.parent
+            / "skills/productivity/google-workspace/scripts/setup.py",
+        )
+        mod = __import__("importlib").util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        client_secret_path = _make_client_secret(tmp_path)
+        token_path = tmp_path / "google_token.json"
+
+        captured_data = []
+
+        resp_body = json.dumps(_make_token_response()).encode()
+        mock_response = MagicMock()
+        mock_response.read.return_value = resp_body
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        original_urlopen = _urllib_request.urlopen
+
+        def capturing_urlopen(req, **kwargs):
+            captured_data.append(req.data)
+            return mock_response
+
+        with patch.object(mod, "TOKEN_PATH", token_path), \
+             patch.object(mod, "CLIENT_SECRET_PATH", client_secret_path), \
+             patch("urllib.request.urlopen", side_effect=capturing_urlopen):
+            mod.exchange_auth_code("4/test-code")
+
+        assert captured_data, "urlopen was not called"
+        body = captured_data[0].decode()
+        assert "code_verifier" not in body
+        assert "code_challenge" not in body
+        assert "grant_type=authorization_code" in body
+
+    def test_http_error_exits_nonzero(self, tmp_path):
+        """An HTTP error from the token endpoint causes a non-zero exit."""
+        _, token_path = self._run(tmp_path, "4/bad-code", http_error=True)
+        assert not token_path.exists()
+
+    def test_saved_token_has_correct_keys(self, tmp_path):
+        """Saved token JSON contains all keys needed by google.oauth2.credentials."""
+        token_json, _ = self._run(tmp_path, "4/test-code")
+        data = json.loads(token_json)
+        for key in ("token", "refresh_token", "token_uri", "client_id", "client_secret", "scopes"):
+            assert key in data, f"Missing key: {key}"
+
+    def test_web_client_secret_format(self, tmp_path):
+        """Also works with 'web' type client secrets (not just 'installed')."""
+        data = {
+            "web": {
+                "client_id": "web-client-id",
+                "client_secret": "web-client-secret",
+                "token_uri": "https://oauth2.googleapis.com/token",
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "redirect_uris": ["http://localhost"],
+            }
+        }
+        client_secret_path = tmp_path / "google_client_secret.json"
+        client_secret_path.write_text(json.dumps(data))
+        token_path = tmp_path / "google_token.json"
+
+        spec = __import__("importlib").util.spec_from_file_location(
+            "setup3",
+            Path(__file__).parent.parent.parent
+            / "skills/productivity/google-workspace/scripts/setup.py",
+        )
+        mod = __import__("importlib").util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        resp_body = json.dumps(_make_token_response()).encode()
+        mock_response = MagicMock()
+        mock_response.read.return_value = resp_body
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch.object(mod, "TOKEN_PATH", token_path), \
+             patch.object(mod, "CLIENT_SECRET_PATH", client_secret_path), \
+             patch("urllib.request.urlopen", return_value=mock_response):
+            mod.exchange_auth_code("4/test-code")
+
+        data = json.loads(token_path.read_text())
+        assert data["client_id"] == "web-client-id"
+
+
+# ---------------------------------------------------------------------------
+# get_auth_url
+# ---------------------------------------------------------------------------
+
+class TestGetAuthUrl:
+
+    def _load_mod(self):
+        import importlib
+        spec = importlib.util.spec_from_file_location(
+            "setup_url",
+            Path(__file__).parent.parent.parent
+            / "skills/productivity/google-workspace/scripts/setup.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_url_contains_no_pkce_params(self, tmp_path, capsys):
+        """Auth URL must not contain code_challenge or code_challenge_method."""
+        mod = self._load_mod()
+        client_secret_path = _make_client_secret(tmp_path)
+
+        with patch.object(mod, "CLIENT_SECRET_PATH", client_secret_path):
+            mod.get_auth_url()
+
+        out = capsys.readouterr().out.strip()
+        assert "code_challenge" not in out
+        assert "code_challenge_method" not in out
+
+    def test_url_contains_required_params(self, tmp_path, capsys):
+        """Auth URL contains client_id, redirect_uri, scope, response_type."""
+        mod = self._load_mod()
+        client_secret_path = _make_client_secret(tmp_path)
+
+        with patch.object(mod, "CLIENT_SECRET_PATH", client_secret_path):
+            mod.get_auth_url()
+
+        out = capsys.readouterr().out.strip()
+        assert "client_id=test-client-id" in out
+        assert "response_type=code" in out
+        assert "redirect_uri=" in out
+        assert "scope=" in out
+        assert "access_type=offline" in out


### PR DESCRIPTION
Fixes #1093

## Problem
On headless systems, `get_auth_url()` generates an auth URL via `Flow.authorization_url()` which includes PKCE parameters. When the user manually copies the auth code and runs `--auth-code`, a new `Flow` object is created — the original PKCE verifier is lost. Google's token endpoint then rejects the exchange with `invalid_grant: Missing code verifier`.

## Fix
- `get_auth_url()`: builds the authorization URL manually without `code_challenge` / `code_challenge_method` parameters
- `exchange_auth_code()`: performs a direct HTTP POST to the token endpoint without PKCE, instead of using `flow.fetch_token()`

Desktop OAuth clients (installed apps) are not required to use PKCE, and Google's token endpoint accepts non-PKCE requests for installed applications.

## Changes
- `skills/productivity/google-workspace/scripts/setup.py`: rewrite `get_auth_url()` and `exchange_auth_code()` to avoid PKCE
- `tests/skills/test_google_oauth_setup.py`: new test file with 8 tests covering both functions