### PR TITLE
fix: Slack thread handling — progress messages, responses, and session isolation

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -157,11 +157,10 @@ class SlackAdapter(BasePlatformAdapter):
                 "text": content,
             }
 
-            # Reply in thread if thread_ts is available
-            if reply_to:
-                kwargs["thread_ts"] = reply_to
-            elif metadata and metadata.get("thread_ts"):
-                kwargs["thread_ts"] = metadata["thread_ts"]
+            # Reply in thread if thread context is available.
+            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
 
             result = await self._app.client.chat_postMessage(**kwargs)
 
@@ -205,12 +204,30 @@ class SlackAdapter(BasePlatformAdapter):
         """Slack doesn't have a direct typing indicator API for bots."""
         pass
 
+    def _resolve_thread_ts(
+        self,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Resolve the correct thread_ts for a Slack API call.
+
+        Prefers metadata thread_id (the thread parent's ts, set by the
+        gateway) over reply_to (which may be a child message's ts).
+        """
+        if metadata:
+            if metadata.get("thread_id"):
+                return metadata["thread_id"]
+            if metadata.get("thread_ts"):
+                return metadata["thread_ts"]
+        return reply_to
+
     async def send_image_file(
         self,
         chat_id: str,
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local image file to Slack by uploading it."""
         if not self._app:
@@ -226,7 +243,7 @@ class SlackAdapter(BasePlatformAdapter):
                 file=image_path,
                 filename=os.path.basename(image_path),
                 initial_comment=caption or "",
-                thread_ts=reply_to,
+                thread_ts=self._resolve_thread_ts(reply_to, metadata),
             )
             return SendResult(success=True, raw_response=result)
 
@@ -246,6 +263,7 @@ class SlackAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image to Slack by uploading the URL as a file."""
         if not self._app:
@@ -264,7 +282,7 @@ class SlackAdapter(BasePlatformAdapter):
                 content=response.content,
                 filename="image.png",
                 initial_comment=caption or "",
-                thread_ts=reply_to,
+                thread_ts=self._resolve_thread_ts(reply_to, metadata),
             )
 
             return SendResult(success=True, raw_response=result)
@@ -286,6 +304,7 @@ class SlackAdapter(BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an audio file to Slack."""
         if not self._app:
@@ -297,7 +316,7 @@ class SlackAdapter(BasePlatformAdapter):
                 file=audio_path,
                 filename=os.path.basename(audio_path),
                 initial_comment=caption or "",
-                thread_ts=reply_to,
+                thread_ts=self._resolve_thread_ts(reply_to, metadata),
             )
             return SendResult(success=True, raw_response=result)
 
@@ -316,6 +335,7 @@ class SlackAdapter(BasePlatformAdapter):
         video_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a video file to Slack."""
         if not self._app:
@@ -330,7 +350,7 @@ class SlackAdapter(BasePlatformAdapter):
                 file=video_path,
                 filename=os.path.basename(video_path),
                 initial_comment=caption or "",
-                thread_ts=reply_to,
+                thread_ts=self._resolve_thread_ts(reply_to, metadata),
             )
             return SendResult(success=True, raw_response=result)
 
@@ -351,6 +371,7 @@ class SlackAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a document/file attachment to Slack."""
         if not self._app:
@@ -367,7 +388,7 @@ class SlackAdapter(BasePlatformAdapter):
                 file=file_path,
                 filename=display_name,
                 initial_comment=caption or "",
-                thread_ts=reply_to,
+                thread_ts=self._resolve_thread_ts(reply_to, metadata),
             )
             return SendResult(success=True, raw_response=result)
 
@@ -419,12 +440,21 @@ class SlackAdapter(BasePlatformAdapter):
         text = event.get("text", "")
         user_id = event.get("user", "")
         channel_id = event.get("channel", "")
-        thread_ts = event.get("thread_ts") or event.get("ts")
         ts = event.get("ts", "")
 
         # Determine if this is a DM or channel message
         channel_type = event.get("channel_type", "")
         is_dm = channel_type == "im"
+
+        # Build thread_ts for session keying.
+        # In channels: fall back to ts so each top-level @mention starts a
+        #   new thread/session (the bot always replies in a thread).
+        # In DMs: only use the real thread_ts — top-level DMs should share
+        #   one continuous session, threaded DMs get their own session.
+        if is_dm:
+            thread_ts = event.get("thread_ts")  # None for top-level DMs
+        else:
+            thread_ts = event.get("thread_ts") or ts  # ts fallback for channels
 
         # In channels, only respond if bot is mentioned
         if not is_dm and self._bot_user_id:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -299,10 +299,21 @@ def build_session_key(source: SessionSource) -> str:
     """Build a deterministic session key from a message source.
 
     This is the single source of truth for session key construction.
-    WhatsApp DMs include chat_id (multi-user), other DMs do not (single owner).
+
+    DM rules:
+      - WhatsApp DMs include chat_id (multi-user support).
+      - Other DMs include thread_id when present (e.g. Slack threaded DMs),
+        so each DM thread gets its own session while top-level DMs share one.
+      - Without thread_id or chat_id, all DMs share a single session.
+
+    Group/channel rules:
+      - thread_id differentiates threads within a channel.
+      - Without thread_id, all messages in a channel share one session.
     """
     platform = source.platform.value
     if source.chat_type == "dm":
+        if source.thread_id:
+            return f"agent:main:{platform}:dm:{source.thread_id}"
         if platform == "whatsapp" and source.chat_id:
             return f"agent:main:{platform}:dm:{source.chat_id}"
         return f"agent:main:{platform}:dm"


### PR DESCRIPTION
## Problem

Tyler reported three issues with the Slack adapter:
1. Tool call progress messages appear in the main channel instead of the thread
2. Bot should always respond in a thread when @mentioned, and that thread should be the session
3. Long-running tasks block the bot from responding in other threads/channels

## Root Causes Found

### 1. Metadata key mismatch (progress messages leaking)
The gateway sets progress metadata as `{"thread_id": source.thread_id}`, but the Slack adapter's `send()` method checked for `metadata.get("thread_ts")`. The key didn't match, so thread context was lost and progress messages went to the main channel.

Every other platform adapter (Telegram, Discord) uses `thread_id` correctly.

### 2. reply_to precedence (responses escaping threads)
For thread replies, `reply_to` was set to the child message's `ts`, but Slack API needs the parent message's `ts` for `thread_ts`. The response could end up outside the thread. Now metadata `thread_id` (which is always the parent's ts) takes priority.

### 3. Single DM session key (cross-session blocking)
All non-WhatsApp DMs shared one session key: `agent:main:slack:dm`. A long-running task in a DM blocked all other DM conversations. Now DMs with `thread_id` get per-thread session keys.

### 4. Bonus: media methods missing metadata parameter
All Slack media methods (`send_image`, `send_voice`, `send_video`, `send_document`, `send_image_file`) only accepted `reply_to` but not `metadata`. Since base.py passes `metadata=_thread_metadata`, media in threads would silently fail (caught by try/except).

## Changes

### `gateway/platforms/slack.py`
- Add `_resolve_thread_ts()` helper — single source of truth for thread_ts resolution. Checks `metadata.thread_id` → `metadata.thread_ts` → `reply_to`.
- Refactor `send()` to use the helper
- Add `metadata` parameter to all 5 media methods, using the helper
- Split thread_ts construction in `_handle_slack_message`:
  - **Channels**: `thread_ts = event.thread_ts || event.ts` (each top-level @mention starts a new thread/session)
  - **DMs**: `thread_ts = event.thread_ts || None` (top-level DMs share one session, threaded DMs get their own)

### `gateway/session.py`
- `build_session_key()`: DMs with `thread_id` now get per-thread session keys
- Updated docstring with clear DM/group rules

## Session Key Behavior After This Change

| Scenario | Session Key | Concurrent? |
|----------|-------------|-------------|
| Channel @mention (top-level) | `...:group:{channel}:{ts}` | ✅ Each mention = new session |
| Channel thread reply | `...:group:{channel}:{parent_ts}` | Same session as parent |
| DM (top-level) | `...:dm` | One continuous session |
| DM (threaded) | `...:dm:{thread_ts}` | ✅ Per-thread session |
| Other platforms | Unchanged | — |

## Test Plan
- All 623 gateway tests pass
- All 61 Slack + session tests pass
- Full suite: 3190 passed (5 pre-existing failures, 168 skipped)