### PR TITLE
fix(tests): patch AIAgent._build_system_prompt instead of non-existent module-level function

### DIFF
--- a/tests/test_real_interrupt_subagent.py
+++ b/tests/test_real_interrupt_subagent.py
@@ -94,7 +94,7 @@ class TestRealSubagentInterrupt(unittest.TestCase):
                     MockOpenAI.return_value = mock_client
 
                     # Also need to patch the system prompt builder
-                    with patch('run_agent.build_system_prompt', return_value="You are a test agent"):
+                    with patch.object(AIAgent, '_build_system_prompt', return_value="You are a test agent"):
                         # Signal when child starts
                         original_run = AIAgent.run_conversation
 


### PR DESCRIPTION
## Problem

`tests/test_real_interrupt_subagent.py` was patching `run_agent.build_system_prompt` — a module-level function that does not exist. The actual implementation is `AIAgent._build_system_prompt`, a private instance method.

This caused CI to fail with:
```
AttributeError: <module 'run_agent'> does not have the attribute 'build_system_prompt'
```

## Fix

Replace `patch('run_agent.build_system_prompt', ...)` with `patch.object(AIAgent, '_build_system_prompt', ...)`.

## Testing

- Target test passes: `1 passed`
- Full suite: `3215 passed, 0 failed`