### PR TITLE
fix(discord): accept metadata in media send methods

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -251,6 +251,7 @@ class DiscordAdapter(BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send audio as a Discord file attachment."""
         if not self._client:
@@ -289,6 +290,7 @@ class DiscordAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         if not self._client:
@@ -326,6 +328,7 @@ class DiscordAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image natively as a Discord file attachment."""
         if not self._client:

--- a/tests/gateway/test_discord_media_metadata.py
+++ b/tests/gateway/test_discord_media_metadata.py
@@ -1,0 +1,9 @@
+import inspect
+
+from gateway.platforms.discord import DiscordAdapter
+
+
+def test_discord_media_methods_accept_metadata_kwarg():
+    for method_name in ("send_voice", "send_image_file", "send_image"):
+        signature = inspect.signature(getattr(DiscordAdapter, method_name))
+        assert "metadata" in signature.parameters, method_name


### PR DESCRIPTION
## Bug Description

Discord media delivery could fail even when tool output succeeded.

When Hermes returned a `MEDIA:` attachment from tools like `text_to_speech`, the base gateway send pipeline passed platform metadata into Discord media delivery calls. On `main`, Discord's `send_voice`, `send_image_file`, and `send_image` methods did not accept a `metadata` kwarg.

## Root Cause

`BasePlatformAdapter` passes `metadata` through media send calls, but the Discord adapter's native media methods had stale signatures that omitted `metadata`.

That created a method-signature mismatch in the Discord attachment-delivery path.

## Fix

- add `metadata: Optional[Dict[str, Any]] = None` to:
  - `DiscordAdapter.send_voice`
  - `DiscordAdapter.send_image_file`
  - `DiscordAdapter.send_image`
- add a regression test covering those method signatures

## How to Verify

1. Trigger a response that returns a `MEDIA:` audio or image attachment in Discord
2. Confirm the attachment appears in the channel/thread
3. Run:
   `python -m pytest tests/gateway/test_discord_media_metadata.py tests/gateway/test_platform_base.py -q`

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [ ] Manual verification of the fix

## Risk Assessment

Low — this only aligns Discord method signatures with the existing base adapter call path. No behavior change beyond accepting the already-passed kwarg.
EOF; __hermes_rc=$?; printf '__HERMES_FENCE_a9f7b3__'; exit $__hermes_rc
