### PR TITLE
feat: add Tavily setup support

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -262,6 +262,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
     4: ["VOICE_TOOLS_OPENAI_KEY", "ELEVENLABS_API_KEY"],
     5: ["WHATSAPP_ENABLED", "WHATSAPP_MODE", "WHATSAPP_ALLOWED_USERS",
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
+    7: ["TAVILY_API_KEY"],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -377,6 +378,14 @@ OPTIONAL_ENV_VARS = {
         "prompt": "Firecrawl API key",
         "url": "https://firecrawl.dev/",
         "tools": ["web_search", "web_extract"],
+        "password": True,
+        "category": "tool",
+    },
+    "TAVILY_API_KEY": {
+        "description": "Tavily API key for Tavily-based research skills and integrations",
+        "prompt": "Tavily API key",
+        "url": "https://app.tavily.com/home",
+        "tools": ["tavily skills", "research integrations"],
         "password": True,
         "category": "tool",
     },
@@ -1054,6 +1063,7 @@ def show_config():
         ("ANTHROPIC_API_KEY", "Anthropic"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
         ("FIRECRAWL_API_KEY", "Firecrawl"),
+        ("TAVILY_API_KEY", "Tavily"),
         ("BROWSERBASE_API_KEY", "Browserbase"),
         ("FAL_KEY", "FAL"),
     ]
@@ -1199,7 +1209,7 @@ def set_config_value(key: str, value: str):
     # Check if it's an API key (goes to .env)
     api_keys = [
         'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
-        'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL', 'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID',
+        'FIRECRAWL_API_KEY', 'TAVILY_API_KEY', 'FIRECRAWL_API_URL', 'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID',
         'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
         'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
         'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -434,6 +434,12 @@ def _print_setup_summary(config: dict, hermes_home):
     else:
         tool_status.append(("Web Search & Extract", False, "FIRECRAWL_API_KEY"))
 
+    # Tavily (skills / integrations)
+    if get_env_value("TAVILY_API_KEY"):
+        tool_status.append(("Tavily Research Integrations", True, None))
+    else:
+        tool_status.append(("Tavily Research Integrations", False, "TAVILY_API_KEY"))
+
     # Browser tools (local Chromium or Browserbase cloud)
     import shutil
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -84,6 +84,7 @@ def show_status(args):
         "MiniMax": "MINIMAX_API_KEY",
         "MiniMax-CN": "MINIMAX_CN_API_KEY",
         "Firecrawl": "FIRECRAWL_API_KEY",
+        "Tavily": "TAVILY_API_KEY",
         "Browserbase": "BROWSERBASE_API_KEY",  # Optional — local browser works without this
         "FAL": "FAL_KEY",
         "Tinker": "TINKER_API_KEY",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -150,9 +150,16 @@ TOOL_CATEGORIES = {
     "web": {
         "name": "Web Search & Extract",
         "setup_title": "Select Search Provider",
-        "setup_note": "A free DuckDuckGo search skill is also included — skip this if you don't need Firecrawl.",
+        "setup_note": "A free DuckDuckGo search skill is also included, and Tavily-based skills/integrations can be configured here too.",
         "icon": "🔍",
         "providers": [
+            {
+                "name": "Tavily",
+                "tag": "Search-first research for Tavily-based skills and integrations",
+                "env_vars": [
+                    {"key": "TAVILY_API_KEY", "prompt": "Tavily API key", "url": "https://app.tavily.com/home"},
+                ],
+            },
             {
                 "name": "Firecrawl Cloud",
                 "tag": "Recommended - hosted service",

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -10,6 +10,8 @@ import yaml
 
 from hermes_cli.config import (
     DEFAULT_CONFIG,
+    ENV_VARS_BY_VERSION,
+    OPTIONAL_ENV_VARS,
     get_hermes_home,
     ensure_hermes_home,
     load_config,
@@ -151,3 +153,12 @@ class TestSaveConfigAtomicity:
                 raw = yaml.safe_load(f)
             assert raw["model"] == "test/atomic-model"
             assert raw["agent"]["max_turns"] == 77
+
+
+class TestOptionalToolKeys:
+    def test_tavily_api_key_is_registered_for_setup_and_migration(self):
+        tavily = OPTIONAL_ENV_VARS["TAVILY_API_KEY"]
+        assert tavily["prompt"] == "Tavily API key"
+        assert tavily["category"] == "tool"
+        assert "research" in tavily["description"].lower()
+        assert "TAVILY_API_KEY" in ENV_VARS_BY_VERSION[7]

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -1,0 +1,14 @@
+from types import SimpleNamespace
+
+from hermes_cli.status import show_status
+
+
+def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Tavily" in output
+    assert "tvly...cdef" in output


### PR DESCRIPTION
Adds Tavily to the setup/configuration flow so users can configure `TAVILY_API_KEY` alongside other optional web research integrations.

What changed:
- register `TAVILY_API_KEY` in optional env var metadata and migration tracking
- show Tavily in `hermes config` / `hermes status`
- surface Tavily in setup summaries and `hermes tools` web provider selection
- add focused CLI tests for config/status coverage

Validation:
- `python -m pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_status.py tests/hermes_cli/test_set_config_value.py -q`
- `python -m pytest tests/hermes_cli/test_setup.py -q`
- `python -m pytest tests/ -q` *(currently has 2 unrelated pre-existing failures on main: `tests/test_cli_provider_resolution.py::test_codex_provider_uses_config_model` and `tests/test_real_interrupt_subagent.py::TestRealSubagentInterrupt::test_interrupt_child_during_api_call`)*

Closes #1069
