### PR TITLE
fix: handle dict/list arguments in tool call validation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4276,6 +4276,14 @@ class AIAgent:
                     invalid_json_args = []
                     for tc in assistant_message.tool_calls:
                         args = tc.function.arguments
+                        # Normalize dict/list arguments to JSON string (llama.cpp/Ollama behavior)
+                        if isinstance(args, dict):
+                            args = json.dumps(args, ensure_ascii=False)
+                        elif isinstance(args, list):
+                            args = json.dumps(args, ensure_ascii=False)
+                        elif not isinstance(args, str):
+                            args = str(args)
+                        tc.function.arguments = args
                         # Treat empty/whitespace strings as empty object
                         if not args or not args.strip():
                             tc.function.arguments = "{}"


### PR DESCRIPTION
## Summary

When using llama-server (llama.cpp) as an OpenAI-compatible backend, tool call arguments may be returned as a dict or list instead of a string. This causes `AttributeError: 'dict' object has no attribute 'strip'` at the tool call argument validation.

## Fix

This fix normalizes dict/list arguments to JSON strings before the `.strip()` call, matching the existing pattern used elsewhere in the codebase (line ~1660).

## Changes

- Added type checking for `tc.function.arguments` before calling `.strip()`
- Normalize dict to JSON string using `json.dumps()`
- Normalize list to JSON string using `json.dumps()`
- Fallback to `str()` for other types

## Testing

This fix follows the same pattern already used at line ~1660 in `run_agent.py`.

## Related

Fixes: #1071