### PR TITLE
fix: preserve Discord attachment support

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -251,6 +251,7 @@ class DiscordAdapter(BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send audio as a Discord file attachment."""
         if not self._client:
@@ -289,6 +290,7 @@ class DiscordAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         if not self._client:
@@ -326,6 +328,7 @@ class DiscordAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image natively as a Discord file attachment."""
         if not self._client:
@@ -383,6 +386,83 @@ class DiscordAdapter(BasePlatformAdapter):
                 exc_info=True,
             )
             return await super().send_image(chat_id, image_url, caption, reply_to)
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a local video file as a Discord attachment."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            import io
+
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            if not channel:
+                return SendResult(success=False, error=f"Channel {chat_id} not found")
+
+            if not os.path.exists(video_path):
+                return SendResult(success=False, error=f"Video file not found: {video_path}")
+
+            filename = os.path.basename(video_path)
+
+            with open(video_path, "rb") as f:
+                file = discord.File(io.BytesIO(f.read()), filename=filename)
+                msg = await channel.send(
+                    content=caption if caption else None,
+                    file=file,
+                )
+                return SendResult(success=True, message_id=str(msg.id))
+
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.error("[%s] Failed to send video, falling back to base adapter: %s", self.name, e, exc_info=True)
+            return await super().send_video(chat_id, video_path, caption, reply_to)
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an arbitrary file as a Discord attachment."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            import io
+
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            if not channel:
+                return SendResult(success=False, error=f"Channel {chat_id} not found")
+
+            if not os.path.exists(file_path):
+                return SendResult(success=False, error=f"File not found: {file_path}")
+
+            filename = file_name or os.path.basename(file_path)
+
+            with open(file_path, "rb") as f:
+                file = discord.File(io.BytesIO(f.read()), filename=filename)
+                msg = await channel.send(
+                    content=caption if caption else None,
+                    file=file,
+                )
+                return SendResult(success=True, message_id=str(msg.id))
+
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.error("[%s] Failed to send document, falling back to base adapter: %s", self.name, e, exc_info=True)
+            return await super().send_document(chat_id, file_path, caption, file_name, reply_to)
     
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator."""

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -171,7 +171,7 @@ from gateway.platforms.discord import DiscordAdapter  # noqa: E402
 class TestDiscordSendImageFile:
     @pytest.fixture
     def adapter(self):
-        config = PlatformConfig(enabled=True, token="fake-token")
+        config = PlatformConfig(enabled=True, token="***")
         a = DiscordAdapter(config)
         a._client = MagicMock()
         return a
@@ -193,6 +193,92 @@ class TestDiscordSendImageFile:
         assert result.success
         assert result.message_id == "99"
         mock_channel.send.assert_awaited_once()
+
+    def test_send_image_file_accepts_metadata_kwarg(self, adapter, tmp_path):
+        """Gateway media pipeline passes metadata=...; Discord adapter should accept it."""
+        img = tmp_path / "screenshot.png"
+        img.write_bytes(b"\x89PNG" + b"\x00" * 50)
+
+        mock_channel = MagicMock()
+        mock_msg = MagicMock()
+        mock_msg.id = 100
+        mock_channel.send = AsyncMock(return_value=mock_msg)
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter.send_image_file(
+                chat_id="67890",
+                image_path=str(img),
+                metadata={"thread_id": "123"},
+            )
+        )
+        assert result.success
+        assert result.message_id == "100"
+
+    def test_send_voice_accepts_metadata_kwarg(self, adapter, tmp_path):
+        """Discord TTS attachments should not crash when the gateway passes metadata."""
+        audio = tmp_path / "voice.mp3"
+        audio.write_bytes(b"ID3" + b"\x00" * 50)
+
+        mock_channel = MagicMock()
+        mock_msg = MagicMock()
+        mock_msg.id = 101
+        mock_channel.send = AsyncMock(return_value=mock_msg)
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter.send_voice(
+                chat_id="67890",
+                audio_path=str(audio),
+                metadata={"thread_id": "123"},
+            )
+        )
+        assert result.success
+        assert result.message_id == "101"
+
+    def test_send_document_uploads_file_attachment(self, adapter, tmp_path):
+        """DiscordAdapter.send_document should upload files, not fall back to text."""
+        pdf = tmp_path / "sample.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+
+        mock_channel = MagicMock()
+        mock_msg = MagicMock()
+        mock_msg.id = 102
+        mock_channel.send = AsyncMock(return_value=mock_msg)
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter.send_document(
+                chat_id="67890",
+                file_path=str(pdf),
+                metadata={"thread_id": "123"},
+            )
+        )
+        assert result.success
+        assert result.message_id == "102"
+        assert "file" in mock_channel.send.call_args.kwargs
+
+    def test_send_video_uploads_file_attachment(self, adapter, tmp_path):
+        """DiscordAdapter.send_video should upload playable video files."""
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 50)
+
+        mock_channel = MagicMock()
+        mock_msg = MagicMock()
+        mock_msg.id = 103
+        mock_channel.send = AsyncMock(return_value=mock_msg)
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter.send_video(
+                chat_id="67890",
+                video_path=str(video),
+                metadata={"thread_id": "123"},
+            )
+        )
+        assert result.success
+        assert result.message_id == "103"
+        assert "file" in mock_channel.send.call_args.kwargs
 
     def test_returns_error_when_file_missing(self, adapter):
         result = asyncio.get_event_loop().run_until_complete(


### PR DESCRIPTION
## Summary
- make DiscordAdapter accept the gateway media pipeline's metadata kwarg for voice/image sends
- send local video and document files as native Discord attachments instead of falling back to text/url behavior
- add regression coverage for metadata acceptance and local attachment uploads

## Test Plan
- ./venv/bin/pytest -o addopts='' -q tests/gateway/test_send_image_file.py

This PR captures the local Discord patch so it stays tracked across future updates.