### PR TITLE
fix: make update respect branch upstream

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1724,6 +1724,40 @@ def _update_via_zip(args):
     print("✓ Update complete!")
 
 
+def _get_update_target(git_cmd: list[str]) -> tuple[str, str, str, str]:
+    """Resolve the current branch and the remote/branch it should update from."""
+    import subprocess
+
+    result = subprocess.run(
+        git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    branch = result.stdout.strip()
+    if branch == "HEAD":
+        raise RuntimeError("Cannot update from a detached HEAD; check out a branch first.")
+
+    remote = "origin"
+    remote_branch = branch
+    upstream_ref = f"{remote}/{remote_branch}"
+
+    upstream = subprocess.run(
+        git_cmd + ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    upstream_name = upstream.stdout.strip()
+    if upstream.returncode == 0 and upstream_name and "/" in upstream_name:
+        remote, remote_branch = upstream_name.split("/", 1)
+        upstream_ref = upstream_name
+
+    return branch, remote, remote_branch, upstream_ref
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version."""
     import subprocess
@@ -1765,21 +1799,12 @@ def cmd_update(args):
         if sys.platform == "win32":
             git_cmd = ["git", "-c", "windows.appendAtomically=false"]
         
-        subprocess.run(git_cmd + ["fetch", "origin"], cwd=PROJECT_ROOT, check=True)
-        
-        # Get current branch
-        result = subprocess.run(
-            git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
-            cwd=PROJECT_ROOT,
-            capture_output=True,
-            text=True,
-            check=True
-        )
-        branch = result.stdout.strip()
+        branch, remote, remote_branch, upstream_ref = _get_update_target(git_cmd)
+        subprocess.run(git_cmd + ["fetch", remote], cwd=PROJECT_ROOT, check=True)
         
         # Check if there are updates
         result = subprocess.run(
-            git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
+            git_cmd + ["rev-list", f"HEAD..{upstream_ref}", "--count"],
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True,
@@ -1793,7 +1818,7 @@ def cmd_update(args):
         
         print(f"→ Found {commit_count} new commit(s)")
         print("→ Pulling updates...")
-        subprocess.run(git_cmd + ["pull", "origin", branch], cwd=PROJECT_ROOT, check=True)
+        subprocess.run(git_cmd + ["pull", remote, remote_branch], cwd=PROJECT_ROOT, check=True)
         
         # Reinstall Python dependencies (prefer uv for speed, fall back to pip)
         print("→ Updating Python dependencies...")

--- a/tests/hermes_cli/test_update.py
+++ b/tests/hermes_cli/test_update.py
@@ -1,0 +1,136 @@
+import argparse
+import importlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+class _RunRecorder:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def __call__(self, cmd, **kwargs):
+        key = tuple(cmd)
+        self.calls.append(list(cmd))
+        if key not in self.responses:
+            pytest.fail(f"Unexpected command: {cmd}")
+
+        result = self.responses[key]
+        if isinstance(result, Exception):
+            raise result
+
+        if kwargs.get("check") and result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                result.returncode,
+                cmd,
+                output=result.stdout,
+                stderr=result.stderr,
+            )
+        return result
+
+
+def _completed(cmd, stdout="", stderr="", returncode=0):
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+
+def _load_main(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    import hermes_cli.main as main
+
+    return importlib.reload(main)
+
+
+def test_cmd_update_uses_tracking_upstream_remote(monkeypatch, tmp_path):
+    main = _load_main(monkeypatch, tmp_path)
+    project_root = tmp_path / "repo"
+    (project_root / ".git").mkdir(parents=True)
+    monkeypatch.setattr(main, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    import tools.skills_sync as skills_sync
+    import hermes_cli.config as config
+
+    monkeypatch.setattr(
+        skills_sync,
+        "sync_skills",
+        lambda quiet=True: {"copied": [], "updated": [], "user_modified": [], "cleaned": []},
+    )
+    monkeypatch.setattr(config, "get_missing_env_vars", lambda required_only=True: [])
+    monkeypatch.setattr(config, "get_missing_config_fields", lambda: [])
+    monkeypatch.setattr(config, "check_config_version", lambda: (1, 1))
+    monkeypatch.setattr(
+        config,
+        "migrate_config",
+        lambda interactive=True, quiet=False: {"env_added": [], "config_added": []},
+    )
+
+    responses = {
+        ("git", "rev-parse", "--abbrev-ref", "HEAD"): _completed(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            stdout="fix/discord-attachment-support\n",
+        ),
+        ("git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): _completed(
+            ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+            stdout="fork/fix/discord-attachment-support\n",
+        ),
+        ("git", "fetch", "fork"): _completed(["git", "fetch", "fork"]),
+        (
+            "git",
+            "rev-list",
+            "HEAD..fork/fix/discord-attachment-support",
+            "--count",
+        ): _completed(
+            ["git", "rev-list", "HEAD..fork/fix/discord-attachment-support", "--count"],
+            stdout="1\n",
+        ),
+        ("git", "pull", "fork", "fix/discord-attachment-support"): _completed(
+            ["git", "pull", "fork", "fix/discord-attachment-support"]
+        ),
+        ("/usr/bin/uv", "pip", "install", "-e", ".", "--quiet"): _completed(
+            ["/usr/bin/uv", "pip", "install", "-e", ".", "--quiet"]
+        ),
+        ("systemctl", "--user", "is-active", "hermes-gateway"): _completed(
+            ["systemctl", "--user", "is-active", "hermes-gateway"],
+            stdout="inactive\n",
+        ),
+    }
+    runner = _RunRecorder(responses)
+    monkeypatch.setattr(subprocess, "run", runner)
+
+    main.cmd_update(argparse.Namespace())
+
+    assert ["git", "fetch", "fork"] in runner.calls
+    assert ["git", "pull", "fork", "fix/discord-attachment-support"] in runner.calls
+
+
+def test_cmd_update_falls_back_to_origin_when_branch_has_no_upstream(monkeypatch, tmp_path):
+    main = _load_main(monkeypatch, tmp_path)
+    project_root = tmp_path / "repo"
+    (project_root / ".git").mkdir(parents=True)
+    monkeypatch.setattr(main, "PROJECT_ROOT", project_root)
+
+    responses = {
+        ("git", "rev-parse", "--abbrev-ref", "HEAD"): _completed(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            stdout="feature/local-only\n",
+        ),
+        ("git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): _completed(
+            ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+            stderr="fatal: no upstream configured\n",
+            returncode=128,
+        ),
+        ("git", "fetch", "origin"): _completed(["git", "fetch", "origin"]),
+        ("git", "rev-list", "HEAD..origin/feature/local-only", "--count"): _completed(
+            ["git", "rev-list", "HEAD..origin/feature/local-only", "--count"],
+            stdout="0\n",
+        ),
+    }
+    runner = _RunRecorder(responses)
+    monkeypatch.setattr(subprocess, "run", runner)
+
+    main.cmd_update(argparse.Namespace())
+
+    assert ["git", "fetch", "origin"] in runner.calls
+    assert ["git", "rev-list", "HEAD..origin/feature/local-only", "--count"] in runner.calls


### PR DESCRIPTION
## Summary
- resolve the current branch's configured upstream before fetching and pulling during `hermes update`
- fall back to `origin/<branch>` when no upstream is configured
- add CLI regression tests covering both tracked fork branches and no-upstream branches

## Test Plan
- ./venv/bin/pytest -o addopts='' -q tests/hermes_cli/test_update.py tests/gateway/test_update_command.py

This fixes `hermes update` failing on branches that track a non-origin remote, such as fork-backed PR branches.