### PR TITLE
fix: default reset policy null values in gateway config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -83,10 +83,14 @@ class SessionResetPolicy:
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionResetPolicy":
+        mode = data.get("mode")
+        at_hour = data.get("at_hour")
+        idle_minutes = data.get("idle_minutes")
+
         return cls(
-            mode=data.get("mode", "both"),
-            at_hour=data.get("at_hour", 4),
-            idle_minutes=data.get("idle_minutes", 1440),
+            mode=mode if mode is not None else "both",
+            at_hour=at_hour if at_hour is not None else 4,
+            idle_minutes=idle_minutes if idle_minutes is not None else 1440,
         )
 
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -82,6 +82,15 @@ class TestSessionResetPolicy:
         assert policy.at_hour == 4
         assert policy.idle_minutes == 1440
 
+    def test_from_dict_treats_null_values_as_defaults(self):
+        restored = SessionResetPolicy.from_dict(
+            {"mode": None, "at_hour": None, "idle_minutes": None}
+        )
+
+        assert restored.mode == "both"
+        assert restored.at_hour == 4
+        assert restored.idle_minutes == 1440
+
 
 class TestGatewayConfigRoundtrip:
     def test_full_roundtrip(self):


### PR DESCRIPTION
## What does this PR do?

Treat explicit `null` values in session reset policy config the same as missing keys, so gateway config loading falls back to the documented defaults instead of propagating `None` into validation.

## Related Issue

Fixes #1119

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- update `SessionResetPolicy.from_dict()` to coalesce `None` values for `mode`, `at_hour`, and `idle_minutes` to their default values
- add a regression test covering explicit `null` values in the parsed policy dict

## How to Test

1. Run `python3 -m pytest -o addopts='' tests/gateway/test_config.py`
2. Confirm `SessionResetPolicy.from_dict({"mode": None, "at_hour": None, "idle_minutes": None})` yields `both`, `4`, and `1440`
3. Restart the gateway with a config containing explicit null reset-policy values and verify it no longer crashes during validation

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / Python 3.9 locally with focused gateway config tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
