### PR TITLE
fix: skip extended thinking params for Haiku models

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -400,8 +400,9 @@ def build_anthropic_kwargs(
 
     # Map reasoning_config to Anthropic's thinking parameter
     # Newer models (4.6+) prefer "adaptive" thinking; older models use "enabled"
+    # Haiku models do NOT support extended thinking at all
     if reasoning_config and isinstance(reasoning_config, dict):
-        if reasoning_config.get("enabled") is not False:
+        if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
             effort = reasoning_config.get("effort", "medium")
             budget = THINKING_BUDGET.get(effort, 8000)
             # Use adaptive thinking for 4.5+ models (they deprecate type=enabled)


### PR DESCRIPTION
## Summary

Fixes a bug where Haiku models (e.g. `claude-haiku-4-5-20251001`) would receive extended thinking parameters, causing a **400 error** from the Anthropic API.

## Bug

The reasoning config logic in `anthropic_adapter.py` uses substring matching to detect model capabilities:

```python
if any(v in model for v in ("4-6", "4-5", "4.6", "4.5")):
```

This check matches Haiku model names like `claude-haiku-4-5-20251001` because they contain the substring `"4-5"`. As a result, the adapter sends `thinking: {type: "adaptive", budget_tokens: ...}` to the API — but Haiku models do not support extended thinking at all, so the API returns a 400 error.

## Root Cause

The substring-based version check does not account for the fact that Haiku models share version substrings (e.g. `4-5`) with Sonnet/Opus models that do support thinking.

## Fix

Added a guard clause to skip thinking parameters entirely when the model name contains `"haiku"`:

```python
if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
```

This ensures Haiku models are never sent thinking parameters, regardless of version substring matches.

## Test plan

- [ ] Verify that requests to `claude-haiku-4-5-20251001` no longer include `thinking` params
- [ ] Verify that `claude-sonnet-4-5-20250514` still gets `thinking: {type: "adaptive", ...}`
- [ ] Verify that older non-Haiku models still get `thinking: {type: "enabled", ...}`