### PR TITLE
fix(anthropic): skip thinking params for Haiku models

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -414,8 +414,9 @@ def build_anthropic_kwargs(
     # Map reasoning_config to Anthropic's thinking parameter.
     # Claude 4.6 models use adaptive thinking + output_config.effort.
     # Older models use manual thinking with budget_tokens.
+    # Haiku models do NOT support extended thinking at all — skip entirely.
     if reasoning_config and isinstance(reasoning_config, dict):
-        if reasoning_config.get("enabled") is not False:
+        if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
             effort = str(reasoning_config.get("effort", "medium")).lower()
             budget = THINKING_BUDGET.get(effort, 8000)
             if _supports_adaptive_thinking(model):


### PR DESCRIPTION
Haiku models don't support extended thinking. Without this guard, `claude-haiku-4-5-20251001` gets `thinking: {type: enabled, budget_tokens: ...}` and returns 400.

Adds `"haiku" not in model.lower()` guard on top of #1128's adaptive thinking refactor. Incorporates the fix from PR #1127 by @frizynn.

Verified live:
- `claude-opus-4-6` → adaptive thinking ✓
- `claude-haiku-4-5-20251001` → no thinking params ✓  
- `claude-sonnet-4-20250514` → enabled thinking ✓