### PR TITLE
fix: Handle explicit null values in SessionResetPolicy config (#1119)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -83,10 +83,30 @@ class SessionResetPolicy:
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionResetPolicy":
+        """
+        Create SessionResetPolicy from dictionary configuration.
+        
+        Handles both missing keys and explicit null values correctly.
+        Python's dict.get() only returns default when key is missing,
+        not when key exists with None/null value — so we check explicitly.
+        """
+        # Handle None values explicitly — data.get() returns None if key exists with null
+        at_hour = data.get("at_hour")
+        if at_hour is None:
+            at_hour = 4
+        
+        idle_minutes = data.get("idle_minutes")
+        if idle_minutes is None:
+            idle_minutes = 1440
+        
+        mode = data.get("mode")
+        if mode is None:
+            mode = "both"
+        
         return cls(
-            mode=data.get("mode", "both"),
-            at_hour=data.get("at_hour", 4),
-            idle_minutes=data.get("idle_minutes", 1440),
+            mode=mode,
+            at_hour=at_hour,
+            idle_minutes=idle_minutes,
         )
 
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -82,6 +82,48 @@ class TestSessionResetPolicy:
         assert policy.at_hour == 4
         assert policy.idle_minutes == 1440
 
+    def test_explicit_null_values_use_defaults(self):
+        """
+        Regression test for issue #1119: explicit null values in config.yaml
+        should use defaults, not None.
+        
+        Python's dict.get() returns None when key exists with null value,
+        which differs from when the key is missing entirely.
+        """
+        # Simulate YAML with explicit null values
+        data = {
+            "mode": None,
+            "at_hour": None,
+            "idle_minutes": None,
+        }
+        policy = SessionResetPolicy.from_dict(data)
+        
+        # Should use defaults, not None
+        assert policy.mode == "both"
+        assert policy.at_hour == 4
+        assert policy.idle_minutes == 1440
+
+    def test_partial_null_values(self):
+        """Partial null values should default while preserving set values."""
+        data = {
+            "mode": "idle",
+            "at_hour": None,  # null
+            "idle_minutes": 60,  # set
+        }
+        policy = SessionResetPolicy.from_dict(data)
+        
+        assert policy.mode == "idle"
+        assert policy.at_hour == 4  # defaulted
+        assert policy.idle_minutes == 60  # preserved
+
+    def test_empty_dict_uses_defaults(self):
+        """Empty dict (missing keys) should use all defaults."""
+        policy = SessionResetPolicy.from_dict({})
+        
+        assert policy.mode == "both"
+        assert policy.at_hour == 4
+        assert policy.idle_minutes == 1440
+
 
 class TestGatewayConfigRoundtrip:
     def test_full_roundtrip(self):


### PR DESCRIPTION
## Summary

When users explicitly set `at_hour` or `idle_minutes` to `null` in their `config.yaml`, the gateway previously failed with a `TypeError`. This PR fixes that by properly handling `null` values in `SessionResetPolicy.from_dict()`.

## Problem

Python's `dict.get()` only returns the default value when a key is **missing**, not when the key exists with a `None`/`null` value:

```yaml
default_reset_policy:
  mode: both
  at_hour: null      # This causes TypeError
  idle_minutes: null # This too
```

## Solution

Explicitly check for `None` values before applying defaults:

```python
at_hour = data.get("at_hour")
if at_hour is None:
    at_hour = 4
```

## Changes

- `gateway/config.py`: Update `SessionResetPolicy.from_dict()` to handle `null` values
- `tests/gateway/test_config.py`: Add regression tests for null value handling

## Testing

All existing tests pass, plus new tests for:
- Explicit null values → use defaults
- Partial null values → defaults for null, preserve set values
- Empty dict → all defaults

Fixes #1119