### PR TITLE
feat: add configurable model profiles and delegation category routing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -215,11 +215,19 @@ def load_cli_config() -> Dict[str, Any]:
             "timeout": 300,    # Max seconds a sandbox script can run before being killed (5 min)
             "max_tool_calls": 50,  # Max RPC tool calls per execution
         },
+        "model_profiles": {
+            "chat": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+            "coding": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+            "planning": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+            "research": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+            "delegation": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+        },
         "delegation": {
             "max_iterations": 45,  # Max tool-calling turns per child agent
             "default_toolsets": ["terminal", "file", "web"],  # Default toolsets for subagents
-            "model": "",       # Subagent model override (empty = inherit parent model)
-            "provider": "",    # Subagent provider override (empty = inherit parent provider)
+            "model": "",       # Subagent model override (legacy; empty = inherit parent model)
+            "provider": "",    # Subagent provider override (legacy; empty = inherit parent provider)
+            "model_profile": "",  # Default profile name for delegate_task (optional)
         },
     }
     
@@ -1137,18 +1145,35 @@ class HermesCLI:
         # env vars would stomp each other.
         _model_config = CLI_CONFIG.get("model", {})
         _config_model = _model_config.get("default", "") if isinstance(_model_config, dict) else (_model_config or "")
-        self.model = model or _config_model or "anthropic/claude-opus-4.6"
+
+        profile_model = ""
+        profile_provider = ""
+        profile_base_url = ""
+        profile_api_key = ""
+        try:
+            from hermes_cli.runtime_provider import resolve_model_profile
+            chat_profile = resolve_model_profile("chat")
+            profile_model = chat_profile.get("model", "")
+            profile_provider = chat_profile.get("provider", "")
+            profile_base_url = chat_profile.get("base_url", "")
+            profile_api_key = chat_profile.get("api_key", "")
+        except Exception:
+            pass
+
+        # Explicit CLI args always win. Then chat profile. Then global model default.
+        self.model = model or profile_model or _config_model or "anthropic/claude-opus-4.6"
         # Track whether model was explicitly chosen by the user or fell back
         # to the global default.  Provider-specific normalisation may override
         # the default silently but should warn when overriding an explicit choice.
         self._model_is_default = not model
 
-        self._explicit_api_key = api_key
-        self._explicit_base_url = base_url
+        self._explicit_api_key = api_key or profile_api_key or None
+        self._explicit_base_url = base_url or profile_base_url or None
 
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (
             provider
+            or profile_provider
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or CLI_CONFIG["model"].get("provider")
             or "auto"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -198,6 +198,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
+        try:
+            from hermes_cli.runtime_provider import resolve_model_for_profile
+            model = resolve_model_for_profile("chat", model)
+        except Exception:
+            pass
+
         # Reasoning config from env or config.yaml
         reasoning_config = None
         effort = os.getenv("HERMES_REASONING_EFFORT", "")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -188,12 +188,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
 
 
 def _resolve_gateway_model() -> str:
-    """Read model from env/config — mirrors the resolution in _run_agent_sync.
-
-    Without this, temporary AIAgent instances (memory flush, /compress) fall
-    back to the hardcoded default ("anthropic/claude-opus-4.6") which fails
-    when the active provider is openai-codex.
-    """
+    """Resolve gateway chat model with optional model_profiles.chat override."""
     model = os.getenv("HERMES_MODEL") or os.getenv("LLM_MODEL") or "anthropic/claude-opus-4.6"
     try:
         import yaml as _y
@@ -206,6 +201,12 @@ def _resolve_gateway_model() -> str:
                 model = _model_cfg
             elif isinstance(_model_cfg, dict):
                 model = _model_cfg.get("default", model)
+    except Exception:
+        pass
+
+    try:
+        from hermes_cli.runtime_provider import resolve_model_for_profile
+        model = resolve_model_for_profile("chat", model)
     except Exception:
         pass
     return model

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -209,13 +209,33 @@ DEFAULT_CONFIG = {
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
     },
 
-    # Subagent delegation — override the provider:model used by delegate_task
-    # so child agents can run on a different (cheaper/faster) provider and model.
-    # Uses the same runtime provider resolution as CLI/gateway startup, so all
-    # configured providers (OpenRouter, Nous, Z.ai, Kimi, etc.) are supported.
+    # Model profiles — optional context-specific model/provider routes.
+    # Keep values empty to inherit the global `model` config.
+    #
+    # Common pattern:
+    #   - chat:      high quality model for direct conversations
+    #   - coding:    strong code model for terminal/file heavy delegated work
+    #   - planning:  cheaper reasoning model for plan/spec subtasks
+    #   - research:  web synthesis model for web-heavy delegated work
+    #
+    # For local OpenAI-compatible endpoints (Ollama/vLLM/LM Studio), set:
+    #   provider: openrouter   (or custom)
+    #   base_url: http://localhost:11434/v1
+    #   api_key_env: OLLAMA_API_KEY  (optional)
+    "model_profiles": {
+        "chat": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+        "coding": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+        "planning": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+        "research": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+        "delegation": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+    },
+
+    # Subagent delegation — legacy override for delegate_task.
+    # If model/provider are set here they take precedence over model_profiles.
     "delegation": {
-        "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
-        "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
+        "model": "",       # empty = inherit parent model
+        "provider": "",    # empty = inherit parent provider + credentials
+        "model_profile": "",  # optional default profile name (coding/planning/research/...)
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -28,6 +28,53 @@ def _get_model_config() -> Dict[str, Any]:
     return {}
 
 
+def _get_model_profiles_config() -> Dict[str, Dict[str, Any]]:
+    config = load_config()
+    profiles = config.get("model_profiles")
+    if isinstance(profiles, dict):
+        normalized: Dict[str, Dict[str, Any]] = {}
+        for name, value in profiles.items():
+            if isinstance(name, str) and isinstance(value, dict):
+                normalized[name.strip().lower()] = dict(value)
+        return normalized
+    return {}
+
+
+def resolve_model_profile(profile: str) -> Dict[str, str]:
+    """Resolve model/provider/base_url/api_key overrides for a named profile.
+
+    Returns empty strings for missing fields so callers can cleanly apply
+    fallback precedence.
+    """
+    key = (profile or "").strip().lower()
+    if not key:
+        return {
+            "model": "",
+            "provider": "",
+            "base_url": "",
+            "api_key": "",
+            "api_key_env": "",
+        }
+
+    profiles = _get_model_profiles_config()
+    raw = profiles.get(key, {})
+    if not isinstance(raw, dict):
+        raw = {}
+
+    api_key_env = str(raw.get("api_key_env", "") or "").strip()
+    api_key = str(raw.get("api_key", "") or "").strip()
+    if (not api_key) and api_key_env:
+        api_key = os.getenv(api_key_env, "").strip()
+
+    return {
+        "model": str(raw.get("model", "") or "").strip(),
+        "provider": str(raw.get("provider", "") or "").strip().lower(),
+        "base_url": str(raw.get("base_url", "") or "").strip(),
+        "api_key": api_key,
+        "api_key_env": api_key_env,
+    }
+
+
 def resolve_requested_provider(requested: Optional[str] = None) -> str:
     """Resolve provider request from explicit arg, env, then config."""
     if requested and requested.strip():
@@ -191,6 +238,13 @@ def resolve_runtime_provider(
     )
     runtime["requested_provider"] = requested_provider
     return runtime
+
+
+def resolve_model_for_profile(profile: str, fallback_model: str) -> str:
+    """Return profile model override when configured, else fallback."""
+    profile_cfg = resolve_model_profile(profile)
+    profile_model = profile_cfg.get("model", "")
+    return profile_model or fallback_model
 
 
 def format_runtime_provider_error(error: Exception) -> str:

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -181,3 +181,36 @@ def test_resolve_requested_provider_precedence(monkeypatch):
     monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "nous")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openai-codex"})
     assert rp.resolve_requested_provider("openrouter") == "openrouter"
+
+
+def test_resolve_model_profile_reads_api_key_env(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "_get_model_profiles_config",
+        lambda: {
+            "coding": {
+                "model": "openai/gpt-5-codex",
+                "provider": "openrouter",
+                "base_url": "http://localhost:11434/v1",
+                "api_key_env": "OLLAMA_API_KEY",
+            }
+        },
+    )
+    monkeypatch.setenv("OLLAMA_API_KEY", "local-key")
+
+    profile = rp.resolve_model_profile("coding")
+
+    assert profile["model"] == "openai/gpt-5-codex"
+    assert profile["provider"] == "openrouter"
+    assert profile["base_url"] == "http://localhost:11434/v1"
+    assert profile["api_key"] == "local-key"
+
+
+def test_resolve_model_for_profile_falls_back_when_empty(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_model_profile", lambda _name: {"model": ""})
+    assert rp.resolve_model_for_profile("chat", "anthropic/claude-sonnet-4") == "anthropic/claude-sonnet-4"
+
+
+def test_resolve_model_for_profile_returns_override(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_model_profile", lambda _name: {"model": "openai/gpt-5-mini"})
+    assert rp.resolve_model_for_profile("chat", "anthropic/claude-sonnet-4") == "openai/gpt-5-mini"

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -24,6 +24,7 @@ from tools.delegate_tool import (
     _build_child_system_prompt,
     _strip_blocked_tools,
     _resolve_delegation_credentials,
+    _infer_model_profile,
 )
 
 
@@ -58,6 +59,7 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
         self.assertIn("max_iterations", props)
+        self.assertIn("model_profile", props)
         self.assertEqual(props["tasks"]["maxItems"], 3)
 
 
@@ -91,6 +93,20 @@ class TestStripBlockedTools(unittest.TestCase):
     def test_empty_input(self):
         result = _strip_blocked_tools([])
         self.assertEqual(result, [])
+
+
+class TestModelProfileInference(unittest.TestCase):
+    def test_coding_profile_for_terminal_or_file(self):
+        self.assertEqual(_infer_model_profile(["terminal"]), "coding")
+        self.assertEqual(_infer_model_profile(["file", "web"]), "coding")
+
+    def test_research_profile_for_web_browser(self):
+        self.assertEqual(_infer_model_profile(["web"]), "research")
+        self.assertEqual(_infer_model_profile(["browser"]), "research")
+
+    def test_planning_profile_by_default(self):
+        self.assertEqual(_infer_model_profile([]), "planning")
+        self.assertEqual(_infer_model_profile(["memory"], goal="write a roadmap"), "planning")
 
 
 class TestDelegateTask(unittest.TestCase):
@@ -536,6 +552,80 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             # But provider/base_url/api_key should inherit from parent
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["base_url"], parent.base_url)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_profile_credentials")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_inferred_profile_used_for_coding_task(self, mock_base_creds, mock_profile_creds, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 45, "model": "", "provider": "", "model_profile": ""}
+        mock_base_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_profile_creds.return_value = {
+            "model": "openai/gpt-5-codex",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-coding",
+            "api_mode": "chat_completions",
+            "profile": "coding",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="Refactor module", toolsets=["terminal", "file"], parent_agent=parent)
+
+            mock_profile_creds.assert_called_once_with("coding")
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "openai/gpt-5-codex")
+            self.assertEqual(kwargs["provider"], "openrouter")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_profile_credentials")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_explicit_model_profile_overrides_inference(self, mock_base_creds, mock_profile_creds, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 45, "model": "", "provider": "", "model_profile": ""}
+        mock_base_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_profile_creds.return_value = {
+            "model": "google/gemini-3-flash-preview",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-plan",
+            "api_mode": "chat_completions",
+            "profile": "planning",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="Summarize architecture",
+                toolsets=["terminal", "file"],
+                model_profile="planning",
+                parent_agent=parent,
+            )
+
+            mock_profile_creds.assert_called_once_with("planning")
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -78,6 +78,61 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     return [t for t in toolsets if t not in blocked_toolset_names]
 
 
+def _infer_model_profile(toolsets: Optional[List[str]], goal: Optional[str] = None) -> str:
+    """Infer best-fit profile from requested toolsets/task intent."""
+    normalized = {str(t).strip().lower() for t in (toolsets or []) if str(t).strip()}
+    if {"terminal", "file"} & normalized:
+        return "coding"
+    if "web" in normalized or "browser" in normalized:
+        return "research"
+    goal_text = (goal or "").strip().lower()
+    if any(token in goal_text for token in ("plan", "roadmap", "spec", "design")):
+        return "planning"
+    return "planning"
+
+
+def _resolve_profile_credentials(profile_name: str) -> dict:
+    """Resolve credentials/model for a named model profile."""
+    from hermes_cli.runtime_provider import resolve_model_profile, resolve_runtime_provider
+
+    profile_cfg = resolve_model_profile(profile_name)
+    configured_model = profile_cfg.get("model") or None
+    configured_provider = profile_cfg.get("provider") or None
+    configured_base_url = profile_cfg.get("base_url") or None
+    configured_api_key = profile_cfg.get("api_key") or None
+
+    if not (configured_provider or configured_base_url or configured_api_key):
+        return {
+            "model": configured_model,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "profile": profile_name,
+        }
+
+    runtime = resolve_runtime_provider(
+        requested=configured_provider,
+        explicit_api_key=configured_api_key,
+        explicit_base_url=configured_base_url,
+    )
+    api_key = runtime.get("api_key", "")
+    if not api_key:
+        raise ValueError(
+            f"Model profile '{profile_name}' resolved but has no API key. "
+            f"Set profile api_key/api_key_env or provider credentials."
+        )
+
+    return {
+        "model": configured_model,
+        "provider": runtime.get("provider"),
+        "base_url": runtime.get("base_url"),
+        "api_key": api_key,
+        "api_mode": runtime.get("api_mode"),
+        "profile": profile_name,
+    }
+
+
 def _build_child_progress_callback(task_index: int, parent_agent, task_count: int = 1) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
@@ -315,6 +370,7 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    model_profile: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -344,21 +400,11 @@ def delegate_task(
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return json.dumps({"error": str(exc)})
-
     # Normalize to task list
     if tasks and isinstance(tasks, list):
         task_list = tasks[:MAX_CONCURRENT_CHILDREN]
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "toolsets": toolsets}]
+        task_list = [{"goal": goal, "context": context, "toolsets": toolsets, "model_profile": model_profile}]
     else:
         return json.dumps({"error": "Provide either 'goal' (single task) or 'tasks' (batch)."})
 
@@ -370,21 +416,65 @@ def delegate_task(
         if not task.get("goal", "").strip():
             return json.dumps({"error": f"Task {i} is missing a 'goal'."})
 
+    # Base legacy delegation credentials (provider/model overrides in
+    # delegation.*). If unset, this resolves to inherit-parent behavior.
+    try:
+        base_creds = _resolve_delegation_credentials(cfg, parent_agent)
+    except ValueError as exc:
+        return json.dumps({"error": str(exc)})
+
+    legacy_override_active = bool((cfg.get("model") or "").strip() or (cfg.get("provider") or "").strip())
+
+    # Build task specs with per-task credential/model routing.
+    prepared_tasks = []
+    default_profile = (cfg.get("model_profile") or "").strip() or None
+    for i, task in enumerate(task_list):
+        task_toolsets = task.get("toolsets") or toolsets
+        requested_profile = (
+            (task.get("model_profile") if isinstance(task, dict) else None)
+            or model_profile
+            or default_profile
+        )
+        inferred_profile = requested_profile or _infer_model_profile(task_toolsets, task.get("goal"))
+
+        creds = dict(base_creds)
+        profile_used = None
+
+        if not legacy_override_active:
+            try:
+                profile_creds = _resolve_profile_credentials(inferred_profile)
+            except ValueError as exc:
+                return json.dumps({"error": str(exc)})
+            for key in ("model", "provider", "base_url", "api_key", "api_mode"):
+                if profile_creds.get(key) is not None:
+                    creds[key] = profile_creds.get(key)
+            profile_used = profile_creds.get("profile")
+
+        prepared_tasks.append({
+            "task_index": i,
+            "goal": task["goal"],
+            "context": task.get("context"),
+            "toolsets": task_toolsets,
+            "creds": creds,
+            "profile": profile_used,
+        })
+
     overall_start = time.monotonic()
     results = []
 
-    n_tasks = len(task_list)
+    n_tasks = len(prepared_tasks)
     # Track goal labels for progress display (truncated for readability)
-    task_labels = [t["goal"][:40] for t in task_list]
+    task_labels = [t["goal"][:40] for t in prepared_tasks]
 
     if n_tasks == 1:
         # Single task -- run directly (no thread pool overhead)
-        t = task_list[0]
+        t = prepared_tasks[0]
+        creds = t["creds"]
         result = _run_single_child(
             task_index=0,
             goal=t["goal"],
             context=t.get("context"),
-            toolsets=t.get("toolsets") or toolsets,
+            toolsets=t.get("toolsets"),
             model=creds["model"],
             max_iterations=effective_max_iter,
             parent_agent=parent_agent,
@@ -407,13 +497,14 @@ def delegate_task(
 
         with ThreadPoolExecutor(max_workers=MAX_CONCURRENT_CHILDREN) as executor:
             futures = {}
-            for i, t in enumerate(task_list):
+            for i, t in enumerate(prepared_tasks):
+                creds = t["creds"]
                 future = executor.submit(
                     _run_single_child,
                     task_index=i,
                     goal=t["goal"],
                     context=t.get("context"),
-                    toolsets=t.get("toolsets") or toolsets,
+                    toolsets=t.get("toolsets"),
                     model=creds["model"],
                     max_iterations=effective_max_iter,
                     parent_agent=parent_agent,
@@ -533,26 +624,38 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation + model profile config.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Returns a flat dict with delegation keys (max_iterations/model/provider/
+    model_profile) plus model_profiles map.
     """
+    full = {}
     try:
         from cli import CLI_CONFIG
-        cfg = CLI_CONFIG.get("delegation", {})
-        if cfg:
-            return cfg
+        if isinstance(CLI_CONFIG, dict) and CLI_CONFIG:
+            full = CLI_CONFIG
     except Exception:
         pass
-    try:
-        from hermes_cli.config import load_config
-        full = load_config()
-        return full.get("delegation", {})
-    except Exception:
-        return {}
+    if not full:
+        try:
+            from hermes_cli.config import load_config
+            full = load_config()
+        except Exception:
+            full = {}
+
+    if not isinstance(full, dict):
+        full = {}
+
+    delegation = full.get("delegation", {})
+    if not isinstance(delegation, dict):
+        delegation = {}
+    model_profiles = full.get("model_profiles", {})
+    if not isinstance(model_profiles, dict):
+        model_profiles = {}
+
+    merged = dict(delegation)
+    merged["model_profiles"] = model_profiles
+    return merged
 
 
 # ---------------------------------------------------------------------------
@@ -616,6 +719,13 @@ DELEGATE_TASK_SCHEMA = {
                     "full-stack tasks."
                 ),
             },
+            "model_profile": {
+                "type": "string",
+                "description": (
+                    "Optional model profile to use for this delegated task. "
+                    "Examples: 'coding', 'planning', 'research'."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -627,6 +737,10 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": "Toolsets for this specific task",
+                        },
+                        "model_profile": {
+                            "type": "string",
+                            "description": "Model profile for this specific task",
                         },
                     },
                     "required": ["goal"],
@@ -664,6 +778,7 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        model_profile=args.get("model_profile"),
         parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
 )


### PR DESCRIPTION
## Summary
- add configurable  (chat/coding/planning/research/delegation) in config defaults
- support per-profile model/provider/base_url/api_key_env/api_key resolution in runtime provider helpers
- apply  to CLI, gateway helper agents, and cron jobs
- extend  with optional  plus automatic category inference:
  - terminal/file -> coding
  - web/browser -> research
  - fallback -> planning
- keep legacy  and  behavior (takes precedence)
- add tests for profile resolution and delegated profile routing

## Why
Users should be able to route chat/planning/coding/research work to different models/providers, including local OpenAI-compatible endpoints, without hard-coding one model for everything.

## Test Plan
- bringing up nodes...
bringing up nodes...

........................................................................ [ 97%]
..                                                                       [100%]
74 passed in 2.61s
- bringing up nodes...
bringing up nodes...

................                                                         [100%]
16 passed in 4.13s
