### PR TITLE
Fix Telegram topic routing for background process updates

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2790,12 +2790,14 @@ class GatewayRunner:
         """Set environment variables for the current session."""
         os.environ["HERMES_SESSION_PLATFORM"] = context.source.platform.value
         os.environ["HERMES_SESSION_CHAT_ID"] = context.source.chat_id
+        if context.source.thread_id:
+            os.environ["HERMES_SESSION_THREAD_ID"] = context.source.thread_id
         if context.source.chat_name:
             os.environ["HERMES_SESSION_CHAT_NAME"] = context.source.chat_name
     
     def _clear_session_env(self) -> None:
         """Clear session environment variables."""
-        for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME"]:
+        for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_THREAD_ID", "HERMES_SESSION_CHAT_NAME"]:
             if var in os.environ:
                 del os.environ[var]
     
@@ -2944,6 +2946,7 @@ class GatewayRunner:
         session_key = watcher.get("session_key", "")
         platform_name = watcher.get("platform", "")
         chat_id = watcher.get("chat_id", "")
+        thread_id = watcher.get("thread_id", "")
         notify_mode = self._load_background_notifications_mode()
 
         logger.debug("Process watcher started: %s (every %ss, notify=%s)",
@@ -2991,7 +2994,8 @@ class GatewayRunner:
                             break
                     if adapter and chat_id:
                         try:
-                            await adapter.send(chat_id, message_text)
+                            send_metadata = {"thread_id": thread_id} if thread_id else None
+                            await adapter.send(chat_id, message_text, metadata=send_metadata)
                         except Exception as e:
                             logger.error("Watcher delivery error: %s", e)
                 break
@@ -3010,7 +3014,8 @@ class GatewayRunner:
                         break
                 if adapter and chat_id:
                     try:
-                        await adapter.send(chat_id, message_text)
+                        send_metadata = {"thread_id": thread_id} if thread_id else None
+                        await adapter.send(chat_id, message_text, metadata=send_metadata)
                     except Exception as e:
                         logger.error("Watcher delivery error: %s", e)
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1035,6 +1035,7 @@ def terminal_tool(
                         "session_key": session_key,
                         "platform": os.getenv("HERMES_SESSION_PLATFORM", ""),
                         "chat_id": os.getenv("HERMES_SESSION_CHAT_ID", ""),
+                        "thread_id": os.getenv("HERMES_SESSION_THREAD_ID", ""),
                     })
 
                 return json.dumps(result_data, ensure_ascii=False)


### PR DESCRIPTION
## Summary

Fix Telegram forum topic routing for background process progress/completion messages.

## What changed

- `gateway/run.py`
  - export `HERMES_SESSION_THREAD_ID` from the active session context
  - persist `thread_id` in background watcher metadata
  - send watcher notifications with `metadata={"thread_id": ...}` so Telegram replies land in the originating topic
- `tools/terminal_tool.py`
  - include `thread_id` in pending watcher payloads

## Why

In Telegram forum chats, background process updates were being delivered with only `chat_id`, which sends them to the default/general topic instead of the originating topic.

## Related issues

- Closes #1144
- Related to #1143

## Notes

This is a focused fix for background-process topic routing only. Mention/wake-gate behavior is intentionally not part of this PR.