### PR TITLE
fix(gateway): handle explicit null values in SessionResetPolicy config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -83,10 +83,18 @@ class SessionResetPolicy:
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionResetPolicy":
+        # Use explicit None checks — dict.get() returns None for keys
+        # with null/None values, bypassing the default parameter.
+        at_hour = data.get("at_hour")
+        if at_hour is None:
+            at_hour = 4
+        idle_minutes = data.get("idle_minutes")
+        if idle_minutes is None:
+            idle_minutes = 1440
         return cls(
             mode=data.get("mode", "both"),
-            at_hour=data.get("at_hour", 4),
-            idle_minutes=data.get("idle_minutes", 1440),
+            at_hour=at_hour,
+            idle_minutes=idle_minutes,
         )
 
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -82,6 +82,32 @@ class TestSessionResetPolicy:
         assert policy.at_hour == 4
         assert policy.idle_minutes == 1440
 
+    def test_from_dict_explicit_null_values(self):
+        """Explicit null values in YAML config should fall back to defaults.
+
+        dict.get() returns None (not the default) when the key exists with
+        a None value, so from_dict must handle this explicitly.
+        See: https://github.com/NousResearch/hermes-agent/issues/1119
+        """
+        data = {"mode": "both", "at_hour": None, "idle_minutes": None}
+        policy = SessionResetPolicy.from_dict(data)
+        assert policy.at_hour == 4
+        assert policy.idle_minutes == 1440
+
+    def test_from_dict_missing_keys(self):
+        """Missing keys should also fall back to defaults."""
+        policy = SessionResetPolicy.from_dict({})
+        assert policy.mode == "both"
+        assert policy.at_hour == 4
+        assert policy.idle_minutes == 1440
+
+    def test_from_dict_partial_null(self):
+        """Only one field null, the other present with a valid value."""
+        data = {"at_hour": None, "idle_minutes": 60}
+        policy = SessionResetPolicy.from_dict(data)
+        assert policy.at_hour == 4
+        assert policy.idle_minutes == 60
+
 
 class TestGatewayConfigRoundtrip:
     def test_full_roundtrip(self):


### PR DESCRIPTION
## Summary

Fixes `TypeError` when users set `at_hour` or `idle_minutes` to `null` in their `config.yaml`. 

`dict.get("key", default)` only returns the default when the key is **missing**, not when it exists with a `None` value. This caused `None` to reach the validation logic (`0 <= None <= 23`), raising a `TypeError` and crashing the gateway on startup.

## Changes

- **`gateway/config.py`**: Replace `data.get("at_hour", 4)` pattern with explicit `None` checks in `SessionResetPolicy.from_dict()`
- **`tests/gateway/test_config.py`**: Add 3 test cases — explicit null values, missing keys, partial null

## Test plan

- [x] Explicit `null` for both `at_hour` and `idle_minutes` → defaults applied
- [x] Missing keys → defaults applied  
- [x] One field `null`, the other valid → only null field gets default
- [x] Existing roundtrip test still passes

Fixes #1119