### PR TITLE
fix(gateway): fall back to module entrypoint when hermes is not on PATH

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2692,6 +2692,7 @@ class GatewayRunner:
         import json
         import shutil
         import subprocess
+        import sys
         from datetime import datetime
 
         project_root = Path(__file__).parent.parent.resolve()
@@ -2702,7 +2703,10 @@ class GatewayRunner:
 
         hermes_bin = shutil.which("hermes")
         if not hermes_bin:
-            return "✗ `hermes` command not found on PATH."
+            # Fallback: use the current Python interpreter with the module
+            # entrypoint.  This covers venv/pipx/module-based installs where
+            # the ``hermes`` script is not on the gateway process's PATH.
+            hermes_bin = f"{sys.executable} -m hermes_cli.main"
 
         # Write marker so the restarted gateway can notify this chat
         pending_path = _hermes_home / ".update_pending.json"

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -86,8 +86,12 @@ class TestHandleUpdateCommand:
         assert "Not a git repository" in result
 
     @pytest.mark.asyncio
-    async def test_no_hermes_binary(self, tmp_path):
-        """Returns error when hermes is not on PATH."""
+    async def test_falls_back_to_module_when_not_on_path(self, tmp_path):
+        """Falls back to ``sys.executable -m hermes_cli.main`` when the
+        ``hermes`` binary is not on PATH.
+
+        See: https://github.com/NousResearch/hermes-agent/issues/1049
+        """
         runner = _make_runner()
         event = _make_event()
 
@@ -98,13 +102,30 @@ class TestHandleUpdateCommand:
         (fake_root / "gateway").mkdir()
         (fake_root / "gateway" / "run.py").touch()
         fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
 
-        with patch("gateway.run._hermes_home", tmp_path), \
+        mock_popen = MagicMock()
+
+        def which_no_hermes(x):
+            if x == "hermes":
+                return None  # hermes not on PATH
+            if x == "systemd-run":
+                return None
+            return None
+
+        with patch("gateway.run._hermes_home", hermes_home), \
              patch("gateway.run.__file__", fake_file), \
-             patch("shutil.which", return_value=None):
+             patch("shutil.which", side_effect=which_no_hermes), \
+             patch("subprocess.Popen", mock_popen):
             result = await runner._handle_update_command(event)
 
-        assert "not found on PATH" in result
+        # Should succeed with fallback, not fail with "not found on PATH"
+        assert "Starting Hermes update" in result
+        # The Popen command should contain the module fallback
+        call_args = mock_popen.call_args[0][0]
+        cmd_str = call_args[2] if len(call_args) > 2 else str(call_args)
+        assert "hermes_cli.main" in cmd_str
 
     @pytest.mark.asyncio
     async def test_writes_pending_marker(self, tmp_path):


### PR DESCRIPTION
## Summary

`/update` hard-failed with `✗ hermes command not found on PATH` even when Hermes was already running. This happens in venv, pipx, or module-based installs where the `hermes` executable is not on the gateway process's PATH.

Now falls back to `sys.executable -m hermes_cli.main` instead of returning an error.

## Changes

- **`gateway/run.py`**: Replace hard-fail with fallback to `{sys.executable} -m hermes_cli.main` when `shutil.which("hermes")` returns `None`
- **`tests/gateway/test_update_command.py`**: Update existing test to verify fallback behavior — checks that the update proceeds and the command string contains the module entrypoint

## Test plan

- [x] `hermes` not on PATH → falls back to module entrypoint, update proceeds
- [x] `hermes` on PATH → existing behavior unchanged (uses binary directly)
- [x] All other existing update command tests unaffected

Fixes #1049