### PR TITLE
fix(gateway): add SSL certificate auto-detection for NixOS and other systems

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25,6 +25,45 @@ from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
 
+# Fix SSL certificate loading on systems where Python doesn't find CA certs automatically
+# This is common on Nix/NixOS systems - must be set BEFORE discord is imported
+import ssl
+
+ca_bundle = None
+ca_paths = ssl.get_default_verify_paths()
+if ca_paths.cafile and os.path.exists(ca_paths.cafile):
+    ca_bundle = ca_paths.cafile
+elif ca_paths.openssl_cafile and os.path.exists(ca_paths.openssl_cafile):
+    ca_bundle = ca_paths.openssl_cafile
+
+if not ca_bundle:
+    try:
+        import certifi
+        ca_bundle = certifi.where()
+    except ImportError:
+        pass
+
+if not ca_bundle:
+    for path in [
+        "/etc/ssl/certs/ca-certificates.crt",  # Debian/Ubuntu/Gentoo
+        "/etc/pki/tls/certs/ca-bundle.crt",  # RHEL/CentOS 7
+        "/etc/pki/tls/certs/ca-bundle.trust.crt",  # RHEL/CentOS 7
+        "/etc/ssl/ca-bundle.pem",  # SUSE/OpenSUSE
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",  # RHEL/CentOS 8+
+        "/etc/ca-certificates/trust-source/anchors",  # Arch
+        "/usr/share/pki/trust/anchors",  # Arch
+        "/etc/ssl/cert.pem",  # Alpine
+        "/etc/pki/tls/cert.pem",  # RHEL/Fedora
+        "/usr/local/etc/openssl@1.1/cert.pem",  # macOS Homebrew Intel
+        "/opt/homebrew/etc/openssl@1.1/cert.pem",  # macOS Homebrew ARM
+    ]:
+        if os.path.exists(path):
+            ca_bundle = path
+            break
+
+if ca_bundle and "SSL_CERT_FILE" not in os.environ:
+    os.environ["SSL_CERT_FILE"] = ca_bundle
+
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 


### PR DESCRIPTION
## Description

This PR fixes SSL certificate issues on systems where Python doesn't automatically find CA certificates (common on NixOS and other non-standard environments).

## Problem

The gateway imports discord early but needs SSL certificates configured before discord is imported. On systems with non-standard certificate locations (like NixOS), this results in SSL verification failures when the gateway tries to connect to Discord.

## Solution

Added automatic CA certificate discovery in gateway/run.py that:
1. Uses Python's default verify paths (ssl.get_default_verify_paths())
2. Falls back to certifi if available
3. Falls back to common system certificate locations for various Linux distributions and macOS
4. Sets SSL_CERT_FILE environment variable if a certificate bundle is found

The fix runs at module import time (before any HTTP libraries like discord are imported) and only sets SSL_CERT_FILE if it's not already set in the environment.

## Testing

Tested on NixOS where the default Python SSL module doesn't find system certificates. After this change, Discord integration works without manual certificate configuration.