### PR TITLE
feat: model routing profiles with per-context model/provider selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) | Install → setup → first conversation in 2 minutes |
 | [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli) | Commands, keybindings, personalities, sessions |
 | [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) | Config file, providers, models, all options |
+| [Model Profiles (draft)](docs/model-profiles.md) | Route chat/planning/coding/research to different models/providers, including local endpoints |
 | [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security) | Command approval, DM pairing, container isolation |
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ tools, toolset system, terminal backends |

--- a/cli.py
+++ b/cli.py
@@ -215,11 +215,19 @@ def load_cli_config() -> Dict[str, Any]:
             "timeout": 300,    # Max seconds a sandbox script can run before being killed (5 min)
             "max_tool_calls": 50,  # Max RPC tool calls per execution
         },
+        "model_profiles": {
+            "chat": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+            "coding": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+            "planning": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+            "research": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+            "delegation": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+        },
         "delegation": {
             "max_iterations": 45,  # Max tool-calling turns per child agent
             "default_toolsets": ["terminal", "file", "web"],  # Default toolsets for subagents
-            "model": "",       # Subagent model override (empty = inherit parent model)
-            "provider": "",    # Subagent provider override (empty = inherit parent provider)
+            "model": "",       # Subagent model override (legacy; empty = inherit parent model)
+            "provider": "",    # Subagent provider override (legacy; empty = inherit parent provider)
+            "model_profile": "",  # Default profile name for delegate_task (optional)
         },
     }
     
@@ -1139,18 +1147,35 @@ class HermesCLI:
         # env vars would stomp each other.
         _model_config = CLI_CONFIG.get("model", {})
         _config_model = _model_config.get("default", "") if isinstance(_model_config, dict) else (_model_config or "")
-        self.model = model or _config_model or "anthropic/claude-opus-4.6"
+
+        profile_model = ""
+        profile_provider = ""
+        profile_base_url = ""
+        profile_api_key = ""
+        try:
+            from hermes_cli.runtime_provider import resolve_model_profile
+            chat_profile = resolve_model_profile("chat")
+            profile_model = chat_profile.get("model", "")
+            profile_provider = chat_profile.get("provider", "")
+            profile_base_url = chat_profile.get("base_url", "")
+            profile_api_key = chat_profile.get("api_key", "")
+        except Exception:
+            pass
+
+        # Explicit CLI args always win. Then chat profile. Then global model default.
+        self.model = model or profile_model or _config_model or "anthropic/claude-opus-4.6"
         # Track whether model was explicitly chosen by the user or fell back
         # to the global default.  Provider-specific normalisation may override
         # the default silently but should warn when overriding an explicit choice.
         self._model_is_default = not model
 
-        self._explicit_api_key = api_key
-        self._explicit_base_url = base_url
+        self._explicit_api_key = api_key or profile_api_key or None
+        self._explicit_base_url = base_url or profile_base_url or None
 
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (
             provider
+            or profile_provider
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or CLI_CONFIG["model"].get("provider")
             or "auto"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -198,6 +198,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
+        try:
+            from hermes_cli.runtime_provider import resolve_model_for_profile
+            model = resolve_model_for_profile("chat", model)
+        except Exception:
+            pass
+
         # Reasoning config from env or config.yaml
         reasoning_config = None
         effort = os.getenv("HERMES_REASONING_EFFORT", "")

--- a/docs/model-profiles.md
+++ b/docs/model-profiles.md
@@ -1,0 +1,151 @@
+# Model Profiles (chat / planning / coding / research)
+
+This feature lets users route different work types to different models/providers.
+
+Instead of one global model for everything, users can configure:
+- chat model (main conversation)
+- coding model (terminal/file-heavy delegated tasks)
+- planning model (specs/roadmaps)
+- research model (web/browser-heavy tasks)
+
+## What was added
+
+- New config section: `model_profiles`
+- New delegation option: `model_profile` (tool argument)
+- New delegation default: `delegation.model_profile` (config)
+- Automatic profile inference for delegated tasks:
+  - `terminal` or `file` toolsets => `coding`
+  - `web` or `browser` toolsets => `research`
+  - otherwise => `planning`
+- `chat` profile is applied to CLI, gateway temporary agents, and cron jobs
+- Legacy `delegation.model` / `delegation.provider` behavior remains and takes precedence
+
+## Config format
+
+Add this to `~/.hermes/config.yaml`:
+
+```yaml
+model:
+  default: anthropic/claude-sonnet-4
+  provider: openrouter
+
+model_profiles:
+  chat:
+    model: anthropic/claude-sonnet-4
+    provider: openrouter
+
+  coding:
+    model: openai/gpt-5-codex
+    provider: openrouter
+
+  planning:
+    model: google/gemini-3-flash-preview
+    provider: openrouter
+
+  research:
+    model: perplexity/sonar-deep-research
+    provider: openrouter
+
+  # Optional catch-all profile if you explicitly choose model_profile=delegation
+  delegation:
+    model: google/gemini-3-flash-preview
+    provider: openrouter
+
+# Optional default profile for delegate_task when not specified
+delegation:
+  model_profile: planning
+```
+
+Each profile supports these fields:
+
+- `model`: model slug
+- `provider`: provider name (`openrouter`, `openai-codex`, `nous`, `zai`, `kimi-coding`, `minimax`, etc.)
+- `base_url`: optional custom OpenAI-compatible endpoint
+- `api_key_env`: environment variable name to read API key from
+- `api_key`: optional inline key (not recommended)
+
+## Local model usage (Ollama / vLLM / LM Studio)
+
+Use a profile with custom `base_url` and an env var key:
+
+```yaml
+model_profiles:
+  coding:
+    model: qwen2.5-coder:32b
+    provider: openrouter
+    base_url: http://localhost:11434/v1
+    api_key_env: OLLAMA_API_KEY
+```
+
+Then set the env var:
+
+```bash
+export OLLAMA_API_KEY=dummy
+```
+
+Notes:
+- Many local OpenAI-compatible servers accept any non-empty key.
+- `api_key_env` is preferred over hardcoding `api_key` in config.
+
+## delegate_task usage
+
+You can force a profile per call:
+
+```json
+{
+  "goal": "Create an implementation plan for migration",
+  "model_profile": "planning"
+}
+```
+
+Or per item in batch mode:
+
+```json
+{
+  "tasks": [
+    {"goal": "Refactor parser", "toolsets": ["terminal", "file"], "model_profile": "coding"},
+    {"goal": "Research alternatives", "toolsets": ["web"], "model_profile": "research"}
+  ]
+}
+```
+
+If omitted, profile is inferred from toolsets (or defaults to planning).
+
+## Precedence rules
+
+### Main chat model
+1. CLI arg `--model`
+2. `model_profiles.chat.model`
+3. `model.default`
+4. built-in fallback
+
+### Main chat provider/base URL/key
+1. explicit CLI/provider args
+2. `model_profiles.chat` provider/base/key
+3. existing provider resolution (`HERMES_INFERENCE_PROVIDER`, `model.provider`, env/auth store)
+
+### delegate_task routing
+1. legacy `delegation.model` / `delegation.provider` (if set) => override everything
+2. explicit `model_profile` on tool call / task item
+3. `delegation.model_profile`
+4. inferred profile from toolsets
+
+## Backward compatibility
+
+Existing configs continue to work.
+
+If users do nothing, Hermes behavior remains effectively unchanged except that profile-based routing becomes available.
+
+## Validation checklist for end users
+
+- `hermes` starts with expected chat model/provider
+- `delegate_task` coding-style tasks hit coding profile
+- `delegate_task` web-style tasks hit research profile
+- cron jobs use chat profile model
+- gateway temporary agents (e.g. memory flush paths) use chat profile model
+
+## Troubleshooting
+
+- If a profile has `provider` but no credentials, delegation will return a clear error.
+- If a profile has only `model`, Hermes keeps parent credentials and only changes model.
+- If local endpoint auth fails, set `api_key_env` and verify the env var is visible to the process.

--- a/docs/model-profiles.md
+++ b/docs/model-profiles.md
@@ -20,9 +20,24 @@ Instead of one global model for everything, users can configure:
 - `chat` profile is applied to CLI, gateway temporary agents, and cron jobs
 - Legacy `delegation.model` / `delegation.provider` behavior remains and takes precedence
 
+## CLI onboarding (no manual file edits)
+
+Use:
+
+```bash
+hermes model
+```
+
+After provider/model setup, Hermes now asks:
+- "Configure model profiles for chat/coding/planning/research now?"
+- then walks each profile interactively
+
+Provider suggestions in that flow are filtered to providers that currently resolve with working credentials.
+Model suggestions are fetched from each provider's live `/models` endpoint when available.
+
 ## Config format
 
-Add this to `~/.hermes/config.yaml`:
+Equivalent config written by the wizard goes to `~/.hermes/config.yaml`:
 
 ```yaml
 model:

--- a/docs/model-profiles.md
+++ b/docs/model-profiles.md
@@ -1,36 +1,46 @@
-# Model Profiles (chat / planning / coding / research)
+# Model Routing Profiles
 
 This feature lets users route different work types to different models/providers.
 
-Instead of one global model for everything, users can configure:
-- chat model (main conversation)
-- coding model (terminal/file-heavy delegated tasks)
-- planning model (specs/roadmaps)
-- research model (web/browser-heavy tasks)
+Instead of one global model for everything, users can configure context-specific routing profiles.
+
+Built-in starter categories:
+- chat
+- coding
+- planning
+- research
+- delegation
+
+Users may also add custom categories such as `ops`, `fast`, `cheap`, `vision`, or `review`.
 
 ## What was added
 
 - New config section: `model_profiles`
 - New delegation option: `model_profile` (tool argument)
 - New delegation default: `delegation.model_profile` (config)
-- Automatic profile inference for delegated tasks:
-  - `terminal` or `file` toolsets => `coding`
-  - `web` or `browser` toolsets => `research`
-  - otherwise => `planning`
-- `chat` profile is applied to CLI, gateway temporary agents, and cron jobs
+- Automatic profile inference for delegated tasks uses configurable ordered routing rules when present.
+- Built-in toolset heuristics remain as a fallback only.
+- `chat` is intended for direct conversation surfaces; CLI/cron should normally inherit the primary model unless explicitly routed.
 - Legacy `delegation.model` / `delegation.provider` behavior remains and takes precedence
 
-## CLI onboarding (no manual file edits)
+## Routing configuration (no manual file edits)
 
 Use:
 
 ```bash
-hermes model
+hermes configure-model-routing
 ```
 
-After provider/model setup, Hermes now asks:
-- "Configure model profiles for chat/coding/planning/research now?"
-- then walks each profile interactively
+This command is separate from `hermes model`.
+
+- `hermes model` remains the primary/default model selector.
+- `hermes configure-model-routing` configures context-specific routing profiles.
+
+The routing flow uses the same Hermes-style interactive picker logic and supports reset:
+
+```bash
+hermes configure-model-routing --reset
+```
 
 Provider suggestions in that flow are filtered to providers that currently resolve with working credentials.
 Model suggestions are fetched from each provider's live `/models` endpoint when available.
@@ -124,7 +134,24 @@ Or per item in batch mode:
 }
 ```
 
-If omitted, profile is inferred from toolsets (or defaults to planning).
+If omitted, profile is inferred from routing rules first, then fallback toolset heuristics.
+
+## Configurable routing rules
+
+Optional ordered rules live under `model_routing.rules`:
+
+```yaml
+model_routing:
+  rules:
+    - if_toolsets_any: [terminal, file]
+      profile: coding
+    - if_toolsets_any: [web, browser]
+      profile: research
+    - if_goal_matches: [deploy, infra, migration]
+      profile: ops
+```
+
+First matching rule wins.
 
 ## Precedence rules
 
@@ -143,21 +170,23 @@ If omitted, profile is inferred from toolsets (or defaults to planning).
 1. legacy `delegation.model` / `delegation.provider` (if set) => override everything
 2. explicit `model_profile` on tool call / task item
 3. `delegation.model_profile`
-4. inferred profile from toolsets
+4. inferred profile from ordered routing rules
+5. fallback heuristic from toolsets
 
 ## Backward compatibility
 
 Existing configs continue to work.
 
-If users do nothing, Hermes behavior remains effectively unchanged except that profile-based routing becomes available.
+- If users do nothing, `hermes model` still behaves as the default-model selector.
+- Routing remains opt-in and can be reset independently.
 
 ## Validation checklist for end users
 
 - `hermes` starts with expected chat model/provider
 - `delegate_task` coding-style tasks hit coding profile
 - `delegate_task` web-style tasks hit research profile
-- cron jobs use chat profile model
-- gateway temporary agents (e.g. memory flush paths) use chat profile model
+- direct chat surfaces use the expected chat profile model
+- delegated tasks use either explicit profile, routing rules, or fallback inference
 
 ## Troubleshooting
 

--- a/docs/model-profiles.md
+++ b/docs/model-profiles.md
@@ -36,13 +36,19 @@ This command is separate from `hermes model`.
 - `hermes model` remains the primary/default model selector.
 - `hermes configure-model-routing` configures context-specific routing profiles.
 
-The routing flow uses the same Hermes-style interactive picker logic and supports reset:
+The routing flow uses the same Hermes-style interactive picker logic:
 
 ```bash
-hermes configure-model-routing --reset
+hermes configure-model-routing              # interactive setup (auto-backup)
+hermes configure-model-routing --reset      # reset to defaults (auto-backup)
+hermes configure-model-routing --restore    # roll back routing sections from backup
+hermes configure-model-routing --restore-full  # roll back entire config from backup
+hermes configure-model-routing --list-backups  # show available backups
 ```
 
 Provider suggestions in that flow are filtered to providers that currently resolve with working credentials.
+
+Every config-modifying operation auto-creates a timestamped backup in `~/.hermes/config-backups/` before writing. Restores can target just model routing sections (leaving other config untouched) or the full config. Even restore creates a `pre_restore` backup, so undo is itself undoable. Auto-rotates at 10 backups.
 Model suggestions are fetched from each provider's live `/models` endpoint when available.
 
 ## Config format

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -188,12 +188,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
 
 
 def _resolve_gateway_model() -> str:
-    """Read model from env/config — mirrors the resolution in _run_agent_sync.
-
-    Without this, temporary AIAgent instances (memory flush, /compress) fall
-    back to the hardcoded default ("anthropic/claude-opus-4.6") which fails
-    when the active provider is openai-codex.
-    """
+    """Resolve gateway chat model with optional model_profiles.chat override."""
     model = os.getenv("HERMES_MODEL") or os.getenv("LLM_MODEL") or "anthropic/claude-opus-4.6"
     try:
         import yaml as _y
@@ -206,6 +201,12 @@ def _resolve_gateway_model() -> str:
                 model = _model_cfg
             elif isinstance(_model_cfg, dict):
                 model = _model_cfg.get("default", model)
+    except Exception:
+        pass
+
+    try:
+        from hermes_cli.runtime_provider import resolve_model_for_profile
+        model = resolve_model_for_profile("chat", model)
     except Exception:
         pass
     return model

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -212,13 +212,33 @@ DEFAULT_CONFIG = {
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
     },
 
-    # Subagent delegation — override the provider:model used by delegate_task
-    # so child agents can run on a different (cheaper/faster) provider and model.
-    # Uses the same runtime provider resolution as CLI/gateway startup, so all
-    # configured providers (OpenRouter, Nous, Z.ai, Kimi, etc.) are supported.
+    # Model profiles — optional context-specific model/provider routes.
+    # Keep values empty to inherit the global `model` config.
+    #
+    # Common pattern:
+    #   - chat:      high quality model for direct conversations
+    #   - coding:    strong code model for terminal/file heavy delegated work
+    #   - planning:  cheaper reasoning model for plan/spec subtasks
+    #   - research:  web synthesis model for web-heavy delegated work
+    #
+    # For local OpenAI-compatible endpoints (Ollama/vLLM/LM Studio), set:
+    #   provider: openrouter   (or custom)
+    #   base_url: http://localhost:11434/v1
+    #   api_key_env: OLLAMA_API_KEY  (optional)
+    "model_profiles": {
+        "chat": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+        "coding": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+        "planning": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+        "research": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+        "delegation": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
+    },
+
+    # Subagent delegation — legacy override for delegate_task.
+    # If model/provider are set here they take precedence over model_profiles.
     "delegation": {
-        "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
-        "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
+        "model": "",       # empty = inherit parent model
+        "provider": "",    # empty = inherit parent provider + credentials
+        "model_profile": "",  # optional default profile name (coding/planning/research/...)
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -976,12 +976,25 @@ _COMMENTED_SECTIONS = """
 """
 
 
-def save_config(config: Dict[str, Any]):
-    """Save configuration to ~/.hermes/config.yaml."""
+def save_config(config: Dict[str, Any], *, backup_reason: str = ""):
+    """Save configuration to ~/.hermes/config.yaml.
+
+    Args:
+        config: The config dict to write.
+        backup_reason: If non-empty, create a timestamped backup before writing.
+            Callers that perform destructive operations should pass a reason string.
+    """
     from utils import atomic_yaml_write
 
     ensure_hermes_home()
     config_path = get_config_path()
+
+    if backup_reason:
+        try:
+            from hermes_cli.config_backup import create_backup
+            create_backup(config_path, reason=backup_reason)
+        except Exception:
+            pass  # Don't block save on backup failure
     normalized = _normalize_max_turns_config(config)
 
     # Build optional commented-out sections for features that are off by

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -233,6 +233,22 @@ DEFAULT_CONFIG = {
         "delegation": {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""},
     },
 
+    # Model routing rules — ordered first-match rules for auto-selecting a
+    # model profile in context-specific flows (e.g. delegated subtasks).
+    #
+    # Example:
+    #   model_routing:
+    #     rules:
+    #       - if_toolsets_any: [terminal, file]
+    #         profile: coding
+    #       - if_toolsets_any: [web, browser]
+    #         profile: research
+    #       - if_goal_matches: [roadmap, spec, plan]
+    #         profile: planning
+    "model_routing": {
+        "rules": [],
+    },
+
     # Subagent delegation — legacy override for delegate_task.
     # If model/provider are set here they take precedence over model_profiles.
     "delegation": {

--- a/hermes_cli/config_backup.py
+++ b/hermes_cli/config_backup.py
@@ -1,0 +1,202 @@
+"""Config backup and restore for non-destructive configuration changes.
+
+Backups are plain copies of config.yaml stored in ~/.hermes/config-backups/
+with timestamped filenames. Selective restore can target just model_profiles
+and model_routing sections without touching other config.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+BACKUP_DIR_NAME = "config-backups"
+MAX_BACKUPS = 10
+
+
+def get_backup_dir() -> Path:
+    """Return the config backup directory path."""
+    from hermes_cli.config import get_hermes_home
+    return get_hermes_home() / BACKUP_DIR_NAME
+
+
+def create_backup(config_path: Path, reason: str = "") -> Optional[Path]:
+    """Create a timestamped backup of config.yaml.
+
+    Args:
+        config_path: Path to the current config.yaml.
+        reason: Short tag for the filename (e.g. "routing", "reset", "pre_restore").
+
+    Returns:
+        Path to the backup file, or None if nothing to back up.
+    """
+    if not config_path.exists():
+        return None
+
+    backup_dir = get_backup_dir()
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    tag = _sanitize_reason(reason)
+    name = f"config_{stamp}_{tag}.yaml" if tag else f"config_{stamp}.yaml"
+    backup_path = backup_dir / name
+
+    # Avoid overwriting if called twice in the same second
+    counter = 1
+    while backup_path.exists():
+        name = f"config_{stamp}_{tag}_{counter}.yaml" if tag else f"config_{stamp}_{counter}.yaml"
+        backup_path = backup_dir / name
+        counter += 1
+
+    shutil.copy2(config_path, backup_path)
+    _secure_file(backup_path)
+    prune_backups()
+    return backup_path
+
+
+def prune_backups(max_count: int = MAX_BACKUPS) -> List[Path]:
+    """Remove oldest backups beyond max_count.
+
+    Returns list of deleted paths.
+    """
+    backup_dir = get_backup_dir()
+    if not backup_dir.is_dir():
+        return []
+
+    backups = sorted(
+        backup_dir.glob("config_*.yaml"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+
+    deleted = []
+    for old in backups[max_count:]:
+        try:
+            old.unlink()
+            deleted.append(old)
+        except OSError as e:
+            logger.debug("Could not delete old backup %s: %s", old, e)
+    return deleted
+
+
+def list_backups() -> List[Tuple[Path, datetime]]:
+    """Return available backups as (path, mtime) tuples, newest first."""
+    backup_dir = get_backup_dir()
+    if not backup_dir.is_dir():
+        return []
+
+    result = []
+    for p in backup_dir.glob("config_*.yaml"):
+        mtime = datetime.fromtimestamp(p.stat().st_mtime)
+        result.append((p, mtime))
+    result.sort(key=lambda x: x[1], reverse=True)
+    return result
+
+
+def restore_routing_sections(backup_path: Path) -> Dict[str, Any]:
+    """Restore only model_profiles and model_routing from a backup.
+
+    Creates a pre-restore backup of the current config first.
+    Other config sections are left untouched.
+
+    Returns the updated config dict.
+    """
+    import yaml
+    from hermes_cli.config import load_config, save_config, get_config_path
+
+    # Load the backup
+    with open(backup_path, encoding="utf-8") as f:
+        backup_data = yaml.safe_load(f) or {}
+
+    # Pre-restore backup
+    create_backup(get_config_path(), reason="pre_restore")
+
+    # Load current config and selectively replace
+    config = load_config()
+    if "model_profiles" in backup_data:
+        config["model_profiles"] = backup_data["model_profiles"]
+    if "model_routing" in backup_data:
+        config["model_routing"] = backup_data["model_routing"]
+
+    save_config(config)
+    return config
+
+
+def restore_full(backup_path: Path) -> Dict[str, Any]:
+    """Restore the entire config from a backup.
+
+    Creates a pre-restore backup of the current config first.
+
+    Returns the restored config dict.
+    """
+    import yaml
+    from hermes_cli.config import save_config, get_config_path
+
+    # Pre-restore backup
+    create_backup(get_config_path(), reason="pre_restore")
+
+    with open(backup_path, encoding="utf-8") as f:
+        backup_data = yaml.safe_load(f) or {}
+
+    save_config(backup_data)
+    return backup_data
+
+
+def format_backup_summary(backup_path: Path) -> str:
+    """Return a one-line summary of what a backup contains."""
+    import yaml
+
+    try:
+        with open(backup_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception:
+        return "(unreadable)"
+
+    parts = []
+
+    profiles = data.get("model_profiles", {})
+    if isinstance(profiles, dict):
+        configured = [k for k, v in profiles.items()
+                      if isinstance(v, dict) and v.get("model")]
+        if configured:
+            parts.append(f"profiles: {', '.join(configured)}")
+        else:
+            parts.append("profiles: defaults")
+    else:
+        parts.append("profiles: missing")
+
+    rules = data.get("model_routing", {})
+    if isinstance(rules, dict):
+        rule_list = rules.get("rules", [])
+        if rule_list:
+            parts.append(f"routing: {len(rule_list)} rule(s)")
+
+    model = data.get("model")
+    if isinstance(model, dict):
+        default = model.get("default", "")
+        if default:
+            parts.append(f"model: {default}")
+    elif isinstance(model, str) and model:
+        parts.append(f"model: {model}")
+
+    return " | ".join(parts) if parts else "(empty config)"
+
+
+def _sanitize_reason(reason: str) -> str:
+    """Sanitize a reason tag for use in filenames."""
+    clean = re.sub(r"[^a-zA-Z0-9_]", "_", (reason or "").strip())
+    return clean[:20].strip("_")
+
+
+def _secure_file(path: Path) -> None:
+    """Set restrictive permissions on a file (Unix only)."""
+    try:
+        path.chmod(0o600)
+    except (OSError, AttributeError):
+        pass  # Windows or permission error — acceptable

--- a/hermes_cli/config_backup.py
+++ b/hermes_cli/config_backup.py
@@ -54,7 +54,7 @@ def create_backup(config_path: Path, reason: str = "") -> Optional[Path]:
         backup_path = backup_dir / name
         counter += 1
 
-    shutil.copy2(config_path, backup_path)
+    shutil.copy(config_path, backup_path)
     _secure_file(backup_path)
     prune_backups()
     return backup_path

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -726,15 +726,62 @@ def cmd_configure_model_routing(args):
     from hermes_cli.config import load_config, save_config
     from hermes_cli.setup import _configure_model_profiles_interactive, _reset_model_profiles_config
 
-    config = load_config()
-    if getattr(args, "reset", False):
-        _reset_model_profiles_config(config)
-        save_config(config)
-        print("Model routing reset to defaults.")
+    # --list-backups
+    if getattr(args, "list_backups", False):
+        from hermes_cli.config_backup import list_backups, format_backup_summary
+        backups = list_backups()
+        if not backups:
+            print("No config backups found.")
+            return
+        print()
+        for i, (path, mtime) in enumerate(backups, 1):
+            summary = format_backup_summary(path)
+            print(f"  {i}. {mtime.strftime('%Y-%m-%d %H:%M:%S')}  {path.name}")
+            print(f"     {summary}")
+        print()
         return
 
+    # --restore or --restore-full
+    if getattr(args, "restore", False) or getattr(args, "restore_full", False):
+        from hermes_cli.config_backup import list_backups, restore_routing_sections, restore_full, format_backup_summary
+        from hermes_cli.setup import prompt_choice
+        full = getattr(args, "restore_full", False)
+        backups = list_backups()
+        if not backups:
+            print("No config backups found. Nothing to restore.")
+            return
+        choices = []
+        for path, mtime in backups:
+            summary = format_backup_summary(path)
+            choices.append(f"{mtime.strftime('%Y-%m-%d %H:%M:%S')}  {summary}")
+        choices.append("Cancel")
+        label = "full config" if full else "model routing"
+        idx = prompt_choice(f"Select a backup to restore {label} from:", choices, len(choices) - 1)
+        if idx is None or idx == len(choices) - 1:
+            print("Restore cancelled.")
+            return
+        backup_path = backups[idx][0]
+        if full:
+            restore_full(backup_path)
+            print(f"Full config restored from {backup_path.name}")
+        else:
+            restore_routing_sections(backup_path)
+            print(f"Model routing restored from {backup_path.name}")
+        print("A pre-restore backup was saved automatically.")
+        return
+
+    config = load_config()
+
+    # --reset (with auto-backup)
+    if getattr(args, "reset", False):
+        _reset_model_profiles_config(config)
+        save_config(config, backup_reason="reset")
+        print("Model routing reset to defaults. A backup was saved automatically.")
+        return
+
+    # Default: interactive wizard (with auto-backup)
     _configure_model_profiles_interactive(config)
-    save_config(config)
+    save_config(config, backup_reason="routing")
     print("Model routing configuration saved.")
 
 
@@ -2357,6 +2404,21 @@ For more help on a command:
         "--reset",
         action="store_true",
         help="Reset model routing profiles and routing rules to defaults"
+    )
+    routing_parser.add_argument(
+        "--restore",
+        action="store_true",
+        help="Restore model routing from a previous backup"
+    )
+    routing_parser.add_argument(
+        "--restore-full",
+        action="store_true",
+        help="Restore the entire config from a previous backup"
+    )
+    routing_parser.add_argument(
+        "--list-backups",
+        action="store_true",
+        help="List available config backups"
     )
     routing_parser.set_defaults(func=cmd_configure_model_routing)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12,6 +12,7 @@ Usage:
     hermes gateway install     # Install gateway service
     hermes gateway uninstall   # Uninstall gateway service
     hermes setup               # Interactive setup wizard
+    hermes configure-model-routing  # Configure context-specific model routing
     hermes logout              # Clear stored authentication
     hermes status              # Show status of all components
     hermes cron                # Manage cron jobs
@@ -718,6 +719,23 @@ def cmd_setup(args):
     """Interactive setup wizard."""
     from hermes_cli.setup import run_setup_wizard
     run_setup_wizard(args)
+
+
+def cmd_configure_model_routing(args):
+    """Configure model routing profiles without overloading the default model command."""
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.setup import _configure_model_profiles_interactive, _reset_model_profiles_config
+
+    config = load_config()
+    if getattr(args, "reset", False):
+        _reset_model_profiles_config(config)
+        save_config(config)
+        print("Model routing reset to defaults.")
+        return
+
+    _configure_model_profiles_interactive(config)
+    save_config(config)
+    print("Model routing configuration saved.")
 
 
 def cmd_model(args):
@@ -2326,6 +2344,21 @@ For more help on a command:
         description="Interactively select your inference provider and default model"
     )
     model_parser.set_defaults(func=cmd_model)
+
+    # =========================================================================
+    # configure-model-routing command
+    # =========================================================================
+    routing_parser = subparsers.add_parser(
+        "configure-model-routing",
+        help="Configure context-specific model routing",
+        description="Configure model routing profiles without changing the primary default model"
+    )
+    routing_parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Reset model routing profiles and routing rules to defaults"
+    )
+    routing_parser.set_defaults(func=cmd_configure_model_routing)
 
     # =========================================================================
     # gateway command

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -40,6 +40,49 @@ def _get_model_profiles_config() -> Dict[str, Dict[str, Any]]:
     return {}
 
 
+def get_primary_model() -> Dict[str, str]:
+    """Get the primary model configuration (model.default + provider).
+
+    Returns a dict with keys: model, provider, base_url, api_key, api_key_env.
+    Empty strings for missing fields.
+    """
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    model_cfg = _get_model_config()
+    model_name = model_cfg.get("default", "")
+    provider_name = model_cfg.get("provider", "")
+
+    if not isinstance(model_name, str):
+        model_name = ""
+    if not isinstance(provider_name, str):
+        provider_name = ""
+
+    model_name = model_name.strip()
+    provider_name = provider_name.strip()
+
+    # If we have a model but no provider, try to resolve runtime
+    if model_name and not provider_name:
+        try:
+            runtime = resolve_runtime_provider(model=model_name, provider="auto")
+            return {
+                "model": model_name,
+                "provider": runtime.get("provider", ""),
+                "base_url": runtime.get("base_url", ""),
+                "api_key": runtime.get("api_key", ""),
+                "api_key_env": "",
+            }
+        except Exception:
+            pass
+
+    return {
+        "model": model_name,
+        "provider": provider_name,
+        "base_url": model_cfg.get("base_url", "") if isinstance(model_cfg.get("base_url"), str) else "",
+        "api_key": model_cfg.get("api_key", "") if isinstance(model_cfg.get("api_key"), str) else "",
+        "api_key_env": model_cfg.get("api_key_env", "") if isinstance(model_cfg.get("api_key_env"), str) else "",
+    }
+
+
 def resolve_model_profile(profile: str) -> Dict[str, str]:
     """Resolve model/provider/base_url/api_key overrides for a named profile.
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -28,6 +28,53 @@ def _get_model_config() -> Dict[str, Any]:
     return {}
 
 
+def _get_model_profiles_config() -> Dict[str, Dict[str, Any]]:
+    config = load_config()
+    profiles = config.get("model_profiles")
+    if isinstance(profiles, dict):
+        normalized: Dict[str, Dict[str, Any]] = {}
+        for name, value in profiles.items():
+            if isinstance(name, str) and isinstance(value, dict):
+                normalized[name.strip().lower()] = dict(value)
+        return normalized
+    return {}
+
+
+def resolve_model_profile(profile: str) -> Dict[str, str]:
+    """Resolve model/provider/base_url/api_key overrides for a named profile.
+
+    Returns empty strings for missing fields so callers can cleanly apply
+    fallback precedence.
+    """
+    key = (profile or "").strip().lower()
+    if not key:
+        return {
+            "model": "",
+            "provider": "",
+            "base_url": "",
+            "api_key": "",
+            "api_key_env": "",
+        }
+
+    profiles = _get_model_profiles_config()
+    raw = profiles.get(key, {})
+    if not isinstance(raw, dict):
+        raw = {}
+
+    api_key_env = str(raw.get("api_key_env", "") or "").strip()
+    api_key = str(raw.get("api_key", "") or "").strip()
+    if (not api_key) and api_key_env:
+        api_key = os.getenv(api_key_env, "").strip()
+
+    return {
+        "model": str(raw.get("model", "") or "").strip(),
+        "provider": str(raw.get("provider", "") or "").strip().lower(),
+        "base_url": str(raw.get("base_url", "") or "").strip(),
+        "api_key": api_key,
+        "api_key_env": api_key_env,
+    }
+
+
 def resolve_requested_provider(requested: Optional[str] = None) -> str:
     """Resolve provider request from explicit arg, env, then config."""
     if requested and requested.strip():
@@ -191,6 +238,13 @@ def resolve_runtime_provider(
     )
     runtime["requested_provider"] = requested_provider
     return runtime
+
+
+def resolve_model_for_profile(profile: str, fallback_model: str) -> str:
+    """Return profile model override when configured, else fallback."""
+    profile_cfg = resolve_model_profile(profile)
+    profile_model = profile_cfg.get("model", "")
+    return profile_model or fallback_model
 
 
 def format_runtime_provider_error(error: Exception) -> str:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -302,11 +302,23 @@ def _configure_model_profiles_interactive(config: Dict[str, Any], allow_custom_p
             continue
 
         if selection == len(choices) - 1:
+            print_info("Base URL: the OpenAI-compatible /v1 endpoint for this provider.")
             base_url = prompt("  Base URL (OpenAI-compatible /v1 endpoint)", current.get("base_url", ""))
+            print_info("API key env var: the name Hermes will use in ~/.hermes/.env to store/read the secret.")
             api_key_env = prompt("  API key env var name (optional)", current.get("api_key_env", ""))
             api_key_default = current.get("api_key", "")
+            print_info("API key: if you type one here, Hermes will save it to ~/.hermes/.env — never config.yaml.")
             api_key = prompt("  API key (optional, leave blank to use env var)", password=True) or api_key_default
-            resolved_key = api_key or (os.getenv(api_key_env, "") if api_key_env else "")
+            api_key_env = str(api_key_env or "").strip()
+            api_key = str(api_key or "").strip()
+            if api_key and not api_key_env:
+                print_warning("Env var name is mandatory if you enter an API key here — otherwise routing may break. Leaving the key unsaved.")
+                resolved_key = ""
+            elif api_key and api_key_env:
+                save_env_value(api_key_env, api_key)
+                resolved_key = api_key
+            else:
+                resolved_key = (os.getenv(api_key_env, "") if api_key_env else "") or api_key_default
 
             suggestions = []
             if base_url and resolved_key:
@@ -329,8 +341,8 @@ def _configure_model_profiles_interactive(config: Dict[str, Any], allow_custom_p
                 "model": str(model_name or "").strip(),
                 "provider": "custom",
                 "base_url": str(base_url or "").strip(),
-                "api_key_env": str(api_key_env or "").strip(),
-                "api_key": str(api_key or "").strip(),
+                "api_key_env": api_key_env,
+                "api_key": "",
             }
             print_success(f"Saved {profile_name} custom profile")
             continue

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -124,17 +124,26 @@ def _sync_model_from_disk(config: Dict[str, Any]) -> None:
         _set_default_model(config, disk_model.strip())
 
 
+def _blank_profile_entry() -> Dict[str, str]:
+    return {"model": "", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""}
+
+
 def _ensure_model_profiles_config(config: Dict[str, Any]) -> Dict[str, Dict[str, str]]:
-    """Ensure model_profiles exists with canonical profile keys."""
+    """Ensure model_profiles exists with canonical profile keys while preserving custom ones."""
     profiles = config.get("model_profiles")
     if not isinstance(profiles, dict):
         profiles = {}
 
-    for name in ("chat", "coding", "planning", "research", "delegation"):
-        entry = profiles.get(name)
+    normalized: Dict[str, Dict[str, str]] = {}
+    for name, entry in profiles.items():
+        if not isinstance(name, str):
+            continue
+        key = name.strip().lower()
+        if not key:
+            continue
         if not isinstance(entry, dict):
             entry = {}
-        profiles[name] = {
+        normalized[key] = {
             "model": str(entry.get("model", "") or "").strip(),
             "provider": str(entry.get("provider", "") or "").strip(),
             "base_url": str(entry.get("base_url", "") or "").strip(),
@@ -142,8 +151,23 @@ def _ensure_model_profiles_config(config: Dict[str, Any]) -> Dict[str, Dict[str,
             "api_key": str(entry.get("api_key", "") or "").strip(),
         }
 
-    config["model_profiles"] = profiles
-    return profiles
+    for name in ("chat", "coding", "planning", "research", "delegation"):
+        normalized.setdefault(name, _blank_profile_entry())
+
+    config["model_profiles"] = normalized
+    return normalized
+
+
+def _ordered_model_profile_names(profiles: Dict[str, Dict[str, str]]) -> List[str]:
+    canonical = ["chat", "coding", "planning", "research", "delegation"]
+    extras = sorted(name for name in profiles.keys() if name not in canonical)
+    return canonical + extras
+
+
+def _reset_model_profiles_config(config: Dict[str, Any]) -> Dict[str, Dict[str, str]]:
+    config["model_profiles"] = {}
+    config["model_routing"] = {"rules": []}
+    return _ensure_model_profiles_config(config)
 
 
 def _discover_working_profile_providers() -> Tuple[List[Tuple[str, dict]], List[str]]:
@@ -196,26 +220,44 @@ def _live_model_suggestions_for_runtime(runtime: dict) -> List[str]:
     return sorted(list(dict.fromkeys(models)))[:40]
 
 
-def _configure_model_profiles_interactive(config: Dict[str, Any]) -> None:
-    """Optional onboarding wizard for per-category model profiles."""
+def _configure_model_profiles_interactive(config: Dict[str, Any], allow_custom_profiles: bool = True) -> None:
+    """Interactive wizard for per-category model routing profiles."""
     from hermes_cli.auth import PROVIDER_REGISTRY
+    from hermes_cli.runtime_provider import get_primary_model
 
-    if not prompt_yes_no("Configure model profiles for chat/coding/planning/research now?", False):
+    # Show primary model info
+    primary = get_primary_model()
+    primary_model = primary.get("model", "")
+    primary_provider = primary.get("provider", "")
+    
+    if primary_model:
+        provider_label = {pid: p.name for pid, p in PROVIDER_REGISTRY.items()}
+        provider_label["openrouter"] = "OpenRouter"
+        provider_label["custom"] = "Custom endpoint"
+        
+        primary_provider_label = provider_label.get(primary_provider, primary_provider)
+        print_info(f"Current primary model: {primary_model} ({primary_provider_label})")
+        print_info("Routing profiles inherit the primary model unless customized:")
+        for profile in ["chat", "coding", "planning", "research"]:
+            print_info(f"  • {profile}: {primary_model} ({primary_provider_label})")
+        print()
+
+    if not prompt_yes_no("Configure model routing profiles now?", False):
         return
 
     profiles = _ensure_model_profiles_config(config)
     working, _errors = _discover_working_profile_providers()
 
     if not working:
-        print_warning("No working providers detected for profile routing right now.")
-        print_info("Finish provider login first, then run `hermes model` again.")
+        print_warning("No working providers detected for model routing right now.")
+        print_info("Finish provider login first, then run `hermes configure-model-routing` again.")
         return
 
     provider_label = {pid: p.name for pid, p in PROVIDER_REGISTRY.items()}
     provider_label["openrouter"] = "OpenRouter"
     provider_label["custom"] = "Custom endpoint"
 
-    ordered_profiles = ["chat", "coding", "planning", "research"]
+    ordered_profiles = _ordered_model_profile_names(profiles)
     for profile_name in ordered_profiles:
         print()
         print_header(f"Model Profile: {profile_name}")
@@ -223,13 +265,21 @@ def _configure_model_profiles_interactive(config: Dict[str, Any]) -> None:
         current = profiles.get(profile_name, {})
         current_model = current.get("model", "")
         current_provider = current.get("provider", "")
+        
+        # Show effective configuration (including primary model inheritance)
+        effective_model = current_model or primary_model
+        effective_provider = current_provider or primary_provider
+        effective_provider_label = provider_label.get(effective_provider, effective_provider)
+        
         if current_model:
             print_info(f"Current: model={current_model} provider={current_provider or 'inherit'}")
+        else:
+            print_info(f"Current: inherits primary model -> {effective_model} ({effective_provider_label})")
 
         if not prompt_yes_no(f"Configure {profile_name} profile?", profile_name == "chat"):
             continue
 
-        choices = ["Inherit main model/provider"]
+        choices = [f"Inherit primary model ({primary_model})"]
         working_ids: List[str] = []
         for pid, runtime in working:
             lbl = provider_label.get(pid, pid)
@@ -240,14 +290,15 @@ def _configure_model_profiles_interactive(config: Dict[str, Any]) -> None:
         selection = prompt_choice("Select provider for this profile:", choices, 0)
 
         if selection == 0:
+            # Explicitly set to primary model (not empty)
             profiles[profile_name] = {
-                "model": "",
-                "provider": "",
-                "base_url": "",
-                "api_key_env": "",
-                "api_key": "",
+                "model": primary_model,
+                "provider": primary_provider,
+                "base_url": primary.get("base_url", ""),
+                "api_key_env": primary.get("api_key_env", ""),
+                "api_key": primary.get("api_key", ""),
             }
-            print_success(f"{profile_name} set to inherit main model/provider")
+            print_success(f"{profile_name} explicitly set to primary model: {primary_model}")
             continue
 
         if selection == len(choices) - 1:
@@ -314,6 +365,16 @@ def _configure_model_profiles_interactive(config: Dict[str, Any]) -> None:
             "api_key": "",
         }
         print_success(f"Saved {profile_name} profile -> {provider_id}:{model_name}")
+
+    if allow_custom_profiles and prompt_yes_no("Add a custom routing profile category?", False):
+        custom_name = prompt("  Profile name (e.g. ops, fast, cheap, vision)").strip().lower()
+        if custom_name:
+            if custom_name in profiles:
+                print_warning(f"Profile '{custom_name}' already exists.")
+            else:
+                profiles[custom_name] = _blank_profile_entry()
+                print_success(f"Added custom profile category: {custom_name}")
+                print_info("Run `hermes configure-model-routing` again to configure it.")
 
 
 # Import config helpers

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -16,7 +16,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +122,198 @@ def _sync_model_from_disk(config: Dict[str, Any]) -> None:
         config["model"] = model_cfg
     elif isinstance(disk_model, str) and disk_model.strip():
         _set_default_model(config, disk_model.strip())
+
+
+def _ensure_model_profiles_config(config: Dict[str, Any]) -> Dict[str, Dict[str, str]]:
+    """Ensure model_profiles exists with canonical profile keys."""
+    profiles = config.get("model_profiles")
+    if not isinstance(profiles, dict):
+        profiles = {}
+
+    for name in ("chat", "coding", "planning", "research", "delegation"):
+        entry = profiles.get(name)
+        if not isinstance(entry, dict):
+            entry = {}
+        profiles[name] = {
+            "model": str(entry.get("model", "") or "").strip(),
+            "provider": str(entry.get("provider", "") or "").strip(),
+            "base_url": str(entry.get("base_url", "") or "").strip(),
+            "api_key_env": str(entry.get("api_key_env", "") or "").strip(),
+            "api_key": str(entry.get("api_key", "") or "").strip(),
+        }
+
+    config["model_profiles"] = profiles
+    return profiles
+
+
+def _discover_working_profile_providers() -> Tuple[List[Tuple[str, dict]], List[str]]:
+    """Return providers that currently resolve with working credentials.
+
+    Returns:
+        ([(provider_id, runtime_dict), ...], errors)
+    """
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    candidates = [
+        "openrouter",
+        "openai-codex",
+        "nous",
+        "zai",
+        "kimi-coding",
+        "minimax",
+        "minimax-cn",
+        "anthropic",
+        "custom",
+    ]
+
+    working: List[Tuple[str, dict]] = []
+    errors: List[str] = []
+    for provider_id in candidates:
+        if provider_id == "custom" and not os.getenv("OPENAI_BASE_URL", "").strip():
+            continue
+        try:
+            runtime = resolve_runtime_provider(requested=provider_id)
+            if runtime.get("api_key") and runtime.get("base_url"):
+                working.append((provider_id, runtime))
+        except Exception as exc:
+            errors.append(f"{provider_id}: {exc}")
+    return working, errors
+
+
+def _live_model_suggestions_for_runtime(runtime: dict) -> List[str]:
+    """Fetch live /models for an already-resolved runtime credential bundle."""
+    from hermes_cli.models import fetch_api_models
+
+    api_key = str(runtime.get("api_key", "") or "")
+    base_url = str(runtime.get("base_url", "") or "")
+    if not api_key or not base_url:
+        return []
+
+    models = fetch_api_models(api_key, base_url)
+    if not models:
+        return []
+    # keep UI usable
+    return sorted(list(dict.fromkeys(models)))[:40]
+
+
+def _configure_model_profiles_interactive(config: Dict[str, Any]) -> None:
+    """Optional onboarding wizard for per-category model profiles."""
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    if not prompt_yes_no("Configure model profiles for chat/coding/planning/research now?", False):
+        return
+
+    profiles = _ensure_model_profiles_config(config)
+    working, _errors = _discover_working_profile_providers()
+
+    if not working:
+        print_warning("No working providers detected for profile routing right now.")
+        print_info("Finish provider login first, then run `hermes model` again.")
+        return
+
+    provider_label = {pid: p.name for pid, p in PROVIDER_REGISTRY.items()}
+    provider_label["openrouter"] = "OpenRouter"
+    provider_label["custom"] = "Custom endpoint"
+
+    ordered_profiles = ["chat", "coding", "planning", "research"]
+    for profile_name in ordered_profiles:
+        print()
+        print_header(f"Model Profile: {profile_name}")
+
+        current = profiles.get(profile_name, {})
+        current_model = current.get("model", "")
+        current_provider = current.get("provider", "")
+        if current_model:
+            print_info(f"Current: model={current_model} provider={current_provider or 'inherit'}")
+
+        if not prompt_yes_no(f"Configure {profile_name} profile?", profile_name == "chat"):
+            continue
+
+        choices = ["Inherit main model/provider"]
+        working_ids: List[str] = []
+        for pid, runtime in working:
+            lbl = provider_label.get(pid, pid)
+            choices.append(f"{lbl} ({runtime.get('base_url', '')})")
+            working_ids.append(pid)
+        choices.append("Custom endpoint (manual)")
+
+        selection = prompt_choice("Select provider for this profile:", choices, 0)
+
+        if selection == 0:
+            profiles[profile_name] = {
+                "model": "",
+                "provider": "",
+                "base_url": "",
+                "api_key_env": "",
+                "api_key": "",
+            }
+            print_success(f"{profile_name} set to inherit main model/provider")
+            continue
+
+        if selection == len(choices) - 1:
+            base_url = prompt("  Base URL (OpenAI-compatible /v1 endpoint)", current.get("base_url", ""))
+            api_key_env = prompt("  API key env var name (optional)", current.get("api_key_env", ""))
+            api_key_default = current.get("api_key", "")
+            api_key = prompt("  API key (optional, leave blank to use env var)", password=True) or api_key_default
+            resolved_key = api_key or (os.getenv(api_key_env, "") if api_key_env else "")
+
+            suggestions = []
+            if base_url and resolved_key:
+                suggestions = _live_model_suggestions_for_runtime(
+                    {"api_key": resolved_key, "base_url": base_url}
+                )
+
+            if suggestions:
+                model_choices = suggestions + ["Custom model"]
+                m_idx = prompt_choice("Select model:", model_choices, 0)
+                if m_idx < len(suggestions):
+                    model_name = suggestions[m_idx]
+                else:
+                    model_name = prompt("  Enter model name", current_model)
+            else:
+                print_warning("Could not fetch live models from this endpoint — enter model manually.")
+                model_name = prompt("  Enter model name", current_model)
+
+            profiles[profile_name] = {
+                "model": str(model_name or "").strip(),
+                "provider": "custom",
+                "base_url": str(base_url or "").strip(),
+                "api_key_env": str(api_key_env or "").strip(),
+                "api_key": str(api_key or "").strip(),
+            }
+            print_success(f"Saved {profile_name} custom profile")
+            continue
+
+        provider_id = working_ids[selection - 1]
+        runtime = dict(working[selection - 1][1])
+        suggestions = _live_model_suggestions_for_runtime(runtime)
+
+        if suggestions:
+            model_choices = suggestions + ["Custom model", f"Keep current ({current_model or 'unset'})"]
+            default_idx = len(model_choices) - 1
+            if current_model in suggestions:
+                default_idx = suggestions.index(current_model)
+            m_idx = prompt_choice("Select model:", model_choices, default_idx)
+            if m_idx < len(suggestions):
+                model_name = suggestions[m_idx]
+            elif m_idx == len(suggestions):
+                model_name = prompt("  Enter model name", current_model)
+            else:
+                model_name = current_model
+        else:
+            print_warning(
+                "Could not fetch live model list for this provider right now — enter model manually."
+            )
+            model_name = prompt("  Enter model name", current_model)
+
+        profiles[profile_name] = {
+            "model": str(model_name or "").strip(),
+            "provider": provider_id,
+            "base_url": "",
+            "api_key_env": "",
+            "api_key": "",
+        }
+        print_success(f"Saved {profile_name} profile -> {provider_id}:{model_name}")
 
 
 # Import config helpers
@@ -1332,6 +1524,11 @@ def setup_model_provider(config: dict):
                 else _final_model
             )
             print_success(f"Model set to: {_display}")
+
+    # Optional per-category onboarding (no manual config file editing needed)
+    # Skip in non-interactive contexts (tests/automation) where stdin isn't a TTY.
+    if getattr(sys.stdin, "isatty", lambda: False)():
+        _configure_model_profiles_interactive(config)
 
     save_config(config)
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1603,7 +1603,7 @@ def setup_model_provider(config: dict):
     if getattr(sys.stdin, "isatty", lambda: False)():
         _configure_model_profiles_interactive(config)
 
-    save_config(config)
+    save_config(config, backup_reason="model_setup")
 
 
 # =============================================================================

--- a/tests/hermes_cli/test_config_backup.py
+++ b/tests/hermes_cli/test_config_backup.py
@@ -1,0 +1,255 @@
+"""Tests for hermes_cli.config_backup module."""
+
+import time
+import argparse
+from pathlib import Path
+
+import yaml
+
+from hermes_cli.config import load_config, save_config
+from hermes_cli.config_backup import (
+    create_backup,
+    prune_backups,
+    list_backups,
+    restore_routing_sections,
+    restore_full,
+    format_backup_summary,
+    get_backup_dir,
+)
+
+
+def _write_config(tmp_path, data):
+    """Helper to write a config.yaml in the fake HERMES_HOME."""
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(data, f)
+    return config_path
+
+
+def test_create_backup_creates_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = _write_config(tmp_path, {"model": "test"})
+
+    result = create_backup(config_path, reason="routing")
+
+    assert result is not None
+    assert result.exists()
+    assert "routing" in result.name
+    assert result.parent == get_backup_dir()
+
+
+def test_create_backup_no_config_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    missing = tmp_path / "config.yaml"
+
+    result = create_backup(missing, reason="test")
+
+    assert result is None
+
+
+def test_create_backup_duplicate_second(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = _write_config(tmp_path, {"model": "test"})
+
+    b1 = create_backup(config_path, reason="dup")
+    b2 = create_backup(config_path, reason="dup")
+
+    assert b1 != b2
+    assert b1.exists()
+    assert b2.exists()
+
+
+def test_prune_backups_keeps_max(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    backup_dir = get_backup_dir()
+    backup_dir.mkdir(parents=True)
+
+    # Create 15 backups with different mtimes
+    for i in range(15):
+        p = backup_dir / f"config_20260313_{100000 + i}.yaml"
+        p.write_text(f"backup {i}")
+        # Ensure distinct mtimes
+        p.touch()
+
+    deleted = prune_backups(max_count=10)
+
+    assert len(deleted) == 5
+    remaining = list(backup_dir.glob("config_*.yaml"))
+    assert len(remaining) == 10
+
+
+def test_list_backups_order(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = _write_config(tmp_path, {"model": "test"})
+
+    b1 = create_backup(config_path, reason="first")
+    time.sleep(1.1)  # ensure distinct mtime (filesystem granularity)
+    b2 = create_backup(config_path, reason="second")
+
+    backups = list_backups()
+    assert len(backups) == 2
+    # Newest first
+    assert "second" in backups[0][0].name
+    assert "first" in backups[1][0].name
+
+
+def test_list_backups_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert list_backups() == []
+
+
+def test_restore_routing_sections_selective(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    # Write initial config with profiles and other settings
+    initial = {
+        "model": {"default": "deepseek-chat", "provider": "auto"},
+        "model_profiles": {
+            "chat": {"model": "gpt-5.4", "provider": "openai-codex", "base_url": "", "api_key_env": "", "api_key": ""},
+            "coding": {"model": "deepseek-chat", "provider": "deepseek", "base_url": "", "api_key_env": "", "api_key": ""},
+        },
+        "model_routing": {"rules": [{"if_toolsets_any": ["terminal"], "profile": "coding"}]},
+        "timezone": "Europe/Helsinki",
+        "display": {"compact": True},
+    }
+    config_path = _write_config(tmp_path, initial)
+
+    # Create a backup of this good state
+    backup = create_backup(config_path, reason="good_state")
+
+    # Now mess up the config
+    messed = dict(initial)
+    messed["model_profiles"] = {}
+    messed["model_routing"] = {"rules": []}
+    messed["timezone"] = "US/Pacific"  # unrelated change
+    _write_config(tmp_path, messed)
+
+    # Restore routing sections only
+    result = restore_routing_sections(backup)
+
+    # Routing sections restored
+    assert result["model_profiles"]["chat"]["model"] == "gpt-5.4"
+    assert len(result["model_routing"]["rules"]) == 1
+    # Unrelated changes preserved (not reverted)
+    assert result["timezone"] == "US/Pacific"
+
+
+def test_restore_full(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    original = {
+        "model": {"default": "deepseek-chat"},
+        "timezone": "Europe/Helsinki",
+        "model_profiles": {"chat": {"model": "gpt-5.4", "provider": "", "base_url": "", "api_key_env": "", "api_key": ""}},
+    }
+    config_path = _write_config(tmp_path, original)
+    backup = create_backup(config_path, reason="original")
+
+    # Overwrite
+    _write_config(tmp_path, {"model": {"default": "something-else"}, "timezone": "US/Pacific"})
+
+    # Full restore
+    result = restore_full(backup)
+
+    assert result["timezone"] == "Europe/Helsinki"
+    assert result["model"]["default"] == "deepseek-chat"
+
+
+def test_restore_creates_pre_restore_backup(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config_path = _write_config(tmp_path, {"model": "test"})
+    backup = create_backup(config_path, reason="original")
+    _write_config(tmp_path, {"model": "changed"})
+
+    restore_routing_sections(backup)
+
+    backups = list_backups()
+    pre_restore = [b for b in backups if "pre_restore" in b[0].name]
+    assert len(pre_restore) >= 1
+
+
+def test_format_backup_summary(tmp_path):
+    path = tmp_path / "config_test.yaml"
+    data = {
+        "model": {"default": "deepseek-chat"},
+        "model_profiles": {
+            "chat": {"model": "gpt-5.4", "provider": "openai-codex"},
+            "coding": {"model": "", "provider": ""},
+            "research": {"model": "gemini-3-flash", "provider": "google"},
+        },
+        "model_routing": {"rules": [{"profile": "coding"}]},
+    }
+    with open(path, "w") as f:
+        yaml.dump(data, f)
+
+    summary = format_backup_summary(path)
+    assert "chat" in summary
+    assert "research" in summary
+    assert "1 rule" in summary
+    assert "deepseek-chat" in summary
+
+
+def test_format_backup_summary_empty(tmp_path):
+    path = tmp_path / "config_empty.yaml"
+    path.write_text("{}")
+    summary = format_backup_summary(path)
+    assert summary  # should not crash
+
+
+def test_save_config_with_backup_reason(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, {"model": "original"})
+
+    config = load_config()
+    config["model"] = "changed"
+    save_config(config, backup_reason="test_save")
+
+    backups = list_backups()
+    assert len(backups) == 1
+    assert "test_save" in backups[0][0].name
+
+
+def test_save_config_without_backup_reason(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, {"model": "original"})
+
+    config = load_config()
+    save_config(config)
+
+    backups = list_backups()
+    assert len(backups) == 0
+
+
+def test_cmd_routing_reset_creates_backup(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.main import cmd_configure_model_routing
+
+    # Set up initial config with profiles
+    initial = {
+        "model_profiles": {"chat": {"model": "gpt-5.4", "provider": "openai-codex", "base_url": "", "api_key_env": "", "api_key": ""}},
+    }
+    _write_config(tmp_path, initial)
+
+    cmd_configure_model_routing(argparse.Namespace(
+        reset=True, restore=False, restore_full=False, list_backups=False,
+    ))
+
+    backups = list_backups()
+    assert len(backups) >= 1
+    assert "reset" in backups[0][0].name
+    out = capsys.readouterr().out.lower()
+    assert "reset" in out
+    assert "backup" in out
+
+
+def test_cmd_routing_list_backups_empty(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.main import cmd_configure_model_routing
+
+    cmd_configure_model_routing(argparse.Namespace(
+        reset=False, restore=False, restore_full=False, list_backups=True,
+    ))
+
+    out = capsys.readouterr().out
+    assert "No config backups found" in out

--- a/tests/hermes_cli/test_model_routing_command.py
+++ b/tests/hermes_cli/test_model_routing_command.py
@@ -1,0 +1,17 @@
+import argparse
+
+from hermes_cli.config import load_config
+from hermes_cli.main import cmd_configure_model_routing
+
+
+def test_configure_model_routing_reset(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cfg = load_config()
+    cfg["model_profiles"]["ops"] = {"model": "x", "provider": "custom", "base_url": "", "api_key_env": "", "api_key": ""}
+
+    cmd_configure_model_routing(argparse.Namespace(reset=True))
+
+    updated = load_config()
+    assert "ops" not in updated["model_profiles"]
+    assert updated["model_routing"] == {"rules": []}
+    assert "reset to defaults" in capsys.readouterr().out.lower()

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -2,7 +2,12 @@ import json
 
 from hermes_cli.auth import _update_config_for_provider, get_active_provider
 from hermes_cli.config import load_config, save_config
-from hermes_cli.setup import setup_model_provider
+from hermes_cli.setup import (
+    setup_model_provider,
+    _discover_working_profile_providers,
+    _configure_model_profiles_interactive,
+    _ensure_model_profiles_config,
+)
 
 
 def _clear_provider_env(monkeypatch):
@@ -95,3 +100,58 @@ def test_custom_setup_clears_active_oauth_provider(tmp_path, monkeypatch):
     assert reloaded["model"]["provider"] == "custom"
     assert reloaded["model"]["base_url"] == "https://custom.example/v1"
     assert reloaded["model"]["default"] == "custom/model"
+
+
+def test_discover_working_profile_providers_filters_failing(monkeypatch):
+    def _fake_resolve(requested=None, **_kwargs):
+        if requested in {"openrouter", "openai-codex"}:
+            return {
+                "provider": requested,
+                "base_url": "https://example.com/v1",
+                "api_key": "k",
+                "api_mode": "chat_completions",
+            }
+        raise RuntimeError("no creds")
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _fake_resolve)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    working, errors = _discover_working_profile_providers()
+
+    ids = [pid for pid, _ in working]
+    assert "openrouter" in ids
+    assert "openai-codex" in ids
+    assert all(pid not in ids for pid in ("nous", "zai", "custom"))
+    assert errors
+
+
+def test_configure_model_profiles_uses_only_working_provider_choices(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cfg = load_config()
+    _ensure_model_profiles_config(cfg)
+
+    # yes: configure wizard, yes: configure chat
+    yes_no_answers = iter([True, True, False, False, False])
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: next(yes_no_answers))
+
+    # provider pick -> first working provider (openrouter), model pick -> first live suggestion
+    prompt_choices = iter([1, 0])
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: next(prompt_choices))
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: "")
+
+    monkeypatch.setattr(
+        "hermes_cli.setup._discover_working_profile_providers",
+        lambda: ([
+            ("openrouter", {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_key": "k"}),
+        ], []),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.setup._live_model_suggestions_for_runtime",
+        lambda _runtime: ["anthropic/claude-sonnet-4"],
+    )
+
+    _configure_model_profiles_interactive(cfg)
+
+    chat = cfg["model_profiles"]["chat"]
+    assert chat["provider"] == "openrouter"
+    assert chat["model"] == "anthropic/claude-sonnet-4"

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -185,3 +185,75 @@ def test_reset_model_profiles_config_keeps_defaults_only(tmp_path, monkeypatch):
 
     assert set(profiles.keys()) == {"chat", "coding", "planning", "research", "delegation"}
     assert cfg["model_routing"] == {"rules": []}
+
+
+def test_custom_endpoint_profile_saves_api_key_to_env_not_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cfg = load_config()
+    _ensure_model_profiles_config(cfg)
+
+    yes_no_answers = iter([True, True, False, False, False, False, False])
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: next(yes_no_answers))
+    prompt_choices = iter([2])  # Custom endpoint (manual)
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: next(prompt_choices))
+    monkeypatch.setattr(
+        "hermes_cli.setup._discover_working_profile_providers",
+        lambda: ([
+            ("openrouter", {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_key": "test-key"}),
+        ], []),
+    )
+
+    prompt_values = iter([
+        "https://example.test/v1",
+        "ROUTING_TEST_KEY",
+        "super-secret-key",
+        "custom-router-model",
+    ])
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_values))
+
+    saved_env = {}
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda key, value: saved_env.setdefault(key, value))
+
+    _configure_model_profiles_interactive(cfg)
+
+    chat = cfg["model_profiles"]["chat"]
+    assert chat["provider"] == "custom"
+    assert chat["base_url"] == "https://example.test/v1"
+    assert chat["api_key_env"] == "ROUTING_TEST_KEY"
+    assert chat["api_key"] == ""
+    assert saved_env["ROUTING_TEST_KEY"] == "super-secret-key"
+
+
+def test_custom_endpoint_profile_requires_env_var_name_for_inline_key(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cfg = load_config()
+    _ensure_model_profiles_config(cfg)
+
+    yes_no_answers = iter([True, True, False, False, False, False, False])
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: next(yes_no_answers))
+    prompt_choices = iter([2])
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: next(prompt_choices))
+    monkeypatch.setattr(
+        "hermes_cli.setup._discover_working_profile_providers",
+        lambda: ([
+            ("openrouter", {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_key": "test-key"}),
+        ], []),
+    )
+
+    prompt_values = iter([
+        "https://example.test/v1",
+        "",
+        "super-secret-key",
+        "custom-router-model",
+    ])
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_values))
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
+
+    _configure_model_profiles_interactive(cfg)
+
+    output = capsys.readouterr().out.lower()
+    chat = cfg["model_profiles"]["chat"]
+    assert "env var name is mandatory" in output
+    assert chat["provider"] == "custom"
+    assert chat["api_key_env"] == ""
+    assert chat["api_key"] == ""

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -7,6 +7,8 @@ from hermes_cli.setup import (
     _discover_working_profile_providers,
     _configure_model_profiles_interactive,
     _ensure_model_profiles_config,
+    _ordered_model_profile_names,
+    _reset_model_profiles_config,
 )
 
 
@@ -130,8 +132,8 @@ def test_configure_model_profiles_uses_only_working_provider_choices(tmp_path, m
     cfg = load_config()
     _ensure_model_profiles_config(cfg)
 
-    # yes: configure wizard, yes: configure chat
-    yes_no_answers = iter([True, True, False, False, False])
+    # yes: configure wizard, yes: configure chat, no: coding/planning/research/delegation/custom add
+    yes_no_answers = iter([True, True, False, False, False, False, False])
     monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: next(yes_no_answers))
 
     # provider pick -> first working provider (openrouter), model pick -> first live suggestion
@@ -142,7 +144,7 @@ def test_configure_model_profiles_uses_only_working_provider_choices(tmp_path, m
     monkeypatch.setattr(
         "hermes_cli.setup._discover_working_profile_providers",
         lambda: ([
-            ("openrouter", {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_key": "k"}),
+            ("openrouter", {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_key": "test-key"}),
         ], []),
     )
     monkeypatch.setattr(
@@ -155,3 +157,31 @@ def test_configure_model_profiles_uses_only_working_provider_choices(tmp_path, m
     chat = cfg["model_profiles"]["chat"]
     assert chat["provider"] == "openrouter"
     assert chat["model"] == "anthropic/claude-sonnet-4"
+
+
+def test_custom_profiles_are_preserved_and_ordered(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cfg = load_config()
+    cfg["model_profiles"] = {
+        "ops": {"model": "gpt-4.1-mini", "provider": "openrouter"},
+        "chat": {"model": "anthropic/claude-sonnet-4", "provider": "openrouter"},
+    }
+
+    profiles = _ensure_model_profiles_config(cfg)
+
+    assert "ops" in profiles
+    ordered = _ordered_model_profile_names(profiles)
+    assert ordered[:5] == ["chat", "coding", "planning", "research", "delegation"]
+    assert ordered[-1] == "ops"
+
+
+def test_reset_model_profiles_config_keeps_defaults_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cfg = load_config()
+    cfg["model_profiles"] = {"ops": {"model": "x", "provider": "custom"}}
+    cfg["model_routing"] = {"rules": [{"profile": "ops", "if_goal_matches": ["deploy"]}]}
+
+    profiles = _reset_model_profiles_config(cfg)
+
+    assert set(profiles.keys()) == {"chat", "coding", "planning", "research", "delegation"}
+    assert cfg["model_routing"] == {"rules": []}

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -181,3 +181,36 @@ def test_resolve_requested_provider_precedence(monkeypatch):
     monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "nous")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openai-codex"})
     assert rp.resolve_requested_provider("openrouter") == "openrouter"
+
+
+def test_resolve_model_profile_reads_api_key_env(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "_get_model_profiles_config",
+        lambda: {
+            "coding": {
+                "model": "openai/gpt-5-codex",
+                "provider": "openrouter",
+                "base_url": "http://localhost:11434/v1",
+                "api_key_env": "OLLAMA_API_KEY",
+            }
+        },
+    )
+    monkeypatch.setenv("OLLAMA_API_KEY", "local-key")
+
+    profile = rp.resolve_model_profile("coding")
+
+    assert profile["model"] == "openai/gpt-5-codex"
+    assert profile["provider"] == "openrouter"
+    assert profile["base_url"] == "http://localhost:11434/v1"
+    assert profile["api_key"] == "local-key"
+
+
+def test_resolve_model_for_profile_falls_back_when_empty(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_model_profile", lambda _name: {"model": ""})
+    assert rp.resolve_model_for_profile("chat", "anthropic/claude-sonnet-4") == "anthropic/claude-sonnet-4"
+
+
+def test_resolve_model_for_profile_returns_override(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_model_profile", lambda _name: {"model": "openai/gpt-5-mini"})
+    assert rp.resolve_model_for_profile("chat", "anthropic/claude-sonnet-4") == "openai/gpt-5-mini"

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -24,6 +24,7 @@ from tools.delegate_tool import (
     _build_child_system_prompt,
     _strip_blocked_tools,
     _resolve_delegation_credentials,
+    _infer_model_profile,
 )
 
 
@@ -58,6 +59,7 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
         self.assertIn("max_iterations", props)
+        self.assertIn("model_profile", props)
         self.assertEqual(props["tasks"]["maxItems"], 3)
 
 
@@ -91,6 +93,20 @@ class TestStripBlockedTools(unittest.TestCase):
     def test_empty_input(self):
         result = _strip_blocked_tools([])
         self.assertEqual(result, [])
+
+
+class TestModelProfileInference(unittest.TestCase):
+    def test_coding_profile_for_terminal_or_file(self):
+        self.assertEqual(_infer_model_profile(["terminal"]), "coding")
+        self.assertEqual(_infer_model_profile(["file", "web"]), "coding")
+
+    def test_research_profile_for_web_browser(self):
+        self.assertEqual(_infer_model_profile(["web"]), "research")
+        self.assertEqual(_infer_model_profile(["browser"]), "research")
+
+    def test_planning_profile_by_default(self):
+        self.assertEqual(_infer_model_profile([]), "planning")
+        self.assertEqual(_infer_model_profile(["memory"], goal="write a roadmap"), "planning")
 
 
 class TestDelegateTask(unittest.TestCase):
@@ -536,6 +552,80 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             # But provider/base_url/api_key should inherit from parent
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["base_url"], parent.base_url)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_profile_credentials")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_inferred_profile_used_for_coding_task(self, mock_base_creds, mock_profile_creds, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 45, "model": "", "provider": "", "model_profile": ""}
+        mock_base_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_profile_creds.return_value = {
+            "model": "openai/gpt-5-codex",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-coding",
+            "api_mode": "chat_completions",
+            "profile": "coding",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="Refactor module", toolsets=["terminal", "file"], parent_agent=parent)
+
+            mock_profile_creds.assert_called_once_with("coding")
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "openai/gpt-5-codex")
+            self.assertEqual(kwargs["provider"], "openrouter")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_profile_credentials")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_explicit_model_profile_overrides_inference(self, mock_base_creds, mock_profile_creds, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 45, "model": "", "provider": "", "model_profile": ""}
+        mock_base_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_profile_creds.return_value = {
+            "model": "google/gemini-3-flash-preview",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-plan",
+            "api_mode": "chat_completions",
+            "profile": "planning",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="Summarize architecture",
+                toolsets=["terminal", "file"],
+                model_profile="planning",
+                parent_agent=parent,
+            )
+
+            mock_profile_creds.assert_called_once_with("planning")
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -108,6 +108,19 @@ class TestModelProfileInference(unittest.TestCase):
         self.assertEqual(_infer_model_profile([]), "planning")
         self.assertEqual(_infer_model_profile(["memory"], goal="write a roadmap"), "planning")
 
+    @patch("hermes_cli.config.load_config")
+    def test_configurable_rules_override_builtin_heuristics(self, mock_load_config):
+        mock_load_config.return_value = {
+            "model_routing": {
+                "rules": [
+                    {"if_toolsets_any": ["terminal"], "profile": "ops"},
+                    {"if_goal_matches": ["test"], "profile": "qa"},
+                ]
+            }
+        }
+        self.assertEqual(_infer_model_profile(["terminal"]), "ops")
+        self.assertEqual(_infer_model_profile(["memory"], goal="test the release flow"), "qa")
+
 
 class TestDelegateTask(unittest.TestCase):
     def test_no_parent_agent(self):
@@ -557,7 +570,13 @@ class TestDelegationProviderIntegration(unittest.TestCase):
     @patch("tools.delegate_tool._resolve_profile_credentials")
     @patch("tools.delegate_tool._resolve_delegation_credentials")
     def test_inferred_profile_used_for_coding_task(self, mock_base_creds, mock_profile_creds, mock_cfg):
-        mock_cfg.return_value = {"max_iterations": 45, "model": "", "provider": "", "model_profile": ""}
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "",
+            "provider": "",
+            "model_profile": "",
+            "model_profiles": {"coding": {"model": "openai/gpt-5-codex", "provider": "openrouter"}},
+        }
         mock_base_creds.return_value = {
             "model": None,
             "provider": None,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -79,13 +79,41 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
 
 
 def _infer_model_profile(toolsets: Optional[List[str]], goal: Optional[str] = None) -> str:
-    """Infer best-fit profile from requested toolsets/task intent."""
+    """Infer best-fit profile from requested toolsets/task intent.
+
+    First applies any user-configured ordered routing rules from config.yaml.
+    Falls back to simple built-in heuristics if no rule matches.
+    """
     normalized = {str(t).strip().lower() for t in (toolsets or []) if str(t).strip()}
+    goal_text = (goal or "").strip().lower()
+
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        routing = config.get("model_routing", {}) if isinstance(config, dict) else {}
+        rules = routing.get("rules", []) if isinstance(routing, dict) else []
+        if isinstance(rules, list):
+            for rule in rules:
+                if not isinstance(rule, dict):
+                    continue
+                profile = str(rule.get("profile", "") or "").strip().lower()
+                if not profile:
+                    continue
+                toolset_any = {str(t).strip().lower() for t in rule.get("if_toolsets_any", []) if str(t).strip()}
+                goal_matches = [str(t).strip().lower() for t in rule.get("if_goal_matches", []) if str(t).strip()]
+                if toolset_any and not (toolset_any & normalized):
+                    continue
+                if goal_matches and not any(token in goal_text for token in goal_matches):
+                    continue
+                if toolset_any or goal_matches:
+                    return profile
+    except Exception:
+        pass
+
     if {"terminal", "file"} & normalized:
         return "coding"
     if "web" in normalized or "browser" in normalized:
         return "research"
-    goal_text = (goal or "").strip().lower()
     if any(token in goal_text for token in ("plan", "roadmap", "spec", "design")):
         return "planning"
     return "planning"
@@ -428,6 +456,17 @@ def delegate_task(
     # Build task specs with per-task credential/model routing.
     prepared_tasks = []
     default_profile = (cfg.get("model_profile") or "").strip() or None
+    model_profiles_cfg = cfg.get("model_profiles", {}) if isinstance(cfg.get("model_profiles"), dict) else {}
+
+    def _profile_has_explicit_config(name: Optional[str]) -> bool:
+        key = (name or "").strip().lower()
+        if not key:
+            return False
+        raw = model_profiles_cfg.get(key, {})
+        if not isinstance(raw, dict):
+            return False
+        return any(str(raw.get(field, "") or "").strip() for field in ("model", "provider", "base_url", "api_key_env", "api_key"))
+
     for i, task in enumerate(task_list):
         task_toolsets = task.get("toolsets") or toolsets
         requested_profile = (
@@ -440,7 +479,7 @@ def delegate_task(
         creds = dict(base_creds)
         profile_used = None
 
-        if not legacy_override_active:
+        if not legacy_override_active and (requested_profile or _profile_has_explicit_config(inferred_profile)):
             try:
                 profile_creds = _resolve_profile_credentials(inferred_profile)
             except ValueError as exc:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -78,6 +78,61 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     return [t for t in toolsets if t not in blocked_toolset_names]
 
 
+def _infer_model_profile(toolsets: Optional[List[str]], goal: Optional[str] = None) -> str:
+    """Infer best-fit profile from requested toolsets/task intent."""
+    normalized = {str(t).strip().lower() for t in (toolsets or []) if str(t).strip()}
+    if {"terminal", "file"} & normalized:
+        return "coding"
+    if "web" in normalized or "browser" in normalized:
+        return "research"
+    goal_text = (goal or "").strip().lower()
+    if any(token in goal_text for token in ("plan", "roadmap", "spec", "design")):
+        return "planning"
+    return "planning"
+
+
+def _resolve_profile_credentials(profile_name: str) -> dict:
+    """Resolve credentials/model for a named model profile."""
+    from hermes_cli.runtime_provider import resolve_model_profile, resolve_runtime_provider
+
+    profile_cfg = resolve_model_profile(profile_name)
+    configured_model = profile_cfg.get("model") or None
+    configured_provider = profile_cfg.get("provider") or None
+    configured_base_url = profile_cfg.get("base_url") or None
+    configured_api_key = profile_cfg.get("api_key") or None
+
+    if not (configured_provider or configured_base_url or configured_api_key):
+        return {
+            "model": configured_model,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "profile": profile_name,
+        }
+
+    runtime = resolve_runtime_provider(
+        requested=configured_provider,
+        explicit_api_key=configured_api_key,
+        explicit_base_url=configured_base_url,
+    )
+    api_key = runtime.get("api_key", "")
+    if not api_key:
+        raise ValueError(
+            f"Model profile '{profile_name}' resolved but has no API key. "
+            f"Set profile api_key/api_key_env or provider credentials."
+        )
+
+    return {
+        "model": configured_model,
+        "provider": runtime.get("provider"),
+        "base_url": runtime.get("base_url"),
+        "api_key": api_key,
+        "api_mode": runtime.get("api_mode"),
+        "profile": profile_name,
+    }
+
+
 def _build_child_progress_callback(task_index: int, parent_agent, task_count: int = 1) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
@@ -315,6 +370,7 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    model_profile: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -344,21 +400,11 @@ def delegate_task(
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return json.dumps({"error": str(exc)})
-
     # Normalize to task list
     if tasks and isinstance(tasks, list):
         task_list = tasks[:MAX_CONCURRENT_CHILDREN]
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "toolsets": toolsets}]
+        task_list = [{"goal": goal, "context": context, "toolsets": toolsets, "model_profile": model_profile}]
     else:
         return json.dumps({"error": "Provide either 'goal' (single task) or 'tasks' (batch)."})
 
@@ -370,21 +416,65 @@ def delegate_task(
         if not task.get("goal", "").strip():
             return json.dumps({"error": f"Task {i} is missing a 'goal'."})
 
+    # Base legacy delegation credentials (provider/model overrides in
+    # delegation.*). If unset, this resolves to inherit-parent behavior.
+    try:
+        base_creds = _resolve_delegation_credentials(cfg, parent_agent)
+    except ValueError as exc:
+        return json.dumps({"error": str(exc)})
+
+    legacy_override_active = bool((cfg.get("model") or "").strip() or (cfg.get("provider") or "").strip())
+
+    # Build task specs with per-task credential/model routing.
+    prepared_tasks = []
+    default_profile = (cfg.get("model_profile") or "").strip() or None
+    for i, task in enumerate(task_list):
+        task_toolsets = task.get("toolsets") or toolsets
+        requested_profile = (
+            (task.get("model_profile") if isinstance(task, dict) else None)
+            or model_profile
+            or default_profile
+        )
+        inferred_profile = requested_profile or _infer_model_profile(task_toolsets, task.get("goal"))
+
+        creds = dict(base_creds)
+        profile_used = None
+
+        if not legacy_override_active:
+            try:
+                profile_creds = _resolve_profile_credentials(inferred_profile)
+            except ValueError as exc:
+                return json.dumps({"error": str(exc)})
+            for key in ("model", "provider", "base_url", "api_key", "api_mode"):
+                if profile_creds.get(key) is not None:
+                    creds[key] = profile_creds.get(key)
+            profile_used = profile_creds.get("profile")
+
+        prepared_tasks.append({
+            "task_index": i,
+            "goal": task["goal"],
+            "context": task.get("context"),
+            "toolsets": task_toolsets,
+            "creds": creds,
+            "profile": profile_used,
+        })
+
     overall_start = time.monotonic()
     results = []
 
-    n_tasks = len(task_list)
+    n_tasks = len(prepared_tasks)
     # Track goal labels for progress display (truncated for readability)
-    task_labels = [t["goal"][:40] for t in task_list]
+    task_labels = [t["goal"][:40] for t in prepared_tasks]
 
     if n_tasks == 1:
         # Single task -- run directly (no thread pool overhead)
-        t = task_list[0]
+        t = prepared_tasks[0]
+        creds = t["creds"]
         result = _run_single_child(
             task_index=0,
             goal=t["goal"],
             context=t.get("context"),
-            toolsets=t.get("toolsets") or toolsets,
+            toolsets=t.get("toolsets"),
             model=creds["model"],
             max_iterations=effective_max_iter,
             parent_agent=parent_agent,
@@ -407,13 +497,14 @@ def delegate_task(
 
         with ThreadPoolExecutor(max_workers=MAX_CONCURRENT_CHILDREN) as executor:
             futures = {}
-            for i, t in enumerate(task_list):
+            for i, t in enumerate(prepared_tasks):
+                creds = t["creds"]
                 future = executor.submit(
                     _run_single_child,
                     task_index=i,
                     goal=t["goal"],
                     context=t.get("context"),
-                    toolsets=t.get("toolsets") or toolsets,
+                    toolsets=t.get("toolsets"),
                     model=creds["model"],
                     max_iterations=effective_max_iter,
                     parent_agent=parent_agent,
@@ -533,26 +624,38 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation + model profile config.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Returns a flat dict with delegation keys (max_iterations/model/provider/
+    model_profile) plus model_profiles map.
     """
+    full = {}
     try:
         from cli import CLI_CONFIG
-        cfg = CLI_CONFIG.get("delegation", {})
-        if cfg:
-            return cfg
+        if isinstance(CLI_CONFIG, dict) and CLI_CONFIG:
+            full = CLI_CONFIG
     except Exception:
         pass
-    try:
-        from hermes_cli.config import load_config
-        full = load_config()
-        return full.get("delegation", {})
-    except Exception:
-        return {}
+    if not full:
+        try:
+            from hermes_cli.config import load_config
+            full = load_config()
+        except Exception:
+            full = {}
+
+    if not isinstance(full, dict):
+        full = {}
+
+    delegation = full.get("delegation", {})
+    if not isinstance(delegation, dict):
+        delegation = {}
+    model_profiles = full.get("model_profiles", {})
+    if not isinstance(model_profiles, dict):
+        model_profiles = {}
+
+    merged = dict(delegation)
+    merged["model_profiles"] = model_profiles
+    return merged
 
 
 # ---------------------------------------------------------------------------
@@ -616,6 +719,13 @@ DELEGATE_TASK_SCHEMA = {
                     "full-stack tasks."
                 ),
             },
+            "model_profile": {
+                "type": "string",
+                "description": (
+                    "Optional model profile to use for this delegated task. "
+                    "Examples: 'coding', 'planning', 'research'."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -627,6 +737,10 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": "Toolsets for this specific task",
+                        },
+                        "model_profile": {
+                            "type": "string",
+                            "description": "Model profile for this specific task",
                         },
                     },
                     "required": ["goal"],
@@ -664,6 +778,7 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        model_profile=args.get("model_profile"),
         parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
 )


### PR DESCRIPTION
## Summary

Adds **model routing profiles** — optional per-context model and provider overrides that let users route different work types to different models. Includes an interactive configuration wizard, routing rules for `delegate_task`, and a config backup/restore system so configuration changes are always reversible.

## Motivation

Hermes currently uses a single model for all operations. In practice, different contexts benefit from different models:

- A strong reasoning model for planning and architecture
- A fast code-focused model for terminal-heavy delegated work
- A web-optimized model for research subtasks
- A cost-effective model for routine delegation

Today this requires manually editing config.yaml with no discovery, validation, or undo.

## What's included

### Model routing profiles (`config.yaml`)

```yaml
model_profiles:
  chat:
    model: anthropic/claude-sonnet-4
    provider: openrouter
  coding:
    model: openai/gpt-5-codex
    provider: openrouter
  planning:
    model: google/gemini-3-flash-preview
    provider: openrouter
  research:
    model: perplexity/sonar-deep-research
    provider: openrouter
```

Each profile supports `model`, `provider`, `base_url`, `api_key_env` — works with any OpenAI-compatible endpoint including local servers (Ollama, vLLM, llama.cpp). Empty profiles inherit from the primary model.

### Interactive configuration wizard

```bash
hermes configure-model-routing             # interactive setup (auto-backup)
hermes configure-model-routing --reset     # reset to defaults (auto-backup)
hermes configure-model-routing --restore   # roll back routing sections from backup
hermes configure-model-routing --restore-full  # roll back entire config from backup
hermes configure-model-routing --list-backups  # show available backups
```

- Auto-discovers providers with working credentials
- Fetches live model lists from each provider's `/models` endpoint
- Per-profile confirmation — never overwrites without asking
- Separate from `hermes model` (which remains the primary model selector)

### Config backup/restore

Every config-modifying routing operation auto-creates a timestamped backup in `~/.hermes/config-backups/` before writing. Restores can target just `model_profiles` + `model_routing` (leaving other config untouched) or the full config. Even restore creates a `pre_restore` backup, so undo is itself undoable. Auto-rotates at 10 backups.

### Routing rules for `delegate_task`

```yaml
model_routing:
  rules:
    - if_toolsets_any: [terminal, file]
      profile: coding
    - if_toolsets_any: [web, browser]
      profile: research
    - if_goal_matches: [plan, spec, roadmap]
      profile: planning
```

First matching rule wins. Falls back to toolset heuristics when no rules match.

### `delegate_task` integration

Explicit profile per call:
```json
{"goal": "Refactor the parser module", "model_profile": "coding"}
```

Or batch mode with mixed profiles:
```json
{
  "tasks": [
    {"goal": "Refactor parser", "toolsets": ["terminal", "file"], "model_profile": "coding"},
    {"goal": "Research alternatives", "toolsets": ["web"], "model_profile": "research"}
  ]
}
```

## Precedence rules

### Chat model
1. CLI `--model` argument
2. `model_profiles.chat.model`
3. `model.default`
4. Built-in fallback

### `delegate_task` routing
1. Legacy `delegation.model`/`delegation.provider` (if set)
2. Explicit `model_profile` on tool call
3. `delegation.model_profile` default
4. Routing rules (`model_routing.rules`)
5. Toolset-based heuristic fallback

## Backward compatibility

- Existing configs work unchanged — all new sections are optional
- `hermes model` behavior is unchanged
- `delegate_task` without `model_profile` uses existing behavior
- `save_config()` API is backward compatible (new `backup_reason` kwarg defaults to empty)
- Legacy `delegation.model`/`delegation.provider` still takes precedence

## Test plan

- [x] `test_config_backup.py` — 15 tests: create, prune, list, selective restore, full restore, pre-restore safety, CLI integration
- [x] `test_model_routing_command.py` — reset with backup, list-backups empty state
- [x] `test_delegate.py` — profile resolution, routing rules, batch mode
- [x] `test_setup.py` — wizard flow, profile normalization, provider discovery
- [x] `test_runtime_provider_resolution.py` — profile inheritance, primary model fallback
- [x] Interactive wizard respects TTY detection — skips in CI/automation
- [x] Cross-platform: `Path`, `shutil.copy2`, no Unix-specific operations
- [x] 318 tests pass

## Files changed

| File | Change |
|------|--------|
| `hermes_cli/config_backup.py` | **New** — backup/restore/prune/list module |
| `hermes_cli/config.py` | `model_profiles`, `model_routing`, `delegation.model_profile` in defaults; `backup_reason` on `save_config` |
| `hermes_cli/runtime_provider.py` | `resolve_model_profile()`, `get_primary_model()`, `resolve_model_for_profile()` |
| `hermes_cli/setup.py` | Interactive wizard, reset, provider discovery |
| `hermes_cli/main.py` | `cmd_configure_model_routing` with `--restore`/`--restore-full`/`--list-backups` |
| `cli.py` | Chat profile resolution in `HermesCLI.__init__` |
| `gateway/run.py` | Gateway chat model reads `model_profiles.chat` |
| `cron/scheduler.py` | Cron reads chat profile |
| `tools/delegate_tool.py` | Profile-aware delegation with routing rules |
| `docs/model-profiles.md` | End-user documentation |
| `tests/` | 6 test files, 100+ new test cases |

🤖 Generated with [Claude Code](https://claude.com/claude-code)