### PR TITLE
feat: add Hugging Face as a first-class inference provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -152,7 +152,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="Hugging Face",
         auth_type="api_key",
         inference_base_url="https://router.huggingface.co/v1",
-        api_key_env_vars=("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"),
+        api_key_env_vars=("HF_TOKEN",),
         base_url_env_var="HF_BASE_URL",
     ),
 }

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -147,6 +147,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
     ),
+    "huggingface": ProviderConfig(
+        id="huggingface",
+        name="Hugging Face",
+        auth_type="api_key",
+        inference_base_url="https://router.huggingface.co/v1",
+        api_key_env_vars=("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"),
+        base_url_env_var="HF_BASE_URL",
+    ),
 }
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -769,6 +769,7 @@ def cmd_model(args):
         "kimi-coding": "Kimi / Moonshot",
         "minimax": "MiniMax",
         "minimax-cn": "MiniMax (China)",
+        "huggingface": "Hugging Face",
         "custom": "Custom endpoint",
     }
     active_label = provider_labels.get(active, active)
@@ -788,6 +789,7 @@ def cmd_model(args):
         ("kimi-coding", "Kimi / Moonshot (Moonshot AI direct API)"),
         ("minimax", "MiniMax (global direct API)"),
         ("minimax-cn", "MiniMax China (domestic direct API)"),
+        ("huggingface", "Hugging Face Inference Providers (20+ open models)"),
     ]
 
     # Add user-defined custom providers from config.yaml
@@ -856,7 +858,7 @@ def cmd_model(args):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("zai", "minimax", "minimax-cn"):
+    elif selected_provider in ("zai", "minimax", "minimax-cn", "huggingface"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
 
@@ -1383,6 +1385,27 @@ _PROVIDER_MODELS = {
         "MiniMax-M2.5",
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
+    ],
+    # Curated model list sourced from https://models.dev (huggingface provider)
+    "huggingface": [
+        "Qwen/Qwen3.5-397B-A17B",
+        "Qwen/Qwen3-235B-A22B-Thinking-2507",
+        "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+        "Qwen/Qwen3-Coder-Next",
+        "Qwen/Qwen3-Next-80B-A3B-Instruct",
+        "Qwen/Qwen3-Next-80B-A3B-Thinking",
+        "deepseek-ai/DeepSeek-R1-0528",
+        "deepseek-ai/DeepSeek-V3.2",
+        "moonshotai/Kimi-K2-Instruct",
+        "moonshotai/Kimi-K2-Instruct-0905",
+        "moonshotai/Kimi-K2.5",
+        "moonshotai/Kimi-K2-Thinking",
+        "MiniMaxAI/MiniMax-M2.5",
+        "MiniMaxAI/MiniMax-M2.1",
+        "XiaomiMiMo/MiMo-V2-Flash",
+        "zai-org/GLM-5",
+        "zai-org/GLM-4.7",
+        "zai-org/GLM-4.7-Flash",
     ],
 }
 
@@ -2263,7 +2286,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "anthropic", "zai", "kimi-coding", "minimax", "minimax-cn"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "anthropic", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -77,6 +77,27 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-sonnet-4-20250514",
         "claude-haiku-4-5-20251001",
     ],
+    # Curated model list sourced from https://models.dev (huggingface provider)
+    "huggingface": [
+        "Qwen/Qwen3.5-397B-A17B",
+        "Qwen/Qwen3-235B-A22B-Thinking-2507",
+        "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+        "Qwen/Qwen3-Coder-Next",
+        "Qwen/Qwen3-Next-80B-A3B-Instruct",
+        "Qwen/Qwen3-Next-80B-A3B-Thinking",
+        "deepseek-ai/DeepSeek-R1-0528",
+        "deepseek-ai/DeepSeek-V3.2",
+        "moonshotai/Kimi-K2-Instruct",
+        "moonshotai/Kimi-K2-Instruct-0905",
+        "moonshotai/Kimi-K2.5",
+        "moonshotai/Kimi-K2-Thinking",
+        "MiniMaxAI/MiniMax-M2.5",
+        "MiniMaxAI/MiniMax-M2.1",
+        "XiaomiMiMo/MiMo-V2-Flash",
+        "zai-org/GLM-5",
+        "zai-org/GLM-4.7",
+        "zai-org/GLM-4.7-Flash",
+    ],
 }
 
 _PROVIDER_LABELS = {
@@ -88,6 +109,7 @@ _PROVIDER_LABELS = {
     "minimax": "MiniMax",
     "minimax-cn": "MiniMax (China)",
     "anthropic": "Anthropic",
+    "huggingface": "Hugging Face",
     "custom": "Custom endpoint",
 }
 
@@ -102,6 +124,7 @@ _PROVIDER_ALIASES = {
     "minimax_cn": "minimax-cn",
     "claude": "anthropic",
     "claude-code": "anthropic",
+    "hf": "huggingface",
 }
 
 
@@ -135,7 +158,7 @@ def list_available_providers() -> list[dict[str, str]]:
     # Canonical providers in display order
     _PROVIDER_ORDER = [
         "openrouter", "nous", "openai-codex",
-        "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic",
+        "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic",
     ]
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}


### PR DESCRIPTION
Register [Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers) (`https://router.huggingface.co/v1`) as a named provider alongside existing ones like Z.AI, Kimi, and MiniMax.

Users can now:
- `hermes chat --provider huggingface`
- Use `hf:model-name` syntax (e.g. `hf:Qwen/Qwen3-235B-A22B-Thinking-2507`)
- Set `HF_TOKEN` in `~/.hermes/.env`
- Select from 18 curated models via `hermes model` picker

Curated model list sourced from [models.dev](https://models.dev). Users can also type any model name manually — it validates against the live `/v1/models` endpoint (120+ models available).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/auth.py` — Added `huggingface` to `PROVIDER_REGISTRY` with `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` env vars and `https://router.huggingface.co/v1` base URL
- `hermes_cli/models.py` — Added curated model list (from models.dev), label, `hf` alias, and provider order entry
- `hermes_cli/main.py` — Added HF to provider menu, dispatch, `--provider` CLI choices, and curated model picker list

## How to Test

1. Set `HF_TOKEN` in `~/.hermes/.env` (get one at https://huggingface.co/settings/tokens)
2. Run `hermes model`, select "Hugging Face Inference Providers"
3. Pick a model from the curated list (e.g. `Qwen/Qwen3-235B-A22B-Thinking-2507`)
4. Chat — verify completions and tool calling work

Or directly: `hermes chat --provider huggingface --model Qwen/Qwen3-235B-A22B-Thinking-2507`

## Tested locally

- Provider registry loads correctly
- `validate_requested_model()` accepts curated models against live API
- Chat completions work via `router.huggingface.co/v1`
- Tool calling works (function calls returned correctly)
- Tested on macOS 15 (Apple Silicon)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.2 (Apple Silicon)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — happy to add docs if wanted
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — can add `HF_TOKEN` example
- [x] I've considered cross-platform impact — N/A (no platform-specific code)

Once merged, we'll add Hermes Agent to the [HF Inference Providers integrations page](https://huggingface.co/docs/inference-providers/integrations/index) as well.