### PR TITLE
fix(cron): use atomic write in save_job_output to prevent data loss on crash

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -431,8 +431,19 @@ def save_job_output(job_id: str, output: str):
     timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S")
     output_file = job_output_dir / f"{timestamp}.md"
     
-    with open(output_file, 'w', encoding='utf-8') as f:
-        f.write(output)
-    _secure_file(output_file)
+    fd, tmp_path = tempfile.mkstemp(dir=str(job_output_dir), suffix='.tmp', prefix='.output_')
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            f.write(output)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, output_file)
+        _secure_file(output_file)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
     
     return output_file


### PR DESCRIPTION
## Summary

Cherry-pick of PR #874 by @alireza78a, rebased onto current main with fixes.

`save_job_output()` used bare `open('w')` which truncates the output file immediately. A crash or OOM kill between truncation and the completed write would silently wipe the job output.

Write now goes to a temp file first, then `os.replace()` swaps it atomically — matching the existing `save_jobs()` pattern in the same file.

### Fixes applied on top of #874:
- **Kept `_secure_dir`/`_secure_file` security calls** from PR #757 (the original PR predated these)
- **Used `except BaseException:`** instead of bare `except:` to match the `save_jobs` pattern
- **Wrapped `os.unlink` in `try/except OSError`** to avoid masking the original exception on cleanup failure

### Tests
- 43 cron tests pass (3 skipped)
- 8 file permission tests pass

Closes #874

Co-authored-by: alireza78a <alireza78a@users.noreply.github.com>