### PR TITLE
feat(skills): opencode skill + fix: doctor cronjob availability

### DIFF
--- a/skills/autonomous-ai-agents/opencode/SKILL.md
+++ b/skills/autonomous-ai-agents/opencode/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: opencode
 description: Delegate coding tasks to OpenCode CLI agent for feature implementation, refactoring, PR review, and long-running autonomous sessions. Requires the opencode CLI installed and authenticated.
-version: 1.1.0
+version: 1.2.0
 author: Hermes Agent
 license: MIT
 metadata:
@@ -12,7 +12,7 @@ metadata:
 
 # OpenCode CLI
 
-Use OpenCode as an autonomous coding worker orchestrated by Hermes terminal/process tools.
+Use [OpenCode](https://opencode.ai) as an autonomous coding worker orchestrated by Hermes terminal/process tools. OpenCode is a provider-agnostic, open-source AI coding agent with a TUI and CLI.
 
 ## When to Use
 
@@ -23,34 +23,100 @@ Use OpenCode as an autonomous coding worker orchestrated by Hermes terminal/proc
 
 ## Prerequisites
 
-- OpenCode installed (`opencode`)
-- Auth configured (`opencode auth list` should show at least one provider)
+- OpenCode installed: `npm i -g opencode-ai@latest` or `brew install anomalyco/tap/opencode`
+- Auth configured: `opencode auth login` or set provider env vars (OPENROUTER_API_KEY, etc.)
+- Verify: `opencode auth list` should show at least one provider
 - Git repository for code tasks (recommended)
-- `pty=true` for interactive sessions
+- `pty=true` for interactive TUI sessions
 
 ## Binary Resolution (Important)
 
 Shell environments may resolve different OpenCode binaries. If behavior differs between your terminal and Hermes, check:
 
+```
 terminal(command="which -a opencode")
 terminal(command="opencode --version")
+```
 
-If needed, pin an explicit binary path in commands:
+If needed, pin an explicit binary path:
 
+```
 terminal(command="$HOME/.opencode/bin/opencode run '...'", workdir="~/project", pty=true)
+```
 
-## Quick Reference
+## One-Shot Tasks
 
-One-shot task:
+Use `opencode run` for bounded, non-interactive tasks:
 
-terminal(command="opencode run 'Add retry logic to API calls and update tests'", workdir="~/project", pty=true)
+```
+terminal(command="opencode run 'Add retry logic to API calls and update tests'", workdir="~/project")
+```
 
-Interactive session (background):
+Attach context files with `-f`:
 
+```
+terminal(command="opencode run 'Review this config for security issues' -f config.yaml -f .env.example", workdir="~/project")
+```
+
+Show model thinking with `--thinking`:
+
+```
+terminal(command="opencode run 'Debug why tests fail in CI' --thinking", workdir="~/project")
+```
+
+Force a specific model:
+
+```
+terminal(command="opencode run 'Refactor auth module' --model openrouter/anthropic/claude-sonnet-4", workdir="~/project")
+```
+
+## Interactive Sessions (Background)
+
+For iterative work requiring multiple exchanges, start the TUI in background:
+
+```
 terminal(command="opencode", workdir="~/project", background=true, pty=true)
+# Returns session_id
+
+# Send a prompt
 process(action="submit", session_id="<id>", data="Implement OAuth refresh flow and add tests")
+
+# Monitor progress
+process(action="poll", session_id="<id>")
 process(action="log", session_id="<id>")
-process(action="submit", session_id="<id>", data="/exit")
+
+# Send follow-up input
+process(action="submit", session_id="<id>", data="Now add error handling for token expiry")
+
+# Exit cleanly — Ctrl+C
+process(action="write", session_id="<id>", data="\x03")
+# Or just kill the process
+process(action="kill", session_id="<id>")
+```
+
+**Important:** Do NOT use `/exit` — it is not a valid OpenCode command and will open an agent selector dialog instead. Use Ctrl+C (`\x03`) or `process(action="kill")` to exit.
+
+### TUI Keybindings
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Submit message (press twice if needed) |
+| `Tab` | Switch between agents (build/plan) |
+| `Ctrl+P` | Open command palette |
+| `Ctrl+X L` | Switch session |
+| `Ctrl+X M` | Switch model |
+| `Ctrl+X N` | New session |
+| `Ctrl+X E` | Open editor |
+| `Ctrl+C` | Exit OpenCode |
+
+### Resuming Sessions
+
+After exiting, OpenCode prints a session ID. Resume with:
+
+```
+terminal(command="opencode -c", workdir="~/project", background=true, pty=true)  # Continue last session
+terminal(command="opencode -s ses_abc123", workdir="~/project", background=true, pty=true)  # Specific session
+```
 
 ## Common Flags
 
@@ -59,48 +125,83 @@ process(action="submit", session_id="<id>", data="/exit")
 | `run 'prompt'` | One-shot execution and exit |
 | `--continue` / `-c` | Continue the last OpenCode session |
 | `--session <id>` / `-s` | Continue a specific session |
-| `--agent <name>` | Choose OpenCode agent/profile |
+| `--agent <name>` | Choose OpenCode agent (build or plan) |
 | `--model provider/model` | Force specific model |
 | `--format json` | Machine-readable output/events |
+| `--file <path>` / `-f` | Attach file(s) to the message |
+| `--thinking` | Show model thinking blocks |
+| `--variant <level>` | Reasoning effort (high, max, minimal) |
+| `--title <name>` | Name the session |
+| `--attach <url>` | Connect to a running opencode server |
 
 ## Procedure
 
 1. Verify tool readiness:
    - `terminal(command="opencode --version")`
    - `terminal(command="opencode auth list")`
-2. For bounded tasks, use `opencode run '...'`.
+2. For bounded tasks, use `opencode run '...'` (no pty needed).
 3. For iterative tasks, start `opencode` with `background=true, pty=true`.
 4. Monitor long tasks with `process(action="poll"|"log")`.
 5. If OpenCode asks for input, respond via `process(action="submit", ...)`.
-6. Summarize file changes, test results, and next steps back to user.
+6. Exit with `process(action="write", data="\x03")` or `process(action="kill")`.
+7. Summarize file changes, test results, and next steps back to user.
 
 ## PR Review Workflow
 
-Safe review in temporary clone:
+OpenCode has a built-in PR command:
 
-terminal(command="REVIEW=$(mktemp -d) && git clone https://github.com/user/repo.git $REVIEW && cd $REVIEW && gh pr checkout 42 && opencode run 'Review this PR vs main. Report bugs, security risks, test gaps, and style issues.'", pty=true)
+```
+terminal(command="opencode pr 42", workdir="~/project", pty=true)
+```
+
+Or review in a temporary clone for isolation:
+
+```
+terminal(command="REVIEW=$(mktemp -d) && git clone https://github.com/user/repo.git $REVIEW && cd $REVIEW && opencode run 'Review this PR vs main. Report bugs, security risks, test gaps, and style issues.' -f $(git diff origin/main --name-only | head -20 | tr '\n' ' ')", pty=true)
+```
 
 ## Parallel Work Pattern
 
 Use separate workdirs/worktrees to avoid collisions:
 
+```
 terminal(command="opencode run 'Fix issue #101 and commit'", workdir="/tmp/issue-101", background=true, pty=true)
 terminal(command="opencode run 'Add parser regression tests and commit'", workdir="/tmp/issue-102", background=true, pty=true)
 process(action="list")
+```
+
+## Session & Cost Management
+
+List past sessions:
+
+```
+terminal(command="opencode session list")
+```
+
+Check token usage and costs:
+
+```
+terminal(command="opencode stats")
+terminal(command="opencode stats --days 7 --models anthropic/claude-sonnet-4")
+```
 
 ## Pitfalls
 
-- Interactive `opencode` sessions require `pty=true`.
+- Interactive `opencode` (TUI) sessions require `pty=true`. The `opencode run` command does NOT need pty.
+- `/exit` is NOT a valid command — it opens an agent selector. Use Ctrl+C to exit the TUI.
 - PATH mismatch can select the wrong OpenCode binary/model config.
 - If OpenCode appears stuck, inspect logs before killing:
   - `process(action="log", session_id="<id>")`
 - Avoid sharing one working directory across parallel OpenCode sessions.
+- Enter may need to be pressed twice to submit in the TUI (once to finalize text, once to send).
 
 ## Verification
 
 Smoke test:
 
-terminal(command="opencode run 'Respond with exactly: OPENCODE_SMOKE_OK'", pty=true)
+```
+terminal(command="opencode run 'Respond with exactly: OPENCODE_SMOKE_OK'")
+```
 
 Success criteria:
 - Output includes `OPENCODE_SMOKE_OK`
@@ -109,8 +210,9 @@ Success criteria:
 
 ## Rules
 
-1. Prefer `opencode run` for one-shot automation.
+1. Prefer `opencode run` for one-shot automation — it's simpler and doesn't need pty.
 2. Use interactive background mode only when iteration is needed.
 3. Always scope OpenCode sessions to a single repo/workdir.
 4. For long tasks, provide progress updates from `process` logs.
 5. Report concrete outcomes (files changed, tests, remaining risks).
+6. Exit interactive sessions with Ctrl+C or kill, never `/exit`.

--- a/skills/autonomous-ai-agents/opencode/SKILL.md
+++ b/skills/autonomous-ai-agents/opencode/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: opencode
+description: Delegate coding tasks to OpenCode CLI agent for feature implementation, refactoring, PR review, and long-running autonomous sessions. Requires the opencode CLI installed and authenticated.
+version: 1.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [Coding-Agent, OpenCode, Autonomous, Refactoring, Code-Review]
+    related_skills: [claude-code, codex, hermes-agent]
+---
+
+# OpenCode CLI
+
+Use OpenCode as an autonomous coding worker orchestrated by Hermes terminal/process tools.
+
+## When to Use
+
+- User explicitly asks to use OpenCode
+- You want an external coding agent to implement/refactor/review code
+- You need long-running coding sessions with progress checks
+- You want parallel task execution in isolated workdirs/worktrees
+
+## Prerequisites
+
+- OpenCode installed (`opencode`)
+- Auth configured (`opencode auth list` should show at least one provider)
+- Git repository for code tasks (recommended)
+- `pty=true` for interactive sessions
+
+## Binary Resolution (Important)
+
+Shell environments may resolve different OpenCode binaries. If behavior differs between your terminal and Hermes, check:
+
+terminal(command="which -a opencode")
+terminal(command="opencode --version")
+
+If needed, pin an explicit binary path in commands:
+
+terminal(command="$HOME/.opencode/bin/opencode run '...'", workdir="~/project", pty=true)
+
+## Quick Reference
+
+One-shot task:
+
+terminal(command="opencode run 'Add retry logic to API calls and update tests'", workdir="~/project", pty=true)
+
+Interactive session (background):
+
+terminal(command="opencode", workdir="~/project", background=true, pty=true)
+process(action="submit", session_id="<id>", data="Implement OAuth refresh flow and add tests")
+process(action="log", session_id="<id>")
+process(action="submit", session_id="<id>", data="/exit")
+
+## Common Flags
+
+| Flag | Use |
+|------|-----|
+| `run 'prompt'` | One-shot execution and exit |
+| `--continue` / `-c` | Continue the last OpenCode session |
+| `--session <id>` / `-s` | Continue a specific session |
+| `--agent <name>` | Choose OpenCode agent/profile |
+| `--model provider/model` | Force specific model |
+| `--format json` | Machine-readable output/events |
+
+## Procedure
+
+1. Verify tool readiness:
+   - `terminal(command="opencode --version")`
+   - `terminal(command="opencode auth list")`
+2. For bounded tasks, use `opencode run '...'`.
+3. For iterative tasks, start `opencode` with `background=true, pty=true`.
+4. Monitor long tasks with `process(action="poll"|"log")`.
+5. If OpenCode asks for input, respond via `process(action="submit", ...)`.
+6. Summarize file changes, test results, and next steps back to user.
+
+## PR Review Workflow
+
+Safe review in temporary clone:
+
+terminal(command="REVIEW=$(mktemp -d) && git clone https://github.com/user/repo.git $REVIEW && cd $REVIEW && gh pr checkout 42 && opencode run 'Review this PR vs main. Report bugs, security risks, test gaps, and style issues.'", pty=true)
+
+## Parallel Work Pattern
+
+Use separate workdirs/worktrees to avoid collisions:
+
+terminal(command="opencode run 'Fix issue #101 and commit'", workdir="/tmp/issue-101", background=true, pty=true)
+terminal(command="opencode run 'Add parser regression tests and commit'", workdir="/tmp/issue-102", background=true, pty=true)
+process(action="list")
+
+## Pitfalls
+
+- Interactive `opencode` sessions require `pty=true`.
+- PATH mismatch can select the wrong OpenCode binary/model config.
+- If OpenCode appears stuck, inspect logs before killing:
+  - `process(action="log", session_id="<id>")`
+- Avoid sharing one working directory across parallel OpenCode sessions.
+
+## Verification
+
+Smoke test:
+
+terminal(command="opencode run 'Respond with exactly: OPENCODE_SMOKE_OK'", pty=true)
+
+Success criteria:
+- Output includes `OPENCODE_SMOKE_OK`
+- Command exits without provider/model errors
+- For code tasks: expected files changed and tests pass
+
+## Rules
+
+1. Prefer `opencode run` for one-shot automation.
+2. Use interactive background mode only when iteration is needed.
+3. Always scope OpenCode sessions to a single repo/workdir.
+4. For long tasks, provide progress updates from `process` logs.
+5. Report concrete outcomes (files changed, tests, remaining risks).


### PR DESCRIPTION
## Changes

### 1. feat(skills): add bundled opencode autonomous-agent skill
Cherry-picked from PR #880 by @arceus77-7, enhanced with hands-on testing.

Adds `opencode` skill under `skills/autonomous-ai-agents/` with:
- One-shot `opencode run` and interactive TUI workflows
- PR review (including `opencode pr` command)
- Parallel work, session/cost management
- TUI keybindings, proper exit instructions
- Fixed `/exit` bug from original PR (not a valid command)

### 2. fix: report cronjob tool as available in hermes doctor
Cherry-picked from PR #895 by @stablegenius49, rebased with conflict resolution.

Sets `HERMES_INTERACTIVE=1` via `setdefault` in `run_doctor()` so CLI-gated tool checks (like cronjob) see the same context as the interactive CLI.

Fixes #878

### Testing
- OpenCode v1.2.25: smoke test passed, `--model` flag verified, interactive TUI tested
- Doctor tests: 8/8 passed (7 existing + 1 new regression test)
- Skills hub tests: 43/43 passed

Co-authored-by: arceus77-7 <261276524+arceus77-7@users.noreply.github.com>
Co-authored-by: stablegenius49 <stablegenius49@users.noreply.github.com>