### PR TITLE
Feat/google news skill

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -905,6 +905,7 @@ def _model_flow_openrouter(config, current_model=""):
         if get_env_value("OPENAI_BASE_URL"):
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
+        save_env_value("HERMES_INFERENCE_PROVIDER", "openrouter")
         _save_model_choice(selected)
 
         # Update config provider and deactivate any OAuth provider
@@ -987,6 +988,7 @@ def _model_flow_nous(config, current_model=""):
 
     selected = _prompt_model_selection(model_ids, current_model=current_model)
     if selected:
+        save_env_value("HERMES_INFERENCE_PROVIDER", "nous")
         _save_model_choice(selected)
         # Reactivate Nous as the provider and update config
         inference_url = creds.get("base_url", "")
@@ -1036,6 +1038,7 @@ def _model_flow_openai_codex(config, current_model=""):
 
     selected = _prompt_model_selection(codex_models, current_model=current_model)
     if selected:
+        save_env_value("HERMES_INFERENCE_PROVIDER", "openai-codex")
         _save_model_choice(selected)
         _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
         # Clear custom endpoint env vars that would otherwise override Codex.
@@ -1092,6 +1095,7 @@ def _model_flow_custom(config):
         save_env_value("OPENAI_API_KEY", api_key)
 
     if model_name:
+        save_env_value("HERMES_INFERENCE_PROVIDER", "custom")
         _save_model_choice(model_name)
 
         # Update config and deactivate any OAuth provider
@@ -1108,6 +1112,7 @@ def _model_flow_custom(config):
         print(f"Default model set to: {model_name} (via {effective_url})")
     else:
         if base_url or api_key:
+            save_env_value("HERMES_INFERENCE_PROVIDER", "custom")
             deactivate_provider()
         print("Endpoint saved. Use `/model` in chat or `hermes model` to set a model.")
 
@@ -1240,6 +1245,7 @@ def _model_flow_named_custom(config, provider_info):
         save_env_value("OPENAI_BASE_URL", base_url)
         if api_key:
             save_env_value("OPENAI_API_KEY", api_key)
+        save_env_value("HERMES_INFERENCE_PROVIDER", "custom")
         _save_model_choice(saved_model)
 
         cfg = load_config()
@@ -1314,6 +1320,7 @@ def _model_flow_named_custom(config, provider_info):
     save_env_value("OPENAI_BASE_URL", base_url)
     if api_key:
         save_env_value("OPENAI_API_KEY", api_key)
+    save_env_value("HERMES_INFERENCE_PROVIDER", "custom")
     _save_model_choice(model_name)
 
     cfg = load_config()
@@ -1427,6 +1434,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         if get_env_value("OPENAI_BASE_URL"):
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
+        save_env_value("HERMES_INFERENCE_PROVIDER", provider_id)
 
         _save_model_choice(selected)
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -888,10 +888,22 @@ def setup_model_provider(config: dict):
         _update_config_for_provider("minimax-cn", pconfig.inference_base_url)
 
     # else: provider_idx == 9 (Keep current) — only shown when a provider already exists
+    # Normalize "keep current" to an explicit provider so downstream logic
+    # (model list + env persistence) doesn't fall back to OpenRouter defaults.
+    if selected_provider is None:
+        if active_oauth and active_oauth in PROVIDER_REGISTRY:
+            selected_provider = active_oauth
+        elif existing_custom:
+            selected_provider = "custom"
+        elif existing_or:
+            selected_provider = "openrouter"
 
     # ── OpenRouter API Key for tools (if not already set) ──
     # Tools (vision, web, MoA) use OpenRouter independently of the main provider.
     # Prompt for OpenRouter key if not set and a non-OpenRouter provider was chosen.
+    if selected_provider in ("nous", "nous-api", "openai-codex", "openrouter", "custom", "zai", "kimi-coding", "minimax", "minimax-cn"):
+        save_env_value("HERMES_INFERENCE_PROVIDER", selected_provider)
+
     if selected_provider in ("nous", "nous-api", "openai-codex", "custom", "zai", "kimi-coding", "minimax", "minimax-cn") and not get_env_value("OPENROUTER_API_KEY"):
         print()
         print_header("OpenRouter API Key (for tools)")

--- a/skills/research/google-news/SKILL.md
+++ b/skills/research/google-news/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: google-news
+description: Full Google News access with homepage, all categories, subcategories, and search. Returns structured JSON with title, source, URL. Uses Scrapling CLI for browser-based fetching.
+version: 5.0.0
+author: Hermes Agent
+tags: [news, google-news, scraping, research, current-events, categories]
+---
+
+# Google News — Complete Category and Subcategory Access
+
+## Overview
+Full Google News access. Homepage, 10 categories with subcategories, and search.
+Returns structured JSON. Categories have subcategory tabs (client-side, dynamic loading).
+
+## Files
+- Script: `SKILL_DIR/scripts/google-news-search.py`
+- Config: `SKILL_DIR/scripts/google-news-categories.json`
+
+`SKILL_DIR` is the directory containing this SKILL.md file.
+
+## Usage
+```bash
+# Homepage
+python3 SKILL_DIR/scripts/google-news-search.py homepage US en 10
+
+# Category
+python3 SKILL_DIR/scripts/google-news-search.py technology US en 10
+
+# Search
+python3 SKILL_DIR/scripts/google-news-search.py search "AI agents" US en 10
+
+# List all categories with subcategories
+python3 SKILL_DIR/scripts/google-news-search.py categories
+```
+
+## Complete Category Structure
+
+### Categories WITHOUT subcategories
+- **Home** (homepage) — Top stories, breaking news
+- **U.S.** — US national news
+- **World** — International news
+- **Local** — Location-based news
+
+### Categories WITH subcategories (tabs at top of page)
+
+**Business** (6 subcategories)
+Latest | Economy | Markets | Jobs | Personal finance | Entrepreneurship
+
+**Technology** (7 subcategories)
+Latest | Mobile | Gadgets | Internet | Virtual reality | Artificial intelligence | Computing
+
+**Entertainment** (7 subcategories)
+Latest | Movies | Music | TV | Books | Arts & design | Celebrities
+
+**Sports** (12 subcategories)
+Latest | NFL | NBA | MLB | NHL | NCAA Football | NCAA Basketball | Soccer | NASCAR | Golf | Tennis | WNBA
+
+**Science** (6 subcategories)
+Latest | Environment | Space | Physics | Genetics | Wildlife
+
+**Health** (6 subcategories)
+Latest | Medication | Health care | Mental health | Nutrition | Fitness
+
+### NOT Categories
+- **Following** — Personal feed of followed topics, requires sign-in, NOT a news category
+- **For You** — Personalized feed, requires sign-in, NOT a browsable category
+
+## Subcategory Technical Notes
+Subcategory tabs are CLIENT-SIDE — they filter content within the parent category page.
+No separate URLs exist for subcategories. Content loads dynamically when tab is clicked.
+To get subcategory-specific content, browser interaction (click tab + wait) is required.
+
+## Aliases
+home, top, top_stories → homepage
+tech → technology
+biz → business
+ent → entertainment
+sci → science
+
+## Regional Presets
+US: region=US, language=en
+UK: region=GB, language=en
+HK: region=HK, language=en
+DE: region=DE, language=de
+
+## JSON Output
+```json
+{
+  "category": "technology",
+  "query": null,
+  "region": "US",
+  "language": "en",
+  "total": 10,
+  "articles": [
+    {"title": "...", "source": "...", "url": "..."}
+  ]
+}
+```
+
+## When to Use vs ddgs
+ddgs: PRIMARY — faster, broader, no browser
+Google News: SUPPLEMENT — category browsing, Google curation, subcategory filtering

--- a/skills/research/google-news/scripts/google-news-categories.json
+++ b/skills/research/google-news/scripts/google-news-categories.json
@@ -1,0 +1,101 @@
+{
+  "description": "Google News category structure for US region. Scraped 2026-03-13.",
+  "last_scraped": "2026-03-13",
+  "region": "US",
+  "structure": "Categories have subcategory tabs (client-side, content loads dynamically)",
+  "following_note": "Following (news.google.com/my/library) is NOT a category - it's a personal feed of topics you follow, requires sign-in",
+  "for_you_note": "For You is personalized feed, requires sign-in, not a browsable category",
+  "categories": {
+    "homepage": {
+      "label": "Home",
+      "type": "homepage",
+      "description": "Top stories and breaking news across all topics",
+      "has_url": true,
+      "subcategories": []
+    },
+    "us": {
+      "id": "CAAqIggKIhxDQkFTRHdvSkwyMHZNRGxqTjNjd0VnSmxiaWdBUAE",
+      "label": "U.S.",
+      "type": "national",
+      "description": "US national news",
+      "has_url": true,
+      "subcategories": []
+    },
+    "world": {
+      "id": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRGx1YlY4U0FtVnVHZ0pWVXlnQVAB",
+      "label": "World",
+      "type": "international",
+      "description": "International news",
+      "has_url": true,
+      "subcategories": []
+    },
+    "business": {
+      "id": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRGx6TVdZU0FtVnVHZ0pWVXlnQVAB",
+      "label": "Business",
+      "type": "topic",
+      "description": "Business, finance, markets, economy, startups",
+      "has_url": true,
+      "subcategories": ["Latest", "Economy", "Markets", "Jobs", "Personal finance", "Entrepreneurship"]
+    },
+    "technology": {
+      "id": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRGRqTVhZU0FtVnVHZ0pWVXlnQVAB",
+      "label": "Technology",
+      "type": "topic",
+      "description": "Tech products, AI, software, hardware, startups",
+      "has_url": true,
+      "subcategories": ["Latest", "Mobile", "Gadgets", "Internet", "Virtual reality", "Artificial intelligence", "Computing"]
+    },
+    "entertainment": {
+      "id": "CAAqJggKIiBDQkFTRWdvSUwyMHZNREpxYW5RU0FtVnVHZ0pWVXlnQVAB",
+      "label": "Entertainment",
+      "type": "topic",
+      "description": "Movies, TV, music, celebrities, pop culture",
+      "has_url": true,
+      "subcategories": ["Latest", "Movies", "Music", "TV", "Books", "Arts & design", "Celebrities"]
+    },
+    "sports": {
+      "id": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRFp1ZEdvU0FtVnVHZ0pWVXlnQVAB",
+      "label": "Sports",
+      "type": "topic",
+      "description": "All sports, leagues, scores",
+      "has_url": true,
+      "subcategories": ["Latest", "NFL", "NBA", "MLB", "NHL", "NCAA Football", "NCAA Basketball", "Soccer", "NASCAR", "Golf", "Tennis", "WNBA"]
+    },
+    "science": {
+      "id": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRFp0Y1RjU0FtVnVHZ0pWVXlnQVAB",
+      "label": "Science",
+      "type": "topic",
+      "description": "Scientific research, discoveries, space",
+      "has_url": true,
+      "subcategories": ["Latest", "Environment", "Space", "Physics", "Genetics", "Wildlife"]
+    },
+    "health": {
+      "id": "CAAqIQgKIhtDQkFTRGdvSUwyMHZNR3QwTlRFU0FtVnVLQUFQAQ",
+      "label": "Health",
+      "type": "topic",
+      "description": "Medical research, healthcare, wellness",
+      "has_url": true,
+      "subcategories": ["Latest", "Medication", "Health care", "Mental health", "Nutrition", "Fitness"]
+    },
+    "local": {
+      "id": "CAAqHAgKIhZDQklTQ2pvSWJHOWpZV3hmZGpJb0FBUAE",
+      "label": "Local",
+      "type": "geographic",
+      "description": "Local news based on location",
+      "has_url": true,
+      "subcategories": []
+    }
+  },
+  "subcategory_notes": [
+    "Subcategory tabs are CLIENT-SIDE - content loads dynamically when clicked",
+    "No separate URLs for subcategories - they filter content within parent category page",
+    "To get subcategory-specific content, browser interaction (click tab) is required",
+    "Subcategories exist for: Business (6), Technology (7), Entertainment (7), Sports (12), Science (6), Health (6)",
+    "U.S., World, and Local have NO subcategory tabs"
+  ],
+  "other_ids_in_html": {
+    "full_coverage": "23 IDs - Dynamic pages for specific breaking stories",
+    "author_pages": "15 IDs - Journalist/commentator profiles",
+    "other": "13 IDs - Various sub-topics, not persistent navigation"
+  }
+}

--- a/skills/research/google-news/scripts/google-news-search.py
+++ b/skills/research/google-news/scripts/google-news-search.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Google News — Full access via Scrapling CLI.
+Supports: homepage, category pages, and search queries.
+Returns structured JSON with title, source, URL for each article.
+
+Usage:
+  python3 google-news-search.py                          # Homepage
+  python3 google-news-search.py technology               # Category
+  python3 google-news-search.py search "AI agents"       # Search
+  python3 google-news-search.py categories               # List all categories
+  python3 google-news-search.py technology GB en 10      # Category + region + limit
+
+Categories: homepage, us, world, business, technology, entertainment,
+            sports, science, health, local
+"""
+
+import subprocess
+import tempfile
+import re
+import json
+import sys
+import os
+
+# Script directory for loading config
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_FILE = os.path.join(SCRIPT_DIR, 'google-news-categories.json')
+
+# Load categories from config, fallback to hardcoded
+def load_categories():
+    try:
+        with open(CONFIG_FILE, 'r') as f:
+            config = json.load(f)
+        cats = {}
+        for key, val in config['categories'].items():
+            cats[key] = val.get('id')
+        return cats, config['categories']
+    except:
+        # Fallback
+        return {
+            "homepage": None,
+            "us": "CAAqIggKIhxDQkFTRHdvSkwyMHZNRGxqTjNjd0VnSmxiaWdBUAE",
+            "world": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRGx1YlY4U0FtVnVHZ0pWVXlnQVAB",
+            "business": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRGx6TVdZU0FtVnVHZ0pWVXlnQVAB",
+            "technology": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRGRqTVhZU0FtVnVHZ0pWVXlnQVAB",
+            "entertainment": "CAAqJggKIiBDQkFTRWdvSUwyMHZNREpxYW5RU0FtVnVHZ0pWVXlnQVAB",
+            "sports": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRFp1ZEdvU0FtVnVHZ0pWVXlnQVAB",
+            "science": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRFp0Y1RjU0FtVnVHZ0pWVXlnQVAB",
+            "health": "CAAqIQgKIhtDQkFTRGdvSUwyMHZNR3QwTlRFU0FtVnVLQUFQAQ",
+            "local": "CAAqHAgKIhZDQklTQ2pvSWJHOWpZV3hmZGpJb0FBUAE",
+        }, None
+
+CATEGORIES, CATEGORY_META = load_categories()
+
+# Aliases for convenience
+ALIASES = {
+    "home": "homepage",
+    "top": "homepage",
+    "top_stories": "homepage",
+    "tech": "technology",
+    "biz": "business",
+    "ent": "entertainment",
+    "sci": "science",
+}
+
+
+def build_url(category, region="US", language="en", query=None):
+    """Build Google News URL for category or search."""
+    hl = f"{language}-{region}"
+    ceid = f"{region}:{language}"
+    
+    if query:
+        return f"https://news.google.com/search?q={query.replace(' ', '+')}&hl={hl}&gl={region}&ceid={ceid}"
+    
+    cat_id = CATEGORIES.get(category)
+    if cat_id is None:
+        return f"https://news.google.com/home?hl={hl}&gl={region}&ceid={ceid}"
+    else:
+        return f"https://news.google.com/topics/{cat_id}?hl={hl}&gl={region}&ceid={ceid}"
+
+
+def fetch_and_parse(url, max_articles=20):
+    """Fetch Google News page and parse articles."""
+    html_file = tempfile.mktemp(suffix='.html')
+    
+    cmd = [
+        "scrapling", "extract", "fetch", url, html_file,
+        "--headless", "--disable-resources",
+        "--timeout", "20000", "--wait", "3000"
+    ]
+    
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        return {"error": f"Fetch failed: {result.stderr}", "articles": []}
+    
+    from scrapling.parser import Selector
+    
+    with open(html_file, 'r', encoding='utf-8') as f:
+        html = f.read()
+    
+    sel = Selector(html)
+    
+    # Parse from aria-labels
+    aria_links = sel.css('a[aria-label]')
+    articles = []
+    seen = set()
+    
+    for a in aria_links:
+        label = a.attrib.get('aria-label', '')
+        href = a.attrib.get('href', '')
+        
+        if len(label) < 20 or not ('./read/' in href or './articles/' in href):
+            continue
+        if label in seen:
+            continue
+        seen.add(label)
+        
+        if href.startswith('./read/'):
+            article_url = f"https://news.google.com/read/{href[7:]}"
+        elif href.startswith('./articles/'):
+            article_url = f"https://news.google.com/articles/{href[12:]}"
+        else:
+            article_url = href
+        
+        label = label.strip().rstrip(' -')
+        parts = label.split(' - ', 1)
+        
+        if len(parts) == 2:
+            title = parts[0].strip()
+            source = parts[1].strip().split(' - ')[0].strip()
+        else:
+            title = label
+            source = ''
+        
+        if len(title) >= 15:
+            articles.append({
+                'title': title,
+                'source': source,
+                'url': article_url
+            })
+    
+    # Cleanup
+    try:
+        os.unlink(html_file)
+    except:
+        pass
+    
+    if max_articles:
+        articles = articles[:max_articles]
+    
+    return articles
+
+
+def list_categories():
+    """List all available categories with descriptions."""
+    if CATEGORY_META:
+        result = []
+        for key, meta in sorted(CATEGORY_META.items()):
+            result.append({
+                'id': key,
+                'label': meta.get('label', key),
+                'type': meta.get('type', 'unknown'),
+                'description': meta.get('description', ''),
+                'has_url': meta.get('url') is not None
+            })
+        return result
+    else:
+        return [{'id': k, 'label': k.title()} for k in CATEGORIES.keys()]
+
+
+def main():
+    args = sys.argv[1:]
+    
+    category = "homepage"
+    region = "US"
+    language = "en"
+    max_results = 20
+    query = None
+    
+    if not args:
+        pass
+    elif args[0] == "search":
+        query = args[1] if len(args) > 1 else "AI agents"
+        region = args[2] if len(args) > 2 else "US"
+        language = args[3] if len(args) > 3 else "en"
+        max_results = int(args[4]) if len(args) > 4 else 20
+    elif args[0] == "categories":
+        cats = list_categories()
+        print(json.dumps({"total": len(cats), "categories": cats}, indent=2))
+        return
+    else:
+        cat = args[0].lower()
+        category = ALIASES.get(cat, cat)
+        
+        if category not in CATEGORIES:
+            print(json.dumps({
+                "error": f"Unknown category: {category}",
+                "available": list(CATEGORIES.keys()),
+                "hint": "Use 'categories' command to list all"
+            }))
+            return
+        
+        region = args[1] if len(args) > 1 else "US"
+        language = args[2] if len(args) > 2 else "en"
+        max_results = int(args[3]) if len(args) > 3 else 20
+    
+    url = build_url(category, region, language, query)
+    articles = fetch_and_parse(url, max_results)
+    
+    result = {
+        "category": category if not query else "search",
+        "query": query,
+        "region": region,
+        "language": language,
+        "total": len(articles),
+        "articles": articles
+    }
+    
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_setup_model_provider.py
+++ b/tests/test_setup_model_provider.py
@@ -1,0 +1,106 @@
+"""Regression tests for interactive setup provider/model persistence."""
+
+from __future__ import annotations
+
+import yaml
+
+
+def _read_env(home):
+    env_path = home / ".env"
+    data = {}
+    if not env_path.exists():
+        return data
+    for line in env_path.read_text().splitlines():
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        data[k] = v
+    return data
+
+
+def test_setup_keep_current_custom_does_not_fall_through(tmp_path, monkeypatch):
+    """Selecting "Keep current" on a custom provider must remain custom."""
+    from hermes_cli.config import save_env_value
+    from hermes_cli.setup import setup_model_provider
+
+    home = tmp_path / "hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    # Existing custom endpoint + OR key (skip optional OpenRouter prompt).
+    save_env_value("OPENAI_BASE_URL", "https://example.invalid/v1")
+    save_env_value("OPENAI_API_KEY", "sk-custom")
+    save_env_value("OPENROUTER_API_KEY", "sk-or")
+
+    monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: None)
+    monkeypatch.setattr("hermes_cli.auth.detect_external_credentials", lambda: [])
+
+    calls = {"count": 0}
+
+    def fake_prompt_choice(_question, choices, default=0):
+        calls["count"] += 1
+        # First menu = provider menu. Pick "Keep current (...)".
+        if calls["count"] == 1:
+            return len(choices) - 1
+        raise AssertionError("Model menu should not appear for keep-current custom")
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: "")
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: False)
+
+    setup_model_provider({"model": "glm-5"})
+
+    env = _read_env(home)
+    assert env.get("HERMES_INFERENCE_PROVIDER") == "custom"
+    assert calls["count"] == 1
+
+
+def test_setup_switch_custom_to_codex_updates_provider(tmp_path, monkeypatch):
+    """Switching provider to OpenAI Codex must persist provider + clear custom URL."""
+    from hermes_cli.config import save_env_value
+    from hermes_cli.setup import setup_model_provider
+
+    home = tmp_path / "hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    # Start from custom endpoint state.
+    save_env_value("OPENAI_BASE_URL", "https://example.invalid/v1")
+    save_env_value("OPENAI_API_KEY", "sk-custom")
+    save_env_value("OPENROUTER_API_KEY", "sk-or")
+
+    monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: None)
+    monkeypatch.setattr("hermes_cli.auth.detect_external_credentials", lambda: [])
+    monkeypatch.setattr("hermes_cli.auth._login_openai_codex", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda: ["openai/gpt-5.3-codex", "openai/gpt-5-codex-mini"],
+    )
+
+    # 1st prompt_choice = provider (OpenAI Codex index), 2nd = model pick.
+    picks = iter([2, 0])
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: next(picks))
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: "")
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: False)
+
+    setup_model_provider({"model": "glm-5"})
+
+    env = _read_env(home)
+    assert env.get("HERMES_INFERENCE_PROVIDER") == "openai-codex"
+    assert env.get("OPENAI_BASE_URL", None) == ""
+
+    cfg = yaml.safe_load((home / "config.yaml").read_text()) or {}
+    model_cfg = cfg.get("model")
+    if isinstance(model_cfg, dict):
+        assert model_cfg.get("provider") == "openai-codex"
+        assert model_cfg.get("default") == "openai/gpt-5.3-codex"
+    else:
+        assert model_cfg == "openai/gpt-5.3-codex"


### PR DESCRIPTION
  ## What does this PR do?

  Adds a new bundled research skill: `google-news`.

  This skill provides Google News homepage/category/search access with structured JSON output (`title`, `source`, `url`)
  and category metadata. The implementation and config are now self-contained in the repo skill directory so it no
  longer depends on a local Windows path (`D:\Hermes\...`).

  Why this approach:
  - Keeps the skill portable and reviewable in-repo.
  - Uses the existing skill pattern (`SKILL.md` + `scripts/`).
  - Preserves your existing Google News logic and category map.

  ## Related Issue

  No linked issue for this contribution.

  Fixes #N/A

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [x] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Added new skill docs:
    - `skills/research/google-news/SKILL.md`
  - Added new skill scripts:
    - `skills/research/google-news/scripts/google-news-search.py`
    - `skills/research/google-news/scripts/google-news-categories.json`
  - Updated usage in `SKILL.md` to use repo-local paths via `SKILL_DIR/scripts/...` instead of `D:\Hermes\scripts\...`.

  ## How to Test

  1. List categories:
     - `python3 skills/research/google-news/scripts/google-news-search.py categories`
  2. Fetch a category:
     - `python3 skills/research/google-news/scripts/google-news-search.py technology US en 5`
  3. Run search:
     - `python3 skills/research/google-news/scripts/google-news-search.py search "AI agents" US en 5`
  4. Verify JSON output includes:
     - `category`, `query`, `region`, `language`, `total`, `articles[]`

  ## Checklist

  ### Code

  - [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`,
  `feat(scope):`, etc.)
  - [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a
  duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [ ] I've run `pytest tests/ -q` and all tests pass
  - [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Windows 11 + WSL (Ubuntu)

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/
  NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## For New Skills

  - [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/
  NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
  - [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/
  CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
  - [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
  - [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

  ## Screenshots / Logs

  Example validation output:

  ```bash
  $ python3 skills/research/google-news/scripts/google-news-search.py categories
  {
    "total": 10,
    "categories": [
      {"id":"business","label":"Business", ...},
      ...
    ]
  }