### PR TITLE
fix: auto-detect provider when switching models via /model

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2805,6 +2805,7 @@ class HermesCLI:
                 from hermes_cli.models import (
                     parse_model_input,
                     validate_requested_model,
+                    detect_provider_for_model,
                     _PROVIDER_LABELS,
                 )
 
@@ -2813,6 +2814,13 @@ class HermesCLI:
                 # Parse provider:model syntax (e.g. "openrouter:anthropic/claude-sonnet-4.5")
                 current_provider = self.provider or self.requested_provider or "openrouter"
                 target_provider, new_model = parse_model_input(raw_input, current_provider)
+
+                # Auto-detect provider when no explicit provider:model syntax was used
+                if target_provider == current_provider:
+                    detected = detect_provider_for_model(new_model, current_provider)
+                    if detected:
+                        target_provider = detected
+
                 provider_changed = target_provider != current_provider
 
                 # If provider is changing, re-resolve credentials for the new provider

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1684,6 +1684,7 @@ class GatewayRunner:
             validate_requested_model,
             curated_models_for_provider,
             normalize_provider,
+            detect_provider_for_model,
             _PROVIDER_LABELS,
         )
 
@@ -1741,6 +1742,13 @@ class GatewayRunner:
 
         # Parse provider:model syntax
         target_provider, new_model = parse_model_input(args, current_provider)
+
+        # Auto-detect provider when no explicit provider:model syntax was used
+        if target_provider == current_provider:
+            detected = detect_provider_for_model(new_model, current_provider)
+            if detected:
+                target_provider = detected
+
         provider_changed = target_provider != current_provider
 
         # Resolve credentials for the target provider (for API probe)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -77,6 +77,21 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-sonnet-4-20250514",
         "claude-haiku-4-5-20251001",
     ],
+    "deepseek": [
+        "deepseek-chat",
+        "deepseek-reasoner",
+    ],
+    "google": [
+        "gemini-3-pro-preview",
+        "gemini-3-flash-preview",
+        "gemini-2.5-flash",
+        "gemini-2.5-pro",
+    ],
+    "nvidia": [
+        "nvidia/llama-3.3-nemotron-super-49b-v1",
+        "nvidia/llama-3.1-nemotron-ultra-253b-v1",
+    ],
+    "ollama": [],  # discovered live via /models endpoint
 }
 
 _PROVIDER_LABELS = {
@@ -88,6 +103,10 @@ _PROVIDER_LABELS = {
     "minimax": "MiniMax",
     "minimax-cn": "MiniMax (China)",
     "anthropic": "Anthropic",
+    "deepseek": "DeepSeek",
+    "google": "Google Gemini",
+    "nvidia": "NVIDIA",
+    "ollama": "Ollama",
     "custom": "Custom endpoint",
 }
 
@@ -100,8 +119,13 @@ _PROVIDER_ALIASES = {
     "moonshot": "kimi-coding",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
+    "github-copilot": "openai-codex",
+    "copilot": "openai-codex",
+    "gh-copilot": "openai-codex",
     "claude": "anthropic",
     "claude-code": "anthropic",
+    "gemini": "google",
+    "google-gemini": "google",
 }
 
 
@@ -209,6 +233,47 @@ def curated_models_for_provider(provider: Optional[str]) -> list[tuple[str, str]
     # Fallback to static catalog
     models = _PROVIDER_MODELS.get(normalized, [])
     return [(m, "") for m in models]
+
+
+def detect_provider_for_model(model_name: str, current_provider: str) -> Optional[str]:
+    """Try to auto-detect which provider serves a given model.
+
+    Checks static catalogs (fast, no network), preferring direct providers
+    over aggregators (nous, openrouter) which list models from many sources.
+    Returns the canonical provider id, or None if no match found.
+    """
+    name = (model_name or "").strip().lower()
+    if not name:
+        return None
+
+    # Aggregators list other providers' models — check them last
+    _AGGREGATORS = {"nous", "openrouter"}
+
+    direct_match = None
+    aggregator_match = None
+
+    # Check static catalogs (fast, no network)
+    for pid, models in _PROVIDER_MODELS.items():
+        if pid == current_provider:
+            continue
+        if any(name == m.lower() for m in models):
+            if pid in _AGGREGATORS:
+                aggregator_match = aggregator_match or pid
+            else:
+                direct_match = pid
+                break  # direct provider wins immediately
+
+    if direct_match:
+        return direct_match
+
+    # Check OpenRouter catalog
+    if current_provider != "openrouter" and not aggregator_match:
+        for mid, _ in OPENROUTER_MODELS:
+            if name == mid.lower():
+                aggregator_match = "openrouter"
+                break
+
+    return aggregator_match
 
 
 def normalize_provider(provider: Optional[str]) -> str:

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -1,6 +1,6 @@
 """Tests for the hermes_cli models module."""
 
-from hermes_cli.models import OPENROUTER_MODELS, menu_labels, model_ids
+from hermes_cli.models import OPENROUTER_MODELS, menu_labels, model_ids, detect_provider_for_model
 
 
 class TestModelIds:
@@ -54,3 +54,26 @@ class TestOpenRouterModels:
     def test_at_least_5_models(self):
         """Sanity check that the models list hasn't been accidentally truncated."""
         assert len(OPENROUTER_MODELS) >= 5
+
+
+class TestDetectProviderForModel:
+    def test_deepseek_chat_detected_from_codex(self):
+        """deepseek-chat should resolve to the deepseek provider."""
+        assert detect_provider_for_model("deepseek-chat", "openai-codex") == "deepseek"
+
+    def test_direct_provider_wins_over_aggregator(self):
+        """claude-opus-4-6 is in both anthropic and nous; direct provider wins."""
+        result = detect_provider_for_model("claude-opus-4-6", "openai-codex")
+        assert result == "anthropic"
+
+    def test_current_provider_model_returns_none(self):
+        """Models belonging to the current provider should not trigger a switch."""
+        assert detect_provider_for_model("gpt-5.2-codex", "openai-codex") is None
+
+    def test_openrouter_catalog_fallback(self):
+        """Models only in the OpenRouter catalog should return openrouter."""
+        assert detect_provider_for_model("anthropic/claude-opus-4.6", "deepseek") == "openrouter"
+
+    def test_unknown_model_returns_none(self):
+        """Completely unknown model names should return None."""
+        assert detect_provider_for_model("nonexistent-model-xyz", "openai-codex") is None


### PR DESCRIPTION
## Summary

The `/model` slash command currently requires explicit `provider:model` syntax to switch providers (e.g., `/model deepseek:deepseek-chat`). If the user types just `/model deepseek-chat` while on a different provider (e.g., `openai-codex`), the model name changes but the provider stays the same — causing silent API errors because the old provider doesn't serve that model.

This PR adds `detect_provider_for_model()` which checks static provider catalogs (no network calls) to find which provider serves the requested model and auto-switches. Direct providers are preferred over aggregators (`nous`, `openrouter`) that list models from many sources.

**Changes:**
- **`hermes_cli/models.py`** — Add `detect_provider_for_model()` function; add `deepseek`, `google`, `nvidia`, `ollama` to static provider catalogs and aliases
- **`gateway/run.py`** — Call auto-detection after `parse_model_input()` in `_handle_model_command()`
- **`cli.py`** — Same auto-detection in the CLI's `/model` handler
- **`tests/hermes_cli/test_models.py`** — 5 tests covering direct match, aggregator deprioritization, current-provider skip, OpenRouter fallback, and unknown models

**Backward-compatible:** Explicit `provider:model` syntax still takes precedence — auto-detection only runs when no provider prefix is given.

## Test plan
- [x] `python -m pytest tests/hermes_cli/test_models.py -x -q` — all 15 tests pass
- [ ] Manual: `/model deepseek-chat` from `openai-codex` provider auto-switches to `deepseek`
- [ ] Manual: `/model deepseek:deepseek-chat` still works as before (explicit syntax)
- [ ] Manual: `/model gpt-5.2-codex` while on `openai-codex` does NOT trigger auto-switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)