### PR TITLE
fix(skills): use generic example in 1password op run snippet

### DIFF
--- a/optional-skills/security/1password/SKILL.md
+++ b/optional-skills/security/1password/SKILL.md
@@ -138,8 +138,8 @@ echo "db_password: {{ op://app-prod/db/password }}" | op inject
 ### Run a command with secret env var
 
 ```bash
-export OPENAI_API_KEY="op://app-prod/openai/api key"
-op run -- sh -c '[ -n "$OPENAI_API_KEY" ] && echo "OPENAI_API_KEY is set" || echo "OPENAI_API_KEY missing"'
+export DB_PASSWORD="op://app-prod/db/password"
+op run -- sh -c '[ -n "$DB_PASSWORD" ] && echo "DB_PASSWORD is set" || echo "DB_PASSWORD missing"'
 ```
 
 ## Guardrails


### PR DESCRIPTION
Swap OPENAI_API_KEY → DB_PASSWORD in the op run example to avoid implying the skill is OpenAI-related.