### PR TITLE
fix(gateway): add platform notes to prevent hallucinated capabilities

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -177,6 +177,26 @@ def build_session_context_prompt(context: SessionContext) -> str:
     elif context.source.user_id:
         lines.append(f"**User ID:** {context.source.user_id}")
     
+    # Platform-specific behavioral notes
+    if context.source.platform == Platform.SLACK:
+        lines.append("")
+        lines.append(
+            "**Platform notes:** You are running inside Slack. "
+            "You do NOT have access to Slack-specific APIs — you cannot search "
+            "channel history, pin/unpin messages, manage channels, or list users. "
+            "Do not promise to perform these actions. If the user asks, explain "
+            "that you can only read messages sent directly to you and respond."
+        )
+    elif context.source.platform == Platform.DISCORD:
+        lines.append("")
+        lines.append(
+            "**Platform notes:** You are running inside Discord. "
+            "You do NOT have access to Discord-specific APIs — you cannot search "
+            "channel history, pin messages, manage roles, or list server members. "
+            "Do not promise to perform these actions. If the user asks, explain "
+            "that you can only read messages sent directly to you and respond."
+        )
+
     # Connected platforms
     platforms_list = ["local (files on this machine)"]
     for p in context.connected_platforms:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -182,7 +182,7 @@ class TestBuildSessionContextPrompt:
             platforms={
                 Platform.DISCORD: PlatformConfig(
                     enabled=True,
-                    token="fake-discord-token",
+                    token="fake-d...oken",
                 ),
             },
         )
@@ -197,6 +197,27 @@ class TestBuildSessionContextPrompt:
         prompt = build_session_context_prompt(ctx)
 
         assert "Discord" in prompt
+        assert "cannot search" in prompt.lower() or "do not have access" in prompt.lower()
+
+    def test_slack_prompt_includes_platform_notes(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.SLACK: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_name="general",
+            chat_type="group",
+            user_name="bob",
+        )
+        ctx = build_session_context(source, config)
+        prompt = build_session_context_prompt(ctx)
+
+        assert "Slack" in prompt
+        assert "cannot search" in prompt.lower()
+        assert "pin" in prompt.lower()
 
     def test_discord_prompt_with_channel_topic(self):
         """Channel topic should appear in the session context prompt."""


### PR DESCRIPTION
## Summary

Adds platform-specific behavioral notes to the session context prompt for Slack and Discord. This tells the agent what it **cannot** do on each platform, preventing it from hallucinating capabilities and promising actions it can't deliver.

### The problem

A user reported that the agent says things like "I'll search your Slack history" or "I'll pin that message" — then goes silent because no Slack-specific tools exist. The agent pattern-matches on the request and generates a plausible-sounding response, but has no way to follow through.

### The fix

When the agent runs on Slack or Discord, the session context prompt now includes:

> **Platform notes:** You are running inside Slack. You do NOT have access to Slack-specific APIs — you cannot search channel history, pin/unpin messages, manage channels, or list users. Do not promise to perform these actions.

This is lightweight (a few lines in the system prompt) and prevents the hallucination without adding any tools to the context budget.

### Files changed

- `gateway/session.py` — Platform-specific notes in `build_session_context_prompt()`
- `tests/gateway/test_session.py` — Tests for Slack and Discord platform notes

### Test plan

```bash
python -m pytest tests/gateway/test_session.py -n0 -q
```

683 gateway tests pass, 0 regressions.