### PR TITLE
fix(context_compressor): prevent consecutive same-role messages after compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -288,7 +288,19 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
 
         if summary:
             last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"
+            first_tail_role = messages[compress_end].get("role", "user") if compress_end < n_messages else None
             summary_role = "user" if last_head_role in ("assistant", "tool") else "assistant"
+            if first_tail_role and summary_role == first_tail_role:
+                flipped = "user" if summary_role == "assistant" else "assistant"
+                head_collides = (
+                    (flipped == "assistant" and last_head_role in ("assistant", "tool"))
+                    or (flipped == "user" and last_head_role == "user")
+                )
+                if not head_collides:
+                    summary_role = flipped
+                else:
+                    summary_role = "user"
+                    summary = "[Summary of previous conversation]\n" + summary
             compressed.append({"role": summary_role, "content": summary})
         else:
             if not self.quiet_mode:


### PR DESCRIPTION
compress_context() picks the summary message role based only on the message before the compression window. If the first message after the window has the same role, the API returns 400 — consecutive same-role messages aren't allowed. This causes long conversations to crash mid-reply with no useful error, forcing the user to /reset and lose their session history.

Fix checks both neighbors when choosing the summary role. If flipping still collides with the head, falls back to "user" with a short prefix.