### PR TITLE
fix(setup): defer config.yaml write until after model selection

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -719,6 +719,7 @@ def setup_model_provider(config: dict):
     selected_provider = (
         None  # "nous", "openai-codex", "openrouter", "custom", or None (keep)
     )
+    selected_base_url = None  # deferred until after model selection
     nous_models = []  # populated if Nous login succeeds
 
     if provider_idx == 0:  # Nous Portal (OAuth)
@@ -977,8 +978,8 @@ def setup_model_provider(config: dict):
         if existing_custom:
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
-        _update_config_for_provider("zai", zai_base_url, default_model="glm-5")
         _set_model_provider(config, "zai", zai_base_url)
+        selected_base_url = zai_base_url
 
     elif provider_idx == 5:  # Kimi / Moonshot
         selected_provider = "kimi-coding"
@@ -1010,8 +1011,8 @@ def setup_model_provider(config: dict):
         if existing_custom:
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
-        _update_config_for_provider("kimi-coding", pconfig.inference_base_url, default_model="kimi-k2.5")
         _set_model_provider(config, "kimi-coding", pconfig.inference_base_url)
+        selected_base_url = pconfig.inference_base_url
 
     elif provider_idx == 6:  # MiniMax
         selected_provider = "minimax"
@@ -1043,8 +1044,8 @@ def setup_model_provider(config: dict):
         if existing_custom:
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
-        _update_config_for_provider("minimax", pconfig.inference_base_url, default_model="MiniMax-M2.5")
         _set_model_provider(config, "minimax", pconfig.inference_base_url)
+        selected_base_url = pconfig.inference_base_url
 
     elif provider_idx == 7:  # MiniMax China
         selected_provider = "minimax-cn"
@@ -1076,8 +1077,8 @@ def setup_model_provider(config: dict):
         if existing_custom:
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
-        _update_config_for_provider("minimax-cn", pconfig.inference_base_url, default_model="MiniMax-M2.5")
         _set_model_provider(config, "minimax-cn", pconfig.inference_base_url)
+        selected_base_url = pconfig.inference_base_url
 
     elif provider_idx == 8:  # Anthropic
         selected_provider = "anthropic"
@@ -1180,8 +1181,8 @@ def setup_model_provider(config: dict):
             save_env_value("OPENAI_API_KEY", "")
         # Don't save base_url for Anthropic — resolve_runtime_provider()
         # always hardcodes it. Stale base_urls contaminate other providers.
-        _update_config_for_provider("anthropic", "", default_model="claude-opus-4-6")
         _set_model_provider(config, "anthropic")
+        selected_base_url = ""
 
     # else: provider_idx == 9 (Keep current) — only shown when a provider already exists
 
@@ -1342,6 +1343,12 @@ def setup_model_provider(config: dict):
                 else _final_model
             )
             print_success(f"Model set to: {_display}")
+
+    # Write provider+base_url to config.yaml only after model selection is complete.
+    # This prevents a race condition where the gateway picks up a new provider
+    # before the model name has been updated to match.
+    if selected_provider in ("zai", "kimi-coding", "minimax", "minimax-cn", "anthropic") and selected_base_url is not None:
+        _update_config_for_provider(selected_provider, selected_base_url)
 
     save_config(config)
 


### PR DESCRIPTION
## Problem

Closes #1182

`_update_config_for_provider()` was called immediately after provider selection for `zai`, `kimi-coding`, `minimax`, `minimax-cn`, and `anthropic` — before model selection happened. Since the gateway re-reads `config.yaml` per-message, this created a race condition where the gateway would pick up the new provider but still use the old (incompatible) model name.

Example: switching from OpenRouter (`anthropic/claude-opus-4.6`) to MiniMax would briefly write `provider: minimax` + `base_url: https://api.minimax.io/v1` to disk while `model.default` was still `anthropic/claude-opus-4.6`. Any gateway message sent during setup would fail.

Even without a race: selecting "Keep current" at model selection would leave an OpenRouter-formatted model name permanently on a non-OpenRouter provider.

## Fix

Capture `selected_base_url` in each affected provider block, then call `_update_config_for_provider()` **once**, after model selection completes, just before `save_config()`. The in-memory `_set_model_provider()` calls are kept in place so the config object stays consistent throughout the setup flow.

## Affected providers
- `zai`
- `kimi-coding`
- `minimax`
- `minimax-cn`
- `anthropic`