### PR TITLE
fix: prevent gateway race condition when switching providers

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -165,7 +165,11 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             else:
                 raise
 
-        summary = response.choices[0].message.content.strip()
+        content = response.choices[0].message.content
+        # Handle cases where content is not a string (e.g., dict from llama.cpp tool calls)
+        if not isinstance(content, str):
+            content = str(content) if content else ""
+        summary = content.strip()
         if not summary.startswith("[CONTEXT SUMMARY]:"):
             summary = "[CONTEXT SUMMARY]: " + summary
         return summary

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -82,10 +82,23 @@ class SessionResetPolicy:
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionResetPolicy":
+        """
+        Create SessionResetPolicy from dictionary configuration.
+        
+        Handles both missing keys and explicit null values correctly.
+        """
+        # Handle None values explicitly — data.get() returns None if key exists with null value
+        at_hour = data.get("at_hour")
+        if at_hour is None:
+            at_hour = 4
+        idle_minutes = data.get("idle_minutes")
+        if idle_minutes is None:
+            idle_minutes = 1440
+        
         return cls(
             mode=data.get("mode", "both"),
-            at_hour=data.get("at_hour", 4),
-            idle_minutes=data.get("idle_minutes", 1440),
+            at_hour=at_hour,
+            idle_minutes=idle_minutes,
         )
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -129,6 +129,11 @@ if _config_path.exists():
             _redact = _security_cfg.get("redact_secrets")
             if _redact is not None:
                 os.environ["HERMES_REDACT_SECRETS"] = str(_redact).lower()
+        # STT settings
+        _stt_cfg = _cfg.get("stt", {})
+        if isinstance(_stt_cfg, dict):
+            _stt_enabled = _stt_cfg.get("enabled", True)
+            os.environ["HERMES_STT_ENABLED"] = str(_stt_enabled).lower()
     except Exception:
         pass  # Non-fatal; gateway can still run with .env values
 
@@ -2260,6 +2265,12 @@ class GatewayRunner:
         Returns:
             The enriched message string with transcriptions prepended.
         """
+        # Check if STT is disabled in config
+        stt_enabled = os.environ.get("HERMES_STT_ENABLED", "true").lower()
+        if stt_enabled == "false":
+            logger.debug("STT disabled in config, skipping transcription")
+            return user_text
+
         from tools.transcription_tools import transcribe_audio
         import asyncio
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1482,8 +1482,16 @@ def detect_external_credentials() -> List[Dict[str, Any]]:
 # CLI Commands — login / logout
 # =============================================================================
 
-def _update_config_for_provider(provider_id: str, inference_base_url: str) -> Path:
-    """Update config.yaml and auth.json to reflect the active provider."""
+def _update_config_for_provider(provider_id: str, inference_base_url: str, default_model: str = None) -> Path:
+    """Update config.yaml and auth.json to reflect the active provider.
+    
+    Args:
+        provider_id: The provider ID (e.g., "minimax", "openai")
+        inference_base_url: The API base URL for the provider
+        default_model: Optional default model name for this provider.
+                       If not provided, the existing model is preserved (which can cause
+                       race conditions when switching providers).
+    """
     # Set active_provider in auth.json so auto-resolution picks this provider
     with _auth_store_lock():
         auth_store = _load_auth_store()
@@ -1511,6 +1519,11 @@ def _update_config_for_provider(provider_id: str, inference_base_url: str) -> Pa
     else:
         model_cfg = {}
 
+    # If a default model is provided, use it to prevent race conditions
+    # where the gateway uses a model name from the previous provider
+    if default_model:
+        model_cfg["default"] = default_model
+    
     model_cfg["provider"] = provider_id
     model_cfg["base_url"] = inference_base_url.rstrip("/")
     config["model"] = model_cfg

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -595,7 +595,7 @@ def setup_model_provider(config: dict):
             if existing_custom:
                 save_env_value("OPENAI_BASE_URL", "")
                 save_env_value("OPENAI_API_KEY", "")
-            _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
+            _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL, "gpt-5.3-codex")
         except SystemExit:
             print_warning("OpenAI Codex login was cancelled or failed.")
             print_info("You can try again later with: hermes model")
@@ -933,7 +933,9 @@ def setup_model_provider(config: dict):
                 if custom:
                     config['model'] = custom
                     save_env_value("LLM_MODEL", custom)
-            _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
+            # Pass the model to prevent race condition - use selected model or fall back to default
+            selected_model = config.get('model', 'gpt-5.3-codex')
+            _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL, selected_model)
         elif selected_provider == "zai":
             # Coding Plan endpoints don't have GLM-5
             is_coding_plan = get_env_value("GLM_BASE_URL") and "coding" in (get_env_value("GLM_BASE_URL") or "")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -758,7 +758,7 @@ def setup_model_provider(config: dict):
         if existing_custom:
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
-        _update_config_for_provider("zai", zai_base_url)
+        _update_config_for_provider("zai", zai_base_url, "glm-4.7")
 
     elif provider_idx == 5:  # Kimi / Moonshot
         selected_provider = "kimi-coding"
@@ -790,7 +790,7 @@ def setup_model_provider(config: dict):
         if existing_custom:
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
-        _update_config_for_provider("kimi-coding", pconfig.inference_base_url)
+        _update_config_for_provider("kimi-coding", pconfig.inference_base_url, "kimi-k2.5")
 
     elif provider_idx == 6:  # MiniMax
         selected_provider = "minimax"
@@ -822,7 +822,7 @@ def setup_model_provider(config: dict):
         if existing_custom:
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
-        _update_config_for_provider("minimax", pconfig.inference_base_url)
+        _update_config_for_provider("minimax", pconfig.inference_base_url, "MiniMax-M2.5")
 
     elif provider_idx == 7:  # MiniMax China
         selected_provider = "minimax-cn"
@@ -854,7 +854,7 @@ def setup_model_provider(config: dict):
         if existing_custom:
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
-        _update_config_for_provider("minimax-cn", pconfig.inference_base_url)
+        _update_config_for_provider("minimax-cn", pconfig.inference_base_url, "MiniMax-M2.5")
 
     # else: provider_idx == 8 (Keep current) — only shown when a provider already exists
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2350,7 +2350,7 @@ class AIAgent:
             "model": self.model,
             "messages": api_messages,
             "tools": self.tools if self.tools else None,
-            "timeout": 900.0,
+            "timeout": float(os.getenv("OPEN_AI_LLM_TIMEOUT", 900.0)),
         }
 
         if self.max_tokens is not None:


### PR DESCRIPTION
When running `hermes setup` or `hermes model` while the gateway is running, `_update_config_for_provider()` writes to config.yaml immediately with the new provider/base_url but preserves the old model name. This creates a race condition where the gateway can send requests with an incompatible model name to the new provider.

## The Problem

- User has OpenRouter with `anthropic/claude-opus-4.6` configured
- User runs `hermes setup` and selects MiniMax as provider
- `_update_config_for_provider()` writes: provider=minimax, base_url=... but model still = anthropic/claude-opus-4.6
- Gateway picks up the config change and sends `anthropic/claude-opus-4.6` to MiniMax API → fails

## The Fix

1. Adds optional `default_model` parameter to `_update_config_for_provider()` in `auth.py`
2. When switching to affected providers (minimax, minimax-cn, zai, kimi-coding), pass a sensible default model
3. The model selection step later can still override this default

## Affected Providers

- MiniMax (default: MiniMax-M2.5)
- MiniMax-CN (default: MiniMax-M2.5)
- Z.AI (default: glm-4.7)
- Kimi (default: kimi-k2.5)

These providers use different model name formats than OpenRouter, so the old model name is always incompatible.