### PR TITLE
fix(session): skip corrupt lines in load_transcript instead of crashing

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -776,7 +776,10 @@ class SessionStore:
             for line in f:
                 line = line.strip()
                 if line:
-                    messages.append(json.loads(line))
+                    try:
+                        messages.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
         
         return messages
 


### PR DESCRIPTION
load_transcript() has no error handling around json.loads(). If the gateway is killed mid-write (OOM, SIGKILL, power loss), the last line of the JSONL file ends up partial. Next time the session loads, json.loads raises JSONDecodeError and the whole transcript load fails — user sees blank context with no history.

Wrapping the parse in try/except json.JSONDecodeError and skipping the bad line is enough. The rest of the history loads fine.