### PR TITLE
fix(gateway): fix dictionary iteration race condition during stop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -718,7 +718,8 @@ class GatewayRunner:
         logger.info("Stopping gateway...")
         self._running = False
         
-        for platform, adapter in self.adapters.items():
+        # Iterate over a copy to avoid "dictionary changed size during iteration"
+        for platform, adapter in list(self.adapters.items()):
             try:
                 await adapter.disconnect()
                 logger.info("✓ %s disconnected", platform.value)


### PR DESCRIPTION
## Problem
The  method iterates over  while another async task could be modifying the dict, causing:



## Solution
Copy the dict before iterating using .

## Changes
- Line 721: Added  wrapper around 
- Added comment explaining the fix

This is a minimal, safe fix that prevents the race condition during gateway shutdown.