### PR TITLE
fix(telegram): escape '(' in URLs for MarkdownV2 compatibility

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -620,10 +620,10 @@ class TelegramAdapter(BasePlatformAdapter):
         text = re.sub(r'(`[^`]+`)', lambda m: _ph(m.group(0)), text)
 
         # 3) Convert markdown links – escape the display text; inside the URL
-        #    only ')' and '\' need escaping per the MarkdownV2 spec.
+        #    '(', ')', and '\\' need escaping per the MarkdownV2 spec.
         def _convert_link(m):
             display = _escape_mdv2(m.group(1))
-            url = m.group(2).replace('\\', '\\\\').replace(')', '\\)')
+            url = m.group(2).replace('\\', '\\\\').replace(')', '\\)').replace('(', '\\(')
             return _ph(f'[{display}]({url})')
 
         text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', _convert_link, text)


### PR DESCRIPTION
## Problem
Telegram's MarkdownV2 requires both '(' and ')' to be escaped in URLs. The previous code only escaped ')', causing parse failures for URLs containing '(' characters (common in query strings like ).

This resulted in messages falling back to plain text with warnings like:


## Solution
Added  to the URL escaping logic.

## Changes
- Line 626: Added '(' escaping in URL processing
- Updated comment to correctly state that '(', ')', and '\' need escaping per MarkdownV2 spec

This ensures URLs with parentheses are properly formatted and messages display with correct Markdown formatting instead of falling back to plain text.