### PR TITLE
fix(telegram): check updater/app state before disconnect

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -195,8 +195,11 @@ class TelegramAdapter(BasePlatformAdapter):
         """Stop polling and disconnect."""
         if self._app:
             try:
-                await self._app.updater.stop()
-                await self._app.stop()
+                # Only stop the updater if it's running
+                if self._app.updater and self._app.updater.running:
+                    await self._app.updater.stop()
+                if self._app.running:
+                    await self._app.stop()
                 await self._app.shutdown()
             except Exception as e:
                 logger.warning("[%s] Error during Telegram disconnect: %s", self.name, e, exc_info=True)


### PR DESCRIPTION
## Problem
The  method unconditionally called  and , causing spurious errors during gateway shutdown:

- 
- 

These errors were caught and logged as warnings, but they represent expected states during shutdown, not actual problems.

## Solution
Check if the updater and app are actually running before attempting to stop them.

## Changes
- Check  before calling 
- Check  before calling 
- Only log warnings for unexpected errors, not normal shutdown states

This eliminates noise in the logs during graceful shutdown.