### PR TITLE
fix: use angle-bracket placeholders in setup completion screen

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -793,7 +793,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                         print(f"  ✓ Saved {name}")
                     print()
             else:
-                print("  Set later with: hermes config set KEY VALUE")
+                print("  Set later with: hermes config set <key> <value>")
     
     # Check for missing config fields
     missing_config = get_missing_config_fields()
@@ -1227,7 +1227,7 @@ def show_config():
     print()
     print(color("─" * 60, Colors.DIM))
     print(color("  hermes config edit     # Edit config file", Colors.DIM))
-    print(color("  hermes config set KEY VALUE", Colors.DIM))
+    print(color("  hermes config set <key> <value>", Colors.DIM))
     print(color("  hermes setup           # Run setup wizard", Colors.DIM))
     print()
 
@@ -1353,7 +1353,7 @@ def config_command(args):
         key = getattr(args, 'key', None)
         value = getattr(args, 'value', None)
         if not key or not value:
-            print("Usage: hermes config set KEY VALUE")
+            print("Usage: hermes config set <key> <value>")
             print()
             print("Examples:")
             print("  hermes config set model anthropic/claude-sonnet-4")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -572,7 +572,7 @@ def _print_setup_summary(config: dict, hermes_home):
     print(
         f"   {color('hermes config edit', Colors.GREEN)}    Open config in your editor"
     )
-    print(f"   {color('hermes config set KEY VALUE', Colors.GREEN)}")
+    print(f"   {color('hermes config set <key> <value>', Colors.GREEN)}")
     print(f"                          Set a specific value")
     print()
     print(f"   Or edit the files directly:")


### PR DESCRIPTION
## Summary

- Replace `KEY VALUE` with `<key> <value>` in all `hermes config set` usage/help strings so that copy-pasting the example does not literally write "KEY" and "VALUE" into the user's configuration.
- Fixes #926

## What changed

Four occurrences across two files:

| File | Line | Context |
|------|------|---------|
| `hermes_cli/setup.py` | 575 | Setup completion summary screen |
| `hermes_cli/config.py` | 796 | Migration prompt ("Set later with...") |
| `hermes_cli/config.py` | 1230 | `hermes config show` footer |
| `hermes_cli/config.py` | 1356 | `hermes config set` usage message |

## Test plan

- [ ] Run `hermes setup` and verify the completion screen shows `hermes config set <key> <value>`
- [ ] Run `hermes config show` and verify the footer hint uses angle-bracket placeholders
- [ ] Run `hermes config set` (no args) and verify the usage line uses angle-bracket placeholders