### PR TITLE
fix: use attribute access on GatewayConfig instead of dict .get()

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -231,6 +231,7 @@ class GatewayRunner:
         self._show_reasoning = self._load_show_reasoning()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
+        self._quick_commands = self._load_quick_commands()
 
         # Wire process registry into session store for reset protection
         from tools.process_registry import process_registry
@@ -571,6 +572,26 @@ class GatewayRunner:
         except Exception:
             pass
         return None
+
+    @staticmethod
+    def _load_quick_commands() -> dict:
+        """Load user-defined quick commands from config.yaml.
+
+        Returns a dict mapping command names to their definitions,
+        or an empty dict if not configured.
+        """
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                qc = cfg.get("quick_commands", {})
+                if isinstance(qc, dict):
+                    return qc
+        except Exception:
+            pass
+        return {}
 
     async def start(self) -> bool:
         """
@@ -1001,7 +1022,7 @@ class GatewayRunner:
         
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
-            quick_commands = self.config.get("quick_commands", {})
+            quick_commands = self._quick_commands
             if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":

--- a/tests/test_quick_commands.py
+++ b/tests/test_quick_commands.py
@@ -97,7 +97,7 @@ class TestGatewayQuickCommands:
     async def test_exec_command_returns_output(self):
         from gateway.run import GatewayRunner
         runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = {"quick_commands": {"limits": {"type": "exec", "command": "echo ok"}}}
+        runner._quick_commands = {"limits": {"type": "exec", "command": "echo ok"}}
         runner._running_agents = {}
         runner._pending_messages = {}
         runner._is_user_authorized = MagicMock(return_value=True)
@@ -110,7 +110,7 @@ class TestGatewayQuickCommands:
     async def test_unsupported_type_returns_error(self):
         from gateway.run import GatewayRunner
         runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = {"quick_commands": {"bad": {"type": "prompt", "command": "echo hi"}}}
+        runner._quick_commands = {"bad": {"type": "prompt", "command": "echo hi"}}
         runner._running_agents = {}
         runner._pending_messages = {}
         runner._is_user_authorized = MagicMock(return_value=True)
@@ -125,7 +125,7 @@ class TestGatewayQuickCommands:
         from gateway.run import GatewayRunner
         import asyncio
         runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = {"quick_commands": {"slow": {"type": "exec", "command": "sleep 100"}}}
+        runner._quick_commands = {"slow": {"type": "exec", "command": "sleep 100"}}
         runner._running_agents = {}
         runner._pending_messages = {}
         runner._is_user_authorized = MagicMock(return_value=True)


### PR DESCRIPTION
## Summary

- **Fix `AttributeError: 'GatewayConfig' object has no attribute 'get'`** when any slash command (e.g. `/start`) is sent on Telegram. `GatewayConfig` is a dataclass, not a dict, so `self.config.get("quick_commands", {})` fails.
- Add `_load_quick_commands()` static method to load `quick_commands` from `~/.hermes/config.yaml`, consistent with the existing pattern used by `_load_reasoning_config`, `_load_fallback_model`, and other ephemeral config loaders in `GatewayRunner`.
- Update gateway tests to set `runner._quick_commands` directly instead of assigning a plain dict to `runner.config` (which was masking the bug).

Fixes #973

## Test plan

- [ ] Send `/start` to the Telegram bot -- should no longer raise `AttributeError`
- [ ] Define `quick_commands` in `~/.hermes/config.yaml` and verify they still work via gateway
- [ ] Run `pytest tests/test_quick_commands.py` -- all gateway quick command tests pass