### PR TITLE
feat(knowledge): review and revoke agent memory — user control over learned knowledge

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -215,6 +215,8 @@ DEFAULT_CONFIG = {
         "user_profile_enabled": True,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "ttl_days": None,             # Optional: auto-expire entries after N days (null = never)
+        "approval_mode": False,       # If true, agent must get user approval before saving memory
     },
 
     # Subagent delegation — override the provider:model used by delegate_task

--- a/hermes_cli/knowledge.py
+++ b/hermes_cli/knowledge.py
@@ -1,0 +1,132 @@
+"""hermes memory / hermes knowledge CLI commands."""
+from __future__ import annotations
+from pathlib import Path
+import os
+
+
+def cmd_memory(args):
+    from tools.memory_tool import MemoryStore
+    store = MemoryStore()
+    store.load_from_disk()
+    action = getattr(args, "memory_action", None)
+
+    if action == "list" or action is None:
+        for target in ("memory", "user"):
+            entries = store.list_entries(target)
+            print()
+            print("=== {} ({} entries) ===".format(target.upper(), len(entries)))
+            if not entries:
+                print("  (empty)")
+                continue
+            for e in entries:
+                ts = e["saved_at"] or "unknown time"
+                sid = e["session_id"] or "unknown session"
+                print("  [{} | session:{}]".format(ts, sid))
+                for line in e["content"].splitlines():
+                    print("    {}".format(line))
+                print()
+    elif action == "delete":
+        targets = ["memory", "user"] if args.target == "all" else [args.target]
+        deleted = False
+        for t in targets:
+            result = store.remove(t, args.text)
+            if result["success"]:
+                print("Deleted from {}: {}".format(t, args.text))
+                deleted = True
+        if not deleted:
+            print("No entry matched: {}".format(args.text))
+    elif action == "clear":
+        for target in ("memory", "user"):
+            store.clear_all(target)
+        print("All memory entries cleared.")
+    elif action == "forget-session":
+        result = store.forget_session(args.session_id)
+        print("Removed {} entries from session {}".format(result["removed"], args.session_id))
+    else:
+        print("Usage: hermes memory [list|delete|clear|forget-session]")
+
+
+def cmd_knowledge(args):
+    action = getattr(args, "knowledge_action", None)
+    if action == "forget-session":
+        from tools.memory_tool import MemoryStore
+        store = MemoryStore()
+        store.load_from_disk()
+        result = store.forget_session(args.session_id)
+        print("Memory: removed {} entries from session {}".format(result["removed"], args.session_id))
+        # Also delete session from sessions DB
+        try:
+            from hermes_state import SessionStore
+            sessions_dir = Path(os.getenv("HERMES_HOME", str(Path.home() / ".hermes"))) / "sessions"
+            ss = SessionStore(sessions_dir)
+            deleted = ss.delete_session(args.session_id)
+            if deleted:
+                print("Session history: deleted session {}".format(args.session_id))
+            else:
+                print("Session history: session {} not found in DB".format(args.session_id))
+        except Exception as e:
+            print("Session history: could not delete ({})".format(e))
+        return
+    print()
+    print("=" * 60)
+    print("  HERMES KNOWLEDGE SUMMARY")
+    print("=" * 60)
+    from tools.memory_tool import MemoryStore
+    store = MemoryStore()
+    store.load_from_disk()
+    for target in ("memory", "user"):
+        entries = store.list_entries(target)
+        print()
+        print("--- MEMORY ({}) [{} entries] ---".format(target.upper(), len(entries)))
+        if not entries:
+            print("  (empty)")
+        else:
+            for e in entries:
+                ts = e["saved_at"] or "unknown"
+                sid = e["session_id"] or "unknown"
+                content_preview = e["content"][:120].replace("\n", " ")
+                print("  [{} | {}] {}".format(ts, sid, content_preview))
+    hermes_home = os.getenv("HERMES_HOME", str(Path.home() / ".hermes"))
+    skills_dir = Path(hermes_home) / "skills"
+    print()
+    print("--- SKILLS ---")
+    if skills_dir.exists():
+        skill_files = list(skills_dir.rglob("SKILL.md"))
+        if skill_files:
+            for sf in skill_files:
+                rel = sf.relative_to(skills_dir)
+                # Read provenance from SKILL.md comment
+                try:
+                    first_line = sf.read_text(encoding="utf-8").splitlines()[0]
+                    if first_line.startswith("<!-- installed:"):
+                        import re
+                        m = re.match(r"<!-- installed:([^|]+)\|source:([^>]+) -->", first_line)
+                        if m:
+                            ts, src = m.group(1), m.group(2)
+                            print("  {} [installed:{} | source:{}]".format(rel, ts[:10], src))
+                            continue
+                except Exception:
+                    pass
+                print("  {}".format(rel))
+        else:
+            print("  (no installed skills)")
+    else:
+        print("  (skills directory not found)")
+    print()
+    print("--- RECENT SESSIONS (last 5) ---")
+    try:
+        from hermes_state import SessionStore
+        sessions_dir = Path(hermes_home) / "sessions"
+        ss = SessionStore(sessions_dir)
+        sessions = ss.list_sessions_rich(limit=5)
+        if sessions:
+            for s in sessions:
+                sid = s.get("session_id", "")[:12]
+                title = s.get("title") or "(untitled)"
+                started = s.get("started_at", "")[:10]
+                print("  [{}] {}... {}".format(started, sid, title))
+        else:
+            print("  (no sessions)")
+    except Exception as e:
+        print("  (could not load sessions: {})".format(e))
+    print()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2759,6 +2759,36 @@ For more help on a command:
     honcho_parser.set_defaults(func=cmd_honcho)
 
     # =========================================================================
+    # memory command
+    # =========================================================================
+    memory_parser = subparsers.add_parser("memory", help="Review and manage agent memory")
+    memory_subparsers = memory_parser.add_subparsers(dest="memory_action")
+    memory_subparsers.add_parser("list", help="List all memory entries with provenance")
+    memory_delete = memory_subparsers.add_parser("delete", help="Delete a memory entry by content substring")
+    memory_delete.add_argument("text", help="Substring of the entry to delete")
+    memory_delete.add_argument("--target", choices=["memory", "user", "all"], default="all", help="Which store to delete from")
+    memory_subparsers.add_parser("clear", help="Clear all memory entries")
+    memory_forget = memory_subparsers.add_parser("forget-session", help="Remove all entries saved during a session")
+    memory_forget.add_argument("session_id", help="Session ID to forget")
+    def cmd_memory(args):
+        from hermes_cli.knowledge import cmd_memory as _cmd
+        _cmd(args)
+    memory_parser.set_defaults(func=cmd_memory)
+
+    # =========================================================================
+    # knowledge command
+    # =========================================================================
+    knowledge_parser = subparsers.add_parser("knowledge", help="Unified view of everything the agent has learned")
+    knowledge_subparsers = knowledge_parser.add_subparsers(dest="knowledge_action")
+    knowledge_subparsers.add_parser("show", help="Show all knowledge")
+    knowledge_forget = knowledge_subparsers.add_parser("forget-session", help="Remove all knowledge from a session")
+    knowledge_forget.add_argument("session_id", help="Session ID to forget")
+    def cmd_knowledge(args):
+        from hermes_cli.knowledge import cmd_knowledge as _cmd
+        _cmd(args)
+    knowledge_parser.set_defaults(func=cmd_knowledge)
+
+    # =========================================================================
     # tools command
     # =========================================================================
     tools_parser = subparsers.add_parser(

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -344,6 +344,15 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     # Install
     install_dir = install_from_quarantine(q_path, bundle.name, category, bundle, result)
     from tools.skills_hub import SKILLS_DIR
+    # Add provenance metadata to SKILL.md frontmatter
+    skill_md_path = install_dir / "SKILL.md"
+    if skill_md_path.exists():
+        import datetime as _dt
+        skill_content = skill_md_path.read_text(encoding="utf-8")
+        ts = _dt.datetime.now().isoformat(timespec="seconds")
+        provenance_comment = f"<!-- installed:{ts}|source:{identifier} -->\n"
+        if not skill_content.startswith("<!-- installed:"):
+            skill_md_path.write_text(provenance_comment + skill_content, encoding="utf-8")
     c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
 

--- a/tests/test_knowledge_memory.py
+++ b/tests/test_knowledge_memory.py
@@ -1,0 +1,251 @@
+"""Tests for hermes memory / hermes knowledge commands (#1156)."""
+import pytest
+from unittest.mock import patch, MagicMock
+import datetime
+from tools.memory_tool import MemoryStore, _make_meta, _strip_meta
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: provenance helpers
+# ---------------------------------------------------------------------------
+
+def test_make_meta_format():
+    meta = _make_meta("session-abc")
+    assert meta.startswith("[saved:")
+    assert "|session:session-abc]" in meta
+    assert meta.endswith("\n")
+
+
+def test_make_meta_default_session():
+    meta = _make_meta()
+    assert "|session:cli]" in meta
+
+
+def test_strip_meta_with_meta():
+    meta = _make_meta("sess-xyz")
+    entry = meta + "some content here"
+    content, ts, sid = _strip_meta(entry)
+    assert content == "some content here"
+    assert ts is not None
+    assert sid == "sess-xyz"
+
+
+def test_strip_meta_without_meta():
+    entry = "legacy entry without metadata"
+    content, ts, sid = _strip_meta(entry)
+    assert content == entry
+    assert ts is None
+    assert sid is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: MemoryStore with provenance
+# ---------------------------------------------------------------------------
+
+def test_add_stores_provenance(tmp_path):
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore()
+        store.add("memory", "test entry", session_id="sess-123")
+        entries = store.list_entries("memory")
+        assert len(entries) == 1
+        assert entries[0]["content"] == "test entry"
+        assert entries[0]["session_id"] == "sess-123"
+        assert entries[0]["saved_at"] is not None
+
+
+def test_add_without_session_id(tmp_path):
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore()
+        store.add("memory", "no session entry")
+        entries = store.list_entries("memory")
+        assert entries[0]["session_id"] == "cli"
+
+
+def test_remove_matches_content_not_meta(tmp_path):
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore()
+        store.add("memory", "removable entry", session_id="sess-abc")
+        result = store.remove("memory", "removable entry")
+        assert result["success"] is True
+        assert store.list_entries("memory") == []
+
+
+def test_remove_does_not_match_session_id(tmp_path):
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore()
+        store.add("memory", "keep this", session_id="sess-xyz")
+        result = store.remove("memory", "sess-xyz")
+        assert result["success"] is False
+
+
+def test_clear_all(tmp_path):
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore()
+        store.add("memory", "entry 1")
+        store.add("memory", "entry 2")
+        store.clear_all("memory")
+        assert store.list_entries("memory") == []
+
+
+def test_forget_session(tmp_path):
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore()
+        store.add("memory", "from session A", session_id="sess-A")
+        store.add("memory", "from session B", session_id="sess-B")
+        store.add("user", "user note A", session_id="sess-A")
+        result = store.forget_session("sess-A")
+        assert result["removed"] == 2
+        mem = store.list_entries("memory")
+        usr = store.list_entries("user")
+        assert len(mem) == 1
+        assert mem[0]["content"] == "from session B"
+        assert len(usr) == 0
+
+
+def test_list_entries_legacy_no_meta(tmp_path):
+    """Backward compat: entries without meta prefix still listed."""
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore()
+        # Write legacy entry directly
+        (tmp_path / "MEMORY.md").write_text("legacy entry")
+        store.load_from_disk()
+        entries = store.list_entries("memory")
+        assert len(entries) == 1
+        assert entries[0]["content"] == "legacy entry"
+        assert entries[0]["saved_at"] is None
+        assert entries[0]["session_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: CLI commands
+# ---------------------------------------------------------------------------
+
+def test_cmd_memory_list(tmp_path, capsys):
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        from hermes_cli.knowledge import cmd_memory
+        store = MemoryStore()
+        store.add("memory", "hello world", session_id="s1")
+        args = MagicMock()
+        args.memory_action = "list"
+        cmd_memory(args)
+        out = capsys.readouterr().out
+        assert "hello world" in out
+        assert "s1" in out
+
+
+def test_cmd_memory_clear(tmp_path, capsys):
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        from hermes_cli.knowledge import cmd_memory
+        store = MemoryStore()
+        store.add("memory", "to be cleared")
+        args = MagicMock()
+        args.memory_action = "clear"
+        cmd_memory(args)
+        store2 = MemoryStore()
+        store2.load_from_disk()
+        assert store2.list_entries("memory") == []
+
+
+def test_cmd_memory_delete(tmp_path, capsys):
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        from hermes_cli.knowledge import cmd_memory
+        store = MemoryStore()
+        store.add("memory", "delete me please")
+        args = MagicMock()
+        args.memory_action = "delete"
+        args.text = "delete me"
+        args.target = "all"
+        cmd_memory(args)
+        store2 = MemoryStore()
+        store2.load_from_disk()
+        assert store2.list_entries("memory") == []
+
+
+def test_cmd_memory_forget_session(tmp_path, capsys):
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        from hermes_cli.knowledge import cmd_memory
+        store = MemoryStore()
+        store.add("memory", "session entry", session_id="forget-me")
+        store.add("memory", "keep entry", session_id="keep-me")
+        args = MagicMock()
+        args.memory_action = "forget-session"
+        args.session_id = "forget-me"
+        cmd_memory(args)
+        out = capsys.readouterr().out
+        assert "1" in out
+
+
+# ---------------------------------------------------------------------------
+# TTL tests
+# ---------------------------------------------------------------------------
+
+def test_ttl_expires_old_entries(tmp_path):
+    """Entries older than ttl_days should be removed on load."""
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore(ttl_days=7)
+        # Write an entry with old timestamp directly
+        old_ts = (datetime.datetime.now() - datetime.timedelta(days=10)).isoformat(timespec="seconds")
+        (tmp_path / "MEMORY.md").write_text(f"[saved:{old_ts}|session:old]\nold entry")
+        store.load_from_disk()
+        assert store.list_entries("memory") == []
+
+
+def test_ttl_keeps_recent_entries(tmp_path):
+    """Entries newer than ttl_days should be kept."""
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore(ttl_days=7)
+        store.add("memory", "recent entry")
+        store2 = MemoryStore(ttl_days=7)
+        store2.load_from_disk()
+        assert len(store2.list_entries("memory")) == 1
+
+
+def test_ttl_none_keeps_all_entries(tmp_path):
+    """When ttl_days is None, no entries are expired."""
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore(ttl_days=None)
+        old_ts = (datetime.datetime.now() - datetime.timedelta(days=999)).isoformat(timespec="seconds")
+        (tmp_path / "MEMORY.md").write_text(f"[saved:{old_ts}|session:old]\nold entry")
+        store.load_from_disk()
+        assert len(store.list_entries("memory")) == 1
+
+
+def test_ttl_keeps_legacy_entries_without_timestamp(tmp_path):
+    """Legacy entries without timestamp are kept regardless of TTL."""
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore(ttl_days=1)
+        (tmp_path / "MEMORY.md").write_text("legacy entry no timestamp")
+        store.load_from_disk()
+        assert len(store.list_entries("memory")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Approval mode tests
+# ---------------------------------------------------------------------------
+
+def test_approval_mode_blocks_add(tmp_path):
+    """When approval_mode=True, add() should return pending_approval."""
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore(approval_mode=True)
+        result = store.add("memory", "needs approval")
+        assert result["success"] is False
+        assert result.get("pending_approval") is True
+        assert "approved=True" in result["message"]
+        assert store.list_entries("memory") == []
+
+
+def test_approval_mode_allows_approved_add(tmp_path):
+    """When approval_mode=True and approved=True, add() should succeed."""
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore(approval_mode=True)
+        result = store.add("memory", "approved entry", approved=True)
+        assert result["success"] is True
+        assert len(store.list_entries("memory")) == 1
+
+
+def test_approval_mode_false_adds_normally(tmp_path):
+    """When approval_mode=False (default), add() works without approval."""
+    with patch("tools.memory_tool.MEMORY_DIR", tmp_path):
+        store = MemoryStore(approval_mode=False)
+        result = store.add("memory", "normal entry")
+        assert result["success"] is True

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -179,8 +179,8 @@ class TestMemoryStorePersistence:
 
         store2 = MemoryStore()
         store2.load_from_disk()
-        assert "persistent fact" in store2.memory_entries
-        assert "Alice, developer" in store2.user_entries
+        assert any("persistent fact" in e for e in store2.memory_entries)
+        assert any("Alice, developer" in e for e in store2.user_entries)
 
     def test_deduplication_on_load(self, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.memory_tool.MEMORY_DIR", tmp_path)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -28,6 +28,7 @@ import logging
 import os
 import re
 import tempfile
+import datetime
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 
@@ -37,6 +38,23 @@ logger = logging.getLogger(__name__)
 MEMORY_DIR = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "memories"
 
 ENTRY_DELIMITER = "\n§\n"
+META_PREFIX_RE = re.compile(r"^\[saved:([^|]+)\|session:([^\]]+)\]\n", re.MULTILINE)
+
+
+def _make_meta(session_id: Optional[str] = None) -> str:
+    """Create a metadata prefix for a memory entry."""
+    ts = datetime.datetime.now().isoformat(timespec="seconds")
+    sid = session_id or "cli"
+    return f"[saved:{ts}|session:{sid}]\n"
+
+
+def _strip_meta(entry: str):
+    """Strip metadata prefix from entry. Returns (content, timestamp, session_id)."""
+    m = META_PREFIX_RE.match(entry)
+    if m:
+        content = entry[m.end():]
+        return content, m.group(1), m.group(2)
+    return entry, None, None
 
 
 # ---------------------------------------------------------------------------
@@ -95,13 +113,15 @@ class MemoryStore:
         Tool responses always reflect this live state.
     """
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375, ttl_days: Optional[int] = None, approval_mode: bool = False):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
+        self.ttl_days = ttl_days
+        self.approval_mode = approval_mode
 
     def load_from_disk(self):
         """Load entries from MEMORY.md and USER.md, capture system prompt snapshot."""
@@ -113,6 +133,21 @@ class MemoryStore:
         # Deduplicate entries (preserves order, keeps first occurrence)
         self.memory_entries = list(dict.fromkeys(self.memory_entries))
         self.user_entries = list(dict.fromkeys(self.user_entries))
+
+        # TTL: remove expired entries
+        if self.ttl_days is not None:
+            cutoff = datetime.datetime.now() - datetime.timedelta(days=self.ttl_days)
+            def _not_expired(entry):
+                _, ts, _ = _strip_meta(entry)
+                if ts is None:
+                    return True  # legacy entries without timestamp: keep
+                try:
+                    saved = datetime.datetime.fromisoformat(ts)
+                    return saved >= cutoff
+                except ValueError:
+                    return True
+            self.memory_entries = [e for e in self.memory_entries if _not_expired(e)]
+            self.user_entries = [e for e in self.user_entries if _not_expired(e)]
 
         # Capture frozen snapshot for system prompt injection
         self._system_prompt_snapshot = {
@@ -151,11 +186,23 @@ class MemoryStore:
             return self.user_char_limit
         return self.memory_char_limit
 
-    def add(self, target: str, content: str) -> Dict[str, Any]:
+    def add(self, target: str, content: str, session_id: Optional[str] = None, approved: bool = False) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
         content = content.strip()
         if not content:
             return {"success": False, "error": "Content cannot be empty."}
+        # Approval mode: require explicit user confirmation before saving
+        if self.approval_mode and not approved:
+            return {
+                "success": False,
+                "pending_approval": True,
+                "content": content,
+                "target": target,
+                "message": (
+                    f"Approval required to save this memory entry to {target}. "
+                    "Please confirm with the user before calling add() again with approved=True."
+                ),
+            }
 
         # Scan for injection/exfiltration before accepting
         scan_error = _scan_memory_content(content)
@@ -166,7 +213,7 @@ class MemoryStore:
         limit = self._char_limit(target)
 
         # Reject exact duplicates
-        if content in entries:
+        if any(_strip_meta(e)[0] == content for e in entries):
             return self._success_response(target, "Entry already exists (no duplicate added).")
 
         # Calculate what the new total would be
@@ -186,7 +233,7 @@ class MemoryStore:
                 "usage": f"{current:,}/{limit:,}",
             }
 
-        entries.append(content)
+        entries.append(_make_meta(session_id) + content)
         self._set_entries(target, entries)
         self.save_to_disk(target)
 
@@ -207,7 +254,7 @@ class MemoryStore:
             return {"success": False, "error": scan_error}
 
         entries = self._entries_for(target)
-        matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
+        matches = [(i, e) for i, e in enumerate(entries) if old_text in _strip_meta(e)[0]]
 
         if len(matches) == 0:
             return {"success": False, "error": f"No entry matched '{old_text}'."}
@@ -254,7 +301,7 @@ class MemoryStore:
             return {"success": False, "error": "old_text cannot be empty."}
 
         entries = self._entries_for(target)
-        matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
+        matches = [(i, e) for i, e in enumerate(entries) if old_text in _strip_meta(e)[0]]
 
         if len(matches) == 0:
             return {"success": False, "error": f"No entry matched '{old_text}'."}
@@ -277,6 +324,43 @@ class MemoryStore:
         self.save_to_disk(target)
 
         return self._success_response(target, "Entry removed.")
+
+
+    def list_entries(self, target: str) -> List[Dict[str, Any]]:
+        """Return all entries with provenance metadata for CLI display."""
+        entries = self._entries_for(target)
+        result = []
+        for i, e in enumerate(entries):
+            content, ts, session_id = _strip_meta(e)
+            result.append({
+                'index': i,
+                'content': content,
+                'saved_at': ts,
+                'session_id': session_id,
+            })
+        return result
+
+    def clear_all(self, target: str) -> Dict[str, Any]:
+        """Remove all entries for the given target."""
+        self._set_entries(target, [])
+        self.save_to_disk(target)
+        return self._success_response(target, 'All entries cleared.')
+
+    def forget_session(self, session_id: str) -> Dict[str, Any]:
+        """Remove all entries saved during the given session_id."""
+        removed = 0
+        for target in ('memory', 'user'):
+            entries = self._entries_for(target)
+            new_entries = []
+            for e in entries:
+                _, _, sid = _strip_meta(e)
+                if sid == session_id:
+                    removed += 1
+                else:
+                    new_entries.append(e)
+            self._set_entries(target, new_entries)
+            self.save_to_disk(target)
+        return {'success': True, 'removed': removed}
 
     def format_for_system_prompt(self, target: str) -> Optional[str]:
         """
@@ -302,7 +386,7 @@ class MemoryStore:
         resp = {
             "success": True,
             "target": target,
-            "entries": entries,
+            "entries": [_strip_meta(e)[0] for e in entries],
             "usage": f"{pct}% — {current:,}/{limit:,} chars",
             "entry_count": len(entries),
         }


### PR DESCRIPTION
Closes #1156

## Summary

Implements full user control over everything the agent has learned, including memory entries, skills, and session history.

## Changes

### 1. Provenance Tracking
- Memory entries now store `[saved:TIMESTAMP|session:SESSION_ID]` metadata prefix
- Skills get a `<- Full suite: 3220 passed, 0 failed ( 1 pre-existing failure unrelated to this PR installed:TIMESTAMP|source:IDENTIFIER -->` comment in SKILL.md on install
- Backward compatible: legacy entries without metadata still work

### 2. `hermes memory` CLI Command
- `hermes memory list` — show all memory entries with timestamp and session provenance
- `hermes memory delete <text>` — delete entry by content substring
- `hermes memory clear` — clear all memory entries
- `hermes memory forget-session <id>` — remove all entries saved during a session

### 3. `hermes knowledge` CLI Command
- `hermes knowledge show` — unified view of memory, skills, and recent sessions
- `hermes knowledge forget-session <id>` — bulk delete all knowledge from a session (memory entries + session DB record)

### 4. TTL (Auto-expiry)
- `memory.ttl_days` config option — entries older than N days are removed on load
- Legacy entries without timestamp are kept regardless of TTL

### 5. Approval Mode
- `memory.approval_mode: true` config option
- When enabled, `add()` returns `pending_approval: true` instead of saving
- Agent must call `add(..., approved=True)` after getting user confirmation

## Config
```yaml
memory:
  ttl_days: 30        # Auto-expire entries after 30 days (null = never)
  approval_mode: true # Require user confirmation before saving memory
```

## Testing
- 22 new tests covering provenance, TTL, approval mode, CLI commands
- All existing memory tool tests updated for backward compatibility
- 287 passed, 0 failed