### PR TITLE
fix: preserve Anthropic cache markers through the adapter

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -404,8 +404,14 @@ def convert_messages_to_anthropic(
         if role == "assistant":
             blocks = []
             if content:
-                text = content if isinstance(content, str) else json.dumps(content)
-                blocks.append({"type": "text", "text": text})
+                if isinstance(content, list):
+                    for part in content:
+                        if isinstance(part, dict):
+                            blocks.append(dict(part))
+                        elif part is not None:
+                            blocks.append({"type": "text", "text": str(part)})
+                else:
+                    blocks.append({"type": "text", "text": str(content)})
             for tc in m.get("tool_calls", []):
                 fn = tc.get("function", {})
                 args = fn.get("arguments", "{}")
@@ -436,6 +442,8 @@ def convert_messages_to_anthropic(
                 "tool_use_id": _sanitize_tool_id(m.get("tool_call_id", "")),
                 "content": result_content,
             }
+            if isinstance(m.get("cache_control"), dict):
+                tool_result["cache_control"] = dict(m["cache_control"])
             # Merge consecutive tool results into one user message
             if (
                 result

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
     _is_oauth_token,
     _refresh_oauth_token,
@@ -490,6 +491,33 @@ class TestConvertMessages:
         # When cache_control is present, system should be a list of blocks
         assert isinstance(system, list)
         assert system[0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_assistant_cache_control_blocks_are_preserved(self):
+        messages = apply_anthropic_cache_control([
+            {"role": "system", "content": "System prompt"},
+            {"role": "assistant", "content": "Hello from assistant"},
+        ])
+
+        _, result = convert_messages_to_anthropic(messages)
+        assistant_blocks = result[0]["content"]
+
+        assert assistant_blocks[0]["type"] == "text"
+        assert assistant_blocks[0]["text"] == "Hello from assistant"
+        assert assistant_blocks[0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_tool_cache_control_is_preserved_on_tool_result_block(self):
+        messages = apply_anthropic_cache_control([
+            {"role": "system", "content": "System prompt"},
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+        ])
+
+        _, result = convert_messages_to_anthropic(messages)
+        tool_block = result[0]["content"][0]
+
+        assert tool_block["type"] == "tool_result"
+        assert tool_block["tool_use_id"] == "tc_1"
+        assert tool_block["content"] == "result"
+        assert tool_block["cache_control"] == {"type": "ephemeral"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- preserve assistant cache-control blocks when converting OpenAI-style messages to Anthropic format
- propagate tool-message cache markers onto generated `tool_result` blocks
- add regression tests for assistant and tool cache marker preservation

## Test plan
- `source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/test_anthropic_adapter.py -n0 -q`
- `source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/ -n0 -q`
  - current main still has 4 unrelated failures in `tests/test_managed_server_tool_support.py` and `tests/test_quick_commands.py`
  - this branch only changes `agent/anthropic_adapter.py` and `tests/test_anthropic_adapter.py`
