### PR TITLE
Fix: Add quick_commands field to GatewayConfig

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -155,6 +155,7 @@ class GatewayConfig:
     
     # Delivery settings
     always_log_local: bool = True  # Always save cron outputs to local files
+    quick_commands: Dict[str, Dict[str, Any]] = field(default_factory=dict)  # User-defined quick commands
     
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
@@ -218,6 +219,7 @@ class GatewayConfig:
             "reset_triggers": self.reset_triggers,
             "sessions_dir": str(self.sessions_dir),
             "always_log_local": self.always_log_local,
+            "quick_commands": self.quick_commands,
         }
     
     @classmethod
@@ -258,6 +260,7 @@ class GatewayConfig:
             reset_triggers=data.get("reset_triggers", ["/new", "/reset"]),
             sessions_dir=sessions_dir,
             always_log_local=data.get("always_log_local", True),
+            quick_commands=data.get("quick_commands", {}),
         )
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1001,7 +1001,7 @@ class GatewayRunner:
         
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
-            quick_commands = self.config.get("quick_commands", {})
+            quick_commands = self.config.quick_commands
             if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":


### PR DESCRIPTION
## Summary
- Add `quick_commands` field to `GatewayConfig` dataclass
- Add `quick_commands` to `to_dict()` serialization
- Add `quick_commands` to `from_dict()` deserialization
- Fix run.py to use attribute access instead of dict `.get()`

## Fixes #973

When sending /start to the Telegram bot, the code was trying to call `.get()` on a GatewayConfig dataclass object, causing `AttributeError: GatewayConfig object has no attribute get`.

This fix adds proper support for the quick_commands feature by:
1. Adding a `quick_commands` field to the GatewayConfig dataclass
2. Serializing/deserializing it properly in to_dict/from_dict
3. Updating the code in run.py to use attribute access (`self.config.quick_commands`) instead of dict-like access (`self.config.get()`)