### PR TITLE
fix(cache_control) treat empty text like None to avoid anthropic api …

### DIFF
--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -21,12 +21,14 @@ def _apply_cache_marker(msg: dict, cache_marker: dict) -> None:
         msg["cache_control"] = cache_marker
         return
 
-    if content is None:
+    if content is None or content == "":
         msg["cache_control"] = cache_marker
         return
 
     if isinstance(content, str):
-        msg["content"] = [{"type": "text", "text": content, "cache_control": cache_marker}]
+        msg["content"] = [
+            {"type": "text", "text": content, "cache_control": cache_marker}
+        ]
         return
 
     if isinstance(content, list) and content:

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -23,6 +23,14 @@ class TestApplyCacheMarker:
         _apply_cache_marker(msg, MARKER)
         assert msg["cache_control"] == MARKER
 
+    def test_empty_string_content_gets_top_level_marker(self):
+        """Empty text blocks cannot have cache_control (Anthropic rejects them)."""
+        msg = {"role": "assistant", "content": ""}
+        _apply_cache_marker(msg, MARKER)
+        assert msg["cache_control"] == MARKER
+        # Must NOT wrap into [{"type": "text", "text": "", "cache_control": ...}]
+        assert msg["content"] == ""
+
     def test_string_content_wrapped_in_list(self):
         msg = {"role": "user", "content": "Hello"}
         _apply_cache_marker(msg, MARKER)


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

A very small bug fix to treat empty text content like None to make anthropic's api happy.

Hermes will sometimes use a tool without saying anything first:

```
{
    "role": "assistant",
    "content": [
        {
            "type": "text",
            "text": "",
            "cache_control": {
                "type": "ephemeral"
            }
        },
        {
            "type": "tool_use",
            "id": "toolu_01SfvanhomGPdTQh5bJQkAW7",
            "name": "skill_view",
            "input": {
                "name": "native-mcp"
            }
        }
    ]
}
```

Note how cache_control is set on the text content. That results in this error:

```
"error": {
    "type": "BadRequestError",
    "message": "Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'messages.29.content.0.text: cache_control cannot be set for empty text blocks'}, 'request_id': 'req_011CZ1ufEBB1WxzQ4yXpYpTU'}",
    "status_code": 400,
    "request_id": "req_011CZ1ufEBB1WxzQ4yXpYpTU",
    "body": {
      "type": "error",
      "error": {
        "type": "invalid_request_error",
        "message": "messages.29.content.0.text: cache_control cannot be set for empty text blocks"
      },
      "request_id": "req_011CZ1ufEBB1WxzQ4yXpYpTU"
    },
    "response_status": 400,
    "response_text": "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"messages.29.content.0.text: cache_control cannot be set for empty text blocks\"},\"request_id\":\"req_011CZ1ufEBB1WxzQ4yXpYpTU\"}"
  }
```

This pull request solves this by using the same logic as when a text content is `None`, setting the cache control on the message rather than the text content block.


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

No related issue that I'm aware of. This is a very small change so I felt it better to just make the pull request but can make an issue if needed.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Ask Hermes to use tools :)

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
  - It looks like there are existing test issues unrelated to this change. Cache tests pass: `pytest tests/ -q -k "cache"`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1 <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or **N/A**
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or **N/A**
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or **N/A**
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or **N/A**
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or **N/A**

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

