### PR TITLE
docs: improve CLI safety with quotes and fix alignment (fixes #926)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,7 +68,7 @@ HONCHO_API_KEY=
 # =============================================================================
 # Backend type: "local", "singularity", "docker", "modal", or "ssh"
 # Terminal backend is configured in ~/.hermes/config.yaml (terminal.backend).
-# Use 'hermes setup' or 'hermes config set terminal.backend docker' to change.
+# Use 'hermes setup' or 'hermes config set "terminal.backend" "docker"' to change.
 # Supported: local, docker, singularity, modal, ssh
 #
 # Only override here if you need to force a backend without touching config.yaml:

--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ hermes              # start chatting!
 ## Getting Started
 
 ```bash
-hermes              # Interactive CLI — start a conversation
-hermes model        # Choose your LLM provider and model
-hermes tools        # Configure which tools are enabled
-hermes config set   # Set individual config values
-hermes gateway      # Start the messaging gateway (Telegram, Discord, etc.)
-hermes setup        # Run the full setup wizard (configures everything at once)
-hermes claw migrate # Migrate from OpenClaw (if coming from OpenClaw)
-hermes update       # Update to the latest version
-hermes doctor       # Diagnose any issues
+hermes                           # Interactive CLI — start a conversation
+hermes model                     # Choose your LLM provider and model
+hermes tools                     # Configure which tools are enabled
+hermes config set "KEY" "VALUE"  # Set individual config values
+hermes gateway                   # Start the messaging gateway (Telegram, Discord, etc.)
+hermes setup                     # Run the full setup wizard (configures everything at once)
+hermes claw migrate              # Migrate from OpenClaw (if coming from OpenClaw)
+hermes update                    # Update to the latest version
+hermes doctor                    # Diagnose any issues
 ```
 
 📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1353,12 +1353,12 @@ def config_command(args):
         key = getattr(args, 'key', None)
         value = getattr(args, 'value', None)
         if not key or not value:
-            print("Usage: hermes config set KEY VALUE")
+            print('Usage: hermes config set "KEY" "VALUE"')
             print()
             print("Examples:")
-            print("  hermes config set model anthropic/claude-sonnet-4")
-            print("  hermes config set terminal.backend docker")
-            print("  hermes config set OPENROUTER_API_KEY sk-or-...")
+            print('  hermes config set "model" "anthropic/claude-sonnet-4"')
+            print('  hermes config set "terminal.backend" "docker"')
+            print('  hermes config set "OPENROUTER_API_KEY" "sk-or-..."')
             sys.exit(1)
         set_config_value(key, value)
     


### PR DESCRIPTION
Hi! This PR fixes #926 by adding quotes to CLI examples for better shell safety. Also improved alignment in README.md.