### PR TITLE
docs: document Codex dashboard attribution behavior

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -147,6 +147,8 @@ def show_status(args):
         print(f"    Refreshed:  {codex_last_refresh}")
     if codex_status.get("error") and not codex_logged_in:
         print(f"    Error:      {codex_status.get('error')}")
+    if codex_logged_in:
+        print(f"    Dashboard:  Hermes traffic appears as Other in the Codex usage dashboard — this is expected")
 
     # =========================================================================
     # API-Key Providers

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -73,6 +73,8 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 
 :::info Codex Note
 The OpenAI Codex provider authenticates via device code (open a URL, enter a code). Credentials are stored at `~/.codex/auth.json` and auto-refresh. No Codex CLI installation required.
+
+Hermes traffic routed through the Codex provider appears as **"Other"** in the [ChatGPT Codex usage dashboard](https://chatgpt.com/codex/settings/usage). This is expected — the dashboard categories (CLI, Exec, Extension, etc.) reflect the official Codex clients, and Hermes uses the same underlying API without a matching attribution header. Usage is still counted correctly; only the category label differs.
 :::
 
 :::warning


### PR DESCRIPTION
## Summary

Addresses #1167.

When Hermes is configured with `provider: openai-codex`, traffic appears as **"Other"** in the [ChatGPT Codex usage dashboard](https://chatgpt.com/codex/settings/usage). This is expected behavior — the dashboard categories (CLI, Exec, Extension, etc.) reflect official Codex clients, and Hermes uses the same underlying API without a matching attribution header. Usage is still counted correctly; only the category label differs.

## Changes

- **`website/docs/user-guide/configuration.md`** — Added an explanation to the existing Codex Note callout clarifying why traffic appears as "Other" and that this is expected
- **`hermes_cli/status.py`** — Added a one-line dashboard hint under the OpenAI Codex auth section in `hermes status` output (shown only when Codex is logged in)

## What was not done

Improved attribution behavior (optional acceptance criterion) was not implemented — the mechanism by which the Codex dashboard assigns categories is not publicly documented, and any attempt to influence it risks spoofing/misrepresentation, which the issue explicitly asks to avoid.