### PR TITLE
fix: preserve thread context for cronjob deliver=origin

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2801,10 +2801,12 @@ class GatewayRunner:
         os.environ["HERMES_SESSION_CHAT_ID"] = context.source.chat_id
         if context.source.chat_name:
             os.environ["HERMES_SESSION_CHAT_NAME"] = context.source.chat_name
+        if context.source.thread_id:
+            os.environ["HERMES_SESSION_THREAD_ID"] = str(context.source.thread_id)
     
     def _clear_session_env(self) -> None:
         """Clear session environment variables."""
-        for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME"]:
+        for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME", "HERMES_SESSION_THREAD_ID"]:
             if var in os.environ:
                 del os.environ[var]
     

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -117,6 +117,36 @@ class TestScheduleCronjob:
         ))
         assert result["repeat"] == "5 times"
 
+    def test_thread_id_captured_in_origin(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "123456")
+        monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "42")
+        import cron.jobs as _jobs
+        created = json.loads(schedule_cronjob(
+            prompt="Thread test",
+            schedule="every 1h",
+            deliver="origin",
+        ))
+        assert created["success"] is True
+        job_id = created["job_id"]
+        job = _jobs.get_job(job_id)
+        assert job["origin"]["thread_id"] == "42"
+
+    def test_thread_id_absent_when_not_set(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "123456")
+        monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
+        import cron.jobs as _jobs
+        created = json.loads(schedule_cronjob(
+            prompt="No thread test",
+            schedule="every 1h",
+            deliver="origin",
+        ))
+        assert created["success"] is True
+        job_id = created["job_id"]
+        job = _jobs.get_job(job_id)
+        assert job["origin"].get("thread_id") is None
+
 
 # =========================================================================
 # list_cronjobs

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -123,6 +123,7 @@ def schedule_cronjob(
             "platform": origin_platform,
             "chat_id": origin_chat_id,
             "chat_name": os.getenv("HERMES_SESSION_CHAT_NAME"),
+            "thread_id": os.getenv("HERMES_SESSION_THREAD_ID"),
         }
     
     try:


### PR DESCRIPTION
## Summary

Fixes #1219.

When a cronjob was created from within a Telegram or Slack thread with `deliver: origin`, messages were delivered to the parent channel instead of the thread.

## Root Cause

The scheduler (`cron/scheduler.py`) already reads `origin.get('thread_id')` and forwards it to delivery helpers. However, the gateway never set `HERMES_SESSION_THREAD_ID` in the session environment, so `cronjob_tools.py` had no way to capture the thread ID into the job's origin metadata.

## Changes

- **`gateway/run.py`** — set `HERMES_SESSION_THREAD_ID` when `context.source.thread_id` is present; clear it in `_clear_session_env`
- **`tools/cronjob_tools.py`** — read `HERMES_SESSION_THREAD_ID` into the origin dict
- **`tests/tools/test_cronjob_tools.py`** — two new tests: thread_id is captured into origin when set, and absent when not set