### PR TITLE
test: cover empty cached Anthropic tool-call turns

### DIFF
--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -519,6 +519,28 @@ class TestConvertMessages:
         assert tool_block["content"] == "result"
         assert tool_block["cache_control"] == {"type": "ephemeral"}
 
+    def test_empty_cached_assistant_tool_turn_converts_without_empty_text_block(self):
+        messages = apply_anthropic_cache_control([
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Find the skill"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_1", "function": {"name": "skill_view", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+        ])
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        assistant_turn = next(msg for msg in result if msg["role"] == "assistant")
+        assistant_blocks = assistant_turn["content"]
+
+        assert all(not (b.get("type") == "text" and b.get("text") == "") for b in assistant_blocks)
+        assert any(b.get("type") == "tool_use" for b in assistant_blocks)
+
 
 # ---------------------------------------------------------------------------
 # Build kwargs


### PR DESCRIPTION
## Summary
- add an integration-style regression test for the empty cached Anthropic tool-call case fixed by PR #1216
- verify prompt caching output converts cleanly through the Anthropic adapter when an assistant tool-call turn has empty content
- lock in behavior so we do not regress back to invalid empty cached text blocks

## Test plan
- `source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/test_anthropic_adapter.py tests/agent/test_prompt_caching.py -n0 -q`
- `source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/ -n0 -q`
  - current main still has 4 unrelated failures in `tests/test_managed_server_tool_support.py` and `tests/test_quick_commands.py`
  - this branch only changes `tests/test_anthropic_adapter.py`
