### PR TITLE
feat(skills): add google-news research skill

### DIFF
--- a/skills/research/google-news/SKILL.md
+++ b/skills/research/google-news/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: google-news
+description: Full Google News access with homepage, all categories, subcategories, and search. Returns structured JSON with title, source, URL. Uses Scrapling CLI for browser-based fetching.
+version: 5.0.0
+author: Hermes Agent
+tags: [news, google-news, scraping, research, current-events, categories]
+---
+
+# Google News — Complete Category and Subcategory Access
+
+## Overview
+Full Google News access. Homepage, 10 categories with subcategories, and search.
+Returns structured JSON. Categories have subcategory tabs (client-side, dynamic loading).
+
+## Files
+- Script: `SKILL_DIR/scripts/google-news-search.py`
+- Config: `SKILL_DIR/scripts/google-news-categories.json`
+
+`SKILL_DIR` is the directory containing this SKILL.md file.
+
+## Usage
+```bash
+# Homepage
+python3 SKILL_DIR/scripts/google-news-search.py homepage US en 10
+
+# Category
+python3 SKILL_DIR/scripts/google-news-search.py technology US en 10
+
+# Search
+python3 SKILL_DIR/scripts/google-news-search.py search "AI agents" US en 10
+
+# List all categories with subcategories
+python3 SKILL_DIR/scripts/google-news-search.py categories
+```
+
+## Complete Category Structure
+
+### Categories WITHOUT subcategories
+- **Home** (homepage) — Top stories, breaking news
+- **U.S.** — US national news
+- **World** — International news
+- **Local** — Location-based news
+
+### Categories WITH subcategories (tabs at top of page)
+
+**Business** (6 subcategories)
+Latest | Economy | Markets | Jobs | Personal finance | Entrepreneurship
+
+**Technology** (7 subcategories)
+Latest | Mobile | Gadgets | Internet | Virtual reality | Artificial intelligence | Computing
+
+**Entertainment** (7 subcategories)
+Latest | Movies | Music | TV | Books | Arts & design | Celebrities
+
+**Sports** (12 subcategories)
+Latest | NFL | NBA | MLB | NHL | NCAA Football | NCAA Basketball | Soccer | NASCAR | Golf | Tennis | WNBA
+
+**Science** (6 subcategories)
+Latest | Environment | Space | Physics | Genetics | Wildlife
+
+**Health** (6 subcategories)
+Latest | Medication | Health care | Mental health | Nutrition | Fitness
+
+### NOT Categories
+- **Following** — Personal feed of followed topics, requires sign-in, NOT a news category
+- **For You** — Personalized feed, requires sign-in, NOT a browsable category
+
+## Subcategory Technical Notes
+Subcategory tabs are CLIENT-SIDE — they filter content within the parent category page.
+No separate URLs exist for subcategories. Content loads dynamically when tab is clicked.
+To get subcategory-specific content, browser interaction (click tab + wait) is required.
+
+## Aliases
+home, top, top_stories → homepage
+tech → technology
+biz → business
+ent → entertainment
+sci → science
+
+## Regional Presets
+US: region=US, language=en
+UK: region=GB, language=en
+HK: region=HK, language=en
+DE: region=DE, language=de
+
+## JSON Output
+```json
+{
+  "category": "technology",
+  "query": null,
+  "region": "US",
+  "language": "en",
+  "total": 10,
+  "articles": [
+    {"title": "...", "source": "...", "url": "..."}
+  ]
+}
+```
+
+## When to Use vs ddgs
+ddgs: PRIMARY — faster, broader, no browser
+Google News: SUPPLEMENT — category browsing, Google curation, subcategory filtering

--- a/skills/research/google-news/scripts/google-news-categories.json
+++ b/skills/research/google-news/scripts/google-news-categories.json
@@ -1,0 +1,101 @@
+{
+  "description": "Google News category structure for US region. Scraped 2026-03-13.",
+  "last_scraped": "2026-03-13",
+  "region": "US",
+  "structure": "Categories have subcategory tabs (client-side, content loads dynamically)",
+  "following_note": "Following (news.google.com/my/library) is NOT a category - it's a personal feed of topics you follow, requires sign-in",
+  "for_you_note": "For You is personalized feed, requires sign-in, not a browsable category",
+  "categories": {
+    "homepage": {
+      "label": "Home",
+      "type": "homepage",
+      "description": "Top stories and breaking news across all topics",
+      "has_url": true,
+      "subcategories": []
+    },
+    "us": {
+      "id": "CAAqIggKIhxDQkFTRHdvSkwyMHZNRGxqTjNjd0VnSmxiaWdBUAE",
+      "label": "U.S.",
+      "type": "national",
+      "description": "US national news",
+      "has_url": true,
+      "subcategories": []
+    },
+    "world": {
+      "id": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRGx1YlY4U0FtVnVHZ0pWVXlnQVAB",
+      "label": "World",
+      "type": "international",
+      "description": "International news",
+      "has_url": true,
+      "subcategories": []
+    },
+    "business": {
+      "id": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRGx6TVdZU0FtVnVHZ0pWVXlnQVAB",
+      "label": "Business",
+      "type": "topic",
+      "description": "Business, finance, markets, economy, startups",
+      "has_url": true,
+      "subcategories": ["Latest", "Economy", "Markets", "Jobs", "Personal finance", "Entrepreneurship"]
+    },
+    "technology": {
+      "id": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRGRqTVhZU0FtVnVHZ0pWVXlnQVAB",
+      "label": "Technology",
+      "type": "topic",
+      "description": "Tech products, AI, software, hardware, startups",
+      "has_url": true,
+      "subcategories": ["Latest", "Mobile", "Gadgets", "Internet", "Virtual reality", "Artificial intelligence", "Computing"]
+    },
+    "entertainment": {
+      "id": "CAAqJggKIiBDQkFTRWdvSUwyMHZNREpxYW5RU0FtVnVHZ0pWVXlnQVAB",
+      "label": "Entertainment",
+      "type": "topic",
+      "description": "Movies, TV, music, celebrities, pop culture",
+      "has_url": true,
+      "subcategories": ["Latest", "Movies", "Music", "TV", "Books", "Arts & design", "Celebrities"]
+    },
+    "sports": {
+      "id": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRFp1ZEdvU0FtVnVHZ0pWVXlnQVAB",
+      "label": "Sports",
+      "type": "topic",
+      "description": "All sports, leagues, scores",
+      "has_url": true,
+      "subcategories": ["Latest", "NFL", "NBA", "MLB", "NHL", "NCAA Football", "NCAA Basketball", "Soccer", "NASCAR", "Golf", "Tennis", "WNBA"]
+    },
+    "science": {
+      "id": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRFp0Y1RjU0FtVnVHZ0pWVXlnQVAB",
+      "label": "Science",
+      "type": "topic",
+      "description": "Scientific research, discoveries, space",
+      "has_url": true,
+      "subcategories": ["Latest", "Environment", "Space", "Physics", "Genetics", "Wildlife"]
+    },
+    "health": {
+      "id": "CAAqIQgKIhtDQkFTRGdvSUwyMHZNR3QwTlRFU0FtVnVLQUFQAQ",
+      "label": "Health",
+      "type": "topic",
+      "description": "Medical research, healthcare, wellness",
+      "has_url": true,
+      "subcategories": ["Latest", "Medication", "Health care", "Mental health", "Nutrition", "Fitness"]
+    },
+    "local": {
+      "id": "CAAqHAgKIhZDQklTQ2pvSWJHOWpZV3hmZGpJb0FBUAE",
+      "label": "Local",
+      "type": "geographic",
+      "description": "Local news based on location",
+      "has_url": true,
+      "subcategories": []
+    }
+  },
+  "subcategory_notes": [
+    "Subcategory tabs are CLIENT-SIDE - content loads dynamically when clicked",
+    "No separate URLs for subcategories - they filter content within parent category page",
+    "To get subcategory-specific content, browser interaction (click tab) is required",
+    "Subcategories exist for: Business (6), Technology (7), Entertainment (7), Sports (12), Science (6), Health (6)",
+    "U.S., World, and Local have NO subcategory tabs"
+  ],
+  "other_ids_in_html": {
+    "full_coverage": "23 IDs - Dynamic pages for specific breaking stories",
+    "author_pages": "15 IDs - Journalist/commentator profiles",
+    "other": "13 IDs - Various sub-topics, not persistent navigation"
+  }
+}

--- a/skills/research/google-news/scripts/google-news-search.py
+++ b/skills/research/google-news/scripts/google-news-search.py
@@ -26,6 +26,94 @@ import os
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 CONFIG_FILE = os.path.join(SCRIPT_DIR, 'google-news-categories.json')
 
+def check_compatibility():
+    """Check system compatibility for google-news skill."""
+    import platform
+    import shutil
+    issues = []
+    warnings = []
+
+    # Python version
+    py = sys.version_info
+    if py < (3, 8):
+        issues.append(f"Python {py.major}.{py.minor} detected. Requires Python >= 3.8")
+    else:
+        print(f"[OK] Python {py.major}.{py.minor}.{py.micro}")
+
+    # Platform
+    system = platform.system()
+    if system not in ("Linux", "Darwin", "Windows"):
+        warnings.append(f"Untested platform: {system}")
+    else:
+        print(f"[OK] Platform: {system} {platform.machine()}")
+
+    # Scrapling CLI - check PATH and common locations
+    scrapling_found = False
+    for loc in ["scrapling", os.path.expanduser("~/.local/bin/scrapling"), "/usr/local/bin/scrapling"]:
+        if shutil.which(loc) or os.path.exists(loc):
+            scrapling_found = True
+            break
+    if not scrapling_found:
+        # Try finding via pip
+        try:
+            r = subprocess.run([sys.executable, "-m", "pip", "show", "scrapling"], capture_output=True, timeout=10)
+            if r.returncode == 0:
+                scrapling_found = True
+                warnings.append("scrapling installed but CLI not in PATH. Add ~/.local/bin to PATH or use full path.")
+        except Exception:
+            pass
+    if scrapling_found:
+        print("[OK] Scrapling CLI available")
+    else:
+        issues.append("scrapling not found. Install: pip install scrapling")
+
+    # Scrapling Python library
+    try:
+        from scrapling.parser import Selector
+        print("[OK] Scrapling Python library available")
+    except ImportError:
+        issues.append("scrapling Python library not found. Install: pip install scrapling")
+
+    return len(issues) == 0, issues, warnings
+
+
+    # Python version
+    py = sys.version_info
+    if py < (3, 8):
+        issues.append(f"Python {py.major}.{py.minor} detected. Requires Python >= 3.8")
+    else:
+        print(f"[OK] Python {py.major}.{py.minor}.{py.micro}")
+
+    # Platform
+    system = platform.system()
+    if system not in ("Linux", "Darwin", "Windows"):
+        warnings.append(f"Untested platform: {system}")
+    else:
+        print(f"[OK] Platform: {system} {platform.machine()}")
+
+    # Scrapling CLI
+    try:
+        r = subprocess.run(["scrapling", "--version"], capture_output=True, timeout=5)
+        if r.returncode == 0:
+            print("[OK] Scrapling CLI installed")
+        else:
+            issues.append("scrapling CLI not found. Install: pip install scrapling")
+    except FileNotFoundError:
+        issues.append("scrapling CLI not found. Install: pip install scrapling")
+    except Exception as e:
+        warnings.append(f"Could not check scrapling: {e}")
+
+    # Scrapling Python library
+    try:
+        from scrapling.parser import Selector
+        print("[OK] Scrapling Python library available")
+    except ImportError:
+        issues.append("scrapling Python library not found. Install: pip install scrapling")
+
+    return len(issues) == 0, issues, warnings
+
+
+
 # Load categories from config, fallback to hardcoded
 def load_categories():
     try:
@@ -179,6 +267,11 @@ def main():
     
     if not args:
         pass
+    elif args[0] == "--check":
+        ok, issues, warnings = check_compatibility()
+        result = {"compatible": ok, "issues": issues, "warnings": warnings}
+        print(json.dumps(result, indent=2))
+        sys.exit(0 if ok else 1)
     elif args[0] == "search":
         query = args[1] if len(args) > 1 else "AI agents"
         region = args[2] if len(args) > 2 else "US"

--- a/skills/research/google-news/scripts/google-news-search.py
+++ b/skills/research/google-news/scripts/google-news-search.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Google News — Full access via Scrapling CLI.
+Supports: homepage, category pages, and search queries.
+Returns structured JSON with title, source, URL for each article.
+
+Usage:
+  python3 google-news-search.py                          # Homepage
+  python3 google-news-search.py technology               # Category
+  python3 google-news-search.py search "AI agents"       # Search
+  python3 google-news-search.py categories               # List all categories
+  python3 google-news-search.py technology GB en 10      # Category + region + limit
+
+Categories: homepage, us, world, business, technology, entertainment,
+            sports, science, health, local
+"""
+
+import subprocess
+import tempfile
+import re
+import json
+import sys
+import os
+
+# Script directory for loading config
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_FILE = os.path.join(SCRIPT_DIR, 'google-news-categories.json')
+
+# Load categories from config, fallback to hardcoded
+def load_categories():
+    try:
+        with open(CONFIG_FILE, 'r') as f:
+            config = json.load(f)
+        cats = {}
+        for key, val in config['categories'].items():
+            cats[key] = val.get('id')
+        return cats, config['categories']
+    except:
+        # Fallback
+        return {
+            "homepage": None,
+            "us": "CAAqIggKIhxDQkFTRHdvSkwyMHZNRGxqTjNjd0VnSmxiaWdBUAE",
+            "world": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRGx1YlY4U0FtVnVHZ0pWVXlnQVAB",
+            "business": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRGx6TVdZU0FtVnVHZ0pWVXlnQVAB",
+            "technology": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRGRqTVhZU0FtVnVHZ0pWVXlnQVAB",
+            "entertainment": "CAAqJggKIiBDQkFTRWdvSUwyMHZNREpxYW5RU0FtVnVHZ0pWVXlnQVAB",
+            "sports": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRFp1ZEdvU0FtVnVHZ0pWVXlnQVAB",
+            "science": "CAAqJggKIiBDQkFTRWdvSUwyMHZNRFp0Y1RjU0FtVnVHZ0pWVXlnQVAB",
+            "health": "CAAqIQgKIhtDQkFTRGdvSUwyMHZNR3QwTlRFU0FtVnVLQUFQAQ",
+            "local": "CAAqHAgKIhZDQklTQ2pvSWJHOWpZV3hmZGpJb0FBUAE",
+        }, None
+
+CATEGORIES, CATEGORY_META = load_categories()
+
+# Aliases for convenience
+ALIASES = {
+    "home": "homepage",
+    "top": "homepage",
+    "top_stories": "homepage",
+    "tech": "technology",
+    "biz": "business",
+    "ent": "entertainment",
+    "sci": "science",
+}
+
+
+def build_url(category, region="US", language="en", query=None):
+    """Build Google News URL for category or search."""
+    hl = f"{language}-{region}"
+    ceid = f"{region}:{language}"
+    
+    if query:
+        return f"https://news.google.com/search?q={query.replace(' ', '+')}&hl={hl}&gl={region}&ceid={ceid}"
+    
+    cat_id = CATEGORIES.get(category)
+    if cat_id is None:
+        return f"https://news.google.com/home?hl={hl}&gl={region}&ceid={ceid}"
+    else:
+        return f"https://news.google.com/topics/{cat_id}?hl={hl}&gl={region}&ceid={ceid}"
+
+
+def fetch_and_parse(url, max_articles=20):
+    """Fetch Google News page and parse articles."""
+    html_file = tempfile.mktemp(suffix='.html')
+    
+    cmd = [
+        "scrapling", "extract", "fetch", url, html_file,
+        "--headless", "--disable-resources",
+        "--timeout", "20000", "--wait", "3000"
+    ]
+    
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        return {"error": f"Fetch failed: {result.stderr}", "articles": []}
+    
+    from scrapling.parser import Selector
+    
+    with open(html_file, 'r', encoding='utf-8') as f:
+        html = f.read()
+    
+    sel = Selector(html)
+    
+    # Parse from aria-labels
+    aria_links = sel.css('a[aria-label]')
+    articles = []
+    seen = set()
+    
+    for a in aria_links:
+        label = a.attrib.get('aria-label', '')
+        href = a.attrib.get('href', '')
+        
+        if len(label) < 20 or not ('./read/' in href or './articles/' in href):
+            continue
+        if label in seen:
+            continue
+        seen.add(label)
+        
+        if href.startswith('./read/'):
+            article_url = f"https://news.google.com/read/{href[7:]}"
+        elif href.startswith('./articles/'):
+            article_url = f"https://news.google.com/articles/{href[12:]}"
+        else:
+            article_url = href
+        
+        label = label.strip().rstrip(' -')
+        parts = label.split(' - ', 1)
+        
+        if len(parts) == 2:
+            title = parts[0].strip()
+            source = parts[1].strip().split(' - ')[0].strip()
+        else:
+            title = label
+            source = ''
+        
+        if len(title) >= 15:
+            articles.append({
+                'title': title,
+                'source': source,
+                'url': article_url
+            })
+    
+    # Cleanup
+    try:
+        os.unlink(html_file)
+    except:
+        pass
+    
+    if max_articles:
+        articles = articles[:max_articles]
+    
+    return articles
+
+
+def list_categories():
+    """List all available categories with descriptions."""
+    if CATEGORY_META:
+        result = []
+        for key, meta in sorted(CATEGORY_META.items()):
+            result.append({
+                'id': key,
+                'label': meta.get('label', key),
+                'type': meta.get('type', 'unknown'),
+                'description': meta.get('description', ''),
+                'has_url': meta.get('url') is not None
+            })
+        return result
+    else:
+        return [{'id': k, 'label': k.title()} for k in CATEGORIES.keys()]
+
+
+def main():
+    args = sys.argv[1:]
+    
+    category = "homepage"
+    region = "US"
+    language = "en"
+    max_results = 20
+    query = None
+    
+    if not args:
+        pass
+    elif args[0] == "search":
+        query = args[1] if len(args) > 1 else "AI agents"
+        region = args[2] if len(args) > 2 else "US"
+        language = args[3] if len(args) > 3 else "en"
+        max_results = int(args[4]) if len(args) > 4 else 20
+    elif args[0] == "categories":
+        cats = list_categories()
+        print(json.dumps({"total": len(cats), "categories": cats}, indent=2))
+        return
+    else:
+        cat = args[0].lower()
+        category = ALIASES.get(cat, cat)
+        
+        if category not in CATEGORIES:
+            print(json.dumps({
+                "error": f"Unknown category: {category}",
+                "available": list(CATEGORIES.keys()),
+                "hint": "Use 'categories' command to list all"
+            }))
+            return
+        
+        region = args[1] if len(args) > 1 else "US"
+        language = args[2] if len(args) > 2 else "en"
+        max_results = int(args[3]) if len(args) > 3 else 20
+    
+    url = build_url(category, region, language, query)
+    articles = fetch_and_parse(url, max_results)
+    
+    result = {
+        "category": category if not query else "search",
+        "query": query,
+        "region": region,
+        "language": language,
+        "total": len(articles),
+        "articles": articles
+    }
+    
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a Google News research skill that fetches headlines from Google News using dynamic content extraction via Scrapling.

**Includes:**
- SKILL.md with usage instructions
- `google-news-search.py` script for searching news by category/query
- `google-news-categories.json` with supported Google News RSS categories

Provides full Google News access including homepage, category browsing, and search — useful for staying current with AI/tech news without manual browsing.