### PR TITLE
docs: improve documentation for core API constants

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1,12 +1,24 @@
-"""Shared constants for Hermes Agent.
-
-Import-safe module with no dependencies — can be imported from anywhere
-without risk of circular imports.
 """
+Shared constants for the Hermes Agent infrastructure.
+
+This module is designed to be 'import-safe' with zero external dependencies, 
+ensuring it can be utilized across the entire agentic stack (gateway, tools, core) 
+without the risk of circular inheritance or import deadlocks.
+"""
+
+# --- OpenRouter Configuration ---
+# OpenRouter serves as a primary unified interface for accessing a wide array 
+# of LLMs. These constants define the routing pathways for model discovery 
+# and inference execution within the agent's reasoning loops.
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 OPENROUTER_MODELS_URL = f"{OPENROUTER_BASE_URL}/models"
 OPENROUTER_CHAT_URL = f"{OPENROUTER_BASE_URL}/chat/completions"
+
+# --- Nous Infrastructure Configuration ---
+# Internal Nous Research inference endpoints. These URLs point to the 
+# optimized hosting environment for Hermes-series models, providing 
+# high-performance, low-latency access to first-party weights.
 
 NOUS_API_BASE_URL = "https://inference-api.nousresearch.com/v1"
 NOUS_API_CHAT_URL = f"{NOUS_API_BASE_URL}/chat/completions"


### PR DESCRIPTION
Following the architectural audit of the v0.2.0 release, this PR enhances the hermes_constants.py file with semantic documentation. While functionally correct, the previous 'bare' constants lacked context for automated RAG analysis and new contributors. These changes clarify the roles of OpenRouter and Nous internal infrastructure, improving the overall transparency of the agent's networking layer.