### PR TITLE
fix: stop local terminal warning without minisweagent

### DIFF
--- a/tests/tools/test_terminal_requirements.py
+++ b/tests/tools/test_terminal_requirements.py
@@ -1,0 +1,15 @@
+import logging
+
+from tools.terminal_tool import check_terminal_requirements
+
+
+def test_local_terminal_requirements_do_not_depend_on_minisweagent(monkeypatch, caplog):
+    """Local backend uses Hermes' own LocalEnvironment wrapper and should not
+    be marked unavailable just because `minisweagent` isn't importable."""
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    with caplog.at_level(logging.ERROR):
+        ok = check_terminal_requirements()
+
+    assert ok is True
+    assert "Terminal requirements check failed" not in caplog.text

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1130,7 +1130,8 @@ def check_terminal_requirements() -> bool:
     
     try:
         if env_type == "local":
-            from minisweagent.environments.local import LocalEnvironment
+            # Local execution uses Hermes' own LocalEnvironment wrapper and does
+            # not depend on minisweagent being importable.
             return True
         elif env_type == "docker":
             from minisweagent.environments.docker import DockerEnvironment


### PR DESCRIPTION
## Summary
- make local terminal requirement checks use Hermes' local backend instead of importing `minisweagent`
- add a regression test covering `TERMINAL_ENV=local` when `minisweagent` is not importable
- verify the repeated startup warning is gone in a live `hermes chat -q` run

## Test plan
- python -m pytest tests/tools/test_terminal_requirements.py -n0 -q
- python -m hermes_cli.main chat -q "Reply with exactly ok"