### PR TITLE
fix(tools): preserve MCP toolsets when saving platform tool config

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -354,9 +354,29 @@ def _get_platform_tools(config: dict, platform: str) -> Set[str]:
 
 
 def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[str]):
-    """Save the selected toolset keys for a platform to config."""
+    """Save the selected toolset keys for a platform to config.
+
+    Preserves any non-configurable toolset entries (like MCP server names)
+    that were already in the config for this platform.
+    """
     config.setdefault("platform_toolsets", {})
-    config["platform_toolsets"][platform] = sorted(enabled_toolset_keys)
+
+    # Get the set of all configurable toolset keys
+    configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
+
+    # Get existing toolsets for this platform
+    existing_toolsets = config.get("platform_toolsets", {}).get(platform, [])
+    if not isinstance(existing_toolsets, list):
+        existing_toolsets = []
+
+    # Preserve any entries that are NOT configurable toolsets (i.e. MCP server names)
+    preserved_entries = {
+        entry for entry in existing_toolsets
+        if entry not in configurable_keys
+    }
+
+    # Merge preserved entries with new enabled toolsets
+    config["platform_toolsets"][platform] = sorted(enabled_toolset_keys | preserved_entries)
     save_config(config)
 
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -26,3 +26,65 @@ def test_platform_toolset_summary_uses_explicit_platform_list():
 
     assert set(summary.keys()) == {"cli"}
     assert summary["cli"] == _get_platform_tools(config, "cli")
+
+
+def test_save_platform_tools_preserves_mcp_server_names():
+    """Ensure MCP server names are preserved when saving platform tools.
+
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/1247
+    """
+    from unittest.mock import patch
+    from hermes_cli.tools_config import _save_platform_tools
+
+    config = {
+        "platform_toolsets": {
+            "cli": ["web", "terminal", "time", "github", "custom-mcp-server"]
+        }
+    }
+
+    new_selection = {"web", "browser"}
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", new_selection)
+
+    saved_toolsets = config["platform_toolsets"]["cli"]
+
+    assert "time" in saved_toolsets
+    assert "github" in saved_toolsets
+    assert "custom-mcp-server" in saved_toolsets
+    assert "web" in saved_toolsets
+    assert "browser" in saved_toolsets
+    assert "terminal" not in saved_toolsets
+
+
+def test_save_platform_tools_handles_empty_existing_config():
+    """Saving platform tools works when no existing config exists."""
+    from unittest.mock import patch
+    from hermes_cli.tools_config import _save_platform_tools
+
+    config = {}
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "telegram", {"web", "terminal"})
+
+    saved_toolsets = config["platform_toolsets"]["telegram"]
+    assert "web" in saved_toolsets
+    assert "terminal" in saved_toolsets
+
+
+def test_save_platform_tools_handles_invalid_existing_config():
+    """Saving platform tools works when existing config is not a list."""
+    from unittest.mock import patch
+    from hermes_cli.tools_config import _save_platform_tools
+
+    config = {
+        "platform_toolsets": {
+            "cli": "invalid-string-value"
+        }
+    }
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", {"web"})
+
+    saved_toolsets = config["platform_toolsets"]["cli"]
+    assert "web" in saved_toolsets


### PR DESCRIPTION
## Problem

Closes #1247

`_save_platform_tools()` overwrote the entire `platform_toolsets` list with only the toolsets known to `CONFIGURABLE_TOOLSETS`. This silently dropped any MCP server toolsets that users had added manually to `config.yaml` whenever `hermes tools` was run and saved.

## Root Cause

`_save_platform_tools()` in `hermes_cli/tools_config.py` replaces the platform's toolset list entirely with the wizard's selections. MCP toolsets are not in `CONFIGURABLE_TOOLSETS` so they are never included in the new list — effectively deleted on every save.

## Fix

Before writing the new toolset list, collect any existing entries that are not in `CONFIGURABLE_TOOLSETS` (i.e. MCP server toolsets) and append them back after the wizard's selections. This ensures MCP toolsets survive a `hermes tools` save.

```python
configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
existing = config["platform_toolsets"].get(platform, [])
preserved = [ts for ts in existing if ts not in configurable_keys]
config["platform_toolsets"][platform] = sorted(enabled_toolset_keys) + preserved
```

## Tests

11 tests passing