### PR TITLE
fix(cron): persist cron sessions to SQLite

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -269,6 +269,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
             quiet_mode=True,
+            platform="cron",
             session_id=f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}",
             session_db=_session_db,
         )
@@ -325,6 +326,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Clean up injected env vars so they don't leak to other jobs
         for key in ("HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME"):
             os.environ.pop(key, None)
+        if _session_db:
+            try:
+                _session_db.close()
+            except Exception as e:
+                logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
 
 
 def tick(verbose: bool = True) -> int:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -156,6 +156,15 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     from run_agent import AIAgent
     
+    # Initialize SQLite session store so cron job messages are persisted
+    # and discoverable via session_search (same pattern as gateway/run.py).
+    _session_db = None
+    try:
+        from hermes_state import SessionDB
+        _session_db = SessionDB()
+    except Exception as e:
+        logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
+    
     job_id = job["id"]
     job_name = job["name"]
     prompt = job["prompt"]
@@ -260,7 +269,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
             quiet_mode=True,
-            session_id=f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+            session_id=f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}",
+            session_db=_session_db,
         )
         
         result = agent.run_conversation(prompt)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -106,6 +106,47 @@ class TestDeliverResultMirrorLogging:
         )
 
 
+class TestRunJobSessionPersistence:
+    def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "ok" in output
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["session_db"] is fake_db
+        assert kwargs["platform"] == "cron"
+        assert kwargs["session_id"].startswith("cron_test-job_")
+        fake_db.close.assert_called_once()
+
+
 class TestRunJobConfigLogging:
     """Verify that config.yaml parse failures are logged, not silently swallowed."""
 


### PR DESCRIPTION
## Summary
- cherry-pick the substantive fix from #907 so cron-created agents pass `session_db` and become recallable via SQLite/session_search
- tag persisted cron-run sessions with `source=cron` instead of falling back to `cli`
- close the per-run SessionDB and add regression coverage for cron session wiring

## Contributor credit
- cherry-picked Ömer Kaz's commit from #907 with authorship preserved
- added a small follow-up commit for cron source tagging and tests

## Test plan
- `python -m pytest tests/cron/test_scheduler.py tests/test_codex_execution_paths.py -n0 -q`
- `python -m pytest tests/ -n0 -q`
- `python -m hermes_cli.main chat -q "Reply with exactly: smoke-ok"`

Closes #907
