### PR TITLE
fix: Preserve MCP tools when saving platform toolsets

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -354,9 +354,31 @@ def _get_platform_tools(config: dict, platform: str) -> Set[str]:
 
 
 def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[str]):
-    """Save the selected toolset keys for a platform to config."""
+    """Save the selected toolset keys for a platform to config.
+    
+    Preserves any non-configurable toolset entries (like MCP server names)
+    that were already in the config for this platform.
+    """
     config.setdefault("platform_toolsets", {})
-    config["platform_toolsets"][platform] = sorted(enabled_toolset_keys)
+    
+    # Get the set of all configurable toolset keys
+    configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
+    
+    # Get existing toolsets for this platform
+    existing_toolsets = config.get("platform_toolsets", {}).get(platform, [])
+    if not isinstance(existing_toolsets, list):
+        existing_toolsets = []
+    
+    # Preserve any entries that are NOT configurable toolsets (i.e., MCP server names, etc.)
+    preserved_entries = {
+        entry for entry in existing_toolsets
+        if entry not in configurable_keys
+    }
+    
+    # Merge preserved entries with new enabled toolsets
+    final_toolsets = enabled_toolset_keys | preserved_entries
+    
+    config["platform_toolsets"][platform] = sorted(final_toolsets)
     save_config(config)
 
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1,6 +1,12 @@
 """Tests for hermes_cli.tools_config platform tool persistence."""
 
-from hermes_cli.tools_config import _get_platform_tools, _platform_toolset_summary
+from unittest.mock import patch
+
+from hermes_cli.tools_config import (
+    _get_platform_tools,
+    _platform_toolset_summary,
+    _save_platform_tools,
+)
 
 
 def test_get_platform_tools_uses_default_when_platform_not_configured():
@@ -26,3 +32,70 @@ def test_platform_toolset_summary_uses_explicit_platform_list():
 
     assert set(summary.keys()) == {"cli"}
     assert summary["cli"] == _get_platform_tools(config, "cli")
+
+
+def test_save_platform_tools_preserves_mcp_server_names():
+    """Ensure MCP server names are preserved when saving platform tools.
+    
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/1247
+    """
+    # Simulate config with MCP servers in platform_toolsets
+    config = {
+        "platform_toolsets": {
+            "cli": ["web", "terminal", "time", "github", "custom-mcp-server"]
+        }
+    }
+    
+    # User selects only "web" and "browser" in the tools wizard
+    new_selection = {"web", "browser"}
+    
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", new_selection)
+    
+    saved_toolsets = config["platform_toolsets"]["cli"]
+    
+    # MCP server names should be preserved
+    assert "time" in saved_toolsets
+    assert "github" in saved_toolsets
+    assert "custom-mcp-server" in saved_toolsets
+    
+    # New selection should be present
+    assert "web" in saved_toolsets
+    assert "browser" in saved_toolsets
+    
+    # "terminal" was not in new selection and IS a configurable toolset,
+    # so it should NOT be preserved
+    assert "terminal" not in saved_toolsets
+
+
+def test_save_platform_tools_handles_empty_existing_config():
+    """Saving platform tools works when no existing config exists."""
+    config = {}
+    
+    new_selection = {"web", "terminal"}
+    
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "telegram", new_selection)
+    
+    saved_toolsets = config["platform_toolsets"]["telegram"]
+    
+    assert "web" in saved_toolsets
+    assert "terminal" in saved_toolsets
+
+
+def test_save_platform_tools_handles_invalid_existing_config():
+    """Saving platform tools works when existing config is not a list."""
+    config = {
+        "platform_toolsets": {
+            "cli": "invalid-string-value"  # Should be a list
+        }
+    }
+    
+    new_selection = {"web"}
+    
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", new_selection)
+    
+    saved_toolsets = config["platform_toolsets"]["cli"]
+    
+    assert "web" in saved_toolsets


### PR DESCRIPTION
## Summary

Fixes #1247 — `hermes tools` command removes MCP tools after saving.

## Problem

When using `hermes tools` to configure toolsets, MCP server names were being removed from `platform_toolsets` because `_save_platform_tools` only saved entries that matched `CONFIGURABLE_TOOLSETS`.

For example, if the user had:
```yaml
platform_toolsets:
  cli: [hermes-cli, time, github]  # time and github are MCP servers
```

After running `hermes tools` and selecting toolsets, the MCP entries would be lost:
```yaml
platform_toolsets:
  cli: [web, terminal, file]  # MCP servers removed!
```

## Solution

Modified `_save_platform_tools` to preserve any non-configurable entries (like MCP server names) that were already in the config, merging them with the user's new selection.

## Testing

Added three test cases:
- `test_save_platform_tools_preserves_mcp_server_names` - verifies MCP names are preserved
- `test_save_platform_tools_handles_empty_existing_config` - works with no existing config
- `test_save_platform_tools_handles_invalid_existing_config` - handles malformed config gracefully