### PR TITLE
feat(providers): add Apple Silicon local provider flow and polish local UX

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -147,6 +147,12 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
     ),
+    "local": ProviderConfig(
+        id="local",
+        name="Local (Apple Silicon)",
+        auth_type="local",
+        inference_base_url="http://localhost:8899/v1",
+    ),
 }
 
 

--- a/hermes_cli/local_provider.py
+++ b/hermes_cli/local_provider.py
@@ -134,6 +134,37 @@ def installed_model_ids(model_ids: list[str]) -> set[str]:
     return {mid for mid in model_ids if is_model_installed(mid)}
 
 
+def list_cached_model_ids(limit: int = 200) -> list[str]:
+    """Best-effort discovery of all cached HF model IDs with snapshots.
+
+    Returns model IDs decoded from hub directory names like:
+      models--org--model  -> org/model
+    """
+    hub_dir = _hf_hub_cache_dir()
+    if not hub_dir.exists():
+        return []
+
+    found: list[str] = []
+    try:
+        for child in hub_dir.iterdir():
+            name = child.name
+            if not name.startswith("models--"):
+                continue
+            snapshots = child / "snapshots"
+            if not snapshots.exists() or not any(snapshots.iterdir()):
+                continue
+            model_id = name[len("models--") :].replace("--", "/")
+            if model_id:
+                found.append(model_id)
+    except Exception:
+        return []
+
+    unique_sorted = sorted(set(found))
+    if limit > 0:
+        return unique_sorted[:limit]
+    return unique_sorted
+
+
 def _pid_file_path() -> Path:
     return get_hermes_home() / "local_server.pid"
 

--- a/hermes_cli/local_provider.py
+++ b/hermes_cli/local_provider.py
@@ -146,17 +146,20 @@ def list_cached_model_ids(limit: int = 200) -> list[str]:
 
     found: list[str] = []
     try:
-        for child in hub_dir.iterdir():
-            name = child.name
-            if not name.startswith("models--"):
+        for entry in sorted(hub_dir.glob("models--*")):
+            snapshots = entry / "snapshots"
+            if not snapshots.exists():
                 continue
-            snapshots = child / "snapshots"
-            if not snapshots.exists() or not any(snapshots.iterdir()):
+            try:
+                if not any(snapshots.iterdir()):
+                    continue
+            except OSError:
                 continue
-            model_id = name[len("models--") :].replace("--", "/")
+
+            model_id = entry.name[len("models--") :].replace("--", "/")
             if model_id:
                 found.append(model_id)
-    except Exception:
+    except OSError:
         return []
 
     unique_sorted = sorted(set(found))

--- a/hermes_cli/local_provider.py
+++ b/hermes_cli/local_provider.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import platform
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+from hermes_cli.config import get_hermes_home, load_config
+
+DEFAULT_PORT = 8899
+
+MODEL_RECOMMENDATIONS: list[dict[str, str | float]] = [
+    {
+        "id": "mlx-community/Qwen3.5-4B-MLX-4bit",
+        "name": "Qwen 3.5 4B (4-bit)",
+        "description": "Fast, lightweight everyday model",
+        "min_ram_gb": 8,
+    },
+    {
+        "id": "mlx-community/Hermes-3-Llama-3.1-8B-4bit",
+        "name": "Hermes 3 8B (4-bit)",
+        "description": "Stable Nous baseline",
+        "min_ram_gb": 8,
+    },
+    {
+        "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
+        "name": "Qwen 3.5 9B (4-bit)",
+        "description": "Strong quality/speed balance",
+        "min_ram_gb": 16,
+    },
+    {
+        "id": "mlx-community/Hermes-4-14B-4bit",
+        "name": "Hermes 4 14B (4-bit)",
+        "description": "Newer Nous model, high quality",
+        "min_ram_gb": 16,
+    },
+    {
+        "id": "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+        "name": "Qwen3 Coder 30B MoE (4-bit)",
+        "description": "Excellent coding, MoE architecture",
+        "min_ram_gb": 20,
+    },
+    {
+        "id": "mlx-community/Qwen3.5-27B-4bit",
+        "name": "Qwen 3.5 27B (4-bit)",
+        "description": "High-quality general model",
+        "min_ram_gb": 32,
+    },
+    {
+        "id": "mlx-community/Qwen3.5-35B-A3B-4bit",
+        "name": "Qwen 3.5 35B-A3B (4-bit)",
+        "description": "Large MoE model for quality-sensitive tasks",
+        "min_ram_gb": 40,
+    },
+    {
+        "id": "mlx-community/Hermes-4-70B-4bit",
+        "name": "Hermes 4 70B (4-bit)",
+        "description": "Nous flagship local model",
+        "min_ram_gb": 48,
+    },
+    {
+        "id": "mlx-community/Qwen3.5-122B-A10B-4bit",
+        "name": "Qwen 3.5 122B-A10B (4-bit)",
+        "description": "Very large model for high-end Apple Silicon",
+        "min_ram_gb": 96,
+    },
+]
+
+
+def detect_hardware() -> Optional[dict[str, object]]:
+    if platform.system() != "Darwin" or platform.machine() != "arm64":
+        return None
+
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "hw.memsize"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        ram_bytes = int(result.stdout.strip())
+        ram_gb = ram_bytes / (1024**3)
+    except Exception:
+        return None
+
+    chip = "Apple Silicon"
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.stdout.strip():
+            chip = result.stdout.strip()
+    except Exception:
+        pass
+
+    return {"chip": chip, "ram_gb": round(ram_gb, 1), "apple_silicon": True}
+
+
+def recommend_models(ram_gb: float) -> list[dict[str, str | float]]:
+    usable = ram_gb * 0.8
+    compatible = [m for m in MODEL_RECOMMENDATIONS if m["min_ram_gb"] <= usable]
+    return sorted(compatible, key=lambda m: m["min_ram_gb"], reverse=True)
+
+
+def _hf_hub_cache_dir() -> Path:
+    hf_home = os.getenv("HF_HOME", "").strip()
+    if hf_home:
+        return Path(hf_home) / "hub"
+    return Path.home() / ".cache" / "huggingface" / "hub"
+
+
+def is_model_installed(model_id: str) -> bool:
+    """Best-effort check whether a model appears in the local HuggingFace cache."""
+    cache_key = "models--" + model_id.replace("/", "--")
+    model_dir = _hf_hub_cache_dir() / cache_key
+    snapshots = model_dir / "snapshots"
+    try:
+        return model_dir.exists() and snapshots.exists() and any(snapshots.iterdir())
+    except Exception:
+        return False
+
+
+def installed_model_ids(model_ids: list[str]) -> set[str]:
+    return {mid for mid in model_ids if is_model_installed(mid)}
+
+
+def _pid_file_path() -> Path:
+    return get_hermes_home() / "local_server.pid"
+
+
+def _log_file_path() -> Path:
+    return get_hermes_home() / "local_server.log"
+
+
+def _read_pid_file() -> Optional[dict]:
+    path = _pid_file_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        pid = data.get("pid")
+        if pid is None:
+            return None
+        os.kill(pid, 0)
+        return data
+    except (json.JSONDecodeError, OSError, TypeError):
+        _remove_pid_file()
+        return None
+
+
+def _write_pid_file(pid: int, model_id: str, port: int) -> None:
+    path = _pid_file_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"pid": pid, "model_id": model_id, "port": port}))
+
+
+def _remove_pid_file() -> None:
+    try:
+        _pid_file_path().unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def check_mlx_lm_installed() -> bool:
+    return importlib.util.find_spec("mlx_lm") is not None
+
+
+def install_mlx_lm() -> bool:
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "mlx-lm"],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def is_server_running(port: int = DEFAULT_PORT) -> bool:
+    try:
+        req = urllib.request.Request(f"http://localhost:{port}/v1/models")
+        with urllib.request.urlopen(req, timeout=3):
+            return True
+    except Exception:
+        return False
+
+
+def get_server_status(port: int = DEFAULT_PORT) -> Optional[dict]:
+    pid_data = _read_pid_file()
+    if pid_data is None:
+        return None
+    running = is_server_running(pid_data.get("port", port))
+    return {
+        "pid": pid_data["pid"],
+        "model_id": pid_data.get("model_id", "unknown"),
+        "port": pid_data.get("port", port),
+        "running": running,
+    }
+
+
+def start_server(
+    model_id: str,
+    port: int = DEFAULT_PORT,
+    timeout: int = 120,
+) -> dict:
+    if is_server_running(port):
+        status = _read_pid_file()
+        if status and status.get("model_id") == model_id:
+            return {
+                "pid": status["pid"],
+                "model_id": model_id,
+                "port": port,
+                "running": True,
+                "reused": True,
+            }
+        stop_server(port)
+
+    log_file = _log_file_path()
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    log_handle = open(log_file, "w")
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mlx_lm",
+            "server",
+            "--model",
+            model_id,
+            "--port",
+            str(port),
+        ],
+        stdout=log_handle,
+        stderr=log_handle,
+    )
+
+    _write_pid_file(proc.pid, model_id, port)
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            _remove_pid_file()
+            raise RuntimeError(
+                f"mlx_lm.server exited with code {proc.returncode}. "
+                f"Check {log_file} for details."
+            )
+        if is_server_running(port):
+            return {
+                "pid": proc.pid,
+                "model_id": model_id,
+                "port": port,
+                "running": True,
+                "reused": False,
+            }
+        time.sleep(2)
+
+    proc.terminate()
+    _remove_pid_file()
+    raise TimeoutError(
+        f"mlx_lm.server did not become ready within {timeout}s. "
+        f"Check {log_file} for details."
+    )
+
+
+def stop_server(port: int = DEFAULT_PORT) -> bool:
+    pid_data = _read_pid_file()
+    if pid_data is None:
+        return False
+
+    pid = pid_data["pid"]
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:
+        _remove_pid_file()
+        return True
+
+    for _ in range(50):
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            _remove_pid_file()
+            return True
+        time.sleep(0.1)
+
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except OSError:
+        pass
+
+    _remove_pid_file()
+    return True
+
+
+def ensure_server(
+    model_id: str,
+    port: int = DEFAULT_PORT,
+    timeout: int = 120,
+) -> dict:
+    status = get_server_status(port)
+    if status and status["running"] and status["model_id"] == model_id:
+        return {
+            "pid": status["pid"],
+            "model_id": model_id,
+            "port": port,
+            "running": True,
+            "reused": True,
+        }
+    return start_server(model_id, port, timeout)
+
+
+def _safe_print(msg: str = "") -> None:
+    try:
+        print(msg)
+    except OSError:
+        pass
+
+
+def _cmd_status() -> None:
+    hw = detect_hardware()
+    if hw:
+        _safe_print(f"Hardware: {hw['chip']} / {hw['ram_gb']} GB")
+    else:
+        _safe_print("Hardware: not Apple Silicon (or detection failed)")
+    _safe_print()
+
+    status = get_server_status()
+    if status is None:
+        _safe_print("Server: not running")
+        return
+
+    if status["running"]:
+        _safe_print(f"Server:  running (PID {status['pid']})")
+        _safe_print(f"Model:   {status['model_id']}")
+        _safe_print(f"Port:    {status['port']}")
+        _safe_print(f"URL:     http://localhost:{status['port']}/v1")
+    else:
+        _safe_print(f"Server:  stopped (stale PID {status['pid']})")
+        _safe_print(f"Model:   {status['model_id']}")
+
+
+def _cmd_start() -> None:
+    local_cfg = load_config().get("local", {})
+    model_id = local_cfg.get("model_id")
+    port = local_cfg.get("port", DEFAULT_PORT)
+
+    if not model_id:
+        _safe_print("No local model configured.")
+        _safe_print("Run 'hermes model' and select Local (Apple Silicon) first.")
+        sys.exit(1)
+
+    if not check_mlx_lm_installed():
+        _safe_print("mlx-lm is not installed.")
+        _safe_print("Install it with: pip install mlx-lm")
+        sys.exit(1)
+
+    if is_server_running(port):
+        status = get_server_status(port)
+        if status and status["model_id"] == model_id:
+            _safe_print(f"Server already running ({model_id}) on port {port}")
+            return
+        _safe_print("Stopping existing server...")
+        stop_server(port)
+
+    _safe_print(f"Starting {model_id} on port {port}...")
+    try:
+        result = start_server(model_id, port)
+        _safe_print(f"Server ready (PID {result['pid']})")
+    except (RuntimeError, TimeoutError) as e:
+        _safe_print(f"Failed to start server: {e}")
+        sys.exit(1)
+
+
+def _cmd_stop() -> None:
+    stopped = stop_server()
+    if stopped:
+        _safe_print("Server stopped.")
+    else:
+        _safe_print("No server running.")
+
+
+def _cmd_models() -> None:
+    hw = detect_hardware()
+    if hw is None:
+        _safe_print(
+            "Apple Silicon not detected. Local models require an Apple Silicon Mac."
+        )
+        sys.exit(1)
+
+    ram_gb = hw["ram_gb"]
+    _safe_print(f"Hardware: {hw['chip']} / {ram_gb} GB")
+    _safe_print()
+
+    models = recommend_models(ram_gb)
+    if not models:
+        _safe_print("No compatible models found for your hardware.")
+        return
+
+    _safe_print("Recommended models:")
+    _safe_print()
+    installed = installed_model_ids([m["id"] for m in models])
+    for idx, m in enumerate(models):
+        tags = []
+        if idx == 0:
+            tags.append("recommended")
+        if m["id"] in installed:
+            tags.append("installed")
+        tag_text = f" [{' | '.join(tags)}]" if tags else ""
+        _safe_print(f"  {m['name']:<40s} {m['description']}{tag_text}")
+        _safe_print(f"  {m['id']}")
+        _safe_print(f"  Requires: {m['min_ram_gb']}+ GB RAM")
+        _safe_print()
+
+
+def local_command(args: object) -> None:
+    subcmd = getattr(args, "local_command", None)
+
+    if subcmd is None or subcmd == "status":
+        _cmd_status()
+    elif subcmd == "start":
+        _cmd_start()
+    elif subcmd == "stop":
+        _cmd_stop()
+    elif subcmd == "models":
+        _cmd_models()
+    else:
+        _cmd_status()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1095,6 +1095,7 @@ def _model_flow_local(config, current_model=""):
         install_mlx_lm,
         recommend_models,
         installed_model_ids,
+        list_cached_model_ids,
         start_server,
     )
 
@@ -1112,19 +1113,26 @@ def _model_flow_local(config, current_model=""):
     print(f"Hardware detected: {hw['chip']} / {hw['ram_gb']}GB")
     print()
 
-    model_ids = [m["id"] for m in recommended]
-    installed = installed_model_ids(model_ids)
-    if installed:
+    recommended_ids = [m["id"] for m in recommended]
+    installed_recommended = installed_model_ids(recommended_ids)
+    installed_all = set(list_cached_model_ids())
+    installed_extra = sorted(installed_all - set(recommended_ids))
+
+    selectable_model_ids = recommended_ids + installed_extra
+
+    if installed_recommended or installed_extra:
         print("Installed models detected:")
-        for mid in model_ids:
-            if mid in installed:
+        for mid in recommended_ids:
+            if mid in installed_recommended:
                 print(f"  - {mid}")
+        for mid in installed_extra:
+            print(f"  - {mid} (not in recommendations)")
         print()
 
-    print(f"Recommended for this hardware: {model_ids[0]}")
+    print(f"Recommended for this hardware: {recommended_ids[0]}")
     print()
 
-    selected = _prompt_model_selection(model_ids, current_model=current_model)
+    selected = _prompt_model_selection(selectable_model_ids, current_model=current_model)
     if not selected:
         print("No change.")
         return

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -528,6 +528,12 @@ def cmd_gateway(args):
     gateway_command(args)
 
 
+def cmd_local(args):
+    """Local MLX server management commands."""
+    from hermes_cli.local_provider import local_command
+    local_command(args)
+
+
 def cmd_whatsapp(args):
     """Set up WhatsApp: choose mode, configure, install bridge, pair via QR."""
     import os
@@ -765,6 +771,7 @@ def cmd_model(args):
         "openrouter": "OpenRouter",
         "nous": "Nous Portal",
         "openai-codex": "OpenAI Codex",
+        "local": "Local (Apple Silicon)",
         "anthropic": "Anthropic",
         "zai": "Z.AI / GLM",
         "kimi-coding": "Kimi / Moonshot",
@@ -784,6 +791,7 @@ def cmd_model(args):
         ("openrouter", "OpenRouter (100+ models, pay-per-use)"),
         ("nous", "Nous Portal (Nous Research subscription)"),
         ("openai-codex", "OpenAI Codex"),
+        ("local", "Local (Apple Silicon)"),
         ("anthropic", "Anthropic (Claude models — API key or Claude Code)"),
         ("zai", "Z.AI / GLM (Zhipu AI direct API)"),
         ("kimi-coding", "Kimi / Moonshot (Moonshot AI direct API)"),
@@ -849,6 +857,8 @@ def cmd_model(args):
         _model_flow_openai_codex(config, current_model)
     elif selected_provider == "custom":
         _model_flow_custom(config)
+    elif selected_provider == "local":
+        _model_flow_local(config, current_model)
     elif selected_provider.startswith("custom:") and selected_provider in _custom_provider_map:
         _model_flow_named_custom(config, _custom_provider_map[selected_provider])
     elif selected_provider == "remove-custom":
@@ -1074,6 +1084,104 @@ def _model_flow_openai_codex(config, current_model=""):
         print("No change.")
 
 
+def _model_flow_local(config, current_model=""):
+    """Local Apple Silicon provider: pick model, ensure server, and activate."""
+    from hermes_cli.auth import _prompt_model_selection, _save_model_choice, deactivate_provider
+    from hermes_cli.config import load_config, save_config, get_env_value, save_env_value
+    from hermes_cli.local_provider import (
+        DEFAULT_PORT,
+        check_mlx_lm_installed,
+        detect_hardware,
+        install_mlx_lm,
+        recommend_models,
+        installed_model_ids,
+        start_server,
+    )
+
+    hw = detect_hardware()
+    if hw is None:
+        print("Local provider requires an Apple Silicon Mac (M1/M2/M3/M4).")
+        return
+
+    recommended = recommend_models(hw["ram_gb"])
+    if not recommended:
+        print("No compatible local models found for this hardware.")
+        print("At least 8GB RAM is recommended for the smallest models.")
+        return
+
+    print(f"Hardware detected: {hw['chip']} / {hw['ram_gb']}GB")
+    print()
+
+    model_ids = [m["id"] for m in recommended]
+    installed = installed_model_ids(model_ids)
+    if installed:
+        print("Installed models detected:")
+        for mid in model_ids:
+            if mid in installed:
+                print(f"  - {mid}")
+        print()
+
+    print(f"Recommended for this hardware: {model_ids[0]}")
+    print()
+
+    selected = _prompt_model_selection(model_ids, current_model=current_model)
+    if not selected:
+        print("No change.")
+        return
+
+    if not check_mlx_lm_installed():
+        try:
+            install = input("mlx-lm is not installed. Install now? [Y/n]: ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            print("Cancelled.")
+            return
+        if install in ("", "y", "yes"):
+            print("Installing mlx-lm...")
+            if not install_mlx_lm():
+                print("Failed to install mlx-lm. Try: pip install mlx-lm")
+                return
+            print("mlx-lm installed.")
+        else:
+            print("Cancelled.")
+            return
+
+    print(f"Starting local server with {selected}...")
+    print("(first run may download model weights)")
+    try:
+        result = start_server(selected, DEFAULT_PORT)
+    except (RuntimeError, TimeoutError) as exc:
+        print(f"Failed to start local server: {exc}")
+        print("You can start it manually later with: hermes local start")
+        return
+
+    if result.get("reused"):
+        print(f"Local server already running (pid {result['pid']}).")
+    else:
+        print(f"Local server started (pid {result['pid']}) on port {DEFAULT_PORT}.")
+
+    if get_env_value("OPENAI_BASE_URL"):
+        save_env_value("OPENAI_BASE_URL", "")
+        save_env_value("OPENAI_API_KEY", "")
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = "local"
+    model["base_url"] = f"http://localhost:{DEFAULT_PORT}/v1"
+    cfg["local"] = {
+        "model_id": selected,
+        "port": DEFAULT_PORT,
+        "auto_start": True,
+    }
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via Local Apple Silicon)")
 
 def _model_flow_custom(config):
     """Custom endpoint: collect URL, API key, and model name.
@@ -2147,7 +2255,7 @@ def _coalesce_session_name_args(argv: list) -> list:
     _SUBCOMMANDS = {
         "chat", "model", "gateway", "setup", "whatsapp", "login", "logout",
         "status", "cron", "doctor", "config", "pairing", "skills", "tools",
-        "sessions", "insights", "version", "update", "uninstall",
+        "sessions", "insights", "version", "update", "uninstall", "local",
     }
     _SESSION_FLAGS = {"-c", "--continue", "-r", "--resume"}
 
@@ -2370,7 +2478,24 @@ For more help on a command:
     gateway_setup = gateway_subparsers.add_parser("setup", help="Configure messaging platforms")
 
     gateway_parser.set_defaults(func=cmd_gateway)
-    
+
+    # =========================================================================
+    # local command
+    # =========================================================================
+    local_parser = subparsers.add_parser(
+        "local",
+        help="Local MLX server management",
+        description="Manage the local MLX inference server (Apple Silicon)",
+    )
+    local_subparsers = local_parser.add_subparsers(dest="local_command")
+
+    local_subparsers.add_parser("status", help="Show local server status")
+    local_subparsers.add_parser("start", help="Start local server")
+    local_subparsers.add_parser("stop", help="Stop local server")
+    local_subparsers.add_parser("models", help="List recommended models for your hardware")
+
+    local_parser.set_defaults(func=cmd_local)
+
     # =========================================================================
     # setup command
     # =========================================================================

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -84,6 +84,7 @@ _PROVIDER_LABELS = {
     "openrouter": "OpenRouter",
     "openai-codex": "OpenAI Codex",
     "nous": "Nous Portal",
+    "local": "Local (Apple Silicon)",
     "zai": "Z.AI / GLM",
     "kimi-coding": "Kimi / Moonshot",
     "minimax": "MiniMax",
@@ -103,6 +104,9 @@ _PROVIDER_ALIASES = {
     "minimax_cn": "minimax-cn",
     "claude": "anthropic",
     "claude-code": "anthropic",
+    "mlx": "local",
+    "apple-silicon": "local",
+    "apple_silicon": "local",
 }
 
 
@@ -135,7 +139,7 @@ def list_available_providers() -> list[dict[str, str]]:
     """
     # Canonical providers in display order
     _PROVIDER_ORDER = [
-        "openrouter", "nous", "openai-codex",
+        "openrouter", "nous", "openai-codex", "local",
         "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic",
     ]
     # Build reverse alias map

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -128,6 +128,36 @@ def resolve_runtime_provider(
         explicit_base_url=explicit_base_url,
     )
 
+    if provider == "local":
+        from hermes_cli.local_provider import (
+            DEFAULT_PORT,
+            check_mlx_lm_installed,
+            ensure_server,
+        )
+
+        local_cfg = load_config().get("local", {})
+        port = local_cfg.get("port", DEFAULT_PORT)
+        model_id = local_cfg.get("model_id")
+        auto_start = local_cfg.get("auto_start", True)
+
+        if auto_start and model_id and check_mlx_lm_installed():
+            try:
+                ensure_server(model_id, port)
+            except Exception:
+                pass
+
+        base_url = f"http://localhost:{port}/v1"
+        return {
+            "provider": "local",
+            "api_mode": "chat_completions",
+            "base_url": base_url,
+            # Local inference does not need a real API key; keep a non-empty
+            # sentinel so shared runtime credential checks pass.
+            "api_key": "***",
+            "source": "local",
+            "requested_provider": requested_provider,
+        }
+
     if provider == "nous":
         creds = resolve_nous_runtime_credentials(
             min_key_ttl_seconds=max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -973,6 +973,7 @@ def setup_model_provider(config: dict):
                 install_mlx_lm,
                 start_server,
                 installed_model_ids,
+                list_cached_model_ids,
                 DEFAULT_PORT,
             )
 
@@ -982,33 +983,53 @@ def setup_model_provider(config: dict):
                 print_info("You need at least 8GB RAM for the smallest model.")
                 selected_provider = None
             else:
-                installed = installed_model_ids([m["id"] for m in recommended])
-                if installed:
-                    print_info(f"Detected {len(installed)} installed model(s) in local cache.")
+                recommended_ids = [m["id"] for m in recommended]
+                installed_recommended = installed_model_ids(recommended_ids)
+                installed_all = set(list_cached_model_ids())
+                installed_extra = sorted(installed_all - set(recommended_ids))
+                installed_any = installed_recommended | set(installed_extra)
+                if installed_any:
+                    print_info(
+                        f"Detected {len(installed_any)} installed model(s) in local cache."
+                    )
+
+                model_entries = list(recommended)
+                for mid in installed_extra:
+                    model_entries.append(
+                        {
+                            "id": mid,
+                            "name": mid,
+                            "description": "Installed local model (not in recommendations)",
+                            "min_ram_gb": 0,
+                        }
+                    )
 
                 model_choices = []
-                for idx, m in enumerate(recommended):
+                for idx, m in enumerate(model_entries):
                     tags = []
                     if idx == 0:
                         tags.append("recommended")
-                    if m["id"] in installed:
+                    if m["id"] in installed_any:
                         tags.append("installed")
                     tag_text = f" [{' | '.join(tags)}]" if tags else ""
-                    model_choices.append(
-                        f"{m['name']} — {m['description']}{tag_text} (needs {m['min_ram_gb']}GB+ RAM)"
-                    )
+                    if m["id"] in installed_extra:
+                        model_choices.append(f"{m['name']} — {m['description']}{tag_text}")
+                    else:
+                        model_choices.append(
+                            f"{m['name']} — {m['description']}{tag_text} (needs {m['min_ram_gb']}GB+ RAM)"
+                        )
                 model_choices.append("Custom MLX model (enter HuggingFace ID)")
 
                 default_model_idx = next(
-                    (i for i, m in enumerate(recommended) if m["id"] in installed),
+                    (i for i, m in enumerate(model_entries) if m["id"] in installed_any),
                     0,
                 )
                 model_idx = prompt_choice(
                     "Select a model to run locally:", model_choices, default_model_idx
                 )
 
-                if model_idx < len(recommended):
-                    local_model_id = recommended[model_idx]["id"]
+                if model_idx < len(model_entries):
+                    local_model_id = model_entries[model_idx]["id"]
                 else:
                     local_model_id = prompt("  HuggingFace model ID (e.g. mlx-community/...)")
                     if not local_model_id:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -14,6 +14,7 @@ Config files are stored in ~/.hermes/ for easy access.
 import importlib.util
 import logging
 import os
+import shutil
 import sys
 from pathlib import Path
 from typing import Optional, Dict, Any
@@ -176,6 +177,21 @@ def print_error(text: str):
     print(color(f"✗ {text}", Colors.RED))
 
 
+def _terminal_columns(default: int = 120) -> int:
+    """Best-effort terminal width detection for menu rendering."""
+    try:
+        return max(40, shutil.get_terminal_size(fallback=(default, 24)).columns)
+    except Exception:
+        return default
+
+
+def _truncate_menu_text(text: str, max_width: int) -> str:
+    """Prevent wrapped menu entries, which can glitch simple_term_menu redraws."""
+    if max_width <= 5 or len(text) <= max_width:
+        return text
+    return text[: max_width - 1] + "…"
+
+
 def prompt(question: str, default: str = None, password: bool = False) -> str:
     """Prompt for input with optional default."""
     if default:
@@ -218,6 +234,9 @@ def prompt_choice(question: str, choices: list, default: int = 0) -> int:
             flags=re.UNICODE,
         )
         menu_choices = [f"  {_emoji_re.sub('', choice).strip()}" for choice in choices]
+        # Keep entries on one line; wrapped entries can visually corrupt redraw.
+        max_item_width = _terminal_columns() - 6
+        menu_choices = [_truncate_menu_text(c, max_item_width) for c in menu_choices]
 
         print_info("  ↑/↓ Navigate  Enter Select  Esc Skip  Ctrl+C Exit")
 
@@ -330,6 +349,9 @@ def prompt_checklist(title: str, items: list, pre_selected: list = None) -> list
             flags=re.UNICODE,
         )
         menu_items = [f"  {_emoji_re.sub('', item).strip()}" for item in items]
+        # Keep entries on one line; wrapped entries can visually corrupt redraw.
+        max_item_width = _terminal_columns() - 6
+        menu_items = [_truncate_menu_text(i, max_item_width) for i in menu_items]
 
         # Map pre-selected indices to the actual menu entry strings
         preselected = [menu_items[i] for i in pre_selected if i < len(menu_items)]

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -691,17 +691,30 @@ def setup_model_provider(config: dict):
     else:
         keep_label = None  # No provider configured — don't show "Keep current"
 
+    from hermes_cli.local_provider import detect_hardware
+
+    hw = detect_hardware()
+    local_available = hw is not None
+
     provider_choices = [
         "Login with Nous Portal (Nous Research subscription — OAuth)",
         "Login with OpenAI Codex",
         "OpenRouter API key (100+ models, pay-per-use)",
         "Custom OpenAI-compatible endpoint (self-hosted / VLLM / etc.)",
+    ]
+    if local_available:
+        provider_choices.append(
+            f"Local (Apple Silicon) — run models on this Mac ({hw['chip']}, {hw['ram_gb']}GB)"
+        )
+    else:
+        provider_choices.append("Local (Apple Silicon) — requires Apple Silicon Mac")
+    provider_choices.extend([
         "Z.AI / GLM (Zhipu AI models)",
         "Kimi / Moonshot (Kimi coding models)",
         "MiniMax (global endpoint)",
         "MiniMax China (mainland China endpoint)",
         "Anthropic (Claude models — API key or Claude Code subscription)",
-    ]
+    ])
     if keep_label:
         provider_choices.append(keep_label)
 
@@ -920,7 +933,141 @@ def setup_model_provider(config: dict):
 
         print_success("Custom endpoint configured")
 
-    elif provider_idx == 4:  # Z.AI / GLM
+    elif provider_idx == 4:  # Local (Apple Silicon)
+        if not local_available:
+            print_error("Local provider requires an Apple Silicon Mac (M1/M2/M3/M4).")
+            print_info("Choose a different provider.")
+            selected_provider = None
+        else:
+            selected_provider = "local"
+            print()
+            print_header("Local (Apple Silicon)")
+            print_info(f"Chip: {hw['chip']}  RAM: {hw['ram_gb']}GB")
+            print()
+
+            from hermes_cli.local_provider import (
+                recommend_models,
+                check_mlx_lm_installed,
+                install_mlx_lm,
+                start_server,
+                installed_model_ids,
+                DEFAULT_PORT,
+            )
+
+            recommended = recommend_models(hw["ram_gb"])
+            if not recommended:
+                print_error("Not enough RAM for any recommended model.")
+                print_info("You need at least 8GB RAM for the smallest model.")
+                selected_provider = None
+            else:
+                installed = installed_model_ids([m["id"] for m in recommended])
+                if installed:
+                    print_info(f"Detected {len(installed)} installed model(s) in local cache.")
+
+                model_choices = []
+                for idx, m in enumerate(recommended):
+                    tags = []
+                    if idx == 0:
+                        tags.append("recommended")
+                    if m["id"] in installed:
+                        tags.append("installed")
+                    tag_text = f" [{' | '.join(tags)}]" if tags else ""
+                    model_choices.append(
+                        f"{m['name']} — {m['description']}{tag_text} (needs {m['min_ram_gb']}GB+ RAM)"
+                    )
+                model_choices.append("Custom MLX model (enter HuggingFace ID)")
+
+                default_model_idx = next(
+                    (i for i, m in enumerate(recommended) if m["id"] in installed),
+                    0,
+                )
+                model_idx = prompt_choice(
+                    "Select a model to run locally:", model_choices, default_model_idx
+                )
+
+                if model_idx < len(recommended):
+                    local_model_id = recommended[model_idx]["id"]
+                else:
+                    local_model_id = prompt("  HuggingFace model ID (e.g. mlx-community/...)")
+                    if not local_model_id:
+                        print_warning("No model specified.")
+                        selected_provider = None
+
+                if selected_provider == "local" and local_model_id:
+                    if not check_mlx_lm_installed():
+                        print()
+                        print_warning("mlx-lm is not installed (required for local inference).")
+                        if prompt_yes_no("Install mlx-lm now?", True):
+                            print_info("Installing mlx-lm (this may take a minute)...")
+                            if install_mlx_lm():
+                                print_success("mlx-lm installed")
+                            else:
+                                print_error("Failed to install mlx-lm.")
+                                print_info("Try manually: pip install mlx-lm")
+                                selected_provider = None
+                        else:
+                            print_warning("Skipped — local provider won't work without mlx-lm.")
+                            selected_provider = None
+
+                if selected_provider == "local" and local_model_id:
+                    port = DEFAULT_PORT
+                    print()
+                    print_info(f"Starting local server with {local_model_id}...")
+                    print_info("(First run downloads the model — this may take a few minutes)")
+                    print()
+
+                    try:
+                        result = start_server(local_model_id, port)
+                        if result["reused"]:
+                            print_success(f"Server already running (pid {result['pid']})")
+                        else:
+                            print_success(f"Server started (pid {result['pid']}) on port {port}")
+                    except (RuntimeError, TimeoutError) as exc:
+                        print_error(f"Failed to start server: {exc}")
+                        print_info("You can start it manually later with: hermes local start")
+                        selected_provider = None
+
+                if selected_provider == "local" and local_model_id:
+                    base_url = f"http://localhost:{port}/v1"
+                    _set_model_provider(config, "local", base_url)
+                    _set_default_model(config, local_model_id)
+                    config["local"] = {
+                        "model_id": local_model_id,
+                        "port": port,
+                        "auto_start": True,
+                    }
+                    save_env_value("LLM_MODEL", local_model_id)
+
+                    import yaml
+
+                    config_path = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "config.yaml"
+                    try:
+                        disk_cfg = {}
+                        if config_path.exists():
+                            disk_cfg = yaml.safe_load(config_path.read_text()) or {}
+                        model_section = disk_cfg.get("model", {})
+                        if isinstance(model_section, str):
+                            model_section = {"default": model_section}
+                        model_section["provider"] = "local"
+                        model_section["base_url"] = base_url
+                        model_section["default"] = local_model_id
+                        disk_cfg["model"] = model_section
+                        disk_cfg["local"] = {
+                            "model_id": local_model_id,
+                            "port": port,
+                            "auto_start": True,
+                        }
+                        config_path.write_text(yaml.safe_dump(disk_cfg, sort_keys=False))
+                    except Exception as e:
+                        logger.debug("Could not save local config: %s", e)
+
+                    if existing_custom:
+                        save_env_value("OPENAI_BASE_URL", "")
+                        save_env_value("OPENAI_API_KEY", "")
+
+                    print_success(f"Local provider configured: {local_model_id}")
+
+    elif provider_idx == 5:  # Z.AI / GLM
         selected_provider = "zai"
         print()
         print_header("Z.AI / GLM API Key")
@@ -981,7 +1128,7 @@ def setup_model_provider(config: dict):
         _update_config_for_provider("zai", zai_base_url, default_model="glm-5")
         _set_model_provider(config, "zai", zai_base_url)
 
-    elif provider_idx == 5:  # Kimi / Moonshot
+    elif provider_idx == 6:  # Kimi / Moonshot
         selected_provider = "kimi-coding"
         print()
         print_header("Kimi / Moonshot API Key")
@@ -1014,7 +1161,7 @@ def setup_model_provider(config: dict):
         _update_config_for_provider("kimi-coding", pconfig.inference_base_url, default_model="kimi-k2.5")
         _set_model_provider(config, "kimi-coding", pconfig.inference_base_url)
 
-    elif provider_idx == 6:  # MiniMax
+    elif provider_idx == 7:  # MiniMax
         selected_provider = "minimax"
         print()
         print_header("MiniMax API Key")
@@ -1047,7 +1194,7 @@ def setup_model_provider(config: dict):
         _update_config_for_provider("minimax", pconfig.inference_base_url, default_model="MiniMax-M2.5")
         _set_model_provider(config, "minimax", pconfig.inference_base_url)
 
-    elif provider_idx == 7:  # MiniMax China
+    elif provider_idx == 8:  # MiniMax China
         selected_provider = "minimax-cn"
         print()
         print_header("MiniMax China API Key")
@@ -1080,7 +1227,7 @@ def setup_model_provider(config: dict):
         _update_config_for_provider("minimax-cn", pconfig.inference_base_url, default_model="MiniMax-M2.5")
         _set_model_provider(config, "minimax-cn", pconfig.inference_base_url)
 
-    elif provider_idx == 8:  # Anthropic
+    elif provider_idx == 9:  # Anthropic
         selected_provider = "anthropic"
         print()
         print_header("Anthropic Authentication")
@@ -1184,7 +1331,7 @@ def setup_model_provider(config: dict):
         _update_config_for_provider("anthropic", "", default_model="claude-opus-4-6")
         _set_model_provider(config, "anthropic")
 
-    # else: provider_idx == 9 (Keep current) — only shown when a provider already exists
+    # else: provider_idx == 10 (Keep current) — only shown when a provider already exists
 
     # ── OpenRouter API Key for tools (if not already set) ──
     # Tools (vision, web, MoA) use OpenRouter independently of the main provider.
@@ -1193,6 +1340,7 @@ def setup_model_provider(config: dict):
         "nous",
         "openai-codex",
         "custom",
+        "local",
         "zai",
         "kimi-coding",
         "minimax",
@@ -1217,7 +1365,7 @@ def setup_model_provider(config: dict):
             )
 
     # ── Model Selection (adapts based on provider) ──
-    if selected_provider != "custom":  # Custom already prompted for model name
+    if selected_provider not in ("custom", "local"):  # These already prompted for model
         print_header("Default Model")
 
         _raw_model = config.get("model", "anthropic/claude-opus-4.6")

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -174,6 +174,7 @@ def test_local_setup_updates_llm_model_env(tmp_path, monkeypatch):
         ],
     )
     monkeypatch.setattr("hermes_cli.local_provider.installed_model_ids", lambda mids: set())
+    monkeypatch.setattr("hermes_cli.local_provider.list_cached_model_ids", lambda limit=200: [])
     monkeypatch.setattr("hermes_cli.local_provider.check_mlx_lm_installed", lambda: True)
     monkeypatch.setattr(
         "hermes_cli.local_provider.start_server",
@@ -191,3 +192,54 @@ def test_local_setup_updates_llm_model_env(tmp_path, monkeypatch):
     assert reloaded["local"]["port"] == 8899
     assert reloaded["local"]["auto_start"] is True
     assert get_env_value("LLM_MODEL") == "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit"
+
+
+def test_local_setup_allows_selecting_cached_non_recommended_model(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+    config = load_config()
+
+    # provider=local, model index=1 (cached non-recommended model)
+    prompt_choices = iter([4, 1])
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt_choice",
+        lambda *args, **kwargs: next(prompt_choices),
+    )
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: True)
+
+    monkeypatch.setattr(
+        "hermes_cli.local_provider.detect_hardware",
+        lambda: {"chip": "Apple M4", "ram_gb": 64.0},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.local_provider.recommend_models",
+        lambda ram_gb: [
+            {
+                "id": "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
+                "name": "Qwen 2.5 Coder 7B (4-bit)",
+                "description": "Good coding, fast",
+                "min_ram_gb": 8,
+            }
+        ],
+    )
+    monkeypatch.setattr("hermes_cli.local_provider.installed_model_ids", lambda mids: set())
+    monkeypatch.setattr(
+        "hermes_cli.local_provider.list_cached_model_ids",
+        lambda limit=200: ["mlx-community/My-Custom-Model-4bit"],
+    )
+    monkeypatch.setattr("hermes_cli.local_provider.check_mlx_lm_installed", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.local_provider.start_server",
+        lambda model_id, port: {"pid": 1234, "reused": True},
+    )
+
+    setup_model_provider(config)
+    save_config(config)
+
+    reloaded = load_config()
+    assert reloaded["model"]["provider"] == "local"
+    assert reloaded["model"]["default"] == "mlx-community/My-Custom-Model-4bit"
+    assert reloaded["local"]["model_id"] == "mlx-community/My-Custom-Model-4bit"
+    assert get_env_value("LLM_MODEL") == "mlx-community/My-Custom-Model-4bit"

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -1,7 +1,7 @@
 import json
 
 from hermes_cli.auth import _update_config_for_provider, get_active_provider
-from hermes_cli.config import load_config, save_config
+from hermes_cli.config import load_config, save_config, get_env_value
 from hermes_cli.setup import setup_model_provider
 
 
@@ -42,7 +42,7 @@ def test_nous_oauth_setup_keeps_current_model_when_syncing_disk_provider(
         "hermes_cli.auth.resolve_nous_runtime_credentials",
         lambda *args, **kwargs: {
             "base_url": "https://inference.example.com/v1",
-            "api_key": "nous-key",
+            "api_key": "nous-test-key",
         },
     )
     monkeypatch.setattr(
@@ -142,3 +142,52 @@ def test_codex_setup_uses_runtime_access_token_for_live_model_list(tmp_path, mon
     assert reloaded["model"]["provider"] == "openai-codex"
     assert reloaded["model"]["default"] == "gpt-5.2-codex"
     assert reloaded["model"]["base_url"] == "https://chatgpt.com/backend-api/codex"
+
+
+def test_local_setup_updates_llm_model_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+    config = load_config()
+
+    prompt_choices = iter([4, 0])  # provider=local, model=first recommended
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt_choice",
+        lambda *args, **kwargs: next(prompt_choices),
+    )
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: True)
+
+    monkeypatch.setattr(
+        "hermes_cli.local_provider.detect_hardware",
+        lambda: {"chip": "Apple M4", "ram_gb": 64.0},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.local_provider.recommend_models",
+        lambda ram_gb: [
+            {
+                "id": "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
+                "name": "Qwen 2.5 Coder 7B (4-bit)",
+                "description": "Good coding, fast",
+                "min_ram_gb": 8,
+            }
+        ],
+    )
+    monkeypatch.setattr("hermes_cli.local_provider.installed_model_ids", lambda mids: set())
+    monkeypatch.setattr("hermes_cli.local_provider.check_mlx_lm_installed", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.local_provider.start_server",
+        lambda model_id, port: {"pid": 1234, "reused": True},
+    )
+
+    setup_model_provider(config)
+    save_config(config)
+
+    reloaded = load_config()
+    assert isinstance(reloaded["model"], dict)
+    assert reloaded["model"]["provider"] == "local"
+    assert reloaded["model"]["default"] == "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit"
+    assert reloaded["local"]["model_id"] == "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit"
+    assert reloaded["local"]["port"] == 8899
+    assert reloaded["local"]["auto_start"] is True
+    assert get_env_value("LLM_MODEL") == "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit"

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -194,19 +194,28 @@ def test_local_setup_updates_llm_model_env(tmp_path, monkeypatch):
     assert get_env_value("LLM_MODEL") == "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit"
 
 
-def test_local_setup_allows_selecting_cached_non_recommended_model(tmp_path, monkeypatch):
+def test_local_setup_includes_and_selects_non_curated_cached_model(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     _clear_provider_env(monkeypatch)
     monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
 
     config = load_config()
 
-    # provider=local, model index=1 (cached non-recommended model)
-    prompt_choices = iter([4, 1])
-    monkeypatch.setattr(
-        "hermes_cli.setup.prompt_choice",
-        lambda *args, **kwargs: next(prompt_choices),
-    )
+    captured_choices = {}
+
+    def _fake_prompt_choice(question, choices, default=0):
+        if "Select your inference provider" in question:
+            return next(i for i, choice in enumerate(choices) if "Local (Apple Silicon)" in choice)
+        if "Select a model to run locally" in question:
+            captured_choices["choices"] = choices
+            return next(
+                i
+                for i, choice in enumerate(choices)
+                if choice.startswith("mlx-community/Qwen2.5-Coder-7B-Instruct-4bit")
+            )
+        return default
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", _fake_prompt_choice)
     monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: True)
 
     monkeypatch.setattr(
@@ -217,17 +226,23 @@ def test_local_setup_allows_selecting_cached_non_recommended_model(tmp_path, mon
         "hermes_cli.local_provider.recommend_models",
         lambda ram_gb: [
             {
-                "id": "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
-                "name": "Qwen 2.5 Coder 7B (4-bit)",
-                "description": "Good coding, fast",
+                "id": "mlx-community/Hermes-3-Llama-3.1-8B-4bit",
+                "name": "Hermes 3 8B (4-bit)",
+                "description": "Stable Nous baseline",
                 "min_ram_gb": 8,
             }
         ],
     )
-    monkeypatch.setattr("hermes_cli.local_provider.installed_model_ids", lambda mids: set())
+    monkeypatch.setattr(
+        "hermes_cli.local_provider.installed_model_ids",
+        lambda mids: {"mlx-community/Hermes-3-Llama-3.1-8B-4bit"},
+    )
     monkeypatch.setattr(
         "hermes_cli.local_provider.list_cached_model_ids",
-        lambda limit=200: ["mlx-community/My-Custom-Model-4bit"],
+        lambda limit=200: [
+            "mlx-community/Hermes-3-Llama-3.1-8B-4bit",
+            "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
+        ],
     )
     monkeypatch.setattr("hermes_cli.local_provider.check_mlx_lm_installed", lambda: True)
     monkeypatch.setattr(
@@ -239,7 +254,10 @@ def test_local_setup_allows_selecting_cached_non_recommended_model(tmp_path, mon
     save_config(config)
 
     reloaded = load_config()
+    assert any(
+        choice.startswith("mlx-community/Qwen2.5-Coder-7B-Instruct-4bit")
+        for choice in captured_choices["choices"]
+    )
     assert reloaded["model"]["provider"] == "local"
-    assert reloaded["model"]["default"] == "mlx-community/My-Custom-Model-4bit"
-    assert reloaded["local"]["model_id"] == "mlx-community/My-Custom-Model-4bit"
-    assert get_env_value("LLM_MODEL") == "mlx-community/My-Custom-Model-4bit"
+    assert reloaded["model"]["default"] == "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit"
+    assert reloaded["local"]["model_id"] == "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit"


### PR DESCRIPTION
## What does this PR do?

Adds a first-class "Local (Apple Silicon)" provider to Hermes Agent. Users can now run `hermes model`, select Local, and get fully local inference via MLX — zero cloud, zero API keys, zero manual configuration.

## How it works

- Detects Apple Silicon hardware and available RAM
- Recommends models from mlx-community that fit the user's machine
- Downloads models automatically from HuggingFace
- Starts and manages an mlx-lm inference server as a background process
- Configures Hermes to use the local endpoint
- Auto-starts the server on subsequent Hermes launches

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a new Local (Apple Silicon) provider path across CLI setup/model flows, with end-to-end local MLX server support.                  
- Added a dedicated local provider module for:
    - Apple Silicon hardware detection
    - RAM-based model recommendations
    - local model cache detection
    - mlx-lm installation checks/install helper
    - local server lifecycle management (start/stop/status/ensure)
    - PID/log tracking for server process state
    - local CLI subcommands (status/start/stop/models)

- Added new CLI command group:
    - hermes local status
    - hermes local start
    - hermes local stop
    - hermes local models

- Wired local provider into model/provider selection and runtime resolution:                                                               
    - provider registry entry for local in hermes_cli/auth.py
    - provider labels/order/aliases in hermes_cli/models.py
    - local branch in runtime provider resolution with auto-start behavior in hermes_cli/runtime_provider.py
    - local provider flow in model selection in hermes_cli/main.py
    - local provider path in setup wizard (including model pick + server bootstrap + config/env updates) in hermes_cli/setup.py

- Added test coverage for local setup config/env behavior:                                                                                 
    - tests/hermes_cli/test_setup.py::test_local_setup_updates_llm_model_env                                                                 

## Changed files:

- hermes_cli/auth.py
- hermes_cli/local_provider.py (new)
- hermes_cli/main.py
- hermes_cli/models.py
- hermes_cli/runtime_provider.py
- hermes_cli/setup.py
- tests/hermes_cli/test_setup.py

## How to Test

1. Run unit test coverage for the local setup path:
- pytest tests/hermes_cli/test_setup.py -k local_setup_updates_llm_model_env

2. Verify new local command surface exists:
- hermes local --help
- hermes local status
- hermes local models

3. On Apple Silicon Mac, run interactive provider setup and select Local (Apple Silicon):
- hermes setup
    - choose Local (Apple Silicon), select a recommended model, allow mlx-lm install if prompted

4. Validate config/env were updated and local server management works:
- confirm config has:
    - model.provider = local
    - model.base_url = http://localhost:8899/v1
    - local.model_id set
    - local.port = 8899
    - local.auto_start = true
- run:
    - hermes local status
    - hermes local start
    - hermes local stop

5. Smoke test chat execution after local provider setup:
- hermes chat -q "hello"
- confirm request runs through local provider configuration without remote provider auth prompts.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!--  macOS 15.7.3 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

<img width="735" height="797" alt="image" src="https://github.com/user-attachments/assets/3dfca805-e749-41d6-91e9-efdff87500a9" />
<img width="851" height="276" alt="image" src="https://github.com/user-attachments/assets/821d330b-add4-432c-836a-6cc3af640338" />
