### PR TITLE
feat(stt): add configurable base_url for OpenAI Whisper STT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,11 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # Get at: https://platform.openai.com/api-keys
 VOICE_TOOLS_OPENAI_KEY=
 
+# Override the Whisper API base URL for compatible endpoints (e.g., Gladia proxy,
+# local whisper-webservice, or any OpenAI-compatible transcription service).
+# Can also be set via stt.openai.base_url in config.yaml.
+# STT_OPENAI_BASE_URL=https://api.openai.com/v1
+
 # =============================================================================
 # SLACK INTEGRATION
 # =============================================================================

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -584,6 +584,13 @@ toolsets:
 stt:
   enabled: true
   model: "whisper-1"  # whisper-1 (cheapest) | gpt-4o-mini-transcribe | gpt-4o-transcribe
+  # OpenAI provider settings:
+  # openai:
+  #   base_url: "https://api.openai.com/v1"  # Override for Whisper-compatible endpoints
+  #   # Examples:
+  #   #   http://127.0.0.1:9100/v1   — local Gladia/whisper proxy
+  #   #   http://localhost:8080/v1    — whisper-webservice or similar
+  #   # Can also be set via STT_OPENAI_BASE_URL environment variable.
 
 # =============================================================================
 # Response Pacing (Messaging Platforms)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -200,6 +200,7 @@ DEFAULT_CONFIG = {
         },
         "openai": {
             "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe
+            # "base_url": "https://api.openai.com/v1",  # Override for compatible endpoints
         },
     },
     

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -170,6 +170,90 @@ class TestTranscribeOpenAI:
         assert result["success"] is True
         assert result["transcript"] == "Hello from OpenAI"
 
+    def test_default_base_url(self, monkeypatch, tmp_path):
+        """Default base_url should be OpenAI when no override is set."""
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        monkeypatch.delenv("STT_OPENAI_BASE_URL", raising=False)
+        audio_file = tmp_path / "test.ogg"
+        audio_file.write_bytes(b"fake audio")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "ok"
+        mock_openai_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools.OpenAI", mock_openai_cls):
+            from tools.transcription_tools import _transcribe_openai
+            _transcribe_openai(str(audio_file), "whisper-1")
+
+        mock_openai_cls.assert_called_once_with(
+            api_key="sk-test", base_url="https://api.openai.com/v1"
+        )
+
+    def test_base_url_from_config(self, monkeypatch, tmp_path):
+        """stt.openai.base_url in config should override the default."""
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        monkeypatch.delenv("STT_OPENAI_BASE_URL", raising=False)
+        audio_file = tmp_path / "test.ogg"
+        audio_file.write_bytes(b"fake audio")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "ok"
+        mock_openai_cls = MagicMock(return_value=mock_client)
+
+        stt_config = {"openai": {"base_url": "http://127.0.0.1:9100/v1"}}
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools.OpenAI", mock_openai_cls):
+            from tools.transcription_tools import _transcribe_openai
+            _transcribe_openai(str(audio_file), "whisper-1", stt_config=stt_config)
+
+        mock_openai_cls.assert_called_once_with(
+            api_key="sk-test", base_url="http://127.0.0.1:9100/v1"
+        )
+
+    def test_base_url_from_env(self, monkeypatch, tmp_path):
+        """STT_OPENAI_BASE_URL env var should override the default."""
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        monkeypatch.setenv("STT_OPENAI_BASE_URL", "http://localhost:8080/v1")
+        audio_file = tmp_path / "test.ogg"
+        audio_file.write_bytes(b"fake audio")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "ok"
+        mock_openai_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools.OpenAI", mock_openai_cls):
+            from tools.transcription_tools import _transcribe_openai
+            _transcribe_openai(str(audio_file), "whisper-1")
+
+        mock_openai_cls.assert_called_once_with(
+            api_key="sk-test", base_url="http://localhost:8080/v1"
+        )
+
+    def test_config_base_url_takes_precedence_over_env(self, monkeypatch, tmp_path):
+        """Config base_url should win over env var."""
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        monkeypatch.setenv("STT_OPENAI_BASE_URL", "http://env-url/v1")
+        audio_file = tmp_path / "test.ogg"
+        audio_file.write_bytes(b"fake audio")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "ok"
+        mock_openai_cls = MagicMock(return_value=mock_client)
+
+        stt_config = {"openai": {"base_url": "http://config-url/v1"}}
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools.OpenAI", mock_openai_cls):
+            from tools.transcription_tools import _transcribe_openai
+            _transcribe_openai(str(audio_file), "whisper-1", stt_config=stt_config)
+
+        mock_openai_cls.assert_called_once_with(
+            api_key="sk-test", base_url="http://config-url/v1"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Main transcribe_audio() dispatch

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -175,8 +175,18 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
-    """Transcribe using OpenAI Whisper API (paid)."""
+def _transcribe_openai(file_path: str, model_name: str, stt_config: Optional[dict] = None) -> Dict[str, Any]:
+    """Transcribe using OpenAI Whisper API or any compatible endpoint.
+
+    The base URL can be overridden via (in priority order):
+      1. ``stt.openai.base_url`` in config.yaml
+      2. ``STT_OPENAI_BASE_URL`` environment variable
+      3. Default: ``https://api.openai.com/v1``
+
+    This allows using alternative Whisper-compatible services such as
+    Gladia proxies, local whisper-webservice instances, or other
+    OpenAI-compatible transcription endpoints.
+    """
     api_key = os.getenv("VOICE_TOOLS_OPENAI_KEY")
     if not api_key:
         return {"success": False, "transcript": "", "error": "VOICE_TOOLS_OPENAI_KEY not set"}
@@ -184,8 +194,15 @@ def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
     if not _HAS_OPENAI:
         return {"success": False, "transcript": "", "error": "openai package not installed"}
 
+    openai_cfg = (stt_config or {}).get("openai", {})
+    base_url = (
+        openai_cfg.get("base_url")
+        or os.getenv("STT_OPENAI_BASE_URL")
+        or "https://api.openai.com/v1"
+    )
+
     try:
-        client = OpenAI(api_key=api_key, base_url="https://api.openai.com/v1")
+        client = OpenAI(api_key=api_key, base_url=base_url)
 
         with open(file_path, "rb") as audio_file:
             transcription = client.audio.transcriptions.create(
@@ -252,7 +269,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
     if provider == "openai":
         openai_cfg = stt_config.get("openai", {})
         model_name = model or openai_cfg.get("model", DEFAULT_OPENAI_MODEL)
-        return _transcribe_openai(file_path, model_name)
+        return _transcribe_openai(file_path, model_name, stt_config=stt_config)
 
     # No provider available
     return {


### PR DESCRIPTION
## Summary

- Add `stt.openai.base_url` config option and `STT_OPENAI_BASE_URL` env var to override the hardcoded `https://api.openai.com/v1` endpoint in the OpenAI Whisper STT provider
- Enables using Whisper-compatible transcription services (Gladia proxies, local whisper-webservice, faster-whisper-server, etc.) without code changes
- Priority: config.yaml > env var > default

## Motivation

The OpenAI Whisper base URL is currently hardcoded in `_transcribe_openai()`. Users running alternative Whisper-compatible endpoints (self-hosted or third-party) cannot use the `openai` STT provider without modifying source code. This is inconsistent with how other hermes components handle endpoint configuration.

## Changes

| File | Change |
|------|--------|
| `tools/transcription_tools.py` | Read `base_url` from config/env with fallback to default |
| `hermes_cli/config.py` | Add commented `base_url` to default STT config |
| `cli-config.yaml.example` | Document the new option with examples |
| `.env.example` | Document `STT_OPENAI_BASE_URL` env var |
| `tests/tools/test_transcription.py` | 4 new tests: default URL, config override, env override, config-takes-precedence |

## Test plan

- [x] All 22 transcription tests pass (`pytest tests/tools/test_transcription.py`)
- [x] New tests verify priority: config > env > default
- [x] Backward compatible — no behavior change without explicit configuration