### PR TITLE
fix: log prompt builder skill parsing fallbacks

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -177,7 +177,8 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
                 desc = desc[:57] + "..."
 
         return True, frontmatter, desc
-    except Exception:
+    except Exception as e:
+        logger.debug("Failed to parse skill file %s: %s", skill_file, e)
         return True, {}, ""
 
 
@@ -194,7 +195,8 @@ def _read_skill_conditions(skill_file: Path) -> dict:
             "fallback_for_tools": hermes.get("fallback_for_tools", []),
             "requires_tools": hermes.get("requires_tools", []),
         }
-    except Exception:
+    except Exception as e:
+        logger.debug("Failed to read skill conditions from %s: %s", skill_file, e)
         return {}
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib
+import logging
 import sys
 
 from agent.prompt_builder import (
@@ -143,6 +144,23 @@ class TestParseSkillFile:
         assert is_compat is True
         assert frontmatter == {}
         assert desc == ""
+
+    def test_logs_parse_failures_and_returns_defaults(self, tmp_path, monkeypatch, caplog):
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text("---\nname: broken\n---\n")
+
+        def boom(*args, **kwargs):
+            raise OSError("read exploded")
+
+        monkeypatch.setattr(type(skill_file), "read_text", boom)
+        with caplog.at_level(logging.DEBUG, logger="agent.prompt_builder"):
+            is_compat, frontmatter, desc = _parse_skill_file(skill_file)
+
+        assert is_compat is True
+        assert frontmatter == {}
+        assert desc == ""
+        assert "Failed to parse skill file" in caplog.text
+        assert str(skill_file) in caplog.text
 
     def test_incompatible_platform_returns_false(self, tmp_path):
         skill_file = tmp_path / "SKILL.md"
@@ -439,6 +457,21 @@ class TestReadSkillConditions:
     def test_missing_file_returns_empty(self, tmp_path):
         conditions = _read_skill_conditions(tmp_path / "missing.md")
         assert conditions == {}
+
+    def test_logs_condition_read_failures_and_returns_empty(self, tmp_path, monkeypatch, caplog):
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text("---\nname: broken\n---\n")
+
+        def boom(*args, **kwargs):
+            raise OSError("read exploded")
+
+        monkeypatch.setattr(type(skill_file), "read_text", boom)
+        with caplog.at_level(logging.DEBUG, logger="agent.prompt_builder"):
+            conditions = _read_skill_conditions(skill_file)
+
+        assert conditions == {}
+        assert "Failed to read skill conditions" in caplog.text
+        assert str(skill_file) in caplog.text
 
 
 class TestSkillShouldShow:


### PR DESCRIPTION
## Summary
- add debug logging for the remaining silent prompt_builder skill parsing fallbacks
- preserve the existing permissive return behavior when skill metadata cannot be read
- add regression tests covering both fallback paths and emitted debug logs

## Context
This replaces the still-relevant prompt_builder portion of #914, whose other logging changes were already superseded on main.

## Test plan
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/agent/test_prompt_builder.py -n0 -q
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/ -n0 -q
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m hermes_cli.main chat -q "Reply with OK only."