### PR TITLE
feat: add blocklist CLI and defaults

### DIFF
--- a/hermes_cli/blocklist.py
+++ b/hermes_cli/blocklist.py
@@ -1,0 +1,158 @@
+"""CLI helpers for user-managed web policy blocklists."""
+
+from __future__ import annotations
+
+from hermes_cli.config import load_config, save_config
+from tools.url_policy import explain_url, normalize_policy_host, refresh_subscriptions
+
+
+def _load_web_policy() -> dict:
+    cfg = load_config()
+    policy = cfg.setdefault(
+        "web_policy",
+        {
+            "enabled": True,
+            "local_blocks": [],
+            "local_exceptions": [],
+            "subscriptions": [],
+            "audit_blocked_attempts": False,
+        },
+    )
+    return cfg
+
+
+def _find_subscription_record(result: dict, source: str, list_id: str) -> dict | None:
+    for entry in result.get("subscriptions", []) or []:
+        if entry.get("source") == source and entry.get("list_id") == list_id:
+            return entry
+    return None
+
+
+def blocklist_command(args) -> None:
+    action = getattr(args, "blocklist_action", None)
+
+    if action == "add":
+        cfg = _load_web_policy()
+        host = normalize_policy_host(getattr(args, "host", ""))
+        if not host:
+            print("Error: invalid host")
+            return
+        blocks = cfg["web_policy"].setdefault("local_blocks", [])
+        if host in blocks:
+            print(f"Block already present: {host}")
+            return
+        blocks.append(host)
+        save_config(cfg)
+        print(f"Added block: {host}")
+        return
+
+    if action == "remove":
+        cfg = _load_web_policy()
+        host = normalize_policy_host(getattr(args, "host", ""))
+        if not host:
+            print("Error: invalid host")
+            return
+        blocks = cfg["web_policy"].setdefault("local_blocks", [])
+        updated = [item for item in blocks if item != host]
+        if len(updated) == len(blocks):
+            print(f"Block not found: {host}")
+            return
+        cfg["web_policy"]["local_blocks"] = updated
+        save_config(cfg)
+        print(f"Removed block: {host}")
+        return
+
+    if action == "subscribe":
+        cfg = _load_web_policy()
+        source = str(getattr(args, "source", "") or "").strip()
+        list_id = str(getattr(args, "list_id", "") or "").strip()
+        if not source or not list_id:
+            print("Error: subscribe requires source and list_id")
+            return
+        subscriptions = cfg["web_policy"].setdefault("subscriptions", [])
+        entry = {"source": source, "list_id": list_id}
+        already_present = entry in subscriptions
+        if not already_present:
+            subscriptions.append(entry)
+            save_config(cfg)
+        result = refresh_subscriptions()
+        subscription = _find_subscription_record(result, source, list_id)
+        prefix = "Already subscribed" if already_present else "Subscribed"
+        if subscription and subscription.get("error"):
+            print(
+                f"{prefix} to {list_id} from {source}, but refresh failed: "
+                f"{subscription['error']}"
+            )
+            return
+        print(f"{prefix} to {list_id} from {source}")
+        return
+
+    if action == "unsubscribe":
+        cfg = _load_web_policy()
+        source = str(getattr(args, "source", "") or "").strip()
+        list_id = str(getattr(args, "list_id", "") or "").strip()
+        subscriptions = cfg["web_policy"].setdefault("subscriptions", [])
+        updated = [
+            item
+            for item in subscriptions
+            if not (item.get("source") == source and item.get("list_id") == list_id)
+        ]
+        if len(updated) == len(subscriptions):
+            print(f"Subscription not found: {list_id} from {source}")
+            return
+        cfg["web_policy"]["subscriptions"] = updated
+        save_config(cfg)
+        print(f"Unsubscribed {list_id} from {source}")
+        return
+
+    if action == "why":
+        url = str(getattr(args, "url", "") or "").strip()
+        if not url:
+            print("Error: why requires a URL")
+            return
+        decision = explain_url(url)
+        print(f"allowed: {decision.allowed}")
+        print(f"decision_source: {decision.decision_source}")
+        print(f"reason: {decision.reason}")
+        if decision.rule_identity:
+            print(f"rule_identity: {decision.rule_identity}")
+        if decision.source_identity:
+            print(f"source_identity: {decision.source_identity}")
+        if decision.source_title:
+            print(f"source_title: {decision.source_title}")
+        return
+
+    if action == "update":
+        result = refresh_subscriptions()
+        error_count = sum(1 for entry in result.get("subscriptions", []) or [] if entry.get("error"))
+        print(
+            f"Refreshed {len(result.get('subscriptions', []))} subscription(s); "
+            f"{result.get('rule_count', 0)} rule(s) active; "
+            f"{error_count} error(s)."
+        )
+        return
+
+    if action == "list":
+        cfg = _load_web_policy()
+        policy = cfg["web_policy"]
+        print("Local blocks:")
+        blocks = policy.get("local_blocks", [])
+        if not blocks:
+            print("  (none)")
+        for host in blocks:
+            print(f"  - {host}")
+        print("Local exceptions:")
+        exceptions = policy.get("local_exceptions", [])
+        if not exceptions:
+            print("  (none)")
+        for host in exceptions:
+            print(f"  - {host}")
+        print("Subscriptions:")
+        subscriptions = policy.get("subscriptions", [])
+        if not subscriptions:
+            print("  (none)")
+        for entry in subscriptions:
+            print(f"  - {entry.get('list_id')} @ {entry.get('source')}")
+        return
+
+    print("Error: unknown blocklist action")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -114,6 +114,15 @@ DEFAULT_CONFIG = {
         "record_sessions": False,  # Auto-record browser sessions as WebM videos
     },
 
+    # Browser/web URL policy for local blocks, exceptions, and subscribed lists.
+    "web_policy": {
+        "enabled": True,
+        "local_blocks": [],
+        "local_exceptions": [],
+        "subscriptions": [],
+        "audit_blocked_attempts": False,
+    },
+
     # Filesystem checkpoints — automatic snapshots before destructive file ops.
     # When enabled, the agent takes a snapshot of the working directory once per
     # conversation turn (on first write_file/patch call).  Use /rollback to restore.
@@ -256,7 +265,7 @@ DEFAULT_CONFIG = {
     "personalities": {},
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 7,
+    "_config_version": 8,
 }
 
 # =============================================================================

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -18,6 +18,7 @@ Usage:
     hermes cron list           # List cron jobs
     hermes cron status         # Check if cron scheduler is running
     hermes doctor              # Check configuration and dependencies
+    hermes blocklist list      # Show web/browser blocklists and subscriptions
     hermes honcho setup                    # Configure Honcho AI memory integration
     hermes honcho status                   # Show Honcho config and connection status
     hermes honcho sessions                 # List directory → session name mappings
@@ -1819,6 +1820,12 @@ def cmd_config(args):
     config_command(args)
 
 
+def cmd_blocklist(args):
+    """Manage web/browser URL blocklists."""
+    from hermes_cli.blocklist import blocklist_command
+    blocklist_command(args)
+
+
 def cmd_version(args):
     """Show version."""
     print(f"Hermes Agent v{__version__} ({__release_date__})")
@@ -2143,7 +2150,7 @@ def _coalesce_session_name_args(argv: list) -> list:
     """
     _SUBCOMMANDS = {
         "chat", "model", "gateway", "setup", "whatsapp", "login", "logout",
-        "status", "cron", "doctor", "config", "pairing", "skills", "tools",
+        "status", "cron", "doctor", "config", "blocklist", "pairing", "skills", "tools",
         "sessions", "insights", "version", "update", "uninstall",
     }
     _SESSION_FLAGS = {"-c", "--continue", "-r", "--resume"}
@@ -2187,6 +2194,7 @@ Examples:
     hermes config                 View configuration
     hermes config edit            Edit config in $EDITOR
     hermes config set model gpt-4 Set a config value
+    hermes blocklist list         Show URL blocklists and subscriptions
     hermes gateway                Run messaging gateway
     hermes -w                     Start in isolated git worktree
     hermes gateway install        Install as system service
@@ -2567,6 +2575,44 @@ For more help on a command:
     config_migrate = config_subparsers.add_parser("migrate", help="Update config with new options")
     
     config_parser.set_defaults(func=cmd_config)
+
+    # =========================================================================
+    # blocklist command
+    # =========================================================================
+    blocklist_parser = subparsers.add_parser(
+        "blocklist",
+        help="Manage browser/web URL blocklists",
+        description="Manage local URL blocks, subscribed domain lists, and policy inspection",
+    )
+    blocklist_subparsers = blocklist_parser.add_subparsers(dest="blocklist_action")
+
+    blocklist_add = blocklist_subparsers.add_parser("add", help="Add a local blocked host")
+    blocklist_add.add_argument("host", help="Host or domain to block")
+
+    blocklist_remove = blocklist_subparsers.add_parser("remove", help="Remove a local blocked host")
+    blocklist_remove.add_argument("host", help="Host or domain to remove")
+
+    blocklist_subscribe = blocklist_subparsers.add_parser(
+        "subscribe",
+        help="Subscribe to a remote or local policy registry list",
+    )
+    blocklist_subscribe.add_argument("source", help="Registry URL or local path")
+    blocklist_subscribe.add_argument("list_id", help="List ID within the registry")
+
+    blocklist_unsubscribe = blocklist_subparsers.add_parser(
+        "unsubscribe",
+        help="Remove a subscribed policy list",
+    )
+    blocklist_unsubscribe.add_argument("source", help="Registry URL or local path")
+    blocklist_unsubscribe.add_argument("list_id", help="List ID within the registry")
+
+    blocklist_why = blocklist_subparsers.add_parser("why", help="Explain how a URL is classified")
+    blocklist_why.add_argument("url", help="URL to evaluate")
+
+    blocklist_subparsers.add_parser("update", help="Refresh subscribed policy lists")
+    blocklist_subparsers.add_parser("list", help="Show current local blocks and subscriptions")
+
+    blocklist_parser.set_defaults(func=cmd_blocklist)
     
     # =========================================================================
     # pairing command

--- a/tests/hermes_cli/test_blocklist.py
+++ b/tests/hermes_cli/test_blocklist.py
@@ -1,0 +1,149 @@
+"""Tests for the hermes blocklist CLI command."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from unittest.mock import patch
+
+from hermes_cli.config import load_config
+
+
+def test_add_blocklist_host_updates_config(capsys):
+    from hermes_cli.blocklist import blocklist_command
+
+    blocklist_command(Namespace(blocklist_action="add", host="Example.COM", source=None, list_id=None, url=None))
+
+    cfg = load_config()
+    assert cfg["web_policy"]["local_blocks"] == ["example.com"]
+    assert "example.com" in capsys.readouterr().out
+
+
+def test_subscribe_adds_deduplicated_subscription(capsys):
+    from hermes_cli.blocklist import blocklist_command
+
+    called = []
+    args = Namespace(
+        blocklist_action="subscribe",
+        host=None,
+        source="https://lists.example/index.yaml",
+        list_id="malware",
+        url=None,
+    )
+    from hermes_cli import blocklist as blocklist_mod
+    blocklist_mod.refresh_subscriptions = lambda: called.append("refresh") or {
+        "success": True,
+        "subscriptions": [],
+        "rule_count": 0,
+    }
+    blocklist_command(args)
+    blocklist_command(args)
+
+    cfg = load_config()
+    assert cfg["web_policy"]["subscriptions"] == [
+        {"source": "https://lists.example/index.yaml", "list_id": "malware"}
+    ]
+    assert called == ["refresh", "refresh"]
+    assert "malware" in capsys.readouterr().out
+
+
+def test_subscribe_reports_refresh_failure(capsys):
+    from hermes_cli.blocklist import blocklist_command
+
+    args = Namespace(
+        blocklist_action="subscribe",
+        host=None,
+        source="https://lists.example/index.yaml",
+        list_id="malware",
+        url=None,
+    )
+    from hermes_cli import blocklist as blocklist_mod
+    blocklist_mod.refresh_subscriptions = lambda: {
+        "success": True,
+        "subscriptions": [
+            {
+                "source": "https://lists.example/index.yaml",
+                "list_id": "malware",
+                "error": "network down",
+            }
+        ],
+        "rule_count": 0,
+    }
+
+    blocklist_command(args)
+
+    assert "refresh failed" in capsys.readouterr().out.lower()
+
+
+def test_remove_reports_not_found(capsys):
+    from hermes_cli.blocklist import blocklist_command
+
+    blocklist_command(Namespace(blocklist_action="remove", host="missing.example", source=None, list_id=None, url=None))
+
+    assert "not found" in capsys.readouterr().out.lower()
+
+
+def test_unsubscribe_reports_not_found(capsys):
+    from hermes_cli.blocklist import blocklist_command
+
+    blocklist_command(
+        Namespace(
+            blocklist_action="unsubscribe",
+            host=None,
+            source="https://lists.example/index.yaml",
+            list_id="malware",
+            url=None,
+        )
+    )
+
+    assert "not found" in capsys.readouterr().out.lower()
+
+
+def test_why_uses_explain_url(capsys, monkeypatch):
+    from hermes_cli.blocklist import blocklist_command
+    from tools.url_policy import PolicyDecision
+
+    monkeypatch.setattr(
+        "hermes_cli.blocklist.explain_url",
+        lambda url: PolicyDecision(
+            allowed=False,
+            requested_url=url,
+            normalized_url=url,
+            host="evil.example",
+            final_url=None,
+            decision_source="shared_list",
+            reason="blocked by shared_list",
+            rule_identity="remote|evil.example",
+            source_identity="remote#malware",
+            source_title="Malware",
+        ),
+    )
+
+    blocklist_command(
+        Namespace(
+            blocklist_action="why",
+            host=None,
+            source=None,
+            list_id=None,
+            url="https://evil.example",
+        )
+    )
+
+    out = capsys.readouterr().out
+    assert "shared_list" in out
+    assert "remote|evil.example" in out
+
+
+def test_main_routes_blocklist_command():
+    import hermes_cli.main as main_mod
+
+    with (
+        patch("hermes_cli.blocklist.blocklist_command") as mock_blocklist,
+        patch("sys.argv", ["hermes", "blocklist", "add", "Example.COM"]),
+    ):
+        main_mod.main()
+
+    mock_blocklist.assert_called_once()
+    args = mock_blocklist.call_args[0][0]
+    assert args.command == "blocklist"
+    assert args.blocklist_action == "add"
+    assert args.host == "Example.COM"

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -50,6 +50,7 @@ class TestLoadConfigDefaults:
             assert "max_turns" not in config
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
+            assert config["web_policy"] == DEFAULT_CONFIG["web_policy"]
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):


### PR DESCRIPTION
**PR Summary**  
- Adds the `web_policy` defaults and `_config_version` bump so CLI, gateway, and tooling know about the URL policy settings.  
- Implements a dedicated `hermes blocklist` command with `add/remove/subscribe/unsubscribe/update/list/why` subcommands and wiring in `hermes_cli/main.py`.  
- Ships `hermes_cli/blocklist.py` plus regression tests (`tests/hermes_cli/test_blocklist.py`) that cover the new routing and `tests/hermes_cli/test_config.py` now validates the `web_policy` defaults.

**Related issue**  
Fixes #1264 (browser/web policy CLI surfaced and documented via the blocklist command and config defaults).

**Testing**  
- `python -m pytest -o addopts='' tests/tools/test_url_policy.py tests/tools/test_web_policy_enforcement.py tests/hermes_cli/test_blocklist.py tests/hermes_cli/test_config.py tests/hermes_cli/test_skills_subparser.py -q` (pass)  
- Full `pytest tests/ -q` currently aborts during collection because `tests/run_interrupt_test.py` exits with `SystemExit(1)` (existing test behavior).