### PR TITLE
test: fix gateway async tests without implicit event loop

### DIFF
--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -17,6 +17,11 @@ from gateway.config import PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, SendResult
 
 
+def _run(coro):
+    """Run a coroutine in a fresh event loop for sync-style tests."""
+    return asyncio.run(coro)
+
+
 # ---------------------------------------------------------------------------
 # MEDIA: extraction tests for image files
 # ---------------------------------------------------------------------------
@@ -97,7 +102,7 @@ class TestTelegramSendImageFile:
         mock_msg.message_id = 42
         adapter._bot.send_photo = AsyncMock(return_value=mock_msg)
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _run(
             adapter.send_image_file(chat_id="12345", image_path=str(img))
         )
         assert result.success
@@ -110,7 +115,7 @@ class TestTelegramSendImageFile:
 
     def test_returns_error_when_file_missing(self, adapter):
         """send_image_file should return error for nonexistent file."""
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _run(
             adapter.send_image_file(chat_id="12345", image_path="/nonexistent/image.png")
         )
         assert not result.success
@@ -119,7 +124,7 @@ class TestTelegramSendImageFile:
     def test_returns_error_when_not_connected(self, adapter):
         """send_image_file should return error when bot is None."""
         adapter._bot = None
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _run(
             adapter.send_image_file(chat_id="12345", image_path="/tmp/img.png")
         )
         assert not result.success
@@ -135,7 +140,7 @@ class TestTelegramSendImageFile:
         adapter._bot.send_photo = AsyncMock(return_value=mock_msg)
 
         long_caption = "A" * 2000
-        asyncio.get_event_loop().run_until_complete(
+        _run(
             adapter.send_image_file(chat_id="12345", image_path=str(img), caption=long_caption)
         )
 
@@ -187,7 +192,7 @@ class TestDiscordSendImageFile:
         mock_channel.send = AsyncMock(return_value=mock_msg)
         adapter._client.get_channel = MagicMock(return_value=mock_channel)
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _run(
             adapter.send_image_file(chat_id="67890", image_path=str(img))
         )
         assert result.success
@@ -195,7 +200,7 @@ class TestDiscordSendImageFile:
         mock_channel.send.assert_awaited_once()
 
     def test_returns_error_when_file_missing(self, adapter):
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _run(
             adapter.send_image_file(chat_id="67890", image_path="/nonexistent.png")
         )
         assert not result.success
@@ -203,7 +208,7 @@ class TestDiscordSendImageFile:
 
     def test_returns_error_when_not_connected(self, adapter):
         adapter._client = None
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _run(
             adapter.send_image_file(chat_id="67890", image_path="/tmp/img.png")
         )
         assert not result.success
@@ -213,7 +218,7 @@ class TestDiscordSendImageFile:
         adapter._client.get_channel = MagicMock(return_value=None)
         adapter._client.fetch_channel = AsyncMock(return_value=None)
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _run(
             adapter.send_image_file(chat_id="99999", image_path="/tmp/img.png")
         )
         assert not result.success
@@ -256,7 +261,7 @@ class TestSlackSendImageFile:
         mock_result = MagicMock()
         adapter._app.client.files_upload_v2 = AsyncMock(return_value=mock_result)
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _run(
             adapter.send_image_file(chat_id="C12345", image_path=str(img))
         )
         assert result.success
@@ -268,7 +273,7 @@ class TestSlackSendImageFile:
         assert call_kwargs["channel"] == "C12345"
 
     def test_returns_error_when_file_missing(self, adapter):
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _run(
             adapter.send_image_file(chat_id="C12345", image_path="/nonexistent.png")
         )
         assert not result.success
@@ -276,7 +281,7 @@ class TestSlackSendImageFile:
 
     def test_returns_error_when_not_connected(self, adapter):
         adapter._app = None
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _run(
             adapter.send_image_file(chat_id="C12345", image_path="/tmp/img.png")
         )
         assert not result.success

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -130,7 +130,7 @@ class TestAppMentionHandler:
              patch.object(_slack_mod, "AsyncSocketModeHandler", return_value=MagicMock()), \
              patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-fake"}), \
              patch("asyncio.create_task"):
-            asyncio.get_event_loop().run_until_complete(adapter.connect())
+            asyncio.run(adapter.connect())
 
         assert "message" in registered_events
         assert "app_mention" in registered_events


### PR DESCRIPTION
## Summary
- replace sync test uses of `asyncio.get_event_loop().run_until_complete(...)` with `asyncio.run(...)` in the gateway send-image and Slack connect tests
- stop relying on an implicitly installed current event loop, which is not guaranteed under Python 3.11+ or xdist workers
- restore green CI/full-suite behavior for the previously failing gateway tests

## Root cause
These tests were synchronous but assumed `asyncio.get_event_loop()` would always return a current loop. Under Python 3.11+ that assumption is no longer reliable in a fresh main thread/worker, so the tests failed with `RuntimeError: There is no current event loop in thread 'MainThread'`.

## Test plan
- `source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/gateway/test_send_image_file.py tests/gateway/test_slack.py::TestAppMentionHandler::test_app_mention_registered_on_connect -n0 -q`
- `source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/ -n0 -q`
