### PR TITLE
fix(patch): avoid corrupting pipe chars in v4a patch apply

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -1,7 +1,10 @@
 """Tests for the V4A patch format parser."""
 
+from types import SimpleNamespace
+
 from tools.patch_parser import (
     OperationType,
+    apply_v4a_operations,
     parse_v4a_patch,
 )
 
@@ -137,3 +140,48 @@ class TestParseInvalidPatch:
         assert ops[0].operation == OperationType.ADD
         assert ops[1].operation == OperationType.DELETE
         assert ops[2].operation == OperationType.UPDATE
+
+
+class TestApplyUpdate:
+    def test_preserves_non_prefix_pipe_characters_in_unmodified_lines(self):
+        patch = """\
+*** Begin Patch
+*** Update File: sample.py
+@@ result @@
+     result = 1
+-    return result
++    return result + 1
+*** End Patch"""
+        operations, err = parse_v4a_patch(patch)
+        assert err is None
+
+        class FakeFileOps:
+            def __init__(self):
+                self.written = None
+
+            def read_file(self, path, offset=1, limit=500):
+                return SimpleNamespace(
+                    content=(
+                        'def run():\n'
+                        '    cmd = "echo a | sed s/a/b/"\n'
+                        '    result = 1\n'
+                        '    return result'
+                    ),
+                    error=None,
+                )
+
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+
+        result = apply_v4a_operations(operations, file_ops)
+
+        assert result.success is True
+        assert file_ops.written == (
+            'def run():\n'
+            '    cmd = "echo a | sed s/a/b/"\n'
+            '    result = 1\n'
+            '    return result + 1'
+        )

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -359,7 +359,7 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     # Parse content (remove line numbers)
     current_lines = []
     for line in read_result.content.split('\n'):
-        if '|' in line:
+        if re.match(r'^\s*\d+\|', line):
             # Line format: "    123|content"
             parts = line.split('|', 1)
             if len(parts) == 2:


### PR DESCRIPTION
## Summary
- salvage the line-number prefix detection fix from PR #970 by @alireza78a
- replace the broad pipe-character check in V4A patch apply with a regex that matches only numbered read_file lines
- add a regression test covering literal pipe characters in unmodified file content during apply_v4a_operations

## Contributor credit
This salvages the substantive fix from PR #970 onto current main, preserving the contributor's authored commit and adding a follow-up regression test.

## Validation
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/tools/test_patch_parser.py::TestApplyUpdate::test_preserves_non_prefix_pipe_characters_in_unmodified_lines -n0 -q
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/tools/test_patch_parser.py -n0 -q
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/ -n0 -q
- interactive PTY validation with actual   hermes command in tmux: read_file + patch-mode edit on /tmp/hermes-pipe-test.py, preserving the b line while changing the return line

## Notes
The interactive validation used the actual 
╭─────────────────────── Ares Agent v0.2.0 (2026.3.12) ────────────────────────╮
│                                       Available Tools                        │
│     ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣤⣤⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀      browser: browser_back, browser_click,  │
│      ⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⠟⠻⣿⣦⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀       ...                                    │
│       ⠀⠀⠀⠀⠀⠀⠀⣠⣾⡿⠋⠀⠀⠀⠙⢿⣷⣄⠀⠀⠀⠀⠀⠀⠀       clarify: clarify                       │
│       ⠀⠀⠀⠀⠀⢀⣾⡿⠋⠀⠀⢠⡄⠀⠀⠙⢿⣷⡀⠀⠀⠀⠀⠀        code_execution: execute_code           │
│       ⠀⠀⠀⠀⣰⣿⠟⠀⠀⠀⣰⣿⣿⣆⠀⠀⠀⠻⣿⣆⠀⠀⠀⠀        cronjob: list_cronjobs,                │
│        ⠀⠀⠀⢰⣿⠏⠀⠀⢀⣾⡿⠉⢿⣷⡀⠀⠀⠹⣿⡆⠀⠀⠀        remove_cronjob, ...                    │
│        ⠀⠀⠀⣿⡟⠀⠀⣠⣿⠟⠀⠀⠀⠻⣿⣄⠀⠀⢻⣿⠀⠀⠀        delegation: delegate_task              │
│        ⠀⠀⠀⣿⡇⠀⠀⠙⠋⠀⠀⚔⠀⠀⠙⠋⠀⠀⢸⣿⠀⠀⠀        file: patch, read_file, search_files,  │
│        ⠀⠀⠀⢿⣧⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣼⡿⠀⠀⠀        write_file                             │
│        ⠀⠀⠀⠘⢿⣷⣄⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⣾⡿⠃⠀⠀⠀        homeassistant_tools: ha_call_service,  │
│        ⠀⠀⠀⠀⠈⠻⣿⣷⣦⣤⣀⣀⣤⣤⣶⣿⠿⠋⠀⠀⠀⠀         ha_get_state, ...                      │
│        ⠀⠀⠀⠀⠀⠀⠀⠉⠛⠿⠿⠿⠿⠛⠉⠀⠀⠀⠀⠀⠀⠀         honcho_tools: honcho_conclude,         │
│         ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⚔⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀         honcho_context, ...                    │
│    ⠀⠀⠀⠀⠀⠀⠀⠀war god online⠀⠀⠀⠀⠀⠀⠀⠀     (and 9 more toolsets...)               │
│                                                                              │
│        gpt-5.4 · Nous Research        Available Skills                       │
│  /home/teknium/.hermes/hermes-agent…  apple: apple-notes, apple-reminders,   │
│    Session: 20260314_035518_1abfc1    findmy, imessage                       │
│                                       autonomous-ai-agents: claude-code,     │
│                                       codex, hermes-agent, opencode          │
│                                       creative: ascii-art, ascii-video,      │
│                                       generative-widgets                     │
│                                       data-science: jupyter-live-kernel      │
│                                       diagramming: excalidraw                │
│                                       dogfood: dogfood                       │
│                                       domain: domain-intel                   │
│                                       email: himalaya                        │
│                                       feeds: blogwatcher                     │
│                                       gaming: minecraft-modpack-server,      │
│                                       pokemon-player                         │
│                                       gifs: gif-search                       │
│                                       github: codebase-inspection,           │
│                                       github-auth, github-code-r...          │
│                                       leisure: find-nearby                   │
│                                       market-data: polymarket                │
│                                       mcp: mcporter, native-mcp              │
│                                       media: youtube-content                 │
│                                       miniverse-world: miniverse-world       │
│                                       mlops: accelerate, audiocraft,         │
│                                       axolotl, chroma, clip, ...             │
│                                       music-creation: heartmula, songsee     │
│                                       note-taking: obsidian                  │
│                                       ocr-and-documents: ocr-and-documents   │
│                                       productivity: google-workspace,        │
│                                       linear, nano-pdf, notion, pow...       │
│                                       research: agentic-research-ideas,      │
│                                       arxiv, duckduckgo-search               │
│                                       smart-home: openhue                    │
│                                       software-development:                  │
│                                       requesting-code-review,                │
│                                       subagent-driven-develop...             │
│                                                                              │
│                                       33 tools · 93 skills · /help for       │
│                                       commands                               │
╰──────────────────────────────────────────────────────────────────────────────╯

[2mHoncho session:[0m ]8;;https://app.honcho.dev/explore?workspace=hermes&view=sessions&session=20260314_035518_1abfc1\[38;5;117m20260314_035518_1abfc1[0m]8;;\
Welcome to Ares Agent! Type your message or /help for commands.


Goodbye! ⚕ CLI command under a PTY/tmux session, had the agent read the temp file, apply a V4A patch, and then re-read the file to confirm the pipe-containing line remained intact.