### PR TITLE
fix(cron): support per-job runtime overrides

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -180,7 +180,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except UnicodeDecodeError:
             load_dotenv(str(_hermes_home / ".env"), override=True, encoding="latin-1")
 
-        model = os.getenv("HERMES_MODEL") or "anthropic/claude-opus-4.6"
+        model = job.get("model") or os.getenv("HERMES_MODEL") or "anthropic/claude-opus-4.6"
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
         _cfg = {}
@@ -191,10 +191,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 with open(_cfg_path) as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 _model_cfg = _cfg.get("model", {})
-                if isinstance(_model_cfg, str):
-                    model = _model_cfg
-                elif isinstance(_model_cfg, dict):
-                    model = _model_cfg.get("default", model)
+                if not job.get("model"):
+                    if isinstance(_model_cfg, str):
+                        model = _model_cfg
+                    elif isinstance(_model_cfg, dict):
+                        model = _model_cfg.get("default", model)
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
@@ -240,7 +241,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         )
         try:
             runtime = resolve_runtime_provider(
-                requested=os.getenv("HERMES_INFERENCE_PROVIDER"),
+                requested=job.get("provider") or os.getenv("HERMES_INFERENCE_PROVIDER"),
+                explicit_api_key=job.get("api_key"),
+                explicit_base_url=job.get("base_url"),
             )
         except Exception as exc:
             message = format_runtime_provider_error(exc)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import types
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -162,3 +163,51 @@ class TestRunJobConfigLogging:
 
         assert any("failed to parse prefill messages" in r.message for r in caplog.records), \
             f"Expected 'failed to parse prefill messages' warning in logs, got: {[r.message for r in caplog.records]}"
+
+
+class TestRunJobPerJobOverrides:
+    def test_job_level_model_and_provider_overrides_are_used(self, tmp_path):
+        config_yaml = tmp_path / "config.yaml"
+        config_yaml.write_text(
+            "model:\n"
+            "  default: gpt-5.4\n"
+            "  provider: openai-codex\n"
+            "  base_url: https://chatgpt.com/backend-api/codex\n"
+        )
+
+        job = {
+            "id": "briefing-job",
+            "name": "briefing",
+            "prompt": "hello",
+            "model": "perplexity-sonar-pro",
+            "provider": "custom",
+            "base_url": "http://127.0.0.1:4000/v1",
+        }
+
+        fake_runtime = {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "http://127.0.0.1:4000/v1",
+            "api_key": "test-key",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=fake_runtime) as runtime_mock:
+            fake_run_agent = types.ModuleType("run_agent")
+            mock_agent_cls = MagicMock()
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            fake_run_agent.AIAgent = mock_agent_cls
+
+            with patch.dict("sys.modules", {"run_agent": fake_run_agent}):
+                run_job(job)
+
+        runtime_mock.assert_called_once_with(
+            requested="custom",
+            explicit_api_key=None,
+            explicit_base_url="http://127.0.0.1:4000/v1",
+        )
+        assert mock_agent_cls.call_args.kwargs["model"] == "perplexity-sonar-pro"


### PR DESCRIPTION
## Summary
- allow cron jobs to override the model at the job level
- allow cron jobs to override provider and base_url when resolving runtime credentials
- ensure config model defaults only apply when the job does not specify a model
- add a regression test covering per-job model/provider/base_url overrides

## Problem
Scheduled jobs currently resolve runtime provider using only the global/default path, which makes it impossible to pin a cron job to a different provider/model route than the interactive default.

In practice, this breaks workflows like:
- keeping the normal Telegram/default runtime on one provider/model
- pinning a specific recurring intel/research briefing job to a different LiteLLM-backed model/provider path

## Fix
- cron/scheduler.py now honors job-level:
  - model
  - provider
  - base_url
  - optional api_key
- config-level model defaults no longer clobber a job-level model
- added a targeted regression test in tests/cron/test_scheduler.py

## Verification
Ran:
pytest -c /dev/null tests/cron/test_scheduler.py::TestRunJobPerJobOverrides::test_job_level_model_and_provider_overrides_are_used -q

Result:
- 1 passed

## Notes
This is intentionally scoped as a cron/runtime bugfix only.
