### PR TITLE
fix(update): salvage autostash update flow from PR #978

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1962,7 +1962,25 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
 
 
 
-def _restore_stashed_changes(git_cmd: list[str], cwd: Path, stash_ref: str) -> None:
+def _restore_stashed_changes(
+    git_cmd: list[str],
+    cwd: Path,
+    stash_ref: str,
+    prompt_user: bool = False,
+) -> bool:
+    if prompt_user:
+        print()
+        print("⚠ Local changes were stashed before updating.")
+        print("  Restoring them may reapply local customizations onto the updated codebase.")
+        print("  Review the result afterward if Hermes behaves unexpectedly.")
+        print("Restore local changes now? [Y/n]")
+        response = input().strip().lower()
+        if response not in ("", "y", "yes"):
+            print("Skipped restoring local changes.")
+            print("Your changes are still preserved in git stash.")
+            print(f"Restore manually with: git stash apply {stash_ref}")
+            return False
+
     print("→ Restoring local changes...")
     restore = subprocess.run(
         git_cmd + ["stash", "apply", stash_ref],
@@ -1981,6 +1999,9 @@ def _restore_stashed_changes(git_cmd: list[str], cwd: Path, stash_ref: str) -> N
         sys.exit(1)
 
     subprocess.run(git_cmd + ["stash", "drop", stash_ref], cwd=cwd, check=True)
+    print("⚠ Local changes were restored on top of the updated codebase.")
+    print("  Review `git diff` / `git status` if Hermes behaves unexpectedly.")
+    return True
 
 
 
@@ -2053,13 +2074,19 @@ def cmd_update(args):
         print(f"→ Found {commit_count} new commit(s)")
 
         auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
+        prompt_for_restore = auto_stash_ref is not None and sys.stdin.isatty() and sys.stdout.isatty()
 
         print("→ Pulling updates...")
         try:
             subprocess.run(git_cmd + ["pull", "origin", branch], cwd=PROJECT_ROOT, check=True)
         finally:
             if auto_stash_ref is not None:
-                _restore_stashed_changes(git_cmd, PROJECT_ROOT, auto_stash_ref)
+                _restore_stashed_changes(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    auto_stash_ref,
+                    prompt_user=prompt_for_restore,
+                )
         
         # Reinstall Python dependencies (prefer uv for speed, fall back to pip)
         print("→ Updating Python dependencies...")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -45,6 +45,7 @@ Usage:
 
 import argparse
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Optional
@@ -1930,9 +1931,61 @@ def _update_via_zip(args):
     print("✓ Update complete!")
 
 
+def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
+    status = subprocess.run(
+        git_cmd + ["status", "--porcelain"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    if not status.stdout.strip():
+        return None
+
+    from datetime import datetime, timezone
+
+    stash_name = datetime.now(timezone.utc).strftime("hermes-update-autostash-%Y%m%d-%H%M%S")
+    print("→ Local changes detected — stashing before update...")
+    subprocess.run(
+        git_cmd + ["stash", "push", "--include-untracked", "-m", stash_name],
+        cwd=cwd,
+        check=True,
+    )
+    stash_ref = subprocess.run(
+        git_cmd + ["rev-parse", "--verify", "refs/stash"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    return stash_ref
+
+
+
+def _restore_stashed_changes(git_cmd: list[str], cwd: Path, stash_ref: str) -> None:
+    print("→ Restoring local changes...")
+    restore = subprocess.run(
+        git_cmd + ["stash", "apply", stash_ref],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if restore.returncode != 0:
+        print("✗ Update pulled new code, but restoring local changes failed.")
+        if restore.stdout.strip():
+            print(restore.stdout.strip())
+        if restore.stderr.strip():
+            print(restore.stderr.strip())
+        print("Your changes are still preserved in git stash.")
+        print(f"Resolve manually with: git stash apply {stash_ref}")
+        sys.exit(1)
+
+    subprocess.run(git_cmd + ["stash", "drop", stash_ref], cwd=cwd, check=True)
+
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version."""
-    import subprocess
     import shutil
     
     print("⚕ Updating Hermes Agent...")
@@ -1998,8 +2051,15 @@ def cmd_update(args):
             return
         
         print(f"→ Found {commit_count} new commit(s)")
+
+        auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
+
         print("→ Pulling updates...")
-        subprocess.run(git_cmd + ["pull", "origin", branch], cwd=PROJECT_ROOT, check=True)
+        try:
+            subprocess.run(git_cmd + ["pull", "origin", branch], cwd=PROJECT_ROOT, check=True)
+        finally:
+            if auto_stash_ref is not None:
+                _restore_stashed_changes(git_cmd, PROJECT_ROOT, auto_stash_ref)
         
         # Reinstall Python dependencies (prefer uv for speed, fall back to pip)
         print("→ Updating Python dependencies...")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -562,9 +562,30 @@ clone_repo() {
         if [ -d "$INSTALL_DIR/.git" ]; then
             log_info "Existing installation found, updating..."
             cd "$INSTALL_DIR"
+
+            local autostash_ref=""
+            if [ -n "$(git status --porcelain)" ]; then
+                local stash_name
+                stash_name="hermes-install-autostash-$(date -u +%Y%m%d-%H%M%S)"
+                log_info "Local changes detected, stashing before update..."
+                git stash push --include-untracked -m "$stash_name"
+                autostash_ref="$(git rev-parse --verify refs/stash)"
+            fi
+
             git fetch origin
             git checkout "$BRANCH"
             git pull origin "$BRANCH"
+
+            if [ -n "$autostash_ref" ]; then
+                log_info "Restoring local changes..."
+                if git stash apply "$autostash_ref"; then
+                    git stash drop "$autostash_ref" >/dev/null
+                else
+                    log_error "Update succeeded, but restoring local changes failed. Your changes are still preserved in git stash."
+                    log_info "Resolve manually with: git stash apply $autostash_ref"
+                    exit 1
+                fi
+            fi
         else
             log_error "Directory exists but is not a git repository: $INSTALL_DIR"
             log_info "Remove it or choose a different directory with --dir"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -577,13 +577,34 @@ clone_repo() {
             git pull origin "$BRANCH"
 
             if [ -n "$autostash_ref" ]; then
-                log_info "Restoring local changes..."
-                if git stash apply "$autostash_ref"; then
-                    git stash drop "$autostash_ref" >/dev/null
+                local restore_now="yes"
+                if [ -t 0 ] && [ -t 1 ]; then
+                    echo
+                    log_warn "Local changes were stashed before updating."
+                    log_warn "Restoring them may reapply local customizations onto the updated codebase."
+                    printf "Restore local changes now? [Y/n] "
+                    read -r restore_answer
+                    case "$restore_answer" in
+                        ""|y|Y|yes|YES|Yes) restore_now="yes" ;;
+                        *) restore_now="no" ;;
+                    esac
+                fi
+
+                if [ "$restore_now" = "yes" ]; then
+                    log_info "Restoring local changes..."
+                    if git stash apply "$autostash_ref"; then
+                        git stash drop "$autostash_ref" >/dev/null
+                        log_warn "Local changes were restored on top of the updated codebase."
+                        log_warn "Review git diff / git status if Hermes behaves unexpectedly."
+                    else
+                        log_error "Update succeeded, but restoring local changes failed. Your changes are still preserved in git stash."
+                        log_info "Resolve manually with: git stash apply $autostash_ref"
+                        exit 1
+                    fi
                 else
-                    log_error "Update succeeded, but restoring local changes failed. Your changes are still preserved in git stash."
-                    log_info "Resolve manually with: git stash apply $autostash_ref"
-                    exit 1
+                    log_info "Skipped restoring local changes."
+                    log_info "Your changes are still preserved in git stash."
+                    log_info "Restore manually with: git stash apply $autostash_ref"
                 fi
             fi
         else

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+from subprocess import CalledProcessError
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import main as hermes_main
+
+
+def test_stash_local_changes_if_needed_returns_none_when_tree_clean(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[-2:] == ["status", "--porcelain"]:
+            return SimpleNamespace(stdout="", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+
+    assert stash_ref is None
+    assert [cmd[-2:] for cmd, _ in calls] == [["status", "--porcelain"]]
+
+
+def test_stash_local_changes_if_needed_returns_specific_stash_commit(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[-2:] == ["status", "--porcelain"]:
+            return SimpleNamespace(stdout=" M hermes_cli/main.py\n?? notes.txt\n", returncode=0)
+        if cmd[1:4] == ["stash", "push", "--include-untracked"]:
+            return SimpleNamespace(stdout="Saved working directory\n", returncode=0)
+        if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
+            return SimpleNamespace(stdout="abc123\n", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+
+    assert stash_ref == "abc123"
+    assert calls[1][0][1:4] == ["stash", "push", "--include-untracked"]
+    assert calls[2][0][-3:] == ["rev-parse", "--verify", "refs/stash"]
+
+
+def test_restore_stashed_changes_applies_specific_stash_and_drops_it(monkeypatch, tmp_path, capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:3] == ["stash", "apply"]:
+            return SimpleNamespace(stdout="applied\n", stderr="", returncode=0)
+        if cmd[1:3] == ["stash", "drop"]:
+            return SimpleNamespace(stdout="dropped\n", stderr="", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123")
+
+    assert calls[0][0] == ["git", "stash", "apply", "abc123"]
+    assert calls[1][0] == ["git", "stash", "drop", "abc123"]
+    assert "Restoring local changes" in capsys.readouterr().out
+
+
+def test_restore_stashed_changes_exits_cleanly_when_apply_fails(monkeypatch, tmp_path, capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:3] == ["stash", "apply"]:
+            return SimpleNamespace(stdout="conflict output\n", stderr="conflict stderr\n", returncode=1)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123")
+
+    out = capsys.readouterr().out
+    assert "Your changes are still preserved in git stash." in out
+    assert "git stash apply abc123" in out
+    assert calls == [(["git", "stash", "apply", "abc123"], {"cwd": tmp_path, "capture_output": True, "text": True})]
+
+
+def test_stash_local_changes_if_needed_raises_when_stash_ref_missing(monkeypatch, tmp_path):
+    def fake_run(cmd, **kwargs):
+        if cmd[-2:] == ["status", "--porcelain"]:
+            return SimpleNamespace(stdout=" M hermes_cli/main.py\n", returncode=0)
+        if cmd[1:4] == ["stash", "push", "--include-untracked"]:
+            return SimpleNamespace(stdout="Saved working directory\n", returncode=0)
+        if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
+            raise CalledProcessError(returncode=128, cmd=cmd)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    with pytest.raises(CalledProcessError):
+        hermes_main._stash_local_changes_if_needed(["git"], Path(tmp_path))

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -46,7 +46,53 @@ def test_stash_local_changes_if_needed_returns_specific_stash_commit(monkeypatch
     assert calls[2][0][-3:] == ["rev-parse", "--verify", "refs/stash"]
 
 
-def test_restore_stashed_changes_applies_specific_stash_and_drops_it(monkeypatch, tmp_path, capsys):
+def test_restore_stashed_changes_prompts_before_applying(monkeypatch, tmp_path, capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:3] == ["stash", "apply"]:
+            return SimpleNamespace(stdout="applied\n", stderr="", returncode=0)
+        if cmd[1:3] == ["stash", "drop"]:
+            return SimpleNamespace(stdout="dropped\n", stderr="", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda: "")
+
+    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
+
+    assert restored is True
+    assert calls[0][0] == ["git", "stash", "apply", "abc123"]
+    assert calls[1][0] == ["git", "stash", "drop", "abc123"]
+    out = capsys.readouterr().out
+    assert "Restore local changes now? [Y/n]" in out
+    assert "restored on top of the updated codebase" in out
+    assert "git diff" in out
+    assert "git status" in out
+
+
+def test_restore_stashed_changes_can_skip_restore_and_keep_stash(monkeypatch, tmp_path, capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda: "n")
+
+    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
+
+    assert restored is False
+    assert calls == []
+    out = capsys.readouterr().out
+    assert "Restore local changes now? [Y/n]" in out
+    assert "Your changes are still preserved in git stash." in out
+    assert "git stash apply abc123" in out
+
+
+def test_restore_stashed_changes_applies_without_prompt_when_disabled(monkeypatch, tmp_path, capsys):
     calls = []
 
     def fake_run(cmd, **kwargs):
@@ -59,11 +105,11 @@ def test_restore_stashed_changes_applies_specific_stash_and_drops_it(monkeypatch
 
     monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
 
-    hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123")
+    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=False)
 
+    assert restored is True
     assert calls[0][0] == ["git", "stash", "apply", "abc123"]
-    assert calls[1][0] == ["git", "stash", "drop", "abc123"]
-    assert "Restoring local changes" in capsys.readouterr().out
+    assert "Restore local changes now?" not in capsys.readouterr().out
 
 
 def test_restore_stashed_changes_exits_cleanly_when_apply_fails(monkeypatch, tmp_path, capsys):
@@ -76,9 +122,10 @@ def test_restore_stashed_changes_exits_cleanly_when_apply_fails(monkeypatch, tmp
         raise AssertionError(f"unexpected command: {cmd}")
 
     monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda: "y")
 
     with pytest.raises(SystemExit, match="1"):
-        hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123")
+        hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
 
     out = capsys.readouterr().out
     assert "Your changes are still preserved in git stash." in out


### PR DESCRIPTION
## Summary
- salvage the auto-stash update flow from PR #978 by @smillunchick onto current main
- stash tracked and untracked repo changes before Updating 163fa4a9..b646440c
Fast-forward
 acp_adapter/__init__.py                            |    1 +
 acp_adapter/__main__.py                            |    5 +
 acp_adapter/auth.py                                |   24 +
 acp_adapter/entry.py                               |   88 ++
 acp_adapter/events.py                              |  171 +++
 acp_adapter/permissions.py                         |   80 ++
 acp_adapter/server.py                              |  333 +++++
 acp_adapter/session.py                             |  203 +++
 acp_adapter/tools.py                               |  215 ++++
 acp_registry/agent.json                            |   12 +
 acp_registry/icon.svg                              |   25 +
 agent/context_compressor.py                        |   41 +-
 agent/display.py                                   |    2 +-
 agent/prompt_builder.py                            |    6 +-
 cli-config.yaml.example                            |   14 +
 cli.py                                             |  246 +++-
 cron/scheduler.py                                  |   18 +-
 docs/acp-setup.md                                  |  229 ++++
 gateway/config.py                                  |   19 +
 gateway/platforms/base.py                          |   20 +-
 gateway/platforms/discord.py                       |  243 +---
 gateway/platforms/slack.py                         |   58 +-
 gateway/platforms/telegram.py                      |    1 +
 gateway/run.py                                     |  207 ++-
 hermes_cli/config.py                               |   28 +-
 hermes_cli/main.py                                 |  130 +-
 hermes_cli/models.py                               |   10 +
 hermes_cli/runtime_provider.py                     |   12 +-
 hermes_cli/setup.py                                |   75 +-
 hermes_cli/skin_engine.py                          |   85 ++
 hermes_cli/status.py                               |   40 +-
 hermes_state.py                                    |    3 -
 optional-skills/productivity/telephony/SKILL.md    |  417 ++++++
 .../productivity/telephony/scripts/telephony.py    | 1343 ++++++++++++++++++++
 pyproject.toml                                     |    5 +-
 run_agent.py                                       |  108 +-
 skills/data-science/DESCRIPTION.md                 |    3 +
 skills/data-science/jupyter-live-kernel/SKILL.md   |  171 +++
 skills/social-media/DESCRIPTION.md                 |    3 +
 skills/social-media/xitter/SKILL.md                |  202 +++
 tests/acp/__init__.py                              |    0
 tests/acp/test_auth.py                             |   56 +
 tests/acp/test_events.py                           |  239 ++++
 tests/acp/test_permissions.py                      |   75 ++
 tests/acp/test_server.py                           |  297 +++++
 tests/acp/test_session.py                          |  112 ++
 tests/acp/test_tools.py                            |  236 ++++
 tests/agent/test_context_compressor.py             |   30 +-
 tests/agent/test_prompt_builder.py                 |   33 +
 tests/conftest.py                                  |   34 +
 tests/cron/test_scheduler.py                       |   41 +
 tests/gateway/test_config.py                       |   39 +-
 tests/gateway/test_email.py                        |   47 +-
 tests/gateway/test_platform_base.py                |   23 +
 tests/gateway/test_reasoning_command.py            |  220 ++++
 tests/gateway/test_send_image_file.py              |   61 +-
 tests/gateway/test_slack.py                        |    2 +-
 tests/gateway/test_update_command.py               |   89 +-
 tests/hermes_cli/test_model_validation.py          |   11 +
 tests/hermes_cli/test_setup_model_provider.py      |  165 +++
 tests/hermes_cli/test_setup_noninteractive.py      |   94 ++
 tests/hermes_cli/test_setup_openclaw_migration.py  |    3 +
 tests/hermes_cli/test_skin_engine.py               |   82 ++
 tests/hermes_cli/test_status_model_provider.py     |   61 +
 tests/skills/test_telephony_skill.py               |  229 ++++
 tests/test_413_compression.py                      |    3 +-
 tests/test_atomic_json_write.py                    |   11 +
 tests/test_batch_runner_checkpoint.py              |    2 +-
 tests/test_cli_provider_resolution.py              |   18 +-
 tests/test_cli_skin_integration.py                 |   95 ++
 tests/test_provider_parity.py                      |   87 ++
 tests/test_quick_commands.py                       |   17 +
 tests/test_run_agent.py                            |  118 +-
 tests/test_runtime_provider_resolution.py          |    7 +
 tests/tools/test_approval.py                       |   12 +
 tests/tools/test_command_guards.py                 |  325 +++++
 tests/tools/test_docker_environment.py             |   88 ++
 tests/tools/test_mcp_tool_issue_948.py             |   86 ++
 tests/tools/test_patch_parser.py                   |   48 +
 tests/tools/test_send_message_tool.py              |  174 ++-
 tests/tools/test_tirith_security.py                |  958 ++++++++++++++
 tests/tools/test_yolo_mode.py                      |   38 +-
 tools/approval.py                                  |  152 ++-
 tools/browser_tool.py                              |   20 +-
 tools/environments/docker.py                       |   70 +
 tools/mcp_tool.py                                  |  119 +-
 tools/patch_parser.py                              |    2 +-
 tools/send_message_tool.py                         |  158 ++-
 tools/terminal_tool.py                             |   19 +-
 tools/tirith_security.py                           |  665 ++++++++++
 toolsets.py                                        |   19 +
 utils.py                                           |   20 +-
 website/docs/developer-guide/acp-internals.md      |  182 +++
 website/docs/developer-guide/agent-loop.md         |  110 ++
 website/docs/developer-guide/architecture.md       |  279 ++--
 .../context-compression-and-caching.md             |   72 ++
 website/docs/developer-guide/cron-internals.md     |   56 +
 website/docs/developer-guide/environments.md       |    4 +
 website/docs/developer-guide/gateway-internals.md  |   95 ++
 website/docs/developer-guide/prompt-assembly.md    |   85 ++
 website/docs/developer-guide/provider-runtime.md   |  116 ++
 website/docs/developer-guide/session-storage.md    |   66 +
 website/docs/developer-guide/tools-runtime.md      |   65 +
 website/docs/developer-guide/trajectory-format.md  |   56 +
 website/docs/getting-started/installation.md       |    1 +
 website/docs/getting-started/quickstart.md         |   11 +
 website/docs/reference/cli-commands.md             |   24 +
 website/docs/user-guide/features/acp.md            |  197 +++
 website/sidebars.ts                                |   13 +
 109 files changed, 11233 insertions(+), 705 deletions(-)
 create mode 100644 acp_adapter/__init__.py
 create mode 100644 acp_adapter/__main__.py
 create mode 100644 acp_adapter/auth.py
 create mode 100644 acp_adapter/entry.py
 create mode 100644 acp_adapter/events.py
 create mode 100644 acp_adapter/permissions.py
 create mode 100644 acp_adapter/server.py
 create mode 100644 acp_adapter/session.py
 create mode 100644 acp_adapter/tools.py
 create mode 100644 acp_registry/agent.json
 create mode 100644 acp_registry/icon.svg
 create mode 100644 docs/acp-setup.md
 create mode 100644 optional-skills/productivity/telephony/SKILL.md
 create mode 100644 optional-skills/productivity/telephony/scripts/telephony.py
 create mode 100644 skills/data-science/DESCRIPTION.md
 create mode 100644 skills/data-science/jupyter-live-kernel/SKILL.md
 create mode 100644 skills/social-media/DESCRIPTION.md
 create mode 100644 skills/social-media/xitter/SKILL.md
 create mode 100644 tests/acp/__init__.py
 create mode 100644 tests/acp/test_auth.py
 create mode 100644 tests/acp/test_events.py
 create mode 100644 tests/acp/test_permissions.py
 create mode 100644 tests/acp/test_server.py
 create mode 100644 tests/acp/test_session.py
 create mode 100644 tests/acp/test_tools.py
 create mode 100644 tests/gateway/test_reasoning_command.py
 create mode 100644 tests/hermes_cli/test_setup_model_provider.py
 create mode 100644 tests/hermes_cli/test_setup_noninteractive.py
 create mode 100644 tests/hermes_cli/test_status_model_provider.py
 create mode 100644 tests/skills/test_telephony_skill.py
 create mode 100644 tests/test_cli_skin_integration.py
 create mode 100644 tests/tools/test_command_guards.py
 create mode 100644 tests/tools/test_docker_environment.py
 create mode 100644 tests/tools/test_mcp_tool_issue_948.py
 create mode 100644 tests/tools/test_tirith_security.py
 create mode 100644 tools/tirith_security.py
 create mode 100644 website/docs/developer-guide/acp-internals.md
 create mode 100644 website/docs/developer-guide/agent-loop.md
 create mode 100644 website/docs/developer-guide/context-compression-and-caching.md
 create mode 100644 website/docs/developer-guide/cron-internals.md
 create mode 100644 website/docs/developer-guide/gateway-internals.md
 create mode 100644 website/docs/developer-guide/prompt-assembly.md
 create mode 100644 website/docs/developer-guide/provider-runtime.md
 create mode 100644 website/docs/developer-guide/session-storage.md
 create mode 100644 website/docs/developer-guide/tools-runtime.md
 create mode 100644 website/docs/developer-guide/trajectory-format.md
 create mode 100644 website/docs/user-guide/features/acp.md
✅ Browser tools ready. Run: python run_agent.py --help
⚕ Updating Hermes Agent...

→ Fetching updates...
→ Found 58 new commit(s)
→ Pulling updates...
→ Updating Python dependencies...
→ Updating Node.js dependencies...

✓ Code updated!

→ Syncing bundled skills...
  + 1 new: xitter
  ↑ 1 updated: ascii-video
  ~ 3 user-modified (kept)

→ Checking configuration for new options...


Would you like to configure them now? [Y/n]:  / existing-install refreshes, then restore them after pull
- add an interactive restore prompt for ⚕ Updating Hermes Agent...

→ Fetching updates...
✓ Already up to date! when running in a real terminal
- add a mitigation warning after successful restore so users know local changes were reapplied onto updated code
- keep the stash intact when the user declines restore or when restore conflicts

## Contributor credit
This PR salvages the substantive update-autostash implementation from #978 onto current main with follow-up UX safeguards.

## Validation
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/hermes_cli/test_update_autostash.py -n0 -q
- bash -n scripts/install.sh
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/ -n0 -q

## Notes
The restore prompt is only shown for interactive ⚕ Updating Hermes Agent...

→ Fetching updates...
✓ Already up to date! runs with a real TTY. The install script keeps safe non-interactive behavior while adding the same warning/skip messaging around restored stashes.