### PR TITLE
feat(skills): make whisper skill cross-platform

### DIFF
--- a/skills/mlops/models/whisper/SKILL.md
+++ b/skills/mlops/models/whisper/SKILL.md
@@ -1,320 +1,165 @@
 ---
 name: whisper
-description: OpenAI's general-purpose speech recognition model. Supports 99 languages, transcription, translation to English, and language identification. Six model sizes from tiny (39M params) to large (1550M params). Use for speech-to-text, podcast transcription, or multilingual audio processing. Best for robust, multilingual ASR.
-version: 1.0.0
-author: Orchestra Research
+description: >
+  Local speech-to-text transcription using Whisper models. Cross-platform:
+  uses mlx-whisper on macOS Apple Silicon, faster-whisper on Linux/Windows.
+  Supports 99 languages, translation to English, and word timestamps.
+  Includes a ready-to-use wrapper script managed with uv.
+version: 2.0.0
+author: Nous Research
 license: MIT
-dependencies: [openai-whisper, transformers, torch]
+prerequisites:
+  commands: [ffmpeg]
 metadata:
   hermes:
-    tags: [Whisper, Speech Recognition, ASR, Multimodal, Multilingual, OpenAI, Speech-To-Text, Transcription, Translation, Audio Processing]
-
+    tags: [Whisper, Speech Recognition, ASR, Multilingual, Speech-To-Text, Transcription, Translation, Audio Processing]
+    requires_toolsets: [terminal]
 ---
 
-# Whisper - Robust Speech Recognition
+# Whisper — Cross-Platform Local Transcription
 
-OpenAI's multilingual speech recognition model.
+Local speech recognition using Whisper models. The included wrapper script
+auto-detects the platform and picks the optimal backend.
 
-## When to use Whisper
+## When to use
 
-**Use when:**
-- Speech-to-text transcription (99 languages)
-- Podcast/video transcription
-- Meeting notes automation
-- Translation to English
+- Speech-to-text transcription (any of 99 languages)
+- Podcast, video, or meeting transcription
+- Translating speech to English text
 - Noisy audio transcription
-- Multilingual audio processing
+- Batch audio file processing
 
-**Metrics**:
-- **72,900+ GitHub stars**
-- 99 languages supported
-- Trained on 680,000 hours of audio
-- MIT License
+## Architecture
 
-**Use alternatives instead**:
-- **AssemblyAI**: Managed API, speaker diarization
-- **Deepgram**: Real-time streaming ASR
-- **Google Speech-to-Text**: Cloud-based
+| Platform | Backend | Acceleration |
+|----------|---------|--------------|
+| macOS (Apple Silicon) | `mlx-whisper` | Metal / ANE |
+| Linux / Windows (NVIDIA GPU) | `faster-whisper` | CUDA |
+| Linux / Windows (CPU only) | `faster-whisper` | CPU (AVX2) |
 
-## Quick start
+Both backends use the same Whisper model weights and produce equivalent
+transcription quality.
 
-### Installation
-
-```bash
-# Requires Python 3.8-3.11
-pip install -U openai-whisper
-
-# Requires ffmpeg
-# macOS: brew install ffmpeg
-# Ubuntu: sudo apt install ffmpeg
-# Windows: choco install ffmpeg
-```
-
-### Basic transcription
-
-```python
-import whisper
-
-# Load model
-model = whisper.load_model("base")
-
-# Transcribe
-result = model.transcribe("audio.mp3")
-
-# Print text
-print(result["text"])
-
-# Access segments
-for segment in result["segments"]:
-    print(f"[{segment['start']:.2f}s - {segment['end']:.2f}s] {segment['text']}")
-```
-
-## Model sizes
-
-```python
-# Available models
-models = ["tiny", "base", "small", "medium", "large", "turbo"]
-
-# Load specific model
-model = whisper.load_model("turbo")  # Fastest, good quality
-```
-
-| Model | Parameters | English-only | Multilingual | Speed | VRAM |
-|-------|------------|--------------|--------------|-------|------|
-| tiny | 39M | ✓ | ✓ | ~32x | ~1 GB |
-| base | 74M | ✓ | ✓ | ~16x | ~1 GB |
-| small | 244M | ✓ | ✓ | ~6x | ~2 GB |
-| medium | 769M | ✓ | ✓ | ~2x | ~5 GB |
-| large | 1550M | ✗ | ✓ | 1x | ~10 GB |
-| turbo | 809M | ✗ | ✓ | ~8x | ~6 GB |
-
-**Recommendation**: Use `turbo` for best speed/quality, `base` for prototyping
-
-## Transcription options
-
-### Language specification
-
-```python
-# Auto-detect language
-result = model.transcribe("audio.mp3")
-
-# Specify language (faster)
-result = model.transcribe("audio.mp3", language="en")
-
-# Supported: en, es, fr, de, it, pt, ru, ja, ko, zh, and 89 more
-```
-
-### Task selection
-
-```python
-# Transcription (default)
-result = model.transcribe("audio.mp3", task="transcribe")
-
-# Translation to English
-result = model.transcribe("spanish.mp3", task="translate")
-# Input: Spanish audio → Output: English text
-```
-
-### Initial prompt
-
-```python
-# Improve accuracy with context
-result = model.transcribe(
-    "audio.mp3",
-    initial_prompt="This is a technical podcast about machine learning and AI."
-)
-
-# Helps with:
-# - Technical terms
-# - Proper nouns
-# - Domain-specific vocabulary
-```
-
-### Timestamps
-
-```python
-# Word-level timestamps
-result = model.transcribe("audio.mp3", word_timestamps=True)
-
-for segment in result["segments"]:
-    for word in segment["words"]:
-        print(f"{word['word']} ({word['start']:.2f}s - {word['end']:.2f}s)")
-```
-
-### Temperature fallback
-
-```python
-# Retry with different temperatures if confidence low
-result = model.transcribe(
-    "audio.mp3",
-    temperature=(0.0, 0.2, 0.4, 0.6, 0.8, 1.0)
-)
-```
-
-## Command line usage
+## Quick reference
 
 ```bash
 # Basic transcription
-whisper audio.mp3
+~/whisper/bin/transcribe-audio recording.ogg
 
-# Specify model
-whisper audio.mp3 --model turbo
+# Specify language (faster + more accurate)
+~/whisper/bin/transcribe-audio --language de interview.mp3
 
-# Output formats
-whisper audio.mp3 --output_format txt     # Plain text
-whisper audio.mp3 --output_format srt     # Subtitles
-whisper audio.mp3 --output_format vtt     # WebVTT
-whisper audio.mp3 --output_format json    # JSON with timestamps
+# JSON output with word-level timestamps
+~/whisper/bin/transcribe-audio --json --word-timestamps lecture.wav
 
-# Language
-whisper audio.mp3 --language Spanish
+# Use a larger model for higher accuracy
+~/whisper/bin/transcribe-audio --model medium podcast.mp3
 
-# Translation
-whisper spanish.mp3 --task translate
+# Translate non-English speech to English text
+~/whisper/bin/transcribe-audio --task translate spanish_audio.mp3
 ```
 
-## Batch processing
+## Setup procedure
 
-```python
-import os
+### Prerequisites
 
-audio_files = ["file1.mp3", "file2.mp3", "file3.mp3"]
+- **ffmpeg** on `PATH` (`brew install ffmpeg` / `apt install ffmpeg` / `choco install ffmpeg`)
+- **uv** — Python package manager (see https://docs.astral.sh/uv/getting-started/installation/)
 
-for audio_file in audio_files:
-    print(f"Transcribing {audio_file}...")
-    result = model.transcribe(audio_file)
+### Installation
 
-    # Save to file
-    output_file = audio_file.replace(".mp3", ".txt")
-    with open(output_file, "w") as f:
-        f.write(result["text"])
+1. Create the working directory:
+
+```text
+~/whisper/
+  .venv/               # managed by uv
+  bin/
+    transcribe-audio   # wrapper script (this skill's scripts/transcribe-audio)
+  cache/huggingface/   # downloaded model weights
+  tmp/                 # ephemeral wav files during transcription
 ```
 
-## Real-time transcription
-
-```python
-# For streaming audio, use faster-whisper
-# pip install faster-whisper
-
-from faster_whisper import WhisperModel
-
-model = WhisperModel("base", device="cuda", compute_type="float16")
-
-# Transcribe with streaming
-segments, info = model.transcribe("audio.mp3", beam_size=5)
-
-for segment in segments:
-    print(f"[{segment.start:.2f}s -> {segment.end:.2f}s] {segment.text}")
-```
-
-## GPU acceleration
-
-```python
-import whisper
-
-# Automatically uses GPU if available
-model = whisper.load_model("turbo")
-
-# Force CPU
-model = whisper.load_model("turbo", device="cpu")
-
-# Force GPU
-model = whisper.load_model("turbo", device="cuda")
-
-# 10-20× faster on GPU
-```
-
-## Integration with other tools
-
-### Subtitle generation
+2. Create a virtual environment and install the backend:
 
 ```bash
-# Generate SRT subtitles
-whisper video.mp4 --output_format srt --language English
-
-# Output: video.srt
+mkdir -p ~/whisper/bin ~/whisper/cache/huggingface ~/whisper/tmp
+cd ~/whisper && uv venv
 ```
 
-### With LangChain
-
-```python
-from langchain.document_loaders import WhisperTranscriptionLoader
-
-loader = WhisperTranscriptionLoader(file_path="audio.mp3")
-docs = loader.load()
-
-# Use transcription in RAG
-from langchain_chroma import Chroma
-from langchain_openai import OpenAIEmbeddings
-
-vectorstore = Chroma.from_documents(docs, OpenAIEmbeddings())
-```
-
-### Extract audio from video
-
+macOS Apple Silicon:
 ```bash
-# Use ffmpeg to extract audio
-ffmpeg -i video.mp4 -vn -acodec pcm_s16le audio.wav
-
-# Then transcribe
-whisper audio.wav
+uv pip install mlx-whisper
 ```
+
+Linux / Windows:
+```bash
+uv pip install faster-whisper
+```
+
+3. Copy `scripts/transcribe-audio` from this skill into `~/whisper/bin/` and
+   make it executable (`chmod +x ~/whisper/bin/transcribe-audio`).
+   Update the shebang to point at the venv Python
+   (`#!/path/to/whisper/.venv/bin/python`).
+
+4. On first use the selected model is downloaded automatically into
+   `~/whisper/cache/huggingface/`.
+
+## CLI options
+
+| Flag | Description |
+|------|-------------|
+| `--model ALIAS` | tiny, base, **small** (default), medium, turbo |
+| `--language CODE` | ISO 639-1 code (`en`, `de`, `ja`, …). Auto-detects if omitted |
+| `--task` | `transcribe` (default) or `translate` (to English) |
+| `--json` | Structured JSON output instead of plain text |
+| `--word-timestamps` | Per-word timing (in JSON mode) |
+| `--initial-prompt` | Domain hint to improve accuracy |
+
+## Model sizes
+
+| Model | Params | Multilingual | Relative speed | VRAM |
+|-------|--------|:------------:|:--------------:|------|
+| tiny | 39 M | ✓ | ~32× | ~1 GB |
+| base | 74 M | ✓ | ~16× | ~1 GB |
+| small | 244 M | ✓ | ~6× | ~2 GB |
+| medium | 769 M | ✓ | ~2× | ~5 GB |
+| large | 1550 M | ✓ | 1× | ~10 GB |
+| turbo | 809 M | ✓ | ~8× | ~6 GB |
+
+Use **turbo** for the best speed / quality trade-off on capable hardware.
 
 ## Best practices
 
-1. **Use turbo model** - Best speed/quality for English
-2. **Specify language** - Faster than auto-detect
-3. **Add initial prompt** - Improves technical terms
-4. **Use GPU** - 10-20× faster
-5. **Batch process** - More efficient
-6. **Convert to WAV** - Better compatibility
-7. **Split long audio** - <30 min chunks
-8. **Check language support** - Quality varies by language
-9. **Use faster-whisper** - 4× faster than openai-whisper
-10. **Monitor VRAM** - Scale model size to hardware
+1. **Specify language** when known — faster and more accurate than auto-detect.
+2. **Use turbo** for long recordings when speed matters.
+3. **Split long audio** — accuracy degrades beyond ~30 minutes.
+4. **Add an initial prompt** for domain-specific terms or proper nouns.
+5. **Pre-convert to WAV** if you hit format issues (ffmpeg handles most formats).
 
-## Performance
+## Pitfalls
 
-| Model | Real-time factor (CPU) | Real-time factor (GPU) |
-|-------|------------------------|------------------------|
-| tiny | ~0.32 | ~0.01 |
-| base | ~0.16 | ~0.01 |
-| turbo | ~0.08 | ~0.01 |
-| large | ~1.0 | ~0.05 |
+- **Hallucinations on silence**: Whisper may invent text for silent segments.
+  Trim silence before transcription if this occurs.
+- **No speaker diarization**: Whisper does not identify speakers. Use
+  whisperX or pyannote-audio if diarization is needed.
+- **Long audio drift**: Accuracy degrades on files longer than ~30 min.
+  Split into chunks and transcribe individually.
+- **Model download size**: First run downloads the model (small ≈ 500 MB,
+  turbo ≈ 1.5 GB). Ensure sufficient disk space.
 
-*Real-time factor: 0.1 = 10× faster than real-time*
+## Verification
 
-## Language support
+After setup, verify with a quick test:
 
-Top-supported languages:
-- English (en)
-- Spanish (es)
-- French (fr)
-- German (de)
-- Italian (it)
-- Portuguese (pt)
-- Russian (ru)
-- Japanese (ja)
-- Korean (ko)
-- Chinese (zh)
-
-Full list: 99 languages total
-
-## Limitations
-
-1. **Hallucinations** - May repeat or invent text
-2. **Long-form accuracy** - Degrades on >30 min audio
-3. **Speaker identification** - No diarization
-4. **Accents** - Quality varies
-5. **Background noise** - Can affect accuracy
-6. **Real-time latency** - Not suitable for live captioning
+```bash
+# Record or download a short audio clip, then:
+~/whisper/bin/transcribe-audio --language en test.wav
+# Should print the transcript to stdout.
+```
 
 ## Resources
 
-- **GitHub**: https://github.com/openai/whisper ⭐ 72,900+
+- **Whisper**: https://github.com/openai/whisper
+- **faster-whisper**: https://github.com/SYSTRAN/faster-whisper
+- **mlx-whisper**: https://github.com/ml-explore/mlx-examples/tree/main/whisper
 - **Paper**: https://arxiv.org/abs/2212.04356
-- **Model Card**: https://github.com/openai/whisper/blob/main/model-card.md
-- **Colab**: Available in repo
-- **License**: MIT
-
-

--- a/skills/mlops/models/whisper/references/languages.md
+++ b/skills/mlops/models/whisper/references/languages.md
@@ -1,189 +1,48 @@
-# Whisper Language Support Guide
+# Whisper Language Support
 
-Complete guide to Whisper's multilingual capabilities.
+99 languages grouped by transcription quality tier.
 
-## Supported languages (99 total)
+## Top-tier support (WER < 10%)
 
-### Top-tier support (WER < 10%)
+English (en), Spanish (es), French (fr), German (de), Italian (it),
+Portuguese (pt), Dutch (nl), Polish (pl), Russian (ru), Japanese (ja),
+Korean (ko), Chinese (zh)
 
-- English (en)
-- Spanish (es)
-- French (fr)
-- German (de)
-- Italian (it)
-- Portuguese (pt)
-- Dutch (nl)
-- Polish (pl)
-- Russian (ru)
-- Japanese (ja)
-- Korean (ko)
-- Chinese (zh)
+## Good support (WER 10–20%)
 
-### Good support (WER 10-20%)
+Arabic (ar), Turkish (tr), Vietnamese (vi), Swedish (sv), Finnish (fi),
+Czech (cs), Romanian (ro), Hungarian (hu), Danish (da), Norwegian (no),
+Thai (th), Hebrew (he), Greek (el), Indonesian (id), Malay (ms)
 
-- Arabic (ar)
-- Turkish (tr)
-- Vietnamese (vi)
-- Swedish (sv)
-- Finnish (fi)
-- Czech (cs)
-- Romanian (ro)
-- Hungarian (hu)
-- Danish (da)
-- Norwegian (no)
-- Thai (th)
-- Hebrew (he)
-- Greek (el)
-- Indonesian (id)
-- Malay (ms)
+## All 99 languages
 
-### Full list (99 languages)
+Afrikaans, Albanian, Amharic, Arabic, Armenian, Assamese, Azerbaijani,
+Bashkir, Basque, Belarusian, Bengali, Bosnian, Breton, Bulgarian, Burmese,
+Cantonese, Catalan, Chinese, Croatian, Czech, Danish, Dutch, English,
+Estonian, Faroese, Finnish, French, Galician, Georgian, German, Greek,
+Gujarati, Haitian Creole, Hausa, Hawaiian, Hebrew, Hindi, Hungarian,
+Icelandic, Indonesian, Italian, Japanese, Javanese, Kannada, Kazakh, Khmer,
+Korean, Lao, Latin, Latvian, Lingala, Lithuanian, Luxembourgish, Macedonian,
+Malagasy, Malay, Malayalam, Maltese, Maori, Marathi, Moldavian, Mongolian,
+Myanmar, Nepali, Norwegian, Nynorsk, Occitan, Pashto, Persian, Polish,
+Portuguese, Punjabi, Pushto, Romanian, Russian, Sanskrit, Serbian, Shona,
+Sindhi, Sinhala, Slovak, Slovenian, Somali, Spanish, Sundanese, Swahili,
+Swedish, Tagalog, Tajik, Tamil, Tatar, Telugu, Thai, Tibetan, Turkish,
+Turkmen, Ukrainian, Urdu, Uzbek, Vietnamese, Welsh, Yiddish, Yoruba
 
-Afrikaans, Albanian, Amharic, Arabic, Armenian, Assamese, Azerbaijani, Bashkir, Basque, Belarusian, Bengali, Bosnian, Breton, Bulgarian, Burmese, Cantonese, Catalan, Chinese, Croatian, Czech, Danish, Dutch, English, Estonian, Faroese, Finnish, French, Galician, Georgian, German, Greek, Gujarati, Haitian Creole, Hausa, Hawaiian, Hebrew, Hindi, Hungarian, Icelandic, Indonesian, Italian, Japanese, Javanese, Kannada, Kazakh, Khmer, Korean, Lao, Latin, Latvian, Lingala, Lithuanian, Luxembourgish, Macedonian, Malagasy, Malay, Malayalam, Maltese, Maori, Marathi, Moldavian, Mongolian, Myanmar, Nepali, Norwegian, Nynorsk, Occitan, Pashto, Persian, Polish, Portuguese, Punjabi, Pushto, Romanian, Russian, Sanskrit, Serbian, Shona, Sindhi, Sinhala, Slovak, Slovenian, Somali, Spanish, Sundanese, Swahili, Swedish, Tagalog, Tajik, Tamil, Tatar, Telugu, Thai, Tibetan, Turkish, Turkmen, Ukrainian, Urdu, Uzbek, Vietnamese, Welsh, Yiddish, Yoruba
+## Model recommendations by tier
 
-## Usage examples
+| Tier | Recommended model | Expected WER |
+|------|-------------------|--------------|
+| Top-tier (en, es, fr, de, …) | base or turbo | < 10% |
+| Good (ar, tr, vi, …) | medium or large | 10–20% |
+| Lower-resource | large | 20–30% |
 
-### Auto-detect language
+## Tips
 
-```python
-import whisper
-
-model = whisper.load_model("turbo")
-
-# Auto-detect language
-result = model.transcribe("audio.mp3")
-
-print(f"Detected language: {result['language']}")
-print(f"Text: {result['text']}")
-```
-
-### Specify language (faster)
-
-```python
-# Specify language for faster transcription
-result = model.transcribe("audio.mp3", language="es")  # Spanish
-result = model.transcribe("audio.mp3", language="fr")  # French
-result = model.transcribe("audio.mp3", language="ja")  # Japanese
-```
-
-### Translation to English
-
-```python
-# Translate any language to English
-result = model.transcribe(
-    "spanish_audio.mp3",
-    task="translate"  # Translates to English
-)
-
-print(f"Original language: {result['language']}")
-print(f"English translation: {result['text']}")
-```
-
-## Language-specific tips
-
-### Chinese
-
-```python
-# Chinese works well with larger models
-model = whisper.load_model("large")
-
-result = model.transcribe(
-    "chinese_audio.mp3",
-    language="zh",
-    initial_prompt="这是一段关于技术的讨论"  # Context helps
-)
-```
-
-### Japanese
-
-```python
-# Japanese benefits from initial prompt
-result = model.transcribe(
-    "japanese_audio.mp3",
-    language="ja",
-    initial_prompt="これは技術的な会議の録音です"
-)
-```
-
-### Arabic
-
-```python
-# Arabic: Use large model for best results
-model = whisper.load_model("large")
-
-result = model.transcribe(
-    "arabic_audio.mp3",
-    language="ar"
-)
-```
-
-## Model size recommendations
-
-| Language Tier | Recommended Model | WER |
-|---------------|-------------------|-----|
-| Top-tier (en, es, fr, de) | base/turbo | < 10% |
-| Good (ar, tr, vi) | medium/large | 10-20% |
-| Lower-resource | large | 20-30% |
-
-## Performance by language
-
-### English
-
-- **tiny**: WER ~15%
-- **base**: WER ~8%
-- **small**: WER ~5%
-- **medium**: WER ~4%
-- **large**: WER ~3%
-- **turbo**: WER ~3.5%
-
-### Spanish
-
-- **tiny**: WER ~20%
-- **base**: WER ~12%
-- **medium**: WER ~6%
-- **large**: WER ~4%
-
-### Chinese
-
-- **small**: WER ~15%
-- **medium**: WER ~8%
-- **large**: WER ~5%
-
-## Best practices
-
-1. **Use English-only models** - Better for small models (tiny/base)
-2. **Specify language** - Faster than auto-detect
-3. **Add initial prompt** - Improves accuracy for technical terms
-4. **Use larger models** - For low-resource languages
-5. **Test on sample** - Quality varies by accent/dialect
-6. **Consider audio quality** - Clear audio = better results
-7. **Check language codes** - Use ISO 639-1 codes (2 letters)
-
-## Language detection
-
-```python
-# Detect language only (no transcription)
-import whisper
-
-model = whisper.load_model("base")
-
-# Load audio
-audio = whisper.load_audio("audio.mp3")
-audio = whisper.pad_or_trim(audio)
-
-# Make log-Mel spectrogram
-mel = whisper.log_mel_spectrogram(audio).to(model.device)
-
-# Detect language
-_, probs = model.detect_language(mel)
-detected_language = max(probs, key=probs.get)
-
-print(f"Detected language: {detected_language}")
-print(f"Confidence: {probs[detected_language]:.2%}")
-```
-
-## Resources
-
-- **Paper**: https://arxiv.org/abs/2212.04356
-- **GitHub**: https://github.com/openai/whisper
-- **Model Card**: https://github.com/openai/whisper/blob/main/model-card.md
+- **Specify the language** with `--language CODE` — skips auto-detection and
+  improves both speed and accuracy.
+- **Use an initial prompt** in the target language to guide recognition of
+  domain-specific terms or proper nouns.
+- **Use a larger model** for lower-resource languages where quality matters.
+- Language codes follow ISO 639-1 (two-letter codes).

--- a/skills/mlops/models/whisper/scripts/transcribe-audio
+++ b/skills/mlops/models/whisper/scripts/transcribe-audio
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Cross-platform Whisper transcription wrapper.
+
+Automatically selects the best backend for the current platform:
+  - macOS Apple Silicon  ->  mlx-whisper  (Metal / ANE acceleration)
+  - Linux / Windows      ->  faster-whisper  (CUDA or CPU)
+
+Audio is normalised to mono 16 kHz WAV via ffmpeg before inference.
+Model weights are cached under ~/whisper/cache/huggingface/.
+"""
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import platform
+import sys
+import tempfile
+from pathlib import Path
+from subprocess import run as _run
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+BASE_DIR = Path.home() / "whisper"
+TMP_DIR = BASE_DIR / "tmp"
+CACHE_DIR = BASE_DIR / "cache"
+HF_HOME = CACHE_DIR / "huggingface"
+
+# ---------------------------------------------------------------------------
+# Backend detection
+# ---------------------------------------------------------------------------
+
+_SYSTEM = platform.system()
+
+
+def _is_apple_silicon() -> bool:
+    return _SYSTEM == "Darwin" and platform.machine() == "arm64"
+
+
+USE_MLX = _is_apple_silicon()
+
+if USE_MLX:
+    try:
+        import mlx_whisper  # noqa: F401  (used later)
+    except ImportError:
+        sys.exit(
+            "Error: mlx-whisper is not installed.\n"
+            "Install it with:  uv pip install mlx-whisper"
+        )
+else:
+    try:
+        from faster_whisper import WhisperModel  # noqa: F401
+    except ImportError:
+        sys.exit(
+            "Error: faster-whisper is not installed.\n"
+            "Install it with:  uv pip install faster-whisper"
+        )
+
+# ---------------------------------------------------------------------------
+# Model aliases
+# ---------------------------------------------------------------------------
+
+_MLX_ALIASES: dict[str, str] = {
+    "tiny": "mlx-community/whisper-tiny",
+    "base": "mlx-community/whisper-base-mlx",
+    "small": "mlx-community/whisper-small-mlx",
+    "medium": "mlx-community/whisper-medium-mlx",
+    "turbo": "mlx-community/whisper-large-v3-turbo",
+}
+
+_FASTER_ALIASES: dict[str, str] = {
+    "tiny": "tiny",
+    "base": "base",
+    "small": "small",
+    "medium": "medium",
+    "large": "large-v3",
+    "turbo": "large-v3-turbo",
+}
+
+DEFAULT_MODEL = "small"
+
+# ---------------------------------------------------------------------------
+# ffmpeg normalisation
+# ---------------------------------------------------------------------------
+
+
+def _ffmpeg_normalise(input_path: Path, output_path: Path) -> None:
+    """Convert *input_path* to mono 16 kHz 16-bit PCM WAV."""
+    proc = _run(
+        [
+            "ffmpeg", "-y",
+            "-i", str(input_path),
+            "-ac", "1",
+            "-ar", "16000",
+            "-c:a", "pcm_s16le",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "unknown error"
+        raise RuntimeError(f"ffmpeg conversion failed: {detail}")
+
+
+# ---------------------------------------------------------------------------
+# Backend: mlx-whisper
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_mlx(
+    wav: str,
+    model: str,
+    language: str | None,
+    task: str,
+    word_timestamps: bool,
+    initial_prompt: str | None,
+) -> dict:
+    repo = _MLX_ALIASES.get(model, model)
+    with contextlib.redirect_stdout(io.StringIO()), \
+         contextlib.redirect_stderr(io.StringIO()):
+        return mlx_whisper.transcribe(
+            wav,
+            path_or_hf_repo=repo,
+            language=language,
+            task=task,
+            word_timestamps=word_timestamps,
+            initial_prompt=initial_prompt,
+            verbose=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Backend: faster-whisper
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_faster(
+    wav: str,
+    model: str,
+    language: str | None,
+    task: str,
+    word_timestamps: bool,
+    initial_prompt: str | None,
+) -> dict:
+    model_id = _FASTER_ALIASES.get(model, model)
+
+    # Pick the best available device.
+    device, compute_type = "cpu", "int8"
+    try:
+        import torch
+        if torch.cuda.is_available():
+            device, compute_type = "cuda", "float16"
+    except ImportError:
+        pass
+
+    fw = WhisperModel(
+        model_id,
+        device=device,
+        compute_type=compute_type,
+        download_root=str(HF_HOME / "hub"),
+    )
+    segments_iter, info = fw.transcribe(
+        wav,
+        language=language,
+        task=task,
+        word_timestamps=word_timestamps,
+        initial_prompt=initial_prompt,
+        beam_size=5,
+    )
+
+    segments: list[dict] = []
+    text_parts: list[str] = []
+    for seg in segments_iter:
+        entry: dict = {"start": seg.start, "end": seg.end, "text": seg.text}
+        if word_timestamps and seg.words:
+            entry["words"] = [
+                {
+                    "word": w.word,
+                    "start": w.start,
+                    "end": w.end,
+                    "probability": w.probability,
+                }
+                for w in seg.words
+            ]
+        segments.append(entry)
+        text_parts.append(seg.text)
+
+    return {
+        "text": "".join(text_parts),
+        "segments": segments,
+        "language": info.language,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Transcribe audio locally with Whisper (cross-platform)",
+    )
+    parser.add_argument("audio", help="Path to an audio or video file")
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help="Model alias (tiny/base/small/medium/turbo) or HF repo",
+    )
+    parser.add_argument("--language", default=None, help="ISO 639-1 code")
+    parser.add_argument(
+        "--task",
+        choices=["transcribe", "translate"],
+        default="transcribe",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit structured JSON instead of plain text",
+    )
+    parser.add_argument(
+        "--word-timestamps",
+        action="store_true",
+        help="Include per-word timestamps (with --json)",
+    )
+    parser.add_argument(
+        "--initial-prompt",
+        default=None,
+        help="Context hint to improve domain-specific accuracy",
+    )
+    args = parser.parse_args()
+
+    # -- Resolve input -------------------------------------------------
+    input_path = Path(args.audio).expanduser().resolve()
+    if not input_path.exists():
+        print(f"Error: file not found: {input_path}", file=sys.stderr)
+        return 2
+
+    # -- Ensure directories --------------------------------------------
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+    HF_HOME.mkdir(parents=True, exist_ok=True)
+    os.environ.setdefault("HF_HOME", str(HF_HOME))
+    os.environ.setdefault("HUGGINGFACE_HUB_CACHE", str(HF_HOME / "hub"))
+    os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+    os.environ.setdefault("TQDM_DISABLE", "1")
+
+    # -- Normalise audio -----------------------------------------------
+    with tempfile.NamedTemporaryFile(
+        suffix=".wav", dir=TMP_DIR, delete=False,
+    ) as tmp:
+        wav_path = Path(tmp.name)
+
+    try:
+        _ffmpeg_normalise(input_path, wav_path)
+        transcribe = _transcribe_mlx if USE_MLX else _transcribe_faster
+        result = transcribe(
+            str(wav_path),
+            args.model,
+            args.language,
+            args.task,
+            args.word_timestamps,
+            args.initial_prompt,
+        )
+    finally:
+        wav_path.unlink(missing_ok=True)
+
+    # -- Output --------------------------------------------------------
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print((result.get("text") or "").strip())
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Make the bundled whisper skill work on all platforms instead of only supporting `openai-whisper` with PyTorch/CUDA.

## Changes

### Architecture
The skill now auto-selects the optimal backend per OS:

| Platform | Backend | Acceleration |
|----------|---------|--------------|
| macOS (Apple Silicon) | `mlx-whisper` | Metal / ANE |
| Linux / Windows (NVIDIA) | `faster-whisper` | CUDA |
| Linux / Windows (CPU) | `faster-whisper` | AVX2 |

Both backends use the same Whisper model weights and produce equivalent transcription quality.

### Files changed

- **SKILL.md** — Rewritten to follow the contribution guidelines structure (When to use → Quick reference → Setup procedure → CLI options → Pitfalls → Verification). Added `requires_toolsets: [terminal]` and `prerequisites.commands: [ffmpeg]`. Removed bloat (LangChain examples, duplicate code blocks, raw API docs).

- **scripts/transcribe-audio** (new) — Cross-platform wrapper script that:
  - Auto-detects Apple Silicon vs Linux/Windows at import time
  - Normalises input audio to mono 16 kHz WAV via ffmpeg
  - Maps model aliases to the correct repos/names per backend
  - Produces a unified output format (plain text or JSON)
  - Manages HuggingFace cache under `~/whisper/cache/huggingface/`

- **references/languages.md** — Trimmed from 190 lines to ~50 lines of essential reference (tier listings, model recommendations, tips). Removed Python code examples that used the raw `whisper` API directly.

### Why faster-whisper?
- 4× faster than `openai-whisper` via CTranslate2
- Works on CPU without PyTorch (lighter install)
- Same model weights, same output quality
- Well-maintained, actively developed

### Testing
Tested the mlx-whisper path on macOS Apple Silicon with multiple audio formats and languages. The faster-whisper path follows the same code structure and uses the established faster-whisper API.