### PR TITLE
feat(skill): add deep-research skill

### DIFF
--- a/skills/research/deep-research/SKILL.md
+++ b/skills/research/deep-research/SKILL.md
@@ -1,642 +1,489 @@
 ---
 name: deep-research
-description: Scientific research methodology for deep investigation. Plans research, auto-discovers available tools and skills, iteratively searches until saturation, evaluates credibility, performs contrarian analysis, verifies claims, and synthesizes structured reports.
-version: 1.0.0
+description: Scientific research methodology for deep investigation with multi-agent debate, quality gates, evidence cards, forecast calibration, and auto-discovered capabilities. Plans research, discovers available tools, iteratively searches until saturation, enforces quality gates with rollback, performs structured debate analysis, and synthesizes verified reports.
+version: 2.0.0
 author: Hermes Agent
 license: MIT
 metadata:
   hermes:
-    tags: [research, analysis, synthesis, scientific-method, investigation]
-    related_skills: [duckduckgo-search, arxiv, polymarket, blogwatcher]
+    tags: [research, analysis, synthesis, scientific-method, investigation, forecasting]
+    related_skills: [duckduckgo-search, arxiv, polymarket, blogwatcher, scrapling]
 ---
 
-# Deep Research — Scientific Investigation Skill
+# Deep Research v2.0 — Scientific Intelligence System
 
 ## What This Is
 
-This is a research methodology skill. It teaches the agent HOW to think like a researcher — not just search and dump results, but plan, investigate, evaluate, reflect, and synthesize.
+This is a complete research methodology skill. It teaches the agent HOW to think like a researcher AND enforces quality through structured processes.
 
-**Critical: The user's initial message is a starting point, not the complete research.** When the user provides info (a tweet, an article, a claim), use it as the seed for deep independent research. Verify their claims, find the original sources, look for additional context, find contradicting evidence, and bring back MORE than what they gave you. You are the expert researcher — they gave you a lead, now go investigate it properly before coming back with findings.
+**New in v2.0:**
+- Multi-agent debate (FOR/AGAINST/ALTERNATIVE analysis)
+- Quality gates with automatic rollback
+- Evidence cards with bias detection
+- Self-learning forecast calibration
+- Auto-discovery of available tools
+- PIVOT/REFINE decision loops
 
 Use this for:
 - Pre-writing research: "I want to write about X — what do I need to know?"
 - Post-writing validation: "I wrote an article — what evidence supports my claims?"
 - Competitive intelligence: "What's happening in X space right now?"
 - Due diligence: "Is this claim true? What do primary sources say?"
+- Forecasting: "Will X happen? What's the probability?"
 - Deep dives: "I need to deeply understand X topic"
 
 ## Helper Scripts
 
-This skill includes two helper scripts:
+This skill includes helper scripts in `scripts/`:
 
 ```bash
 # Session manager and report generator
-python3 SKILL_DIR/scripts/deep_research.py init "Is AI replacing programmers?"
+python3 scripts/deep_research.py init "Is AI replacing programmers?"
 
-# Quality scorer for proof-based saturation checks
-python3 SKILL_DIR/scripts/quality_score.py assess --proof proof.json
-python3 SKILL_DIR/scripts/quality_score.py checklist
+# Quality scoring with proof validation
+python3 scripts/quality_score.py assess --proof proof.json
+
+# Evidence cards with bias detection
+python3 scripts/evidence_cards.py add --claim "X" --source "url"
+
+# Quality gates with rollback
+python3 scripts/gates.py all --proof proof.json
+
+# Multi-agent debate
+python3 scripts/debate.py init --hypothesis "X will happen"
+
+# Forecast history and calibration
+python3 scripts/forecast_history.py log --question "X?" --prob 65 --method polymarket
+
+# Capability auto-discovery
+python3 scripts/capability_map.py discover
 ```
 
-`SKILL_DIR` is the directory containing this SKILL.md file.
+State directory: `$HERMES_HOME/state/deep-research/` or `~/.hermes/state/deep-research/`
 
-Deep research sessions are stored in a writable state directory by default:
-- `$HERMES_DEEP_RESEARCH_STATE_DIR` if set
-- otherwise `$HERMES_HOME/state/deep-research`
-- otherwise `~/.hermes/state/deep-research`
+---
 
 ## Research Methodology
 
 Real researchers don't search once and stop. They follow iterative cycles:
 
 ```
-QUESTION → PLAN → SEARCH → EVALUATE → REFLECT → IDENTIFY GAPS → FILL GAPS → VERIFY → SYNTHESIZE
-                                      ↑                                    |
-                                      └────────── (if not saturated) ─────┘
+QUESTION → CAPABILITY_DISCOVER → PLAN → SEARCH → DEBATE → GATES → REFLECT → PIVOT/REFINE → VERIFY → SYNTHESIZE
+                ↑                                                            ↓
+                └────────────── (if gates fail, rollback to this point) ─────┘
 ```
 
-Each cycle gets you closer to truth. You stop when you reach saturation — when new searches stop yielding new relevant information and all critical gaps are filled. Maximum 3 cycles to prevent bloat.
+---
 
-## Phase 1: Question Definition and Hypothesis
+## Phase 0: Capability Discovery (NEW)
 
-Before searching anything, define clearly:
+MANDATORY. Before any research, discover what tools are available.
 
-1. **Core question**: What exactly am I trying to answer?
-2. **Sub-questions**: What smaller questions need answering first?
-3. **Hypothesis**: Form an initial hypothesis before searching. "I think X is true because Y." This is NOT a conclusion — it is a lens that makes your searches more targeted. You will revise or discard it as evidence accumulates.
-4. **Claims to verify**: What specific claims need evidence?
-5. **Contradictions to resolve**: What conflicts exist in my understanding?
-6. **Success criteria**: How will I know the research is complete?
-
-Output: A research plan with numbered questions, a hypothesis, and success criteria.
-
-## Phase 2: Tool Discovery and Capability Mapping
-
-MANDATORY. Never skip this phase because you "already know" the tools. Last time you did, you missed Polymarket and used the wrong search syntax.
-
-### Step 1: Discover Skills
-
-Call `skills_list()` to get all available skills. Filter for research-relevant ones:
-
-- Any skill with tags: `research`, `news`, `web`, `scraping`, `search`, `social-media`, `browser`, `market-data`
-- Any skill whose description mentions: search, fetch, scrape, extract, browser, social, news, prediction, market
-
-For each relevant skill, call `skill_view(name)` to load its documentation and understand:
-- What it does
-- How to invoke it (exact commands/arguments)
-- What inputs it needs
-- Any environment requirements
-
-Skills know their own CLI syntax. Read the SKILL.md and use it. Do not guess at flags.
-
-### Step 2: Discover Built-in Tools
-
-Check what built-in tools you have access to. For research, these are relevant:
-
-- `browser_navigate` / `browser_snapshot` / `browser_click` — for interactive browsing of JS-rendered pages, paywalled content, or sites that block scraping
-- `web_search` — built-in web search if available
-
-### Step 3: Verify Optional Tools
+### Auto-Discovery
 
 ```bash
-# Check tools referenced by discovered skills (use names from SKILL.md)
-for cmd in ddgs twitter scrapling curl python3 node; do
-    command -v $cmd >/dev/null 2>&1 && echo "$cmd: available" || echo "$cmd: not found"
-done
+python3 scripts/capability_map.py discover
 ```
 
-### Step 4: Build Capability Map
+This returns:
+- Available skills (deep-research, duckduckgo-search, polymarket, etc.)
+- Available tools (ddgs, scrapling, curl, etc.)
+- Built-in tools (browser_navigate, terminal, etc.)
+- Capability index (what can be done with available tools)
 
-Create a capability map from what you discovered. Include EVERY research-relevant skill, even ones you think you won't need:
+### Build Capability Map
 
-| Research Need | Available Tool/Skill | How to Use (from SKILL.md) |
-|---------------|---------------------|---------------------------|
-| General web search | [discovered skill] | [exact syntax from its docs] |
-| News search | [discovered skill] | [exact syntax from its docs] |
-| Social media / X | [discovered skill] | [exact syntax from its docs] |
-| Article extraction | [discovered skill] | [exact syntax from its docs] |
-| Prediction markets | [discovered skill] | [exact syntax from its docs] |
-| Interactive browsing | [built-in tools] | browser_navigate, snapshot, click |
-| Academic papers | [discovered skill or web fallback] | [exact syntax or site: filter] |
+From the discovery output, build a capability map:
 
-### Step 5: Identify Research-Type Specific Tools
-
-Based on the research topic, identify which tools from the capability map are especially relevant:
-
-- **Forecasting questions** -> prediction markets (Polymarket), analyst reports, historical base rates
-- **Geopolitical/military** -> Wikipedia (often best aggregate for active conflicts), news search, expert commentary
-- **Technical/academic** -> arxiv, academic search, primary papers
-- **Company/market** -> financial news, SEC filings, analyst reports
-- **Fact-checking** -> primary sources, official statements, data verification
+| Research Need | Available Tool | How to Use |
+|---------------|----------------|------------|
+| General search | [discovered] | [from skill docs] |
+| News search | [discovered] | [from skill docs] |
+| Prediction markets | [discovered] | [from skill docs] |
+| Academic papers | [discovered] | [from skill docs] |
+| Article extraction | [discovered] | [from skill docs] |
 
 ### Fallback Priority
 
-When primary search tools aren't available or fail:
-
-1. **Skill-based tools** (loaded via skill_view) — always preferred
-2. **Built-in tools** (browser_navigate, read_file, etc.) — reliable fallback
-3. **Scrapling** (if installed) — for direct URL fetching
-4. **curl** (always available) — last resort for HTTP requests
+When primary tools aren't available:
+1. Skill-based tools (loaded via skill_view) — preferred
+2. Built-in tools (browser_navigate, terminal) — reliable fallback
+3. Python packages (scrapling, ddgs) — if installed
+4. curl (always available) — last resort
 
 ### Paywall/Access Escalation Ladder
 
-When a key source is inaccessible:
-1. Try `scrapling extract get` (basic fetch)
-2. Try `scrapling extract fetch` with `--headless --disable-resources` (JS rendering)
-3. Try `scrapling extract stealthy-fetch` with `--solve-cloudflare` (anti-bot bypass)
-4. Try `browser_navigate` + `browser_snapshot` (interactive browser)
-5. Search for the same story/topic from a different accessible source
-6. Search for social media discussion about the article (often quotes key content)
-7. If all fail, note as gap and move on — do not spend more than 2 attempts on one URL
+1. Try scrapling extract get (basic fetch)
+2. Try scrapling extract stealthy-fetch (anti-bot bypass)
+3. Try browser_navigate + browser_snapshot (interactive)
+4. Search for same story from different source
+5. Search for social media discussion
+6. If all fail, note as gap and move on
 
-For 404/dead links: skip immediately at step 1 and go to step 5 (find alternative source).
+---
+
+## Phase 1: Question Definition and Hypothesis
+
+Before searching, define clearly:
+
+1. **Core question**: What exactly am I trying to answer?
+2. **Sub-questions**: What smaller questions need answering first?
+3. **Hypothesis**: Form an initial hypothesis. "I think X is true because Y."
+4. **Claims to verify**: What specific claims need evidence?
+5. **Success criteria**: How will I know research is complete?
+
+### Initialize Debate
+
+```bash
+python3 scripts/debate.py init --hypothesis "I believe X will happen because Y"
+```
+
+This sets up the multi-agent debate framework.
+
+---
+
+## Phase 2: Initialize Evidence Cards
+
+Create an evidence card deck:
+
+```bash
+python3 scripts/evidence_cards.py init --session "session-id"
+```
+
+Every piece of evidence will become a structured card with:
+- Claim text
+- Source URL and tier
+- Verification status
+- Bias flags (auto-detected)
+- Debate analysis
+
+---
 
 ## Phase 3: Parallel Search Execution
 
-Using the capability map from Phase 2, execute searches across multiple sources.
+Using the capability map from Phase 0, execute searches across multiple sources.
 
 ### Execution Pattern
 
-For each research question, run multiple searches. Use two strategies depending on what you're searching with:
-
 **Strategy A: Same tool, multiple queries — use execute_code batching**
 
-When the same tool (e.g., your web search tool from the capability map) can answer multiple sub-questions, batch all queries into a single `execute_code` block. This is faster than multiple calls, keeps all results in one context, and lets you process/compare immediately.
-
-Read the tool's SKILL.md for exact import/syntax, then batch like:
-
 ```python
-# Example pattern — substitute YOUR tool's Python API from its SKILL.md
-# (Shown here using ddgs as illustration; use whatever tool you discovered)
-from ddgs import DDGS
+from hermes_tools import terminal
 
+# Batch all searches into one execute_code block
 queries = {
     "topic aspect 1": "query text 1",
     "topic aspect 2": "query text 2",
-    "topic aspect 3": "query text 3",
 }
 
 for label, query in queries.items():
     print(f"=== {label} ===")
-    with DDGS() as d:
-        for r in d.text(query, max_results=5):
-            print(f"  {r['title']}")
-            print(f"  {r.get('href', 'N/A')}")
-            print(f"  {r.get('body', '')[:200]}")
-            print()
+    # Use discovered tool from capability map
 ```
 
 **Strategy B: Different tools needed — use delegate_task batch mode**
 
-When sub-questions need different tools (one needs search, another needs scraping, another needs browser), use `delegate_task` with the `tasks` array for parallel execution.
+When sub-questions need different tools, use parallel delegation.
 
-**Strategy C: Deep article reading — use execute_code with your extraction tool**
+### Add Evidence Cards
 
-For extracting full content from key URLs found during search, batch multiple URLs into one execute_code block using your extraction tool's API (loaded from its SKILL.md).
+After each search, add evidence cards:
 
-### Search Angles to Cover
-
-For a typical research topic, ensure you search from at least these angles:
-
-1. **Broad web search** — general coverage, multiple viewpoints
-2. **News search** — recent developments, breaking news, timelines
-3. **Social/sentiment** — expert opinions, prediction markets (if tools available)
-4. **Deep article read** — extract full content from 3-5 most important URLs found
-5. **Contrarian/expert depth** — analyst reports, primary data, alternative viewpoints
-
-### Source Diversity Rule
-
-For each sub-question, use at least 2 different source types. Never rely on a single search tool or a single source. Cross-reference everything.
-
-### Handling Failures
-
-- Tool returns empty results -> try alternative tool from your capability map
-- Tool errors out -> fall back down the priority chain (skill -> built-in -> scrapling -> curl)
-- Paywalled content -> follow the Paywall/Access Escalation Ladder from Phase 2
-- 404/dead link -> skip immediately and find alternative, do not debug dead URLs
-- Need to read specific URL that scraping cannot handle -> use browser_navigate
-
-### Incremental Proof Building (Critical)
-
-Do NOT wait until the end to build the proof object. Build it AS YOU RESEARCH. After each search round, update the proof:
-
-1. **After each search batch**: add new sub-questions answered, new sources found, new source tiers
-2. **After contrarian searches**: immediately add contrarian_searches entries with query/found_evidence/result_summary
-3. **After reading key articles**: immediately rate claims as verified/supported/unverified
-4. **After finding contradictions**: add to contradictions list with resolved status
-
-Save proof to a local JSON file after each major search round, for example `proof.json`. This prevents memory loss between rounds and makes the final scoring step a formality.
-
-Initial proof template to create at start of Phase 3:
-```json
-{
-  "sub_questions": [{"question": "...", "answered": false, "sources": []}],
-  "source_types_used": [],
-  "source_tiers": {"tier1": 0, "tier2": 0, "tier3": 0, "tier4": 0, "tier5": 0},
-  "contrarian_searches": [],
-  "claims": [],
-  "hypothesis_revised": false,
-  "hypothesis_original": "...",
-  "contradictions": [],
-  "gaps_identified": [],
-  "search_rounds": 0,
-  "ai_inference_labeled": true
-}
-```
-
-## Phase 4: Critical Evaluation
-
-Not all sources are equal. Evaluate each finding:
-
-### Source Hierarchy
-- **Tier 1 — Primary**: Original data, official reports, direct quotes, government statistics, company filings
-- **Tier 2 — Expert analysis**: Peer-reviewed papers, recognized analysts (Goldman Sachs, ING, etc.), research firms (Windward, etc.)
-- **Tier 3 — Credible reporting**: Reputable news outlets (Reuters, Bloomberg, AP, BBC), industry publications
-- **Tier 4 — Secondary**: Blog posts, opinion pieces, regional news, think tank reports
-- **Tier 5 — Unverified**: Social media, anonymous claims, user-generated content
-
-### Red Flags to Watch For
-- Claims without citations
-- Single-source reporting
-- Conflicts of interest (who benefits from this narrative?)
-- Outdated information (check dates!)
-- Emotional language over factual language
-- Correlation presented as causation
-- Survivorship bias
-
-### Cross-Reference Rule
-- 1 source saying something = interesting, needs verification
-- 2 independent sources = credible claim
-- 3+ independent sources = established fact
-- Primary source contradicts secondary = trust primary
-- Prediction markets (Polymarket, Metaculus) = crowd-sourced probability, valuable for forecasting
-
-## Phase 5: Self-Reflection and Contrarian Search (Critical)
-
-This is what separates research from searching. After initial search results are in, BEFORE synthesis:
-
-### Mandatory Reflection Questions
-
-1. **State your hypothesis explicitly.** Write it out: "Based on what I've found so far, I believe X because Y."
-
-2. **What contradicts your hypothesis?** Look at your findings — what evidence pushes against what you initially believed? Flag contradictions explicitly.
-
-3. **What would a skeptic say?** Write out the counter-argument to your thesis.
-
-4. **Search for the counter-argument.** This is NOT optional. Run at least one search specifically designed to find evidence AGAINST your hypothesis:
-   - "[topic] bear case"
-   - "[topic] why wrong"
-   - "[topic] alternative explanation"
-   - "[topic] criticism"
-   - "[forecast number] why will not happen"
-
-5. **Assess confidence honestly:**
-   - High: multiple primary sources, consistent data, prediction markets align
-   - Medium: some supporting evidence, gaps remain, expert disagreement
-   - Low: speculative, few sources, contradictions unresolved
-
-6. **Note surprises.** What did you find that you did NOT expect? These are often where the real insight lives.
-
-### Hypothesis Revision
-
-After reflection and contrarian search, explicitly state:
-- Original hypothesis
-- Evidence for
-- Evidence against
-- Revised hypothesis (if changed)
-- Confidence level
-
-## Phase 6: Gap Analysis and Iterative Loop with Quality Scoring
-
-This is where most AI research fails. It stops after one round. We force iteration using a proof-based quality score that the agent CANNOT fake — the score is computed from actual evidence, not vibes.
-
-### The Scoring System
-
-A script at `SKILL_DIR/scripts/quality_score.py` computes quality from a **proof object** (JSON). The agent provides evidence, the script computes the score. You cannot advance until the score hits 0.90 (SATURATED).
-
-**8 dimensions, weighted:**
-- Sub-Question Coverage (20%) — all questions answered with sources
-- Contrarian Evidence (15%) — searched against your hypothesis
-- Claim Verification (15%) — claims traced to sources, AI inference labeled
-- Source Diversity (10%) — multiple source types used
-- Source Quality (10%) — primary/analyst sources outweigh blogs
-- Hypothesis Revision (10%) — updated based on evidence
-- Contradiction Resolution (10%) — contradictions found and resolved
-- Gap Analysis & Saturation (10%) — gaps identified, ranked, critical ones filled
-
-### Step 1: Identify Specific Gaps
-
-After Phase 5, write out every gap explicitly:
-
-- **Unanswered sub-questions**: Which of your original questions still lack sufficient evidence?
-- **Weak evidence areas**: Where do you only have Tier 4-5 sources?
-- **Contradictions unresolved**: Where do credible sources disagree and you haven't found the resolution?
-- **Missing data points**: Numbers, dates, quantities you need but don't have
-- **Unverified claims**: Things that seem true but only have single-source support
-
-### Step 2: Rank Gaps by Impact
-
-Not all gaps matter equally. Rank each gap:
-- **Critical**: Without this, the core answer is unreliable
-- **Important**: Would significantly strengthen the conclusion
-- **Nice to have**: Adds depth but doesn't change the answer
-
-### Step 3: Targeted Gap-Filling Searches
-
-For each Critical and Important gap, run a targeted search designed SPECIFICALLY to fill that gap:
-- Data gaps -> search for the specific number/term
-- Source quality gaps -> search for primary sources (official reports, government data)
-- Contradiction gaps -> search for the resolution
-- Expert opinion gaps -> search for analyst commentary or academic analysis
-
-### Step 4: Build Proof Object and Score
-
-After each round, build a proof JSON with:
-- sub_questions: list with question/answered/sources for each
-- source_types_used: list of tool types used
-- source_tiers: count by tier (tier1=primary, tier2=analyst, tier3=reporting, tier4=secondary, tier5=unverified)
-- contrarian_searches: list with query/found_evidence/result_summary
-- claims: list with claim/status/sources (status: verified/supported/ai_inference/unverified)
-- hypothesis_revised: true/false + original and revised text
-- contradictions: list with description/resolved/resolution
-- gaps_identified: list with gap/rank(filled=true/false)
-- search_rounds: how many iterations performed
-- ai_inference_labeled: true/false
-
-Save to file, run:
 ```bash
-python3 SKILL_DIR/scripts/quality_score.py assess --proof proof.json
+python3 scripts/evidence_cards.py add \
+  --claim "X costs Y" \
+  --source "https://..." \
+  --type "primary" \
+  --credibility 4
 ```
 
-Run `python3 SKILL_DIR/scripts/quality_score.py checklist` to see the full proof requirements.
+Bias flags are auto-detected based on source type.
 
-### Step 5: Loop Until Saturated
+---
 
-**Score thresholds:**
-- **>= 0.90 SATURATED**: Proceed to Phase 7 (Verification Pass)
-- **0.70-0.89 GOOD**: Identify weak dimensions, run targeted gap-filling, rescore
-- **0.50-0.69 ADEQUATE**: Significant gaps. Run full gap analysis round, rescore
-- **< 0.50 INSUFFICIENT**: Major problems. Go back to Phase 3-5 with focus on weakest dimensions
+## Phase 4: Multi-Agent Debate (NEW)
 
-**Maximum 3 rounds** to prevent bloat. If still below 0.90 after 3 rounds, proceed anyway but flag confidence as LOW and list specific deficiencies in final output.
+This is what separates research from searching. After initial evidence collection:
 
-**The score can go down.** If a new search round reveals problems (new contradictions, claims turn out false, source quality drops), the score decreases. This prevents the agent from just going through the motions.
+### Run Structured Debate
+
+```bash
+# Add arguments from each perspective
+python3 scripts/debate.py argue --side proponent --argument "Evidence shows X because..." --evidence "url"
+
+python3 scripts/debate.py argue --side skeptic --argument "However, Y contradicts this because..." --evidence "url"
+
+python3 scripts/debate.py argue --side alternative --argument "Actually, Z might be the real cause..." --alternative-hypothesis "Z is happening because W"
+```
+
+### Debate Requirements
+
+- Proponent must cite specific evidence
+- Skeptic must search for counter-evidence
+- Alternative must propose different explanation
+- Minimum 2 arguments per side
+- Evidence must be cited (not just claimed)
+
+### Synthesize Debate
+
+```bash
+python3 scripts/debate.py synthesize
+```
+
+The agent must fill in:
+- Strongest argument for hypothesis
+- Strongest argument against hypothesis
+- Key evidence on both sides
+- Unresolved questions
+- Whether hypothesis should be revised
+
+---
+
+## Phase 5: Quality Gates (NEW)
+
+Gates enforce minimum standards. If a gate fails, the pipeline rolls back.
+
+### Run All Gates
+
+```bash
+python3 scripts/gates.py all --proof proof.json
+```
+
+### Gate Definitions
+
+| Gate | Pass Criteria | Rollback Target |
+|------|--------------|-----------------|
+| hypothesis_stated | Hypothesis explicitly stated | planning |
+| evidence_diversity | 2+ source types used | search |
+| source_quality | At least 1 Tier 1-2 source | search |
+| claim_verification | 50%+ claims verified | gap_filling |
+| contrarian_evidence | Searched against hypothesis | reflection |
+| probability_grounding | Forecast tied to market/base rate | search |
+| saturation | 80%+ critical gaps filled | gap_filling |
+| freshness | Recent sources for time-sensitive topics | search |
+
+### Gate Failure Handling
+
+If a CRITICAL gate fails:
+1. Note the failure and rollback target
+2. Execute rollback (go back to earlier phase)
+3. Fix the issue
+4. Re-run gates
+
+Maximum 2 rollback cycles to prevent infinite loops.
+
+---
+
+## Phase 6: PIVOT/REFINE Decision (NEW)
+
+After debate and gates, make a decision:
+
+### Decision Types
+
+| Decision | When | Action |
+|----------|------|--------|
+| PROCEED | Gates passed, hypothesis supported | Continue to verification |
+| REFINE | Minor gaps, hypothesis mostly supported | Fill gaps, strengthen evidence |
+| PIVOT | Hypothesis contradicted by evidence | Formulate new hypothesis, restart debate |
+
+### Record Decision
+
+```bash
+python3 scripts/debate.py verdict --findings "finding1|finding2|finding3"
+```
+
+### PIVOT Process
+
+If pivoting:
+```bash
+python3 scripts/debate.py pivot --new-hypothesis "New hypothesis" --reason "Old hypothesis contradicted by X"
+```
+
+Maximum 2 pivots per research session.
+
+---
 
 ## Phase 7: Verification Pass
 
-Before synthesizing the final output, verify each key claim you plan to make:
+Before synthesizing, verify each key claim:
 
-1. **List every specific claim** in your draft answer (numbers, dates, names, causal relationships)
-2. **Trace each claim** back to its source
-3. **Rate each claim**: Verified (2+ independent sources), Supported (1 good source), Unverified (no direct source)
-4. **Flag any claims that are AI inference** vs. directly sourced — label these as your analysis, not fact
+1. List every specific claim in your draft
+2. Trace each claim back to its source
+3. Rate each claim: Verified (2+ sources), Supported (1 source), AI inference (your analysis), Unverified (remove)
+4. Update evidence card verification status:
 
-This step prevents hallucination and overconfident assertions. If any key claim is Unverified, either search for a source or remove the claim.
+```bash
+python3 scripts/evidence_cards.py verify --card-id "card-xxx" --status verified --notes "Cross-referenced with source Y"
+```
+
+---
 
 ## Phase 8: Synthesis
 
-Structure the findings into a clear, authoritative output.
+Structure findings into output.
 
-### Internal Report Structure (for your reasoning)
-
-Use this structure internally. Adapt the output to the user's platform and request type (see Output Format Adaptation below).
-
-```
-# Research Report: [Topic]
-Date: [timestamp]
-Core Question: [original question]
-Hypothesis: [initial -> revised]
-Rounds: [number of search iterations performed]
-
-## Executive Summary
-[3-5 sentence summary of key findings]
-
-## Key Findings
-1. [Finding with source]
-2. [Finding with source]
-
-## Evidence by Sub-Question
-[Sub-question 1]: Conclusion, evidence, confidence, remaining gaps
-[Sub-question 2]: ...
-
-## Hypothesis Evaluation
-- Evidence supporting: [...]
-- Evidence contradicting: [...]
-- Contrarian search results: [...]
-- Revised hypothesis: [...]
-
-## Claim Verification
-- Verified (2+ sources): [list]
-- Supported (1 good source): [list]
-- AI inference (labelled as analysis): [list]
-- Unverified (removed from output): [list]
-
-## Contradictions Found
-- [Contradiction 1: Source A says X, Source B says Y]
-- [Resolution or remaining uncertainty]
-
-## Gap Iteration Log
-Round 1 gaps identified: [...]
-Round 2 gaps filled: [...]
-Round 2 remaining: [...]
-Saturation achieved: [Yes/No, why]
-
-## Gaps and Limitations
-- [What we couldn't verify and why we stopped looking]
-- [What's outside our knowledge]
-
-## Sources
-[List with tier classification]
-```
-
-## Chain of Thought (Internal Process — Do Not Output)
-
-Throughout research, maintain internal reasoning discipline. The user never sees this — it's your thinking process:
-
-1. **Form hypothesis** before searching
-2. **Search with intent** — each query should test or expand understanding
-3. **Note surprises** — when results contradict expectations, that's where insight lives
-4. **Cross-reference** — never rely on single sources
-5. **Contrarian search** — actively find evidence AGAINST your hypothesis
-6. **Revise hypothesis** — update as evidence accumulates
-7. **Assess confidence** honestly
-
-### Probability Estimation Methodology (for forecast/scenario questions)
-
-When the research involves estimating probabilities (scenarios, forecasts, outcomes), do NOT just guess. Use this methodology:
-
-1. **Check prediction markets** (Polymarket, Metaculus, Manifold) for crowd-sourced probabilities. These are real-money bets and often more accurate than expert opinions.
-
-2. **Find analyst forecasts** — investment banks (Goldman, Morgan Stanley, JPMorgan), think tanks (RAND, CFR, IISS), and research firms publish probability-weighted scenarios.
-
-3. **Use historical base rates** — what happened in similar situations? (e.g., "of the last 10 wars involving a great power, X ended in negotiation, Y ended in frozen conflict, Z ended in escalation")
-
-4. **Apply the Bayesian framework** — start with base rate, adjust for specific evidence. State your adjustment reasoning.
-
-5. **Label probability sources clearly**:
-   - "X% per [Polymarket as of date]" = crowd-sourced real-money estimate
-   - "X% per [Goldman Sachs]" = expert analyst estimate
-   - "X% estimated based on [reasoning]" = your analysis (lower confidence)
-   - "X% historical base rate from [source]" = reference class estimate
-
-6. **Never present probabilities without methodology**. The user needs to know if it's a Polymarket number or a guess.
-
-7. **State uncertainty ranges, not point estimates** — "35-45%" is more honest than "40%" when you're uncertain.
-
-The deep research script (`SKILL_DIR/scripts/deep_research.py`) can maintain a lightweight research activity log for archival if useful, but the user-facing output should be the research report or briefing — never raw internal reasoning.
-
-## Output Format Adaptation
-
-Adapt output to the user's platform and request type:
-
-### Military Briefing Format (default for most requests)
-
-Use this format unless the user explicitly asks for something else. Inspired by military SITREPs — scannable, no fluff, right to the point:
+### Briefing Format (Default)
 
 ```
 SITREP: [TOPIC] — [TIMEFRAME]
 [Date] | Confidence: [High/Medium/Low]
 
 CURRENT STATE
-- [What's happening right now with numbers]
-- [Current price/data/status]
-- [Key context, 1-2 sentences max per point]
+- [What's happening with numbers]
+- [Key context]
 
 KEY INTEL
-1. [Most important finding with source]
-2. [Second finding with source]
-3. [Third finding with source]
-4. [Fourth finding with source]
+1. [Finding with source]
+2. [Finding with source]
+3. [Finding with source]
 
 ESTIMATE / FORECAST (if applicable)
-[Simple table or list of scenarios]
-MOST LIKELY: [single line with number]
+[Scenarios with probabilities]
+MOST LIKELY: [single line]
 
 KEY VARIABLE
-[The one thing that determines which scenario happens]
+[The one thing that determines outcome]
 
 BOTTOM LINE
-[What the user should do/expect in 1-2 sentences]
+[Actionable recommendation]
 ```
 
-Rules for briefing format:
-- No executive summary sections — just lead with the answer
-- No "research methodology" explanation — user doesn't care
-- No credibility score tables — weave sources into the text
-- Use all-caps section headers (CURRENT STATE, KEY INTEL, etc.) for scannability
-- Numbers inline, not footnoted
-- 3-5 bullets per section max
-- End with BOTTOM LINE, not "further research needed"
+### Telegram Rules
 
-### Formal Report Mode
+- NO markdown tables (use code blocks or lists)
+- NO markdown headers (use ALL CAPS)
+- Bold, italic, code blocks OK
 
-Full structured report with executive summary, findings by sub-question, contradictions, gaps, and source list. Use ONLY when:
-- User explicitly asks for a report
-- Research supports an article/whitepaper the user is writing
-- Save to file and provide file path
+---
 
-### Quick Answer
+## Forecasting-Specific Methodology
 
-Direct answer with key evidence, no report structure. Use for fact-checks and single-question lookups. Still be specific — name sources, cite numbers, state confidence.
+When the research involves estimating probabilities:
 
-Regardless of format: always be credible and authoritative. State what you know, what you're uncertain about, and what evidence supports each claim. Never hedge with "some sources say" without naming which sources and what they actually say.
+### Step 1: Check Prediction Markets
 
-### Platform Detection
-- Telegram: briefing format, no tables (Telegram Bot API doesn't render markdown tables), no markdown headers
-- Discord: briefing format, limited markdown ok
-- CLI: any format, can save files
-- Unknown: briefing format by default
+```bash
+python3 scripts/capability_map.py recommend --type forecast
+```
 
-### Telegram Table Workaround
-Telegram doesn't render markdown tables. Use one of these instead:
-- Simple lists with aligned spacing
-- Pipe-separated lines (manual alignment)
-- Dash-separated key-value pairs
-- For complex data, generate an image file and send as media
+Use Polymarket, Metaculus, or similar for crowd-sourced probabilities.
 
-### Streaming vs Monolithic Delivery
+### Step 2: Find Analyst Forecasts
 
-For complex multi-topic research, consider splitting into multiple messages:
+Search for:
+- Investment bank reports (Goldman, Morgan Stanley, JPMorgan)
+- Think tank analyses (RAND, CFR, IISS)
+- Research firm reports
 
-**When to split:**
-- Answer has 3+ distinct sections (like pathway analysis)
-- Total output would be 500+ words
-- User is on Telegram (hard to read walls of text on mobile)
+### Step 3: Use Historical Base Rates
 
-**When to keep together:**
-- Simple fact-check or quick answer
-- User explicitly asks for a report
-- Content is tightly interconnected and splitting would lose coherence
+"What happened in similar situations?"
 
-**Splitting strategy:**
-1. Message 1: BOTTOM LINE + KEY INTEL (the answer, up front)
-2. Message 2+: Supporting details (if user wants more)
-3. Or: SITREP header + sections, keep under 400 words per message
+### Step 4: Apply Bayesian Framework
 
-The goal: user gets the answer immediately, details are available if they want them.
+Start with base rate, adjust for specific evidence.
 
-## Example Workflows
+### Step 5: Log Forecast for Calibration
 
-### Workflow 1: Pre-Article Research
-User: "I want to write about why most AI agents fail in production"
+```bash
+python3 scripts/forecast_history.py log \
+  --question "Will X happen by Y date?" \
+  --prob 65 \
+  --method polymarket \
+  --methodology "Base rate 40% + new evidence adjustment +25%" \
+  --category "geopolitical"
+```
 
-1. Define question and hypothesis
-2. Discover tools (skills_list, skill_view for relevant skills)
-3. Batch search: web search + news search in one execute_code block using discovered tools
-4. Social angle: search social media tool for expert opinions
-5. Deep read: extract full content from 3-5 key articles using discovered extraction tool
-6. Contrarian search: "AI agents succeed in production" / "why AI agents will work"
-7. Synthesize into briefing
+### Step 6: Later, Resolve and Learn
 
-### Workflow 2: Fact-Check / Due Diligence
-User: "I read on X that [claim]. Is this true?"
+```bash
+python3 scripts/forecast_history.py resolve --id "f-xxx" --outcome true --lesson "Underestimated speed of escalation"
+```
 
-1. Parse the claim into verifiable sub-claims
-2. Hypothesis: "This claim is likely [true/false] because [reasoning]"
-3. Search for original source (not just people talking about the claim)
-4. Search for supporting evidence
-5. Search for contradicting evidence (mandatory)
-6. Quick answer with confidence level and best evidence
+### Calibration Tracking
 
-### Workflow 3: Forecast / Estimation
-User: "What will [X] cost/look like in [future date]?"
+```bash
+python3 scripts/forecast_history.py calibration
+```
 
-1. Current state: find current prices/data
-2. Driving factors: find what influences the variable
-3. Expert forecasts: search for analyst predictions
-4. Prediction markets: check Polymarket or similar for crowd probabilities
-5. Scenario analysis: present base/bull/bear cases with probability estimates
-6. Contrarian: search for "why [forecast] is wrong"
-7. Synthesize with explicit confidence levels per scenario
+Returns:
+- Brier score (lower = better calibrated)
+- Calibration curve (predicted vs actual)
+- Topic-specific biases
+- Recommendations for improvement
+
+---
+
+## Quality Score System
+
+The quality_score.py script enforces quality through proof objects.
+
+### Proof Object Structure
+
+```json
+{
+  "sub_questions": [
+    {"question": "...", "answered": true, "sources": ["url1", "url2"]}
+  ],
+  "source_types_used": ["web_search", "news", "prediction_market"],
+  "source_tiers": {"tier1": 2, "tier2": 3, "tier3": 1, "tier4": 0, "tier5": 0},
+  "contrarian_searches": [
+    {"query": "why X is wrong", "found_evidence": true, "result_summary": "..."}
+  ],
+  "claims": [
+    {"claim": "X costs Y", "status": "verified", "sources": ["url1", "url2"]}
+  ],
+  "hypothesis_revised": true,
+  "hypothesis_original": "I think X...",
+  "hypothesis_revised_text": "I now think Y...",
+  "contradictions": [
+    {"contradiction": "Source A says X, Source B says Y", "resolved": true, "resolution": "..."}
+  ],
+  "gaps_identified": [
+    {"gap": "...", "rank": "critical", "filled": true}
+  ],
+  "search_rounds": 2,
+  "ai_inference_labeled": true
+}
+```
+
+### Score Thresholds
+
+- >= 0.90: SATURATED — proceed to output
+- 0.70-0.89: GOOD — targeted gap-filling needed
+- 0.50-0.69: ADEQUATE — significant gaps
+- < 0.50: INSUFFICIENT — major improvements needed
+
+---
 
 ## Pitfalls
 
-- **Don't confuse searching with researching** — searching finds information, researching finds truth
-- **Don't stop at first result** — first page of Google isn't research
-- **Don't ignore contradictions** — they're where the insight lives
-- **Don't cherry-pick** — actively search for evidence against your hypothesis
-- **Don't present correlation as causation** — flag it explicitly
-- **Don't trust secondary sources over primary** — always trace back
-- **Don't skip the reflection/contrarian phase** — it's the most important part
-- **Don't over-research** — know when you have enough to answer the question
-- **Don't guess at CLI syntax** — read the skill docs, use what they say
-- **Don't write more tool calls when fewer will do** — batch queries in execute_code instead of separate calls
-- **Don't stop at one search round** — run at least one gap analysis iteration before synthesis
-- **Don't present AI inference as sourced fact** — if you're drawing a conclusion from multiple data points, label it as your analysis
-- **Don't conflate "I searched" with "I found"** — a search returning empty results is itself a finding (this data may not exist publicly)
+- Don't confuse searching with researching
+- Don't stop at first result
+- Don't ignore contradictions
+- Don't cherry-pick evidence
+- Don't present correlation as causation
+- Don't skip the debate phase
+- Don't skip quality gates
+- Don't present AI inference as sourced fact
+- Don't guess at CLI syntax — read skill docs
+- Don't present probabilities without grounding
+- Don't pivot endlessly — max 2 pivots
+- Don't skip calibration tracking for forecasts
 
-## Verification
+---
+
+## Verification Checklist
 
 A good research session produces:
-1. Clear answer to the original question (with confidence level)
-2. Supporting evidence with sources cited inline
-3. Contradictions found (not hidden) and resolved where possible
-4. Hypothesis stated and either supported or revised based on evidence
-5. Contrarian evidence explicitly addressed
-6. Gap analysis performed with at least one iteration loop back
-7. Saturation achieved (Critical gaps filled with 2+ independent sources)
-8. Key claims verified (traced back to sources, rated Verified/Supported/Unverified)
-9. AI inference clearly separated from sourced fact
-10. Gaps identified (what we still don't know, with justification for stopping)
-11. Scenario analysis with probability estimates (for forecast-type questions)
-12. Full source list with tier classification
+
+1. Clear answer with confidence level
+2. Evidence cards with verification status
+3. Debate synthesis (FOR/AGAINST/ALTERNATIVE)
+4. Gates passed (or explicit gaps noted)
+5. Quality score >= 0.70
+6. Hypothesis stated and either supported or revised
+7. Contrarian evidence addressed
+8. AI inference clearly separated from fact
+9. For forecasts: probability logged with methodology
+10. Calibration recommendations if applicable

--- a/skills/research/deep-research/SKILL.md
+++ b/skills/research/deep-research/SKILL.md
@@ -1,0 +1,642 @@
+---
+name: deep-research
+description: Scientific research methodology for deep investigation. Plans research, auto-discovers available tools and skills, iteratively searches until saturation, evaluates credibility, performs contrarian analysis, verifies claims, and synthesizes structured reports.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [research, analysis, synthesis, scientific-method, investigation]
+    related_skills: [duckduckgo-search, arxiv, polymarket, blogwatcher]
+---
+
+# Deep Research — Scientific Investigation Skill
+
+## What This Is
+
+This is a research methodology skill. It teaches the agent HOW to think like a researcher — not just search and dump results, but plan, investigate, evaluate, reflect, and synthesize.
+
+**Critical: The user's initial message is a starting point, not the complete research.** When the user provides info (a tweet, an article, a claim), use it as the seed for deep independent research. Verify their claims, find the original sources, look for additional context, find contradicting evidence, and bring back MORE than what they gave you. You are the expert researcher — they gave you a lead, now go investigate it properly before coming back with findings.
+
+Use this for:
+- Pre-writing research: "I want to write about X — what do I need to know?"
+- Post-writing validation: "I wrote an article — what evidence supports my claims?"
+- Competitive intelligence: "What's happening in X space right now?"
+- Due diligence: "Is this claim true? What do primary sources say?"
+- Deep dives: "I need to deeply understand X topic"
+
+## Helper Scripts
+
+This skill includes two helper scripts:
+
+```bash
+# Session manager and report generator
+python3 SKILL_DIR/scripts/deep_research.py init "Is AI replacing programmers?"
+
+# Quality scorer for proof-based saturation checks
+python3 SKILL_DIR/scripts/quality_score.py assess --proof proof.json
+python3 SKILL_DIR/scripts/quality_score.py checklist
+```
+
+`SKILL_DIR` is the directory containing this SKILL.md file.
+
+Deep research sessions are stored in a writable state directory by default:
+- `$HERMES_DEEP_RESEARCH_STATE_DIR` if set
+- otherwise `$HERMES_HOME/state/deep-research`
+- otherwise `~/.hermes/state/deep-research`
+
+## Research Methodology
+
+Real researchers don't search once and stop. They follow iterative cycles:
+
+```
+QUESTION → PLAN → SEARCH → EVALUATE → REFLECT → IDENTIFY GAPS → FILL GAPS → VERIFY → SYNTHESIZE
+                                      ↑                                    |
+                                      └────────── (if not saturated) ─────┘
+```
+
+Each cycle gets you closer to truth. You stop when you reach saturation — when new searches stop yielding new relevant information and all critical gaps are filled. Maximum 3 cycles to prevent bloat.
+
+## Phase 1: Question Definition and Hypothesis
+
+Before searching anything, define clearly:
+
+1. **Core question**: What exactly am I trying to answer?
+2. **Sub-questions**: What smaller questions need answering first?
+3. **Hypothesis**: Form an initial hypothesis before searching. "I think X is true because Y." This is NOT a conclusion — it is a lens that makes your searches more targeted. You will revise or discard it as evidence accumulates.
+4. **Claims to verify**: What specific claims need evidence?
+5. **Contradictions to resolve**: What conflicts exist in my understanding?
+6. **Success criteria**: How will I know the research is complete?
+
+Output: A research plan with numbered questions, a hypothesis, and success criteria.
+
+## Phase 2: Tool Discovery and Capability Mapping
+
+MANDATORY. Never skip this phase because you "already know" the tools. Last time you did, you missed Polymarket and used the wrong search syntax.
+
+### Step 1: Discover Skills
+
+Call `skills_list()` to get all available skills. Filter for research-relevant ones:
+
+- Any skill with tags: `research`, `news`, `web`, `scraping`, `search`, `social-media`, `browser`, `market-data`
+- Any skill whose description mentions: search, fetch, scrape, extract, browser, social, news, prediction, market
+
+For each relevant skill, call `skill_view(name)` to load its documentation and understand:
+- What it does
+- How to invoke it (exact commands/arguments)
+- What inputs it needs
+- Any environment requirements
+
+Skills know their own CLI syntax. Read the SKILL.md and use it. Do not guess at flags.
+
+### Step 2: Discover Built-in Tools
+
+Check what built-in tools you have access to. For research, these are relevant:
+
+- `browser_navigate` / `browser_snapshot` / `browser_click` — for interactive browsing of JS-rendered pages, paywalled content, or sites that block scraping
+- `web_search` — built-in web search if available
+
+### Step 3: Verify Optional Tools
+
+```bash
+# Check tools referenced by discovered skills (use names from SKILL.md)
+for cmd in ddgs twitter scrapling curl python3 node; do
+    command -v $cmd >/dev/null 2>&1 && echo "$cmd: available" || echo "$cmd: not found"
+done
+```
+
+### Step 4: Build Capability Map
+
+Create a capability map from what you discovered. Include EVERY research-relevant skill, even ones you think you won't need:
+
+| Research Need | Available Tool/Skill | How to Use (from SKILL.md) |
+|---------------|---------------------|---------------------------|
+| General web search | [discovered skill] | [exact syntax from its docs] |
+| News search | [discovered skill] | [exact syntax from its docs] |
+| Social media / X | [discovered skill] | [exact syntax from its docs] |
+| Article extraction | [discovered skill] | [exact syntax from its docs] |
+| Prediction markets | [discovered skill] | [exact syntax from its docs] |
+| Interactive browsing | [built-in tools] | browser_navigate, snapshot, click |
+| Academic papers | [discovered skill or web fallback] | [exact syntax or site: filter] |
+
+### Step 5: Identify Research-Type Specific Tools
+
+Based on the research topic, identify which tools from the capability map are especially relevant:
+
+- **Forecasting questions** -> prediction markets (Polymarket), analyst reports, historical base rates
+- **Geopolitical/military** -> Wikipedia (often best aggregate for active conflicts), news search, expert commentary
+- **Technical/academic** -> arxiv, academic search, primary papers
+- **Company/market** -> financial news, SEC filings, analyst reports
+- **Fact-checking** -> primary sources, official statements, data verification
+
+### Fallback Priority
+
+When primary search tools aren't available or fail:
+
+1. **Skill-based tools** (loaded via skill_view) — always preferred
+2. **Built-in tools** (browser_navigate, read_file, etc.) — reliable fallback
+3. **Scrapling** (if installed) — for direct URL fetching
+4. **curl** (always available) — last resort for HTTP requests
+
+### Paywall/Access Escalation Ladder
+
+When a key source is inaccessible:
+1. Try `scrapling extract get` (basic fetch)
+2. Try `scrapling extract fetch` with `--headless --disable-resources` (JS rendering)
+3. Try `scrapling extract stealthy-fetch` with `--solve-cloudflare` (anti-bot bypass)
+4. Try `browser_navigate` + `browser_snapshot` (interactive browser)
+5. Search for the same story/topic from a different accessible source
+6. Search for social media discussion about the article (often quotes key content)
+7. If all fail, note as gap and move on — do not spend more than 2 attempts on one URL
+
+For 404/dead links: skip immediately at step 1 and go to step 5 (find alternative source).
+
+## Phase 3: Parallel Search Execution
+
+Using the capability map from Phase 2, execute searches across multiple sources.
+
+### Execution Pattern
+
+For each research question, run multiple searches. Use two strategies depending on what you're searching with:
+
+**Strategy A: Same tool, multiple queries — use execute_code batching**
+
+When the same tool (e.g., your web search tool from the capability map) can answer multiple sub-questions, batch all queries into a single `execute_code` block. This is faster than multiple calls, keeps all results in one context, and lets you process/compare immediately.
+
+Read the tool's SKILL.md for exact import/syntax, then batch like:
+
+```python
+# Example pattern — substitute YOUR tool's Python API from its SKILL.md
+# (Shown here using ddgs as illustration; use whatever tool you discovered)
+from ddgs import DDGS
+
+queries = {
+    "topic aspect 1": "query text 1",
+    "topic aspect 2": "query text 2",
+    "topic aspect 3": "query text 3",
+}
+
+for label, query in queries.items():
+    print(f"=== {label} ===")
+    with DDGS() as d:
+        for r in d.text(query, max_results=5):
+            print(f"  {r['title']}")
+            print(f"  {r.get('href', 'N/A')}")
+            print(f"  {r.get('body', '')[:200]}")
+            print()
+```
+
+**Strategy B: Different tools needed — use delegate_task batch mode**
+
+When sub-questions need different tools (one needs search, another needs scraping, another needs browser), use `delegate_task` with the `tasks` array for parallel execution.
+
+**Strategy C: Deep article reading — use execute_code with your extraction tool**
+
+For extracting full content from key URLs found during search, batch multiple URLs into one execute_code block using your extraction tool's API (loaded from its SKILL.md).
+
+### Search Angles to Cover
+
+For a typical research topic, ensure you search from at least these angles:
+
+1. **Broad web search** — general coverage, multiple viewpoints
+2. **News search** — recent developments, breaking news, timelines
+3. **Social/sentiment** — expert opinions, prediction markets (if tools available)
+4. **Deep article read** — extract full content from 3-5 most important URLs found
+5. **Contrarian/expert depth** — analyst reports, primary data, alternative viewpoints
+
+### Source Diversity Rule
+
+For each sub-question, use at least 2 different source types. Never rely on a single search tool or a single source. Cross-reference everything.
+
+### Handling Failures
+
+- Tool returns empty results -> try alternative tool from your capability map
+- Tool errors out -> fall back down the priority chain (skill -> built-in -> scrapling -> curl)
+- Paywalled content -> follow the Paywall/Access Escalation Ladder from Phase 2
+- 404/dead link -> skip immediately and find alternative, do not debug dead URLs
+- Need to read specific URL that scraping cannot handle -> use browser_navigate
+
+### Incremental Proof Building (Critical)
+
+Do NOT wait until the end to build the proof object. Build it AS YOU RESEARCH. After each search round, update the proof:
+
+1. **After each search batch**: add new sub-questions answered, new sources found, new source tiers
+2. **After contrarian searches**: immediately add contrarian_searches entries with query/found_evidence/result_summary
+3. **After reading key articles**: immediately rate claims as verified/supported/unverified
+4. **After finding contradictions**: add to contradictions list with resolved status
+
+Save proof to a local JSON file after each major search round, for example `proof.json`. This prevents memory loss between rounds and makes the final scoring step a formality.
+
+Initial proof template to create at start of Phase 3:
+```json
+{
+  "sub_questions": [{"question": "...", "answered": false, "sources": []}],
+  "source_types_used": [],
+  "source_tiers": {"tier1": 0, "tier2": 0, "tier3": 0, "tier4": 0, "tier5": 0},
+  "contrarian_searches": [],
+  "claims": [],
+  "hypothesis_revised": false,
+  "hypothesis_original": "...",
+  "contradictions": [],
+  "gaps_identified": [],
+  "search_rounds": 0,
+  "ai_inference_labeled": true
+}
+```
+
+## Phase 4: Critical Evaluation
+
+Not all sources are equal. Evaluate each finding:
+
+### Source Hierarchy
+- **Tier 1 — Primary**: Original data, official reports, direct quotes, government statistics, company filings
+- **Tier 2 — Expert analysis**: Peer-reviewed papers, recognized analysts (Goldman Sachs, ING, etc.), research firms (Windward, etc.)
+- **Tier 3 — Credible reporting**: Reputable news outlets (Reuters, Bloomberg, AP, BBC), industry publications
+- **Tier 4 — Secondary**: Blog posts, opinion pieces, regional news, think tank reports
+- **Tier 5 — Unverified**: Social media, anonymous claims, user-generated content
+
+### Red Flags to Watch For
+- Claims without citations
+- Single-source reporting
+- Conflicts of interest (who benefits from this narrative?)
+- Outdated information (check dates!)
+- Emotional language over factual language
+- Correlation presented as causation
+- Survivorship bias
+
+### Cross-Reference Rule
+- 1 source saying something = interesting, needs verification
+- 2 independent sources = credible claim
+- 3+ independent sources = established fact
+- Primary source contradicts secondary = trust primary
+- Prediction markets (Polymarket, Metaculus) = crowd-sourced probability, valuable for forecasting
+
+## Phase 5: Self-Reflection and Contrarian Search (Critical)
+
+This is what separates research from searching. After initial search results are in, BEFORE synthesis:
+
+### Mandatory Reflection Questions
+
+1. **State your hypothesis explicitly.** Write it out: "Based on what I've found so far, I believe X because Y."
+
+2. **What contradicts your hypothesis?** Look at your findings — what evidence pushes against what you initially believed? Flag contradictions explicitly.
+
+3. **What would a skeptic say?** Write out the counter-argument to your thesis.
+
+4. **Search for the counter-argument.** This is NOT optional. Run at least one search specifically designed to find evidence AGAINST your hypothesis:
+   - "[topic] bear case"
+   - "[topic] why wrong"
+   - "[topic] alternative explanation"
+   - "[topic] criticism"
+   - "[forecast number] why will not happen"
+
+5. **Assess confidence honestly:**
+   - High: multiple primary sources, consistent data, prediction markets align
+   - Medium: some supporting evidence, gaps remain, expert disagreement
+   - Low: speculative, few sources, contradictions unresolved
+
+6. **Note surprises.** What did you find that you did NOT expect? These are often where the real insight lives.
+
+### Hypothesis Revision
+
+After reflection and contrarian search, explicitly state:
+- Original hypothesis
+- Evidence for
+- Evidence against
+- Revised hypothesis (if changed)
+- Confidence level
+
+## Phase 6: Gap Analysis and Iterative Loop with Quality Scoring
+
+This is where most AI research fails. It stops after one round. We force iteration using a proof-based quality score that the agent CANNOT fake — the score is computed from actual evidence, not vibes.
+
+### The Scoring System
+
+A script at `SKILL_DIR/scripts/quality_score.py` computes quality from a **proof object** (JSON). The agent provides evidence, the script computes the score. You cannot advance until the score hits 0.90 (SATURATED).
+
+**8 dimensions, weighted:**
+- Sub-Question Coverage (20%) — all questions answered with sources
+- Contrarian Evidence (15%) — searched against your hypothesis
+- Claim Verification (15%) — claims traced to sources, AI inference labeled
+- Source Diversity (10%) — multiple source types used
+- Source Quality (10%) — primary/analyst sources outweigh blogs
+- Hypothesis Revision (10%) — updated based on evidence
+- Contradiction Resolution (10%) — contradictions found and resolved
+- Gap Analysis & Saturation (10%) — gaps identified, ranked, critical ones filled
+
+### Step 1: Identify Specific Gaps
+
+After Phase 5, write out every gap explicitly:
+
+- **Unanswered sub-questions**: Which of your original questions still lack sufficient evidence?
+- **Weak evidence areas**: Where do you only have Tier 4-5 sources?
+- **Contradictions unresolved**: Where do credible sources disagree and you haven't found the resolution?
+- **Missing data points**: Numbers, dates, quantities you need but don't have
+- **Unverified claims**: Things that seem true but only have single-source support
+
+### Step 2: Rank Gaps by Impact
+
+Not all gaps matter equally. Rank each gap:
+- **Critical**: Without this, the core answer is unreliable
+- **Important**: Would significantly strengthen the conclusion
+- **Nice to have**: Adds depth but doesn't change the answer
+
+### Step 3: Targeted Gap-Filling Searches
+
+For each Critical and Important gap, run a targeted search designed SPECIFICALLY to fill that gap:
+- Data gaps -> search for the specific number/term
+- Source quality gaps -> search for primary sources (official reports, government data)
+- Contradiction gaps -> search for the resolution
+- Expert opinion gaps -> search for analyst commentary or academic analysis
+
+### Step 4: Build Proof Object and Score
+
+After each round, build a proof JSON with:
+- sub_questions: list with question/answered/sources for each
+- source_types_used: list of tool types used
+- source_tiers: count by tier (tier1=primary, tier2=analyst, tier3=reporting, tier4=secondary, tier5=unverified)
+- contrarian_searches: list with query/found_evidence/result_summary
+- claims: list with claim/status/sources (status: verified/supported/ai_inference/unverified)
+- hypothesis_revised: true/false + original and revised text
+- contradictions: list with description/resolved/resolution
+- gaps_identified: list with gap/rank(filled=true/false)
+- search_rounds: how many iterations performed
+- ai_inference_labeled: true/false
+
+Save to file, run:
+```bash
+python3 SKILL_DIR/scripts/quality_score.py assess --proof proof.json
+```
+
+Run `python3 SKILL_DIR/scripts/quality_score.py checklist` to see the full proof requirements.
+
+### Step 5: Loop Until Saturated
+
+**Score thresholds:**
+- **>= 0.90 SATURATED**: Proceed to Phase 7 (Verification Pass)
+- **0.70-0.89 GOOD**: Identify weak dimensions, run targeted gap-filling, rescore
+- **0.50-0.69 ADEQUATE**: Significant gaps. Run full gap analysis round, rescore
+- **< 0.50 INSUFFICIENT**: Major problems. Go back to Phase 3-5 with focus on weakest dimensions
+
+**Maximum 3 rounds** to prevent bloat. If still below 0.90 after 3 rounds, proceed anyway but flag confidence as LOW and list specific deficiencies in final output.
+
+**The score can go down.** If a new search round reveals problems (new contradictions, claims turn out false, source quality drops), the score decreases. This prevents the agent from just going through the motions.
+
+## Phase 7: Verification Pass
+
+Before synthesizing the final output, verify each key claim you plan to make:
+
+1. **List every specific claim** in your draft answer (numbers, dates, names, causal relationships)
+2. **Trace each claim** back to its source
+3. **Rate each claim**: Verified (2+ independent sources), Supported (1 good source), Unverified (no direct source)
+4. **Flag any claims that are AI inference** vs. directly sourced — label these as your analysis, not fact
+
+This step prevents hallucination and overconfident assertions. If any key claim is Unverified, either search for a source or remove the claim.
+
+## Phase 8: Synthesis
+
+Structure the findings into a clear, authoritative output.
+
+### Internal Report Structure (for your reasoning)
+
+Use this structure internally. Adapt the output to the user's platform and request type (see Output Format Adaptation below).
+
+```
+# Research Report: [Topic]
+Date: [timestamp]
+Core Question: [original question]
+Hypothesis: [initial -> revised]
+Rounds: [number of search iterations performed]
+
+## Executive Summary
+[3-5 sentence summary of key findings]
+
+## Key Findings
+1. [Finding with source]
+2. [Finding with source]
+
+## Evidence by Sub-Question
+[Sub-question 1]: Conclusion, evidence, confidence, remaining gaps
+[Sub-question 2]: ...
+
+## Hypothesis Evaluation
+- Evidence supporting: [...]
+- Evidence contradicting: [...]
+- Contrarian search results: [...]
+- Revised hypothesis: [...]
+
+## Claim Verification
+- Verified (2+ sources): [list]
+- Supported (1 good source): [list]
+- AI inference (labelled as analysis): [list]
+- Unverified (removed from output): [list]
+
+## Contradictions Found
+- [Contradiction 1: Source A says X, Source B says Y]
+- [Resolution or remaining uncertainty]
+
+## Gap Iteration Log
+Round 1 gaps identified: [...]
+Round 2 gaps filled: [...]
+Round 2 remaining: [...]
+Saturation achieved: [Yes/No, why]
+
+## Gaps and Limitations
+- [What we couldn't verify and why we stopped looking]
+- [What's outside our knowledge]
+
+## Sources
+[List with tier classification]
+```
+
+## Chain of Thought (Internal Process — Do Not Output)
+
+Throughout research, maintain internal reasoning discipline. The user never sees this — it's your thinking process:
+
+1. **Form hypothesis** before searching
+2. **Search with intent** — each query should test or expand understanding
+3. **Note surprises** — when results contradict expectations, that's where insight lives
+4. **Cross-reference** — never rely on single sources
+5. **Contrarian search** — actively find evidence AGAINST your hypothesis
+6. **Revise hypothesis** — update as evidence accumulates
+7. **Assess confidence** honestly
+
+### Probability Estimation Methodology (for forecast/scenario questions)
+
+When the research involves estimating probabilities (scenarios, forecasts, outcomes), do NOT just guess. Use this methodology:
+
+1. **Check prediction markets** (Polymarket, Metaculus, Manifold) for crowd-sourced probabilities. These are real-money bets and often more accurate than expert opinions.
+
+2. **Find analyst forecasts** — investment banks (Goldman, Morgan Stanley, JPMorgan), think tanks (RAND, CFR, IISS), and research firms publish probability-weighted scenarios.
+
+3. **Use historical base rates** — what happened in similar situations? (e.g., "of the last 10 wars involving a great power, X ended in negotiation, Y ended in frozen conflict, Z ended in escalation")
+
+4. **Apply the Bayesian framework** — start with base rate, adjust for specific evidence. State your adjustment reasoning.
+
+5. **Label probability sources clearly**:
+   - "X% per [Polymarket as of date]" = crowd-sourced real-money estimate
+   - "X% per [Goldman Sachs]" = expert analyst estimate
+   - "X% estimated based on [reasoning]" = your analysis (lower confidence)
+   - "X% historical base rate from [source]" = reference class estimate
+
+6. **Never present probabilities without methodology**. The user needs to know if it's a Polymarket number or a guess.
+
+7. **State uncertainty ranges, not point estimates** — "35-45%" is more honest than "40%" when you're uncertain.
+
+The deep research script (`SKILL_DIR/scripts/deep_research.py`) can maintain a lightweight research activity log for archival if useful, but the user-facing output should be the research report or briefing — never raw internal reasoning.
+
+## Output Format Adaptation
+
+Adapt output to the user's platform and request type:
+
+### Military Briefing Format (default for most requests)
+
+Use this format unless the user explicitly asks for something else. Inspired by military SITREPs — scannable, no fluff, right to the point:
+
+```
+SITREP: [TOPIC] — [TIMEFRAME]
+[Date] | Confidence: [High/Medium/Low]
+
+CURRENT STATE
+- [What's happening right now with numbers]
+- [Current price/data/status]
+- [Key context, 1-2 sentences max per point]
+
+KEY INTEL
+1. [Most important finding with source]
+2. [Second finding with source]
+3. [Third finding with source]
+4. [Fourth finding with source]
+
+ESTIMATE / FORECAST (if applicable)
+[Simple table or list of scenarios]
+MOST LIKELY: [single line with number]
+
+KEY VARIABLE
+[The one thing that determines which scenario happens]
+
+BOTTOM LINE
+[What the user should do/expect in 1-2 sentences]
+```
+
+Rules for briefing format:
+- No executive summary sections — just lead with the answer
+- No "research methodology" explanation — user doesn't care
+- No credibility score tables — weave sources into the text
+- Use all-caps section headers (CURRENT STATE, KEY INTEL, etc.) for scannability
+- Numbers inline, not footnoted
+- 3-5 bullets per section max
+- End with BOTTOM LINE, not "further research needed"
+
+### Formal Report Mode
+
+Full structured report with executive summary, findings by sub-question, contradictions, gaps, and source list. Use ONLY when:
+- User explicitly asks for a report
+- Research supports an article/whitepaper the user is writing
+- Save to file and provide file path
+
+### Quick Answer
+
+Direct answer with key evidence, no report structure. Use for fact-checks and single-question lookups. Still be specific — name sources, cite numbers, state confidence.
+
+Regardless of format: always be credible and authoritative. State what you know, what you're uncertain about, and what evidence supports each claim. Never hedge with "some sources say" without naming which sources and what they actually say.
+
+### Platform Detection
+- Telegram: briefing format, no tables (Telegram Bot API doesn't render markdown tables), no markdown headers
+- Discord: briefing format, limited markdown ok
+- CLI: any format, can save files
+- Unknown: briefing format by default
+
+### Telegram Table Workaround
+Telegram doesn't render markdown tables. Use one of these instead:
+- Simple lists with aligned spacing
+- Pipe-separated lines (manual alignment)
+- Dash-separated key-value pairs
+- For complex data, generate an image file and send as media
+
+### Streaming vs Monolithic Delivery
+
+For complex multi-topic research, consider splitting into multiple messages:
+
+**When to split:**
+- Answer has 3+ distinct sections (like pathway analysis)
+- Total output would be 500+ words
+- User is on Telegram (hard to read walls of text on mobile)
+
+**When to keep together:**
+- Simple fact-check or quick answer
+- User explicitly asks for a report
+- Content is tightly interconnected and splitting would lose coherence
+
+**Splitting strategy:**
+1. Message 1: BOTTOM LINE + KEY INTEL (the answer, up front)
+2. Message 2+: Supporting details (if user wants more)
+3. Or: SITREP header + sections, keep under 400 words per message
+
+The goal: user gets the answer immediately, details are available if they want them.
+
+## Example Workflows
+
+### Workflow 1: Pre-Article Research
+User: "I want to write about why most AI agents fail in production"
+
+1. Define question and hypothesis
+2. Discover tools (skills_list, skill_view for relevant skills)
+3. Batch search: web search + news search in one execute_code block using discovered tools
+4. Social angle: search social media tool for expert opinions
+5. Deep read: extract full content from 3-5 key articles using discovered extraction tool
+6. Contrarian search: "AI agents succeed in production" / "why AI agents will work"
+7. Synthesize into briefing
+
+### Workflow 2: Fact-Check / Due Diligence
+User: "I read on X that [claim]. Is this true?"
+
+1. Parse the claim into verifiable sub-claims
+2. Hypothesis: "This claim is likely [true/false] because [reasoning]"
+3. Search for original source (not just people talking about the claim)
+4. Search for supporting evidence
+5. Search for contradicting evidence (mandatory)
+6. Quick answer with confidence level and best evidence
+
+### Workflow 3: Forecast / Estimation
+User: "What will [X] cost/look like in [future date]?"
+
+1. Current state: find current prices/data
+2. Driving factors: find what influences the variable
+3. Expert forecasts: search for analyst predictions
+4. Prediction markets: check Polymarket or similar for crowd probabilities
+5. Scenario analysis: present base/bull/bear cases with probability estimates
+6. Contrarian: search for "why [forecast] is wrong"
+7. Synthesize with explicit confidence levels per scenario
+
+## Pitfalls
+
+- **Don't confuse searching with researching** — searching finds information, researching finds truth
+- **Don't stop at first result** — first page of Google isn't research
+- **Don't ignore contradictions** — they're where the insight lives
+- **Don't cherry-pick** — actively search for evidence against your hypothesis
+- **Don't present correlation as causation** — flag it explicitly
+- **Don't trust secondary sources over primary** — always trace back
+- **Don't skip the reflection/contrarian phase** — it's the most important part
+- **Don't over-research** — know when you have enough to answer the question
+- **Don't guess at CLI syntax** — read the skill docs, use what they say
+- **Don't write more tool calls when fewer will do** — batch queries in execute_code instead of separate calls
+- **Don't stop at one search round** — run at least one gap analysis iteration before synthesis
+- **Don't present AI inference as sourced fact** — if you're drawing a conclusion from multiple data points, label it as your analysis
+- **Don't conflate "I searched" with "I found"** — a search returning empty results is itself a finding (this data may not exist publicly)
+
+## Verification
+
+A good research session produces:
+1. Clear answer to the original question (with confidence level)
+2. Supporting evidence with sources cited inline
+3. Contradictions found (not hidden) and resolved where possible
+4. Hypothesis stated and either supported or revised based on evidence
+5. Contrarian evidence explicitly addressed
+6. Gap analysis performed with at least one iteration loop back
+7. Saturation achieved (Critical gaps filled with 2+ independent sources)
+8. Key claims verified (traced back to sources, rated Verified/Supported/Unverified)
+9. AI inference clearly separated from sourced fact
+10. Gaps identified (what we still don't know, with justification for stopping)
+11. Scenario analysis with probability estimates (for forecast-type questions)
+12. Full source list with tier classification

--- a/skills/research/deep-research/scripts/capability_map.py
+++ b/skills/research/deep-research/scripts/capability_map.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""
+Capability Map — Auto-Discovery of Available Research Tools
+
+Automatically discovers what tools, skills, and capabilities are available
+in the current Hermes environment. This makes deep-research work with
+whatever tools are installed, not hardcoded assumptions.
+
+Usage:
+  python3 capability_map.py discover              # Discover all capabilities
+  python3 capability_map.py check --tool ddgs     # Check if specific tool available
+  python3 capability_map.py recommend --type forecast  # Recommend tools for task type
+  python3 capability_map.py export                # Export capability map as JSON
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SKILL_DIR = os.path.dirname(SCRIPT_DIR)
+HERMES_HOME = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
+SKILLS_DIR = os.path.join(HERMES_HOME, "skills")
+
+
+# Known tool patterns and their research utility
+TOOL_SIGNATURES = {
+    # Search tools
+    "ddgs": {
+        "name": "DuckDuckGo Search",
+        "type": "web_search",
+        "tier": "primary",
+        "install": "pip install duckduckgo-search",
+        "use_for": ["general_search", "news_search", "image_search"],
+    },
+    "scrapling": {
+        "name": "Scrapling Web Fetcher",
+        "type": "web_fetch",
+        "tier": "primary",
+        "install": "pip install scrapling",
+        "use_for": ["article_extraction", "stealth_fetch", "cloudflare_bypass"],
+    },
+    "curl": {
+        "name": "curl HTTP Client",
+        "type": "http_client",
+        "tier": "fallback",
+        "install": "apt-get install curl",
+        "use_for": ["http_requests", "api_calls"],
+    },
+    "wget": {
+        "name": "wget Downloader",
+        "type": "http_client",
+        "tier": "fallback",
+        "install": "apt-get install wget",
+        "use_for": ["file_download", "http_requests"],
+    },
+    
+    # Social media
+    "twitter": {
+        "name": "Twitter CLI",
+        "type": "social_media",
+        "tier": "primary",
+        "install": "pip install twitter-api",
+        "use_for": ["twitter_search", "twitter_read", "sentiment"],
+    },
+    
+    # Academic
+    "arxiv": {
+        "name": "arXiv API",
+        "type": "academic",
+        "tier": "primary",
+        "install": "pip install arxiv",
+        "use_for": ["paper_search", "academic_research"],
+    },
+    
+    # Prediction markets
+    "polymarket": {
+        "name": "Polymarket CLI",
+        "type": "prediction_market",
+        "tier": "primary",
+        "install": "pip install polymarket",
+        "use_for": ["probability_estimates", "crowd_forecasts", "market_sentiment"],
+    },
+    
+    # Python packages
+    "python3": {
+        "name": "Python 3",
+        "type": "runtime",
+        "tier": "essential",
+        "install": "apt-get install python3",
+        "use_for": ["scripting", "data_processing"],
+    },
+    
+    # Browser
+    "chrome": {
+        "name": "Chrome Browser",
+        "type": "browser",
+        "tier": "interactive",
+        "install": "system dependent",
+        "use_for": ["interactive_browsing", "js_rendering", "paywall_access"],
+    },
+    
+    # Financial data (via Python packages)
+    "yfinance": {
+        "name": "Yahoo Finance",
+        "type": "financial_data",
+        "tier": "primary",
+        "install": "pip install yfinance",
+        "use_for": ["stock_data", "market_data", "historical_prices"],
+    },
+    
+    # News
+    "newsapi": {
+        "name": "News API",
+        "type": "news",
+        "tier": "primary",
+        "install": "pip install newsapi-python",
+        "use_for": ["news_search", "headlines"],
+    },
+}
+
+# Skill patterns to look for
+SKILL_SIGNATURES = {
+    "deep-research": {
+        "name": "Deep Research Methodology",
+        "provides": ["research_methodology", "quality_scoring", "evidence_cards"],
+    },
+    "duckduckgo-search": {
+        "name": "DuckDuckGo Search Skill",
+        "provides": ["web_search", "news_search"],
+    },
+    "arxiv": {
+        "name": "arXiv Search Skill",
+        "provides": ["academic_search", "paper_fetch"],
+    },
+    "polymarket": {
+        "name": "Polymarket Skill",
+        "provides": ["prediction_market", "probability_estimates"],
+    },
+    "scrapling": {
+        "name": "Scrapling Skill",
+        "provides": ["web_fetch", "article_extraction"],
+    },
+    "google-news": {
+        "name": "Google News Skill",
+        "provides": ["news_search", "current_events"],
+    },
+    "x-twitter-cli": {
+        "name": "X/Twitter CLI Skill",
+        "provides": ["twitter_search", "twitter_read", "social_sentiment"],
+    },
+    "blogwatcher": {
+        "name": "Blog Watcher Skill",
+        "provides": ["rss_monitoring", "blog_tracking"],
+    },
+}
+
+# Built-in Hermes tools
+BUILTIN_TOOLS = {
+    "browser_navigate": {"type": "browser", "use_for": ["interactive_browsing"]},
+    "browser_snapshot": {"type": "browser", "use_for": ["page_capture"]},
+    "browser_click": {"type": "browser", "use_for": ["interaction"]},
+    "browser_vision": {"type": "browser", "use_for": ["visual_analysis"]},
+    "web_search": {"type": "web_search", "use_for": ["general_search"]},
+    "web_extract": {"type": "web_fetch", "use_for": ["article_extraction"]},
+    "terminal": {"type": "runtime", "use_for": ["command_execution"]},
+    "execute_code": {"type": "runtime", "use_for": ["scripting"]},
+}
+
+
+def check_command_exists(cmd: str) -> bool:
+    """Check if a command is available in PATH."""
+    try:
+        result = subprocess.run(
+            ["which", cmd],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def check_python_package(package: str) -> bool:
+    """Check if a Python package is installed."""
+    try:
+        result = subprocess.run(
+            ["python3", "-c", f"import {package}"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def discover_skills() -> Dict[str, dict]:
+    """Discover installed Hermes skills."""
+    skills = {}
+    
+    if not os.path.exists(SKILLS_DIR):
+        return skills
+    
+    # Walk through skills directory
+    for root, dirs, files in os.walk(SKILLS_DIR):
+        if "SKILL.md" in files:
+            skill_path = os.path.join(root, "SKILL.md")
+            skill_name = os.path.basename(root)
+            
+            # Try to read skill metadata
+            try:
+                with open(skill_path, "r", encoding="utf-8") as f:
+                    content = f.read(2000)  # Read first 2KB
+                
+                # Extract name and description from YAML frontmatter
+                name = skill_name
+                description = ""
+                provides = []
+                
+                if "---" in content:
+                    parts = content.split("---", 2)
+                    if len(parts) >= 2:
+                        yaml_part = parts[1]
+                        for line in yaml_part.split("\n"):
+                            if line.startswith("name:"):
+                                name = line.split(":", 1)[1].strip().strip('"')
+                            if line.startswith("description:"):
+                                description = line.split(":", 1)[1].strip().strip('"')
+                            if line.startswith("  - ") and "provides" in yaml_part:
+                                provides.append(line.strip("- ").strip())
+                
+                # Check against known signatures
+                for sig_name, sig_data in SKILL_SIGNATURES.items():
+                    if sig_name.lower() in skill_name.lower():
+                        provides = sig_data.get("provides", provides)
+                        break
+                
+                skills[skill_name] = {
+                    "name": name,
+                    "path": root,
+                    "description": description[:100],
+                    "provides": provides,
+                }
+                
+            except Exception as e:
+                skills[skill_name] = {
+                    "name": skill_name,
+                    "path": root,
+                    "error": str(e),
+                }
+    
+    return skills
+
+
+def discover_tools() -> Dict[str, dict]:
+    """Discover available CLI tools and Python packages."""
+    tools = {}
+    
+    for cmd, signature in TOOL_SIGNATURES.items():
+        if cmd in ["python3", "curl", "wget"]:
+            # CLI tool
+            available = check_command_exists(cmd)
+        else:
+            # Python package or CLI
+            available = check_python_package(cmd) or check_command_exists(cmd)
+        
+        if available:
+            tools[cmd] = {
+                **signature,
+                "available": True,
+            }
+    
+    return tools
+
+
+def discover_builtin_tools() -> Dict[str, dict]:
+    """Return built-in Hermes tools (always available)."""
+    return {
+        name: {**data, "available": True}
+        for name, data in BUILTIN_TOOLS.items()
+    }
+
+
+def build_capability_map() -> dict:
+    """Build complete capability map."""
+    skills = discover_skills()
+    tools = discover_tools()
+    builtins = discover_builtin_tools()
+    
+    # Build capability index (what can we do?)
+    capabilities = {}
+    
+    # From skills
+    for skill_name, skill_data in skills.items():
+        for cap in skill_data.get("provides", []):
+            if cap not in capabilities:
+                capabilities[cap] = []
+            capabilities[cap].append({
+                "source": "skill",
+                "name": skill_name,
+                "priority": 1,
+            })
+    
+    # From tools
+    for tool_name, tool_data in tools.items():
+        for use in tool_data.get("use_for", []):
+            if use not in capabilities:
+                capabilities[use] = []
+            capabilities[use].append({
+                "source": "tool",
+                "name": tool_name,
+                "priority": 2,
+            })
+    
+    # From builtins
+    for tool_name, tool_data in builtins.items():
+        for use in tool_data.get("use_for", []):
+            if use not in capabilities:
+                capabilities[use] = []
+            capabilities[use].append({
+                "source": "builtin",
+                "name": tool_name,
+                "priority": 3,
+            })
+    
+    # Sort by priority
+    for cap in capabilities:
+        capabilities[cap].sort(key=lambda x: x["priority"])
+    
+    return {
+        "skills": skills,
+        "tools": tools,
+        "builtins": builtins,
+        "capabilities": capabilities,
+        "summary": {
+            "skills_count": len(skills),
+            "tools_count": len(tools),
+            "builtins_count": len(builtins),
+            "capabilities_count": len(capabilities),
+        },
+    }
+
+
+def cmd_discover(args):
+    """Discover all capabilities."""
+    cap_map = build_capability_map()
+    
+    if args.quiet:
+        print(json.dumps(cap_map, indent=2))
+    else:
+        print("=" * 60)
+        print("  CAPABILITY MAP")
+        print("=" * 60)
+        print()
+        
+        print(f"  SKILLS: {cap_map['summary']['skills_count']}")
+        for name, data in list(cap_map['skills'].items())[:10]:
+            provides = ", ".join(data.get("provides", [])[:3])
+            print(f"    - {name}: {provides}")
+        
+        print()
+        print(f"  TOOLS: {cap_map['summary']['tools_count']}")
+        for name, data in cap_map['tools'].items():
+            uses = ", ".join(data.get("use_for", [])[:3])
+            print(f"    - {name}: {uses}")
+        
+        print()
+        print(f"  BUILT-INS: {cap_map['summary']['builtins_count']}")
+        
+        print()
+        print(f"  CAPABILITIES: {cap_map['summary']['capabilities_count']}")
+        for cap, sources in list(cap_map['capabilities'].items())[:15]:
+            primary = sources[0] if sources else None
+            if primary:
+                print(f"    - {cap}: {primary['name']} ({primary['source']})")
+        
+        print()
+        print("=" * 60)
+    
+    return 0
+
+
+def cmd_check(args):
+    """Check if a specific tool is available."""
+    cap_map = build_capability_map()
+    
+    tool_name = args.tool.lower()
+    
+    # Check in tools
+    if tool_name in cap_map["tools"]:
+        print(json.dumps({
+            "available": True,
+            "tool": tool_name,
+            "details": cap_map["tools"][tool_name],
+        }, indent=2))
+        return 0
+    
+    # Check in skills
+    for skill_name, skill_data in cap_map["skills"].items():
+        if tool_name in skill_name.lower():
+            print(json.dumps({
+                "available": True,
+                "type": "skill",
+                "name": skill_name,
+                "details": skill_data,
+            }, indent=2))
+            return 0
+    
+    # Check in builtins
+    if tool_name in cap_map["builtins"]:
+        print(json.dumps({
+            "available": True,
+            "type": "builtin",
+            "name": tool_name,
+            "details": cap_map["builtins"][tool_name],
+        }, indent=2))
+        return 0
+    
+    # Not found
+    signature = TOOL_SIGNATURES.get(tool_name, {})
+    print(json.dumps({
+        "available": False,
+        "tool": tool_name,
+        "install_hint": signature.get("install", "Unknown tool"),
+    }, indent=2))
+    return 1
+
+
+def cmd_recommend(args):
+    """Recommend tools for a specific task type."""
+    cap_map = build_capability_map()
+    
+    task_type = args.type.lower()
+    
+    # Map task types to capabilities
+    task_capability_map = {
+        "forecast": ["prediction_market", "probability_estimates", "market_sentiment"],
+        "search": ["web_search", "general_search", "news_search"],
+        "academic": ["academic_search", "paper_search", "paper_fetch"],
+        "news": ["news_search", "current_events", "headlines"],
+        "social": ["twitter_search", "social_sentiment", "sentiment"],
+        "financial": ["stock_data", "market_data", "historical_prices"],
+        "extraction": ["article_extraction", "web_fetch", "stealth_fetch"],
+        "interactive": ["interactive_browsing", "js_rendering", "paywall_access"],
+    }
+    
+    needed_caps = task_capability_map.get(task_type, [task_type])
+    
+    recommendations = []
+    for cap in needed_caps:
+        if cap in cap_map["capabilities"]:
+            for source in cap_map["capabilities"][cap]:
+                recommendations.append({
+                    "capability": cap,
+                    "tool": source["name"],
+                    "source": source["source"],
+                    "priority": source["priority"],
+                })
+    
+    if not recommendations:
+        print(f"No tools found for task type: {task_type}")
+        print(f"Available capabilities: {list(cap_map['capabilities'].keys())[:20]}")
+        return 1
+    
+    # Sort by priority
+    recommendations.sort(key=lambda x: x["priority"])
+    
+    print(f"RECOMMENDED TOOLS FOR: {task_type}")
+    print("=" * 50)
+    
+    for rec in recommendations[:10]:
+        print(f"  [{rec['source']}] {rec['tool']} → {rec['capability']}")
+    
+    return 0
+
+
+def cmd_export(args):
+    """Export capability map as JSON."""
+    cap_map = build_capability_map()
+    
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(cap_map, f, indent=2)
+        print(f"Exported to: {args.output}")
+    else:
+        print(json.dumps(cap_map, indent=2))
+    
+    return 0
+
+
+def cmd_missing(args):
+    """Show missing critical tools."""
+    cap_map = build_capability_map()
+    
+    critical_tools = ["ddgs", "scrapling", "polymarket"]
+    critical_caps = ["web_search", "prediction_market", "article_extraction"]
+    
+    missing_tools = []
+    missing_caps = []
+    
+    for tool in critical_tools:
+        if tool not in cap_map["tools"]:
+            missing_tools.append({
+                "tool": tool,
+                "install": TOOL_SIGNATURES.get(tool, {}).get("install", "unknown"),
+            })
+    
+    for cap in critical_caps:
+        if cap not in cap_map["capabilities"] or not cap_map["capabilities"][cap]:
+            missing_caps.append(cap)
+    
+    result = {
+        "missing_tools": missing_tools,
+        "missing_capabilities": missing_caps,
+        "recommendations": [],
+    }
+    
+    if missing_tools:
+        result["recommendations"].append("Install missing tools with pip:")
+        for t in missing_tools:
+            result["recommendations"].append(f"  pip install {t['tool']}")
+    
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Capability Map — Auto-Discovery of Research Tools")
+    sub = parser.add_subparsers(dest="command")
+    
+    # discover
+    p_discover = sub.add_parser("discover", help="Discover all capabilities")
+    p_discover.add_argument("--quiet", action="store_true", help="Output JSON only")
+    
+    # check
+    p_check = sub.add_parser("check", help="Check if specific tool available")
+    p_check.add_argument("--tool", required=True, help="Tool name to check")
+    
+    # recommend
+    p_recommend = sub.add_parser("recommend", help="Recommend tools for task type")
+    p_recommend.add_argument("--type", required=True, 
+                            help="Task type (forecast, search, academic, news, social, financial, extraction, interactive)")
+    
+    # export
+    p_export = sub.add_parser("export", help="Export capability map")
+    p_export.add_argument("--output", help="Output file path")
+    
+    # missing
+    sub.add_parser("missing", help="Show missing critical tools")
+    
+    args = parser.parse_args()
+    
+    if not args.command:
+        parser.print_help()
+        return 1
+    
+    commands = {
+        "discover": cmd_discover,
+        "check": cmd_check,
+        "recommend": cmd_recommend,
+        "export": cmd_export,
+        "missing": cmd_missing,
+    }
+    
+    return commands[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/research/deep-research/scripts/debate.py
+++ b/skills/research/deep-research/scripts/debate.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""
+Multi-Agent Debate — Structured FOR/AGAINST Analysis
+
+Simulates a debate between multiple analysts with different perspectives.
+This forces the researcher to confront counter-arguments and strengthen
+their analysis.
+
+Usage:
+  python3 debate.py init --hypothesis "X will happen"    # Initialize debate
+  python3 debate.py argue --side for --argument "..."    # Add argument
+  python3 debate.py synthesize                            # Generate synthesis
+  python3 debate.py verdict                               # Final verdict
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from datetime import datetime
+from typing import Optional, List
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SKILL_DIR = os.path.dirname(SCRIPT_DIR)
+
+
+def get_state_dir():
+    """Return a writable state directory."""
+    override = os.environ.get("HERMES_DEEP_RESEARCH_STATE_DIR")
+    if override:
+        return override
+    hermes_home = os.environ.get("HERMES_HOME")
+    if hermes_home:
+        return os.path.join(hermes_home, "state", "deep-research")
+    return str(Path.home() / ".hermes" / "state" / "deep-research")
+
+
+STATE_DIR = get_state_dir()
+DEBATE_FILE = os.path.join(STATE_DIR, "debate.json")
+
+
+def timestamp():
+    return datetime.now().astimezone().strftime("%Y-%m-%d %H:%M %Z")
+
+
+def load_debate() -> dict:
+    """Load debate state."""
+    if os.path.exists(DEBATE_FILE):
+        with open(DEBATE_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_debate(data: dict):
+    """Save debate state."""
+    os.makedirs(os.path.dirname(DEBATE_FILE), exist_ok=True)
+    with open(DEBATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def cmd_init(args):
+    """Initialize a new debate."""
+    debate = {
+        "hypothesis": args.hypothesis,
+        "created": timestamp(),
+        "status": "open",
+        "analysts": {
+            "proponent": {
+                "role": "Argues FOR the hypothesis",
+                "arguments": [],
+                "evidence_cited": [],
+                "strength": None,
+            },
+            "skeptic": {
+                "role": "Argues AGAINST the hypothesis",
+                "arguments": [],
+                "evidence_cited": [],
+                "strength": None,
+            },
+            "alternative": {
+                "role": "Proposes ALTERNATIVE explanation",
+                "alternative_hypothesis": None,
+                "arguments": [],
+                "evidence_cited": [],
+            },
+        },
+        "synthesis": None,
+        "verdict": None,
+        "rounds": 0,
+        "history": [],
+    }
+    
+    save_debate(debate)
+    
+    print(json.dumps({
+        "initialized": True,
+        "hypothesis": args.hypothesis,
+        "analysts": ["proponent", "skeptic", "alternative"],
+        "next_steps": [
+            "Add arguments with: debate.py argue --side <proponent|skeptic|alternative> --argument '...'",
+            "Each analyst should cite specific evidence",
+            "Run synthesize when debate is complete",
+        ]
+    }, indent=2))
+    return 0
+
+
+def cmd_argue(args):
+    """Add an argument from an analyst."""
+    debate = load_debate()
+    
+    if not debate:
+        print("No debate initialized. Run: debate.py init --hypothesis '...'")
+        return 1
+    
+    side = args.side.lower()
+    if side not in ["proponent", "skeptic", "alternative"]:
+        print(f"Unknown side: {side}. Use: proponent, skeptic, or alternative")
+        return 1
+    
+    argument = {
+        "content": args.argument,
+        "evidence": args.evidence,
+        "strength": args.strength,
+        "timestamp": timestamp(),
+    }
+    
+    debate["analysts"][side]["arguments"].append(argument)
+    
+    if args.evidence:
+        debate["analysts"][side]["evidence_cited"].append(args.evidence)
+    
+    if args.strength:
+        debate["analysts"][side]["strength"] = args.strength
+    
+    debate["rounds"] += 1
+    debate["history"].append({
+        "action": "argue",
+        "side": side,
+        "summary": args.argument[:100],
+        "timestamp": timestamp(),
+    })
+    
+    # Handle alternative hypothesis
+    if side == "alternative" and args.alternative_hypothesis:
+        debate["analysts"]["alternative"]["alternative_hypothesis"] = args.alternative_hypothesis
+    
+    save_debate(debate)
+    
+    print(json.dumps({
+        "added": True,
+        "side": side,
+        "argument_count": len(debate["analysts"][side]["arguments"]),
+        "total_rounds": debate["rounds"],
+    }, indent=2))
+    return 0
+
+
+def cmd_counter(args):
+    """Add a counter-argument."""
+    debate = load_debate()
+    
+    if not debate:
+        print("No debate initialized.")
+        return 1
+    
+    # Determine counter side
+    if args.to == "proponent":
+        counter_side = "skeptic"
+    elif args.to == "skeptic":
+        counter_side = "proponent"
+    else:
+        counter_side = args.to
+    
+    argument = {
+        "content": args.argument,
+        "counters": args.to,
+        "evidence": args.evidence,
+        "timestamp": timestamp(),
+    }
+    
+    debate["analysts"][counter_side]["arguments"].append(argument)
+    debate["rounds"] += 1
+    
+    if args.evidence:
+        debate["analysts"][counter_side]["evidence_cited"].append(args.evidence)
+    
+    debate["history"].append({
+        "action": "counter",
+        "side": counter_side,
+        "counters": args.to,
+        "summary": args.argument[:100],
+        "timestamp": timestamp(),
+    })
+    
+    save_debate(debate)
+    
+    print(json.dumps({
+        "counter_added": True,
+        "from": counter_side,
+        "counters": args.to,
+    }, indent=2))
+    return 0
+
+
+def cmd_synthesize(args):
+    """Generate synthesis of the debate."""
+    debate = load_debate()
+    
+    if not debate:
+        print("No debate initialized.")
+        return 1
+    
+    proponent_args = debate["analysts"]["proponent"]["arguments"]
+    skeptic_args = debate["analysts"]["skeptic"]["arguments"]
+    alternative_args = debate["analysts"]["alternative"]["arguments"]
+    
+    # Count arguments
+    p_count = len(proponent_args)
+    s_count = len(skeptic_args)
+    a_count = len(alternative_args)
+    
+    # Check if debate is balanced
+    balance = abs(p_count - s_count)
+    if balance > 2:
+        print(f"WARNING: Debate is unbalanced. Proponent: {p_count}, Skeptic: {s_count}")
+        print("Consider adding more arguments from the weaker side.")
+    
+    # Generate synthesis structure (agent will fill in details)
+    synthesis = {
+        "summary": None,  # Agent fills
+        "strongest_for": None,  # Agent fills
+        "strongest_against": None,  # Agent fills
+        "key_evidence": {
+            "for": [],
+            "against": [],
+        },
+        "unresolved_questions": [],
+        "revised_confidence": None,
+        "hypothesis_should_revise": None,
+        "revised_hypothesis": None,
+    }
+    
+    debate["synthesis"] = synthesis
+    debate["status"] = "synthesized"
+    debate["history"].append({
+        "action": "synthesize",
+        "timestamp": timestamp(),
+    })
+    
+    save_debate(debate)
+    
+    print(json.dumps({
+        "synthesis_created": True,
+        "argument_counts": {
+            "proponent": p_count,
+            "skeptic": s_count,
+            "alternative": a_count,
+        },
+        "balance": "balanced" if balance <= 2 else "unbalanced",
+        "synthesis_fields_to_complete": [
+            "summary",
+            "strongest_for",
+            "strongest_against",
+            "key_evidence.for",
+            "key_evidence.against",
+            "unresolved_questions",
+            "revised_confidence",
+            "hypothesis_should_revise",
+        ],
+        "instruction": "Agent must fill synthesis fields based on debate arguments",
+    }, indent=2))
+    return 0
+
+
+def cmd_verdict(args):
+    """Render final verdict."""
+    debate = load_debate()
+    
+    if not debate:
+        print("No debate initialized.")
+        return 1
+    
+    if not debate.get("synthesis"):
+        print("No synthesis found. Run: debate.py synthesize")
+        return 1
+    
+    # Calculate scores based on arguments and evidence
+    p_strength = debate["analysts"]["proponent"].get("strength") or len(debate["analysts"]["proponent"]["arguments"])
+    s_strength = debate["analysts"]["skeptic"].get("strength") or len(debate["analysts"]["skeptic"]["arguments"])
+    
+    total = p_strength + s_strength
+    if total == 0:
+        p_ratio = 0.5
+    else:
+        p_ratio = p_strength / total
+    
+    # Determine verdict
+    if p_ratio >= 0.7:
+        verdict = "STRONG_SUPPORT"
+        confidence = "high"
+    elif p_ratio >= 0.55:
+        verdict = "MODERATE_SUPPORT"
+        confidence = "medium"
+    elif p_ratio >= 0.45:
+        verdict = "INCONCLUSIVE"
+        confidence = "low"
+    elif p_ratio >= 0.3:
+        verdict = "MODERATE_OPPOSITION"
+        confidence = "medium"
+    else:
+        verdict = "STRONG_OPPOSITION"
+        confidence = "high"
+    
+    # Check for alternative hypothesis
+    alt_hyp = debate["analysts"]["alternative"].get("alternative_hypothesis")
+    if alt_hyp and len(debate["analysts"]["alternative"]["arguments"]) >= 2:
+        alternative_strength = "moderate"
+    else:
+        alternative_strength = "weak"
+    
+    verdict_data = {
+        "verdict": verdict,
+        "confidence": confidence,
+        "proponent_strength": p_strength,
+        "skeptic_strength": s_strength,
+        "hypothesis_support_ratio": round(p_ratio, 2),
+        "alternative_hypothesis": alt_hyp,
+        "alternative_strength": alternative_strength,
+        "key_findings": args.findings.split("|") if args.findings else [],
+        "recommendation": generate_recommendation(verdict, confidence, alt_hyp),
+        "timestamp": timestamp(),
+    }
+    
+    debate["verdict"] = verdict_data
+    debate["status"] = "complete"
+    save_debate(debate)
+    
+    print("=" * 60)
+    print("  DEBATE VERDICT")
+    print("=" * 60)
+    print()
+    print(f"  Hypothesis: {debate['hypothesis']}")
+    print()
+    print(f"  VERDICT: {verdict}")
+    print(f"  Confidence: {confidence}")
+    print()
+    print(f"  Proponent strength: {p_strength}")
+    print(f"  Skeptic strength: {s_strength}")
+    print(f"  Support ratio: {p_ratio:.0%}")
+    
+    if alt_hyp:
+        print()
+        print(f"  Alternative hypothesis: {alt_hyp}")
+    
+    print()
+    print(f"  RECOMMENDATION:")
+    print(f"  {verdict_data['recommendation']}")
+    
+    print()
+    print(json.dumps(verdict_data, indent=2))
+    return 0
+
+
+def generate_recommendation(verdict: str, confidence: str, alt_hyp: Optional[str]) -> str:
+    """Generate recommendation based on verdict."""
+    recommendations = {
+        "STRONG_SUPPORT": "The evidence strongly supports the hypothesis. Proceed with high confidence. Consider documenting key supporting evidence.",
+        "MODERATE_SUPPORT": "The evidence moderately supports the hypothesis. Proceed with medium confidence. Address remaining counter-arguments.",
+        "INCONCLUSIVE": "The evidence is inconclusive. Either gather more data or reformulate the hypothesis. Do not proceed with high confidence forecasts.",
+        "MODERATE_OPPOSITION": "The evidence moderately opposes the hypothesis. Consider revising or pivoting to an alternative explanation.",
+        "STRONG_OPPOSITION": "The evidence strongly opposes the hypothesis. PIVOT required. Abandon this hypothesis and explore alternatives.",
+    }
+    
+    base = recommendations.get(verdict, "Analyze the debate arguments and make a decision.")
+    
+    if alt_hyp:
+        base += f" Alternative hypothesis '{alt_hyp[:50]}...' shows promise."
+    
+    return base
+
+
+def cmd_show(args):
+    """Show current debate state."""
+    debate = load_debate()
+    
+    if not debate:
+        print("No debate initialized.")
+        return 1
+    
+    print("=" * 60)
+    print("  CURRENT DEBATE")
+    print("=" * 60)
+    print()
+    print(f"  Hypothesis: {debate['hypothesis']}")
+    print(f"  Status: {debate['status']}")
+    print(f"  Rounds: {debate['rounds']}")
+    print()
+    
+    print("  PROPONENT (FOR):")
+    for i, arg in enumerate(debate["analysts"]["proponent"]["arguments"][:5], 1):
+        print(f"    {i}. {arg['content'][:80]}...")
+    
+    print()
+    print("  SKEPTIC (AGAINST):")
+    for i, arg in enumerate(debate["analysts"]["skeptic"]["arguments"][:5], 1):
+        print(f"    {i}. {arg['content'][:80]}...")
+    
+    if debate["analysts"]["alternative"].get("alternative_hypothesis"):
+        print()
+        print("  ALTERNATIVE HYPOTHESIS:")
+        print(f"    {debate['analysts']['alternative']['alternative_hypothesis']}")
+        for i, arg in enumerate(debate["analysts"]["alternative"]["arguments"][:3], 1):
+            print(f"    {i}. {arg['content'][:80]}...")
+    
+    if debate.get("verdict"):
+        print()
+        print("  VERDICT:")
+        print(f"    {debate['verdict']['verdict']} (confidence: {debate['verdict']['confidence']})")
+    
+    return 0
+
+
+def cmd_pivot(args):
+    """Record a PIVOT decision."""
+    debate = load_debate()
+    
+    if not debate:
+        print("No debate initialized.")
+        return 1
+    
+    pivot = {
+        "from_hypothesis": debate["hypothesis"],
+        "to_hypothesis": args.new_hypothesis,
+        "reason": args.reason,
+        "timestamp": timestamp(),
+    }
+    
+    debate["pivots"] = debate.get("pivots", [])
+    debate["pivots"].append(pivot)
+    debate["hypothesis"] = args.new_hypothesis
+    
+    # Reset arguments
+    for analyst in debate["analysts"]:
+        debate["analysts"][analyst]["arguments"] = []
+        debate["analysts"][analyst]["evidence_cited"] = []
+    
+    debate["synthesis"] = None
+    debate["verdict"] = None
+    debate["status"] = "open"
+    debate["rounds"] = 0
+    
+    debate["history"].append({
+        "action": "pivot",
+        "from": pivot["from_hypothesis"][:50],
+        "to": pivot["to_hypothesis"][:50],
+        "timestamp": timestamp(),
+    })
+    
+    save_debate(debate)
+    
+    print(json.dumps({
+        "pivoted": True,
+        "from": pivot["from_hypothesis"],
+        "to": pivot["to_hypothesis"],
+        "pivot_count": len(debate["pivots"]),
+        "warning": "Max 2 pivots recommended. Consider gathering more evidence instead of endless pivoting.",
+    }, indent=2))
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Multi-Agent Debate — Structured FOR/AGAINST Analysis")
+    sub = parser.add_subparsers(dest="command")
+    
+    # init
+    p_init = sub.add_parser("init", help="Initialize new debate")
+    p_init.add_argument("--hypothesis", required=True, help="Hypothesis to debate")
+    
+    # argue
+    p_argue = sub.add_parser("argue", help="Add argument from an analyst")
+    p_argue.add_argument("--side", required=True, choices=["proponent", "skeptic", "alternative"])
+    p_argue.add_argument("--argument", required=True, help="The argument")
+    p_argue.add_argument("--evidence", help="Evidence cited")
+    p_argue.add_argument("--strength", type=int, help="Argument strength (1-10)")
+    p_argue.add_argument("--alternative-hypothesis", help="For alternative side: the alternative hypothesis")
+    
+    # counter
+    p_counter = sub.add_parser("counter", help="Add counter-argument")
+    p_counter.add_argument("--to", required=True, help="Side being countered")
+    p_counter.add_argument("--argument", required=True)
+    p_counter.add_argument("--evidence", help="Evidence cited")
+    
+    # synthesize
+    sub.add_parser("synthesize", help="Generate debate synthesis")
+    
+    # verdict
+    p_verdict = sub.add_parser("verdict", help="Render final verdict")
+    p_verdict.add_argument("--findings", help="Key findings (pipe-separated)")
+    
+    # show
+    sub.add_parser("show", help="Show current debate state")
+    
+    # pivot
+    p_pivot = sub.add_parser("pivot", help="PIVOT to new hypothesis")
+    p_pivot.add_argument("--new-hypothesis", required=True, help="New hypothesis")
+    p_pivot.add_argument("--reason", required=True, help="Why pivoting")
+    
+    args = parser.parse_args()
+    
+    if not args.command:
+        parser.print_help()
+        return 1
+    
+    commands = {
+        "init": cmd_init,
+        "argue": cmd_argue,
+        "counter": cmd_counter,
+        "synthesize": cmd_synthesize,
+        "verdict": cmd_verdict,
+        "show": cmd_show,
+        "pivot": cmd_pivot,
+    }
+    
+    return commands[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/research/deep-research/scripts/deep_research.py
+++ b/skills/research/deep-research/scripts/deep_research.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""
+Deep Research — Research session manager and report generator.
+
+Manages research sessions, tracks findings, generates reports.
+Works with all available research tools (Google News, DDG, arxiv, etc.)
+
+Usage:
+  python3 deep_research.py init "Is AI replacing programmers?"     # New session
+  python3 deep_research.py plan                                     # Show research plan
+  python3 deep_research.py log "Found paper showing 40% increase"   # Log finding
+  python3 deep_research.py source "https://..." "title" "type" --credibility 4
+  python3 deep_research.py reflect                                  # Run reflection
+  python3 deep_research.py report                                   # Generate report
+  python3 deep_research.py activity                                 # Show research activity log
+  python3 deep_research.py sessions                                 # List all sessions
+"""
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from datetime import datetime
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SKILL_DIR = os.path.dirname(SCRIPT_DIR)
+
+
+def get_state_dir():
+    """Return a writable state directory for deep research sessions."""
+    override = os.environ.get("HERMES_DEEP_RESEARCH_STATE_DIR")
+    if override:
+        return override
+
+    hermes_home = os.environ.get("HERMES_HOME")
+    if hermes_home:
+        return os.path.join(hermes_home, "state", "deep-research")
+
+    return str(Path.home() / ".hermes" / "state" / "deep-research")
+
+
+STATE_DIR = get_state_dir()
+SESSIONS_DIR = os.path.join(STATE_DIR, "sessions")
+
+def now_local():
+    """Return current time in system's local timezone."""
+    return datetime.now().astimezone()
+
+
+def timestamp():
+    return now_local().strftime("%Y-%m-%d %H:%M %Z")
+
+
+def date_slug():
+    return now_local().strftime("%Y-%m-%d")
+
+
+def get_session_path(name=None):
+    """Get path to session directory."""
+    if name:
+        return os.path.join(SESSIONS_DIR, name)
+    # Find latest session
+    if not os.path.exists(SESSIONS_DIR):
+        return None
+    sessions = sorted(os.listdir(SESSIONS_DIR), reverse=True)
+    if sessions:
+        return os.path.join(SESSIONS_DIR, sessions[0])
+    return None
+
+
+def load_session(session_path):
+    """Load session data."""
+    data_file = os.path.join(session_path, "session.json")
+    if os.path.exists(data_file):
+        with open(data_file, encoding="utf-8") as f:
+            data = json.load(f)
+            if "research_log" not in data and "chain_of_thought" in data:
+                data["research_log"] = data.pop("chain_of_thought")
+            return data
+    return None
+
+
+def save_session(session_path, data):
+    """Save session data."""
+    os.makedirs(session_path, exist_ok=True)
+    data_file = os.path.join(session_path, "session.json")
+    with open(data_file, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def cmd_init(args):
+    """Initialize a new research session."""
+    # Create a privacy-safe session name without embedding the topic in the path
+    session_name = f"{date_slug()}_{uuid.uuid4().hex[:8]}"
+    session_path = os.path.join(SESSIONS_DIR, session_name)
+
+    if os.path.exists(session_path):
+        print(f"Session already exists: {session_name}")
+        return 1
+
+    session = {
+        "name": session_name,
+        "topic": args.topic,
+        "created": timestamp(),
+        "status": "planning",
+        "questions": [],
+        "sub_questions": [],
+        "sources": [],
+        "findings": [],
+        "contradictions": [],
+        "gaps": [],
+        "research_log": [],
+        "confidence": None,
+        "report": None,
+    }
+
+    # Parse initial questions if provided
+    if args.questions:
+        for q in args.questions.split("|"):
+            session["sub_questions"].append(q.strip())
+
+    save_session(session_path, session)
+
+    # Add initial research log entry
+    session["research_log"].append({
+        "step": 1,
+        "phase": "init",
+        "timestamp": timestamp(),
+        "content": f"Research session initialized.\nCore question: {args.topic}",
+    })
+    save_session(session_path, session)
+
+    print(json.dumps({
+        "session": session_name,
+        "path": session_path,
+        "topic": args.topic,
+        "status": "planning",
+    }, indent=2))
+    return 0
+
+
+def cmd_plan(args):
+    """Show or update research plan."""
+    session_path = get_session_path(args.session)
+    if not session_path:
+        print("No active session. Run: python3 deep_research.py init 'topic'")
+        return 1
+
+    session = load_session(session_path)
+    if not session:
+        print("Could not load session")
+        return 1
+
+    if args.add_question:
+        session["sub_questions"].append(args.add_question)
+        session["research_log"].append({
+            "step": len(session["research_log"]) + 1,
+            "phase": "planning",
+            "timestamp": timestamp(),
+            "content": f"Added sub-question: {args.add_question}",
+        })
+        save_session(session_path, session)
+        print(f"Added: {args.add_question}")
+
+    # Display current plan
+    plan = {
+        "session": session["name"],
+        "topic": session["topic"],
+        "status": session["status"],
+        "sub_questions": session["sub_questions"],
+        "sources_found": len(session["sources"]),
+        "findings": len(session["findings"]),
+        "confidence": session["confidence"],
+    }
+    print(json.dumps(plan, indent=2))
+    return 0
+
+
+def cmd_log(args):
+    """Log a finding."""
+    session_path = get_session_path(args.session)
+    if not session_path:
+        print("No active session")
+        return 1
+
+    session = load_session(session_path)
+
+    finding = {
+        "content": args.finding,
+        "timestamp": timestamp(),
+        "source_url": args.source or None,
+        "credibility": args.credibility or None,
+        "type": args.type or "observation",
+    }
+    session["findings"].append(finding)
+
+    # Add to research log
+    session["research_log"].append({
+        "step": len(session["research_log"]) + 1,
+        "phase": "evaluation",
+        "timestamp": timestamp(),
+        "content": f"Finding logged: {args.finding}",
+    })
+
+    save_session(session_path, session)
+    print(json.dumps({"logged": True, "total_findings": len(session["findings"])}, indent=2))
+    return 0
+
+
+def cmd_source(args):
+    """Add a source."""
+    session_path = get_session_path(args.session)
+    if not session_path:
+        print("No active session")
+        return 1
+
+    session = load_session(session_path)
+
+    source = {
+        "url": args.url,
+        "title": args.title,
+        "type": args.source_type,
+        "credibility": args.credibility or 3,
+        "accessed": timestamp(),
+    }
+    session["sources"].append(source)
+
+    session["research_log"].append({
+        "step": len(session["research_log"]) + 1,
+        "phase": "search",
+        "timestamp": timestamp(),
+        "content": f"Source added: {args.title} (credibility: {source['credibility']}/5)",
+    })
+
+    save_session(session_path, session)
+    print(json.dumps({"added": True, "total_sources": len(session["sources"])}, indent=2))
+    return 0
+
+
+def cmd_reflect(args):
+    """Run reflection phase."""
+    session_path = get_session_path(args.session)
+    if not session_path:
+        print("No active session")
+        return 1
+
+    session = load_session(session_path)
+
+    print("=" * 60)
+    print("  REFLECTION PHASE")
+    print("=" * 60)
+    print()
+
+    # Generate reflection prompts
+    findings_count = len(session["findings"])
+    sources_count = len(session["sources"])
+    contradictions = len(session["contradictions"])
+    gaps = len(session["gaps"])
+
+    reflection = {
+        "session": session["name"],
+        "topic": session["topic"],
+        "stats": {
+            "findings": findings_count,
+            "sources": sources_count,
+            "contradictions": contradictions,
+            "gaps": gaps,
+        },
+        "reflection_prompts": [
+            f"1. What did you expect to find that you didn't? (Gaps: {gaps} identified)",
+            f"2. What contradicts what you thought? (Contradictions: {contradictions} found)",
+            f"3. What new questions arose from findings?",
+            f"4. What are your biases? Are you confirming or investigating?",
+            f"5. What would a skeptic say about your findings?",
+            f"6. What's your confidence level? (Current: {session['confidence'] or 'not set'})",
+        ],
+        "credibility_breakdown": {},
+    }
+
+    # Calculate credibility breakdown
+    for s in session["sources"]:
+        cred = s.get("credibility", 3)
+        key = f"{cred}/5"
+        reflection["credibility_breakdown"][key] = reflection["credibility_breakdown"].get(key, 0) + 1
+
+    print(json.dumps(reflection, indent=2))
+
+    # Log reflection
+    session["research_log"].append({
+        "step": len(session["research_log"]) + 1,
+        "phase": "reflection",
+        "timestamp": timestamp(),
+        "content": f"Reflection phase. Stats: {findings_count} findings, {sources_count} sources, {contradictions} contradictions, {gaps} gaps",
+    })
+    save_session(session_path, session)
+    return 0
+
+
+def cmd_report(args):
+    """Generate research report."""
+    session_path = get_session_path(args.session)
+    if not session_path:
+        print("No active session")
+        return 1
+
+    session = load_session(session_path)
+
+    # Generate markdown report
+    report = f"""# Research Report: {session['topic']}
+
+**Date**: {timestamp()}
+**Session**: {session['name']}
+**Status**: {session['status']}
+**Confidence**: {session['confidence'] or 'Not assessed'}
+
+## Executive Summary
+
+{session.get('summary', '[Summary not yet written. Add with: python3 deep_research.py summary "..."]')}
+
+## Research Questions
+
+"""
+    for i, q in enumerate(session["sub_questions"], 1):
+        report += f"{i}. {q}\n"
+
+    report += f"\n## Key Findings ({len(session['findings'])})\n\n"
+    for i, f in enumerate(session["findings"], 1):
+        cred = f" (credibility: {f['credibility']}/5)" if f.get("credibility") else ""
+        src = f" — [source]({f['source_url']})" if f.get("source_url") else ""
+        report += f"{i}. {f['content']}{cred}{src}\n"
+
+    if session["contradictions"]:
+        report += f"\n## Contradictions Found ({len(session['contradictions'])})\n\n"
+        for c in session["contradictions"]:
+            report += f"- {c}\n"
+
+    if session["gaps"]:
+        report += f"\n## Gaps and Limitations ({len(session['gaps'])})\n\n"
+        for g in session["gaps"]:
+            report += f"- {g}\n"
+
+    report += f"\n## Sources ({len(session['sources'])})\n\n"
+    for i, s in enumerate(session["sources"], 1):
+        report += f"{i}. [{s['title']}]({s['url']}) — {s['type']} — credibility {s['credibility']}/5 — accessed {s['accessed']}\n"
+
+    # Save report
+    report_path = os.path.join(session_path, "report.md")
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write(report)
+
+    session["report"] = report_path
+    session["status"] = "complete"
+    save_session(session_path, session)
+
+    print(json.dumps({
+        "report_generated": True,
+        "path": report_path,
+        "sections": ["summary", "findings", "contradictions", "gaps", "sources"],
+        "stats": {
+            "findings": len(session["findings"]),
+            "sources": len(session["sources"]),
+            "contradictions": len(session["contradictions"]),
+            "gaps": len(session["gaps"]),
+        },
+    }, indent=2))
+    return 0
+
+
+def cmd_activity(args):
+    """Show research activity log."""
+    session_path = get_session_path(args.session)
+    if not session_path:
+        print("No active session")
+        return 1
+
+    session = load_session(session_path)
+
+    for entry in session["research_log"]:
+        print(f"[Step {entry['step']}] {entry['phase'].upper()} ({entry['timestamp']})")
+        print(f"  {entry['content']}")
+        print()
+
+    return 0
+
+
+def cmd_sessions(args):
+    """List all research sessions."""
+    if not os.path.exists(SESSIONS_DIR):
+        print("No sessions found")
+        return 0
+
+    sessions = []
+    for name in sorted(os.listdir(SESSIONS_DIR), reverse=True):
+        session_path = os.path.join(SESSIONS_DIR, name)
+        data = load_session(session_path)
+        if data:
+            sessions.append({
+                "name": name,
+                "topic": data["topic"][:60],
+                "status": data["status"],
+                "findings": len(data["findings"]),
+                "sources": len(data["sources"]),
+                "created": data["created"],
+            })
+
+    print(json.dumps({"total": len(sessions), "sessions": sessions[:10]}, indent=2))
+    return 0
+
+
+def cmd_contradiction(args):
+    """Log a contradiction."""
+    session_path = get_session_path(args.session)
+    if not session_path:
+        print("No active session")
+        return 1
+
+    session = load_session(session_path)
+    session["contradictions"].append(args.description)
+
+    session["research_log"].append({
+        "step": len(session["research_log"]) + 1,
+        "phase": "evaluation",
+        "timestamp": timestamp(),
+        "content": f"Contradiction found: {args.description}",
+    })
+
+    save_session(session_path, session)
+    print(json.dumps({"logged": True, "total_contradictions": len(session["contradictions"])}, indent=2))
+    return 0
+
+
+def cmd_gap(args):
+    """Log a knowledge gap."""
+    session_path = get_session_path(args.session)
+    if not session_path:
+        print("No active session")
+        return 1
+
+    session = load_session(session_path)
+    session["gaps"].append(args.description)
+
+    session["research_log"].append({
+        "step": len(session["research_log"]) + 1,
+        "phase": "reflection",
+        "timestamp": timestamp(),
+        "content": f"Gap identified: {args.description}",
+    })
+
+    save_session(session_path, session)
+    print(json.dumps({"logged": True, "total_gaps": len(session["gaps"])}, indent=2))
+    return 0
+
+
+def cmd_confidence(args):
+    """Set confidence level."""
+    session_path = get_session_path(args.session)
+    if not session_path:
+        print("No active session")
+        return 1
+
+    session = load_session(session_path)
+    session["confidence"] = args.level
+
+    session["research_log"].append({
+        "step": len(session["research_log"]) + 1,
+        "phase": "reflection",
+        "timestamp": timestamp(),
+        "content": f"Confidence set: {args.level}",
+    })
+
+    save_session(session_path, session)
+    print(json.dumps({"confidence": args.level}, indent=2))
+    return 0
+
+
+def cmd_summary(args):
+    """Set executive summary."""
+    session_path = get_session_path(args.session)
+    if not session_path:
+        print("No active session")
+        return 1
+
+    session = load_session(session_path)
+    session["summary"] = args.text
+    save_session(session_path, session)
+    print(json.dumps({"summary_set": True}, indent=2))
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Deep Research — Research session manager")
+    sub = parser.add_subparsers(dest="command")
+
+    # init
+    p_init = sub.add_parser("init", help="Start new research session")
+    p_init.add_argument("topic", help="Research topic or question")
+    p_init.add_argument("--questions", help="Sub-questions separated by |")
+
+    # plan
+    p_plan = sub.add_parser("plan", help="Show/update research plan")
+    p_plan.add_argument("--add-question", help="Add a sub-question")
+    p_plan.add_argument("--session", help="Session name")
+
+    # log
+    p_log = sub.add_parser("log", help="Log a finding")
+    p_log.add_argument("finding", help="Finding description")
+    p_log.add_argument("--source", help="Source URL")
+    p_log.add_argument("--credibility", type=int, help="Credibility score 1-5")
+    p_log.add_argument("--type", help="Finding type: data, quote, analysis, observation")
+    p_log.add_argument("--session", help="Session name")
+
+    # source
+    p_source = sub.add_parser("source", help="Add a source")
+    p_source.add_argument("url", help="Source URL")
+    p_source.add_argument("title", help="Source title")
+    p_source.add_argument("source_type", help="Type: news, academic, blog, social, primary")
+    p_source.add_argument("--credibility", type=int, help="Credibility 1-5")
+    p_source.add_argument("--session", help="Session name")
+
+    # reflect
+    p_reflect = sub.add_parser("reflect", help="Run reflection phase")
+    p_reflect.add_argument("--session", help="Session name")
+
+    # report
+    p_report = sub.add_parser("report", help="Generate research report")
+    p_report.add_argument("--session", help="Session name")
+
+    # activity
+    p_activity = sub.add_parser("activity", help="Show research activity log")
+    p_activity.add_argument("--session", help="Session name")
+
+    # sessions
+    sub.add_parser("sessions", help="List all sessions")
+
+    # contradiction
+    p_contra = sub.add_parser("contradiction", help="Log a contradiction")
+    p_contra.add_argument("description", help="Contradiction description")
+    p_contra.add_argument("--session", help="Session name")
+
+    # gap
+    p_gap = sub.add_parser("gap", help="Log a knowledge gap")
+    p_gap.add_argument("description", help="Gap description")
+    p_gap.add_argument("--session", help="Session name")
+
+    # confidence
+    p_conf = sub.add_parser("confidence", help="Set confidence level")
+    p_conf.add_argument("level", choices=["high", "medium", "low"], help="Confidence level")
+    p_conf.add_argument("--session", help="Session name")
+
+    # summary
+    p_summary = sub.add_parser("summary", help="Set executive summary")
+    p_summary.add_argument("text", help="Summary text")
+    p_summary.add_argument("--session", help="Session name")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    commands = {
+        "init": cmd_init,
+        "plan": cmd_plan,
+        "log": cmd_log,
+        "source": cmd_source,
+        "reflect": cmd_reflect,
+        "report": cmd_report,
+        "activity": cmd_activity,
+        "sessions": cmd_sessions,
+        "contradiction": cmd_contradiction,
+        "gap": cmd_gap,
+        "confidence": cmd_confidence,
+        "summary": cmd_summary,
+    }
+
+    handler = commands.get(args.command)
+    if handler:
+        return handler(args)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/research/deep-research/scripts/evidence_cards.py
+++ b/skills/research/deep-research/scripts/evidence_cards.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""
+Evidence Cards — Structured Evidence Tracking for Deep Research
+
+Every piece of evidence becomes a card with metadata, verification status,
+and bias detection. This prevents claims from floating unanchored.
+
+Usage:
+  python3 evidence_cards.py init                        # Create new card deck
+  python3 evidence_cards.py add --claim "X" --source "url" --type "primary"
+  python3 evidence_cards.py verify --card-id "card-001" --status "verified"
+  python3 evidence_cards.py debate --card-id "card-001"  # Generate FOR/AGAINST
+  python3 evidence_cards.py export                       # Export all cards as JSON
+"""
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from datetime import datetime
+from typing import Optional
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SKILL_DIR = os.path.dirname(SCRIPT_DIR)
+
+
+def get_state_dir():
+    """Return a writable state directory for evidence cards."""
+    override = os.environ.get("HERMES_DEEP_RESEARCH_STATE_DIR")
+    if override:
+        return override
+    hermes_home = os.environ.get("HERMES_HOME")
+    if hermes_home:
+        return os.path.join(hermes_home, "state", "deep-research")
+    return str(Path.home() / ".hermes" / "state" / "deep-research")
+
+
+STATE_DIR = get_state_dir()
+CARDS_DIR = os.path.join(STATE_DIR, "evidence_cards")
+
+
+def timestamp():
+    return datetime.now().astimezone().strftime("%Y-%m-%d %H:%M %Z")
+
+
+def load_deck(deck_path: str) -> dict:
+    """Load the evidence card deck."""
+    if os.path.exists(deck_path):
+        with open(deck_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {"cards": [], "created": timestamp(), "session": None}
+
+
+def save_deck(deck_path: str, deck: dict):
+    """Save the evidence card deck."""
+    os.makedirs(os.path.dirname(deck_path), exist_ok=True)
+    with open(deck_path, "w", encoding="utf-8") as f:
+        json.dump(deck, f, indent=2, ensure_ascii=False)
+
+
+def classify_source_type(url: str, source_type: Optional[str] = None) -> str:
+    """Classify source type from URL or explicit type."""
+    if source_type:
+        return source_type
+    
+    url_lower = url.lower()
+    
+    # Prediction markets
+    if any(x in url_lower for x in ["polymarket", "metaculus", "manifold", "predictit"]):
+        return "prediction_market"
+    
+    # Government/official
+    if any(x in url_lower for x in [".gov", ".mil", "whitehouse", "state.gov", "congress"]):
+        return "government"
+    
+    # Financial data
+    if any(x in url_lower for x in ["bloomberg", "reuters", "ft.com", "wsj", "cnbc"]):
+        return "financial_news"
+    
+    # Analyst reports
+    if any(x in url_lower for x in ["goldman", "morgan", "jpmorgan", "analyst", "research"]):
+        return "analyst_report"
+    
+    # Academic
+    if any(x in url_lower for x in ["arxiv", "scholar", "acm.org", "ieee", "nature", "science.org"]):
+        return "academic"
+    
+    # News
+    if any(x in url_lower for x in ["news", "bbc", "cnn", "nytimes", "washingtonpost", "apnews"]):
+        return "news"
+    
+    # Social
+    if any(x in url_lower for x in ["twitter", "x.com", "reddit", "threads"]):
+        return "social_media"
+    
+    # Think tanks
+    if any(x in url_lower for x in ["rand", "brookings", "cfr.org", "csis", "heritage"]):
+        return "think_tank"
+    
+    return "web"
+
+
+def classify_source_tier(source_type: str, credibility_override: Optional[int] = None) -> str:
+    """Classify source tier (1-5) based on type."""
+    if credibility_override:
+        return f"tier{credibility_override}"
+    
+    tier_map = {
+        "government": "tier1",
+        "prediction_market": "tier1",  # Real-money forecasts are high signal
+        "analyst_report": "tier2",
+        "academic": "tier2",
+        "think_tank": "tier2",
+        "financial_news": "tier3",
+        "news": "tier3",
+        "web": "tier4",
+        "blog": "tier4",
+        "social_media": "tier5",
+    }
+    return tier_map.get(source_type, "tier4")
+
+
+def detect_bias_flags(url: str, claim: str, source_type: str) -> list:
+    """Detect potential bias flags for a source."""
+    flags = []
+    url_lower = url.lower()
+    claim_lower = claim.lower()
+    
+    # Financial conflict of interest
+    if source_type == "analyst_report":
+        if any(x in url_lower for x in ["goldman", "morgan", "jpmorgan"]):
+            flags.append({
+                "type": "financial_conflict",
+                "note": "Investment bank may have trading position in related assets",
+                "severity": "medium"
+            })
+    
+    # Political bias
+    if any(x in url_lower for x in ["heritage", "brookings", "csis"]):
+        flags.append({
+            "type": "institutional_bias",
+            "note": "Think tank may have ideological or funding-driven perspective",
+            "severity": "low"
+            })
+    
+    # Prediction market caveats
+    if source_type == "prediction_market":
+        flags.append({
+            "type": "market_caveat",
+            "note": "Prediction market reflects crowd probability, not expert consensus. May be thin liquidity.",
+            "severity": "info"
+        })
+    
+    # Social media
+    if source_type == "social_media":
+        flags.append({
+            "type": "unverified_source",
+            "note": "Social media source - verify with primary source before relying",
+            "severity": "high"
+        })
+    
+    # Recency check (for claims about current events)
+    if any(word in claim_lower for word in ["will", "forecast", "predict", "expected"]):
+        flags.append({
+            "type": "time_sensitive",
+            "note": "Forecast claim - verify timestamp and check for updates",
+            "severity": "info"
+        })
+    
+    return flags
+
+
+def create_evidence_card(
+    claim: str,
+    source_url: str,
+    source_title: Optional[str] = None,
+    source_type: Optional[str] = None,
+    credibility: Optional[int] = None,
+    excerpt: Optional[str] = None,
+    context: Optional[str] = None,
+) -> dict:
+    """Create a structured evidence card."""
+    card_id = f"card-{uuid.uuid4().hex[:8]}"
+    detected_type = classify_source_type(source_url, source_type)
+    tier = classify_source_tier(detected_type, credibility)
+    bias_flags = detect_bias_flags(source_url, claim, detected_type)
+    
+    return {
+        "card_id": card_id,
+        "claim": claim,
+        "source": {
+            "url": source_url,
+            "title": source_title or source_url,
+            "type": detected_type,
+            "tier": tier,
+            "accessed": timestamp(),
+        },
+        "verification": {
+            "status": "unverified",  # unverified, supported, verified, disputed
+            "cross_references": [],
+            "verification_notes": None,
+        },
+        "excerpt": excerpt,
+        "context": context,
+        "bias_flags": bias_flags,
+        "debate": None,  # Populated by debate command
+        "metadata": {
+            "created": timestamp(),
+            "last_updated": timestamp(),
+        }
+    }
+
+
+def cmd_init(args):
+    """Initialize a new evidence card deck."""
+    deck_path = os.path.join(CARDS_DIR, "deck.json")
+    
+    if os.path.exists(deck_path) and not args.force:
+        print(f"Deck already exists: {deck_path}")
+        print("Use --force to overwrite")
+        return 1
+    
+    deck = {
+        "cards": [],
+        "created": timestamp(),
+        "session": args.session or None,
+        "statistics": {
+            "total_cards": 0,
+            "verified": 0,
+            "supported": 0,
+            "unverified": 0,
+            "disputed": 0,
+            "tier_counts": {"tier1": 0, "tier2": 0, "tier3": 0, "tier4": 0, "tier5": 0},
+        }
+    }
+    
+    save_deck(deck_path, deck)
+    print(json.dumps({"deck": deck_path, "created": True, "cards": 0}, indent=2))
+    return 0
+
+
+def cmd_add(args):
+    """Add a new evidence card."""
+    deck_path = os.path.join(CARDS_DIR, "deck.json")
+    deck = load_deck(deck_path)
+    
+    card = create_evidence_card(
+        claim=args.claim,
+        source_url=args.source,
+        source_title=args.title,
+        source_type=args.type,
+        credibility=args.credibility,
+        excerpt=args.excerpt,
+        context=args.context,
+    )
+    
+    deck["cards"].append(card)
+    
+    # Update statistics
+    deck["statistics"]["total_cards"] = len(deck["cards"])
+    tier = card["source"]["tier"]
+    deck["statistics"]["tier_counts"][tier] = deck["statistics"]["tier_counts"].get(tier, 0) + 1
+    
+    save_deck(deck_path, deck)
+    
+    print(json.dumps({
+        "added": True,
+        "card_id": card["card_id"],
+        "tier": card["source"]["tier"],
+        "bias_flags": len(card["bias_flags"]),
+        "total_cards": deck["statistics"]["total_cards"],
+    }, indent=2))
+    return 0
+
+
+def cmd_verify(args):
+    """Update verification status of a card."""
+    deck_path = os.path.join(CARDS_DIR, "deck.json")
+    deck = load_deck(deck_path)
+    
+    card = None
+    for c in deck["cards"]:
+        if c["card_id"] == args.card_id:
+            card = c
+            break
+    
+    if not card:
+        print(f"Card not found: {args.card_id}")
+        return 1
+    
+    old_status = card["verification"]["status"]
+    card["verification"]["status"] = args.status
+    card["verification"]["verification_notes"] = args.notes
+    card["metadata"]["last_updated"] = timestamp()
+    
+    if args.cross_ref:
+        card["verification"]["cross_references"].append(args.cross_ref)
+    
+    # Update statistics
+    if old_status != args.status:
+        deck["statistics"][old_status] = max(0, deck["statistics"].get(old_status, 0) - 1)
+        deck["statistics"][args.status] = deck["statistics"].get(args.status, 0) + 1
+    
+    save_deck(deck_path, deck)
+    
+    print(json.dumps({
+        "updated": True,
+        "card_id": card["card_id"],
+        "old_status": old_status,
+        "new_status": args.status,
+    }, indent=2))
+    return 0
+
+
+def cmd_debate(args):
+    """Generate FOR/AGAINST debate for a card's claim."""
+    deck_path = os.path.join(CARDS_DIR, "deck.json")
+    deck = load_deck(deck_path)
+    
+    card = None
+    for c in deck["cards"]:
+        if c["card_id"] == args.card_id:
+            card = c
+            break
+    
+    if not card:
+        print(f"Card not found: {args.card_id}")
+        return 1
+    
+    # Generate debate structure (the agent will fill in the arguments)
+    debate = {
+        "claim": card["claim"],
+        "analyst_for": {
+            "argument": None,  # Agent fills this
+            "evidence_needed": [],
+            "strength": None,
+        },
+        "analyst_against": {
+            "argument": None,  # Agent fills this
+            "evidence_needed": [],
+            "strength": None,
+        },
+        "analyst_alternative": {
+            "alternative_hypothesis": None,
+            "argument": None,
+            "evidence_needed": [],
+        },
+        "synthesis": {
+            "winner": None,  # "for", "against", "inconclusive"
+            "confidence": None,
+            "key_evidence": [],
+            "remaining_gaps": [],
+        },
+        "generated": timestamp(),
+    }
+    
+    card["debate"] = debate
+    save_deck(deck_path, deck)
+    
+    print(json.dumps({
+        "debate_created": True,
+        "card_id": card["card_id"],
+        "claim": card["claim"],
+        "instruction": "Agent must fill in analyst_for, analyst_against, analyst_alternative, and synthesis fields",
+        "fields_to_complete": [
+            "debate.analyst_for.argument",
+            "debate.analyst_for.evidence_needed",
+            "debate.analyst_for.strength",
+            "debate.analyst_against.argument",
+            "debate.analyst_against.evidence_needed",
+            "debate.analyst_against.strength",
+            "debate.analyst_alternative.alternative_hypothesis",
+            "debate.analyst_alternative.argument",
+            "debate.synthesis.winner",
+            "debate.synthesis.confidence",
+            "debate.synthesis.key_evidence",
+        ]
+    }, indent=2))
+    return 0
+
+
+def cmd_export(args):
+    """Export all evidence cards as JSON."""
+    deck_path = os.path.join(CARDS_DIR, "deck.json")
+    deck = load_deck(deck_path)
+    
+    # Calculate additional statistics
+    tier_counts = {"tier1": 0, "tier2": 0, "tier3": 0, "tier4": 0, "tier5": 0}
+    status_counts = {"verified": 0, "supported": 0, "unverified": 0, "disputed": 0}
+    bias_flag_count = 0
+    
+    for card in deck["cards"]:
+        tier_counts[card["source"]["tier"]] = tier_counts.get(card["source"]["tier"], 0) + 1
+        status_counts[card["verification"]["status"]] = status_counts.get(card["verification"]["status"], 0) + 1
+        bias_flag_count += len(card.get("bias_flags", []))
+    
+    export = {
+        "deck": deck,
+        "analysis": {
+            "total_cards": len(deck["cards"]),
+            "tier_distribution": tier_counts,
+            "verification_distribution": status_counts,
+            "total_bias_flags": bias_flag_count,
+            "quality_score": calculate_quality_score(tier_counts, status_counts),
+        },
+        "exported": timestamp(),
+    }
+    
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(export, f, indent=2, ensure_ascii=False)
+        print(f"Exported to: {args.output}")
+    else:
+        print(json.dumps(export, indent=2))
+    
+    return 0
+
+
+def calculate_quality_score(tier_counts: dict, status_counts: dict) -> float:
+    """Calculate a quality score based on tier and verification distribution."""
+    total = sum(tier_counts.values())
+    if total == 0:
+        return 0.0
+    
+    # Tier quality: tier1=1.0, tier2=0.8, tier3=0.5, tier4=0.3, tier5=0.1
+    tier_quality = (
+        tier_counts.get("tier1", 0) * 1.0 +
+        tier_counts.get("tier2", 0) * 0.8 +
+        tier_counts.get("tier3", 0) * 0.5 +
+        tier_counts.get("tier4", 0) * 0.3 +
+        tier_counts.get("tier5", 0) * 0.1
+    ) / total
+    
+    # Verification quality: verified=1.0, supported=0.7, unverified=0.3, disputed=0.0
+    total_verified = sum(status_counts.values())
+    if total_verified == 0:
+        verification_quality = 0.0
+    else:
+        verification_quality = (
+            status_counts.get("verified", 0) * 1.0 +
+            status_counts.get("supported", 0) * 0.7 +
+            status_counts.get("unverified", 0) * 0.3 +
+            status_counts.get("disputed", 0) * 0.0
+        ) / total_verified
+    
+    # Combined score (60% verification, 40% source quality)
+    return round(0.6 * verification_quality + 0.4 * tier_quality, 3)
+
+
+def cmd_summary(args):
+    """Show summary of evidence cards."""
+    deck_path = os.path.join(CARDS_DIR, "deck.json")
+    deck = load_deck(deck_path)
+    
+    total = len(deck["cards"])
+    if total == 0:
+        print("No evidence cards found. Use 'add' command to create cards.")
+        return 0
+    
+    # Count by tier
+    tier_counts = {"tier1": 0, "tier2": 0, "tier3": 0, "tier4": 0, "tier5": 0}
+    status_counts = {"verified": 0, "supported": 0, "unverified": 0, "disputed": 0}
+    
+    for card in deck["cards"]:
+        tier_counts[card["source"]["tier"]] = tier_counts.get(card["source"]["tier"], 0) + 1
+        status_counts[card["verification"]["status"]] = status_counts.get(card["verification"]["status"], 0) + 1
+    
+    quality = calculate_quality_score(tier_counts, status_counts)
+    
+    summary = {
+        "total_cards": total,
+        "tiers": tier_counts,
+        "verification": status_counts,
+        "quality_score": quality,
+        "quality_interpretation": (
+            "HIGH" if quality >= 0.7 else
+            "MEDIUM" if quality >= 0.5 else
+            "LOW"
+        ),
+    }
+    
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evidence Cards — Structured Evidence Tracking")
+    sub = parser.add_subparsers(dest="command")
+    
+    # init
+    p_init = sub.add_parser("init", help="Initialize new evidence card deck")
+    p_init.add_argument("--session", help="Session ID to link cards to")
+    p_init.add_argument("--force", action="store_true", help="Overwrite existing deck")
+    
+    # add
+    p_add = sub.add_parser("add", help="Add new evidence card")
+    p_add.add_argument("--claim", required=True, help="The claim or finding")
+    p_add.add_argument("--source", required=True, help="Source URL")
+    p_add.add_argument("--title", help="Source title")
+    p_add.add_argument("--type", help="Source type (auto-detected if not provided)")
+    p_add.add_argument("--credibility", type=int, help="Credibility score 1-5")
+    p_add.add_argument("--excerpt", help="Relevant excerpt from source")
+    p_add.add_argument("--context", help="Additional context")
+    
+    # verify
+    p_verify = sub.add_parser("verify", help="Update verification status")
+    p_verify.add_argument("--card-id", required=True, help="Card ID to update")
+    p_verify.add_argument("--status", required=True, 
+                          choices=["unverified", "supported", "verified", "disputed"],
+                          help="Verification status")
+    p_verify.add_argument("--notes", help="Verification notes")
+    p_verify.add_argument("--cross-ref", help="Cross-reference URL")
+    
+    # debate
+    p_debate = sub.add_parser("debate", help="Generate debate structure for a claim")
+    p_debate.add_argument("--card-id", required=True, help="Card ID to debate")
+    
+    # export
+    p_export = sub.add_parser("export", help="Export all evidence cards")
+    p_export.add_argument("--output", help="Output file path")
+    
+    # summary
+    sub.add_parser("summary", help="Show evidence card summary")
+    
+    args = parser.parse_args()
+    
+    if not args.command:
+        parser.print_help()
+        return 1
+    
+    commands = {
+        "init": cmd_init,
+        "add": cmd_add,
+        "verify": cmd_verify,
+        "debate": cmd_debate,
+        "export": cmd_export,
+        "summary": cmd_summary,
+    }
+    
+    return commands[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/research/deep-research/scripts/forecast_history.py
+++ b/skills/research/deep-research/scripts/forecast_history.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+"""
+Forecast History — Self-Learning Calibration Tracker
+
+Tracks forecast history, measures accuracy, and learns from mistakes.
+Over time, this builds a calibration profile that improves future forecasts.
+
+Usage:
+  python3 forecast_history.py init                          # Initialize tracker
+  python3 forecast_history.py log --question "X?" --prob 65 --method "polymarket"
+  python3 forecast_history.py resolve --id "f-xxx" --outcome true
+  python3 forecast_history.py calibration                   # Show calibration stats
+  python3 forecast_history.py lessons                       # Extract lessons from mistakes
+  python3 forecast_history.py report                        # Full accuracy report
+"""
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from datetime import datetime, timedelta
+from typing import Optional, List, Dict
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SKILL_DIR = os.path.dirname(SCRIPT_DIR)
+
+
+def get_state_dir():
+    """Return a writable state directory."""
+    override = os.environ.get("HERMES_DEEP_RESEARCH_STATE_DIR")
+    if override:
+        return override
+    hermes_home = os.environ.get("HERMES_HOME")
+    if hermes_home:
+        return os.path.join(hermes_home, "state", "deep-research")
+    return str(Path.home() / ".hermes" / "state" / "deep-research")
+
+
+STATE_DIR = get_state_dir()
+HISTORY_FILE = os.path.join(STATE_DIR, "forecast_history.json")
+
+
+def timestamp():
+    return datetime.now().astimezone().strftime("%Y-%m-%d %H:%M %Z")
+
+
+def date_slug():
+    return datetime.now().astimezone().strftime("%Y-%m-%d")
+
+
+def load_history() -> dict:
+    """Load forecast history."""
+    if os.path.exists(HISTORY_FILE):
+        with open(HISTORY_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {
+        "forecasts": [],
+        "calibration": {
+            "total": 0,
+            "resolved": 0,
+            "correct": 0,
+            "brier_score": None,
+            "calibration_curve": {},
+        },
+        "lessons": [],
+        "topic_biases": {},
+        "method_performance": {},
+        "created": timestamp(),
+    }
+
+
+def save_history(data: dict):
+    """Save forecast history."""
+    os.makedirs(os.path.dirname(HISTORY_FILE), exist_ok=True)
+    with open(HISTORY_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def calculate_brier_score(forecasts: List[dict]) -> float:
+    """
+    Calculate Brier score for resolved forecasts.
+    Brier = (1/N) * Σ(forecast - outcome)²
+    Lower is better (0 = perfect, 1 = worst).
+    """
+    resolved = [f for f in forecasts if f.get("resolved") and f.get("outcome") is not None]
+    if not resolved:
+        return None
+    
+    scores = []
+    for f in resolved:
+        prob = f["probability"] / 100.0  # Convert to 0-1 scale
+        outcome = 1.0 if f["outcome"] else 0.0
+        scores.append((prob - outcome) ** 2)
+    
+    return sum(scores) / len(scores)
+
+
+def calculate_calibration_curve(forecasts: List[dict]) -> dict:
+    """
+    Calculate calibration curve.
+    Groups forecasts by probability buckets and compares to actual outcomes.
+    """
+    buckets = {
+        "0-20": {"forecasts": [], "outcomes": []},
+        "20-40": {"forecasts": [], "outcomes": []},
+        "40-60": {"forecasts": [], "outcomes": []},
+        "60-80": {"forecasts": [], "outcomes": []},
+        "80-100": {"forecasts": [], "outcomes": []},
+    }
+    
+    for f in forecasts:
+        if not f.get("resolved") or f.get("outcome") is None:
+            continue
+        
+        prob = f["probability"]
+        outcome = 1 if f["outcome"] else 0
+        
+        if prob < 20:
+            buckets["0-20"]["forecasts"].append(prob)
+            buckets["0-20"]["outcomes"].append(outcome)
+        elif prob < 40:
+            buckets["20-40"]["forecasts"].append(prob)
+            buckets["20-40"]["outcomes"].append(outcome)
+        elif prob < 60:
+            buckets["40-60"]["forecasts"].append(prob)
+            buckets["40-60"]["outcomes"].append(outcome)
+        elif prob < 80:
+            buckets["60-80"]["forecasts"].append(prob)
+            buckets["60-80"]["outcomes"].append(outcome)
+        else:
+            buckets["80-100"]["forecasts"].append(prob)
+            buckets["80-100"]["outcomes"].append(outcome)
+    
+    curve = {}
+    for bucket, data in buckets.items():
+        if data["forecasts"]:
+            avg_forecast = sum(data["forecasts"]) / len(data["forecasts"])
+            actual_rate = sum(data["outcomes"]) / len(data["outcomes"]) * 100
+            curve[bucket] = {
+                "avg_forecast": round(avg_forecast, 1),
+                "actual_rate": round(actual_rate, 1),
+                "count": len(data["forecasts"]),
+                "calibration_error": round(abs(avg_forecast - actual_rate), 1),
+            }
+    
+    return curve
+
+
+def detect_topic_bias(forecasts: List[dict]) -> dict:
+    """Detect bias patterns by topic category."""
+    categories = {}
+    
+    for f in forecasts:
+        if not f.get("resolved"):
+            continue
+        
+        topic = f.get("topic_category", "general")
+        if topic not in categories:
+            categories[topic] = {"count": 0, "correct": 0, "overconfident": 0, "underconfident": 0}
+        
+        categories[topic]["count"] += 1
+        if f.get("correct"):
+            categories[topic]["correct"] += 1
+        
+        # Check over/underconfidence
+        prob = f["probability"]
+        outcome = f["outcome"]
+        if outcome and prob < 50:
+            categories[topic]["underconfident"] += 1
+        elif not outcome and prob > 50:
+            categories[topic]["overconfident"] += 1
+    
+    # Calculate accuracy by category
+    for cat, stats in categories.items():
+        if stats["count"] > 0:
+            stats["accuracy"] = round(stats["correct"] / stats["count"] * 100, 1)
+            stats["bias_direction"] = (
+                "overconfident" if stats["overconfident"] > stats["underconfident"] else
+                "underconfident" if stats["underconfident"] > stats["overconfident"] else
+                "calibrated"
+            )
+    
+    return categories
+
+
+def cmd_init(args):
+    """Initialize forecast tracker."""
+    data = {
+        "forecasts": [],
+        "calibration": {
+            "total": 0,
+            "resolved": 0,
+            "correct": 0,
+            "brier_score": None,
+            "calibration_curve": {},
+        },
+        "lessons": [],
+        "topic_biases": {},
+        "method_performance": {},
+        "created": timestamp(),
+    }
+    save_history(data)
+    print(json.dumps({"initialized": True, "file": HISTORY_FILE}, indent=2))
+    return 0
+
+
+def cmd_log(args):
+    """Log a new forecast."""
+    data = load_history()
+    
+    forecast_id = f"f-{uuid.uuid4().hex[:8]}"
+    
+    forecast = {
+        "id": forecast_id,
+        "question": args.question,
+        "probability": args.prob,
+        "probability_range": args.range,
+        "method": args.method,
+        "methodology": args.methodology,
+        "confidence": args.confidence,
+        "topic_category": args.category,
+        "created": timestamp(),
+        "resolve_by": args.resolve_by,
+        "sources": args.sources.split("|") if args.sources else [],
+        "notes": args.notes,
+        "resolved": False,
+        "outcome": None,
+        "correct": None,
+        "resolved_at": None,
+    }
+    
+    data["forecasts"].append(forecast)
+    data["calibration"]["total"] = len(data["forecasts"])
+    
+    # Track method usage
+    method = args.method
+    if method not in data["method_performance"]:
+        data["method_performance"][method] = {"count": 0, "correct": 0}
+    data["method_performance"][method]["count"] += 1
+    
+    save_history(data)
+    
+    print(json.dumps({
+        "logged": True,
+        "forecast_id": forecast_id,
+        "question": args.question,
+        "probability": f"{args.prob}%",
+        "method": args.method,
+    }, indent=2))
+    return 0
+
+
+def cmd_resolve(args):
+    """Resolve a forecast with actual outcome."""
+    data = load_history()
+    
+    # Find the forecast
+    forecast = None
+    for f in data["forecasts"]:
+        if f["id"] == args.id:
+            forecast = f
+            break
+    
+    if not forecast:
+        print(f"Forecast not found: {args.id}")
+        return 1
+    
+    # Update forecast
+    forecast["resolved"] = True
+    forecast["outcome"] = args.outcome
+    forecast["resolved_at"] = timestamp()
+    
+    # Calculate if forecast was "correct"
+    # A forecast is correct if:
+    # - Predicted >50% and outcome was True, OR
+    # - Predicted <50% and outcome was False
+    prob = forecast["probability"]
+    outcome = args.outcome
+    
+    if (prob > 50 and outcome) or (prob < 50 and not outcome):
+        forecast["correct"] = True
+    elif prob == 50:
+        forecast["correct"] = None  # Can't be correct/incorrect at exactly 50%
+    else:
+        forecast["correct"] = False
+    
+    # Update calibration
+    resolved = [f for f in data["forecasts"] if f.get("resolved")]
+    data["calibration"]["resolved"] = len(resolved)
+    data["calibration"]["correct"] = sum(1 for f in resolved if f.get("correct"))
+    data["calibration"]["brier_score"] = calculate_brier_score(data["forecasts"])
+    data["calibration"]["calibration_curve"] = calculate_calibration_curve(data["forecasts"])
+    
+    # Update method performance
+    method = forecast.get("method")
+    if method and method in data["method_performance"]:
+        if forecast["correct"]:
+            data["method_performance"][method]["correct"] += 1
+    
+    # Update topic biases
+    data["topic_biases"] = detect_topic_bias(data["forecasts"])
+    
+    # Generate lesson if forecast was wrong
+    if forecast["correct"] == False and args.lesson:
+        lesson = {
+            "forecast_id": args.id,
+            "question": forecast["question"],
+            "predicted": f"{prob}%",
+            "outcome": "Yes" if outcome else "No",
+            "lesson": args.lesson,
+            "category": forecast.get("topic_category", "general"),
+            "timestamp": timestamp(),
+            "time_decay": 1.0,  # Decreases over time
+        }
+        data["lessons"].append(lesson)
+    
+    save_history(data)
+    
+    print(json.dumps({
+        "resolved": True,
+        "forecast_id": args.id,
+        "outcome": "Yes" if args.outcome else "No",
+        "forecast_correct": forecast["correct"],
+        "brier_score": data["calibration"]["brier_score"],
+    }, indent=2))
+    return 0
+
+
+def cmd_calibration(args):
+    """Show calibration statistics."""
+    data = load_history()
+    cal = data["calibration"]
+    
+    result = {
+        "total_forecasts": cal["total"],
+        "resolved": cal["resolved"],
+        "accuracy": round(cal["correct"] / cal["resolved"] * 100, 1) if cal["resolved"] > 0 else None,
+        "brier_score": cal["brier_score"],
+        "interpretation": interpret_brier(cal["brier_score"]),
+        "calibration_curve": cal["calibration_curve"],
+        "topic_biases": data["topic_biases"],
+        "method_performance": data["method_performance"],
+    }
+    
+    print(json.dumps(result, indent=2))
+    
+    # Print human-readable summary
+    print()
+    print("=" * 50)
+    print("  CALIBRATION SUMMARY")
+    print("=" * 50)
+    
+    if cal["resolved"] > 0:
+        print(f"  Resolved forecasts: {cal['resolved']}")
+        print(f"  Accuracy (binary):  {result['accuracy']}%")
+        if cal["brier_score"]:
+            print(f"  Brier score:        {cal['brier_score']:.3f} ({interpret_brier(cal['brier_score'])})")
+    
+    if cal["calibration_curve"]:
+        print()
+        print("  CALIBRATION CURVE:")
+        for bucket, stats in cal["calibration_curve"].items():
+            print(f"    {bucket}: predicted {stats['avg_forecast']:.0f}% → actual {stats['actual_rate']:.0f}% (n={stats['count']})")
+    
+    return 0
+
+
+def interpret_brier(score: Optional[float]) -> str:
+    """Interpret Brier score."""
+    if score is None:
+        return "No resolved forecasts"
+    if score <= 0.1:
+        return "Excellent (very well calibrated)"
+    if score <= 0.2:
+        return "Good"
+    if score <= 0.3:
+        return "Fair"
+    if score <= 0.5:
+        return "Poor (needs improvement)"
+    return "Very poor (major calibration issues)"
+
+
+def cmd_lessons(args):
+    """Show lessons learned from incorrect forecasts."""
+    data = load_history()
+    
+    if not data["lessons"]:
+        print("No lessons recorded yet. Lessons are added when resolving incorrect forecasts with --lesson.")
+        return 0
+    
+    # Apply time decay (30-day half-life)
+    now = datetime.now().astimezone()
+    for lesson in data["lessons"]:
+        if lesson.get("timestamp"):
+            lesson_time = datetime.fromisoformat(lesson["timestamp"])
+            days_old = (now - lesson_time).days
+            lesson["time_decay"] = max(0.1, 0.5 ** (days_old / 30))
+    
+    # Sort by recency and time-decay
+    lessons = sorted(data["lessons"], key=lambda x: x.get("timestamp", ""), reverse=True)
+    
+    if args.category:
+        lessons = [l for l in lessons if l.get("category") == args.category]
+    
+    print(f"LESSONS LEARNED ({len(lessons)} total)")
+    print("=" * 60)
+    
+    for i, lesson in enumerate(lessons[:20], 1):
+        print(f"\n{i}. [{lesson.get('category', 'general')}] {lesson['question'][:60]}...")
+        print(f"   Predicted: {lesson['predicted']} | Outcome: {lesson['outcome']}")
+        print(f"   Lesson: {lesson['lesson']}")
+        print(f"   Decay: {lesson['time_decay']:.2f}")
+    
+    return 0
+
+
+def cmd_report(args):
+    """Generate full accuracy report."""
+    data = load_history()
+    
+    # Calculate various stats
+    resolved = [f for f in data["forecasts"] if f.get("resolved")]
+    unresolved = [f for f in data["forecasts"] if not f.get("resolved")]
+    
+    # By method
+    method_stats = {}
+    for f in resolved:
+        method = f.get("method", "unknown")
+        if method not in method_stats:
+            method_stats[method] = {"total": 0, "correct": 0, "brier": []}
+        method_stats[method]["total"] += 1
+        if f.get("correct"):
+            method_stats[method]["correct"] += 1
+        # Brier component
+        prob = f["probability"] / 100
+        outcome = 1 if f["outcome"] else 0
+        method_stats[method]["brier"].append((prob - outcome) ** 2)
+    
+    for method, stats in method_stats.items():
+        stats["accuracy"] = round(stats["correct"] / stats["total"] * 100, 1) if stats["total"] > 0 else None
+        stats["brier"] = round(sum(stats["brier"]) / len(stats["brier"]), 3) if stats["brier"] else None
+    
+    # By topic
+    topic_stats = {}
+    for f in resolved:
+        topic = f.get("topic_category", "general")
+        if topic not in topic_stats:
+            topic_stats[topic] = {"total": 0, "correct": 0}
+        topic_stats[topic]["total"] += 1
+        if f.get("correct"):
+            topic_stats[topic]["correct"] += 1
+    
+    for topic, stats in topic_stats.items():
+        stats["accuracy"] = round(stats["correct"] / stats["total"] * 100, 1) if stats["total"] > 0 else None
+    
+    report = {
+        "summary": {
+            "total_forecasts": len(data["forecasts"]),
+            "resolved": len(resolved),
+            "unresolved": len(unresolved),
+            "overall_accuracy": round(sum(1 for f in resolved if f.get("correct")) / len(resolved) * 100, 1) if resolved else None,
+            "brier_score": data["calibration"]["brier_score"],
+        },
+        "by_method": method_stats,
+        "by_topic": topic_stats,
+        "calibration_curve": data["calibration"]["calibration_curve"],
+        "lessons_count": len(data["lessons"]),
+        "recommendations": generate_recommendations(data),
+    }
+    
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+        print(f"Report saved to: {args.output}")
+    else:
+        print(json.dumps(report, indent=2))
+    
+    return 0
+
+
+def generate_recommendations(data: dict) -> List[str]:
+    """Generate recommendations based on calibration data."""
+    recommendations = []
+    
+    # Check calibration curve
+    curve = data["calibration"].get("calibration_curve", {})
+    for bucket, stats in curve.items():
+        if stats.get("calibration_error", 0) > 20:
+            if stats["avg_forecast"] > stats["actual_rate"]:
+                recommendations.append(f"You're overconfident in {bucket}% range. Predicted {stats['avg_forecast']:.0f}% but only {stats['actual_rate']:.0f}% came true. Dial back predictions.")
+            else:
+                recommendations.append(f"You're underconfident in {bucket}% range. Predicted {stats['avg_forecast']:.0f}% but {stats['actual_rate']:.0f}% came true. Be bolder.")
+    
+    # Check topic biases
+    for topic, stats in data.get("topic_biases", {}).items():
+        if stats.get("count", 0) >= 3:
+            if stats.get("bias_direction") == "overconfident":
+                recommendations.append(f"You tend to be overconfident on '{topic}' topics. Consider wider probability ranges or more skepticism.")
+            elif stats.get("bias_direction") == "underconfident":
+                recommendations.append(f"You tend to be underconfident on '{topic}' topics. Your predictions are better than you think.")
+    
+    # Check Brier score
+    brier = data["calibration"].get("brier_score")
+    if brier and brier > 0.3:
+        recommendations.append("Your Brier score is high (>0.3). Focus on: (1) using prediction markets more, (2) researching base rates, (3) being more humble with extreme predictions.")
+    
+    return recommendations
+
+
+def cmd_list(args):
+    """List forecasts (optionally unresolved only)."""
+    data = load_history()
+    
+    forecasts = data["forecasts"]
+    if args.unresolved:
+        forecasts = [f for f in forecasts if not f.get("resolved")]
+    
+    if args.category:
+        forecasts = [f for f in forecasts if f.get("topic_category") == args.category]
+    
+    forecasts = sorted(forecasts, key=lambda x: x.get("created", ""), reverse=True)
+    
+    print(f"FORECASTS ({len(forecasts)} shown)")
+    print("=" * 60)
+    
+    for f in forecasts[:20]:
+        status = "RESOLVED" if f.get("resolved") else "PENDING"
+        outcome = f"→ {'Yes' if f['outcome'] else 'No'}" if f.get("resolved") else ""
+        print(f"  [{f['id']}] {f['probability']}% {status} {outcome}")
+        print(f"      {f['question'][:70]}...")
+        print()
+    
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Forecast History — Self-Learning Calibration Tracker")
+    sub = parser.add_subparsers(dest="command")
+    
+    # init
+    sub.add_parser("init", help="Initialize forecast tracker")
+    
+    # log
+    p_log = sub.add_parser("log", help="Log a new forecast")
+    p_log.add_argument("--question", required=True, help="The forecasting question")
+    p_log.add_argument("--prob", type=float, required=True, help="Probability estimate (0-100)")
+    p_log.add_argument("--range", help="Probability range (e.g., '60-70')")
+    p_log.add_argument("--method", required=True, help="Method used (polymarket, analyst, base_rate, intuition)")
+    p_log.add_argument("--methodology", help="Detailed methodology")
+    p_log.add_argument("--confidence", choices=["high", "medium", "low"], default="medium")
+    p_log.add_argument("--category", help="Topic category (geopolitical, market, technology)")
+    p_log.add_argument("--resolve-by", help="Expected resolution date")
+    p_log.add_argument("--sources", help="Sources used, pipe-separated")
+    p_log.add_argument("--notes", help="Additional notes")
+    
+    # resolve
+    p_resolve = sub.add_parser("resolve", help="Resolve a forecast")
+    p_resolve.add_argument("--id", required=True, help="Forecast ID")
+    p_resolve.add_argument("--outcome", type=lambda x: x.lower() == "true", required=True, help="Actual outcome (true/false)")
+    p_resolve.add_argument("--lesson", help="Lesson learned (for incorrect forecasts)")
+    
+    # calibration
+    sub.add_parser("calibration", help="Show calibration statistics")
+    
+    # lessons
+    p_lessons = sub.add_parser("lessons", help="Show lessons learned")
+    p_lessons.add_argument("--category", help="Filter by category")
+    
+    # report
+    p_report = sub.add_parser("report", help="Generate full accuracy report")
+    p_report.add_argument("--output", help="Output file path")
+    
+    # list
+    p_list = sub.add_parser("list", help="List forecasts")
+    p_list.add_argument("--unresolved", action="store_true", help="Only show unresolved")
+    p_list.add_argument("--category", help="Filter by category")
+    
+    args = parser.parse_args()
+    
+    if not args.command:
+        parser.print_help()
+        return 1
+    
+    commands = {
+        "init": cmd_init,
+        "log": cmd_log,
+        "resolve": cmd_resolve,
+        "calibration": cmd_calibration,
+        "lessons": cmd_lessons,
+        "report": cmd_report,
+        "list": cmd_list,
+    }
+    
+    return commands[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/research/deep-research/scripts/gates.py
+++ b/skills/research/deep-research/scripts/gates.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+"""
+Quality Gates — Enforce Minimum Standards with Rollback
+
+Gates are checkpoints that research must pass before continuing.
+If a gate fails, the pipeline rolls back to a previous stage.
+
+This ensures research quality is enforced, not just hoped for.
+
+Usage:
+  python3 gates.py init                           # Initialize gate system
+  python3 gates.py check --gate diversity         # Run a specific gate
+  python3 gates.py status                         # Show all gate statuses
+  python3 gates.py rollback --gate diversity      # Rollback after gate failure
+  python3 gates.py reset                          # Reset all gates
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from datetime import datetime
+from typing import Optional, Tuple
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SKILL_DIR = os.path.dirname(SCRIPT_DIR)
+
+
+def get_state_dir():
+    """Return a writable state directory."""
+    override = os.environ.get("HERMES_DEEP_RESEARCH_STATE_DIR")
+    if override:
+        return override
+    hermes_home = os.environ.get("HERMES_HOME")
+    if hermes_home:
+        return os.path.join(hermes_home, "state", "deep-research")
+    return str(Path.home() / ".hermes" / "state" / "deep-research")
+
+
+STATE_DIR = get_state_dir()
+GATES_FILE = os.path.join(STATE_DIR, "gates.json")
+
+
+# Gate definitions with pass criteria and rollback targets
+GATES = {
+    "evidence_diversity": {
+        "name": "Evidence Diversity Gate",
+        "description": "Have I used 2+ source types?",
+        "pass_criteria": "source_types_used >= 2",
+        "rollback_target": "search",  # Go back to search phase
+        "critical": True,
+        "weight": 1.0,
+    },
+    "claim_verification": {
+        "name": "Claim Verification Gate",
+        "description": "Are key claims verified by 2+ sources?",
+        "pass_criteria": "verified_claims / total_claims >= 0.5",
+        "rollback_target": "gap_filling",
+        "critical": True,
+        "weight": 1.0,
+    },
+    "probability_grounding": {
+        "name": "Probability Grounding Gate",
+        "description": "Is probability estimate tied to prediction market, analyst forecast, or base rate?",
+        "pass_criteria": "probability_sources >= 1",
+        "rollback_target": "search",
+        "critical": True,
+        "weight": 1.0,
+    },
+    "source_quality": {
+        "name": "Source Quality Gate",
+        "description": "Are there any Tier 1-2 sources?",
+        "pass_criteria": "tier1_count + tier2_count >= 1",
+        "rollback_target": "search",
+        "critical": True,
+        "weight": 0.8,
+    },
+    "contrarian_evidence": {
+        "name": "Contrarian Evidence Gate",
+        "description": "Did I search for evidence against my hypothesis?",
+        "pass_criteria": "contrarian_searches >= 1",
+        "rollback_target": "reflection",
+        "critical": True,
+        "weight": 0.9,
+    },
+    "hypothesis_stated": {
+        "name": "Hypothesis Stated Gate",
+        "description": "Is my hypothesis explicitly stated before research?",
+        "pass_criteria": "hypothesis_stated == true",
+        "rollback_target": "planning",
+        "critical": False,
+        "weight": 0.5,
+    },
+    "saturation": {
+        "name": "Saturation Gate",
+        "description": "Have critical gaps been filled?",
+        "pass_criteria": "critical_gaps_filled / critical_gaps >= 0.8",
+        "rollback_target": "gap_filling",
+        "critical": True,
+        "weight": 1.0,
+    },
+    "freshness": {
+        "name": "Freshness Gate",
+        "description": "Is evidence from the last 7 days (for current events)?",
+        "pass_criteria": "recent_sources >= 1 OR topic_not_time_sensitive",
+        "rollback_target": "search",
+        "critical": False,
+        "weight": 0.7,
+    },
+}
+
+# Gate execution order (check in this sequence)
+GATE_ORDER = [
+    "hypothesis_stated",
+    "evidence_diversity",
+    "source_quality",
+    "claim_verification",
+    "contrarian_evidence",
+    "probability_grounding",
+    "saturation",
+    "freshness",
+]
+
+
+def timestamp():
+    return datetime.now().astimezone().strftime("%Y-%m-%d %H:%M %Z")
+
+
+def load_gates() -> dict:
+    """Load gate state."""
+    if os.path.exists(GATES_FILE):
+        with open(GATES_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {
+        "gates": {},
+        "created": timestamp(),
+        "current_phase": "planning",
+        "rollback_history": [],
+        "proof": {},
+    }
+
+
+def save_gates(state: dict):
+    """Save gate state."""
+    os.makedirs(os.path.dirname(GATES_FILE), exist_ok=True)
+    with open(GATES_FILE, "w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, ensure_ascii=False)
+
+
+def init_gate_state(gate_id: str) -> dict:
+    """Initialize state for a gate."""
+    return {
+        "id": gate_id,
+        "name": GATES[gate_id]["name"],
+        "status": "pending",  # pending, passed, failed, skipped
+        "checked_at": None,
+        "result": None,
+        "notes": [],
+        "retry_count": 0,
+    }
+
+
+def cmd_init(args):
+    """Initialize the gate system."""
+    state = {
+        "gates": {gid: init_gate_state(gid) for gid in GATES},
+        "created": timestamp(),
+        "current_phase": "planning",
+        "rollback_history": [],
+        "proof": {},
+    }
+    save_gates(state)
+    print(json.dumps({
+        "initialized": True,
+        "gates": len(GATES),
+        "gate_order": GATE_ORDER,
+    }, indent=2))
+    return 0
+
+
+def check_evidence_diversity(proof: dict) -> Tuple[bool, str, list]:
+    """Check if 2+ source types were used."""
+    types = proof.get("source_types_used", [])
+    count = len(set(types))
+    
+    if count >= 2:
+        return True, f"PASS: {count} source types used", []
+    elif count == 1:
+        return False, f"FAIL: Only 1 source type ({types[0]}). Need at least 2.", [
+            "Add a different source type (e.g., if you used web search, add news or prediction market)"
+        ]
+    else:
+        return False, "FAIL: No source types recorded", [
+            "Record which tools you used in source_types_used array"
+        ]
+
+
+def check_claim_verification(proof: dict) -> Tuple[bool, str, list]:
+    """Check if key claims are verified."""
+    claims = proof.get("claims", [])
+    if not claims:
+        return False, "FAIL: No claims recorded", ["Add claims to the proof object"]
+    
+    total = len(claims)
+    verified = sum(1 for c in claims if c.get("status") == "verified")
+    supported = sum(1 for c in claims if c.get("status") == "supported")
+    
+    good = verified + supported
+    ratio = good / total if total > 0 else 0
+    
+    if ratio >= 0.5:
+        return True, f"PASS: {good}/{total} claims verified/supported ({ratio:.0%})", []
+    else:
+        return False, f"FAIL: Only {good}/{total} claims verified/supported ({ratio:.0%}). Need 50%+.", [
+            f"Find sources for {total - good} unverified claims",
+            "Or remove claims you cannot verify"
+        ]
+
+
+def check_probability_grounding(proof: dict) -> Tuple[bool, str, list]:
+    """Check if probability estimate is grounded."""
+    # Check if this is a forecasting question
+    topic = proof.get("topic", "").lower()
+    forecast_keywords = ["will", "forecast", "predict", "probability", "chance", "%", "likely"]
+    is_forecast = any(kw in topic for kw in forecast_keywords)
+    
+    if not is_forecast:
+        return True, "PASS: Not a forecasting question, probability gate not applicable", []
+    
+    # Check for probability sources
+    prob_sources = proof.get("probability_sources", [])
+    prediction_market = proof.get("prediction_market_data")
+    analyst_forecast = proof.get("analyst_forecast_data")
+    base_rate = proof.get("historical_base_rate")
+    
+    sources = []
+    if prediction_market:
+        sources.append("prediction_market")
+    if analyst_forecast:
+        sources.append("analyst_forecast")
+    if base_rate:
+        sources.append("base_rate")
+    sources.extend(prob_sources)
+    
+    if len(sources) >= 1:
+        return True, f"PASS: Probability grounded in {', '.join(sources)}", []
+    else:
+        return False, "FAIL: Probability estimate not grounded", [
+            "Check Polymarket or Metaculus for crowd-sourced probability",
+            "Find analyst forecasts (Goldman, JPMorgan, etc.)",
+            "Research historical base rates for similar events"
+        ]
+
+
+def check_source_quality(proof: dict) -> Tuple[bool, str, list]:
+    """Check for Tier 1-2 sources."""
+    tiers = proof.get("source_tiers", {})
+    t1 = tiers.get("tier1", 0)
+    t2 = tiers.get("tier2", 0)
+    
+    if t1 + t2 >= 1:
+        return True, f"PASS: {t1} Tier 1 + {t2} Tier 2 sources", []
+    else:
+        return False, "FAIL: No Tier 1 or Tier 2 sources found", [
+            "Find primary sources (government data, official reports)",
+            "Or find expert analysis (analyst reports, peer-reviewed papers)"
+        ]
+
+
+def check_contrarian_evidence(proof: dict) -> Tuple[bool, str, list]:
+    """Check for contrarian searches."""
+    contrarian = proof.get("contrarian_searches", [])
+    
+    if len(contrarian) >= 1:
+        found_evidence = sum(1 for c in contrarian if c.get("found_evidence"))
+        return True, f"PASS: {len(contrarian)} contrarian search(es), {found_evidence} found evidence", []
+    else:
+        return False, "FAIL: No contrarian searches performed", [
+            "Search for evidence AGAINST your hypothesis",
+            "Try queries like: 'why X is wrong', 'X bear case', 'X criticism'"
+        ]
+
+
+def check_hypothesis_stated(proof: dict) -> Tuple[bool, str, list]:
+    """Check if hypothesis is explicitly stated."""
+    hypothesis = proof.get("hypothesis_original")
+    
+    if hypothesis:
+        return True, "PASS: Hypothesis stated", []
+    else:
+        return False, "FAIL: No hypothesis stated", [
+            "State your initial hypothesis before researching",
+            "Format: 'I believe X will happen because Y'"
+        ]
+
+
+def check_saturation(proof: dict) -> Tuple[bool, str, list]:
+    """Check if critical gaps are filled."""
+    gaps = proof.get("gaps_identified", [])
+    
+    if not gaps:
+        return False, "FAIL: No gap analysis performed", [
+            "Identify gaps in your research",
+            "Rank each gap: critical, important, nice_to_have"
+        ]
+    
+    critical = [g for g in gaps if g.get("rank") == "critical"]
+    if not critical:
+        return True, "PASS: No critical gaps identified", []
+    
+    filled = sum(1 for g in critical if g.get("filled"))
+    ratio = filled / len(critical)
+    
+    if ratio >= 0.8:
+        return True, f"PASS: {filled}/{len(critical)} critical gaps filled", []
+    else:
+        return False, f"FAIL: Only {filled}/{len(critical)} critical gaps filled. Need 80%+.", [
+            f"Fill {len(critical) - filled} remaining critical gaps",
+            "Or explain why gap cannot be filled"
+        ]
+
+
+def check_freshness(proof: dict) -> Tuple[bool, str, list]:
+    """Check evidence freshness (7-day rule)."""
+    topic = proof.get("topic", "").lower()
+    
+    # Topics that require fresh data
+    time_sensitive = any(kw in topic for kw in 
+        ["war", "conflict", "election", "market", "price", "current", "latest", "today", "now"])
+    
+    if not time_sensitive:
+        return True, "PASS: Topic is not time-sensitive", []
+    
+    recent = proof.get("recent_sources_count", 0)
+    if recent >= 1:
+        return True, f"PASS: {recent} recent source(s) found", []
+    else:
+        return False, "FAIL: No recent sources for time-sensitive topic", [
+            "Find sources from the last 7 days",
+            "Check news feeds for latest developments"
+        ]
+
+
+CHECKERS = {
+    "evidence_diversity": check_evidence_diversity,
+    "claim_verification": check_claim_verification,
+    "probability_grounding": check_probability_grounding,
+    "source_quality": check_source_quality,
+    "contrarian_evidence": check_contrarian_evidence,
+    "hypothesis_stated": check_hypothesis_stated,
+    "saturation": check_saturation,
+    "freshness": check_freshness,
+}
+
+
+def cmd_check(args):
+    """Run a specific gate check."""
+    state = load_gates()
+    
+    if args.gate not in GATES:
+        print(f"Unknown gate: {args.gate}")
+        print(f"Available gates: {list(GATES.keys())}")
+        return 1
+    
+    # Load proof from file if provided
+    if args.proof:
+        with open(args.proof, "r", encoding="utf-8") as f:
+            state["proof"] = json.load(f)
+    elif args.proof_json:
+        state["proof"] = json.loads(args.proof_json)
+    else:
+        # Use existing proof in state
+        pass
+    
+    gate_def = GATES[args.gate]
+    checker = CHECKERS[args.gate]
+    
+    passed, message, actions = checker(state["proof"])
+    
+    # Update gate state
+    gate_state = state["gates"][args.gate]
+    gate_state["status"] = "passed" if passed else "failed"
+    gate_state["checked_at"] = timestamp()
+    gate_state["result"] = {
+        "passed": passed,
+        "message": message,
+        "actions": actions,
+    }
+    if not passed:
+        gate_state["retry_count"] += 1
+    
+    save_gates(state)
+    
+    result = {
+        "gate": args.gate,
+        "name": gate_def["name"],
+        "passed": passed,
+        "message": message,
+        "actions_needed": actions if not passed else [],
+        "rollback_target": gate_def["rollback_target"] if not passed else None,
+        "critical": gate_def["critical"],
+    }
+    
+    print(json.dumps(result, indent=2))
+    
+    if not passed and gate_def["critical"]:
+        print(f"\n⚠️  CRITICAL GATE FAILED")
+        print(f"   Rollback target: {gate_def['rollback_target']}")
+        print(f"   Actions needed:")
+        for a in actions:
+            print(f"   - {a}")
+    
+    return 0 if passed else 1
+
+
+def cmd_all(args):
+    """Run all gates in order."""
+    state = load_gates()
+    
+    if args.proof:
+        with open(args.proof, "r", encoding="utf-8") as f:
+            state["proof"] = json.load(f)
+    
+    results = []
+    failed_critical = []
+    
+    for gate_id in GATE_ORDER:
+        gate_def = GATES[gate_id]
+        checker = CHECKERS[gate_id]
+        
+        passed, message, actions = checker(state["proof"])
+        
+        gate_state = state["gates"][gate_id]
+        gate_state["status"] = "passed" if passed else "failed"
+        gate_state["checked_at"] = timestamp()
+        gate_state["result"] = {
+            "passed": passed,
+            "message": message,
+            "actions": actions,
+        }
+        
+        results.append({
+            "gate": gate_id,
+            "name": gate_def["name"],
+            "passed": passed,
+            "critical": gate_def["critical"],
+            "message": message,
+        })
+        
+        if not passed and gate_def["critical"]:
+            failed_critical.append({
+                "gate": gate_id,
+                "rollback": gate_def["rollback_target"],
+                "actions": actions,
+            })
+    
+    save_gates(state)
+    
+    # Summary
+    passed_count = sum(1 for r in results if r["passed"])
+    total = len(results)
+    
+    print("=" * 60)
+    print("  GATE CHECK RESULTS")
+    print("=" * 60)
+    print()
+    
+    for r in results:
+        status = "✓ PASS" if r["passed"] else "✗ FAIL"
+        critical = " [CRITICAL]" if r["critical"] else ""
+        print(f"  {status}  {r['name']}{critical}")
+        if not r["passed"]:
+            print(f"         {r['message']}")
+    
+    print()
+    print(f"  PASSED: {passed_count}/{total}")
+    
+    if failed_critical:
+        print()
+        print("  ⚠️  CRITICAL GATES FAILED:")
+        for fc in failed_critical:
+            print(f"     - {fc['gate']} → rollback to '{fc['rollback']}'")
+            for a in fc["actions"]:
+                print(f"       → {a}")
+        print()
+        print("  ACTION: Fix issues and re-run gates")
+    else:
+        print()
+        print("  ✓ ALL CRITICAL GATES PASSED")
+    
+    return 0 if not failed_critical else 1
+
+
+def cmd_status(args):
+    """Show status of all gates."""
+    state = load_gates()
+    
+    print(json.dumps({
+        "current_phase": state.get("current_phase"),
+        "gates": {
+            gid: {
+                "status": g["status"],
+                "checked_at": g["checked_at"],
+            }
+            for gid, g in state["gates"].items()
+        },
+        "rollback_count": len(state.get("rollback_history", [])),
+    }, indent=2))
+    return 0
+
+
+def cmd_rollback(args):
+    """Record a rollback action."""
+    state = load_gates()
+    
+    if args.gate not in GATES:
+        print(f"Unknown gate: {args.gate}")
+        return 1
+    
+    gate_def = GATES[args.gate]
+    rollback = {
+        "gate": args.gate,
+        "rollback_to": gate_def["rollback_target"],
+        "reason": args.reason or "Gate failed",
+        "timestamp": timestamp(),
+    }
+    
+    state["rollback_history"].append(rollback)
+    state["current_phase"] = gate_def["rollback_target"]
+    
+    # Reset gate status
+    state["gates"][args.gate] = init_gate_state(args.gate)
+    
+    save_gates(state)
+    
+    print(json.dumps({
+        "rolled_back": True,
+        "from_gate": args.gate,
+        "to_phase": gate_def["rollback_target"],
+        "total_rollbacks": len(state["rollback_history"]),
+    }, indent=2))
+    return 0
+
+
+def cmd_reset(args):
+    """Reset all gates."""
+    state = {
+        "gates": {gid: init_gate_state(gid) for gid in GATES},
+        "created": timestamp(),
+        "current_phase": "planning",
+        "rollback_history": [],
+        "proof": {},
+    }
+    save_gates(state)
+    print(json.dumps({"reset": True, "gates": len(GATES)}, indent=2))
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Quality Gates — Enforce Minimum Research Standards")
+    sub = parser.add_subparsers(dest="command")
+    
+    # init
+    sub.add_parser("init", help="Initialize gate system")
+    
+    # check
+    p_check = sub.add_parser("check", help="Run a specific gate")
+    p_check.add_argument("--gate", required=True, choices=list(GATES.keys()), help="Gate to check")
+    p_check.add_argument("--proof", help="Path to proof JSON file")
+    p_check.add_argument("--proof-json", help="Proof JSON as string")
+    
+    # all
+    p_all = sub.add_parser("all", help="Run all gates")
+    p_all.add_argument("--proof", help="Path to proof JSON file")
+    
+    # status
+    sub.add_parser("status", help="Show gate statuses")
+    
+    # rollback
+    p_rollback = sub.add_parser("rollback", help="Record rollback after gate failure")
+    p_rollback.add_argument("--gate", required=True, help="Gate that failed")
+    p_rollback.add_argument("--reason", help="Reason for rollback")
+    
+    # reset
+    sub.add_parser("reset", help="Reset all gates")
+    
+    args = parser.parse_args()
+    
+    if not args.command:
+        parser.print_help()
+        return 1
+    
+    commands = {
+        "init": cmd_init,
+        "check": cmd_check,
+        "all": cmd_all,
+        "status": cmd_status,
+        "rollback": cmd_rollback,
+        "reset": cmd_reset,
+    }
+    
+    return commands[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/research/deep-research/scripts/quality_score.py
+++ b/skills/research/deep-research/scripts/quality_score.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""
+Deep Research Quality Scorer — Proof-Based Validation
+
+The agent doesn't rate itself. It provides PROOF OBJECTS and this script
+computes the score. If the proof is weak or missing, the score reflects that.
+
+Usage:
+  python3 quality_score.py assess --proof proof.json
+  python3 quality_score.py checklist
+
+Proof object format (JSON):
+{
+  "sub_questions": [
+    {"question": "What is X?", "answered": true, "sources": ["url1", "url2"]},
+    {"question": "Why does Y?", "answered": false, "sources": []}
+  ],
+  "source_types_used": ["web_search", "news", "scraping"],
+  "source_tiers": {"tier1": 2, "tier2": 3, "tier3": 1, "tier4": 0, "tier5": 0},
+  "contrarian_searches": [
+    {"query": "why X is wrong", "found_evidence": true, "result_summary": "..."}
+  ],
+  "claims": [
+    {"claim": "X costs Y", "status": "verified", "sources": ["url1", "url2"]},
+    {"claim": "Z will happen", "status": "supported", "sources": ["url1"]},
+    {"claim": "A is true", "status": "ai_inference", "sources": []},
+    {"claim": "B is true", "status": "unverified", "sources": []}
+  ],
+  "hypothesis_revised": true,
+  "hypothesis_original": "I think X because Y",
+  "hypothesis_revised_text": "I now think X' because Z",
+  "contradictions": [
+    {"contradiction": "Source A says X, Source B says Y", "resolved": true, "resolution": "..."},
+    {"contradiction": "...", "resolved": false, "resolution": ""}
+  ],
+  "gaps_identified": [
+    {"gap": "Missing data on Z", "rank": "critical", "filled": true},
+    {"gap": "Unclear timeline", "rank": "important", "filled": false},
+    {"gap": "Nice to have detail", "rank": "nice_to_have", "filled": false}
+  ],
+  "search_rounds": 2,
+  "ai_inference_labeled": true,
+  "platform": "telegram"
+}
+"""
+
+import json
+import sys
+import argparse
+from typing import Optional
+
+
+# Quality dimensions with weights (total = 1.0)
+DIMENSIONS = {
+    "coverage": {
+        "name": "Sub-Question Coverage",
+        "weight": 0.20,
+        "description": "All sub-questions answered with at least 1 source each",
+    },
+    "diversity": {
+        "name": "Source Diversity",
+        "weight": 0.10,
+        "description": "Multiple source types used (not just one search tool)",
+    },
+    "source_quality": {
+        "name": "Source Quality",
+        "weight": 0.10,
+        "description": "Higher-tier sources (primary/analyst) outweigh lower-tier",
+    },
+    "contrarian": {
+        "name": "Contrarian Evidence",
+        "weight": 0.15,
+        "description": "Actively searched for evidence against the hypothesis",
+    },
+    "verification": {
+        "name": "Claim Verification",
+        "weight": 0.15,
+        "description": "Key claims traced to sources, AI inference labeled",
+    },
+    "revision": {
+        "name": "Hypothesis Revision",
+        "weight": 0.10,
+        "description": "Hypothesis updated based on evidence",
+    },
+    "contradictions": {
+        "name": "Contradiction Resolution",
+        "weight": 0.10,
+        "description": "Contradictions identified and resolved where possible",
+    },
+    "saturation": {
+        "name": "Gap Analysis & Saturation",
+        "weight": 0.10,
+        "description": "Gaps identified, ranked, and critical gaps filled",
+    },
+}
+
+MIN_SEARCH_ROUNDS = 2
+MIN_CONTRARIAN_SEARCHES = 1
+MIN_SOURCE_TYPES = 2
+MIN_TIER1_TIER2_SOURCES = 1
+
+
+def score_coverage(proof: dict) -> tuple[float, list[str]]:
+    """Score sub-question coverage. Deductions for unanswered questions."""
+    questions = proof.get("sub_questions", [])
+    if not questions:
+        return 0.0, ["No sub-questions defined — coverage cannot be assessed"]
+
+    total = len(questions)
+    answered = sum(1 for q in questions if q.get("answered") and q.get("sources"))
+    unanswered = total - answered
+
+    score = answered / total
+    notes = []
+    if unanswered > 0:
+        unanswered_qs = [q["question"] for q in questions if not q.get("answered") or not q.get("sources")]
+        for q in unanswered_qs:
+            notes.append(f"UNANSWERED: {q}")
+        score -= 0.05 * unanswered  # penalty per unanswered
+
+    return max(0.0, min(1.0, score)), notes
+
+
+def score_diversity(proof: dict) -> tuple[float, list[str]]:
+    """Score source type diversity. Need at least MIN_SOURCE_TYPES different types."""
+    types = proof.get("source_types_used", [])
+    count = len(set(types))
+
+    if count == 0:
+        return 0.0, ["No source types recorded"]
+    elif count == 1:
+        return 0.3, [f"Only 1 source type used ({types[0]}). Add at least {MIN_SOURCE_TYPES - 1} more."]
+    elif count == 2:
+        return 0.7, [f"2 source types used: {', '.join(types)}"]
+    elif count >= 3:
+        return 1.0, [f"{count} source types used: {', '.join(types)}"]
+    return 0.5, []
+
+
+def score_source_quality(proof: dict) -> tuple[float, list[str]]:
+    """Score based on source tier distribution. Higher tiers = better."""
+    tiers = proof.get("source_tiers", {})
+    t1 = tiers.get("tier1", 0)
+    t2 = tiers.get("tier2", 0)
+    t3 = tiers.get("tier3", 0)
+    t4 = tiers.get("tier4", 0)
+    t5 = tiers.get("tier5", 0)
+
+    total = t1 + t2 + t3 + t4 + t5
+    if total == 0:
+        return 0.0, ["No sources recorded"]
+
+    # Weighted: tier1=1.0, tier2=0.8, tier3=0.5, tier4=0.2, tier5=0.0
+    quality_sum = t1 * 1.0 + t2 * 0.8 + t3 * 0.5 + t4 * 0.2 + t5 * 0.0
+    score = quality_sum / total
+
+    notes = []
+    if t1 + t2 == 0:
+        notes.append("WARNING: No Tier 1-2 sources (primary/analyst). Only reporting and secondary.")
+        score -= 0.2
+    if t5 > t1 + t2 + t3:
+        notes.append("WARNING: More unverified sources than verified ones.")
+
+    return max(0.0, min(1.0, score)), notes
+
+
+def score_contrarian(proof: dict) -> tuple[float, list[str]]:
+    """Score contrarian search. Must have explicit searches against hypothesis."""
+    searches = proof.get("contradictions_found", [])  # legacy key
+    contrarian = proof.get("contrarian_searches", [])
+
+    if not contrarian:
+        # Check if contradictions list has evidence
+        if searches:
+            return 0.3, ["Contradictions found but no explicit contrarian search performed"]
+        return 0.0, ["No contrarian searches performed. Run searches against your hypothesis."]
+
+    count = len(contrarian)
+    with_evidence = sum(1 for s in contrarian if s.get("found_evidence"))
+
+    if count < MIN_CONTRARIAN_SEARCHES:
+        return 0.2, [f"Only {count} contrarian search(es). Minimum {MIN_CONTRARIAN_SEARCHES} required."]
+
+    if with_evidence == 0:
+        return 0.5, ["Contrarian searches run but no contradictory evidence found (or not searched properly)"]
+
+    score = min(1.0, 0.6 + (with_evidence * 0.2))
+    return score, [f"{count} contrarian searches, {with_evidence} found evidence against hypothesis"]
+
+
+def score_verification(proof: dict) -> tuple[float, list[str]]:
+    """Score claim verification. Claims must be rated and traced."""
+    claims = proof.get("claims", [])
+    if not claims:
+        return 0.0, ["No claims recorded for verification"]
+
+    total = len(claims)
+    verified = sum(1 for c in claims if c.get("status") == "verified")
+    supported = sum(1 for c in claims if c.get("status") == "supported")
+    ai_inference = sum(1 for c in claims if c.get("status") == "ai_inference")
+    unverified = sum(1 for c in claims if c.get("status") == "unverified")
+
+    notes = []
+
+    # Penalty for unverified claims that should be verified
+    if unverified > 0:
+        notes.append(f"{unverified} UNVERIFIED claim(s) — should be removed or sourced")
+
+    # Penalty if AI inference not labeled
+    if not proof.get("ai_inference_labeled", False):
+        # Check if any claims look like inference but aren't labeled
+        unlabeled_inference = sum(1 for c in claims if c.get("status") not in ["verified", "supported", "ai_inference", "unverified"])
+        if unlabeled_inference > 0:
+            notes.append(f"{unlabeled_inference} claims have unclear status — label as verified/supported/ai_inference/unverified")
+
+    # Score: verified+sourced = good, unverified = bad, ai_inference labeled = fine
+    good_claims = verified + supported
+    score = (good_claims / total) * 0.8 + (0.2 if ai_inference > 0 and proof.get("ai_inference_labeled") else 0)
+
+    # Hard penalty for unverified claims
+    score -= 0.1 * unverified
+
+    return max(0.0, min(1.0, score)), notes
+
+
+def score_revision(proof: dict) -> tuple[float, list[str]]:
+    """Score hypothesis revision. Must be revised if evidence contradicts original."""
+    revised = proof.get("hypothesis_revised", False)
+    original = proof.get("hypothesis_original", "")
+    revised_text = proof.get("hypothesis_revised_text", "")
+
+    if not original:
+        return 0.0, ["No hypothesis stated"]
+
+    if not revised:
+        # Check if there's contradicting evidence that should have triggered revision
+        contradictions = proof.get("contradictions", [])
+        contrarian = proof.get("contrarian_searches", [])
+        found_against = any(c.get("found_evidence") for c in contrarian) if contrarian else False
+
+        if found_against or any(c.get("resolved") for c in contradictions):
+            return 0.3, ["Evidence contradicts original hypothesis but hypothesis was NOT revised — this is a red flag"]
+        return 0.7, ["Hypothesis stated but not revised (no strong contradicting evidence found)"]
+
+    if revised and revised_text:
+        # Good — revised and stated
+        if revised_text == original:
+            return 0.5, ["Hypothesis marked as revised but text is identical to original"]
+        return 1.0, [f"Hypothesis revised: '{original}' -> '{revised_text}'"]
+
+    return 0.5, ["Hypothesis marked as revised but revised text not provided"]
+
+
+def score_contradictions(proof: dict) -> tuple[float, list[str]]:
+    """Score contradiction handling. Identify AND resolve."""
+    contradictions = proof.get("contradictions", [])
+    if not contradictions:
+        # No contradictions might mean none found OR not looked for
+        contrarian = proof.get("contrarian_searches", [])
+        if not contrarian:
+            return 0.3, ["No contradictions recorded and no contrarian searches — may not have looked"]
+        return 0.7, ["No contradictions found (contrarian searches were performed)"]
+
+    total = len(contradictions)
+    resolved = sum(1 for c in contradictions if c.get("resolved"))
+
+    if resolved == 0:
+        return 0.2, [f"{total} contradiction(s) identified but NONE resolved"]
+
+    score = resolved / total
+    return score, [f"{resolved}/{total} contradictions resolved"]
+
+
+def score_saturation(proof: dict) -> tuple[float, list[str]]:
+    """Score gap analysis and saturation. Must have multiple rounds for full score."""
+    gaps = proof.get("gaps_identified", [])
+    rounds = proof.get("search_rounds", 1)
+
+    notes = []
+
+    if not gaps:
+        if rounds < MIN_SEARCH_ROUNDS:
+            return 0.1, [f"No gaps recorded and only {rounds} search round(s). Run gap analysis."]
+        return 0.4, ["No gaps recorded but multiple search rounds performed"]
+
+    # Check gap ranking
+    ranked = sum(1 for g in gaps if g.get("rank") in ["critical", "important", "nice_to_have"])
+    if ranked < len(gaps):
+        notes.append(f"{len(gaps) - ranked} gap(s) not ranked by impact")
+
+    # Check critical gaps filled
+    critical = [g for g in gaps if g.get("rank") == "critical"]
+    critical_filled = sum(1 for g in critical if g.get("filled"))
+
+    if critical and critical_filled < len(critical):
+        notes.append(f"{len(critical) - critical_filled} CRITICAL gap(s) still unfilled")
+        return 0.4, notes
+
+    # Round bonus
+    if rounds < MIN_SEARCH_ROUNDS:
+        notes.append(f"Only {rounds} search round(s). Minimum {MIN_SEARCH_ROUNDS} recommended.")
+        return 0.6, notes
+
+    # All good
+    score = 0.7 + (0.1 * min(rounds - 1, 3))  # bonus for extra rounds, capped at 3
+    filled = sum(1 for g in gaps if g.get("filled"))
+    if filled == len(gaps):
+        score = min(1.0, score + 0.1)
+
+    return score, notes
+
+
+def compute_score(proof: dict) -> dict:
+    """Compute overall quality score from proof object."""
+    scorers = {
+        "coverage": score_coverage,
+        "diversity": score_diversity,
+        "source_quality": score_source_quality,
+        "contrarian": score_contrarian,
+        "verification": score_verification,
+        "revision": score_revision,
+        "contradictions": score_contradictions,
+        "saturation": score_saturation,
+    }
+
+    results = {}
+    total_score = 0.0
+    all_notes = []
+
+    for key, scorer in scorers.items():
+        dim = DIMENSIONS[key]
+        score, notes = scorer(proof)
+        weighted = score * dim["weight"]
+        total_score += weighted
+        results[key] = {
+            "name": dim["name"],
+            "weight": dim["weight"],
+            "raw_score": round(score, 2),
+            "weighted_score": round(weighted, 3),
+            "notes": notes,
+        }
+        all_notes.extend(notes)
+
+    # Determine status
+    if total_score >= 0.90:
+        status = "SATURATED"
+        message = "Research is complete and high quality."
+    elif total_score >= 0.70:
+        status = "GOOD"
+        message = "Research is solid but could be improved."
+    elif total_score >= 0.50:
+        status = "ADEQUATE"
+        message = "Research has significant gaps. Address weak dimensions."
+    else:
+        status = "INSUFFICIENT"
+        message = "Research is below acceptable quality. Major improvements needed."
+
+    # Weak dimensions (below 0.5 raw)
+    weak = [r["name"] for r in results.values() if r["raw_score"] < 0.5]
+
+    return {
+        "score": round(total_score, 3),
+        "status": status,
+        "message": message,
+        "dimensions": results,
+        "weak_dimensions": weak,
+        "actionable_notes": all_notes,
+        "search_rounds": proof.get("search_rounds", 1),
+    }
+
+
+def print_checklist():
+    """Print the proof checklist the agent must fill."""
+    print("""
+=== DEEP RESEARCH QUALITY PROOF CHECKLIST ===
+
+Before computing score, the agent must provide a proof JSON with:
+
+1. SUB-QUESTIONS (Coverage)
+   - List all sub-questions from Phase 1
+   - Mark each as answered: true/false
+   - List sources for each answered question
+
+2. SOURCE TYPES (Diversity)
+   - List all tool types used (e.g., "ddgs", "scrapling", "twitter", "browser")
+   - Minimum 2 different types required
+
+3. SOURCE TIERS (Quality)
+   - Count sources by tier:
+     tier1: Primary (gov data, official reports, direct quotes)
+     tier2: Expert analysis (analyst reports, peer-reviewed)
+     tier3: Credible reporting (Reuters, Bloomberg, BBC)
+     tier4: Secondary (blogs, opinion, regional news)
+     tier5: Unverified (social media, anonymous)
+
+4. CONTRARIAN SEARCHES (Contrarian)
+   - List searches run AGAINST your hypothesis
+   - For each: query, whether evidence was found, summary
+   - Minimum 1 required
+
+5. CLAIMS (Verification)
+   - List every specific claim in your draft answer
+   - Rate each: "verified" (2+ sources), "supported" (1 source),
+     "ai_inference" (your analysis, label it), "unverified" (remove it)
+   - Set ai_inference_labeled: true
+
+6. HYPOTHESIS (Revision)
+   - State original hypothesis (from Phase 1)
+   - Set hypothesis_revised: true/false
+   - If revised, state revised hypothesis
+
+7. CONTRADICTIONS
+   - List contradictions found between sources
+   - For each: description, resolved: true/false, resolution text
+
+8. GAPS (Saturation)
+   - List gaps identified in gap analysis
+   - Rank each: "critical", "important", "nice_to_have"
+   - Mark filled: true/false for each
+   - Record search_rounds (how many iterations)
+
+Run: python3 quality_score.py assess --proof your_proof.json
+""")
+
+
+def cmd_assess(args):
+    """Assess research quality from proof file."""
+    try:
+        with open(args.proof, 'r', encoding='utf-8') as f:
+            proof = json.load(f)
+    except FileNotFoundError:
+        print(f"Error: Proof file '{args.proof}' not found")
+        return 1
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON in proof file: {e}")
+        return 1
+
+    result = compute_score(proof)
+
+    # Output
+    print(json.dumps(result, indent=2))
+
+    # Also print human-readable summary
+    print(f"\n=== QUALITY SCORE: {result['score']:.3f} ({result['status']}) ===")
+    print(f"{result['message']}\n")
+
+    for key, dim in result["dimensions"].items():
+        bar = "█" * int(dim["raw_score"] * 20) + "░" * (20 - int(dim["raw_score"] * 20))
+        print(f"  {dim['name']:30s} {bar} {dim['raw_score']:.2f} (weight: {dim['weight']:.0%})")
+        for note in dim["notes"]:
+            print(f"    -> {note}")
+
+    if result["weak_dimensions"]:
+        print(f"\n  WEAK: {', '.join(result['weak_dimensions'])}")
+
+    if result["score"] < 0.90:
+        print(f"\n  NOT SATURATED — continue research loop")
+    else:
+        print(f"\n  SATURATED — proceed to synthesis")
+
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Deep Research Quality Scorer")
+    sub = parser.add_subparsers(dest="command")
+
+    p_assess = sub.add_parser("assess", help="Assess quality from proof JSON")
+    p_assess.add_argument("--proof", required=True, help="Path to proof JSON file")
+
+    sub.add_parser("checklist", help="Print the proof checklist")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    if args.command == "checklist":
+        print_checklist()
+        return 0
+    elif args.command == "assess":
+        return cmd_assess(args)
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a new bundled `skills/research/deep-research` skill for iterative, proof-driven research
- include a session manager helper script and a quality scorer helper script
- make the helper code portable by using a writable state directory instead of repo-local/session paths
- avoid user-specific artifacts by excluding saved sessions, hardcoded machine paths, and sample outputs

## What this skill adds
- structured multi-phase research workflow: plan, search, evaluate, reflect, gap-fill, verify, synthesize
- mandatory tool discovery and capability mapping before deep investigations
- contrarian search and hypothesis revision steps
- proof-based saturation scoring with `quality_score.py`
- lightweight research activity logging and report generation with `deep_research.py`

## Portability / privacy notes
- no hardcoded machine-specific directories
- no sample session outputs or personal data included
- helper script stores session state in:
  - `$HERMES_DEEP_RESEARCH_STATE_DIR` if set
  - otherwise `$HERMES_HOME/state/deep-research`
  - otherwise `~/.hermes/state/deep-research`
- helper script uses privacy-safe session IDs instead of embedding research topics into directory names

## Validation
- `python3 -m py_compile skills/research/deep-research/scripts/deep_research.py skills/research/deep-research/scripts/quality_score.py`
- manual scan for hardcoded paths / user-specific strings on the committed files only
EOF; __hermes_rc=$?; printf '__HERMES_FENCE_a9f7b3__'; exit $__hermes_rc
