### PR TITLE
fix: add project root to PYTHONPATH in execute_code sandbox

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -440,6 +440,11 @@ def execute_code(
                 child_env[k] = v
         child_env["HERMES_RPC_SOCKET"] = sock_path
         child_env["PYTHONDONTWRITEBYTECODE"] = "1"
+        # Ensure the hermes-agent root is importable in the sandbox so
+        # modules like minisweagent_path are available to child scripts.
+        _hermes_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        _existing_pp = child_env.get("PYTHONPATH", "")
+        child_env["PYTHONPATH"] = _hermes_root + (os.pathsep + _existing_pp if _existing_pp else "")
         # Inject user's configured timezone so datetime.now() in sandboxed
         # code reflects the correct wall-clock time.
         _tz_name = os.getenv("HERMES_TIMEZONE", "").strip()


### PR DESCRIPTION
## Summary

- The `execute_code` sandbox spawns child processes with `cwd` set to a temporary directory but never includes the hermes-agent project root in `PYTHONPATH`
- This causes `ImportError` for project-root modules like `minisweagent_path` when the agent runs code via `execute_code` (e.g. self-diagnostics, analysis scripts)
- Fix: prepend the project root to `PYTHONPATH` in the child process environment

## Reproduction

1. Run `hermes chat`
2. Ask the agent to do a self-assessment using `execute_code`
3. Any script that imports `minisweagent_path` or other project-root modules fails with `ModuleNotFoundError`

## Test plan

- [ ] Run `execute_code` with a script that does `import minisweagent_path` — should succeed
- [ ] Run `execute_code` with a script that uses `from hermes_tools import terminal` — should still work
- [ ] Verify sandbox security: child env still excludes secrets (API keys, tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)