### PR TITLE
fix: defer discord adapter annotations

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Discord platform adapter.
 

--- a/tests/gateway/test_discord_imports.py
+++ b/tests/gateway/test_discord_imports.py
@@ -1,0 +1,23 @@
+"""Import-safety tests for the Discord gateway adapter."""
+
+import builtins
+import importlib
+import sys
+
+
+class TestDiscordImportSafety:
+    def test_module_imports_even_when_discord_dependency_is_missing(self, monkeypatch):
+        original_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "discord" or name.startswith("discord."):
+                raise ImportError("discord unavailable for test")
+            return original_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.delitem(sys.modules, "gateway.platforms.discord", raising=False)
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        module = importlib.import_module("gateway.platforms.discord")
+
+        assert module.DISCORD_AVAILABLE is False
+        assert module.discord is None


### PR DESCRIPTION
## Summary
- add postponed annotation evaluation to `gateway.platforms.discord`
- add a regression test proving the module still imports when `discord.py` is unavailable

## Why
The Discord adapter treats `discord.py` as optional, but the module still referenced types like `discord.Interaction` in annotations. On Python 3.11 those annotations were evaluated eagerly, so importing the module crashed with `AttributeError: 'NoneType' object has no attribute 'Interaction'` after the optional import fallback set `discord = None`.

This surfaced when running `python -m hermes_cli.main gateway restart` from the dev `.venv` on a machine where `discord.py` was not installed there.

## Test plan
- `source .venv/bin/activate && python -m pytest tests/gateway/test_discord_imports.py -n0 -q`
- `source .venv/bin/activate && python -m pytest tests/gateway/test_discord_imports.py tests/gateway/test_discord_opus.py tests/gateway/test_discord_slash_commands.py tests/gateway/test_discord_free_response.py -n0 -q`
- `source .venv/bin/activate && python -c "import gateway.platforms.discord as m; print('IMPORT_OK', m.DISCORD_AVAILABLE)"`
