### PR TITLE
fix(telegram): use HTML parse mode for reliable message formatting

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -101,7 +101,8 @@ PLATFORM_HINTS = {
     ),
     "telegram": (
         "You are on a text messaging communication platform, Telegram. "
-        "Please do not use markdown as it does not render. "
+        "You can use standard markdown formatting — it will be rendered as "
+        "formatted text (bold, italic, code blocks, links, etc.). "
         "You can send media files natively: to deliver a file to the user, "
         "include MEDIA:/absolute/path/to/file in your response. Images "
         "(.png, .jpg, .webp) appear as photos, audio (.ogg) sends as voice "

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import os
 import re
+from html import escape as _html_escape
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -66,30 +67,191 @@ def check_telegram_requirements() -> bool:
     return TELEGRAM_AVAILABLE
 
 
-# Matches every character that MarkdownV2 requires to be backslash-escaped
-# when it appears outside a code span or fenced code block.
-_MDV2_ESCAPE_RE = re.compile(r'([_*\[\]()~`>#\+\-=|{}.!\\])')
+def _is_parse_error(exc: Exception) -> bool:
+    """Check if a Telegram API exception is an HTML/entity parse error."""
+    msg = str(exc).lower()
+    return "parse" in msg or "entity" in msg or "html" in msg
 
 
-def _escape_mdv2(text: str) -> str:
-    """Escape Telegram MarkdownV2 special characters with a preceding backslash."""
-    return _MDV2_ESCAPE_RE.sub(r'\\\1', text)
+def _markdown_to_telegram_html(text: str) -> str:
+    """Convert markdown text to Telegram-supported HTML.
 
+    Handles the common markdown constructs that LLMs produce: fenced code
+    blocks (with language tags), inline code, bold, italic, strikethrough,
+    links, headers, blockquotes, and horizontal rules.
 
-def _strip_mdv2(text: str) -> str:
-    """Strip MarkdownV2 escape backslashes to produce clean plain text.
-
-    Also removes MarkdownV2 bold markers (*text* -> text) so the fallback
-    doesn't show stray asterisks from header/bold conversion.
+    Telegram HTML reference: https://core.telegram.org/bots/api#html-style
     """
-    # Remove escape backslashes before special characters
-    cleaned = re.sub(r'\\([_*\[\]()~`>#\+\-=|{}.!\\])', r'\1', text)
-    # Remove MarkdownV2 bold markers that format_message converted from **bold**
-    cleaned = re.sub(r'\*([^*]+)\*', r'\1', cleaned)
-    # Remove MarkdownV2 italic markers that format_message converted from *italic*
-    # Use word boundary (\b) to avoid breaking snake_case like my_variable_name
-    cleaned = re.sub(r'(?<!\w)_([^_]+)_(?!\w)', r'\1', cleaned)
-    return cleaned
+    if not text:
+        return text
+
+    placeholders: dict[str, str] = {}
+    counter = [0]
+
+    def _ph(html_fragment: str) -> str:
+        key = f"\x00PH{counter[0]}\x00"
+        counter[0] += 1
+        placeholders[key] = html_fragment
+        return key
+
+    # --- Phase 1: protect regions whose content must stay verbatim ---
+
+    # Fenced code blocks: ```lang\ncode\n```
+    def _sub_fenced(m: re.Match) -> str:
+        lang = m.group(1) or ""
+        code = _html_escape(m.group(2).rstrip("\n"))
+        if lang:
+            return _ph(
+                f'<pre><code class="language-{_html_escape(lang)}">'
+                f"{code}</code></pre>"
+            )
+        return _ph(f"<pre>{code}</pre>")
+
+    text = re.sub(
+        r"```[ \t]*(\w*)\s*\n(.*?)```",
+        _sub_fenced,
+        text,
+        flags=re.DOTALL,
+    )
+
+    # Inline code: `code`
+    text = re.sub(
+        r"`([^`\n]+)`",
+        lambda m: _ph(f"<code>{_html_escape(m.group(1))}</code>"),
+        text,
+    )
+
+    # Links: [text](url) — extract before HTML-escaping so URLs stay clean
+    def _sub_link(m: re.Match) -> str:
+        display = _html_escape(m.group(1))
+        url = _html_escape(m.group(2))
+        return _ph(f'<a href="{url}">{display}</a>')
+
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", _sub_link, text)
+
+    # --- Phase 2: HTML-escape all remaining text ---
+    text = _html_escape(text)
+
+    # --- Phase 3: block-level conversions (operate on escaped text) ---
+
+    # Headers: # Title -> <b>Title</b>
+    def _sub_header(m: re.Match) -> str:
+        inner = m.group(1).strip()
+        inner = re.sub(r"\*\*(.+?)\*\*", r"\1", inner)
+        return f"<b>{inner}</b>"
+
+    text = re.sub(r"^#{1,6}\s+(.+)$", _sub_header, text, flags=re.MULTILINE)
+
+    # Blockquotes: consecutive > lines grouped into one <blockquote>
+    # After HTML-escaping, > has become &gt;
+    def _sub_blockquote(m: re.Match) -> str:
+        lines = m.group(0).split("\n")
+        inner_lines = [re.sub(r"^&gt;\s?", "", line) for line in lines if line]
+        return f"<blockquote>{''.join(inner_lines)}</blockquote>"
+
+    text = re.sub(
+        r"(?:^&gt;\s?.+(?:\n|$))+",
+        _sub_blockquote,
+        text,
+        flags=re.MULTILINE,
+    )
+
+    # Horizontal rules: --- or *** or ___
+    text = re.sub(
+        r"^(?:-{3,}|\*{3,}|_{3,})$", "\u2015" * 3, text, flags=re.MULTILINE
+    )
+
+    # --- Phase 4: inline formatting ---
+
+    # Bold: **text** -> <b>text</b>
+    text = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", text)
+
+    # Strikethrough: ~~text~~ -> <s>text</s>
+    text = re.sub(r"~~(.+?)~~", r"<s>\1</s>", text)
+
+    # Italic: *text* -> <i>text</i>
+    # Negative lookbehind/ahead for word chars avoids matching inside
+    # expressions like a*b*c or list markers (* item).
+    text = re.sub(r"(?<!\w)\*([^*\n]+?)\*(?!\w)", r"<i>\1</i>", text)
+
+    # Italic: _text_ -> <i>text</i>
+    # Avoid matching underscores inside snake_case identifiers.
+    text = re.sub(r"(?<!\w)_([^_\n]+?)_(?!\w)", r"<i>\1</i>", text)
+
+    # --- Phase 5: restore placeholders (reverse order for nesting) ---
+    for key in reversed(list(placeholders.keys())):
+        text = text.replace(key, placeholders[key])
+
+    return text
+
+
+def _strip_html_tags(text: str) -> str:
+    """Remove HTML tags to produce plain text (for fallback sending)."""
+    return re.sub(r"<[^>]+>", "", text)
+
+
+def _split_html_chunks(text: str, max_length: int = 4096) -> list[str]:
+    """Split an HTML message into chunks that respect tag boundaries.
+
+    When a split falls inside a ``<pre>`` block, the tag is closed at the
+    chunk boundary and reopened in the next chunk.  Each chunk in a
+    multi-part response receives a ``(N/M)`` indicator suffix.
+    """
+    if len(text) <= max_length:
+        return [text]
+
+    INDICATOR_RESERVE = 10  # room for " (XX/XX)"
+    PRE_CLOSE = "</pre>"
+    PRE_OPEN = "<pre>"
+
+    chunks: list[str] = []
+    remaining = text
+    carry_pre = False  # whether the previous chunk ended mid-<pre>
+
+    while remaining:
+        prefix = PRE_OPEN if carry_pre else ""
+        headroom = max_length - INDICATOR_RESERVE - len(prefix) - len(PRE_CLOSE)
+        if headroom < 1:
+            headroom = max_length // 2
+
+        if len(prefix) + len(remaining) <= max_length - INDICATOR_RESERVE:
+            chunks.append(prefix + remaining)
+            break
+
+        region = remaining[:headroom]
+
+        split_at = region.rfind("\n")
+        if split_at < headroom // 2:
+            split_at = region.rfind(" ")
+        if split_at < 1:
+            split_at = headroom
+
+        chunk_body = remaining[:split_at]
+        remaining = remaining[split_at:].lstrip()
+
+        full_chunk = prefix + chunk_body
+
+        in_pre = carry_pre
+        for m in re.finditer(r"</?pre(?:\s[^>]*)?>", chunk_body, re.IGNORECASE):
+            tag = m.group(0)
+            if tag.startswith("</"):
+                in_pre = False
+            else:
+                in_pre = True
+
+        if in_pre:
+            full_chunk += PRE_CLOSE
+            carry_pre = True
+        else:
+            carry_pre = False
+
+        chunks.append(full_chunk)
+
+    if len(chunks) > 1:
+        total = len(chunks)
+        chunks = [f"{chunk} ({i + 1}/{total})" for i, chunk in enumerate(chunks)]
+
+    return chunks
 
 
 class TelegramAdapter(BasePlatformAdapter):
@@ -221,49 +383,48 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send a message to a Telegram chat."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
-        
+
         try:
-            # Format and split message if needed
             formatted = self.format_message(content)
-            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
-            
+            chunks = _split_html_chunks(formatted, self.MAX_MESSAGE_LENGTH)
+
             message_ids = []
             thread_id = metadata.get("thread_id") if metadata else None
-            
+
             for i, chunk in enumerate(chunks):
-                # Try Markdown first, fall back to plain text if it fails
                 try:
                     msg = await self._bot.send_message(
                         chat_id=int(chat_id),
                         text=chunk,
-                        parse_mode=ParseMode.MARKDOWN_V2,
+                        parse_mode=ParseMode.HTML,
                         reply_to_message_id=int(reply_to) if reply_to and i == 0 else None,
                         message_thread_id=int(thread_id) if thread_id else None,
                     )
-                except Exception as md_error:
-                    # Markdown parsing failed, try plain text
-                    if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
-                        logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
-                        # Strip MDV2 escape backslashes so the user doesn't
-                        # see raw backslashes littered through the message.
-                        plain_chunk = _strip_mdv2(chunk)
+                except Exception as html_error:
+                    if _is_parse_error(html_error):
+                        logger.warning(
+                            "[%s] HTML parse failed, falling back to plain text: %s",
+                            self.name,
+                            html_error,
+                        )
+                        plain_chunk = _strip_html_tags(chunk)
                         msg = await self._bot.send_message(
                             chat_id=int(chat_id),
                             text=plain_chunk,
-                            parse_mode=None,  # Plain text
+                            parse_mode=None,
                             reply_to_message_id=int(reply_to) if reply_to and i == 0 else None,
                             message_thread_id=int(thread_id) if thread_id else None,
                         )
                     else:
-                        raise  # Re-raise if not a parse error
+                        raise
                 message_ids.append(str(msg.message_id))
-            
+
             return SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,
                 raw_response={"message_ids": message_ids}
             )
-            
+
         except Exception as e:
             logger.error("[%s] Failed to send Telegram message: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
@@ -284,15 +445,22 @@ class TelegramAdapter(BasePlatformAdapter):
                     chat_id=int(chat_id),
                     message_id=int(message_id),
                     text=formatted,
-                    parse_mode=ParseMode.MARKDOWN_V2,
+                    parse_mode=ParseMode.HTML,
                 )
-            except Exception:
-                # Fallback: retry without markdown formatting
-                await self._bot.edit_message_text(
-                    chat_id=int(chat_id),
-                    message_id=int(message_id),
-                    text=content,
-                )
+            except Exception as html_error:
+                if _is_parse_error(html_error):
+                    logger.warning(
+                        "[%s] HTML parse failed on edit, falling back to plain text: %s",
+                        self.name,
+                        html_error,
+                    )
+                    await self._bot.edit_message_text(
+                        chat_id=int(chat_id),
+                        message_id=int(message_id),
+                        text=_strip_html_tags(formatted) or content,
+                    )
+                else:
+                    raise
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             logger.error(
@@ -592,84 +760,8 @@ class TelegramAdapter(BasePlatformAdapter):
             return {"name": str(chat_id), "type": "dm", "error": str(e)}
     
     def format_message(self, content: str) -> str:
-        """
-        Convert standard markdown to Telegram MarkdownV2 format.
-
-        Protected regions (code blocks, inline code) are extracted first so
-        their contents are never modified.  Standard markdown constructs
-        (headers, bold, italic, links) are translated to MarkdownV2 syntax,
-        and all remaining special characters are escaped.
-        """
-        if not content:
-            return content
-
-        placeholders: dict = {}
-        counter = [0]
-
-        def _ph(value: str) -> str:
-            """Stash *value* behind a placeholder token that survives escaping."""
-            key = f"\x00PH{counter[0]}\x00"
-            counter[0] += 1
-            placeholders[key] = value
-            return key
-
-        text = content
-
-        # 1) Protect fenced code blocks (``` ... ```)
-        text = re.sub(
-            r'(```(?:[^\n]*\n)?[\s\S]*?```)',
-            lambda m: _ph(m.group(0)),
-            text,
-        )
-
-        # 2) Protect inline code (`...`)
-        text = re.sub(r'(`[^`]+`)', lambda m: _ph(m.group(0)), text)
-
-        # 3) Convert markdown links – escape the display text; inside the URL
-        #    only ')' and '\' need escaping per the MarkdownV2 spec.
-        def _convert_link(m):
-            display = _escape_mdv2(m.group(1))
-            url = m.group(2).replace('\\', '\\\\').replace(')', '\\)')
-            return _ph(f'[{display}]({url})')
-
-        text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', _convert_link, text)
-
-        # 4) Convert markdown headers (## Title) → bold *Title*
-        def _convert_header(m):
-            inner = m.group(1).strip()
-            # Strip redundant bold markers that may appear inside a header
-            inner = re.sub(r'\*\*(.+?)\*\*', r'\1', inner)
-            return _ph(f'*{_escape_mdv2(inner)}*')
-
-        text = re.sub(
-            r'^#{1,6}\s+(.+)$', _convert_header, text, flags=re.MULTILINE
-        )
-
-        # 5) Convert bold: **text** → *text* (MarkdownV2 bold)
-        text = re.sub(
-            r'\*\*(.+?)\*\*',
-            lambda m: _ph(f'*{_escape_mdv2(m.group(1))}*'),
-            text,
-        )
-
-        # 6) Convert italic: *text* (single asterisk) → _text_ (MarkdownV2 italic)
-        #    [^*\n]+ prevents matching across newlines (which would corrupt
-        #    bullet lists using * markers and multi-line content).
-        text = re.sub(
-            r'\*([^*\n]+)\*',
-            lambda m: _ph(f'_{_escape_mdv2(m.group(1))}_'),
-            text,
-        )
-
-        # 7) Escape remaining special characters in plain text
-        text = _escape_mdv2(text)
-
-        # 8) Restore placeholders in reverse insertion order so that
-        #    nested references (a placeholder inside another) resolve correctly.
-        for key in reversed(list(placeholders.keys())):
-            text = text.replace(key, placeholders[key])
-
-        return text
+        """Convert standard markdown to Telegram HTML."""
+        return _markdown_to_telegram_html(content)
     
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages."""

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -1,11 +1,10 @@
-"""Tests for Telegram MarkdownV2 formatting in gateway/platforms/telegram.py.
+"""Tests for Telegram HTML formatting via TelegramAdapter.format_message().
 
-Covers: _escape_mdv2 (pure function), format_message (markdown-to-MarkdownV2
-conversion pipeline), and edge cases that could produce invalid MarkdownV2
-or corrupt user-visible content.
+Covers the markdown-to-HTML conversion pipeline used by the adapter's send
+and edit methods, including edge cases that could produce invalid HTML or
+corrupt user-visible content.
 """
 
-import re
 import sys
 from unittest.mock import MagicMock
 
@@ -23,7 +22,7 @@ def _ensure_telegram_mock():
         return
     mod = MagicMock()
     mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
     mod.constants.ChatType.GROUP = "group"
     mod.constants.ChatType.SUPERGROUP = "supergroup"
     mod.constants.ChatType.CHANNEL = "channel"
@@ -34,7 +33,7 @@ def _ensure_telegram_mock():
 
 _ensure_telegram_mock()
 
-from gateway.platforms.telegram import TelegramAdapter, _escape_mdv2, _strip_mdv2  # noqa: E402
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -48,41 +47,6 @@ def adapter():
 
 
 # =========================================================================
-# _escape_mdv2
-# =========================================================================
-
-
-class TestEscapeMdv2:
-    def test_escapes_all_special_characters(self):
-        special = r'_*[]()~`>#+-=|{}.!\ '
-        escaped = _escape_mdv2(special)
-        # Every special char should be preceded by backslash
-        for ch in r'_*[]()~`>#+-=|{}.!\  ':
-            if ch == ' ':
-                continue
-            assert f'\\{ch}' in escaped
-
-    def test_empty_string(self):
-        assert _escape_mdv2("") == ""
-
-    def test_no_special_characters(self):
-        assert _escape_mdv2("hello world 123") == "hello world 123"
-
-    def test_backslash_escaped(self):
-        assert _escape_mdv2("a\\b") == "a\\\\b"
-
-    def test_dot_escaped(self):
-        assert _escape_mdv2("v2.0") == "v2\\.0"
-
-    def test_exclamation_escaped(self):
-        assert _escape_mdv2("wow!") == "wow\\!"
-
-    def test_mixed_text_and_specials(self):
-        result = _escape_mdv2("Hello (world)!")
-        assert result == "Hello \\(world\\)\\!"
-
-
-# =========================================================================
 # format_message - basic conversions
 # =========================================================================
 
@@ -92,17 +56,17 @@ class TestFormatMessageBasic:
         assert adapter.format_message("") == ""
 
     def test_none_input(self, adapter):
-        # content is falsy, returned as-is
         assert adapter.format_message(None) is None
-
-    def test_plain_text_specials_escaped(self, adapter):
-        result = adapter.format_message("Price is $5.00!")
-        assert "\\." in result
-        assert "\\!" in result
 
     def test_plain_text_no_markdown(self, adapter):
         result = adapter.format_message("Hello world")
         assert result == "Hello world"
+
+    def test_html_entities_escaped(self, adapter):
+        result = adapter.format_message("a < b > c & d")
+        assert "&lt;" in result
+        assert "&gt;" in result
+        assert "&amp;" in result
 
 
 # =========================================================================
@@ -111,39 +75,35 @@ class TestFormatMessageBasic:
 
 
 class TestFormatMessageCodeBlocks:
-    def test_fenced_code_block_preserved(self, adapter):
+    def test_fenced_code_block_wrapped_in_pre(self, adapter):
         text = "Before\n```python\nprint('hello')\n```\nAfter"
         result = adapter.format_message(text)
-        # Code block contents must NOT be escaped
-        assert "```python\nprint('hello')\n```" in result
-        # But "After" should have no escaping needed (plain text)
+        assert '<pre><code class="language-python">' in result
+        assert "</code></pre>" in result
+        assert "Before" in result
         assert "After" in result
 
-    def test_inline_code_preserved(self, adapter):
+    def test_inline_code_wrapped(self, adapter):
         text = "Use `my_var` here"
         result = adapter.format_message(text)
-        # Inline code content must NOT be escaped
-        assert "`my_var`" in result
-        # The surrounding text's underscore-free content should be fine
-        assert "Use" in result
+        assert "<code>my_var</code>" in result
 
-    def test_code_block_special_chars_not_escaped(self, adapter):
+    def test_code_block_html_escaped(self, adapter):
         text = "```\nif (x > 0) { return !x; }\n```"
         result = adapter.format_message(text)
-        # Inside code block, > and ! and { should NOT be escaped
-        assert "if (x > 0) { return !x; }" in result
+        assert "&gt;" in result
+        assert "<b>" not in result
 
-    def test_inline_code_special_chars_not_escaped(self, adapter):
-        text = "Run `rm -rf ./*` carefully"
+    def test_inline_code_html_escaped(self, adapter):
+        text = "Run `a<b>c` carefully"
         result = adapter.format_message(text)
-        assert "`rm -rf ./*`" in result
+        assert "<code>a&lt;b&gt;c</code>" in result
 
     def test_multiple_code_blocks(self, adapter):
         text = "```\nblock1\n```\ntext\n```\nblock2\n```"
         result = adapter.format_message(text)
         assert "block1" in result
         assert "block2" in result
-        # "text" between blocks should be present
         assert "text" in result
 
 
@@ -155,29 +115,20 @@ class TestFormatMessageCodeBlocks:
 class TestFormatMessageBoldItalic:
     def test_bold_converted(self, adapter):
         result = adapter.format_message("This is **bold** text")
-        # MarkdownV2 bold uses single *
-        assert "*bold*" in result
-        # Original ** should be gone
-        assert "**" not in result
+        assert "<b>bold</b>" in result
 
-    def test_italic_converted(self, adapter):
+    def test_italic_asterisk_converted(self, adapter):
         result = adapter.format_message("This is *italic* text")
-        # MarkdownV2 italic uses _
-        assert "_italic_" in result
+        assert "<i>italic</i>" in result
 
-    def test_bold_with_special_chars(self, adapter):
-        result = adapter.format_message("**hello.world!**")
-        # Content inside bold should be escaped
-        assert "*hello\\.world\\!*" in result
-
-    def test_italic_with_special_chars(self, adapter):
-        result = adapter.format_message("*hello.world*")
-        assert "_hello\\.world_" in result
+    def test_italic_underscore_converted(self, adapter):
+        result = adapter.format_message("This is _italic_ text")
+        assert "<i>italic</i>" in result
 
     def test_bold_and_italic_in_same_line(self, adapter):
         result = adapter.format_message("**bold** and *italic*")
-        assert "*bold*" in result
-        assert "_italic_" in result
+        assert "<b>bold</b>" in result
+        assert "<i>italic</i>" in result
 
 
 # =========================================================================
@@ -188,35 +139,23 @@ class TestFormatMessageBoldItalic:
 class TestFormatMessageHeaders:
     def test_h1_converted_to_bold(self, adapter):
         result = adapter.format_message("# Title")
-        # Header becomes bold in MarkdownV2
-        assert "*Title*" in result
-        # Hash should be removed
-        assert "#" not in result
+        assert "<b>Title</b>" in result
 
     def test_h2_converted(self, adapter):
         result = adapter.format_message("## Subtitle")
-        assert "*Subtitle*" in result
+        assert "<b>Subtitle</b>" in result
 
     def test_header_with_inner_bold_stripped(self, adapter):
-        # Headers strip redundant **...** inside
         result = adapter.format_message("## **Important**")
-        # Should be *Important* not ***Important***
-        assert "*Important*" in result
-        count = result.count("*")
-        # Should have exactly 2 asterisks (open + close)
-        assert count == 2
-
-    def test_header_with_special_chars(self, adapter):
-        result = adapter.format_message("# Hello (World)!")
-        assert "\\(" in result
-        assert "\\)" in result
-        assert "\\!" in result
+        assert "<b>Important</b>" in result
+        # Should not have nested <b> tags
+        assert result.count("<b>") == 1
 
     def test_multiline_headers(self, adapter):
         text = "# First\nSome text\n## Second"
         result = adapter.format_message(text)
-        assert "*First*" in result
-        assert "*Second*" in result
+        assert "<b>First</b>" in result
+        assert "<b>Second</b>" in result
         assert "Some text" in result
 
 
@@ -228,71 +167,39 @@ class TestFormatMessageHeaders:
 class TestFormatMessageLinks:
     def test_markdown_link_converted(self, adapter):
         result = adapter.format_message("[Click here](https://example.com)")
-        assert "[Click here](https://example.com)" in result
-
-    def test_link_display_text_escaped(self, adapter):
-        result = adapter.format_message("[Hello!](https://example.com)")
-        # The ! in display text should be escaped
-        assert "Hello\\!" in result
-
-    def test_link_url_parentheses_escaped(self, adapter):
-        result = adapter.format_message("[link](https://example.com/path_(1))")
-        # The ) in URL should be escaped
-        assert "\\)" in result
+        assert '<a href="https://example.com">Click here</a>' in result
 
     def test_link_with_surrounding_text(self, adapter):
         result = adapter.format_message("Visit [Google](https://google.com) today.")
-        assert "[Google](https://google.com)" in result
-        assert "today\\." in result
+        assert '<a href="https://google.com">Google</a>' in result
+        assert "Visit" in result
+        assert "today." in result
 
 
 # =========================================================================
-# format_message - BUG: italic regex spans newlines
+# format_message - italic does not span newlines
 # =========================================================================
 
 
 class TestItalicNewlineBug:
-    r"""Italic regex ``\*([^*]+)\*`` matched across newlines, corrupting content.
-
-    This affects bullet lists using * markers and any text where * appears
-    at the end of one line and start of another.
-    """
+    r"""Italic regex must not match across newlines."""
 
     def test_bullet_list_not_corrupted(self, adapter):
-        """Bullet list items using * must NOT be merged into italic."""
         text = "* Item one\n* Item two\n* Item three"
         result = adapter.format_message(text)
-        # Each item should appear in the output (not eaten by italic conversion)
         assert "Item one" in result
         assert "Item two" in result
         assert "Item three" in result
-        # Should NOT contain _ (italic markers) wrapping list items
-        assert "_" not in result or "Item" not in result.split("_")[1] if "_" in result else True
-
-    def test_asterisk_list_items_preserved(self, adapter):
-        """Each * list item should remain as a separate line, not become italic."""
-        text = "* Alpha\n* Beta"
-        result = adapter.format_message(text)
-        # Both items must be present in output
-        assert "Alpha" in result
-        assert "Beta" in result
-        # The text between first * and second * must NOT become italic
-        lines = result.split("\n")
-        assert len(lines) >= 2
 
     def test_italic_does_not_span_lines(self, adapter):
-        """*text on\nmultiple lines* should NOT become italic."""
         text = "Start *across\nlines* end"
         result = adapter.format_message(text)
-        # Should NOT have underscore italic markers wrapping cross-line text
-        # If this fails, the italic regex is matching across newlines
-        assert "_across\nlines_" not in result
+        assert "<i>across\nlines</i>" not in result
 
     def test_single_line_italic_still_works(self, adapter):
-        """Normal single-line italic must still convert correctly."""
         text = "This is *italic* text"
         result = adapter.format_message(text)
-        assert "_italic_" in result
+        assert "<i>italic</i>" in result
 
 
 # =========================================================================
@@ -304,48 +211,39 @@ class TestFormatMessageComplex:
     def test_code_block_with_bold_outside(self, adapter):
         text = "**Note:**\n```\ncode here\n```"
         result = adapter.format_message(text)
-        assert "*Note:*" in result or "*Note\\:*" in result
-        assert "```\ncode here\n```" in result
+        assert "<b>" in result
+        assert "<pre>" in result
 
     def test_bold_inside_code_not_converted(self, adapter):
-        """Bold markers inside code blocks should not be converted."""
         text = "```\n**not bold**\n```"
         result = adapter.format_message(text)
+        assert "<b>" not in result
         assert "**not bold**" in result
 
     def test_link_inside_code_not_converted(self, adapter):
         text = "`[not a link](url)`"
         result = adapter.format_message(text)
-        assert "`[not a link](url)`" in result
+        assert "<a " not in result
+        assert "[not a link](url)" in result
 
     def test_header_after_code_block(self, adapter):
         text = "```\ncode\n```\n## Title"
         result = adapter.format_message(text)
-        assert "*Title*" in result
-        assert "```\ncode\n```" in result
+        assert "<b>Title</b>" in result
 
     def test_multiple_bold_segments(self, adapter):
         result = adapter.format_message("**a** and **b** and **c**")
-        assert result.count("*") >= 6  # 3 bold pairs = 6 asterisks
-
-    def test_special_chars_in_plain_text(self, adapter):
-        result = adapter.format_message("Price: $5.00 (50% off!)")
-        assert "\\." in result
-        assert "\\(" in result
-        assert "\\)" in result
-        assert "\\!" in result
+        assert result.count("<b>") == 3
 
     def test_empty_bold(self, adapter):
-        """**** (empty bold) should not crash."""
         result = adapter.format_message("****")
         assert result is not None
 
     def test_empty_code_block(self, adapter):
         result = adapter.format_message("```\n```")
-        assert "```" in result
+        assert "<pre>" in result
 
     def test_placeholder_collision(self, adapter):
-        """Many formatting elements should not cause placeholder collisions."""
         text = (
             "# Header\n"
             "**bold1** *italic1* `code1`\n"
@@ -354,41 +252,12 @@ class TestFormatMessageComplex:
             "[link](https://url.com)"
         )
         result = adapter.format_message(text)
-        # No placeholder tokens should leak into output
         assert "\x00" not in result
-        # All elements should be present
         assert "Header" in result
         assert "block" in result
         assert "url.com" in result
 
-
-# =========================================================================
-# _strip_mdv2 — plaintext fallback
-# =========================================================================
-
-
-class TestStripMdv2:
-    def test_removes_escape_backslashes(self):
-        assert _strip_mdv2(r"hello\.world\!") == "hello.world!"
-
-    def test_removes_bold_markers(self):
-        assert _strip_mdv2("*bold text*") == "bold text"
-
-    def test_removes_italic_markers(self):
-        assert _strip_mdv2("_italic text_") == "italic text"
-
-    def test_removes_both_bold_and_italic(self):
-        result = _strip_mdv2("*bold* and _italic_")
-        assert result == "bold and italic"
-
-    def test_preserves_snake_case(self):
-        assert _strip_mdv2("my_variable_name") == "my_variable_name"
-
-    def test_preserves_multi_underscore_identifier(self):
-        assert _strip_mdv2("some_func_call here") == "some_func_call here"
-
-    def test_plain_text_unchanged(self):
-        assert _strip_mdv2("plain text") == "plain text"
-
-    def test_empty_string(self):
-        assert _strip_mdv2("") == ""
+    def test_snake_case_not_italicized(self, adapter):
+        result = adapter.format_message("my_variable_name")
+        assert "<i>" not in result
+        assert "my_variable_name" in result

--- a/tests/gateway/test_telegram_html.py
+++ b/tests/gateway/test_telegram_html.py
@@ -1,0 +1,277 @@
+"""Tests for Telegram HTML formatting helpers in gateway/platforms/telegram.py."""
+
+import sys
+from unittest.mock import MagicMock
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants"):
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import (  # noqa: E402
+    _markdown_to_telegram_html as markdown_to_telegram_html,
+    _split_html_chunks as split_html_chunks,
+    _strip_html_tags as strip_html_tags,
+)
+
+
+class TestFencedCodeBlocks:
+    def test_basic_fenced_block(self):
+        md = "```\nprint('hi')\n```"
+        result = markdown_to_telegram_html(md)
+        assert "<pre>" in result
+        assert "print(" in result
+        assert "</pre>" in result
+
+    def test_fenced_block_with_language(self):
+        md = "```python\nprint('hi')\n```"
+        result = markdown_to_telegram_html(md)
+        assert '<pre><code class="language-python">' in result
+        assert "print(" in result
+        assert "</code></pre>" in result
+
+    def test_fenced_block_escapes_html(self):
+        md = "```\n<div>a & b</div>\n```"
+        result = markdown_to_telegram_html(md)
+        assert "&lt;div&gt;" in result
+        assert "&amp;" in result
+
+    def test_fenced_block_preserves_markdown(self):
+        md = "```\n**not bold** and *not italic*\n```"
+        result = markdown_to_telegram_html(md)
+        assert "<b>" not in result
+        assert "<i>" not in result
+        assert "**not bold**" in result
+
+    def test_multiple_code_blocks(self):
+        md = "Before\n```\nblock1\n```\nMiddle\n```\nblock2\n```\nAfter"
+        result = markdown_to_telegram_html(md)
+        assert result.count("<pre>") == 2
+        assert result.count("</pre>") == 2
+        assert "Before" in result
+        assert "Middle" in result
+        assert "After" in result
+
+
+class TestInlineCode:
+    def test_inline_code(self):
+        assert markdown_to_telegram_html("use `foo()`") == "use <code>foo()</code>"
+
+    def test_inline_code_escapes_html(self):
+        result = markdown_to_telegram_html("use `a<b>c`")
+        assert result == "use <code>a&lt;b&gt;c</code>"
+
+    def test_inline_code_not_processed_for_formatting(self):
+        result = markdown_to_telegram_html("`**bold**`")
+        assert "<b>" not in result
+        assert "**bold**" in result
+
+
+class TestBold:
+    def test_bold(self):
+        assert markdown_to_telegram_html("**hello**") == "<b>hello</b>"
+
+    def test_bold_mid_sentence(self):
+        result = markdown_to_telegram_html("this is **important** stuff")
+        assert result == "this is <b>important</b> stuff"
+
+    def test_multiple_bold(self):
+        result = markdown_to_telegram_html("**a** and **b**")
+        assert result == "<b>a</b> and <b>b</b>"
+
+
+class TestItalic:
+    def test_italic_asterisk(self):
+        assert markdown_to_telegram_html("*hello*") == "<i>hello</i>"
+
+    def test_italic_underscore(self):
+        assert markdown_to_telegram_html("_hello_") == "<i>hello</i>"
+
+    def test_no_italic_in_snake_case(self):
+        result = markdown_to_telegram_html("my_variable_name")
+        assert "<i>" not in result
+        assert "my_variable_name" in result
+
+    def test_no_italic_mid_word(self):
+        result = markdown_to_telegram_html("some*thing*here")
+        assert "<i>" not in result
+
+
+class TestStrikethrough:
+    def test_strikethrough(self):
+        assert markdown_to_telegram_html("~~deleted~~") == "<s>deleted</s>"
+
+    def test_strikethrough_mid_sentence(self):
+        result = markdown_to_telegram_html("this is ~~wrong~~ right")
+        assert result == "this is <s>wrong</s> right"
+
+
+class TestLinks:
+    def test_basic_link(self):
+        result = markdown_to_telegram_html("[click](https://example.com)")
+        assert result == '<a href="https://example.com">click</a>'
+
+    def test_link_with_special_chars(self):
+        result = markdown_to_telegram_html("[a&b](https://example.com?a=1&b=2)")
+        assert "a&amp;b" in result
+        assert "a=1&amp;b=2" in result
+
+    def test_link_display_text_not_formatted(self):
+        result = markdown_to_telegram_html("[**bold link**](https://example.com)")
+        # The display text should be escaped, not formatted
+        assert "**bold link**" in result
+
+
+class TestHeaders:
+    def test_h1(self):
+        assert markdown_to_telegram_html("# Title") == "<b>Title</b>"
+
+    def test_h3(self):
+        assert markdown_to_telegram_html("### Section") == "<b>Section</b>"
+
+    def test_header_strips_nested_bold(self):
+        result = markdown_to_telegram_html("## **Bold Title**")
+        assert result == "<b>Bold Title</b>"
+
+    def test_header_mid_text(self):
+        result = markdown_to_telegram_html("Before\n## Header\nAfter")
+        assert "<b>Header</b>" in result
+        assert "Before" in result
+        assert "After" in result
+
+
+class TestBlockquotes:
+    def test_single_line_blockquote(self):
+        result = markdown_to_telegram_html("> quote")
+        assert "<blockquote>" in result
+        assert "quote" in result
+        assert "</blockquote>" in result
+
+    def test_multiline_blockquote(self):
+        result = markdown_to_telegram_html("> line1\n> line2")
+        # Should be grouped into one blockquote
+        assert result.count("<blockquote>") == 1
+        assert "line1" in result
+        assert "line2" in result
+
+
+class TestHorizontalRules:
+    def test_triple_dash(self):
+        result = markdown_to_telegram_html("---")
+        assert "\u2015" in result
+
+    def test_triple_asterisk(self):
+        result = markdown_to_telegram_html("***")
+        # *** could be interpreted as bold italic empty, but as a line by
+        # itself it should be a horizontal rule
+        assert "\u2015" in result or "<i>" in result
+
+    def test_rule_between_text(self):
+        result = markdown_to_telegram_html("above\n---\nbelow")
+        assert "above" in result
+        assert "below" in result
+
+
+class TestHtmlEscaping:
+    def test_angle_brackets_escaped(self):
+        result = markdown_to_telegram_html("a < b > c")
+        assert "&lt;" in result
+        assert "&gt;" in result
+
+    def test_ampersand_escaped(self):
+        result = markdown_to_telegram_html("a & b")
+        assert "&amp;" in result
+
+    def test_html_tags_in_plain_text_escaped(self):
+        result = markdown_to_telegram_html("<script>alert('xss')</script>")
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result
+
+
+class TestCombined:
+    def test_bold_and_code(self):
+        result = markdown_to_telegram_html("**bold** and `code`")
+        assert "<b>bold</b>" in result
+        assert "<code>code</code>" in result
+
+    def test_header_with_code_block(self):
+        md = "## Setup\n\n```bash\npip install foo\n```"
+        result = markdown_to_telegram_html(md)
+        assert "<b>Setup</b>" in result
+        assert '<pre><code class="language-bash">' in result
+
+    def test_realistic_llm_output(self):
+        md = (
+            "## Summary\n\n"
+            "Here's a **quick** overview:\n\n"
+            "- First item\n"
+            "- Second *important* item\n\n"
+            "```python\ndef hello():\n    print('world')\n```\n\n"
+            "See [docs](https://example.com) for more."
+        )
+        result = markdown_to_telegram_html(md)
+        assert "<b>Summary</b>" in result
+        assert "<b>quick</b>" in result
+        assert "<i>important</i>" in result
+        assert '<pre><code class="language-python">' in result
+        assert '<a href="https://example.com">docs</a>' in result
+
+    def test_empty_input(self):
+        assert markdown_to_telegram_html("") == ""
+        assert markdown_to_telegram_html(None) is None
+
+    def test_plain_text_passthrough(self):
+        assert markdown_to_telegram_html("just plain text") == "just plain text"
+
+
+class TestStripHtmlTags:
+    def test_strips_tags(self):
+        assert strip_html_tags("<b>bold</b>") == "bold"
+
+    def test_strips_nested_tags(self):
+        assert strip_html_tags("<b><i>text</i></b>") == "text"
+
+    def test_preserves_plain_text(self):
+        assert strip_html_tags("no tags here") == "no tags here"
+
+    def test_preserves_entities(self):
+        assert strip_html_tags("a &amp; b") == "a &amp; b"
+
+
+class TestSplitHtmlChunks:
+    def test_short_message_no_split(self):
+        chunks = split_html_chunks("hello", 100)
+        assert chunks == ["hello"]
+
+    def test_long_message_splits(self):
+        text = "word " * 1000  # ~5000 chars
+        chunks = split_html_chunks(text, 100)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert len(chunk) <= 100
+
+    def test_split_adds_indicators(self):
+        text = "a " * 2500  # ~5000 chars
+        chunks = split_html_chunks(text, 100)
+        assert "(1/" in chunks[0]
+        assert f"({len(chunks)}/{len(chunks)})" in chunks[-1]
+
+    def test_split_preserves_pre_blocks(self):
+        text = "before\n<pre>" + "x" * 200 + "</pre>\nafter"
+        chunks = split_html_chunks(text, 150)
+        # If a chunk ends mid-<pre>, it should close and reopen
+        for chunk in chunks:
+            if "<pre>" in chunk:
+                assert "</pre>" in chunk


### PR DESCRIPTION
## Summary

- **Replace MarkdownV2 with HTML parse mode** for Telegram message formatting. MarkdownV2 required escaping 18+ special characters (`_`, `*`, `[`, `]`, `(`, `)`, `~`, `` ` ``, `>`, `#`, `+`, `-`, `=`, `|`, `{`, `}`, `.`, `!`) and was fragile with LLM-generated content that frequently contains these characters unescaped. HTML mode only needs `&`, `<`, `>` escaped and natively supports all formatting Telegram offers.
- **Add a zero-dependency markdown-to-HTML converter** (`_markdown_to_telegram_html`) that handles fenced code blocks, inline code, bold, italic, strikethrough, links, headers, blockquotes, and horizontal rules. Uses a placeholder pattern to protect code blocks, inline code, and links from double-processing during conversion.
- **Add HTML-aware message chunking** (`_split_html_chunks`) that properly closes and reopens `<pre>` tags at chunk boundaries, preventing malformed HTML when long messages are split.
- **Add plain-text fallback** (`_strip_html_tags`) — if Telegram still rejects the HTML (edge cases), the message is retried with all tags stripped.
- **Update the Telegram platform hint** in `prompt_builder.py` to inform the agent that markdown formatting is now supported and will be rendered correctly.

## Changes

| File | What changed |
|------|-------------|
| `gateway/platforms/telegram.py` | Replaced `_MDV2_ESCAPE_RE`, `_escape_mdv2`, `_strip_mdv2` with `_markdown_to_telegram_html`, `_strip_html_tags`, `_split_html_chunks`. Updated `send()`, `edit_message()`, and `format_message()` to use `ParseMode.HTML`. |
| `agent/prompt_builder.py` | Updated Telegram platform hint from "do not use markdown" to "markdown will be rendered as formatted text". |
| `tests/gateway/test_telegram_html.py` | **New** — 45 unit tests for the converter, tag stripper, and chunk splitter. |
| `tests/gateway/test_telegram_format.py` | Rewritten from MarkdownV2 assertions to HTML assertions (31 tests). |

## Design decisions

- **No external dependencies** — the converter is ~120 lines of straightforward regex-based processing, avoiding a dependency on `markdown-it-py` or similar libraries.
- **Functions live in the adapter module** (`telegram.py`) — follows the existing architecture where formatting is part of the platform adapter, not a separate utility.
- **Placeholder pattern** — code blocks, inline code, and links are replaced with null-byte placeholders before HTML-escaping and inline formatting, then restored at the end. This prevents double-escaping and ensures code content is never processed as markdown.

## Test plan

- [x] 76 tests pass (`test_telegram_html.py` + `test_telegram_format.py`)
- [ ] Manual testing with a live Telegram bot to verify formatting renders correctly
- [ ] Verify fallback works when HTML is rejected (e.g., malformed edge case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)