### PR TITLE
test(cron): add cross-timezone naive timestamp regression

### DIFF
--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -328,6 +328,34 @@ class TestCronTimezone:
             "Overdue job was skipped — _ensure_aware likely shifted absolute time"
         )
 
+    def test_get_due_jobs_naive_cross_timezone(self, tmp_path, monkeypatch):
+        """Naive past timestamps must be detected as due even when Hermes tz
+        is behind system local tz — the scenario that triggered #806."""
+        import cron.jobs as jobs_module
+        monkeypatch.setattr(jobs_module, "CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr(jobs_module, "JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr(jobs_module, "OUTPUT_DIR", tmp_path / "cron" / "output")
+
+        # Use a Hermes timezone far behind UTC so that the numeric wall time
+        # of the naive timestamp exceeds _hermes_now's wall time — this would
+        # have caused a false "not due" with the old replace(tzinfo=...) approach.
+        os.environ["HERMES_TIMEZONE"] = "Pacific/Midway"  # UTC-11
+        hermes_time.reset_cache()
+
+        from cron.jobs import create_job, load_jobs, save_jobs, get_due_jobs
+        create_job(prompt="Cross-tz job", schedule="every 1h")
+        jobs = load_jobs()
+
+        # Force a naive past timestamp (system-local wall time, 10 min ago)
+        naive_past = (datetime.now() - timedelta(minutes=10)).isoformat()
+        jobs[0]["next_run_at"] = naive_past
+        save_jobs(jobs)
+
+        due = get_due_jobs()
+        assert len(due) == 1, (
+            "Naive past timestamp should be due regardless of Hermes timezone"
+        )
+
     def test_create_job_stores_tz_aware_timestamps(self, tmp_path, monkeypatch):
         """New jobs store timezone-aware created_at and next_run_at."""
         import cron.jobs as jobs_module


### PR DESCRIPTION
## Summary
- cherry-pick the remaining regression coverage from PR #1308 by @0xNyk onto current main
- add an end-to-end cron test using `Pacific/Midway` to cover a large Hermes-vs-system timezone mismatch
- keep the already-merged fix from PR #949 unchanged; this is coverage only

## Test plan
- `python -m pytest tests/test_timezone.py::TestCronTimezone::test_get_due_jobs_naive_cross_timezone -n0 -q`
- `python -m pytest tests/test_timezone.py tests/cron/test_jobs.py tests/tools/test_cronjob_tools.py -n0 -q`
- `python -m pytest tests/ -n0 -q`

Follow-up to PR #949.
Salvages the remaining useful test coverage from PR #1308 and supersedes PR #929 for this topic.
