### PR TITLE
feat: pre-call tool sanitization and post-call tool interception

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1968,6 +1968,52 @@ class AIAgent:
 
         return messages
 
+    @staticmethod
+    def _cap_delegate_task_calls(tool_calls: list) -> list:
+        """Enforce MAX_CONCURRENT_CHILDREN on delegate_task calls in one turn.
+
+        The delegate_tool already caps the *task list* inside a single call,
+        but the model can emit multiple separate ``delegate_task`` tool_calls
+        in one turn.  This method truncates the excess, preserving all
+        non-delegate calls and the first MAX_CONCURRENT_CHILDREN delegate ones.
+
+        Returns a new list (original is not mutated) or the original list
+        object if no truncation was needed.
+        """
+        from tools.delegate_tool import MAX_CONCURRENT_CHILDREN
+        delegate_tcs = [tc for tc in tool_calls if tc.function.name == "delegate_task"]
+        if len(delegate_tcs) <= MAX_CONCURRENT_CHILDREN:
+            return tool_calls
+        non_delegate = [tc for tc in tool_calls if tc.function.name != "delegate_task"]
+        truncated = non_delegate + delegate_tcs[:MAX_CONCURRENT_CHILDREN]
+        logger.warning(
+            "Truncated %d excess delegate_task call(s) to enforce "
+            "MAX_CONCURRENT_CHILDREN=%d limit",
+            len(delegate_tcs) - MAX_CONCURRENT_CHILDREN, MAX_CONCURRENT_CHILDREN,
+        )
+        return truncated
+
+    @staticmethod
+    def _deduplicate_tool_calls(tool_calls: list) -> list:
+        """Remove duplicate (tool_name, arguments) pairs within a single turn.
+
+        Some models occasionally emit the same call twice.  Only the first
+        occurrence of each unique ``(name, arguments)`` pair is kept.
+
+        Returns a new list (original is not mutated) or the original list
+        object if no duplicates were found.
+        """
+        seen: set = set()
+        unique: list = []
+        for tc in tool_calls:
+            key = (tc.function.name, tc.function.arguments)
+            if key not in seen:
+                seen.add(key)
+                unique.append(tc)
+            else:
+                logger.warning("Removed duplicate tool call: %s", tc.function.name)
+        return unique if len(unique) < len(tool_calls) else tool_calls
+
     def _repair_tool_call(self, tool_name: str) -> str | None:
         """Attempt to repair a mismatched tool name before aborting.
 
@@ -5394,45 +5440,14 @@ class AIAgent:
                     self._invalid_json_retries = 0
 
                     # ── Phase 2a: Hard subagent limit ─────────────────────
-                    # The delegate_tool caps the task *list* inside a single
-                    # call, but the model can emit multiple separate
-                    # delegate_task tool_calls in one turn.  Truncate the
-                    # excess here, before dispatch and before the assistant
-                    # message is serialised into history.
-                    from tools.delegate_tool import MAX_CONCURRENT_CHILDREN as _MAX_CHILDREN
-                    _delegate_tcs = [
-                        tc for tc in assistant_message.tool_calls
-                        if tc.function.name == "delegate_task"
-                    ]
-                    if len(_delegate_tcs) > _MAX_CHILDREN:
-                        _non_delegate = [
-                            tc for tc in assistant_message.tool_calls
-                            if tc.function.name != "delegate_task"
-                        ]
-                        assistant_message.tool_calls = _non_delegate + _delegate_tcs[:_MAX_CHILDREN]
-                        logger.warning(
-                            "Truncated %d excess delegate_task call(s) to enforce "
-                            "MAX_CONCURRENT_CHILDREN=%d limit",
-                            len(_delegate_tcs) - _MAX_CHILDREN, _MAX_CHILDREN,
-                        )
+                    assistant_message.tool_calls = self._cap_delegate_task_calls(
+                        assistant_message.tool_calls
+                    )
 
                     # ── Phase 2b: Tool call deduplication ─────────────────
-                    # Some models emit the same (tool_name, arguments) pair
-                    # more than once in a single turn.  Keep only the first
-                    # occurrence to avoid redundant work and API waste.
-                    _seen_calls: set = set()
-                    _unique_calls: list = []
-                    for _tc in assistant_message.tool_calls:
-                        _tc_key = (_tc.function.name, _tc.function.arguments)
-                        if _tc_key not in _seen_calls:
-                            _seen_calls.add(_tc_key)
-                            _unique_calls.append(_tc)
-                        else:
-                            logger.warning(
-                                "Removed duplicate tool call: %s", _tc.function.name
-                            )
-                    if len(_unique_calls) < len(assistant_message.tool_calls):
-                        assistant_message.tool_calls = _unique_calls
+                    assistant_message.tool_calls = self._deduplicate_tool_calls(
+                        assistant_message.tool_calls
+                    )
 
                     assistant_msg = self._build_assistant_message(assistant_message, finish_reason)
                     

--- a/run_agent.py
+++ b/run_agent.py
@@ -1899,7 +1899,7 @@ class AIAgent:
     def _get_tool_call_id_static(tc) -> str:
         """Extract call ID from a tool_call entry (dict or object)."""
         if isinstance(tc, dict):
-            return tc.get("id", "")
+            return tc.get("id", "") or ""
         return getattr(tc, "id", "") or ""
 
     @staticmethod
@@ -1981,15 +1981,22 @@ class AIAgent:
         object if no truncation was needed.
         """
         from tools.delegate_tool import MAX_CONCURRENT_CHILDREN
-        delegate_tcs = [tc for tc in tool_calls if tc.function.name == "delegate_task"]
-        if len(delegate_tcs) <= MAX_CONCURRENT_CHILDREN:
+        delegate_count = sum(1 for tc in tool_calls if tc.function.name == "delegate_task")
+        if delegate_count <= MAX_CONCURRENT_CHILDREN:
             return tool_calls
-        non_delegate = [tc for tc in tool_calls if tc.function.name != "delegate_task"]
-        truncated = non_delegate + delegate_tcs[:MAX_CONCURRENT_CHILDREN]
+        kept_delegates = 0
+        truncated = []
+        for tc in tool_calls:
+            if tc.function.name == "delegate_task":
+                if kept_delegates < MAX_CONCURRENT_CHILDREN:
+                    truncated.append(tc)
+                    kept_delegates += 1
+            else:
+                truncated.append(tc)
         logger.warning(
             "Truncated %d excess delegate_task call(s) to enforce "
             "MAX_CONCURRENT_CHILDREN=%d limit",
-            len(delegate_tcs) - MAX_CONCURRENT_CHILDREN, MAX_CONCURRENT_CHILDREN,
+            delegate_count - MAX_CONCURRENT_CHILDREN, MAX_CONCURRENT_CHILDREN,
         )
         return truncated
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1891,6 +1891,83 @@ class AIAgent:
 
         return "\n\n".join(prompt_parts)
     
+    # =========================================================================
+    # Message sanitisation helpers (Phase 1 — pre-call guardrail)
+    # =========================================================================
+
+    @staticmethod
+    def _get_tool_call_id_static(tc) -> str:
+        """Extract call ID from a tool_call entry (dict or object)."""
+        if isinstance(tc, dict):
+            return tc.get("id", "")
+        return getattr(tc, "id", "") or ""
+
+    @staticmethod
+    def _sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Fix orphaned tool_call / tool_result pairs before every LLM call.
+
+        Mirrors ContextCompressor._sanitize_tool_pairs() but runs
+        unconditionally — not gated on whether compression is enabled.
+
+        Failure mode 1 — orphaned result: a ``role=tool`` message references a
+          ``tool_call_id`` whose assistant ``tool_calls`` entry was removed
+          (e.g. by session reload or manual manipulation).  The API rejects
+          this with "No tool call found for function call output with
+          call_id …".
+        Failure mode 2 — orphaned call: an assistant message has ``tool_calls``
+          entries whose ``role=tool`` results were dropped.  The API rejects
+          because every tool_call must be followed by a matching result.
+        """
+        surviving_call_ids: set = set()
+        for msg in messages:
+            if msg.get("role") == "assistant":
+                for tc in msg.get("tool_calls") or []:
+                    cid = AIAgent._get_tool_call_id_static(tc)
+                    if cid:
+                        surviving_call_ids.add(cid)
+
+        result_call_ids: set = set()
+        for msg in messages:
+            if msg.get("role") == "tool":
+                cid = msg.get("tool_call_id")
+                if cid:
+                    result_call_ids.add(cid)
+
+        # 1. Drop tool results with no matching assistant call
+        orphaned_results = result_call_ids - surviving_call_ids
+        if orphaned_results:
+            messages = [
+                m for m in messages
+                if not (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
+            ]
+            logger.debug(
+                "Pre-call sanitizer: removed %d orphaned tool result(s)",
+                len(orphaned_results),
+            )
+
+        # 2. Inject stub results for calls whose result was dropped
+        missing_results = surviving_call_ids - result_call_ids
+        if missing_results:
+            patched: List[Dict[str, Any]] = []
+            for msg in messages:
+                patched.append(msg)
+                if msg.get("role") == "assistant":
+                    for tc in msg.get("tool_calls") or []:
+                        cid = AIAgent._get_tool_call_id_static(tc)
+                        if cid in missing_results:
+                            patched.append({
+                                "role": "tool",
+                                "content": "[Result unavailable — see context summary above]",
+                                "tool_call_id": cid,
+                            })
+            messages = patched
+            logger.debug(
+                "Pre-call sanitizer: added %d stub tool result(s)",
+                len(missing_results),
+            )
+
+        return messages
+
     def _repair_tool_call(self, tool_name: str) -> str | None:
         """Attempt to repair a mismatched tool name before aborting.
 
@@ -4412,11 +4489,10 @@ class AIAgent:
                 api_messages = apply_anthropic_cache_control(api_messages, cache_ttl=self._cache_ttl)
 
             # Safety net: strip orphaned tool results / add stubs for missing
-            # results before sending to the API.  The compressor handles this
-            # during compression, but orphans can also sneak in from session
-            # loading or manual message manipulation.
-            if hasattr(self, 'context_compressor') and self.context_compressor:
-                api_messages = self.context_compressor._sanitize_tool_pairs(api_messages)
+            # results before sending to the API.  Runs unconditionally — not
+            # gated on context_compressor — so orphans from session loading or
+            # manual message manipulation are always caught.
+            api_messages = self._sanitize_api_messages(api_messages)
 
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)
@@ -5316,7 +5392,48 @@ class AIAgent:
                     
                     # Reset retry counter on successful JSON validation
                     self._invalid_json_retries = 0
-                    
+
+                    # ── Phase 2a: Hard subagent limit ─────────────────────
+                    # The delegate_tool caps the task *list* inside a single
+                    # call, but the model can emit multiple separate
+                    # delegate_task tool_calls in one turn.  Truncate the
+                    # excess here, before dispatch and before the assistant
+                    # message is serialised into history.
+                    from tools.delegate_tool import MAX_CONCURRENT_CHILDREN as _MAX_CHILDREN
+                    _delegate_tcs = [
+                        tc for tc in assistant_message.tool_calls
+                        if tc.function.name == "delegate_task"
+                    ]
+                    if len(_delegate_tcs) > _MAX_CHILDREN:
+                        _non_delegate = [
+                            tc for tc in assistant_message.tool_calls
+                            if tc.function.name != "delegate_task"
+                        ]
+                        assistant_message.tool_calls = _non_delegate + _delegate_tcs[:_MAX_CHILDREN]
+                        logger.warning(
+                            "Truncated %d excess delegate_task call(s) to enforce "
+                            "MAX_CONCURRENT_CHILDREN=%d limit",
+                            len(_delegate_tcs) - _MAX_CHILDREN, _MAX_CHILDREN,
+                        )
+
+                    # ── Phase 2b: Tool call deduplication ─────────────────
+                    # Some models emit the same (tool_name, arguments) pair
+                    # more than once in a single turn.  Keep only the first
+                    # occurrence to avoid redundant work and API waste.
+                    _seen_calls: set = set()
+                    _unique_calls: list = []
+                    for _tc in assistant_message.tool_calls:
+                        _tc_key = (_tc.function.name, _tc.function.arguments)
+                        if _tc_key not in _seen_calls:
+                            _seen_calls.add(_tc_key)
+                            _unique_calls.append(_tc)
+                        else:
+                            logger.warning(
+                                "Removed duplicate tool call: %s", _tc.function.name
+                            )
+                    if len(_unique_calls) < len(assistant_message.tool_calls):
+                        assistant_message.tool_calls = _unique_calls
+
                     assistant_msg = self._build_assistant_message(assistant_message, finish_reason)
                     
                     # If this turn has both content AND tool_calls, capture the content

--- a/tests/test_agent_guardrails.py
+++ b/tests/test_agent_guardrails.py
@@ -1,0 +1,269 @@
+"""Unit tests for AIAgent pre/post-LLM-call guardrails (issue #626).
+
+Covers three static methods introduced in run_agent.py:
+  - AIAgent._sanitize_api_messages()   — Phase 1: orphaned tool pair repair
+  - AIAgent._cap_delegate_task_calls() — Phase 2a: subagent concurrency limit
+  - AIAgent._deduplicate_tool_calls()  — Phase 2b: identical call deduplication
+"""
+
+import types
+
+import pytest
+
+from run_agent import AIAgent
+from tools.delegate_tool import MAX_CONCURRENT_CHILDREN
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_tc(name: str, arguments: str = "{}") -> types.SimpleNamespace:
+    """Create a minimal tool_call SimpleNamespace mirroring the OpenAI SDK object."""
+    tc = types.SimpleNamespace()
+    tc.function = types.SimpleNamespace(name=name, arguments=arguments)
+    return tc
+
+
+def assistant_msg_with_calls(*tool_calls) -> dict:
+    """Build a dict-style assistant message carrying tool_calls."""
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": list(tool_calls),
+    }
+
+
+def tool_result(call_id: str, content: str = "ok") -> dict:
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+def assistant_dict_call(call_id: str, name: str = "terminal") -> dict:
+    """Dict-style tool_call (as stored in message history, not the SDK object)."""
+    return {"id": call_id, "function": {"name": name, "arguments": "{}"}}
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — _sanitize_api_messages
+# ---------------------------------------------------------------------------
+
+class TestSanitizeApiMessages:
+    """AIAgent._sanitize_api_messages() repairs orphaned tool pairs."""
+
+    def test_orphaned_result_removed(self):
+        """A role=tool message whose call_id has no matching assistant entry is dropped."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("c1")]},
+            tool_result("c1"),
+            tool_result("c_ORPHAN"),   # no matching call — must be removed
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert len(out) == 2
+        assert all(m.get("tool_call_id") != "c_ORPHAN" for m in out)
+
+    def test_orphaned_call_gets_stub_result(self):
+        """An assistant tool_call with no matching result gets a synthetic stub appended."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("c2")]},
+            # deliberately no role=tool message
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert len(out) == 2
+        stub = out[1]
+        assert stub["role"] == "tool"
+        assert stub["tool_call_id"] == "c2"
+        assert stub["content"]  # non-empty placeholder
+
+    def test_clean_messages_pass_through_unchanged(self):
+        """A well-formed message list is returned as-is (same object)."""
+        msgs = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "tool_calls": [assistant_dict_call("c3")]},
+            tool_result("c3"),
+            {"role": "assistant", "content": "done"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out == msgs
+
+    def test_mixed_orphaned_result_and_orphaned_call(self):
+        """One orphaned result is removed AND one orphaned call gets a stub."""
+        msgs = [
+            # call c4 has a result — clean pair
+            {"role": "assistant", "tool_calls": [
+                assistant_dict_call("c4"),
+                assistant_dict_call("c5"),   # c5 has NO result → stub needed
+            ]},
+            tool_result("c4"),
+            tool_result("c_DANGLING"),       # no call → must be removed
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+
+        ids = [m.get("tool_call_id") for m in out if m.get("role") == "tool"]
+        assert "c_DANGLING" not in ids,  "orphaned result survived"
+        assert "c4" in ids,              "clean result was removed"
+        assert "c5" in ids,              "stub for orphaned call missing"
+
+    def test_empty_list_is_safe(self):
+        assert AIAgent._sanitize_api_messages([]) == []
+
+    def test_no_tool_messages_at_all(self):
+        """Pure text conversation — nothing to repair."""
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out == msgs
+
+    def test_sdk_object_tool_calls_supported(self):
+        """tool_calls stored as SDK-style objects (with .id attribute) are handled."""
+        tc_obj = types.SimpleNamespace(id="c6", function=types.SimpleNamespace(
+            name="terminal", arguments="{}"
+        ))
+        msgs = [
+            {"role": "assistant", "tool_calls": [tc_obj]},
+            # no result → stub expected
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert len(out) == 2
+        assert out[1]["tool_call_id"] == "c6"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2a — _cap_delegate_task_calls
+# ---------------------------------------------------------------------------
+
+class TestCapDelegateTaskCalls:
+    """AIAgent._cap_delegate_task_calls() truncates excess delegate_task calls."""
+
+    def test_excess_delegates_truncated_to_limit(self):
+        """More than MAX_CONCURRENT_CHILDREN delegate_task calls → truncated."""
+        tcs = [make_tc("delegate_task") for _ in range(MAX_CONCURRENT_CHILDREN + 2)]
+        out = AIAgent._cap_delegate_task_calls(tcs)
+        delegate_count = sum(1 for tc in out if tc.function.name == "delegate_task")
+        assert delegate_count == MAX_CONCURRENT_CHILDREN
+
+    def test_non_delegate_calls_preserved_after_truncation(self):
+        """Non-delegate tool calls survive the cap even when delegates are trimmed."""
+        tcs = (
+            [make_tc("delegate_task") for _ in range(MAX_CONCURRENT_CHILDREN + 1)]
+            + [make_tc("terminal"), make_tc("web_search")]
+        )
+        out = AIAgent._cap_delegate_task_calls(tcs)
+        names = [tc.function.name for tc in out]
+        assert "terminal" in names
+        assert "web_search" in names
+
+    def test_exactly_at_limit_passes_through(self):
+        """Exactly MAX_CONCURRENT_CHILDREN delegate_task calls — no truncation."""
+        tcs = [make_tc("delegate_task") for _ in range(MAX_CONCURRENT_CHILDREN)]
+        out = AIAgent._cap_delegate_task_calls(tcs)
+        assert out is tcs   # same object — not rebuilt
+        assert len(out) == MAX_CONCURRENT_CHILDREN
+
+    def test_below_limit_passes_through(self):
+        """Fewer than MAX_CONCURRENT_CHILDREN — list returned unchanged."""
+        tcs = [make_tc("delegate_task") for _ in range(MAX_CONCURRENT_CHILDREN - 1)]
+        out = AIAgent._cap_delegate_task_calls(tcs)
+        assert out is tcs
+
+    def test_no_delegate_calls_unchanged(self):
+        """No delegate_task calls at all — list returned unchanged."""
+        tcs = [make_tc("terminal"), make_tc("web_search")]
+        out = AIAgent._cap_delegate_task_calls(tcs)
+        assert out is tcs
+
+    def test_empty_list_safe(self):
+        out = AIAgent._cap_delegate_task_calls([])
+        assert out == []
+
+    def test_original_list_not_mutated(self):
+        """The input list must not be modified in place."""
+        tcs = [make_tc("delegate_task") for _ in range(MAX_CONCURRENT_CHILDREN + 2)]
+        original_len = len(tcs)
+        AIAgent._cap_delegate_task_calls(tcs)
+        assert len(tcs) == original_len
+
+
+# ---------------------------------------------------------------------------
+# Phase 2b — _deduplicate_tool_calls
+# ---------------------------------------------------------------------------
+
+class TestDeduplicateToolCalls:
+    """AIAgent._deduplicate_tool_calls() removes identical (name, args) pairs."""
+
+    def test_duplicate_pair_deduplicated(self):
+        """Two identical (tool_name, arguments) entries → only first survives."""
+        tcs = [
+            make_tc("web_search", '{"query":"foo"}'),
+            make_tc("web_search", '{"query":"foo"}'),   # duplicate
+        ]
+        out = AIAgent._deduplicate_tool_calls(tcs)
+        assert len(out) == 1
+        assert out[0].function.name == "web_search"
+
+    def test_multiple_duplicates_across_tools(self):
+        """Duplicates in multiple tool types are all removed."""
+        tcs = [
+            make_tc("web_search", '{"q":"a"}'),
+            make_tc("web_search", '{"q":"a"}'),   # dup
+            make_tc("terminal",   '{"cmd":"ls"}'),
+            make_tc("terminal",   '{"cmd":"ls"}'),  # dup
+            make_tc("terminal",   '{"cmd":"pwd"}'), # different args — keep
+        ]
+        out = AIAgent._deduplicate_tool_calls(tcs)
+        assert len(out) == 3
+
+    def test_same_tool_different_args_not_deduplicated(self):
+        """Same tool name but different arguments — both are kept."""
+        tcs = [
+            make_tc("terminal", '{"cmd":"ls"}'),
+            make_tc("terminal", '{"cmd":"pwd"}'),
+        ]
+        out = AIAgent._deduplicate_tool_calls(tcs)
+        assert out is tcs   # unchanged — same object returned
+
+    def test_different_tools_same_args_not_deduplicated(self):
+        """Same arguments string on different tools — both are kept."""
+        tcs = [
+            make_tc("tool_a", '{"x":1}'),
+            make_tc("tool_b", '{"x":1}'),
+        ]
+        out = AIAgent._deduplicate_tool_calls(tcs)
+        assert out is tcs
+
+    def test_clean_list_returned_unchanged(self):
+        """No duplicates → original list object returned."""
+        tcs = [
+            make_tc("web_search", '{"q":"x"}'),
+            make_tc("terminal",   '{"cmd":"ls"}'),
+        ]
+        out = AIAgent._deduplicate_tool_calls(tcs)
+        assert out is tcs
+
+    def test_single_call_unchanged(self):
+        tcs = [make_tc("terminal")]
+        out = AIAgent._deduplicate_tool_calls(tcs)
+        assert out is tcs
+
+    def test_empty_list_safe(self):
+        out = AIAgent._deduplicate_tool_calls([])
+        assert out == []
+
+    def test_first_occurrence_kept_not_last(self):
+        """When deduplicating, the first instance is preserved."""
+        tc1 = make_tc("terminal", '{"cmd":"ls"}')
+        tc2 = make_tc("terminal", '{"cmd":"ls"}')
+        out = AIAgent._deduplicate_tool_calls([tc1, tc2])
+        assert len(out) == 1
+        assert out[0] is tc1
+
+    def test_original_list_not_mutated(self):
+        """The input list must not be modified in place."""
+        tcs = [
+            make_tc("web_search", '{"q":"dup"}'),
+            make_tc("web_search", '{"q":"dup"}'),
+        ]
+        original_len = len(tcs)
+        AIAgent._deduplicate_tool_calls(tcs)
+        assert len(tcs) == original_len

--- a/tests/test_agent_guardrails.py
+++ b/tests/test_agent_guardrails.py
@@ -8,8 +8,6 @@ Covers three static methods introduced in run_agent.py:
 
 import types
 
-import pytest
-
 from run_agent import AIAgent
 from tools.delegate_tool import MAX_CONCURRENT_CHILDREN
 
@@ -23,15 +21,6 @@ def make_tc(name: str, arguments: str = "{}") -> types.SimpleNamespace:
     tc = types.SimpleNamespace()
     tc.function = types.SimpleNamespace(name=name, arguments=arguments)
     return tc
-
-
-def assistant_msg_with_calls(*tool_calls) -> dict:
-    """Build a dict-style assistant message carrying tool_calls."""
-    return {
-        "role": "assistant",
-        "content": None,
-        "tool_calls": list(tool_calls),
-    }
 
 
 def tool_result(call_id: str, content: str = "ok") -> dict:
@@ -186,24 +175,20 @@ class TestCapDelegateTaskCalls:
 
     def test_interleaved_order_preserved(self):
         """Original ordering of delegate and non-delegate calls is preserved."""
-        d1 = make_tc("delegate_task", '{"task":"a"}')
+        # Build MAX_CONCURRENT_CHILDREN + 1 delegates interleaved with
+        # two non-delegate calls after the first and second delegates.
+        delegates = [make_tc("delegate_task", f'{{"task":"{i}"}}')
+                     for i in range(MAX_CONCURRENT_CHILDREN + 1)]
         t1 = make_tc("terminal", '{"cmd":"ls"}')
-        d2 = make_tc("delegate_task", '{"task":"b"}')
         w1 = make_tc("web_search", '{"q":"x"}')
-        d3 = make_tc("delegate_task", '{"task":"c"}')
-        d4 = make_tc("delegate_task", '{"task":"d"}')  # excess
-        tcs = [d1, t1, d2, w1, d3, d4]
+        # Interleave: d0, terminal, d1, web_search, d2, ..., d_excess
+        tcs = [delegates[0], t1, delegates[1], w1] + delegates[2:]
         out = AIAgent._cap_delegate_task_calls(tcs)
-        names = [tc.function.name for tc in out]
-        # Only first MAX_CONCURRENT_CHILDREN delegates kept, but relative
-        # order with non-delegates must be preserved.
-        assert names == ["delegate_task", "terminal", "delegate_task",
-                         "web_search", "delegate_task"]
-        assert out[0] is d1
-        assert out[1] is t1
-        assert out[2] is d2
-        assert out[3] is w1
-        assert out[4] is d3
+        # The last delegate should be dropped; everything else stays in order.
+        expected = [delegates[0], t1, delegates[1], w1] + delegates[2:MAX_CONCURRENT_CHILDREN]
+        assert len(out) == len(expected)
+        for i, (actual, exp) in enumerate(zip(out, expected)):
+            assert actual is exp, f"mismatch at index {i}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_guardrails.py
+++ b/tests/test_agent_guardrails.py
@@ -184,6 +184,27 @@ class TestCapDelegateTaskCalls:
         AIAgent._cap_delegate_task_calls(tcs)
         assert len(tcs) == original_len
 
+    def test_interleaved_order_preserved(self):
+        """Original ordering of delegate and non-delegate calls is preserved."""
+        d1 = make_tc("delegate_task", '{"task":"a"}')
+        t1 = make_tc("terminal", '{"cmd":"ls"}')
+        d2 = make_tc("delegate_task", '{"task":"b"}')
+        w1 = make_tc("web_search", '{"q":"x"}')
+        d3 = make_tc("delegate_task", '{"task":"c"}')
+        d4 = make_tc("delegate_task", '{"task":"d"}')  # excess
+        tcs = [d1, t1, d2, w1, d3, d4]
+        out = AIAgent._cap_delegate_task_calls(tcs)
+        names = [tc.function.name for tc in out]
+        # Only first MAX_CONCURRENT_CHILDREN delegates kept, but relative
+        # order with non-delegates must be preserved.
+        assert names == ["delegate_task", "terminal", "delegate_task",
+                         "web_search", "delegate_task"]
+        assert out[0] is d1
+        assert out[1] is t1
+        assert out[2] is d2
+        assert out[3] is w1
+        assert out[4] is d3
+
 
 # ---------------------------------------------------------------------------
 # Phase 2b — _deduplicate_tool_calls
@@ -267,3 +288,47 @@ class TestDeduplicateToolCalls:
         original_len = len(tcs)
         AIAgent._deduplicate_tool_calls(tcs)
         assert len(tcs) == original_len
+
+    def test_json_key_order_treated_as_distinct(self):
+        """Different JSON key ordering produces different argument strings.
+
+        Deduplication uses raw string comparison, so semantically equivalent
+        JSON with different key order is intentionally treated as distinct.
+        This test documents that behaviour explicitly.
+        """
+        tcs = [
+            make_tc("web_search", '{"query":"foo","lang":"en"}'),
+            make_tc("web_search", '{"lang":"en","query":"foo"}'),
+        ]
+        out = AIAgent._deduplicate_tool_calls(tcs)
+        assert len(out) == 2
+        assert out is tcs  # no dedup happened — same object returned
+
+
+# ---------------------------------------------------------------------------
+# _get_tool_call_id_static
+# ---------------------------------------------------------------------------
+
+class TestGetToolCallIdStatic:
+    """AIAgent._get_tool_call_id_static() extracts call IDs from dicts and objects."""
+
+    def test_dict_with_valid_id(self):
+        assert AIAgent._get_tool_call_id_static({"id": "call_123"}) == "call_123"
+
+    def test_dict_with_none_id(self):
+        assert AIAgent._get_tool_call_id_static({"id": None}) == ""
+
+    def test_dict_without_id_key(self):
+        assert AIAgent._get_tool_call_id_static({"function": {}}) == ""
+
+    def test_object_with_valid_id(self):
+        tc = types.SimpleNamespace(id="call_456")
+        assert AIAgent._get_tool_call_id_static(tc) == "call_456"
+
+    def test_object_with_none_id(self):
+        tc = types.SimpleNamespace(id=None)
+        assert AIAgent._get_tool_call_id_static(tc) == ""
+
+    def test_object_without_id_attr(self):
+        tc = types.SimpleNamespace()
+        assert AIAgent._get_tool_call_id_static(tc) == ""


### PR DESCRIPTION
Two reliability gaps in the agent loop, both in `run_agent.py`.

## Phase 1 — Pre-call message sanitization

`_sanitize_api_messages()` now runs unconditionally before every LLM 
call. Previously this only happened inside the context compressor, so 
sessions that were interrupted mid-turn, reloaded from disk, or running 
with compression disabled could silently accumulate dangling tool call / 
tool result pairs — causing "No tool call found for call_id" API errors 
that are confusing to diagnose.

The logic mirrors `ContextCompressor._sanitize_tool_pairs()` but lives 
on `AIAgent` as a static method so it runs regardless of whether 
compression is enabled.

## Phase 2 — Post-model-call interception

Two checks run after the model responds but before tool calls are 
dispatched. Both extracted as static methods so they're independently 
testable.

`_cap_delegate_task_calls()` — truncates excess `delegate_task` calls 
to `MAX_CONCURRENT_CHILDREN`. The existing cap in `delegate_tool.py` 
only covers explicit task arrays inside a single call; this covers the 
case where the model emits multiple independent `delegate_task` calls in 
one turn.

`_deduplicate_tool_calls()` — drops duplicate `(tool_name, arguments)` 
pairs within a single turn. Runs after the cap so any edge cases from 
truncation are caught too.

## Tests

`tests/test_agent_guardrails.py` — 23 tests across 3 classes covering 
both happy path and edge cases (empty lists, input mutation checks, SDK 
object vs dict tool call formats).

Phase 3 (formal middleware chain) left out intentionally — happy to 
tackle it in a follow-up if the team wants to go that direction.

Closes #626