### PR TITLE
fix: make config set examples use placeholder syntax

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -821,7 +821,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                         print(f"  ✓ Saved {name}")
                     print()
             else:
-                print("  Set later with: hermes config set KEY VALUE")
+                print("  Set later with: hermes config set <key> <value>")
     
     # Check for missing config fields
     missing_config = get_missing_config_fields()
@@ -1265,7 +1265,7 @@ def show_config():
     print()
     print(color("─" * 60, Colors.DIM))
     print(color("  hermes config edit     # Edit config file", Colors.DIM))
-    print(color("  hermes config set KEY VALUE", Colors.DIM))
+    print(color("  hermes config set <key> <value>", Colors.DIM))
     print(color("  hermes setup           # Run setup wizard", Colors.DIM))
     print()
 
@@ -1391,7 +1391,7 @@ def config_command(args):
         key = getattr(args, 'key', None)
         value = getattr(args, 'value', None)
         if not key or not value:
-            print("Usage: hermes config set KEY VALUE")
+            print("Usage: hermes config set <key> <value>")
             print()
             print("Examples:")
             print("  hermes config set model anthropic/claude-sonnet-4")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1506,7 +1506,7 @@ def config_command(args):
         print("Available commands:")
         print("  hermes config           Show current configuration")
         print("  hermes config edit      Open config in editor")
-        print("  hermes config set K V   Set a config value")
+        print("  hermes config set <key> <value>   Set a config value")
         print("  hermes config check     Check for missing/outdated config")
         print("  hermes config migrate   Update config with new options")
         print("  hermes config path      Show config file path")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -602,7 +602,7 @@ def _print_setup_summary(config: dict, hermes_home):
     print(
         f"   {color('hermes config edit', Colors.GREEN)}    Open config in your editor"
     )
-    print(f"   {color('hermes config set KEY VALUE', Colors.GREEN)}")
+    print(f"   {color('hermes config set <key> <value>', Colors.GREEN)}")
     print(f"                          Set a specific value")
     print()
     print(f"   Or edit the files directly:")

--- a/tests/hermes_cli/test_placeholder_usage.py
+++ b/tests/hermes_cli/test_placeholder_usage.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from hermes_cli.config import config_command
+from hermes_cli.config import config_command, show_config
 from hermes_cli.setup import _print_setup_summary
 
 
@@ -19,6 +19,25 @@ def test_config_set_usage_marks_placeholders(capsys):
     assert exc.value.code == 1
     out = capsys.readouterr().out
     assert "Usage: hermes config set <key> <value>" in out
+
+
+def test_config_unknown_command_help_marks_placeholders(capsys):
+    args = Namespace(config_command="wat")
+
+    with pytest.raises(SystemExit) as exc:
+        config_command(args)
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "hermes config set <key> <value>   Set a config value" in out
+
+
+def test_show_config_marks_placeholders(tmp_path, capsys):
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        show_config()
+
+    out = capsys.readouterr().out
+    assert "hermes config set <key> <value>" in out
 
 
 def test_setup_summary_marks_placeholders(tmp_path, capsys):

--- a/tests/hermes_cli/test_placeholder_usage.py
+++ b/tests/hermes_cli/test_placeholder_usage.py
@@ -1,0 +1,29 @@
+"""Tests for CLI placeholder text in config/setup output."""
+
+import os
+from argparse import Namespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import config_command
+from hermes_cli.setup import _print_setup_summary
+
+
+def test_config_set_usage_marks_placeholders(capsys):
+    args = Namespace(config_command="set", key=None, value=None)
+
+    with pytest.raises(SystemExit) as exc:
+        config_command(args)
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "Usage: hermes config set <key> <value>" in out
+
+
+def test_setup_summary_marks_placeholders(tmp_path, capsys):
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        _print_setup_summary({"tts": {"provider": "edge"}}, tmp_path)
+
+    out = capsys.readouterr().out
+    assert "hermes config set <key> <value>" in out


### PR DESCRIPTION
## Summary
- cherry-pick stablegenius49's placeholder syntax fix from #957 onto current main
- update the remaining config fallback help text to use `<key> <value>` too
- add regression tests for setup summary, config usage, show config output, and fallback help output

## Testing
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/hermes_cli/test_placeholder_usage.py tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_config.py -n0 -q
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/ -n0 -q
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m hermes_cli.main config set
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m hermes_cli.main config show

Closes #926

Credit to @stablegenius49 for the original fix in #957.