### PR TITLE
Normalize resolved path in _is_write_denied using os.path.normpath

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -77,7 +77,7 @@ WRITE_DENIED_PREFIXES = [
 
 def _is_write_denied(path: str) -> bool:
     """Return True if path is on the write deny list."""
-    resolved = os.path.realpath(os.path.expanduser(path))
+    resolved = os.path.normpath(os.path.realpath(os.path.expanduser(str(path))))
     if resolved in WRITE_DENIED_PATHS:
         return True
     for prefix in WRITE_DENIED_PREFIXES:


### PR DESCRIPTION
Adds path normalization in `_is_write_denied` using `os.path.normpath`.

This ensures paths containing segments like `..` or redundant separators
are normalized before comparison against the deny list.

The change improves robustness of the path checks while preserving
existing behavior.

Tests:
- tests/tools/test_write_deny.py pass locally