### PR TITLE
fix(test): isolate codex provider tests from local env

### DIFF
--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -187,7 +187,10 @@ def test_codex_provider_replaces_incompatible_default_model(monkeypatch):
     monkeypatch.delenv("LLM_MODEL", raising=False)
     monkeypatch.delenv("OPENAI_MODEL", raising=False)
     # Ensure local user config does not leak a model into the test
-    monkeypatch.setitem(cli.CLI_CONFIG, "model", {})
+    monkeypatch.setitem(cli.CLI_CONFIG, "model", {
+        "default": "",
+        "base_url": "https://openrouter.ai/api/v1",
+    })
 
     def _runtime_resolve(**kwargs):
         return {

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -186,6 +186,8 @@ def test_codex_provider_replaces_incompatible_default_model(monkeypatch):
 
     monkeypatch.delenv("LLM_MODEL", raising=False)
     monkeypatch.delenv("OPENAI_MODEL", raising=False)
+    # Ensure local user config does not leak a model into the test
+    monkeypatch.setitem(cli.CLI_CONFIG, "model", {})
 
     def _runtime_resolve(**kwargs):
         return {
@@ -240,6 +242,11 @@ def test_codex_provider_uses_config_model(monkeypatch):
 
     monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
     monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    # Prevent live API call from overriding the config model
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.2-codex"],
+    )
 
     shell = cli.HermesCLI(compact=True, max_turns=1)
 


### PR DESCRIPTION
## Summary
- salvage PR #1037 onto current main by cherry-picking the contributor's test-isolation fixes with authorship preserved
- prevent test_codex_provider_uses_config_model from hitting live Codex model discovery when local credentials are present
- clear config-backed model state in the incompatible-default-model Codex test so local user config cannot leak into _model_is_default
- keep the follow-up fixture shape needed to avoid the base_url KeyError on current main

## Test plan
- python -m pytest tests/test_cli_provider_resolution.py -n0 -q
- python -m pytest tests/ -n0 -q

Salvages #1037