### PR TITLE
fix(vision): surface actual error reason instead of generic message

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -354,6 +354,7 @@ async def vision_analyze_tool(
         # Prepare error response
         result = {
             "success": False,
+            "error": error_msg,
             "analysis": analysis,
         }
         


### PR DESCRIPTION
## Summary
- salvage the structured vision error-field fix from #1038 onto current main
- keep the existing failure analysis text, but also return a top-level `error` field so callers can inspect the reason programmatically

## Test plan
- python -m pytest tests/tools/test_vision_tools.py -n0 -q
- python -m pytest tests/ -n0 -q
- python -m hermes_cli.main chat -q "Reply with OK."