### PR TITLE
fix(update): reinstall editable package with extras 

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2088,21 +2088,21 @@ def cmd_update(args):
                     prompt_user=prompt_for_restore,
                 )
         
-        # Reinstall Python dependencies (prefer uv for speed, fall back to pip)
+        # Reinstall Python dependencies.
+        # Require the full extras install to succeed so updates do not silently
+        # skip optional runtime dependencies that the installer normally brings in.
         print("→ Updating Python dependencies...")
         uv_bin = shutil.which("uv")
         if uv_bin:
             subprocess.run(
-                [uv_bin, "pip", "install", "-e", ".", "--quiet"],
+                [uv_bin, "pip", "install", "-e", ".[all]", "--quiet"],
                 cwd=PROJECT_ROOT, check=True,
                 env={**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
             )
         else:
             venv_pip = PROJECT_ROOT / "venv" / ("Scripts" if sys.platform == "win32" else "bin") / "pip"
-            if venv_pip.exists():
-                subprocess.run([str(venv_pip), "install", "-e", ".", "--quiet"], cwd=PROJECT_ROOT, check=True)
-            else:
-                subprocess.run(["pip", "install", "-e", ".", "--quiet"], cwd=PROJECT_ROOT, check=True)
+            pip_cmd = [str(venv_pip)] if venv_pip.exists() else ["pip"]
+            subprocess.run(pip_cmd + ["install", "-e", ".[all]", "--quiet"], cwd=PROJECT_ROOT, check=True)
         
         # Check for Node.js deps
         if (PROJECT_ROOT / "package.json").exists():

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from hermes_cli import config as hermes_config
 from hermes_cli import main as hermes_main
 
 
@@ -147,3 +148,45 @@ def test_stash_local_changes_if_needed_raises_when_stash_ref_missing(monkeypatch
 
     with pytest.raises(CalledProcessError):
         hermes_main._stash_local_changes_if_needed(["git"], Path(tmp_path))
+
+
+def test_cmd_update_requires_full_extras_install_to_succeed(monkeypatch, tmp_path):
+    (tmp_path / ".git").mkdir()
+    recorded_commands = []
+
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(hermes_main, "_restore_stashed_changes", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(hermes_config, "get_missing_env_vars", lambda required_only=True: [])
+    monkeypatch.setattr(hermes_config, "get_missing_config_fields", lambda: [])
+    monkeypatch.setattr(hermes_config, "check_config_version", lambda: (5, 5))
+    monkeypatch.setattr(hermes_config, "migrate_config", lambda **_kwargs: {"env_added": [], "config_added": []})
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    def fake_run(cmd, **kwargs):
+        recorded_commands.append((cmd, kwargs))
+        if cmd == ["git", "fetch", "origin"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+        if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
+            return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
+        if cmd == ["git", "pull", "origin", "main"]:
+            return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
+        if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[all]", "--quiet"]:
+            raise CalledProcessError(returncode=1, cmd=cmd)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    install_calls = [cmd for cmd, _kwargs in recorded_commands if cmd[:4] == ["/usr/bin/uv", "pip", "install", "-e"]]
+    assert install_calls == [["/usr/bin/uv", "pip", "install", "-e", ".[all]", "--quiet"]]
+
+    extras_call = next(kwargs for cmd, kwargs in recorded_commands if cmd == install_calls[0])
+    expected_env = {**hermes_main.os.environ, "VIRTUAL_ENV": str(tmp_path / "venv")}
+    assert extras_call["cwd"] == tmp_path
+    assert extras_call["check"] is True
+    assert extras_call["env"] == expected_env


### PR DESCRIPTION
## What does this PR do?

Modifies `hermes update` to use `.[all]` to include extras when updating dependencies, to fix cases where extras are added later in development. Currently `.[all]` is used by install, but not by the `update` command.



## Related Issue

Fixes #1336 

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

As above, use `.[all]` for complete dependency updates. The LLM made a few formatting changes that you can nit at, I glomarize them.

## How to Test

Before the discord voice update: install version, then update after voice. voice channel connect fails because of missing deps in venv. (PyNaCl, davey)

## Checklist

idk

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

