### PR TITLE
fix(honcho): correct `seed_ai_identity` to use `session.add_messages()`

### DIFF
--- a/honcho_integration/session.py
+++ b/honcho_integration/session.py
@@ -927,6 +927,11 @@ class HonchoSessionManager:
             return False
 
         assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
+        honcho_session = self._sessions_cache.get(session.honcho_session_id)
+        if not honcho_session:
+            logger.warning("No Honcho session cached for '%s', skipping AI seed", session_key)
+            return False
+
         try:
             wrapped = (
                 f"<ai_identity_seed>\n"
@@ -935,7 +940,7 @@ class HonchoSessionManager:
                 f"{content.strip()}\n"
                 f"</ai_identity_seed>"
             )
-            assistant_peer.add_message("assistant", wrapped)
+            honcho_session.add_messages([assistant_peer.message(wrapped)])
             logger.info("Seeded AI identity from '%s' into %s", source, session_key)
             return True
         except Exception as e:


### PR DESCRIPTION
## What

Fixes `hermes honcho identity <file>` which currently crashes with `'Peer' object has no attribute 'add_message'`.

## Why

The `seed_ai_identity` method in `honcho_integration/session.py` calls a non-existent `add_message()` on an Honcho SDK `Peer` object. The Honcho `Peer` class exposes `.message(content)` to create message objects, but actual message persistence goes through `session.add_messages([...])`.

This pattern is already correctly used in the same file at line 294 for regular message sync — the identity seeding code just missed it.

## Changes

- `seed_ai_identity()`: replaced `assistant_peer.add_message("assistant", wrapped)` with `honcho_session.add_messages([assistant_peer.message(wrapped)])`
- Added guard for missing Honcho session cache (consistent with existing patterns in the file)

## Testing

Before: `hermes honcho identity ~/.hermes/SOUL.md` → error
After: `hermes honcho identity ~/.hermes/SOUL.md` → successfully seeds AI peer identity

## Related

Closes #1349

---

*Fix discovered and implemented by Yuqi (Hermes Agent) — Angello Picasso's AI companion, working autonomously in a terminal session.*
