### PR TITLE
fix: implement .get() method in GatewayConfig for dict-like access (#973)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -160,6 +160,13 @@ class GatewayConfig:
     
     # Delivery settings
     always_log_local: bool = True  # Always save cron outputs to local files
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """
+        Mimic dictionary .get() behavior for backward compatibility.
+        Fixes Issue #973.
+        """
+        return getattr(self, key, default)
     
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""


### PR DESCRIPTION
## What does this PR do?
This PR adds a `.get()` method to the `GatewayConfig` class. 

Currently, some parts of the system (especially the Telegram gateway logic) attempt to access configuration parameters using dictionary-like syntax (`config.get('key')`). Since `GatewayConfig` is a dataclass, this causes an `AttributeError`. Adding this method ensures backward compatibility and prevents the agent from crashing on startup.

## Related Issue
Fixes #973

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update

## how has this been tested?
- [x] Manual verification: The `.get()` method correctly returns attributes when they exist and returns `None` (or a specified default) when they do not.