### PR TITLE
fix(#878): verify crontab binary existence in requirements check

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -369,9 +369,13 @@ def check_cronjob_requirements() -> bool:
     """
     Check if cronjob tools can be used.
 
+    Requires 'crontab' executable to be present in the system PATH.
     Available in interactive CLI mode and gateway/messaging platforms.
-    Cronjobs are server-side scheduled tasks so they work from any interface.
     """
+    # Fix for issue #878: ensure crontab binary is actually available
+    if not shutil.which("crontab"):
+        return False
+
     return bool(
         os.getenv("HERMES_INTERACTIVE")
         or os.getenv("HERMES_GATEWAY_SESSION")


### PR DESCRIPTION
## What does this PR do?
This PR fixes a false-positive diagnostic issue in hermes doctor where cronjob tools were reported as available even if the crontab binary was missing from the system.

I have updated check_cronjob_requirements in tools/cronjob_tools.py to use shutil.which("crontab"). This ensures that the agent correctly identifies whether the system is actually capable of running cron jobs before marking the tool as available.

## Related Issue
Fixes #878

## Type of Change
[x] Bug fix (non-breaking change which fixes an issue)

[ ] New feature (non-breaking change which adds functionality)

[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
