### PR TITLE
fix(#1002): expand environment blocklist to cover all major LLM providers

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -56,6 +56,17 @@ def _build_provider_env_blocklist() -> frozenset:
         "ANTHROPIC_TOKEN",         # OAuth token (not in registry as env var)
         "CLAUDE_CODE_OAUTH_TOKEN",
         "LLM_MODEL",
+        # Expanded isolation for other major providers (Issue #1002)
+        "GOOGLE_API_KEY",          # Gemini / Google AI Studio
+        "DEEPSEEK_API_KEY",        # DeepSeek
+        "MISTRAL_API_KEY",         # Mistral AI
+        "GROQ_API_KEY",            # Groq
+        "TOGETHER_API_KEY",        # Together AI
+        "PERPLEXITY_API_KEY",      # Perplexity
+        "COHERE_API_KEY",          # Cohere
+        "FIREWORKS_API_KEY",       # Fireworks AI
+        "XAI_API_KEY",             # xAI (Grok)
+        "HELICONE_API_KEY",        # LLM Observability proxy
     })
     return frozenset(blocked)
 


### PR DESCRIPTION
## What does this PR do?
This PR completes the environment isolation for terminal subprocesses initiated by Hermes. 

While some variables were already blocked, this update expands the `_HERMES_PROVIDER_ENV_BLOCKLIST` to include other major providers (Google, DeepSeek, Mistral, Groq, etc.). This ensures that external CLI tools (like `deepseek-cli` or custom scripts) do not get misrouted by Hermes-internal configurations stored in `~/.hermes/.env`.

## Related Issue
Fixes #1002 (Full coverage)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (expanding existing isolation logic)