### PR TITLE
fix: escape parens and braces in fork bomb regex pattern

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -413,3 +413,20 @@ class TestViewFullCommand:
         # After first 'v', is_truncated becomes False, so second 'v' -> deny
         assert result == "deny"
 
+
+class TestForkBombDetection:
+    """The fork bomb regex must match the classic :(){ :|:& };: pattern."""
+
+    def test_classic_fork_bomb(self):
+        dangerous, key, desc = detect_dangerous_command(":(){ :|:& };:")
+        assert dangerous is True, "classic fork bomb not detected"
+        assert "fork bomb" in desc.lower()
+
+    def test_fork_bomb_with_spaces(self):
+        dangerous, key, desc = detect_dangerous_command(":()  {  : | :&  } ; :")
+        assert dangerous is True, "fork bomb with extra spaces not detected"
+
+    def test_colon_in_safe_command_not_flagged(self):
+        dangerous, key, desc = detect_dangerous_command("echo hello:world")
+        assert dangerous is False
+

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -38,7 +38,7 @@ DANGEROUS_PATTERNS = [
     (r'\bsystemctl\s+(stop|disable|mask)\b', "stop/disable system service"),
     (r'\bkill\s+-9\s+-1\b', "kill all processes"),
     (r'\bpkill\s+-9\b', "force kill processes"),
-    (r':()\s*{\s*:\s*\|\s*:&\s*}\s*;:', "fork bomb"),
+    (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
     (r'\b(bash|sh|zsh)\s+-c\s+', "shell command via -c flag"),
     (r'\b(python[23]?|perl|ruby|node)\s+-[ec]\s+', "script execution via -e/-c flag"),
     (r'\b(curl|wget)\b.*\|\s*(ba)?sh\b', "pipe remote content to shell"),


### PR DESCRIPTION
## Summary
- cherry-pick PR #1078's fork-bomb regex fix onto current main with authorship preserved
- add the contributor's targeted regression tests for the classic `:(){ :|:& };:` form, a whitespace variant, and a safe colon-containing command

## Contributor credit
Salvages PR #1078 by cherry-picking the contributor commit onto current main with authorship preserved.

## Test plan
- `python -m pytest tests/tools/test_approval.py -n0 -q`

## Notes
- I also attempted the full suite locally. It hit an unrelated existing failure in `tests/test_api_key_providers.py::TestResolveProvider::test_auto_detects_minimax_cn_key`, outside the touched files for this PR.