### PR TITLE
test: protect atomic temp cleanup on interrupts

### DIFF
--- a/tests/test_atomic_json_write.py
+++ b/tests/test_atomic_json_write.py
@@ -68,6 +68,22 @@ class TestAtomicJsonWrite:
         tmp_files = [f for f in tmp_path.iterdir() if ".tmp" in f.name]
         assert len(tmp_files) == 0
 
+    def test_cleans_up_temp_file_on_baseexception(self, tmp_path):
+        class SimulatedAbort(BaseException):
+            pass
+
+        target = tmp_path / "data.json"
+        original = {"preserved": True}
+        target.write_text(json.dumps(original), encoding="utf-8")
+
+        with patch("utils.json.dump", side_effect=SimulatedAbort):
+            with pytest.raises(SimulatedAbort):
+                atomic_json_write(target, {"new": True})
+
+        tmp_files = [f for f in tmp_path.iterdir() if ".tmp" in f.name]
+        assert len(tmp_files) == 0
+        assert json.loads(target.read_text(encoding="utf-8")) == original
+
     def test_accepts_string_path(self, tmp_path):
         target = str(tmp_path / "string_path.json")
         atomic_json_write(target, {"string": True})

--- a/tests/test_atomic_yaml_write.py
+++ b/tests/test_atomic_yaml_write.py
@@ -1,0 +1,44 @@
+"""Tests for utils.atomic_yaml_write — crash-safe YAML file writes."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from utils import atomic_yaml_write
+
+
+class TestAtomicYamlWrite:
+    def test_writes_valid_yaml(self, tmp_path):
+        target = tmp_path / "data.yaml"
+        data = {"key": "value", "nested": {"a": 1}}
+
+        atomic_yaml_write(target, data)
+
+        assert yaml.safe_load(target.read_text(encoding="utf-8")) == data
+
+    def test_cleans_up_temp_file_on_baseexception(self, tmp_path):
+        class SimulatedAbort(BaseException):
+            pass
+
+        target = tmp_path / "data.yaml"
+        original = {"preserved": True}
+        target.write_text(yaml.safe_dump(original), encoding="utf-8")
+
+        with patch("utils.yaml.dump", side_effect=SimulatedAbort):
+            with pytest.raises(SimulatedAbort):
+                atomic_yaml_write(target, {"new": True})
+
+        tmp_files = [f for f in tmp_path.iterdir() if ".tmp" in f.name]
+        assert len(tmp_files) == 0
+        assert yaml.safe_load(target.read_text(encoding="utf-8")) == original
+
+    def test_appends_extra_content(self, tmp_path):
+        target = tmp_path / "data.yaml"
+
+        atomic_yaml_write(target, {"key": "value"}, extra_content="\n# comment\n")
+
+        text = target.read_text(encoding="utf-8")
+        assert "key: value" in text
+        assert "# comment" in text

--- a/utils.py
+++ b/utils.py
@@ -50,6 +50,8 @@ def atomic_json_write(
             os.fsync(f.fileno())
         os.replace(tmp_path, path)
     except BaseException:
+        # Intentionally catch BaseException so temp-file cleanup still runs for
+        # KeyboardInterrupt/SystemExit before re-raising the original signal.
         try:
             os.unlink(tmp_path)
         except OSError:
@@ -96,6 +98,8 @@ def atomic_yaml_write(
             os.fsync(f.fileno())
         os.replace(tmp_path, path)
     except BaseException:
+        # Match atomic_json_write: cleanup must also happen for process-level
+        # interruptions before we re-raise them.
         try:
             os.unlink(tmp_path)
         except OSError:


### PR DESCRIPTION
## Summary
- add regression coverage proving `atomic_json_write()` cleans up temp files and preserves the original file when a `BaseException` interrupts the write
- add dedicated `atomic_yaml_write()` tests for normal writes, appended extra content, and interrupt cleanup
- document in `utils.py` why `except BaseException` is intentional in these atomic helpers

## Why
PR #1017 proposed changing `except BaseException` to `except Exception` in `atomic_json_write()`. That would skip temp-file cleanup on `KeyboardInterrupt` / `SystemExit`. This follow-up locks in the current desired behavior with tests and clarifying comments instead of changing the exception policy.

## Test plan
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m py_compile utils.py tests/test_atomic_json_write.py tests/test_atomic_yaml_write.py
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/test_atomic_json_write.py tests/test_atomic_yaml_write.py -n0 -q
- source /home/teknium/.hermes/hermes-agent/.venv/bin/activate && python -m pytest tests/ -n0 -q

Note: the local full-suite run hit one unrelated env-sensitive failure in `tests/test_api_key_providers.py::TestResolveProvider::test_auto_detects_minimax_cn_key` because local auto-detect resolves to an already-configured provider before the MiniMax env var. This follow-up does not touch that area.