### PR TITLE
fix: preserve thread context for cronjob 'deliver: origin'

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3469,10 +3469,12 @@ class GatewayRunner:
         os.environ["HERMES_SESSION_CHAT_ID"] = context.source.chat_id
         if context.source.chat_name:
             os.environ["HERMES_SESSION_CHAT_NAME"] = context.source.chat_name
+        if context.source.thread_id:
+            os.environ["HERMES_SESSION_THREAD_ID"] = str(context.source.thread_id)
     
     def _clear_session_env(self) -> None:
         """Clear session environment variables."""
-        for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME"]:
+        for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME", "HERMES_SESSION_THREAD_ID"]:
             if var in os.environ:
                 del os.environ[var]
     

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -72,6 +72,7 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             "platform": origin_platform,
             "chat_id": origin_chat_id,
             "chat_name": os.getenv("HERMES_SESSION_CHAT_NAME"),
+            "thread_id": os.getenv("HERMES_SESSION_THREAD_ID"),
         }
     return None
 


### PR DESCRIPTION
## Summary

Fixes #1219

When creating a cronjob with `deliver: origin` from within a Telegram or Slack thread, the job now delivers to the original thread instead of the parent channel.

## Root Cause

The gateway wasn't setting `HERMES_SESSION_THREAD_ID` in the environment, so cronjobs couldn't capture thread context even though the scheduler already supports it via the `thread_id` field in origin metadata.

## Changes

| File | Change |
|------|--------|
| `gateway/run.py` | Set `HERMES_SESSION_THREAD_ID` in `_set_session_env()` when `context.source.thread_id` is present |
| `gateway/run.py` | Include `HERMES_SESSION_THREAD_ID` in `_clear_session_env()` |
| `tools/cronjob_tools.py` | Capture `thread_id` from environment in `_origin_from_env()` |

## Testing

- Verified fix works for one-shot cronjobs
- Verified fix works for recurring cronjobs  
- Both auto-delete and permanent jobs preserve thread context

## Impact

All users who want recurring automated messages to stay within threads (Telegram/Slack) will now have proper thread context preservation. Critical for:
- Thread-specific reminders
- Contextual follow-ups
- Organized group conversations

---

*This is a 4-line change with minimal risk.*