### PR TITLE
feat: eager fallback to backup model on rate-limit errors

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4865,6 +4865,13 @@ class AIAgent:
                         # This is often rate limiting or provider returning malformed response
                         retry_count += 1
                         
+                        # Eager fallback: empty/malformed responses are a common
+                        # rate-limit symptom.  Switch to fallback immediately
+                        # rather than retrying with extended backoff.
+                        if not self._fallback_activated and self._try_activate_fallback():
+                            retry_count = 0
+                            continue
+
                         # Check for error field in response (some providers include this)
                         error_msg = "Unknown"
                         provider_name = "Unknown"
@@ -5178,6 +5185,24 @@ class AIAgent:
                     # A 413 is a payload-size error — the correct response is to
                     # compress history and retry, not abort immediately.
                     status_code = getattr(api_error, "status_code", None)
+
+                    # Eager fallback for rate-limit errors (429 or quota exhaustion).
+                    # When a fallback model is configured, switch immediately instead
+                    # of burning through retries with exponential backoff -- the
+                    # primary provider won't recover within the retry window.
+                    is_rate_limited = (
+                        status_code == 429
+                        or "rate limit" in error_msg
+                        or "too many requests" in error_msg
+                        or "rate_limit" in error_msg
+                        or "usage limit" in error_msg
+                        or "quota" in error_msg
+                    )
+                    if is_rate_limited and not self._fallback_activated:
+                        if self._try_activate_fallback():
+                            retry_count = 0
+                            continue
+
                     is_payload_too_large = (
                         status_code == 413
                         or 'request entity too large' in error_msg


### PR DESCRIPTION
## Summary

When a fallback model is configured via `fallback_model` in config.yaml, the agent now switches to it **immediately** upon detecting rate-limit conditions instead of exhausting all retries with exponential backoff.

**Problem:** When the primary provider is rate-limited (429, quota exhaustion, billing cycle limit), the current retry loop burns through 3 attempts with extended backoff (5s → 10s → 20s) before trying the fallback. The primary provider is unlikely to recover within this window, so the delay is wasted.

**Fix:** Two eager-fallback checks are added:

1. **Invalid/empty API responses** (common rate-limit symptom where the provider returns a response with no choices or missing content) — fallback is attempted immediately after the first failure.

2. **Exception-based rate limits** (HTTP 429, quota exhaustion, usage limit, billing errors) — a new `is_rate_limited` check runs before the existing 413/4xx handlers and switches immediately.

Both paths are guarded by `_fallback_activated` to preserve the existing one-shot semantics.

## Test plan

- [ ] Configure a primary model with a rate-limited/exhausted API key and a working fallback model
- [ ] Send a message — verify the agent switches to fallback on the first failure instead of retrying 3 times
- [ ] Verify non-rate-limit errors (auth failures, invalid model, etc.) still follow existing retry/abort behavior
- [ ] Verify fallback only activates once per session (one-shot guard)