### PR TITLE
fix: ⚕ → ☤ (give Hermes his own staff back)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/banner.png" alt="Hermes Agent" width="100%">
 </p>
 
-# Hermes Agent ⚕
+# Hermes Agent ☤
 
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>


### PR DESCRIPTION
The project header uses ⚕ where it should use ☤

⚕ — this is the Rod of Asclepius. Single snake, no wings, god of medicine.

☤ — this is the Caduceus. Twin snakes, winged staff, actual attribute of Hermes.

Usually the mixup is in reverse: Medicine borrowing Hermes' “cooler” symbol. 
This is the rare reverse case: Hermes got handed the pharmacist's stick.