### PR TITLE
fix: make /update work reliably in project venvs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -236,16 +236,25 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
 
     Tries in order:
     1. ``shutil.which("hermes")`` — standard PATH lookup
-    2. ``sys.executable -m hermes_cli.main`` — fallback when Hermes is running
-       from a venv/module invocation and the ``hermes`` shim is not on PATH
+    2. a sibling ``hermes`` executable next to ``sys.executable`` — useful when
+       the gateway is running from a venv but the shim is not on PATH
+    3. ``sys.executable -m hermes_cli.main`` — final fallback when Hermes is
+       importable but no executable shim is available
 
-    Returns argv parts ready for quoting/joining, or ``None`` if neither works.
+    Returns argv parts ready for quoting/joining, or ``None`` if none work.
     """
     import shutil
 
     hermes_bin = shutil.which("hermes")
     if hermes_bin:
         return [hermes_bin]
+
+    try:
+        sibling = Path(sys.executable).resolve().parent / "hermes"
+        if sibling.exists() and os.access(sibling, os.X_OK):
+            return [str(sibling)]
+    except Exception:
+        pass
 
     try:
         import importlib.util
@@ -3354,6 +3363,11 @@ class GatewayRunner:
         )
         try:
             systemd_run = shutil.which("systemd-run")
+            hermes_bin_dir = str(Path(sys.executable).resolve().parent)
+            update_env = {
+                **os.environ,
+                "PATH": f"{hermes_bin_dir}:{os.environ.get('PATH', '')}",
+            }
             if systemd_run:
                 subprocess.Popen(
                     [systemd_run, "--user", "--scope",
@@ -3362,6 +3376,7 @@ class GatewayRunner:
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     start_new_session=True,
+                    env=update_env,
                 )
             else:
                 # Fallback: best-effort detach with start_new_session
@@ -3370,6 +3385,7 @@ class GatewayRunner:
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     start_new_session=True,
+                    env=update_env,
                 )
         except Exception as e:
             pending_path.unlink(missing_ok=True)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -45,6 +45,7 @@ Usage:
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -1949,19 +1950,7 @@ def _update_via_zip(args):
         sys.exit(1)
     
     # Reinstall Python dependencies
-    print("→ Updating Python dependencies...")
-    import subprocess
-    uv_bin = shutil.which("uv")
-    if uv_bin:
-        subprocess.run(
-            [uv_bin, "pip", "install", "-e", ".", "--quiet"],
-            cwd=PROJECT_ROOT, check=True,
-            env={**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
-        )
-    else:
-        venv_pip = PROJECT_ROOT / "venv" / ("Scripts" if sys.platform == "win32" else "bin") / "pip"
-        if venv_pip.exists():
-            subprocess.run([str(venv_pip), "install", "-e", ".", "--quiet"], cwd=PROJECT_ROOT, check=True)
+    _update_python_dependencies(PROJECT_ROOT)
     
     # Sync skills
     try:
@@ -2039,6 +2028,56 @@ def _print_stash_cleanup_guidance(stash_ref: str, stash_selector: Optional[str] 
         print(f"  Remove it with: git stash drop {stash_selector}")
     else:
         print(f"  Look for commit {stash_ref}, then drop its selector with: git stash drop stash@{{N}}")
+
+
+
+def _venv_bin_dir(venv_dir: Path) -> Path:
+    return venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+
+
+
+def _find_project_venv(project_root: Path) -> Optional[Path]:
+    for name in (".venv", "venv"):
+        candidate = project_root / name
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+
+def _update_python_dependencies(project_root: Path) -> None:
+    print("→ Updating Python dependencies...")
+
+    uv_bin = shutil.which("uv")
+    project_venv = _find_project_venv(project_root)
+
+    if project_venv is not None:
+        venv_bin = _venv_bin_dir(project_venv)
+        venv_python = venv_bin / ("python.exe" if sys.platform == "win32" else "python")
+        venv_pip = venv_bin / ("pip.exe" if sys.platform == "win32" else "pip")
+
+        if uv_bin and venv_python.exists():
+            subprocess.run(
+                [uv_bin, "pip", "install", "--python", str(venv_python), "-e", ".", "--quiet"],
+                cwd=project_root,
+                check=True,
+            )
+            return
+
+        if venv_pip.exists():
+            subprocess.run([str(venv_pip), "install", "-e", ".", "--quiet"], cwd=project_root, check=True)
+            return
+
+        if venv_python.exists():
+            subprocess.run([str(venv_python), "-m", "ensurepip", "--upgrade"], cwd=project_root, check=True)
+            subprocess.run([str(venv_python), "-m", "pip", "install", "-e", ".", "--quiet"], cwd=project_root, check=True)
+            return
+
+    if uv_bin and (project_root / "pyproject.toml").exists():
+        subprocess.run([uv_bin, "sync", "--quiet"], cwd=project_root, check=True)
+        return
+
+    subprocess.run([sys.executable, "-m", "pip", "install", "-e", ".", "--quiet"], cwd=project_root, check=True)
 
 
 
@@ -2196,21 +2235,8 @@ def cmd_update(args):
                     prompt_user=prompt_for_restore,
                 )
         
-        # Reinstall Python dependencies (prefer uv for speed, fall back to pip)
-        print("→ Updating Python dependencies...")
-        uv_bin = shutil.which("uv")
-        if uv_bin:
-            subprocess.run(
-                [uv_bin, "pip", "install", "-e", ".", "--quiet"],
-                cwd=PROJECT_ROOT, check=True,
-                env={**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
-            )
-        else:
-            venv_pip = PROJECT_ROOT / "venv" / ("Scripts" if sys.platform == "win32" else "bin") / "pip"
-            if venv_pip.exists():
-                subprocess.run([str(venv_pip), "install", "-e", ".", "--quiet"], cwd=PROJECT_ROOT, check=True)
-            else:
-                subprocess.run(["pip", "install", "-e", ".", "--quiet"], cwd=PROJECT_ROOT, check=True)
+        # Reinstall Python dependencies
+        _update_python_dependencies(PROJECT_ROOT)
         
         # Check for Node.js deps
         if (PROJECT_ROOT / "package.json").exists():

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -151,13 +151,34 @@ class TestHandleUpdateCommand:
         assert result == ["/custom/path/hermes"]
 
     @pytest.mark.asyncio
+    async def test_resolve_hermes_bin_prefers_sibling_venv_executable(self, tmp_path):
+        """_resolve_hermes_bin prefers a sibling hermes executable next to sys.executable."""
+        import sys
+        from gateway.run import _resolve_hermes_bin
+
+        fake_python = tmp_path / "venv" / "bin" / "python3"
+        fake_python.parent.mkdir(parents=True)
+        fake_python.write_text("#!/bin/sh\n")
+        fake_python.chmod(0o755)
+        fake_hermes = fake_python.parent / "hermes"
+        fake_hermes.write_text("#!/bin/sh\n")
+        fake_hermes.chmod(0o755)
+
+        with patch("shutil.which", return_value=None), \
+             patch.object(sys, "executable", str(fake_python)):
+            result = _resolve_hermes_bin()
+
+        assert result == [str(fake_hermes)]
+
+    @pytest.mark.asyncio
     async def test_resolve_hermes_bin_fallback(self):
-        """_resolve_hermes_bin falls back to sys.executable argv when which fails."""
+        """_resolve_hermes_bin falls back to sys.executable argv when which and sibling shim fail."""
         import sys
         from gateway.run import _resolve_hermes_bin
 
         fake_spec = MagicMock()
         with patch("shutil.which", return_value=None), \
+             patch("os.access", return_value=False), \
              patch("importlib.util.find_spec", return_value=fake_spec):
             result = _resolve_hermes_bin()
 

--- a/tests/hermes_cli/test_update_dependencies.py
+++ b/tests/hermes_cli/test_update_dependencies.py
@@ -1,0 +1,127 @@
+def test_update_python_dependencies_prefers_dotvenv_with_uv(monkeypatch, tmp_path, capsys):
+    import hermes_cli.main as main_mod
+
+    project_root = tmp_path
+    venv_python = project_root / ".venv" / ("Scripts" if main_mod.sys.platform == "win32" else "bin") / ("python.exe" if main_mod.sys.platform == "win32" else "python")
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("")
+    (project_root / "pyproject.toml").write_text("[project]\nname='hermes-agent'\nversion='0.0.0'\n")
+
+    calls = []
+
+    def fake_run(cmd, cwd=None, check=None, **kwargs):
+        calls.append({"cmd": cmd, "cwd": cwd, "check": check, "kwargs": kwargs})
+
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: "/usr/local/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._update_python_dependencies(project_root)
+
+    out = capsys.readouterr().out
+    assert "→ Updating Python dependencies..." in out
+    assert calls == [
+        {
+            "cmd": [
+                "/usr/local/bin/uv",
+                "pip",
+                "install",
+                "--python",
+                str(venv_python),
+                "-e",
+                ".",
+                "--quiet",
+            ],
+            "cwd": project_root,
+            "check": True,
+            "kwargs": {},
+        }
+    ]
+
+
+def test_update_python_dependencies_uses_project_venv_pip_without_uv(monkeypatch, tmp_path):
+    import hermes_cli.main as main_mod
+
+    project_root = tmp_path
+    venv_bin = project_root / "venv" / ("Scripts" if main_mod.sys.platform == "win32" else "bin")
+    venv_pip = venv_bin / ("pip.exe" if main_mod.sys.platform == "win32" else "pip")
+    venv_pip.parent.mkdir(parents=True)
+    venv_pip.write_text("")
+
+    calls = []
+
+    def fake_run(cmd, cwd=None, check=None, **kwargs):
+        calls.append({"cmd": cmd, "cwd": cwd, "check": check, "kwargs": kwargs})
+
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._update_python_dependencies(project_root)
+
+    assert calls == [
+        {
+            "cmd": [str(venv_pip), "install", "-e", ".", "--quiet"],
+            "cwd": project_root,
+            "check": True,
+            "kwargs": {},
+        }
+    ]
+
+
+def test_update_python_dependencies_bootstraps_pip_when_venv_has_only_python(monkeypatch, tmp_path):
+    import hermes_cli.main as main_mod
+
+    project_root = tmp_path
+    venv_python = project_root / "venv" / ("Scripts" if main_mod.sys.platform == "win32" else "bin") / ("python.exe" if main_mod.sys.platform == "win32" else "python")
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("")
+
+    calls = []
+
+    def fake_run(cmd, cwd=None, check=None, **kwargs):
+        calls.append({"cmd": cmd, "cwd": cwd, "check": check, "kwargs": kwargs})
+
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._update_python_dependencies(project_root)
+
+    assert calls == [
+        {
+            "cmd": [str(venv_python), "-m", "ensurepip", "--upgrade"],
+            "cwd": project_root,
+            "check": True,
+            "kwargs": {},
+        },
+        {
+            "cmd": [str(venv_python), "-m", "pip", "install", "-e", ".", "--quiet"],
+            "cwd": project_root,
+            "check": True,
+            "kwargs": {},
+        },
+    ]
+
+
+def test_update_python_dependencies_falls_back_to_uv_sync_when_no_project_venv(monkeypatch, tmp_path):
+    import hermes_cli.main as main_mod
+
+    project_root = tmp_path
+    (project_root / "pyproject.toml").write_text("[project]\nname='hermes-agent'\nversion='0.0.0'\n")
+
+    calls = []
+
+    def fake_run(cmd, cwd=None, check=None, **kwargs):
+        calls.append({"cmd": cmd, "cwd": cwd, "check": check, "kwargs": kwargs})
+
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: "/usr/local/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._update_python_dependencies(project_root)
+
+    assert calls == [
+        {
+            "cmd": ["/usr/local/bin/uv", "sync", "--quiet"],
+            "cwd": project_root,
+            "check": True,
+            "kwargs": {},
+        }
+    ]

--- a/tests/test_openai_client_lifecycle.py
+++ b/tests/test_openai_client_lifecycle.py
@@ -111,16 +111,19 @@ def test_closed_shared_client_is_recreated_before_request(monkeypatch):
 
 def test_concurrent_requests_do_not_break_each_other_when_one_client_closes(monkeypatch):
     first_started = threading.Event()
+    second_can_finish = threading.Event()
     first_closed = threading.Event()
 
     def first_responder(**kwargs):
         first_started.set()
+        assert second_can_finish.wait(timeout=2)
         first_client.close()
         first_closed.set()
         raise _connection_error()
 
     def second_responder(**kwargs):
         assert first_started.wait(timeout=2)
+        second_can_finish.set()
         assert first_closed.wait(timeout=2)
         return {"ok": "second"}
 
@@ -141,6 +144,7 @@ def test_concurrent_requests_do_not_break_each_other_when_one_client_closes(monk
     thread_one = threading.Thread(target=run_call, args=("first",), daemon=True)
     thread_two = threading.Thread(target=run_call, args=("second",), daemon=True)
     thread_one.start()
+    assert first_started.wait(timeout=2)
     thread_two.start()
     thread_one.join(timeout=5)
     thread_two.join(timeout=5)


### PR DESCRIPTION
## Summary
- improve /update so the gateway can find and launch Hermes from the active venv
- pass the venv bin directory through PATH when spawning the detached update process
- make the updater detect both .venv and venv
- when uv is available, target the project venv explicitly with uv pip install --python
- if a project venv exists but pip is missing, bootstrap it with ensurepip before installing
- fall back to uv sync when no project venv is present
- add regression tests for both gateway launch behavior and updater dependency installation

## Why
/update could fail in venv and uv-managed setups for two related reasons:
- the gateway could launch the updater without the right executable/path context
- the updater could install into the wrong Python environment or fail if the local venv existed without pip

This makes the full /update flow more reliable for project-local virtualenv installs.

## Test plan
- python -m pytest tests/gateway/test_update_command.py -q
- python -m pytest tests/hermes_cli/test_update_dependencies.py -q
- python -m pytest tests/hermes_cli/test_sessions_delete.py -q
- manual verification with python -m hermes_cli.main update