### PR TITLE
fix(gateway): avoid recursive ExecStop in user systemd unit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -350,8 +350,6 @@ def get_hermes_cli_path() -> str:
 # =============================================================================
 
 def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
-    import shutil
-
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
     venv_dir = str(PROJECT_ROOT / "venv")
@@ -360,7 +358,6 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
 
     # Build a PATH that includes the venv, node_modules, and standard system dirs
     sane_path = f"{venv_bin}:{node_bin}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-    hermes_cli = shutil.which("hermes") or f"{python_path} -m hermes_cli.main"
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
@@ -399,7 +396,6 @@ After=network.target
 [Service]
 Type=simple
 ExecStart={python_path} -m hermes_cli.main gateway run --replace
-ExecStop={hermes_cli} gateway stop
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
@@ -407,7 +403,7 @@ Restart=on-failure
 RestartSec=10
 KillMode=mixed
 KillSignal=SIGTERM
-TimeoutStopSec=15
+TimeoutStopSec=60
 StandardOutput=journal
 StandardError=journal
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -53,6 +53,15 @@ class TestSystemdServiceRefresh:
         ]
 
 
+class TestGeneratedSystemdUnits:
+    def test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "ExecStart=" in unit
+        assert "ExecStop=" not in unit
+        assert "TimeoutStopSec=60" in unit
+
+
 class TestGatewayStopCleanup:
     def test_stop_sweeps_manual_gateway_processes_after_service_stop(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"


### PR DESCRIPTION
## Summary
- remove `ExecStop=hermes gateway stop` from the generated user systemd unit
- keep `TimeoutStopSec=60` for the user unit so the gateway has time to shut down cleanly
- add a regression test covering the generated user unit

## Why
The user systemd unit currently generates an `ExecStop` command that calls `hermes gateway stop`, which in turn calls `systemctl --user stop hermes-gateway` on the same unit. That makes stop/restart behavior self-referential and can lead to timeout-prone shutdowns.

This change keeps shutdown under systemd's normal signal handling for the user unit instead of recursively re-entering service stop logic.

## Test Plan
- `python -m pytest tests/hermes_cli/test_gateway_service.py -q`
- `python -m pytest tests/gateway/ -q`