### PR TITLE
fix: recognize Claude Code OAuth credentials in startup gate

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -144,6 +144,18 @@ def _has_any_provider_configured() -> bool:
         except Exception:
             pass
 
+
+    # Check for Claude Code OAuth credentials (~/.claude/.credentials.json)
+    # These are used by resolve_anthropic_token() at runtime but were missing
+    # from this startup gate check.
+    try:
+        from agent.anthropic_adapter import read_claude_code_credentials, is_claude_code_token_valid
+        creds = read_claude_code_credentials()
+        if creds and (is_claude_code_token_valid(creds) or creds.get("refreshToken")):
+            return True
+    except Exception:
+        pass
+
     return False
 
 


### PR DESCRIPTION
## Problem

When using Claude Code OAuth as the sole authentication method (no `ANTHROPIC_TOKEN` or `ANTHROPIC_API_KEY` env vars), running `hermes` shows:

```
It looks like Hermes isn't configured yet -- no API keys or providers found.
Run:  hermes setup
```

This happens even though `resolve_anthropic_token()` successfully uses `~/.claude/.credentials.json` at runtime.

## Root Cause

`_has_any_provider_configured()` in `main.py` checks:
1. Provider env vars (ANTHROPIC_TOKEN, ANTHROPIC_API_KEY, etc.)
2. `.env` file for those keys
3. `auth.json` active provider

It never checks Claude Code OAuth credentials (`~/.claude/.credentials.json`), which is source #3 in `resolve_anthropic_token()`'s priority chain.

## Fix

Add a fallback check for Claude Code credentials at the end of `_has_any_provider_configured()`. If a valid token or refresh token is present, the provider is considered configured.

This is relevant for users who:
- Authenticate via `claude login` (Max/Pro subscription)
- Intentionally removed hardcoded API keys from `.env` to use OAuth auto-refresh
- Run `hermes` without any `ANTHROPIC_*` env vars set