### PR TITLE
feat(agent): expand Execution Integrity Layer for post-tool verification

### DIFF
--- a/agent/execution_verifier.py
+++ b/agent/execution_verifier.py
@@ -9,7 +9,7 @@ continues reasoning.
 Supported verifications (MVP):
   - terminal / git clone  → target directory exists
   - write_file            → file exists and size is non-zero
-  - patch                 → modified files exist and contain expected changes
+  - patch                 → modified/created files still exist after the tool claims success
 
 The verifier is deliberately conservative: it only fires for operations it
 understands and attaches a structured ``_verification`` block to the tool
@@ -212,7 +212,7 @@ def _verify_write_file(args: Dict[str, Any], result_data: Dict[str, Any]) -> Opt
                     status=WARNING,
                     tool_name="write_file",
                     check="file_written",
-                    message=f"file was written but is empty: {resolved}",
+                    message=f"file exists but is empty; result may be incomplete or intentional: {resolved}",
                     details=details,
                 )
         except OSError:

--- a/agent/execution_verifier.py
+++ b/agent/execution_verifier.py
@@ -8,7 +8,7 @@ continues reasoning.
 
 Supported verifications (MVP):
   - terminal / git clone  → target directory exists
-  - write_file            → file exists and size is non-zero
+  - write_file            → file exists; empty files are flagged as warnings
   - patch                 → modified/created files still exist after the tool claims success
 
 The verifier is deliberately conservative: it only fires for operations it
@@ -228,7 +228,7 @@ def _verify_write_file(args: Dict[str, Any], result_data: Dict[str, Any]) -> Opt
 
 
 def _verify_patch(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optional[VerificationResult]:
-    """Verify patch: modified files still exist and patch claims success."""
+    """Verify patch: modified/created files still exist after the tool claims success."""
     if not result_data.get("success"):
         return None
 

--- a/agent/execution_verifier.py
+++ b/agent/execution_verifier.py
@@ -191,7 +191,7 @@ def _verify_terminal(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optio
 
 
 def _verify_write_file(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optional[VerificationResult]:
-    """Verify write_file: target file exists and has non-zero size."""
+    """Verify write_file: target file exists; empty files are flagged as warnings."""
     if result_data.get("error"):
         return None
 

--- a/agent/execution_verifier.py
+++ b/agent/execution_verifier.py
@@ -13,8 +13,14 @@ Supported verifications (MVP):
 
 The verifier is deliberately conservative: it only fires for operations it
 understands and attaches a structured ``_verification`` block to the tool
-result JSON.  On mismatch it sets ``verified: false`` with a human-readable
-``message`` that the model can use to decide whether to retry or replan.
+result JSON.  Status is one of:
+
+  - ``"verified"``  — world state matches expectations
+  - ``"warning"``   — result may be incomplete (e.g. empty file)
+  - ``"mismatch"``  — environment state contradicts tool output
+
+On warning or mismatch a top-level ``_warning`` string is injected so the
+model cannot ignore the signal.
 
 Integration point:
   model_tools.handle_function_call() calls ``verify_tool_result()`` after
@@ -37,10 +43,16 @@ logger = logging.getLogger(__name__)
 # Verification result
 # ---------------------------------------------------------------------------
 
+# Valid status values for VerificationResult.status
+VERIFIED = "verified"
+WARNING = "warning"
+MISMATCH = "mismatch"
+
+
 @dataclass
 class VerificationResult:
     """Structured outcome of a post-tool verification check."""
-    verified: bool
+    status: str  # "verified", "warning", or "mismatch"
     tool_name: str
     check: str  # short label, e.g. "dir_exists", "file_written"
     message: str = ""
@@ -48,7 +60,7 @@ class VerificationResult:
 
     def to_dict(self) -> dict:
         d: dict = {
-            "verified": self.verified,
+            "status": self.status,
             "tool": self.tool_name,
             "check": self.check,
         }
@@ -155,10 +167,10 @@ def _verify_terminal(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optio
 
         exists = os.path.isdir(target)
         return VerificationResult(
-            verified=exists,
+            status=VERIFIED if exists else MISMATCH,
             tool_name="terminal",
             check="git_clone_dir_exists",
-            message="" if exists else f"VERIFICATION FAILED: git clone target directory does not exist: {target}",
+            message="" if exists else f"git clone target directory does not exist: {target}",
             details={"expected_dir": target, "exists": exists},
         )
 
@@ -168,10 +180,10 @@ def _verify_terminal(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optio
         target = _resolve_path(m2.group(1))
         exists = os.path.isdir(target)
         return VerificationResult(
-            verified=exists,
+            status=VERIFIED if exists else MISMATCH,
             tool_name="terminal",
             check="mkdir_dir_exists",
-            message="" if exists else f"VERIFICATION FAILED: mkdir target does not exist: {target}",
+            message="" if exists else f"mkdir target does not exist: {target}",
             details={"expected_dir": target, "exists": exists},
         )
 
@@ -197,20 +209,20 @@ def _verify_write_file(args: Dict[str, Any], result_data: Dict[str, Any]) -> Opt
             details["size_bytes"] = size
             if size == 0:
                 return VerificationResult(
-                    verified=False,
+                    status=WARNING,
                     tool_name="write_file",
                     check="file_written",
-                    message=f"VERIFICATION WARNING: file was written but is empty: {resolved}",
+                    message=f"file was written but is empty: {resolved}",
                     details=details,
                 )
         except OSError:
             pass
 
     return VerificationResult(
-        verified=exists,
+        status=VERIFIED if exists else MISMATCH,
         tool_name="write_file",
         check="file_written",
-        message="" if exists else f"VERIFICATION FAILED: written file does not exist: {resolved}",
+        message="" if exists else f"written file does not exist: {resolved}",
         details=details,
     )
 
@@ -236,16 +248,16 @@ def _verify_patch(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optional
         if not os.path.exists(resolved):
             missing.append(resolved)
 
-    verified = len(missing) == 0 and len(all_files) > 0
+    ok = len(missing) == 0 and len(all_files) > 0
     details: Dict[str, Any] = {"files_checked": [_resolve_path(f) for f in all_files]}
     if missing:
         details["missing"] = missing
 
     return VerificationResult(
-        verified=verified,
+        status=VERIFIED if ok else MISMATCH,
         tool_name="patch",
         check="patched_files_exist",
-        message="" if verified else f"VERIFICATION FAILED: patched file(s) missing: {', '.join(missing)}",
+        message="" if ok else f"patched file(s) missing: {', '.join(missing)}",
         details=details,
     )
 
@@ -308,11 +320,17 @@ def verify_tool_result(
 
     result_data["_verification"] = vr.to_dict()
 
-    if not vr.verified:
-        logger.warning("Execution verification FAILED for %s: %s", tool_name, vr.message)
+    if vr.status == WARNING:
+        logger.warning("Execution verification WARNING for %s: %s", tool_name, vr.message)
         result_data["_warning"] = (
-            "\u26a0\ufe0f VERIFICATION FAILED: Do not assume this step succeeded. "
+            "\u26a0\ufe0f VERIFICATION WARNING: Result may be incomplete. "
             "Re-check environment before proceeding."
+        )
+    elif vr.status == MISMATCH:
+        logger.warning("Execution verification MISMATCH for %s: %s", tool_name, vr.message)
+        result_data["_warning"] = (
+            "\u274c VERIFICATION FAILED: Tool result conflicts with environment state. "
+            "Do not assume this step succeeded. Re-check or retry."
         )
 
     return json.dumps(result_data, ensure_ascii=False)

--- a/agent/execution_verifier.py
+++ b/agent/execution_verifier.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Execution Integrity Layer — post-tool-call verification.
+
+After critical tool calls complete, this module independently verifies
+that the expected world-state change actually occurred before the agent
+continues reasoning.
+
+Supported verifications (MVP):
+  - terminal / git clone  → target directory exists
+  - write_file            → file exists and size is non-zero
+  - patch                 → modified files exist and contain expected changes
+
+The verifier is deliberately conservative: it only fires for operations it
+understands and attaches a structured ``_verification`` block to the tool
+result JSON.  On mismatch it sets ``verified: false`` with a human-readable
+``message`` that the model can use to decide whether to retry or replan.
+
+Integration point:
+  model_tools.handle_function_call() calls ``verify_tool_result()`` after
+  registry.dispatch() returns.  The cost is one to a few stat/read syscalls
+  per tool call — negligible relative to an LLM round-trip.
+"""
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Verification result
+# ---------------------------------------------------------------------------
+
+@dataclass
+class VerificationResult:
+    """Structured outcome of a post-tool verification check."""
+    verified: bool
+    tool_name: str
+    check: str  # short label, e.g. "dir_exists", "file_written"
+    message: str = ""
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        d: dict = {
+            "verified": self.verified,
+            "tool": self.tool_name,
+            "check": self.check,
+        }
+        if self.message:
+            d["message"] = self.message
+        if self.details:
+            d["details"] = self.details
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Per-tool verification strategies
+# ---------------------------------------------------------------------------
+
+# Regex for mkdir
+_MKDIR_RE = re.compile(r"\bmkdir\s+(?:-p\s+)?(\S+)", re.IGNORECASE)
+
+
+def _resolve_path(raw: str) -> str:
+    """Expand ~ and resolve to absolute."""
+    return str(Path(os.path.expanduser(raw)).resolve())
+
+
+# git clone flags that consume the next token as their value
+_GIT_CLONE_VALUE_FLAGS = {
+    "-b", "--branch", "--depth", "--jobs", "-j", "--reference",
+    "--reference-if-able", "--origin", "-o", "--upload-pack", "-u",
+    "--template", "--config", "-c", "--separate-git-dir", "--filter",
+    "--server-option", "--bundle-uri",
+}
+
+
+def _parse_git_clone_positionals(command: str) -> Optional[List[str]]:
+    """Extract positional args (repo URL, optional dir) from a git clone command.
+
+    Returns None if the command is not a git clone, otherwise a list of
+    1 or 2 positional arguments.
+    """
+    # Quick check before tokenizing
+    if "git" not in command.lower() or "clone" not in command.lower():
+        return None
+
+    import shlex
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+
+    # Find "git clone" subsequence
+    try:
+        git_idx = next(i for i, t in enumerate(tokens) if t.lower() == "git")
+    except StopIteration:
+        return None
+    remaining = tokens[git_idx + 1:]
+    if not remaining or remaining[0].lower() != "clone":
+        return None
+    remaining = remaining[1:]  # skip "clone"
+
+    positionals: List[str] = []
+    i = 0
+    while i < len(remaining):
+        tok = remaining[i]
+        if tok.startswith("-"):
+            if tok in _GIT_CLONE_VALUE_FLAGS:
+                i += 2  # skip flag + its value
+            elif "=" in tok:
+                i += 1  # --flag=value
+            else:
+                i += 1  # boolean flag like --bare, --recurse-submodules
+        else:
+            positionals.append(tok)
+            i += 1
+
+    return positionals if positionals else None
+
+
+def _verify_terminal(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optional[VerificationResult]:
+    """Verify terminal tool outcomes.
+
+    Currently checks:
+    - git clone  → target directory exists
+    - mkdir      → directory exists
+    """
+    command = args.get("command", "")
+    exit_code = result_data.get("exit_code", -1)
+
+    # Only verify commands that claim success
+    if exit_code != 0:
+        return None
+
+    # --- git clone ---
+    positionals = _parse_git_clone_positionals(command)
+    if positionals:
+        repo_url = positionals[0]
+        if len(positionals) >= 2:
+            target = _resolve_path(positionals[1])
+        else:
+            # Infer dir name from repo URL
+            repo_name = repo_url.rstrip("/").rsplit("/", 1)[-1]
+            if repo_name.endswith(".git"):
+                repo_name = repo_name[:-4]
+            workdir = args.get("workdir") or "."
+            target = _resolve_path(os.path.join(workdir, repo_name))
+
+        exists = os.path.isdir(target)
+        return VerificationResult(
+            verified=exists,
+            tool_name="terminal",
+            check="git_clone_dir_exists",
+            message="" if exists else f"VERIFICATION FAILED: git clone target directory does not exist: {target}",
+            details={"expected_dir": target, "exists": exists},
+        )
+
+    # --- mkdir ---
+    m2 = _MKDIR_RE.search(command)
+    if m2:
+        target = _resolve_path(m2.group(1))
+        exists = os.path.isdir(target)
+        return VerificationResult(
+            verified=exists,
+            tool_name="terminal",
+            check="mkdir_dir_exists",
+            message="" if exists else f"VERIFICATION FAILED: mkdir target does not exist: {target}",
+            details={"expected_dir": target, "exists": exists},
+        )
+
+    return None
+
+
+def _verify_write_file(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optional[VerificationResult]:
+    """Verify write_file: target file exists and has non-zero size."""
+    if result_data.get("error"):
+        return None
+
+    path = args.get("path", "")
+    if not path:
+        return None
+
+    resolved = _resolve_path(path)
+    exists = os.path.isfile(resolved)
+
+    details: Dict[str, Any] = {"expected_path": resolved, "exists": exists}
+    if exists:
+        try:
+            size = os.path.getsize(resolved)
+            details["size_bytes"] = size
+            if size == 0:
+                return VerificationResult(
+                    verified=False,
+                    tool_name="write_file",
+                    check="file_written",
+                    message=f"VERIFICATION WARNING: file was written but is empty: {resolved}",
+                    details=details,
+                )
+        except OSError:
+            pass
+
+    return VerificationResult(
+        verified=exists,
+        tool_name="write_file",
+        check="file_written",
+        message="" if exists else f"VERIFICATION FAILED: written file does not exist: {resolved}",
+        details=details,
+    )
+
+
+def _verify_patch(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optional[VerificationResult]:
+    """Verify patch: modified files still exist and patch claims success."""
+    if not result_data.get("success"):
+        return None
+
+    files_modified = result_data.get("files_modified", [])
+    files_created = result_data.get("files_created", [])
+    all_files = files_modified + files_created
+
+    if not all_files:
+        # replace mode — check path arg
+        path = args.get("path", "")
+        if path:
+            all_files = [path]
+
+    missing: List[str] = []
+    for f in all_files:
+        resolved = _resolve_path(f)
+        if not os.path.exists(resolved):
+            missing.append(resolved)
+
+    verified = len(missing) == 0 and len(all_files) > 0
+    details: Dict[str, Any] = {"files_checked": [_resolve_path(f) for f in all_files]}
+    if missing:
+        details["missing"] = missing
+
+    return VerificationResult(
+        verified=verified,
+        tool_name="patch",
+        check="patched_files_exist",
+        message="" if verified else f"VERIFICATION FAILED: patched file(s) missing: {', '.join(missing)}",
+        details=details,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table
+# ---------------------------------------------------------------------------
+
+_VERIFIERS = {
+    "terminal": _verify_terminal,
+    "write_file": _verify_write_file,
+    "patch": _verify_patch,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def verify_tool_result(
+    tool_name: str,
+    tool_args: Dict[str, Any],
+    result_json: str,
+) -> str:
+    """Run post-call verification and attach ``_verification`` to the result.
+
+    Parameters
+    ----------
+    tool_name : str
+        Registered tool name (e.g. ``"terminal"``, ``"write_file"``).
+    tool_args : dict
+        The arguments originally passed to the tool handler.
+    result_json : str
+        The JSON string returned by ``registry.dispatch()``.
+
+    Returns
+    -------
+    str
+        The (possibly augmented) JSON string. If no verifier fires or the
+        result is not parseable JSON, the original string is returned
+        unchanged.
+    """
+    verifier = _VERIFIERS.get(tool_name)
+    if verifier is None:
+        return result_json
+
+    try:
+        result_data = json.loads(result_json)
+    except (json.JSONDecodeError, TypeError):
+        return result_json
+
+    try:
+        vr = verifier(tool_args, result_data)
+    except Exception:
+        logger.debug("Verification for %s raised; skipping", tool_name, exc_info=True)
+        return result_json
+
+    if vr is None:
+        return result_json
+
+    result_data["_verification"] = vr.to_dict()
+
+    if not vr.verified:
+        logger.warning("Execution verification FAILED for %s: %s", tool_name, vr.message)
+        result_data["_warning"] = (
+            "\u26a0\ufe0f VERIFICATION FAILED: Do not assume this step succeeded. "
+            "Re-check environment before proceeding."
+        )
+
+    return json.dumps(result_data, ensure_ascii=False)

--- a/agent/execution_verifier.py
+++ b/agent/execution_verifier.py
@@ -6,17 +6,26 @@ After critical tool calls complete, this module independently verifies
 that the expected world-state change actually occurred before the agent
 continues reasoning.
 
-Supported verifications (MVP):
-  - terminal / git clone  → target directory exists
-  - write_file            → file exists; empty files are flagged as warnings
-  - patch                 → modified/created files still exist after the tool claims success
+Supported verifications:
+  - terminal / git clone   -> target directory exists
+  - terminal / git init    -> .git directory exists
+  - terminal / mkdir       -> directory exists
+  - terminal / cp          -> destination exists
+  - terminal / mv          -> destination exists
+  - terminal / rm          -> targets no longer exist
+  - terminal / touch       -> file exists
+  - write_file             -> file exists; empty files flagged only when content was non-empty
+  - patch                  -> modified/created files still exist
+  - read_file              -> content returned; error with similar_files -> warning
+  - browser_navigate       -> success field; bot detection -> warning
+  - web_extract            -> results non-empty; per-URL errors -> warning/mismatch
 
 The verifier is deliberately conservative: it only fires for operations it
 understands and attaches a structured ``_verification`` block to the tool
 result JSON.  Status is one of:
 
   - ``"verified"``  — world state matches expectations
-  - ``"warning"``   — result may be incomplete (e.g. empty file)
+  - ``"warning"``   — result may be incomplete (e.g. partial extraction)
   - ``"mismatch"``  — environment state contradicts tool output
 
 On warning or mismatch a top-level ``_warning`` string is injected so the
@@ -32,6 +41,7 @@ import json
 import logging
 import os
 import re
+import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -72,17 +82,91 @@ class VerificationResult:
 
 
 # ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_path(raw: str) -> str:
+    """Expand ~ and resolve to absolute."""
+    return str(Path(os.path.expanduser(raw)).resolve())
+
+
+def _extract_simple_command(command: str, cmd_name: str) -> Optional[str]:
+    """Extract the segment of a compound command that contains *cmd_name*.
+
+    Splits on ``&&``, ``||``, ``;``, and ``|`` and returns the first segment
+    that contains the given command name as a whole word.  Returns ``None`` if
+    no segment matches.
+    """
+    segments = re.split(r'\s*(?:&&|\|\||[;|])\s*', command)
+    for seg in segments:
+        if re.search(rf'\b{re.escape(cmd_name)}\b', seg):
+            return seg.strip()
+    return None
+
+
+def _parse_positionals(
+    segment: str,
+    cmd_name: str,
+    value_flags: Optional[set] = None,
+) -> Optional[List[str]]:
+    """Extract positional arguments from a simple command.
+
+    Tokenises *segment* with ``shlex.split``, locates *cmd_name*, then walks
+    the remaining tokens skipping flags (``-…``) and their values.
+
+    Parameters
+    ----------
+    segment : str
+        A single shell command (no ``&&`` / ``||`` / ``;`` / ``|``).
+    cmd_name : str
+        The command to locate (e.g. ``"cp"``, ``"mv"``).
+    value_flags : set, optional
+        Flags that consume the next token as their value (e.g. ``{"-t"}``).
+
+    Returns
+    -------
+    list[str] | None
+        The positional arguments, or ``None`` if *cmd_name* was not found.
+    """
+    try:
+        tokens = shlex.split(segment)
+    except ValueError:
+        tokens = segment.split()
+
+    try:
+        cmd_idx = next(i for i, t in enumerate(tokens) if t == cmd_name)
+    except StopIteration:
+        return None
+
+    remaining = tokens[cmd_idx + 1:]
+    value_flags = value_flags or set()
+    positionals: List[str] = []
+    i = 0
+    while i < len(remaining):
+        tok = remaining[i]
+        if tok.startswith("-"):
+            if tok in value_flags:
+                i += 2  # skip flag + its value
+            elif "=" in tok:
+                i += 1  # --flag=value
+            else:
+                i += 1  # boolean flag
+        else:
+            positionals.append(tok)
+            i += 1
+
+    return positionals if positionals else None
+
+
+# ---------------------------------------------------------------------------
 # Per-tool verification strategies
 # ---------------------------------------------------------------------------
 
 # Regex for mkdir
 _MKDIR_RE = re.compile(r"\bmkdir\s+(?:-p\s+)?(\S+)", re.IGNORECASE)
 
-
-def _resolve_path(raw: str) -> str:
-    """Expand ~ and resolve to absolute."""
-    return str(Path(os.path.expanduser(raw)).resolve())
-
+# Regex for git init (optional target dir)
+_GIT_INIT_RE = re.compile(r"\bgit\s+init\b(?:\s+(\S+))?", re.IGNORECASE)
 
 # git clone flags that consume the next token as their value
 _GIT_CLONE_VALUE_FLAGS = {
@@ -91,6 +175,9 @@ _GIT_CLONE_VALUE_FLAGS = {
     "--template", "--config", "-c", "--separate-git-dir", "--filter",
     "--server-option", "--bundle-uri",
 }
+
+# touch flags that consume the next token as their value
+_TOUCH_VALUE_FLAGS = {"-t", "-r", "-d", "--date", "--reference"}
 
 
 def _parse_git_clone_positionals(command: str) -> Optional[List[str]]:
@@ -103,7 +190,6 @@ def _parse_git_clone_positionals(command: str) -> Optional[List[str]]:
     if "git" not in command.lower() or "clone" not in command.lower():
         return None
 
-    import shlex
     try:
         tokens = shlex.split(command)
     except ValueError:
@@ -140,9 +226,14 @@ def _parse_git_clone_positionals(command: str) -> Optional[List[str]]:
 def _verify_terminal(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optional[VerificationResult]:
     """Verify terminal tool outcomes.
 
-    Currently checks:
-    - git clone  → target directory exists
-    - mkdir      → directory exists
+    Checks:
+    - git clone  -> target directory exists
+    - git init   -> .git directory exists
+    - mkdir      -> directory exists
+    - cp         -> destination exists
+    - mv         -> destination exists
+    - rm         -> targets no longer exist
+    - touch      -> file exists
     """
     command = args.get("command", "")
     exit_code = result_data.get("exit_code", -1)
@@ -174,6 +265,24 @@ def _verify_terminal(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optio
             details={"expected_dir": target, "exists": exists},
         )
 
+    # --- git init ---
+    m_init = _GIT_INIT_RE.search(command)
+    if m_init:
+        # Skip bare repos — they don't have a .git subdirectory
+        if "--bare" in command:
+            return None
+        target_dir = m_init.group(1) if m_init.group(1) else (args.get("workdir") or ".")
+        resolved = _resolve_path(target_dir)
+        git_dir = os.path.join(resolved, ".git")
+        exists = os.path.isdir(git_dir)
+        return VerificationResult(
+            status=VERIFIED if exists else MISMATCH,
+            tool_name="terminal",
+            check="git_init_dir_exists",
+            message="" if exists else f"git init: .git directory does not exist in {resolved}",
+            details={"expected_dir": resolved, "git_dir_exists": exists},
+        )
+
     # --- mkdir ---
     m2 = _MKDIR_RE.search(command)
     if m2:
@@ -187,11 +296,92 @@ def _verify_terminal(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optio
             details={"expected_dir": target, "exists": exists},
         )
 
+    # --- cp ---
+    seg = _extract_simple_command(command, "cp")
+    if seg is not None:
+        positionals = _parse_positionals(seg, "cp")
+        if positionals and len(positionals) >= 2:
+            dest = _resolve_path(positionals[-1])
+            exists = os.path.exists(dest)
+            return VerificationResult(
+                status=VERIFIED if exists else MISMATCH,
+                tool_name="terminal",
+                check="cp_dest_exists",
+                message="" if exists else f"cp destination does not exist: {dest}",
+                details={"expected_path": dest, "exists": exists},
+            )
+
+    # --- mv ---
+    seg = _extract_simple_command(command, "mv")
+    if seg is not None:
+        positionals = _parse_positionals(seg, "mv")
+        if positionals and len(positionals) >= 2:
+            dest = _resolve_path(positionals[-1])
+            exists = os.path.exists(dest)
+            return VerificationResult(
+                status=VERIFIED if exists else MISMATCH,
+                tool_name="terminal",
+                check="mv_dest_exists",
+                message="" if exists else f"mv destination does not exist: {dest}",
+                details={"expected_path": dest, "exists": exists},
+            )
+
+    # --- rm ---
+    seg = _extract_simple_command(command, "rm")
+    if seg is not None:
+        positionals = _parse_positionals(seg, "rm")
+        if positionals:
+            # Skip if any target uses glob patterns — too unreliable
+            if any(c in t for t in positionals for c in ("*", "?", "[")):
+                return None
+            still_exist: List[str] = []
+            resolved_targets: List[str] = []
+            for t in positionals:
+                resolved = _resolve_path(t)
+                resolved_targets.append(resolved)
+                if os.path.exists(resolved):
+                    still_exist.append(resolved)
+            ok = len(still_exist) == 0
+            details: Dict[str, Any] = {"targets": resolved_targets}
+            if still_exist:
+                details["still_exist"] = still_exist
+            return VerificationResult(
+                status=VERIFIED if ok else MISMATCH,
+                tool_name="terminal",
+                check="rm_targets_removed",
+                message="" if ok else f"rm target(s) still exist: {', '.join(still_exist)}",
+                details=details,
+            )
+
+    # --- touch ---
+    seg = _extract_simple_command(command, "touch")
+    if seg is not None:
+        positionals = _parse_positionals(seg, "touch", value_flags=_TOUCH_VALUE_FLAGS)
+        if positionals:
+            missing: List[str] = []
+            resolved_targets = []
+            for t in positionals:
+                resolved = _resolve_path(t)
+                resolved_targets.append(resolved)
+                if not os.path.exists(resolved):
+                    missing.append(resolved)
+            ok = len(missing) == 0
+            details = {"expected_paths": resolved_targets}
+            if missing:
+                details["missing"] = missing
+            return VerificationResult(
+                status=VERIFIED if ok else MISMATCH,
+                tool_name="terminal",
+                check="touch_file_exists",
+                message="" if ok else f"touch target(s) do not exist: {', '.join(missing)}",
+                details=details,
+            )
+
     return None
 
 
 def _verify_write_file(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optional[VerificationResult]:
-    """Verify write_file: target file exists; empty files are flagged as warnings."""
+    """Verify write_file: target file exists; empty files flagged only when content was non-empty."""
     if result_data.get("error"):
         return None
 
@@ -208,13 +398,17 @@ def _verify_write_file(args: Dict[str, Any], result_data: Dict[str, Any]) -> Opt
             size = os.path.getsize(resolved)
             details["size_bytes"] = size
             if size == 0:
-                return VerificationResult(
-                    status=WARNING,
-                    tool_name="write_file",
-                    check="file_written",
-                    message=f"file exists but is empty; result may be incomplete or intentional: {resolved}",
-                    details=details,
-                )
+                intended_content = args.get("content", "")
+                if intended_content:
+                    # Non-empty content was expected but file is empty
+                    return VerificationResult(
+                        status=WARNING,
+                        tool_name="write_file",
+                        check="file_written",
+                        message=f"file exists but is empty despite non-empty content arg: {resolved}",
+                        details=details,
+                    )
+                # Content was intentionally empty — fall through to VERIFIED
         except OSError:
             pass
 
@@ -262,6 +456,147 @@ def _verify_patch(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optional
     )
 
 
+def _verify_read_file(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optional[VerificationResult]:
+    """Verify read_file: check that content was returned without error."""
+    error = result_data.get("error")
+    if error:
+        similar = result_data.get("similar_files", [])
+        details: Dict[str, Any] = {"error": error}
+        if similar:
+            details["similar_files"] = similar
+            return VerificationResult(
+                status=WARNING,
+                tool_name="read_file",
+                check="file_read",
+                message=f"read_file error: {error}; similar files available",
+                details=details,
+            )
+        return VerificationResult(
+            status=MISMATCH,
+            tool_name="read_file",
+            check="file_read",
+            message=f"read_file error with no alternatives: {error}",
+            details=details,
+        )
+
+    # Success case: content present
+    content = result_data.get("content", "")
+    if content:
+        return VerificationResult(
+            status=VERIFIED,
+            tool_name="read_file",
+            check="file_read",
+            message="",
+            details={
+                "file_size": result_data.get("file_size", 0),
+                "truncated": result_data.get("truncated", False),
+            },
+        )
+
+    # No error but also no content — genuinely empty file is valid, no opinion
+    return None
+
+
+def _verify_browser_navigate(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optional[VerificationResult]:
+    """Verify browser_navigate: check success and bot detection."""
+    success = result_data.get("success")
+
+    if success is None:
+        return None  # no success field — can't verify
+
+    if not success:
+        return VerificationResult(
+            status=MISMATCH,
+            tool_name="browser_navigate",
+            check="navigation_success",
+            message=f"Navigation failed: {result_data.get('error', 'unknown error')}",
+            details={"url": args.get("url", ""), "error": result_data.get("error")},
+        )
+
+    # Success but check for bot detection
+    if result_data.get("bot_detection_warning"):
+        return VerificationResult(
+            status=WARNING,
+            tool_name="browser_navigate",
+            check="navigation_success",
+            message="Navigation succeeded but bot detection was triggered",
+            details={
+                "url": result_data.get("url", args.get("url", "")),
+                "title": result_data.get("title", ""),
+                "bot_detection": True,
+            },
+        )
+
+    return VerificationResult(
+        status=VERIFIED,
+        tool_name="browser_navigate",
+        check="navigation_success",
+        message="",
+        details={
+            "url": result_data.get("url", args.get("url", "")),
+            "title": result_data.get("title", ""),
+        },
+    )
+
+
+def _verify_web_extract(args: Dict[str, Any], result_data: Dict[str, Any]) -> Optional[VerificationResult]:
+    """Verify web_extract: check that results contain content."""
+    # Handle top-level error
+    if result_data.get("error"):
+        return VerificationResult(
+            status=MISMATCH,
+            tool_name="web_extract",
+            check="extraction_results",
+            message=f"web_extract failed: {result_data.get('error')}",
+            details={"error": result_data.get("error")},
+        )
+
+    results = result_data.get("results", [])
+    if not results:
+        return VerificationResult(
+            status=MISMATCH,
+            tool_name="web_extract",
+            check="extraction_results",
+            message="web_extract returned no results",
+            details={"result_count": 0},
+        )
+
+    # Count successes and failures per URL
+    succeeded: List[str] = []
+    failed: List[str] = []
+    for r in results:
+        if r.get("error") or not r.get("content"):
+            failed.append(r.get("url", "unknown"))
+        else:
+            succeeded.append(r.get("url", "unknown"))
+
+    if not succeeded:
+        return VerificationResult(
+            status=MISMATCH,
+            tool_name="web_extract",
+            check="extraction_results",
+            message=f"All {len(failed)} URL(s) failed to extract content",
+            details={"failed_urls": failed, "succeeded": 0, "failed": len(failed)},
+        )
+
+    if failed:
+        return VerificationResult(
+            status=WARNING,
+            tool_name="web_extract",
+            check="extraction_results",
+            message=f"{len(failed)} of {len(results)} URL(s) failed to extract",
+            details={"failed_urls": failed, "succeeded": len(succeeded), "failed": len(failed)},
+        )
+
+    return VerificationResult(
+        status=VERIFIED,
+        tool_name="web_extract",
+        check="extraction_results",
+        message="",
+        details={"succeeded": len(succeeded), "urls": succeeded},
+    )
+
+
 # ---------------------------------------------------------------------------
 # Dispatch table
 # ---------------------------------------------------------------------------
@@ -270,6 +605,9 @@ _VERIFIERS = {
     "terminal": _verify_terminal,
     "write_file": _verify_write_file,
     "patch": _verify_patch,
+    "read_file": _verify_read_file,
+    "browser_navigate": _verify_browser_navigate,
+    "web_extract": _verify_web_extract,
 }
 
 

--- a/demo_execution_verifier.py
+++ b/demo_execution_verifier.py
@@ -117,7 +117,7 @@ def main():
         _pp("8. web_search — no verifier, unchanged passthrough", result)
 
     print(f"\n{'='*60}")
-    print("  Demo complete. All verification checks ran successfully.")
+    print("  Demo complete. Verification checks executed across pass, warning, and mismatch scenarios.")
     print(f"{'='*60}\n")
 
 

--- a/demo_execution_verifier.py
+++ b/demo_execution_verifier.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Demo: Execution Integrity Layer
+
+Shows how verify_tool_result() augments tool outputs with post-call
+verification metadata.  Run this standalone — no LLM or server needed.
+
+Usage:
+    python3 demo_execution_verifier.py
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Ensure project root is on the path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agent.execution_verifier import verify_tool_result
+
+
+def _pp(label: str, result_json: str):
+    """Pretty-print a verification result."""
+    print(f"\n{'='*60}")
+    print(f"  {label}")
+    print(f"{'='*60}")
+    try:
+        data = json.loads(result_json)
+        print(json.dumps(data, indent=2))
+    except json.JSONDecodeError:
+        print(result_json)
+
+
+def main():
+    print("Execution Integrity Layer — Demo")
+    print("Demonstrates post-tool-call verification for terminal, write_file, and patch.\n")
+
+    with tempfile.TemporaryDirectory(prefix="hermes-demo-") as tmpdir:
+
+        # ── 1. git clone — SUCCESS ─────────────────────────────────────
+        clone_dir = os.path.join(tmpdir, "my-project")
+        os.makedirs(clone_dir)  # simulate successful clone
+
+        result = verify_tool_result(
+            "terminal",
+            {"command": f"git clone https://github.com/user/my-project.git {clone_dir}"},
+            json.dumps({"output": "Cloning into 'my-project'...\ndone.", "exit_code": 0, "error": None}),
+        )
+        _pp("1. git clone — directory EXISTS (pass)", result)
+
+        # ── 2. git clone — FAILURE ─────────────────────────────────────
+        missing_dir = os.path.join(tmpdir, "ghost-repo")
+        result = verify_tool_result(
+            "terminal",
+            {"command": f"git clone https://github.com/user/ghost-repo.git {missing_dir}"},
+            json.dumps({"output": "Cloning into 'ghost-repo'...\ndone.", "exit_code": 0, "error": None}),
+        )
+        _pp("2. git clone — directory MISSING (fail)", result)
+
+        # ── 3. write_file — SUCCESS ────────────────────────────────────
+        written_file = os.path.join(tmpdir, "hello.py")
+        Path(written_file).write_text("print('hello world')\n")
+
+        result = verify_tool_result(
+            "write_file",
+            {"path": written_file, "content": "print('hello world')\n"},
+            json.dumps({"bytes_written": 21}),
+        )
+        _pp("3. write_file — file EXISTS and non-empty (pass)", result)
+
+        # ── 4. write_file — EMPTY FILE ─────────────────────────────────
+        empty_file = os.path.join(tmpdir, "empty.txt")
+        Path(empty_file).write_text("")
+
+        result = verify_tool_result(
+            "write_file",
+            {"path": empty_file, "content": ""},
+            json.dumps({"bytes_written": 0}),
+        )
+        _pp("4. write_file — file EXISTS but EMPTY (warning)", result)
+
+        # ── 5. write_file — MISSING FILE ───────────────────────────────
+        result = verify_tool_result(
+            "write_file",
+            {"path": os.path.join(tmpdir, "vanished.py"), "content": "x=1"},
+            json.dumps({"bytes_written": 3}),
+        )
+        _pp("5. write_file — file MISSING after write (fail)", result)
+
+        # ── 6. patch — SUCCESS ─────────────────────────────────────────
+        patched_file = os.path.join(tmpdir, "app.py")
+        Path(patched_file).write_text("x = 2\n")
+
+        result = verify_tool_result(
+            "patch",
+            {"path": patched_file, "old_string": "x = 1", "new_string": "x = 2"},
+            json.dumps({"success": True, "diff": "- x = 1\n+ x = 2", "files_modified": [patched_file]}),
+        )
+        _pp("6. patch — modified file EXISTS (pass)", result)
+
+        # ── 7. patch — MISSING AFTER PATCH ──────────────────────────────
+        result = verify_tool_result(
+            "patch",
+            {"path": os.path.join(tmpdir, "deleted.py")},
+            json.dumps({"success": True, "diff": "...", "files_modified": [os.path.join(tmpdir, "deleted.py")]}),
+        )
+        _pp("7. patch — modified file MISSING (fail)", result)
+
+        # ── 8. Unrelated tool — passthrough ─────────────────────────────
+        result = verify_tool_result(
+            "web_search",
+            {"query": "python asyncio"},
+            json.dumps({"results": [{"title": "asyncio docs", "url": "https://..."}]}),
+        )
+        _pp("8. web_search — no verifier, unchanged passthrough", result)
+
+    print(f"\n{'='*60}")
+    print("  Demo complete. All verification checks ran successfully.")
+    print(f"{'='*60}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo_execution_verifier.py
+++ b/demo_execution_verifier.py
@@ -35,7 +35,8 @@ def _pp(label: str, result_json: str):
 
 def main():
     print("Execution Integrity Layer — Demo")
-    print("Demonstrates post-tool-call verification for terminal, write_file, and patch.\n")
+    print("Demonstrates post-tool-call verification for terminal, write_file,")
+    print("patch, read_file, browser_navigate, and web_extract.\n")
 
     with tempfile.TemporaryDirectory(prefix="hermes-demo-") as tmpdir:
 
@@ -70,7 +71,7 @@ def main():
         )
         _pp("3. write_file — file EXISTS and non-empty (pass)", result)
 
-        # ── 4. write_file — EMPTY FILE ─────────────────────────────────
+        # ── 4. write_file — EMPTY FILE (intentional) ──────────────────
         empty_file = os.path.join(tmpdir, "empty.txt")
         Path(empty_file).write_text("")
 
@@ -79,7 +80,7 @@ def main():
             {"path": empty_file, "content": ""},
             json.dumps({"bytes_written": 0}),
         )
-        _pp("4. write_file — file EXISTS but EMPTY (warning)", result)
+        _pp("4. write_file — file EXISTS, intentionally empty (pass)", result)
 
         # ── 5. write_file — MISSING FILE ───────────────────────────────
         result = verify_tool_result(
@@ -116,8 +117,102 @@ def main():
         )
         _pp("8. web_search — no verifier, unchanged passthrough", result)
 
+        # ── 9. terminal cp — destination EXISTS ─────────────────────────
+        cp_src = os.path.join(tmpdir, "src.txt")
+        cp_dest = os.path.join(tmpdir, "dest.txt")
+        Path(cp_src).write_text("data")
+        Path(cp_dest).write_text("data")
+
+        result = verify_tool_result(
+            "terminal",
+            {"command": f"cp {cp_src} {cp_dest}"},
+            json.dumps({"output": "", "exit_code": 0, "error": None}),
+        )
+        _pp("9. terminal cp — destination EXISTS (pass)", result)
+
+        # ── 10. terminal rm — target REMOVED ────────────────────────────
+        rm_target = os.path.join(tmpdir, "to_delete.txt")
+        # target does NOT exist — rm succeeded
+        result = verify_tool_result(
+            "terminal",
+            {"command": f"rm {rm_target}"},
+            json.dumps({"output": "", "exit_code": 0, "error": None}),
+        )
+        _pp("10. terminal rm — target REMOVED (pass)", result)
+
+        # ── 11. terminal touch — file EXISTS ────────────────────────────
+        touch_file = os.path.join(tmpdir, "touched.txt")
+        Path(touch_file).write_text("")
+
+        result = verify_tool_result(
+            "terminal",
+            {"command": f"touch {touch_file}"},
+            json.dumps({"output": "", "exit_code": 0, "error": None}),
+        )
+        _pp("11. terminal touch — file EXISTS (pass)", result)
+
+        # ── 12. terminal git init — .git EXISTS ─────────────────────────
+        init_dir = os.path.join(tmpdir, "new-repo")
+        os.makedirs(os.path.join(init_dir, ".git"))
+
+        result = verify_tool_result(
+            "terminal",
+            {"command": f"git init {init_dir}"},
+            json.dumps({"output": "Initialized empty Git repository", "exit_code": 0, "error": None}),
+        )
+        _pp("12. terminal git init — .git EXISTS (pass)", result)
+
+        # ── 13. read_file — content returned ────────────────────────────
+        result = verify_tool_result(
+            "read_file",
+            {"path": "/some/file.py"},
+            json.dumps({"content": "1|print('hello')\n2|print('world')", "total_lines": 2, "file_size": 28, "error": None}),
+        )
+        _pp("13. read_file — content returned (pass)", result)
+
+        # ── 14. read_file — error with similar_files ────────────────────
+        result = verify_tool_result(
+            "read_file",
+            {"path": "/tmp/foo.py"},
+            json.dumps({"error": "File not found: /tmp/foo.py", "similar_files": ["/tmp/foo2.py", "/tmp/foobar.py"]}),
+        )
+        _pp("14. read_file — error with similar_files (warning)", result)
+
+        # ── 15. browser_navigate — success ──────────────────────────────
+        result = verify_tool_result(
+            "browser_navigate",
+            {"url": "https://example.com"},
+            json.dumps({"success": True, "url": "https://example.com", "title": "Example Domain"}),
+        )
+        _pp("15. browser_navigate — success (pass)", result)
+
+        # ── 16. browser_navigate — bot detection ────────────────────────
+        result = verify_tool_result(
+            "browser_navigate",
+            {"url": "https://protected-site.com"},
+            json.dumps({
+                "success": True,
+                "url": "https://protected-site.com",
+                "title": "Verify you are human",
+                "bot_detection_warning": "Page title suggests bot detection",
+            }),
+        )
+        _pp("16. browser_navigate — bot detection triggered (warning)", result)
+
+        # ── 17. web_extract — partial failure ───────────────────────────
+        result = verify_tool_result(
+            "web_extract",
+            {"urls": ["https://a.com", "https://b.com"]},
+            json.dumps({"results": [
+                {"url": "https://a.com", "title": "A", "content": "Page A content extracted successfully."},
+                {"url": "https://b.com", "error": "Connection timeout", "content": ""},
+            ]}),
+        )
+        _pp("17. web_extract — partial failure (warning)", result)
+
     print(f"\n{'='*60}")
-    print("  Demo complete. Verification checks executed across pass, warning, and mismatch scenarios.")
+    print("  Demo complete. Verification checks executed across pass,")
+    print("  warning, and mismatch scenarios for 6 tool types.")
     print(f"{'='*60}\n")
 
 

--- a/demo_without_verifier.py
+++ b/demo_without_verifier.py
@@ -2,7 +2,7 @@
 """
 Demo: Raw tool output WITHOUT Execution Integrity Layer.
 
-Shows the same 8 scenarios as demo_execution_verifier.py but returns
+Shows the same 17 scenarios as demo_execution_verifier.py but returns
 raw tool output with NO _verification or _warning fields — this is
 what the model sees when the verifier is disabled.
 
@@ -31,7 +31,7 @@ def _pp(label: str, result_json: str):
 
 def main():
     print("Raw Tool Output — No Verification (Before)")
-    print("Same 8 scenarios, but the model gets ONLY the tool's own JSON.\n")
+    print("Same 17 scenarios, but the model gets ONLY the tool's own JSON.\n")
 
     with tempfile.TemporaryDirectory(prefix="hermes-demo-") as tmpdir:
 
@@ -53,12 +53,12 @@ def main():
         result = json.dumps({"bytes_written": 21})
         _pp("3. write_file — file EXISTS and non-empty (no verification)", result)
 
-        # ── 4. write_file — EMPTY FILE ─────────────────────────────────
+        # ── 4. write_file — EMPTY FILE (intentional) ──────────────────
         empty_file = os.path.join(tmpdir, "empty.txt")
         Path(empty_file).write_text("")
 
         result = json.dumps({"bytes_written": 0})
-        _pp("4. write_file — file EXISTS but EMPTY (no verification)", result)
+        _pp("4. write_file — file EXISTS, intentionally empty (no verification)", result)
 
         # ── 5. write_file — MISSING FILE ───────────────────────────────
         result = json.dumps({"bytes_written": 3})
@@ -80,9 +80,54 @@ def main():
         result = json.dumps({"results": [{"title": "asyncio docs", "url": "https://..."}]})
         _pp("8. web_search — passthrough (no verification)", result)
 
+        # ── 9. terminal cp — destination EXISTS ─────────────────────────
+        result = json.dumps({"output": "", "exit_code": 0, "error": None})
+        _pp("9. terminal cp — destination EXISTS (no verification)", result)
+
+        # ── 10. terminal rm — target REMOVED ────────────────────────────
+        result = json.dumps({"output": "", "exit_code": 0, "error": None})
+        _pp("10. terminal rm — target REMOVED (no verification)", result)
+
+        # ── 11. terminal touch — file EXISTS ────────────────────────────
+        result = json.dumps({"output": "", "exit_code": 0, "error": None})
+        _pp("11. terminal touch — file EXISTS (no verification)", result)
+
+        # ── 12. terminal git init — .git EXISTS ─────────────────────────
+        result = json.dumps({"output": "Initialized empty Git repository", "exit_code": 0, "error": None})
+        _pp("12. terminal git init — .git EXISTS (no verification)", result)
+
+        # ── 13. read_file — content returned ────────────────────────────
+        result = json.dumps({"content": "1|print('hello')\n2|print('world')", "total_lines": 2, "file_size": 28, "error": None})
+        _pp("13. read_file — content returned (no verification)", result)
+
+        # ── 14. read_file — error with similar_files ────────────────────
+        result = json.dumps({"error": "File not found: /tmp/foo.py", "similar_files": ["/tmp/foo2.py", "/tmp/foobar.py"]})
+        _pp("14. read_file — error with similar_files (no verification)", result)
+
+        # ── 15. browser_navigate — success ──────────────────────────────
+        result = json.dumps({"success": True, "url": "https://example.com", "title": "Example Domain"})
+        _pp("15. browser_navigate — success (no verification)", result)
+
+        # ── 16. browser_navigate — bot detection ────────────────────────
+        result = json.dumps({
+            "success": True,
+            "url": "https://protected-site.com",
+            "title": "Verify you are human",
+            "bot_detection_warning": "Page title suggests bot detection",
+        })
+        _pp("16. browser_navigate — bot detection triggered (no verification)", result)
+
+        # ── 17. web_extract — partial failure ───────────────────────────
+        result = json.dumps({"results": [
+            {"url": "https://a.com", "title": "A", "content": "Page A content extracted successfully."},
+            {"url": "https://b.com", "error": "Connection timeout", "content": ""},
+        ]})
+        _pp("17. web_extract — partial failure (no verification)", result)
+
     print(f"\n{'='*60}")
     print("  Demo complete. Notice: NO _verification or _warning fields.")
-    print("  The model has no signal that scenarios 2, 4, 5, 7 failed.")
+    print("  The model has no signal that scenarios 2, 5, 7, 14, 16, 17")
+    print("  had issues requiring attention.")
     print(f"{'='*60}\n")
 
 

--- a/demo_without_verifier.py
+++ b/demo_without_verifier.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Demo: Raw tool output WITHOUT Execution Integrity Layer.
+
+Shows the same 8 scenarios as demo_execution_verifier.py but returns
+raw tool output with NO _verification or _warning fields — this is
+what the model sees when the verifier is disabled.
+
+Compare side-by-side:
+    python3 demo_without_verifier.py   # raw output (before)
+    python3 demo_execution_verifier.py # augmented output (after)
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+
+def _pp(label: str, result_json: str):
+    """Pretty-print a raw tool result."""
+    print(f"\n{'='*60}")
+    print(f"  {label}")
+    print(f"{'='*60}")
+    try:
+        data = json.loads(result_json)
+        print(json.dumps(data, indent=2))
+    except json.JSONDecodeError:
+        print(result_json)
+
+
+def main():
+    print("Raw Tool Output — No Verification (Before)")
+    print("Same 8 scenarios, but the model gets ONLY the tool's own JSON.\n")
+
+    with tempfile.TemporaryDirectory(prefix="hermes-demo-") as tmpdir:
+
+        # ── 1. git clone — SUCCESS ─────────────────────────────────────
+        clone_dir = os.path.join(tmpdir, "my-project")
+        os.makedirs(clone_dir)  # simulate successful clone
+
+        result = json.dumps({"output": "Cloning into 'my-project'...\ndone.", "exit_code": 0, "error": None})
+        _pp("1. git clone — directory EXISTS (no verification)", result)
+
+        # ── 2. git clone — FAILURE ─────────────────────────────────────
+        result = json.dumps({"output": "Cloning into 'ghost-repo'...\ndone.", "exit_code": 0, "error": None})
+        _pp("2. git clone — directory MISSING (no verification)", result)
+
+        # ── 3. write_file — SUCCESS ────────────────────────────────────
+        written_file = os.path.join(tmpdir, "hello.py")
+        Path(written_file).write_text("print('hello world')\n")
+
+        result = json.dumps({"bytes_written": 21})
+        _pp("3. write_file — file EXISTS and non-empty (no verification)", result)
+
+        # ── 4. write_file — EMPTY FILE ─────────────────────────────────
+        empty_file = os.path.join(tmpdir, "empty.txt")
+        Path(empty_file).write_text("")
+
+        result = json.dumps({"bytes_written": 0})
+        _pp("4. write_file — file EXISTS but EMPTY (no verification)", result)
+
+        # ── 5. write_file — MISSING FILE ───────────────────────────────
+        result = json.dumps({"bytes_written": 3})
+        _pp("5. write_file — file MISSING after write (no verification)", result)
+
+        # ── 6. patch — SUCCESS ─────────────────────────────────────────
+        patched_file = os.path.join(tmpdir, "app.py")
+        Path(patched_file).write_text("x = 2\n")
+
+        result = json.dumps({"success": True, "diff": "- x = 1\n+ x = 2", "files_modified": [patched_file]})
+        _pp("6. patch — modified file EXISTS (no verification)", result)
+
+        # ── 7. patch — MISSING AFTER PATCH ──────────────────────────────
+        deleted_path = os.path.join(tmpdir, "deleted.py")
+        result = json.dumps({"success": True, "diff": "...", "files_modified": [deleted_path]})
+        _pp("7. patch — modified file MISSING (no verification)", result)
+
+        # ── 8. Unrelated tool — passthrough ─────────────────────────────
+        result = json.dumps({"results": [{"title": "asyncio docs", "url": "https://..."}]})
+        _pp("8. web_search — passthrough (no verification)", result)
+
+    print(f"\n{'='*60}")
+    print("  Demo complete. Notice: NO _verification or _warning fields.")
+    print("  The model has no signal that scenarios 2, 4, 5, 7 failed.")
+    print(f"{'='*60}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/model_tools.py
+++ b/model_tools.py
@@ -28,6 +28,7 @@ from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import registry
 from toolsets import resolve_toolset, validate_toolset
+from agent.execution_verifier import verify_tool_result
 
 logger = logging.getLogger(__name__)
 
@@ -308,11 +309,12 @@ def handle_function_call(
                 enabled_tools=sandbox_enabled,
             )
 
-        return registry.dispatch(
+        result = registry.dispatch(
             function_name, function_args,
             task_id=task_id,
             user_task=user_task,
         )
+        return verify_tool_result(function_name, function_args, result)
 
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"

--- a/tests/agent/test_execution_verifier.py
+++ b/tests/agent/test_execution_verifier.py
@@ -47,7 +47,7 @@ class TestVerificationResult:
     def test_to_dict_warning(self):
         vr = VerificationResult(
             status=WARNING, tool_name="write_file", check="file_written",
-            message="file was written but is empty: /tmp/empty.txt",
+            message="file exists but is empty; result may be incomplete or intentional: /tmp/empty.txt",
         )
         d = vr.to_dict()
         assert d["status"] == "warning"

--- a/tests/agent/test_execution_verifier.py
+++ b/tests/agent/test_execution_verifier.py
@@ -1,0 +1,293 @@
+"""Tests for agent.execution_verifier — post-tool-call verification."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from agent.execution_verifier import (
+    VerificationResult,
+    verify_tool_result,
+    _verify_terminal,
+    _verify_write_file,
+    _verify_patch,
+)
+
+
+# ===================================================================
+# VerificationResult
+# ===================================================================
+
+class TestVerificationResult:
+    def test_to_dict_success(self):
+        vr = VerificationResult(
+            verified=True, tool_name="terminal", check="git_clone_dir_exists",
+        )
+        d = vr.to_dict()
+        assert d["verified"] is True
+        assert d["tool"] == "terminal"
+        assert d["check"] == "git_clone_dir_exists"
+        assert "message" not in d  # empty message excluded
+
+    def test_to_dict_failure_includes_message(self):
+        vr = VerificationResult(
+            verified=False, tool_name="write_file", check="file_written",
+            message="VERIFICATION FAILED: file missing",
+            details={"expected_path": "/tmp/foo.py", "exists": False},
+        )
+        d = vr.to_dict()
+        assert d["verified"] is False
+        assert "VERIFICATION FAILED" in d["message"]
+        assert d["details"]["exists"] is False
+
+
+# ===================================================================
+# Terminal verifier
+# ===================================================================
+
+class TestTerminalVerifier:
+    def test_git_clone_with_explicit_dir_exists(self, tmp_path):
+        target = tmp_path / "myrepo"
+        target.mkdir()
+        args = {"command": f"git clone https://github.com/user/repo.git {target}"}
+        result_data = {"output": "Cloning...", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.verified is True
+        assert vr.check == "git_clone_dir_exists"
+
+    def test_git_clone_with_explicit_dir_missing(self, tmp_path):
+        target = tmp_path / "nonexistent"
+        args = {"command": f"git clone https://github.com/user/repo.git {target}"}
+        result_data = {"output": "Cloning...", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.verified is False
+        assert "VERIFICATION FAILED" in vr.message
+
+    def test_git_clone_inferred_dir_exists(self, tmp_path):
+        # Simulate: git clone https://github.com/user/my-project.git
+        # Should infer dir name "my-project" relative to workdir
+        target = tmp_path / "my-project"
+        target.mkdir()
+        args = {
+            "command": "git clone https://github.com/user/my-project.git",
+            "workdir": str(tmp_path),
+        }
+        result_data = {"output": "Cloning...", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.verified is True
+
+    def test_git_clone_inferred_dir_missing(self, tmp_path):
+        args = {
+            "command": "git clone https://github.com/user/my-project.git",
+            "workdir": str(tmp_path),
+        }
+        result_data = {"output": "Cloning...", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.verified is False
+
+    def test_git_clone_nonzero_exit_skipped(self):
+        args = {"command": "git clone https://github.com/user/repo.git /tmp/x"}
+        result_data = {"output": "fatal: ...", "exit_code": 128, "error": "clone failed"}
+        vr = _verify_terminal(args, result_data)
+        assert vr is None  # no verification on failure
+
+    def test_mkdir_exists(self, tmp_path):
+        target = tmp_path / "newdir"
+        target.mkdir()
+        args = {"command": f"mkdir -p {target}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.verified is True
+        assert vr.check == "mkdir_dir_exists"
+
+    def test_mkdir_missing(self, tmp_path):
+        target = tmp_path / "ghost"
+        args = {"command": f"mkdir {target}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.verified is False
+
+    def test_unrelated_command_returns_none(self):
+        args = {"command": "ls -la"}
+        result_data = {"output": "total 0", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is None
+
+    def test_git_clone_with_flags(self, tmp_path):
+        target = tmp_path / "repo"
+        target.mkdir()
+        args = {"command": f"git clone --depth 1 --branch main https://github.com/user/repo.git {target}"}
+        result_data = {"output": "Cloning...", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.verified is True
+
+
+# ===================================================================
+# write_file verifier
+# ===================================================================
+
+class TestWriteFileVerifier:
+    def test_file_exists_and_nonempty(self, tmp_path):
+        f = tmp_path / "hello.py"
+        f.write_text("print('hello')")
+        args = {"path": str(f)}
+        result_data = {"bytes_written": 14}
+        vr = _verify_write_file(args, result_data)
+        assert vr is not None
+        assert vr.verified is True
+        assert vr.details["size_bytes"] == 14
+
+    def test_file_missing(self, tmp_path):
+        args = {"path": str(tmp_path / "missing.py")}
+        result_data = {"bytes_written": 10}
+        vr = _verify_write_file(args, result_data)
+        assert vr is not None
+        assert vr.verified is False
+        assert "VERIFICATION FAILED" in vr.message
+
+    def test_file_exists_but_empty(self, tmp_path):
+        f = tmp_path / "empty.txt"
+        f.write_text("")
+        args = {"path": str(f)}
+        result_data = {"bytes_written": 0}
+        vr = _verify_write_file(args, result_data)
+        assert vr is not None
+        assert vr.verified is False
+        assert "empty" in vr.message.lower()
+
+    def test_skipped_on_error_result(self):
+        args = {"path": "/some/file.py"}
+        result_data = {"error": "Permission denied"}
+        vr = _verify_write_file(args, result_data)
+        assert vr is None
+
+    def test_skipped_on_no_path(self):
+        args = {}
+        result_data = {"bytes_written": 10}
+        vr = _verify_write_file(args, result_data)
+        assert vr is None
+
+
+# ===================================================================
+# patch verifier
+# ===================================================================
+
+class TestPatchVerifier:
+    def test_patched_file_exists(self, tmp_path):
+        f = tmp_path / "main.py"
+        f.write_text("x = 1")
+        args = {"path": str(f), "old_string": "x = 1", "new_string": "x = 2"}
+        result_data = {"success": True, "diff": "...", "files_modified": [str(f)]}
+        vr = _verify_patch(args, result_data)
+        assert vr is not None
+        assert vr.verified is True
+
+    def test_patched_file_missing(self, tmp_path):
+        missing = str(tmp_path / "gone.py")
+        args = {"path": missing}
+        result_data = {"success": True, "diff": "...", "files_modified": [missing]}
+        vr = _verify_patch(args, result_data)
+        assert vr is not None
+        assert vr.verified is False
+        assert "missing" in vr.message.lower()
+
+    def test_replace_mode_fallback_to_path_arg(self, tmp_path):
+        f = tmp_path / "app.js"
+        f.write_text("const x = 1;")
+        args = {"path": str(f), "old_string": "const x = 1;", "new_string": "const x = 2;"}
+        result_data = {"success": True, "diff": "..."}
+        # No files_modified or files_created in result (replace mode)
+        vr = _verify_patch(args, result_data)
+        assert vr is not None
+        assert vr.verified is True
+
+    def test_skipped_on_failure(self):
+        args = {"path": "/tmp/foo.py"}
+        result_data = {"success": False, "error": "Could not find old_string"}
+        vr = _verify_patch(args, result_data)
+        assert vr is None
+
+
+# ===================================================================
+# Integration: verify_tool_result
+# ===================================================================
+
+class TestVerifyToolResult:
+    def test_augments_terminal_result(self, tmp_path):
+        target = tmp_path / "repo"
+        target.mkdir()
+        args = {"command": f"git clone https://github.com/x/repo.git {target}"}
+        original = json.dumps({"output": "done", "exit_code": 0, "error": None})
+        result = verify_tool_result("terminal", args, original)
+        parsed = json.loads(result)
+        assert "_verification" in parsed
+        assert parsed["_verification"]["verified"] is True
+        assert "_warning" not in parsed  # no warning on success
+
+    def test_augments_write_file_result(self, tmp_path):
+        f = tmp_path / "out.txt"
+        f.write_text("data")
+        args = {"path": str(f)}
+        original = json.dumps({"bytes_written": 4})
+        result = verify_tool_result("write_file", args, original)
+        parsed = json.loads(result)
+        assert "_verification" in parsed
+        assert parsed["_verification"]["verified"] is True
+        assert "_warning" not in parsed  # no warning on success
+
+    def test_no_verifier_returns_unchanged(self):
+        original = json.dumps({"results": [1, 2, 3]})
+        result = verify_tool_result("web_search", {}, original)
+        assert result == original
+
+    def test_non_json_returns_unchanged(self):
+        raw = "not valid json at all"
+        result = verify_tool_result("terminal", {"command": "ls"}, raw)
+        assert result == raw
+
+    def test_unrelated_terminal_command_returns_unchanged(self):
+        original = json.dumps({"output": "hello", "exit_code": 0, "error": None})
+        result = verify_tool_result("terminal", {"command": "echo hello"}, original)
+        parsed = json.loads(result)
+        # No _verification because echo doesn't trigger any verifier
+        assert "_verification" not in parsed
+
+    def test_failure_propagates_warning_message(self, tmp_path):
+        missing = str(tmp_path / "nope")
+        args = {"command": f"git clone https://github.com/x/repo.git {missing}"}
+        original = json.dumps({"output": "done", "exit_code": 0, "error": None})
+        result = verify_tool_result("terminal", args, original)
+        parsed = json.loads(result)
+        assert parsed["_verification"]["verified"] is False
+        assert "VERIFICATION FAILED" in parsed["_verification"]["message"]
+        # Top-level _warning must be present and prominent
+        assert "_warning" in parsed
+        assert "VERIFICATION FAILED" in parsed["_warning"]
+        assert "Do not assume this step succeeded" in parsed["_warning"]
+
+    def test_write_file_missing_has_top_level_warning(self, tmp_path):
+        args = {"path": str(tmp_path / "gone.py")}
+        original = json.dumps({"bytes_written": 10})
+        result = verify_tool_result("write_file", args, original)
+        parsed = json.loads(result)
+        assert parsed["_verification"]["verified"] is False
+        assert "_warning" in parsed
+        assert "VERIFICATION FAILED" in parsed["_warning"]
+
+    def test_patch_missing_has_top_level_warning(self, tmp_path):
+        missing = str(tmp_path / "deleted.py")
+        args = {"path": missing}
+        original = json.dumps({"success": True, "diff": "...", "files_modified": [missing]})
+        result = verify_tool_result("patch", args, original)
+        parsed = json.loads(result)
+        assert parsed["_verification"]["verified"] is False
+        assert "_warning" in parsed
+        assert "Do not assume this step succeeded" in parsed["_warning"]

--- a/tests/agent/test_execution_verifier.py
+++ b/tests/agent/test_execution_verifier.py
@@ -12,6 +12,9 @@ from agent.execution_verifier import (
     _verify_terminal,
     _verify_write_file,
     _verify_patch,
+    VERIFIED,
+    WARNING,
+    MISMATCH,
 )
 
 
@@ -20,26 +23,35 @@ from agent.execution_verifier import (
 # ===================================================================
 
 class TestVerificationResult:
-    def test_to_dict_success(self):
+    def test_to_dict_verified(self):
         vr = VerificationResult(
-            verified=True, tool_name="terminal", check="git_clone_dir_exists",
+            status=VERIFIED, tool_name="terminal", check="git_clone_dir_exists",
         )
         d = vr.to_dict()
-        assert d["verified"] is True
+        assert d["status"] == "verified"
         assert d["tool"] == "terminal"
         assert d["check"] == "git_clone_dir_exists"
         assert "message" not in d  # empty message excluded
 
-    def test_to_dict_failure_includes_message(self):
+    def test_to_dict_mismatch_includes_message(self):
         vr = VerificationResult(
-            verified=False, tool_name="write_file", check="file_written",
-            message="VERIFICATION FAILED: file missing",
+            status=MISMATCH, tool_name="write_file", check="file_written",
+            message="written file does not exist: /tmp/foo.py",
             details={"expected_path": "/tmp/foo.py", "exists": False},
         )
         d = vr.to_dict()
-        assert d["verified"] is False
-        assert "VERIFICATION FAILED" in d["message"]
+        assert d["status"] == "mismatch"
+        assert "does not exist" in d["message"]
         assert d["details"]["exists"] is False
+
+    def test_to_dict_warning(self):
+        vr = VerificationResult(
+            status=WARNING, tool_name="write_file", check="file_written",
+            message="file was written but is empty: /tmp/empty.txt",
+        )
+        d = vr.to_dict()
+        assert d["status"] == "warning"
+        assert "empty" in d["message"]
 
 
 # ===================================================================
@@ -54,7 +66,7 @@ class TestTerminalVerifier:
         result_data = {"output": "Cloning...", "exit_code": 0, "error": None}
         vr = _verify_terminal(args, result_data)
         assert vr is not None
-        assert vr.verified is True
+        assert vr.status == VERIFIED
         assert vr.check == "git_clone_dir_exists"
 
     def test_git_clone_with_explicit_dir_missing(self, tmp_path):
@@ -63,12 +75,10 @@ class TestTerminalVerifier:
         result_data = {"output": "Cloning...", "exit_code": 0, "error": None}
         vr = _verify_terminal(args, result_data)
         assert vr is not None
-        assert vr.verified is False
-        assert "VERIFICATION FAILED" in vr.message
+        assert vr.status == MISMATCH
+        assert "does not exist" in vr.message
 
     def test_git_clone_inferred_dir_exists(self, tmp_path):
-        # Simulate: git clone https://github.com/user/my-project.git
-        # Should infer dir name "my-project" relative to workdir
         target = tmp_path / "my-project"
         target.mkdir()
         args = {
@@ -78,7 +88,7 @@ class TestTerminalVerifier:
         result_data = {"output": "Cloning...", "exit_code": 0, "error": None}
         vr = _verify_terminal(args, result_data)
         assert vr is not None
-        assert vr.verified is True
+        assert vr.status == VERIFIED
 
     def test_git_clone_inferred_dir_missing(self, tmp_path):
         args = {
@@ -88,7 +98,7 @@ class TestTerminalVerifier:
         result_data = {"output": "Cloning...", "exit_code": 0, "error": None}
         vr = _verify_terminal(args, result_data)
         assert vr is not None
-        assert vr.verified is False
+        assert vr.status == MISMATCH
 
     def test_git_clone_nonzero_exit_skipped(self):
         args = {"command": "git clone https://github.com/user/repo.git /tmp/x"}
@@ -103,7 +113,7 @@ class TestTerminalVerifier:
         result_data = {"output": "", "exit_code": 0, "error": None}
         vr = _verify_terminal(args, result_data)
         assert vr is not None
-        assert vr.verified is True
+        assert vr.status == VERIFIED
         assert vr.check == "mkdir_dir_exists"
 
     def test_mkdir_missing(self, tmp_path):
@@ -112,7 +122,7 @@ class TestTerminalVerifier:
         result_data = {"output": "", "exit_code": 0, "error": None}
         vr = _verify_terminal(args, result_data)
         assert vr is not None
-        assert vr.verified is False
+        assert vr.status == MISMATCH
 
     def test_unrelated_command_returns_none(self):
         args = {"command": "ls -la"}
@@ -127,7 +137,7 @@ class TestTerminalVerifier:
         result_data = {"output": "Cloning...", "exit_code": 0, "error": None}
         vr = _verify_terminal(args, result_data)
         assert vr is not None
-        assert vr.verified is True
+        assert vr.status == VERIFIED
 
 
 # ===================================================================
@@ -142,7 +152,7 @@ class TestWriteFileVerifier:
         result_data = {"bytes_written": 14}
         vr = _verify_write_file(args, result_data)
         assert vr is not None
-        assert vr.verified is True
+        assert vr.status == VERIFIED
         assert vr.details["size_bytes"] == 14
 
     def test_file_missing(self, tmp_path):
@@ -150,8 +160,8 @@ class TestWriteFileVerifier:
         result_data = {"bytes_written": 10}
         vr = _verify_write_file(args, result_data)
         assert vr is not None
-        assert vr.verified is False
-        assert "VERIFICATION FAILED" in vr.message
+        assert vr.status == MISMATCH
+        assert "does not exist" in vr.message
 
     def test_file_exists_but_empty(self, tmp_path):
         f = tmp_path / "empty.txt"
@@ -160,7 +170,7 @@ class TestWriteFileVerifier:
         result_data = {"bytes_written": 0}
         vr = _verify_write_file(args, result_data)
         assert vr is not None
-        assert vr.verified is False
+        assert vr.status == WARNING
         assert "empty" in vr.message.lower()
 
     def test_skipped_on_error_result(self):
@@ -188,7 +198,7 @@ class TestPatchVerifier:
         result_data = {"success": True, "diff": "...", "files_modified": [str(f)]}
         vr = _verify_patch(args, result_data)
         assert vr is not None
-        assert vr.verified is True
+        assert vr.status == VERIFIED
 
     def test_patched_file_missing(self, tmp_path):
         missing = str(tmp_path / "gone.py")
@@ -196,7 +206,7 @@ class TestPatchVerifier:
         result_data = {"success": True, "diff": "...", "files_modified": [missing]}
         vr = _verify_patch(args, result_data)
         assert vr is not None
-        assert vr.verified is False
+        assert vr.status == MISMATCH
         assert "missing" in vr.message.lower()
 
     def test_replace_mode_fallback_to_path_arg(self, tmp_path):
@@ -204,10 +214,9 @@ class TestPatchVerifier:
         f.write_text("const x = 1;")
         args = {"path": str(f), "old_string": "const x = 1;", "new_string": "const x = 2;"}
         result_data = {"success": True, "diff": "..."}
-        # No files_modified or files_created in result (replace mode)
         vr = _verify_patch(args, result_data)
         assert vr is not None
-        assert vr.verified is True
+        assert vr.status == VERIFIED
 
     def test_skipped_on_failure(self):
         args = {"path": "/tmp/foo.py"}
@@ -229,8 +238,8 @@ class TestVerifyToolResult:
         result = verify_tool_result("terminal", args, original)
         parsed = json.loads(result)
         assert "_verification" in parsed
-        assert parsed["_verification"]["verified"] is True
-        assert "_warning" not in parsed  # no warning on success
+        assert parsed["_verification"]["status"] == "verified"
+        assert "_warning" not in parsed  # no warning on verified
 
     def test_augments_write_file_result(self, tmp_path):
         f = tmp_path / "out.txt"
@@ -240,8 +249,8 @@ class TestVerifyToolResult:
         result = verify_tool_result("write_file", args, original)
         parsed = json.loads(result)
         assert "_verification" in parsed
-        assert parsed["_verification"]["verified"] is True
-        assert "_warning" not in parsed  # no warning on success
+        assert parsed["_verification"]["status"] == "verified"
+        assert "_warning" not in parsed  # no warning on verified
 
     def test_no_verifier_returns_unchanged(self):
         original = json.dumps({"results": [1, 2, 3]})
@@ -257,37 +266,53 @@ class TestVerifyToolResult:
         original = json.dumps({"output": "hello", "exit_code": 0, "error": None})
         result = verify_tool_result("terminal", {"command": "echo hello"}, original)
         parsed = json.loads(result)
-        # No _verification because echo doesn't trigger any verifier
         assert "_verification" not in parsed
 
-    def test_failure_propagates_warning_message(self, tmp_path):
+    # --- mismatch cases: ❌ VERIFICATION FAILED ---
+
+    def test_mismatch_terminal_has_failed_warning(self, tmp_path):
         missing = str(tmp_path / "nope")
         args = {"command": f"git clone https://github.com/x/repo.git {missing}"}
         original = json.dumps({"output": "done", "exit_code": 0, "error": None})
         result = verify_tool_result("terminal", args, original)
         parsed = json.loads(result)
-        assert parsed["_verification"]["verified"] is False
-        assert "VERIFICATION FAILED" in parsed["_verification"]["message"]
-        # Top-level _warning must be present and prominent
+        assert parsed["_verification"]["status"] == "mismatch"
         assert "_warning" in parsed
         assert "VERIFICATION FAILED" in parsed["_warning"]
-        assert "Do not assume this step succeeded" in parsed["_warning"]
+        assert "conflicts with environment state" in parsed["_warning"]
 
-    def test_write_file_missing_has_top_level_warning(self, tmp_path):
+    def test_mismatch_write_file_has_failed_warning(self, tmp_path):
         args = {"path": str(tmp_path / "gone.py")}
         original = json.dumps({"bytes_written": 10})
         result = verify_tool_result("write_file", args, original)
         parsed = json.loads(result)
-        assert parsed["_verification"]["verified"] is False
+        assert parsed["_verification"]["status"] == "mismatch"
         assert "_warning" in parsed
         assert "VERIFICATION FAILED" in parsed["_warning"]
+        assert "conflicts with environment state" in parsed["_warning"]
 
-    def test_patch_missing_has_top_level_warning(self, tmp_path):
+    def test_mismatch_patch_has_failed_warning(self, tmp_path):
         missing = str(tmp_path / "deleted.py")
         args = {"path": missing}
         original = json.dumps({"success": True, "diff": "...", "files_modified": [missing]})
         result = verify_tool_result("patch", args, original)
         parsed = json.loads(result)
-        assert parsed["_verification"]["verified"] is False
+        assert parsed["_verification"]["status"] == "mismatch"
         assert "_warning" in parsed
-        assert "Do not assume this step succeeded" in parsed["_warning"]
+        assert "VERIFICATION FAILED" in parsed["_warning"]
+
+    # --- warning cases: ⚠️ VERIFICATION WARNING ---
+
+    def test_warning_empty_file_has_warning_text(self, tmp_path):
+        f = tmp_path / "empty.txt"
+        f.write_text("")
+        args = {"path": str(f)}
+        original = json.dumps({"bytes_written": 0})
+        result = verify_tool_result("write_file", args, original)
+        parsed = json.loads(result)
+        assert parsed["_verification"]["status"] == "warning"
+        assert "_warning" in parsed
+        assert "VERIFICATION WARNING" in parsed["_warning"]
+        assert "Result may be incomplete" in parsed["_warning"]
+        # Must NOT contain the mismatch text
+        assert "VERIFICATION FAILED" not in parsed["_warning"]

--- a/tests/agent/test_execution_verifier.py
+++ b/tests/agent/test_execution_verifier.py
@@ -12,6 +12,9 @@ from agent.execution_verifier import (
     _verify_terminal,
     _verify_write_file,
     _verify_patch,
+    _verify_read_file,
+    _verify_browser_navigate,
+    _verify_web_extract,
     VERIFIED,
     WARNING,
     MISMATCH,
@@ -47,7 +50,7 @@ class TestVerificationResult:
     def test_to_dict_warning(self):
         vr = VerificationResult(
             status=WARNING, tool_name="write_file", check="file_written",
-            message="file exists but is empty; result may be incomplete or intentional: /tmp/empty.txt",
+            message="file exists but is empty despite non-empty content arg: /tmp/empty.txt",
         )
         d = vr.to_dict()
         assert d["status"] == "warning"
@@ -59,6 +62,8 @@ class TestVerificationResult:
 # ===================================================================
 
 class TestTerminalVerifier:
+    # --- git clone ---
+
     def test_git_clone_with_explicit_dir_exists(self, tmp_path):
         target = tmp_path / "myrepo"
         target.mkdir()
@@ -106,6 +111,54 @@ class TestTerminalVerifier:
         vr = _verify_terminal(args, result_data)
         assert vr is None  # no verification on failure
 
+    def test_git_clone_with_flags(self, tmp_path):
+        target = tmp_path / "repo"
+        target.mkdir()
+        args = {"command": f"git clone --depth 1 --branch main https://github.com/user/repo.git {target}"}
+        result_data = {"output": "Cloning...", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+
+    # --- git init ---
+
+    def test_git_init_success(self, tmp_path):
+        target = tmp_path / "myproject"
+        target.mkdir()
+        (target / ".git").mkdir()
+        args = {"command": f"git init {target}"}
+        result_data = {"output": "Initialized empty Git repository", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+        assert vr.check == "git_init_dir_exists"
+
+    def test_git_init_missing(self, tmp_path):
+        target = tmp_path / "myproject"
+        target.mkdir()  # no .git subdir
+        args = {"command": f"git init {target}"}
+        result_data = {"output": "Initialized empty Git repository", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == MISMATCH
+        assert ".git" in vr.message
+
+    def test_git_init_no_arg_uses_workdir(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        args = {"command": "git init", "workdir": str(tmp_path)}
+        result_data = {"output": "Initialized empty Git repository", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+
+    def test_git_init_bare_skipped(self):
+        args = {"command": "git init --bare myrepo"}
+        result_data = {"output": "Initialized empty Git repository", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is None
+
+    # --- mkdir ---
+
     def test_mkdir_exists(self, tmp_path):
         target = tmp_path / "newdir"
         target.mkdir()
@@ -124,20 +177,146 @@ class TestTerminalVerifier:
         assert vr is not None
         assert vr.status == MISMATCH
 
+    # --- cp ---
+
+    def test_cp_dest_exists(self, tmp_path):
+        src = tmp_path / "src.txt"
+        src.write_text("data")
+        dest = tmp_path / "dest.txt"
+        dest.write_text("data")
+        args = {"command": f"cp {src} {dest}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+        assert vr.check == "cp_dest_exists"
+
+    def test_cp_dest_missing(self, tmp_path):
+        src = tmp_path / "src.txt"
+        dest = tmp_path / "dest.txt"
+        args = {"command": f"cp {src} {dest}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == MISMATCH
+        assert "does not exist" in vr.message
+
+    def test_cp_with_flags(self, tmp_path):
+        src = tmp_path / "srcdir"
+        src.mkdir()
+        dest = tmp_path / "destdir"
+        dest.mkdir()
+        args = {"command": f"cp -r {src} {dest}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+
+    def test_compound_command_cp(self, tmp_path):
+        src = tmp_path / "a.txt"
+        src.write_text("hi")
+        dest = tmp_path / "b.txt"
+        dest.write_text("hi")
+        args = {"command": f"cp {src} {dest} && echo done"}
+        result_data = {"output": "done", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+        assert vr.check == "cp_dest_exists"
+
+    # --- mv ---
+
+    def test_mv_dest_exists(self, tmp_path):
+        dest = tmp_path / "moved.txt"
+        dest.write_text("data")
+        args = {"command": f"mv {tmp_path / 'orig.txt'} {dest}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+        assert vr.check == "mv_dest_exists"
+
+    def test_mv_dest_missing(self, tmp_path):
+        dest = tmp_path / "gone.txt"
+        args = {"command": f"mv {tmp_path / 'orig.txt'} {dest}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == MISMATCH
+
+    # --- rm ---
+
+    def test_rm_targets_removed(self, tmp_path):
+        target = tmp_path / "deleteme.txt"
+        # target does NOT exist — rm succeeded
+        args = {"command": f"rm {target}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+        assert vr.check == "rm_targets_removed"
+
+    def test_rm_targets_still_exist(self, tmp_path):
+        target = tmp_path / "stubborn.txt"
+        target.write_text("still here")
+        args = {"command": f"rm {target}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == MISMATCH
+        assert "still exist" in vr.message
+
+    def test_rm_with_rf_flag(self, tmp_path):
+        target = tmp_path / "somedir"
+        # target does NOT exist — rm -rf succeeded
+        args = {"command": f"rm -rf {target}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+
+    def test_rm_glob_skipped(self):
+        args = {"command": "rm *.tmp"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is None
+
+    # --- touch ---
+
+    def test_touch_file_exists(self, tmp_path):
+        target = tmp_path / "newfile.txt"
+        target.write_text("")
+        args = {"command": f"touch {target}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+        assert vr.check == "touch_file_exists"
+
+    def test_touch_file_missing(self, tmp_path):
+        target = tmp_path / "phantom.txt"
+        args = {"command": f"touch {target}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == MISMATCH
+
+    def test_touch_with_value_flags(self, tmp_path):
+        target = tmp_path / "dated.txt"
+        target.write_text("")
+        args = {"command": f"touch -t 202301010000 {target}"}
+        result_data = {"output": "", "exit_code": 0, "error": None}
+        vr = _verify_terminal(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+
+    # --- unrelated ---
+
     def test_unrelated_command_returns_none(self):
         args = {"command": "ls -la"}
         result_data = {"output": "total 0", "exit_code": 0, "error": None}
         vr = _verify_terminal(args, result_data)
         assert vr is None
-
-    def test_git_clone_with_flags(self, tmp_path):
-        target = tmp_path / "repo"
-        target.mkdir()
-        args = {"command": f"git clone --depth 1 --branch main https://github.com/user/repo.git {target}"}
-        result_data = {"output": "Cloning...", "exit_code": 0, "error": None}
-        vr = _verify_terminal(args, result_data)
-        assert vr is not None
-        assert vr.status == VERIFIED
 
 
 # ===================================================================
@@ -148,7 +327,7 @@ class TestWriteFileVerifier:
     def test_file_exists_and_nonempty(self, tmp_path):
         f = tmp_path / "hello.py"
         f.write_text("print('hello')")
-        args = {"path": str(f)}
+        args = {"path": str(f), "content": "print('hello')"}
         result_data = {"bytes_written": 14}
         vr = _verify_write_file(args, result_data)
         assert vr is not None
@@ -156,22 +335,44 @@ class TestWriteFileVerifier:
         assert vr.details["size_bytes"] == 14
 
     def test_file_missing(self, tmp_path):
-        args = {"path": str(tmp_path / "missing.py")}
+        args = {"path": str(tmp_path / "missing.py"), "content": "x = 1"}
         result_data = {"bytes_written": 10}
         vr = _verify_write_file(args, result_data)
         assert vr is not None
         assert vr.status == MISMATCH
         assert "does not exist" in vr.message
 
-    def test_file_exists_but_empty(self, tmp_path):
+    def test_file_exists_but_empty_intentional(self, tmp_path):
+        """Empty file with empty content arg → VERIFIED (intentional)."""
         f = tmp_path / "empty.txt"
+        f.write_text("")
+        args = {"path": str(f), "content": ""}
+        result_data = {"bytes_written": 0}
+        vr = _verify_write_file(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+
+    def test_file_exists_but_empty_no_content_key(self, tmp_path):
+        """Empty file with no content key in args → VERIFIED (no expectation)."""
+        f = tmp_path / "empty2.txt"
         f.write_text("")
         args = {"path": str(f)}
         result_data = {"bytes_written": 0}
         vr = _verify_write_file(args, result_data)
         assert vr is not None
+        assert vr.status == VERIFIED
+
+    def test_file_exists_but_empty_unexpected(self, tmp_path):
+        """Empty file but content arg was non-empty → WARNING."""
+        f = tmp_path / "empty3.txt"
+        f.write_text("")
+        args = {"path": str(f), "content": "some data that should be here"}
+        result_data = {"bytes_written": 0}
+        vr = _verify_write_file(args, result_data)
+        assert vr is not None
         assert vr.status == WARNING
         assert "empty" in vr.message.lower()
+        assert "non-empty content" in vr.message.lower()
 
     def test_skipped_on_error_result(self):
         args = {"path": "/some/file.py"}
@@ -226,6 +427,139 @@ class TestPatchVerifier:
 
 
 # ===================================================================
+# read_file verifier
+# ===================================================================
+
+class TestReadFileVerifier:
+    def test_success_with_content(self):
+        args = {"path": "/some/file.py"}
+        result_data = {"content": "1|hello\n2|world", "total_lines": 2, "file_size": 11, "error": None}
+        vr = _verify_read_file(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+        assert vr.check == "file_read"
+        assert vr.details["file_size"] == 11
+
+    def test_error_with_similar_files(self):
+        args = {"path": "/tmp/foo.py"}
+        result_data = {"error": "File not found: /tmp/foo.py", "similar_files": ["/tmp/foo2.py", "/tmp/foobar.py"]}
+        vr = _verify_read_file(args, result_data)
+        assert vr is not None
+        assert vr.status == WARNING
+        assert "similar files available" in vr.message
+        assert vr.details["similar_files"] == ["/tmp/foo2.py", "/tmp/foobar.py"]
+
+    def test_error_without_similar_files(self):
+        args = {"path": "/tmp/foo.py"}
+        result_data = {"error": "File not found: /tmp/foo.py"}
+        vr = _verify_read_file(args, result_data)
+        assert vr is not None
+        assert vr.status == MISMATCH
+        assert "no alternatives" in vr.message
+
+    def test_no_content_no_error(self):
+        """Empty file read — no opinion."""
+        args = {"path": "/some/empty.txt"}
+        result_data = {"content": "", "total_lines": 0, "file_size": 0, "error": None}
+        vr = _verify_read_file(args, result_data)
+        assert vr is None
+
+
+# ===================================================================
+# browser_navigate verifier
+# ===================================================================
+
+class TestBrowserNavigateVerifier:
+    def test_navigation_success(self):
+        args = {"url": "https://example.com"}
+        result_data = {"success": True, "url": "https://example.com", "title": "Example Domain"}
+        vr = _verify_browser_navigate(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+        assert vr.check == "navigation_success"
+
+    def test_navigation_failed(self):
+        args = {"url": "https://example.com"}
+        result_data = {"success": False, "error": "Connection refused"}
+        vr = _verify_browser_navigate(args, result_data)
+        assert vr is not None
+        assert vr.status == MISMATCH
+        assert "Connection refused" in vr.message
+
+    def test_navigation_bot_detection(self):
+        args = {"url": "https://example.com"}
+        result_data = {
+            "success": True,
+            "url": "https://example.com",
+            "title": "Verify you are human",
+            "bot_detection_warning": "Page title suggests bot detection",
+        }
+        vr = _verify_browser_navigate(args, result_data)
+        assert vr is not None
+        assert vr.status == WARNING
+        assert "bot detection" in vr.message.lower()
+
+    def test_no_success_field(self):
+        args = {"url": "https://example.com"}
+        result_data = {"url": "https://example.com"}
+        vr = _verify_browser_navigate(args, result_data)
+        assert vr is None
+
+
+# ===================================================================
+# web_extract verifier
+# ===================================================================
+
+class TestWebExtractVerifier:
+    def test_all_urls_succeeded(self):
+        args = {"urls": ["https://a.com", "https://b.com"]}
+        result_data = {"results": [
+            {"url": "https://a.com", "title": "A", "content": "Page A content"},
+            {"url": "https://b.com", "title": "B", "content": "Page B content"},
+        ]}
+        vr = _verify_web_extract(args, result_data)
+        assert vr is not None
+        assert vr.status == VERIFIED
+        assert vr.details["succeeded"] == 2
+
+    def test_all_urls_failed(self):
+        args = {"urls": ["https://a.com"]}
+        result_data = {"results": [
+            {"url": "https://a.com", "error": "timeout", "content": ""},
+        ]}
+        vr = _verify_web_extract(args, result_data)
+        assert vr is not None
+        assert vr.status == MISMATCH
+        assert "failed to extract" in vr.message.lower()
+
+    def test_partial_failure(self):
+        args = {"urls": ["https://a.com", "https://b.com"]}
+        result_data = {"results": [
+            {"url": "https://a.com", "title": "A", "content": "Page A content"},
+            {"url": "https://b.com", "error": "timeout", "content": ""},
+        ]}
+        vr = _verify_web_extract(args, result_data)
+        assert vr is not None
+        assert vr.status == WARNING
+        assert "1 of 2" in vr.message
+
+    def test_empty_results(self):
+        args = {"urls": ["https://a.com"]}
+        result_data = {"results": []}
+        vr = _verify_web_extract(args, result_data)
+        assert vr is not None
+        assert vr.status == MISMATCH
+        assert "no results" in vr.message.lower()
+
+    def test_top_level_error(self):
+        args = {"urls": ["https://a.com"]}
+        result_data = {"error": "Content was inaccessible"}
+        vr = _verify_web_extract(args, result_data)
+        assert vr is not None
+        assert vr.status == MISMATCH
+
+
+# ===================================================================
 # Integration: verify_tool_result
 # ===================================================================
 
@@ -244,13 +578,37 @@ class TestVerifyToolResult:
     def test_augments_write_file_result(self, tmp_path):
         f = tmp_path / "out.txt"
         f.write_text("data")
-        args = {"path": str(f)}
+        args = {"path": str(f), "content": "data"}
         original = json.dumps({"bytes_written": 4})
         result = verify_tool_result("write_file", args, original)
         parsed = json.loads(result)
         assert "_verification" in parsed
         assert parsed["_verification"]["status"] == "verified"
         assert "_warning" not in parsed  # no warning on verified
+
+    def test_augments_read_file_result(self):
+        args = {"path": "/some/file.py"}
+        original = json.dumps({"content": "1|hello", "total_lines": 1, "file_size": 5, "error": None})
+        result = verify_tool_result("read_file", args, original)
+        parsed = json.loads(result)
+        assert "_verification" in parsed
+        assert parsed["_verification"]["status"] == "verified"
+
+    def test_augments_browser_navigate_result(self):
+        args = {"url": "https://example.com"}
+        original = json.dumps({"success": True, "url": "https://example.com", "title": "Example"})
+        result = verify_tool_result("browser_navigate", args, original)
+        parsed = json.loads(result)
+        assert "_verification" in parsed
+        assert parsed["_verification"]["status"] == "verified"
+
+    def test_augments_web_extract_result(self):
+        args = {"urls": ["https://example.com"]}
+        original = json.dumps({"results": [{"url": "https://example.com", "content": "data", "title": "Ex"}]})
+        result = verify_tool_result("web_extract", args, original)
+        parsed = json.loads(result)
+        assert "_verification" in parsed
+        assert parsed["_verification"]["status"] == "verified"
 
     def test_no_verifier_returns_unchanged(self):
         original = json.dumps({"results": [1, 2, 3]})
@@ -268,7 +626,7 @@ class TestVerifyToolResult:
         parsed = json.loads(result)
         assert "_verification" not in parsed
 
-    # --- mismatch cases: ❌ VERIFICATION FAILED ---
+    # --- mismatch cases: VERIFICATION FAILED ---
 
     def test_mismatch_terminal_has_failed_warning(self, tmp_path):
         missing = str(tmp_path / "nope")
@@ -282,7 +640,7 @@ class TestVerifyToolResult:
         assert "conflicts with environment state" in parsed["_warning"]
 
     def test_mismatch_write_file_has_failed_warning(self, tmp_path):
-        args = {"path": str(tmp_path / "gone.py")}
+        args = {"path": str(tmp_path / "gone.py"), "content": "x = 1"}
         original = json.dumps({"bytes_written": 10})
         result = verify_tool_result("write_file", args, original)
         parsed = json.loads(result)
@@ -301,12 +659,21 @@ class TestVerifyToolResult:
         assert "_warning" in parsed
         assert "VERIFICATION FAILED" in parsed["_warning"]
 
-    # --- warning cases: ⚠️ VERIFICATION WARNING ---
+    def test_mismatch_browser_navigate_has_failed_warning(self):
+        args = {"url": "https://example.com"}
+        original = json.dumps({"success": False, "error": "Connection refused"})
+        result = verify_tool_result("browser_navigate", args, original)
+        parsed = json.loads(result)
+        assert parsed["_verification"]["status"] == "mismatch"
+        assert "_warning" in parsed
+        assert "VERIFICATION FAILED" in parsed["_warning"]
+
+    # --- warning cases: VERIFICATION WARNING ---
 
     def test_warning_empty_file_has_warning_text(self, tmp_path):
         f = tmp_path / "empty.txt"
         f.write_text("")
-        args = {"path": str(f)}
+        args = {"path": str(f), "content": "data that should be here"}
         original = json.dumps({"bytes_written": 0})
         result = verify_tool_result("write_file", args, original)
         parsed = json.loads(result)
@@ -316,3 +683,25 @@ class TestVerifyToolResult:
         assert "Result may be incomplete" in parsed["_warning"]
         # Must NOT contain the mismatch text
         assert "VERIFICATION FAILED" not in parsed["_warning"]
+
+    def test_warning_web_extract_partial_has_warning_text(self):
+        args = {"urls": ["https://a.com", "https://b.com"]}
+        original = json.dumps({"results": [
+            {"url": "https://a.com", "content": "data", "title": "A"},
+            {"url": "https://b.com", "error": "timeout", "content": ""},
+        ]})
+        result = verify_tool_result("web_extract", args, original)
+        parsed = json.loads(result)
+        assert parsed["_verification"]["status"] == "warning"
+        assert "_warning" in parsed
+        assert "VERIFICATION WARNING" in parsed["_warning"]
+        assert "VERIFICATION FAILED" not in parsed["_warning"]
+
+    def test_warning_read_file_similar_files_has_warning_text(self):
+        args = {"path": "/tmp/foo.py"}
+        original = json.dumps({"error": "File not found", "similar_files": ["/tmp/foo2.py"]})
+        result = verify_tool_result("read_file", args, original)
+        parsed = json.loads(result)
+        assert parsed["_verification"]["status"] == "warning"
+        assert "_warning" in parsed
+        assert "VERIFICATION WARNING" in parsed["_warning"]


### PR DESCRIPTION
## Summary

This PR expands Hermes' **Execution Integrity Layer** with broader post-tool-call verification across high-signal tools.

Today, when a tool reports success, the agent typically trusts the returned JSON and continues reasoning. In some cases, however, the reported result does not match the actual observable environment state.

This change adds lightweight postcondition checks after supported tool calls so Hermes can surface obvious mismatches and incomplete results instead of silently trusting tool output.

## What this adds

Supported verifications:

- `terminal`
  - `git clone` → verify target directory exists
  - `git init` → verify `.git` directory exists
  - `mkdir` → verify directory exists
  - `cp` → verify destination exists
  - `mv` → verify destination exists
  - `rm` → verify targets no longer exist
  - `touch` → verify file exists

- `write_file`
  - verify file exists
  - avoid warning on intentionally empty content
  - warn only when non-empty content was expected but the file is empty

- `patch`
  - verify modified/created files still exist

- `read_file`
  - verify content was returned when successful
  - surface a warning when the file is missing but similar files are available

- `browser_navigate`
  - verify success/failure signaling
  - surface a warning when navigation succeeded but bot detection was triggered

- `web_extract`
  - verify extraction produced non-empty results
  - surface warnings for partial extraction failures
  - surface mismatches when all URLs fail or no results are returned

## Verification status

Each supported verifier returns one of:

- `verified` — environment state matches expectations
- `warning` — result may be incomplete or needs attention
- `mismatch` — environment state contradicts the reported tool result

On `warning` or `mismatch`, a `_warning` field is injected so the model receives an explicit signal instead of silently continuing.

## Motivation

While testing Hermes tool workflows, I noticed a recurring failure mode:

- a tool reports success
- the expected state change did not actually occur
- the agent continues reasoning as if the step succeeded

This PR adds lightweight postcondition checks to catch some of those cases earlier.

It is intentionally conservative:
- only operations with simple, low-cost observable postconditions are verified
- it does **not** attempt to guarantee semantic correctness
- it does **not** attempt to verify every tool

## Implementation

New file:

- `agent/execution_verifier.py`

Integration point:

```python
result = registry.dispatch(...)
return verify_tool_result(function_name, function_args, result)
