### PR TITLE
fix: thread safety for concurrent subagent delegation

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -35,6 +35,7 @@ than the provider's default.
 import json
 import logging
 import os
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
@@ -146,7 +147,6 @@ class _CodexCompletionsAdapter:
     def create(self, **kwargs) -> Any:
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
-        kwargs.get("temperature")
 
         # Separate system/instructions from conversation messages.
         # Convert chat.completions multimodal content blocks to Responses
@@ -863,7 +863,6 @@ def auxiliary_max_tokens_param(value: int) -> dict:
 # Client cache: (provider, async_mode) -> (client, default_model)
 # Protected by _client_cache_lock for thread safety — subagent threads
 # call call_llm() concurrently for compression, session search, etc.
-import threading
 _client_cache: Dict[tuple, tuple] = {}
 _client_cache_lock = threading.Lock()
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -146,7 +146,7 @@ class _CodexCompletionsAdapter:
     def create(self, **kwargs) -> Any:
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
-        temperature = kwargs.get("temperature")
+        kwargs.get("temperature")
 
         # Separate system/instructions from conversation messages.
         # Convert chat.completions multimodal content blocks to Responses
@@ -702,6 +702,50 @@ def resolve_provider_client(
     return None, None
 
 
+def resolve_provider_credentials(
+    provider: str,
+    model: str,
+) -> Optional[dict]:
+    """Resolve a provider+model into a complete credentials bundle.
+
+    Thin wrapper around :func:`resolve_provider_client` that also derives
+    ``api_mode`` from the provider name.  Used by every code path that
+    needs to construct or switch to a new provider: fallback activation,
+    the ``switch_model`` tool, and per-task delegation overrides.
+
+    Returns a dict on success::
+
+        {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4-6",
+            "base_url": "https://...",
+            "api_key": "sk-...",
+            "api_mode": "chat_completions",
+            "client": <OpenAI>,       # ready-to-use client object
+        }
+
+    Returns ``None`` if the provider is not configured (no API key).
+    """
+    client, _ = resolve_provider_client(provider, model=model, raw_codex=True)
+    if client is None:
+        return None
+
+    api_mode = "chat_completions"
+    if provider == "openai-codex":
+        api_mode = "codex_responses"
+    elif provider == "anthropic":
+        api_mode = "anthropic_messages"
+
+    return {
+        "provider": provider,
+        "model": model,
+        "base_url": str(client.base_url),
+        "api_key": client.api_key,
+        "api_mode": api_mode,
+        "client": client,
+    }
+
+
 # ── Public API ──────────────────────────────────────────────────────────────
 
 def get_text_auxiliary_client(task: str = "") -> Tuple[Optional[OpenAI], Optional[str]]:
@@ -817,20 +861,35 @@ def auxiliary_max_tokens_param(value: int) -> dict:
 # constructing clients and calling .chat.completions.create().
 
 # Client cache: (provider, async_mode) -> (client, default_model)
+# Protected by _client_cache_lock for thread safety — subagent threads
+# call call_llm() concurrently for compression, session search, etc.
+import threading
 _client_cache: Dict[tuple, tuple] = {}
+_client_cache_lock = threading.Lock()
 
 
 def _get_cached_client(
     provider: str, model: str = None, async_mode: bool = False,
 ) -> Tuple[Optional[Any], Optional[str]]:
-    """Get or create a cached client for the given provider."""
+    """Get or create a cached client for the given provider.
+
+    Thread-safe: multiple subagent threads may resolve clients concurrently.
+    """
     cache_key = (provider, async_mode)
-    if cache_key in _client_cache:
-        cached_client, cached_default = _client_cache[cache_key]
-        return cached_client, model or cached_default
+    with _client_cache_lock:
+        if cache_key in _client_cache:
+            cached_client, cached_default = _client_cache[cache_key]
+            return cached_client, model or cached_default
+    # Build outside the lock — resolve_provider_client can be slow (network)
     client, default_model = resolve_provider_client(provider, model, async_mode)
     if client is not None:
-        _client_cache[cache_key] = (client, default_model)
+        with _client_cache_lock:
+            # Double-check: another thread may have populated it
+            if cache_key not in _client_cache:
+                _client_cache[cache_key] = (client, default_model)
+            else:
+                # Use the already-cached client to avoid duplicates
+                client, default_model = _client_cache[cache_key]
     return client, model or default_model
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -18,6 +18,7 @@ import json
 import os
 import re
 import sqlite3
+import threading
 import time
 from pathlib import Path
 from typing import Dict, Any, List, Optional
@@ -104,6 +105,7 @@ class SessionDB:
         self.db_path = db_path or DEFAULT_DB_PATH
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
+        self._lock = threading.Lock()
         self._conn = sqlite3.connect(
             str(self.db_path),
             check_same_thread=False,
@@ -173,9 +175,10 @@ class SessionDB:
 
     def close(self):
         """Close the database connection."""
-        if self._conn:
-            self._conn.close()
-            self._conn = None
+        with self._lock:
+            if self._conn:
+                self._conn.close()
+                self._conn = None
 
     # =========================================================================
     # Session lifecycle
@@ -192,59 +195,64 @@ class SessionDB:
         parent_session_id: str = None,
     ) -> str:
         """Create a new session record. Returns the session_id."""
-        self._conn.execute(
-            """INSERT INTO sessions (id, source, user_id, model, model_config,
-               system_prompt, parent_session_id, started_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                session_id,
-                source,
-                user_id,
-                model,
-                json.dumps(model_config) if model_config else None,
-                system_prompt,
-                parent_session_id,
-                time.time(),
-            ),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                """INSERT INTO sessions (id, source, user_id, model, model_config,
+                   system_prompt, parent_session_id, started_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    source,
+                    user_id,
+                    model,
+                    json.dumps(model_config) if model_config else None,
+                    system_prompt,
+                    parent_session_id,
+                    time.time(),
+                ),
+            )
+            self._conn.commit()
         return session_id
 
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session as ended."""
-        self._conn.execute(
-            "UPDATE sessions SET ended_at = ?, end_reason = ? WHERE id = ?",
-            (time.time(), end_reason, session_id),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "UPDATE sessions SET ended_at = ?, end_reason = ? WHERE id = ?",
+                (time.time(), end_reason, session_id),
+            )
+            self._conn.commit()
 
     def update_system_prompt(self, session_id: str, system_prompt: str) -> None:
         """Store the full assembled system prompt snapshot."""
-        self._conn.execute(
-            "UPDATE sessions SET system_prompt = ? WHERE id = ?",
-            (system_prompt, session_id),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "UPDATE sessions SET system_prompt = ? WHERE id = ?",
+                (system_prompt, session_id),
+            )
+            self._conn.commit()
 
     def update_token_counts(
         self, session_id: str, input_tokens: int = 0, output_tokens: int = 0
     ) -> None:
         """Increment token counters on a session."""
-        self._conn.execute(
-            """UPDATE sessions SET
-               input_tokens = input_tokens + ?,
-               output_tokens = output_tokens + ?
-               WHERE id = ?""",
-            (input_tokens, output_tokens, session_id),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                """UPDATE sessions SET
+                   input_tokens = input_tokens + ?,
+                   output_tokens = output_tokens + ?
+                   WHERE id = ?""",
+                (input_tokens, output_tokens, session_id),
+            )
+            self._conn.commit()
 
     def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Get a session by ID."""
-        cursor = self._conn.execute(
-            "SELECT * FROM sessions WHERE id = ?", (session_id,)
-        )
-        row = cursor.fetchone()
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM sessions WHERE id = ?", (session_id,)
+            )
+            row = cursor.fetchone()
         return dict(row) if row else None
 
     # Maximum length for session titles
@@ -305,38 +313,41 @@ class SessionDB:
         Empty/whitespace-only strings are normalized to None (clearing the title).
         """
         title = self.sanitize_title(title)
-        if title:
-            # Check uniqueness (allow the same session to keep its own title)
+        with self._lock:
+            if title:
+                # Check uniqueness (allow the same session to keep its own title)
+                cursor = self._conn.execute(
+                    "SELECT id FROM sessions WHERE title = ? AND id != ?",
+                    (title, session_id),
+                )
+                conflict = cursor.fetchone()
+                if conflict:
+                    raise ValueError(
+                        f"Title '{title}' is already in use by session {conflict['id']}"
+                    )
             cursor = self._conn.execute(
-                "SELECT id FROM sessions WHERE title = ? AND id != ?",
+                "UPDATE sessions SET title = ? WHERE id = ?",
                 (title, session_id),
             )
-            conflict = cursor.fetchone()
-            if conflict:
-                raise ValueError(
-                    f"Title '{title}' is already in use by session {conflict['id']}"
-                )
-        cursor = self._conn.execute(
-            "UPDATE sessions SET title = ? WHERE id = ?",
-            (title, session_id),
-        )
-        self._conn.commit()
-        return cursor.rowcount > 0
+            self._conn.commit()
+            return cursor.rowcount > 0
 
     def get_session_title(self, session_id: str) -> Optional[str]:
         """Get the title for a session, or None."""
-        cursor = self._conn.execute(
-            "SELECT title FROM sessions WHERE id = ?", (session_id,)
-        )
-        row = cursor.fetchone()
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT title FROM sessions WHERE id = ?", (session_id,)
+            )
+            row = cursor.fetchone()
         return row["title"] if row else None
 
     def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""
-        cursor = self._conn.execute(
-            "SELECT * FROM sessions WHERE title = ?", (title,)
-        )
-        row = cursor.fetchone()
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM sessions WHERE title = ?", (title,)
+            )
+            row = cursor.fetchone()
         return dict(row) if row else None
 
     def resolve_session_by_title(self, title: str) -> Optional[str]:
@@ -353,12 +364,13 @@ class SessionDB:
         # Also search for numbered variants: "title #2", "title #3", etc.
         # Escape SQL LIKE wildcards (%, _) in the title to prevent false matches
         escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-        cursor = self._conn.execute(
-            "SELECT id, title, started_at FROM sessions "
-            "WHERE title LIKE ? ESCAPE '\\' ORDER BY started_at DESC",
-            (f"{escaped} #%",),
-        )
-        numbered = cursor.fetchall()
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT id, title, started_at FROM sessions "
+                "WHERE title LIKE ? ESCAPE '\\' ORDER BY started_at DESC",
+                (f"{escaped} #%",),
+            )
+            numbered = cursor.fetchall()
 
         if numbered:
             # Return the most recent numbered variant
@@ -384,11 +396,12 @@ class SessionDB:
         # Find all existing numbered variants
         # Escape SQL LIKE wildcards (%, _) in the base to prevent false matches
         escaped = base.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-        cursor = self._conn.execute(
-            "SELECT title FROM sessions WHERE title = ? OR title LIKE ? ESCAPE '\\'",
-            (base, f"{escaped} #%"),
-        )
-        existing = [row["title"] for row in cursor.fetchall()]
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT title FROM sessions WHERE title = ? OR title LIKE ? ESCAPE '\\'",
+                (base, f"{escaped} #%"),
+            )
+            existing = [row["title"] for row in cursor.fetchall()]
 
         if not existing:
             return base  # No conflict, use the base name as-is
@@ -436,9 +449,11 @@ class SessionDB:
             LIMIT ? OFFSET ?
         """
         params = (source, limit, offset) if source else (limit, offset)
-        cursor = self._conn.execute(query, params)
+        with self._lock:
+            cursor = self._conn.execute(query, params)
+            rows = cursor.fetchall()
         sessions = []
-        for row in cursor.fetchall():
+        for row in rows:
             s = dict(row)
             # Build the preview from the raw substring
             raw = s.pop("_preview_raw", "").strip()
@@ -472,52 +487,54 @@ class SessionDB:
         Also increments the session's message_count (and tool_call_count
         if role is 'tool' or tool_calls is present).
         """
-        cursor = self._conn.execute(
-            """INSERT INTO messages (session_id, role, content, tool_call_id,
-               tool_calls, tool_name, timestamp, token_count, finish_reason)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                session_id,
-                role,
-                content,
-                tool_call_id,
-                json.dumps(tool_calls) if tool_calls else None,
-                tool_name,
-                time.time(),
-                token_count,
-                finish_reason,
-            ),
-        )
-        msg_id = cursor.lastrowid
-
-        # Update counters
-        # Count actual tool calls from the tool_calls list (not from tool responses).
-        # A single assistant message can contain multiple parallel tool calls.
-        num_tool_calls = 0
-        if tool_calls is not None:
-            num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
-        if num_tool_calls > 0:
-            self._conn.execute(
-                """UPDATE sessions SET message_count = message_count + 1,
-                   tool_call_count = tool_call_count + ? WHERE id = ?""",
-                (num_tool_calls, session_id),
+        with self._lock:
+            cursor = self._conn.execute(
+                """INSERT INTO messages (session_id, role, content, tool_call_id,
+                   tool_calls, tool_name, timestamp, token_count, finish_reason)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    role,
+                    content,
+                    tool_call_id,
+                    json.dumps(tool_calls) if tool_calls else None,
+                    tool_name,
+                    time.time(),
+                    token_count,
+                    finish_reason,
+                ),
             )
-        else:
-            self._conn.execute(
-                "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
-                (session_id,),
-            )
+            msg_id = cursor.lastrowid
 
-        self._conn.commit()
+            # Update counters
+            # Count actual tool calls from the tool_calls list (not from tool responses).
+            # A single assistant message can contain multiple parallel tool calls.
+            num_tool_calls = 0
+            if tool_calls is not None:
+                num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
+            if num_tool_calls > 0:
+                self._conn.execute(
+                    """UPDATE sessions SET message_count = message_count + 1,
+                       tool_call_count = tool_call_count + ? WHERE id = ?""",
+                    (num_tool_calls, session_id),
+                )
+            else:
+                self._conn.execute(
+                    "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
+                    (session_id,),
+                )
+
+            self._conn.commit()
         return msg_id
 
     def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages for a session, ordered by timestamp."""
-        cursor = self._conn.execute(
-            "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp, id",
-            (session_id,),
-        )
-        rows = cursor.fetchall()
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp, id",
+                (session_id,),
+            )
+            rows = cursor.fetchall()
         result = []
         for row in rows:
             msg = dict(row)
@@ -534,13 +551,15 @@ class SessionDB:
         Load messages in the OpenAI conversation format (role + content dicts).
         Used by the gateway to restore conversation history.
         """
-        cursor = self._conn.execute(
-            "SELECT role, content, tool_call_id, tool_calls, tool_name "
-            "FROM messages WHERE session_id = ? ORDER BY timestamp, id",
-            (session_id,),
-        )
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT role, content, tool_call_id, tool_calls, tool_name "
+                "FROM messages WHERE session_id = ? ORDER BY timestamp, id",
+                (session_id,),
+            )
+            raw_rows = cursor.fetchall()
         messages = []
-        for row in cursor.fetchall():
+        for row in raw_rows:
             msg = {"role": row["role"], "content": row["content"]}
             if row["tool_call_id"]:
                 msg["tool_call_id"] = row["tool_call_id"]
@@ -650,32 +669,33 @@ class SessionDB:
             LIMIT ? OFFSET ?
         """
 
-        try:
-            cursor = self._conn.execute(sql, params)
-        except sqlite3.OperationalError:
-            # FTS5 query syntax error despite sanitization — return empty
-            return []
-        matches = [dict(row) for row in cursor.fetchall()]
-
-        # Add surrounding context (1 message before + after each match)
-        for match in matches:
+        with self._lock:
             try:
-                ctx_cursor = self._conn.execute(
-                    """SELECT role, content FROM messages
-                       WHERE session_id = ? AND id >= ? - 1 AND id <= ? + 1
-                       ORDER BY id""",
-                    (match["session_id"], match["id"], match["id"]),
-                )
-                context_msgs = [
-                    {"role": r["role"], "content": (r["content"] or "")[:200]}
-                    for r in ctx_cursor.fetchall()
-                ]
-                match["context"] = context_msgs
-            except Exception:
-                match["context"] = []
+                cursor = self._conn.execute(sql, params)
+            except sqlite3.OperationalError:
+                # FTS5 query syntax error despite sanitization — return empty
+                return []
+            matches = [dict(row) for row in cursor.fetchall()]
 
-            # Remove full content from result (snippet is enough, saves tokens)
-            match.pop("content", None)
+            # Add surrounding context (1 message before + after each match)
+            for match in matches:
+                try:
+                    ctx_cursor = self._conn.execute(
+                        """SELECT role, content FROM messages
+                           WHERE session_id = ? AND id >= ? - 1 AND id <= ? + 1
+                           ORDER BY id""",
+                        (match["session_id"], match["id"], match["id"]),
+                    )
+                    context_msgs = [
+                        {"role": r["role"], "content": (r["content"] or "")[:200]}
+                        for r in ctx_cursor.fetchall()
+                    ]
+                    match["context"] = context_msgs
+                except Exception:
+                    match["context"] = []
+
+                # Remove full content from result (snippet is enough, saves tokens)
+                match.pop("content", None)
 
         return matches
 
@@ -686,17 +706,18 @@ class SessionDB:
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
         """List sessions, optionally filtered by source."""
-        if source:
-            cursor = self._conn.execute(
-                "SELECT * FROM sessions WHERE source = ? ORDER BY started_at DESC LIMIT ? OFFSET ?",
-                (source, limit, offset),
-            )
-        else:
-            cursor = self._conn.execute(
-                "SELECT * FROM sessions ORDER BY started_at DESC LIMIT ? OFFSET ?",
-                (limit, offset),
-            )
-        return [dict(row) for row in cursor.fetchall()]
+        with self._lock:
+            if source:
+                cursor = self._conn.execute(
+                    "SELECT * FROM sessions WHERE source = ? ORDER BY started_at DESC LIMIT ? OFFSET ?",
+                    (source, limit, offset),
+                )
+            else:
+                cursor = self._conn.execute(
+                    "SELECT * FROM sessions ORDER BY started_at DESC LIMIT ? OFFSET ?",
+                    (limit, offset),
+                )
+            return [dict(row) for row in cursor.fetchall()]
 
     # =========================================================================
     # Utility
@@ -704,23 +725,25 @@ class SessionDB:
 
     def session_count(self, source: str = None) -> int:
         """Count sessions, optionally filtered by source."""
-        if source:
-            cursor = self._conn.execute(
-                "SELECT COUNT(*) FROM sessions WHERE source = ?", (source,)
-            )
-        else:
-            cursor = self._conn.execute("SELECT COUNT(*) FROM sessions")
-        return cursor.fetchone()[0]
+        with self._lock:
+            if source:
+                cursor = self._conn.execute(
+                    "SELECT COUNT(*) FROM sessions WHERE source = ?", (source,)
+                )
+            else:
+                cursor = self._conn.execute("SELECT COUNT(*) FROM sessions")
+            return cursor.fetchone()[0]
 
     def message_count(self, session_id: str = None) -> int:
         """Count messages, optionally for a specific session."""
-        if session_id:
-            cursor = self._conn.execute(
-                "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
-            )
-        else:
-            cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
-        return cursor.fetchone()[0]
+        with self._lock:
+            if session_id:
+                cursor = self._conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
+                )
+            else:
+                cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
+            return cursor.fetchone()[0]
 
     # =========================================================================
     # Export and cleanup
@@ -748,26 +771,28 @@ class SessionDB:
 
     def clear_messages(self, session_id: str) -> None:
         """Delete all messages for a session and reset its counters."""
-        self._conn.execute(
-            "DELETE FROM messages WHERE session_id = ?", (session_id,)
-        )
-        self._conn.execute(
-            "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
-            (session_id,),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "DELETE FROM messages WHERE session_id = ?", (session_id,)
+            )
+            self._conn.execute(
+                "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
+                (session_id,),
+            )
+            self._conn.commit()
 
     def delete_session(self, session_id: str) -> bool:
         """Delete a session and all its messages. Returns True if found."""
-        cursor = self._conn.execute(
-            "SELECT COUNT(*) FROM sessions WHERE id = ?", (session_id,)
-        )
-        if cursor.fetchone()[0] == 0:
-            return False
-        self._conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
-        self._conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
-        self._conn.commit()
-        return True
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT COUNT(*) FROM sessions WHERE id = ?", (session_id,)
+            )
+            if cursor.fetchone()[0] == 0:
+                return False
+            self._conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+            self._conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+            self._conn.commit()
+            return True
 
     def prune_sessions(self, older_than_days: int = 90, source: str = None) -> int:
         """
@@ -777,22 +802,23 @@ class SessionDB:
         import time as _time
         cutoff = _time.time() - (older_than_days * 86400)
 
-        if source:
-            cursor = self._conn.execute(
-                """SELECT id FROM sessions
-                   WHERE started_at < ? AND ended_at IS NOT NULL AND source = ?""",
-                (cutoff, source),
-            )
-        else:
-            cursor = self._conn.execute(
-                "SELECT id FROM sessions WHERE started_at < ? AND ended_at IS NOT NULL",
-                (cutoff,),
-            )
-        session_ids = [row["id"] for row in cursor.fetchall()]
+        with self._lock:
+            if source:
+                cursor = self._conn.execute(
+                    """SELECT id FROM sessions
+                       WHERE started_at < ? AND ended_at IS NOT NULL AND source = ?""",
+                    (cutoff, source),
+                )
+            else:
+                cursor = self._conn.execute(
+                    "SELECT id FROM sessions WHERE started_at < ? AND ended_at IS NOT NULL",
+                    (cutoff,),
+                )
+            session_ids = [row["id"] for row in cursor.fetchall()]
 
-        for sid in session_ids:
-            self._conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
-            self._conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
+            for sid in session_ids:
+                self._conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
+                self._conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
 
-        self._conn.commit()
+            self._conn.commit()
         return len(session_ids)

--- a/run_agent.py
+++ b/run_agent.py
@@ -345,7 +345,8 @@ class AIAgent:
         # Subagent delegation state
         self._delegate_depth = 0        # 0 = top-level agent, incremented for children
         self._active_children = []      # Running child AIAgents (for interrupt propagation)
-        
+        self._active_children_lock = threading.Lock()
+
         # Store OpenRouter provider preferences
         self.providers_allowed = providers_allowed
         self.providers_ignored = providers_ignored
@@ -1388,7 +1389,9 @@ class AIAgent:
         # Signal all tools to abort any in-flight operations immediately
         _set_interrupt(True)
         # Propagate interrupt to any running child agents (subagent delegation)
-        for child in self._active_children:
+        with self._active_children_lock:
+            children_snapshot = list(self._active_children)
+        for child in children_snapshot:
             try:
                 child.interrupt(message)
             except Exception as e:
@@ -2570,6 +2573,44 @@ class AIAgent:
             raise result["error"]
         return result["response"]
 
+    # ── Provider credential swap ─────────────────────────────────────────
+
+    def _apply_provider_credentials(self, creds: dict) -> None:
+        """Apply a resolved credentials bundle to this agent in-place.
+
+        *creds* is a dict from :func:`resolve_provider_credentials` with
+        keys: provider, model, base_url, api_key, api_mode, client.
+
+        Handles the OpenAI-vs-Anthropic client split and re-evaluates
+        prompt-caching eligibility.
+        """
+        self.model = creds["model"]
+        self.provider = creds["provider"]
+        self.base_url = creds["base_url"]
+        self.api_mode = creds["api_mode"]
+
+        if creds["api_mode"] == "anthropic_messages":
+            from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
+            effective_key = creds["api_key"] or resolve_anthropic_token() or ""
+            self._anthropic_api_key = effective_key
+            self._anthropic_client = build_anthropic_client(effective_key)
+            self.client = None
+            self._client_kwargs = {}
+        else:
+            self.client = creds["client"]
+            self._client_kwargs = {
+                "api_key": creds["api_key"],
+                "base_url": creds["base_url"],
+            }
+
+        # Re-evaluate prompt caching for the new provider/model
+        is_native_anthropic = creds["api_mode"] == "anthropic_messages"
+        self._use_prompt_caching = (
+            ("openrouter" in creds["base_url"].lower()
+             and "claude" in creds["model"].lower())
+            or is_native_anthropic
+        )
+
     # ── Provider fallback ──────────────────────────────────────────────────
 
     def _try_activate_fallback(self) -> bool:
@@ -2579,10 +2620,6 @@ class AIAgent:
         OpenAI client, model slug, and provider in-place so the retry loop
         can continue with the new backend.  One-shot: returns False if
         already activated or not configured.
-
-        Uses the centralized provider router (resolve_provider_client) for
-        auth resolution and client construction — no duplicated provider→key
-        mappings.
         """
         if self._fallback_activated or not self._fallback_model:
             return False
@@ -2593,56 +2630,18 @@ class AIAgent:
         if not fb_provider or not fb_model:
             return False
 
-        # Use centralized router for client construction.
-        # raw_codex=True because the main agent needs direct responses.stream()
-        # access for Codex providers.
         try:
-            from agent.auxiliary_client import resolve_provider_client
-            fb_client, _ = resolve_provider_client(
-                fb_provider, model=fb_model, raw_codex=True)
-            if fb_client is None:
+            from agent.auxiliary_client import resolve_provider_credentials
+            creds = resolve_provider_credentials(fb_provider, fb_model)
+            if creds is None:
                 logging.warning(
                     "Fallback to %s failed: provider not configured",
                     fb_provider)
                 return False
 
-            # Determine api_mode from provider
-            fb_api_mode = "chat_completions"
-            if fb_provider == "openai-codex":
-                fb_api_mode = "codex_responses"
-            elif fb_provider == "anthropic":
-                fb_api_mode = "anthropic_messages"
-            fb_base_url = str(fb_client.base_url)
-
             old_model = self.model
-            self.model = fb_model
-            self.provider = fb_provider
-            self.base_url = fb_base_url
-            self.api_mode = fb_api_mode
+            self._apply_provider_credentials(creds)
             self._fallback_activated = True
-
-            if fb_api_mode == "anthropic_messages":
-                # Build native Anthropic client instead of using OpenAI client
-                from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
-                effective_key = fb_client.api_key or resolve_anthropic_token() or ""
-                self._anthropic_api_key = effective_key
-                self._anthropic_client = build_anthropic_client(effective_key)
-                self.client = None
-                self._client_kwargs = {}
-            else:
-                # Swap OpenAI client and config in-place
-                self.client = fb_client
-                self._client_kwargs = {
-                    "api_key": fb_client.api_key,
-                    "base_url": fb_base_url,
-                }
-
-            # Re-evaluate prompt caching for the new provider/model
-            is_native_anthropic = fb_api_mode == "anthropic_messages"
-            self._use_prompt_caching = (
-                ("openrouter" in fb_base_url.lower() and "claude" in fb_model.lower())
-                or is_native_anthropic
-            )
 
             print(
                 f"{self.log_prefix}🔄 Primary model failed — switching to fallback: "
@@ -3205,6 +3204,8 @@ class AIAgent:
                 toolsets=function_args.get("toolsets"),
                 tasks=function_args.get("tasks"),
                 max_iterations=function_args.get("max_iterations"),
+                model=function_args.get("model"),
+                provider=function_args.get("provider"),
                 parent_agent=self,
             )
         else:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -14,6 +14,7 @@ from agent.auxiliary_client import (
     _read_codex_access_token,
     _get_auxiliary_provider,
     _resolve_forced_provider,
+    resolve_provider_credentials,
     _resolve_auto,
 )
 
@@ -405,3 +406,50 @@ class TestAuxiliaryMaxTokensParam:
              patch("agent.auxiliary_client._read_codex_access_token", return_value=None):
             result = auxiliary_max_tokens_param(1024)
         assert result == {"max_tokens": 1024}
+
+
+class TestResolveProviderCredentials:
+    """Tests for resolve_provider_credentials() — thin wrapper over resolve_provider_client."""
+
+    @patch("agent.auxiliary_client.resolve_provider_client")
+    def test_returns_credential_bundle(self, mock_rpc):
+        mock_client = MagicMock()
+        mock_client.base_url = "https://openrouter.ai/api/v1"
+        mock_client.api_key = "sk-or-key"
+        mock_rpc.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+        result = resolve_provider_credentials("openrouter", "google/gemini-3-flash-preview")
+        assert result is not None
+        assert result["provider"] == "openrouter"
+        assert result["model"] == "google/gemini-3-flash-preview"
+        assert result["base_url"] == "https://openrouter.ai/api/v1"
+        assert result["api_key"] == "sk-or-key"
+        assert result["api_mode"] == "chat_completions"
+        assert result["client"] is mock_client
+        mock_rpc.assert_called_once_with("openrouter", model="google/gemini-3-flash-preview", raw_codex=True)
+
+    @patch("agent.auxiliary_client.resolve_provider_client")
+    def test_returns_none_when_no_client(self, mock_rpc):
+        mock_rpc.return_value = (None, None)
+        result = resolve_provider_credentials("openrouter", "some-model")
+        assert result is None
+
+    @patch("agent.auxiliary_client.resolve_provider_client")
+    def test_codex_api_mode(self, mock_rpc):
+        mock_client = MagicMock()
+        mock_client.base_url = "https://chatgpt.com/backend-api/codex"
+        mock_client.api_key = "codex-token"
+        mock_rpc.return_value = (mock_client, "gpt-5.3-codex")
+
+        result = resolve_provider_credentials("openai-codex", "gpt-5.3-codex")
+        assert result["api_mode"] == "codex_responses"
+
+    @patch("agent.auxiliary_client.resolve_provider_client")
+    def test_anthropic_api_mode(self, mock_rpc):
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.anthropic.com"
+        mock_client.api_key = "sk-ant-key"
+        mock_rpc.return_value = (mock_client, "claude-sonnet-4-6")
+
+        result = resolve_provider_credentials("anthropic", "claude-sonnet-4-6")
+        assert result["api_mode"] == "anthropic_messages"

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -24,6 +24,7 @@ from tools.delegate_tool import (
     _build_child_system_prompt,
     _strip_blocked_tools,
     _resolve_delegation_credentials,
+    _resolve_task_credentials,
 )
 
 
@@ -650,21 +651,25 @@ class TestDelegationProviderIntegration(unittest.TestCase):
         }
         parent = _make_mock_parent(depth=0)
 
-        with patch("tools.delegate_tool._run_single_child") as mock_run:
-            mock_run.return_value = {
-                "task_index": 0, "status": "completed",
-                "summary": "Done", "api_calls": 1, "duration_seconds": 1.0
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
             }
+            MockAgent.return_value = mock_child
 
             tasks = [{"goal": "Task A"}, {"goal": "Task B"}]
             delegate_task(tasks=tasks, parent_agent=parent)
 
-            for call in mock_run.call_args_list:
-                self.assertEqual(call.kwargs.get("model"), "meta-llama/llama-4-scout")
-                self.assertEqual(call.kwargs.get("override_provider"), "openrouter")
-                self.assertEqual(call.kwargs.get("override_base_url"), "https://openrouter.ai/api/v1")
-                self.assertEqual(call.kwargs.get("override_api_key"), "sk-or-batch")
-                self.assertEqual(call.kwargs.get("override_api_mode"), "chat_completions")
+            # Both children should have been constructed with the resolved credentials
+            self.assertEqual(MockAgent.call_count, 2)
+            for call in MockAgent.call_args_list:
+                _, kwargs = call
+                self.assertEqual(kwargs["model"], "meta-llama/llama-4-scout")
+                self.assertEqual(kwargs["provider"], "openrouter")
+                self.assertEqual(kwargs["base_url"], "https://openrouter.ai/api/v1")
+                self.assertEqual(kwargs["api_key"], "sk-or-batch")
+                self.assertEqual(kwargs["api_mode"], "chat_completions")
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")
@@ -699,6 +704,107 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             # But provider/base_url/api_key should inherit from parent
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["base_url"], parent.base_url)
+
+
+class TestResolveTaskCredentials(unittest.TestCase):
+    """Tests for per-task provider:model credential resolution."""
+
+    def _default_creds(self):
+        return {
+            "model": "anthropic/claude-sonnet-4-6",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-default",
+            "api_mode": "chat_completions",
+        }
+
+    def test_no_provider_returns_defaults(self):
+        """Task with no provider uses config-level defaults."""
+        parent = _make_mock_parent()
+        defaults = self._default_creds()
+        result = _resolve_task_credentials({}, defaults, parent)
+        self.assertEqual(result, defaults)
+
+    def test_no_provider_with_model_override(self):
+        """Task with model but no provider overrides model only."""
+        parent = _make_mock_parent()
+        defaults = self._default_creds()
+        result = _resolve_task_credentials(
+            {"model": "google/gemini-3-flash-preview"}, defaults, parent,
+        )
+        self.assertEqual(result["model"], "google/gemini-3-flash-preview")
+        # Everything else unchanged
+        self.assertEqual(result["provider"], defaults["provider"])
+        self.assertEqual(result["api_key"], defaults["api_key"])
+
+    def test_empty_provider_treated_as_no_provider(self):
+        """Whitespace-only provider falls through to defaults."""
+        parent = _make_mock_parent()
+        defaults = self._default_creds()
+        result = _resolve_task_credentials({"provider": "  "}, defaults, parent)
+        self.assertEqual(result, defaults)
+
+    @patch("agent.auxiliary_client.resolve_provider_credentials")
+    def test_per_task_provider_resolves_credentials(self, mock_resolve):
+        """Task with provider resolves fresh credentials."""
+        mock_resolve.return_value = {
+            "provider": "nous",
+            "model": "hermes-3-llama-3.1-8b",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "nous-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent()
+        defaults = self._default_creds()
+        result = _resolve_task_credentials(
+            {"provider": "nous", "model": "hermes-3-llama-3.1-8b"},
+            defaults, parent,
+        )
+        self.assertEqual(result["provider"], "nous")
+        self.assertEqual(result["model"], "hermes-3-llama-3.1-8b")
+        self.assertEqual(result["api_key"], "nous-key")
+        mock_resolve.assert_called_once_with("nous", "hermes-3-llama-3.1-8b")
+
+    @patch("agent.auxiliary_client.resolve_provider_credentials")
+    def test_per_task_provider_not_configured_falls_back(self, mock_resolve):
+        """When provider resolves to None, falls back to defaults."""
+        mock_resolve.return_value = None
+        parent = _make_mock_parent()
+        defaults = self._default_creds()
+        result = _resolve_task_credentials(
+            {"provider": "nonexistent"}, defaults, parent,
+        )
+        self.assertEqual(result, defaults)
+
+    @patch("agent.auxiliary_client.resolve_provider_credentials")
+    def test_per_task_provider_resolution_error_falls_back(self, mock_resolve):
+        """When credential resolution raises, falls back to defaults."""
+        mock_resolve.side_effect = RuntimeError("API key missing")
+        parent = _make_mock_parent()
+        defaults = self._default_creds()
+        result = _resolve_task_credentials(
+            {"provider": "broken"}, defaults, parent,
+        )
+        self.assertEqual(result, defaults)
+
+    @patch("agent.auxiliary_client.resolve_provider_credentials")
+    def test_per_task_model_none_falls_back_to_default_model(self, mock_resolve):
+        """When per-task provider resolves but model is empty, uses default model."""
+        mock_resolve.return_value = {
+            "provider": "nous",
+            "model": "",  # empty from resolution
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "nous-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent()
+        defaults = self._default_creds()
+        result = _resolve_task_credentials(
+            {"provider": "nous"}, defaults, parent,
+        )
+        # model falls back to default_creds model since resolved model is empty
+        self.assertEqual(result["model"], defaults["model"])
+        self.assertEqual(result["provider"], "nous")
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -16,13 +16,9 @@ The parent's context only sees the delegation call and the summary result,
 never the child's intermediate tool calls or reasoning.
 """
 
-import contextlib
-import io
 import json
 import logging
 logger = logging.getLogger(__name__)
-import os
-import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional
@@ -157,7 +153,7 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
     return _callback
 
 
-def _run_single_child(
+def _build_child_agent(
     task_index: int,
     goal: str,
     context: Optional[str],
@@ -166,27 +162,21 @@ def _run_single_child(
     max_iterations: int,
     parent_agent,
     task_count: int = 1,
-    # Credential overrides from delegation config (provider:model resolution)
     override_provider: Optional[str] = None,
     override_base_url: Optional[str] = None,
     override_api_key: Optional[str] = None,
     override_api_mode: Optional[str] = None,
-) -> Dict[str, Any]:
-    """
-    Spawn and run a single child agent. Called from within a thread.
-    Returns a structured result dict.
+) -> "AIAgent":
+    """Build a child AIAgent in the calling thread.
 
-    When override_* params are set (from delegation config), the child uses
-    those credentials instead of inheriting from the parent.  This enables
-    routing subagents to a different provider:model pair (e.g. cheap/fast
-    model on OpenRouter while the parent runs on Nous Portal).
+    Constructing OpenAI/httpx clients is NOT thread-safe (SSL init,
+    connection pool setup, etc.), so this MUST run in the main thread.
+    The returned agent can then be handed to a worker thread for
+    ``run_conversation()``.
     """
     from run_agent import AIAgent
 
-    child_start = time.monotonic()
-
     # When no explicit toolsets given, inherit from parent's enabled toolsets
-    # so disabled tools (e.g. web) don't leak to subagents.
     if toolsets:
         child_toolsets = _strip_blocked_tools(toolsets)
     elif parent_agent and getattr(parent_agent, "enabled_toolsets", None):
@@ -196,64 +186,75 @@ def _run_single_child(
 
     child_prompt = _build_child_system_prompt(goal, context)
 
-    try:
-        # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
-        parent_api_key = getattr(parent_agent, "api_key", None)
-        if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
-            parent_api_key = parent_agent._client_kwargs.get("api_key")
+    parent_api_key = getattr(parent_agent, "api_key", None)
+    if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
+        parent_api_key = parent_agent._client_kwargs.get("api_key")
 
-        # Build progress callback to relay tool calls to parent display
-        child_progress_cb = _build_child_progress_callback(task_index, parent_agent, task_count)
+    child_progress_cb = _build_child_progress_callback(task_index, parent_agent, task_count)
+    shared_budget = getattr(parent_agent, "iteration_budget", None)
 
-        # Share the parent's iteration budget so subagent tool calls
-        # count toward the session-wide limit.
-        shared_budget = getattr(parent_agent, "iteration_budget", None)
+    effective_model = model or parent_agent.model
+    effective_provider = override_provider or getattr(parent_agent, "provider", None)
+    effective_base_url = override_base_url or parent_agent.base_url
+    effective_api_key = override_api_key or parent_api_key
+    effective_api_mode = override_api_mode or getattr(parent_agent, "api_mode", None)
 
-        # Resolve effective credentials: config override > parent inherit
-        effective_model = model or parent_agent.model
-        effective_provider = override_provider or getattr(parent_agent, "provider", None)
-        effective_base_url = override_base_url or parent_agent.base_url
-        effective_api_key = override_api_key or parent_api_key
-        effective_api_mode = override_api_mode or getattr(parent_agent, "api_mode", None)
+    child = AIAgent(
+        base_url=effective_base_url,
+        api_key=effective_api_key,
+        model=effective_model,
+        provider=effective_provider,
+        api_mode=effective_api_mode,
+        max_iterations=max_iterations,
+        max_tokens=getattr(parent_agent, "max_tokens", None),
+        reasoning_config=getattr(parent_agent, "reasoning_config", None),
+        prefill_messages=getattr(parent_agent, "prefill_messages", None),
+        enabled_toolsets=child_toolsets,
+        quiet_mode=True,
+        ephemeral_system_prompt=child_prompt,
+        log_prefix=f"[subagent-{task_index}]",
+        platform=parent_agent.platform,
+        skip_context_files=True,
+        skip_memory=True,
+        clarify_callback=None,
+        session_db=getattr(parent_agent, '_session_db', None),
+        providers_allowed=parent_agent.providers_allowed,
+        providers_ignored=parent_agent.providers_ignored,
+        providers_order=parent_agent.providers_order,
+        provider_sort=parent_agent.provider_sort,
+        tool_progress_callback=child_progress_cb,
+        iteration_budget=shared_budget,
+    )
 
-        child = AIAgent(
-            base_url=effective_base_url,
-            api_key=effective_api_key,
-            model=effective_model,
-            provider=effective_provider,
-            api_mode=effective_api_mode,
-            max_iterations=max_iterations,
-            max_tokens=getattr(parent_agent, "max_tokens", None),
-            reasoning_config=getattr(parent_agent, "reasoning_config", None),
-            prefill_messages=getattr(parent_agent, "prefill_messages", None),
-            enabled_toolsets=child_toolsets,
-            quiet_mode=True,
-            ephemeral_system_prompt=child_prompt,
-            log_prefix=f"[subagent-{task_index}]",
-            platform=parent_agent.platform,
-            skip_context_files=True,
-            skip_memory=True,
-            clarify_callback=None,
-            session_db=getattr(parent_agent, '_session_db', None),
-            providers_allowed=parent_agent.providers_allowed,
-            providers_ignored=parent_agent.providers_ignored,
-            providers_order=parent_agent.providers_order,
-            provider_sort=parent_agent.provider_sort,
-            tool_progress_callback=child_progress_cb,
-            iteration_budget=shared_budget,
-        )
+    child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
 
-        # Set delegation depth so children can't spawn grandchildren
-        child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
-
-        # Register child for interrupt propagation
-        if hasattr(parent_agent, '_active_children'):
+    if hasattr(parent_agent, '_active_children'):
+        with parent_agent._active_children_lock:
             parent_agent._active_children.append(child)
 
-        # Run with stdout/stderr suppressed to prevent interleaved output
-        devnull = io.StringIO()
-        with contextlib.redirect_stdout(devnull), contextlib.redirect_stderr(devnull):
-            result = child.run_conversation(user_message=goal)
+    return child
+
+
+def _run_single_child(
+    task_index: int,
+    goal: str,
+    child: "AIAgent",
+    parent_agent,
+) -> Dict[str, Any]:
+    """Run a pre-built child agent's conversation. Safe to call from a thread.
+
+    The child agent (and its httpx client) was already constructed in the
+    main thread by ``_build_child_agent()``.
+    """
+    child_start = time.monotonic()
+    child_progress_cb = getattr(child, "tool_progress_callback", None)
+
+    try:
+        # Child runs with quiet_mode=True so it suppresses its own output.
+        # Do NOT use contextlib.redirect_stdout here — it mutates the global
+        # sys.stdout and races with the spinner thread when multiple children
+        # start concurrently, causing segfaults.
+        result = child.run_conversation(user_message=goal)
 
         # Flush any remaining batched progress to gateway
         if child_progress_cb and hasattr(child_progress_cb, '_flush'):
@@ -362,8 +363,9 @@ def _run_single_child(
         # Unregister child from interrupt propagation
         if hasattr(parent_agent, '_active_children'):
             try:
-                parent_agent._active_children.remove(child)
-            except (ValueError, UnboundLocalError) as e:
+                with parent_agent._active_children_lock:
+                    parent_agent._active_children.remove(child)
+            except (ValueError, AttributeError) as e:
                 logger.debug("Could not remove child from active_children: %s", e)
 
 
@@ -373,14 +375,18 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets)
-      - Batch:  provide tasks array [{goal, context, toolsets}, ...]
+      - Single: provide goal (+ optional context, toolsets, model, provider)
+      - Batch:  provide tasks array [{goal, context, toolsets, model, provider}, ...]
+
+    Per-task model/provider override the delegation config defaults.
 
     Returns JSON with results array, one entry per task.
     """
@@ -416,7 +422,8 @@ def delegate_task(
     if tasks and isinstance(tasks, list):
         task_list = tasks[:MAX_CONCURRENT_CHILDREN]
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "toolsets": toolsets}]
+        task_list = [{"goal": goal, "context": context, "toolsets": toolsets,
+                      "model": model, "provider": provider}]
     else:
         return json.dumps({"error": "Provide either 'goal' (single task) or 'tasks' (batch)."})
 
@@ -435,22 +442,37 @@ def delegate_task(
     # Track goal labels for progress display (truncated for readability)
     task_labels = [t["goal"][:40] for t in task_list]
 
-    if n_tasks == 1:
-        # Single task -- run directly (no thread pool overhead)
-        t = task_list[0]
-        result = _run_single_child(
-            task_index=0,
+    # ── Build all child agents in the main thread ─────────────────────
+    # AIAgent construction creates httpx/SSL clients which are NOT
+    # thread-safe to initialize concurrently.  Build them serially here,
+    # then hand the pre-built agents to worker threads for run_conversation().
+    children = []
+    for i, t in enumerate(task_list):
+        task_creds = _resolve_task_credentials(t, creds, parent_agent)
+        child = _build_child_agent(
+            task_index=i,
             goal=t["goal"],
             context=t.get("context"),
             toolsets=t.get("toolsets") or toolsets,
-            model=creds["model"],
+            model=task_creds["model"],
             max_iterations=effective_max_iter,
             parent_agent=parent_agent,
-            task_count=1,
-            override_provider=creds["provider"],
-            override_base_url=creds["base_url"],
-            override_api_key=creds["api_key"],
-            override_api_mode=creds["api_mode"],
+            task_count=n_tasks,
+            override_provider=task_creds["provider"],
+            override_base_url=task_creds["base_url"],
+            override_api_key=task_creds["api_key"],
+            override_api_mode=task_creds["api_mode"],
+        )
+        children.append((i, t, child))
+
+    if n_tasks == 1:
+        # Single task -- run directly (no thread pool overhead)
+        i, t, child = children[0]
+        result = _run_single_child(
+            task_index=0,
+            goal=t["goal"],
+            child=child,
+            parent_agent=parent_agent,
         )
         results.append(result)
     else:
@@ -458,28 +480,15 @@ def delegate_task(
         completed_count = 0
         spinner_ref = getattr(parent_agent, '_delegate_spinner', None)
 
-        # Save stdout/stderr before the executor — redirect_stdout in child
-        # threads races on sys.stdout and can leave it as devnull permanently.
-        _saved_stdout = sys.stdout
-        _saved_stderr = sys.stderr
-
         with ThreadPoolExecutor(max_workers=MAX_CONCURRENT_CHILDREN) as executor:
             futures = {}
-            for i, t in enumerate(task_list):
+            for i, t, child in children:
                 future = executor.submit(
                     _run_single_child,
                     task_index=i,
                     goal=t["goal"],
-                    context=t.get("context"),
-                    toolsets=t.get("toolsets") or toolsets,
-                    model=creds["model"],
-                    max_iterations=effective_max_iter,
+                    child=child,
                     parent_agent=parent_agent,
-                    task_count=n_tasks,
-                    override_provider=creds["provider"],
-                    override_base_url=creds["base_url"],
-                    override_api_key=creds["api_key"],
-                    override_api_mode=creds["api_mode"],
                 )
                 futures[future] = i
 
@@ -522,10 +531,6 @@ def delegate_task(
                     except Exception as e:
                         logger.debug("Spinner update_text failed: %s", e)
 
-        # Restore stdout/stderr in case redirect_stdout race left them as devnull
-        sys.stdout = _saved_stdout
-        sys.stderr = _saved_stderr
-
         # Sort by task_index so results match input order
         results.sort(key=lambda r: r["task_index"])
 
@@ -535,6 +540,46 @@ def delegate_task(
         "results": results,
         "total_duration_seconds": total_duration,
     }, ensure_ascii=False)
+
+
+def _resolve_task_credentials(task: dict, default_creds: dict, parent_agent) -> dict:
+    """Resolve per-task credentials, falling back to config-level defaults.
+
+    If the task specifies a provider (and optionally model), resolve fresh
+    credentials via the shared :func:`resolve_provider_credentials` helper.
+    Otherwise use the default_creds from the delegation config.
+    """
+    task_provider = (task.get("provider") or "").strip().lower()
+    task_model = (task.get("model") or "").strip()
+
+    if not task_provider:
+        # No per-task provider — use config defaults, but allow model override
+        result = dict(default_creds)
+        if task_model:
+            result["model"] = task_model
+        return result
+
+    # Per-task provider specified — resolve credentials
+    try:
+        from agent.auxiliary_client import resolve_provider_credentials
+        creds = resolve_provider_credentials(task_provider, task_model or "")
+        if creds is None:
+            logger.warning(
+                "Per-task provider '%s' not configured, falling back to defaults",
+                task_provider,
+            )
+            return default_creds
+
+        return {
+            "model": creds["model"] or default_creds.get("model"),
+            "provider": creds["provider"],
+            "base_url": creds["base_url"],
+            "api_key": creds["api_key"],
+            "api_mode": creds["api_mode"],
+        }
+    except Exception as exc:
+        logger.error("Failed to resolve per-task provider '%s': %s", task_provider, exc)
+        return default_creds
 
 
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
@@ -686,6 +731,8 @@ DELEGATE_TASK_SCHEMA = {
                             "items": {"type": "string"},
                             "description": "Toolsets for this specific task",
                         },
+                        "model": {"type": "string", "description": "Model ID override for this task"},
+                        "provider": {"type": "string", "description": "Provider override for this task"},
                     },
                     "required": ["goal"],
                 },
@@ -694,6 +741,21 @@ DELEGATE_TASK_SCHEMA = {
                     "Batch mode: up to 3 tasks to run in parallel. Each gets "
                     "its own subagent with isolated context and terminal session. "
                     "When provided, top-level goal/context/toolsets are ignored."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Model ID for this subagent. Overrides the delegation config default. "
+                    "E.g. 'anthropic/claude-sonnet-4-6'. Requires 'provider' to be set."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Provider for this subagent. Overrides the delegation config default. "
+                    "E.g. 'openrouter', 'nous', 'anthropic'. Use switch_model(action='list') "
+                    "to see available providers."
                 ),
             },
             "max_iterations": {
@@ -722,6 +784,8 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        model=args.get("model"),
+        provider=args.get("provider"),
         parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
 )


### PR DESCRIPTION
## What does this PR do?

Fixes three thread-safety issues that cause crashes and data races when running multiple subagents concurrently via `delegate_task` in batch mode.

We observed segfaults and intermittent corruption when delegating 3+ tasks concurrently. Root causes:

1. **`redirect_stdout` racing with the spinner thread** — `contextlib.redirect_stdout` mutates the global `sys.stdout`. When multiple child agents start concurrently in a `ThreadPoolExecutor`, the race between redirect and the spinner thread corrupts the file descriptor, causing a segfault. The redirect was redundant anyway since child agents already run with `quiet_mode=True`.

2. **httpx/SSL client construction from worker threads** — `AIAgent` construction creates httpx clients and initializes SSL contexts. Running this concurrently from the thread pool caused intermittent failures. Fix: split `_run_single_child()` into `_build_child_agent()` (serial, main thread) + `_run_single_child()` (parallel, worker threads).

3. **Shared `SessionDB` instance written from multiple threads** — Subagents inherit the parent's `SessionDB` and call `create_session()`, `append_message()`, etc. from their worker threads with no synchronization. Fix: add a `threading.Lock` to `SessionDB`.

4. **`_active_children` list mutation during interrupt propagation** — The parent's `interrupt()` iterates `_active_children` while worker threads are appending/removing children. Fix: add `_active_children_lock`.

Also includes:
- Extract `_apply_provider_credentials()` to deduplicate the provider-swap logic used by fallback activation
- Add per-task `model`/`provider` overrides to `delegate_task` so individual subtasks can target different backends
- Add `resolve_provider_credentials()` helper to `auxiliary_client.py` (shared by fallback, delegation, and future model-switching code)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py`: Split `_run_single_child` into `_build_child_agent` (main thread) + `_run_single_child` (worker thread). Remove `redirect_stdout`/`redirect_stderr`. Add `_resolve_task_credentials()` for per-task provider overrides. Use `_active_children_lock` for child registration/removal.
- `hermes_state.py`: Add `threading.Lock` to `SessionDB`, wrap all connection access in `with self._lock`.
- `run_agent.py`: Add `_active_children_lock` to `AIAgent.__init__`. Use lock in `interrupt()`. Extract `_apply_provider_credentials()`. Refactor `_try_activate_fallback()` to use it. Pass `model`/`provider` through to `delegate_task`.
- `agent/auxiliary_client.py`: Add `resolve_provider_credentials()` helper. Add `_client_cache_lock` for thread-safe client resolution.

## How to Test

1. Run a batch delegation with 3+ concurrent tasks: provide a prompt that triggers `delegate_task` with multiple subtasks
2. Verify no segfaults, no "database is locked" errors, no interleaved output
3. Interrupt a running batch delegation — verify all children stop cleanly

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A