### PR TITLE
feat: add Kilo Code (kilocode) as first-class inference provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -57,6 +57,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "minimax": "MiniMax-M2.5-highspeed",
     "minimax-cn": "MiniMax-M2.5-highspeed",
     "anthropic": "claude-haiku-4-5-20251001",
+    "kilocode": "google/gemini-3-flash-preview",
 }
 
 # OpenRouter app attribution headers

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -147,6 +147,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
     ),
+    "kilocode": ProviderConfig(
+        id="kilocode",
+        name="Kilo Code",
+        auth_type="api_key",
+        inference_base_url="https://api.kilo.ai/api/gateway",
+        api_key_env_vars=("KILOCODE_API_KEY",),
+        base_url_env_var="KILOCODE_BASE_URL",
+    ),
 }
 
 
@@ -524,6 +532,7 @@ def resolve_provider(
         "kimi": "kimi-coding", "moonshot": "kimi-coding",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
         "claude": "anthropic", "claude-code": "anthropic",
+        "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -46,6 +46,7 @@ _PROVIDER_ENV_HINTS = (
     "KIMI_API_KEY",
     "MINIMAX_API_KEY",
     "MINIMAX_CN_API_KEY",
+    "KILOCODE_API_KEY",
 )
 
 
@@ -570,6 +571,7 @@ def run_doctor(args):
         # MiniMax APIs don't support /models endpoint — https://github.com/NousResearch/hermes-agent/issues/811
         ("MiniMax",          ("MINIMAX_API_KEY",),                            None,                                  "MINIMAX_BASE_URL", False),
         ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         None,                                  "MINIMAX_CN_BASE_URL", False),
+        ("Kilo Code",        ("KILOCODE_API_KEY",),                           "https://api.kilo.ai/api/gateway/models", "KILOCODE_BASE_URL", True),
     ]
     for _pname, _env_vars, _default_url, _base_env, _supports_health_check in _apikey_providers:
         _key = ""

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -768,6 +768,7 @@ def cmd_model(args):
         "kimi-coding": "Kimi / Moonshot",
         "minimax": "MiniMax",
         "minimax-cn": "MiniMax (China)",
+        "kilocode": "Kilo Code",
         "custom": "Custom endpoint",
     }
     active_label = provider_labels.get(active, active)
@@ -787,6 +788,7 @@ def cmd_model(args):
         ("kimi-coding", "Kimi / Moonshot (Moonshot AI direct API)"),
         ("minimax", "MiniMax (global direct API)"),
         ("minimax-cn", "MiniMax China (domestic direct API)"),
+        ("kilocode", "Kilo Code (Kilo Gateway API)"),
     ]
 
     # Add user-defined custom providers from config.yaml
@@ -855,7 +857,7 @@ def cmd_model(args):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("zai", "minimax", "minimax-cn"):
+    elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
 
@@ -1390,6 +1392,13 @@ _PROVIDER_MODELS = {
         "MiniMax-M2.5",
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
+    ],
+    "kilocode": [
+        "anthropic/claude-opus-4.6",
+        "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.4",
+        "google/gemini-3-pro-preview",
+        "google/gemini-3-flash-preview",
     ],
 }
 
@@ -2459,7 +2468,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "anthropic", "zai", "kimi-coding", "minimax", "minimax-cn"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "anthropic", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -69,6 +69,13 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
     ],
+    "kilocode": [
+        "anthropic/claude-opus-4.6",
+        "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.4",
+        "google/gemini-3-pro-preview",
+        "google/gemini-3-flash-preview",
+    ],
     "anthropic": [
         "claude-opus-4-6",
         "claude-sonnet-4-6",
@@ -88,6 +95,7 @@ _PROVIDER_LABELS = {
     "kimi-coding": "Kimi / Moonshot",
     "minimax": "MiniMax",
     "minimax-cn": "MiniMax (China)",
+    "kilocode": "Kilo Code",
     "anthropic": "Anthropic",
     "custom": "Custom endpoint",
 }
@@ -101,6 +109,9 @@ _PROVIDER_ALIASES = {
     "moonshot": "kimi-coding",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
+    "kilo": "kilocode",
+    "kilo-code": "kilocode",
+    "kilo-gateway": "kilocode",
     "claude": "anthropic",
     "claude-code": "anthropic",
 }
@@ -136,7 +147,7 @@ def list_available_providers() -> list[dict[str, str]]:
     # Canonical providers in display order
     _PROVIDER_ORDER = [
         "openrouter", "nous", "openai-codex",
-        "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic",
+        "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic",
     ]
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -59,6 +59,13 @@ _DEFAULT_PROVIDER_MODELS = {
     "kimi-coding": ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "minimax": ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"],
     "minimax-cn": ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"],
+    "kilocode": [
+        "anthropic/claude-opus-4.6",
+        "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.4",
+        "google/gemini-3-pro-preview",
+        "google/gemini-3-flash-preview",
+    ],
 }
 
 
@@ -760,6 +767,7 @@ def setup_model_provider(config: dict):
         "Kimi / Moonshot (Kimi coding models)",
         "MiniMax (global endpoint)",
         "MiniMax China (mainland China endpoint)",
+        "Kilo Code (Kilo Gateway API)",
         "Anthropic (Claude models — API key or Claude Code subscription)",
     ]
     if keep_label:
@@ -1140,7 +1148,40 @@ def setup_model_provider(config: dict):
         _update_config_for_provider("minimax-cn", pconfig.inference_base_url, default_model="MiniMax-M2.5")
         _set_model_provider(config, "minimax-cn", pconfig.inference_base_url)
 
-    elif provider_idx == 8:  # Anthropic
+    elif provider_idx == 8:  # Kilo Code
+        selected_provider = "kilocode"
+        print()
+        print_header("Kilo Code API Key")
+        pconfig = PROVIDER_REGISTRY["kilocode"]
+        print_info(f"Provider: {pconfig.name}")
+        print_info(f"Base URL: {pconfig.inference_base_url}")
+        print_info("Get your API key at: https://kilo.ai/")
+        print()
+
+        existing_key = get_env_value("KILOCODE_API_KEY")
+        if existing_key:
+            print_info(f"Current: {existing_key[:8]}... (configured)")
+            if prompt_yes_no("Update API key?", False):
+                api_key = prompt("  Kilo Code API key", password=True)
+                if api_key:
+                    save_env_value("KILOCODE_API_KEY", api_key)
+                    print_success("Kilo Code API key updated")
+        else:
+            api_key = prompt("  Kilo Code API key", password=True)
+            if api_key:
+                save_env_value("KILOCODE_API_KEY", api_key)
+                print_success("Kilo Code API key saved")
+            else:
+                print_warning("Skipped - agent won't work without an API key")
+
+        # Clear custom endpoint vars if switching
+        if existing_custom:
+            save_env_value("OPENAI_BASE_URL", "")
+            save_env_value("OPENAI_API_KEY", "")
+        _update_config_for_provider("kilocode", pconfig.inference_base_url, default_model="anthropic/claude-opus-4.6")
+        _set_model_provider(config, "kilocode", pconfig.inference_base_url)
+
+    elif provider_idx == 9:  # Anthropic
         selected_provider = "anthropic"
         print()
         print_header("Anthropic Authentication")
@@ -1244,7 +1285,7 @@ def setup_model_provider(config: dict):
         _update_config_for_provider("anthropic", "", default_model="claude-opus-4-6")
         _set_model_provider(config, "anthropic")
 
-    # else: provider_idx == 9 (Keep current) — only shown when a provider already exists
+    # else: provider_idx == 10 (Keep current) — only shown when a provider already exists
     # Normalize "keep current" to an explicit provider so downstream logic
     # doesn't fall back to the generic OpenRouter/static-model path.
     if selected_provider is None:
@@ -1414,7 +1455,7 @@ def setup_model_provider(config: dict):
                     _set_default_model(config, custom)
             _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
             _set_model_provider(config, "openai-codex", DEFAULT_CODEX_BASE_URL)
-        elif selected_provider in ("zai", "kimi-coding", "minimax", "minimax-cn"):
+        elif selected_provider in ("zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"):
             _setup_provider_model_selection(
                 config, selected_provider, current_model,
                 prompt_choice, prompt,

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -37,6 +37,7 @@ class TestProviderRegistry:
         ("kimi-coding", "Kimi / Moonshot", "api_key"),
         ("minimax", "MiniMax", "api_key"),
         ("minimax-cn", "MiniMax (China)", "api_key"),
+        ("kilocode", "Kilo Code", "api_key"),
     ])
     def test_provider_registered(self, provider_id, name, auth_type):
         assert provider_id in PROVIDER_REGISTRY
@@ -65,11 +66,17 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("MINIMAX_CN_API_KEY",)
         assert pconfig.base_url_env_var == "MINIMAX_CN_BASE_URL"
 
+    def test_kilocode_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["kilocode"]
+        assert pconfig.api_key_env_vars == ("KILOCODE_API_KEY",)
+        assert pconfig.base_url_env_var == "KILOCODE_BASE_URL"
+
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["minimax"].inference_base_url == "https://api.minimax.io/v1"
         assert PROVIDER_REGISTRY["minimax-cn"].inference_base_url == "https://api.minimaxi.com/v1"
+        assert PROVIDER_REGISTRY["kilocode"].inference_base_url == "https://api.kilo.ai/api/gateway"
 
     def test_oauth_providers_unchanged(self):
         """Ensure we didn't break the existing OAuth providers."""
@@ -87,6 +94,7 @@ PROVIDER_ENV_VARS = (
     "OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
     "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
     "KIMI_API_KEY", "KIMI_BASE_URL", "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
+    "KILOCODE_API_KEY", "KILOCODE_BASE_URL",
     "OPENAI_BASE_URL",
 )
 
@@ -162,6 +170,22 @@ class TestResolveProvider:
     def test_auto_detects_minimax_cn_key(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_CN_API_KEY", "test-mm-cn-key")
         assert resolve_provider("auto") == "minimax-cn"
+
+    def test_explicit_kilocode(self):
+        assert resolve_provider("kilocode") == "kilocode"
+
+    def test_alias_kilo(self):
+        assert resolve_provider("kilo") == "kilocode"
+
+    def test_alias_kilo_code(self):
+        assert resolve_provider("kilo-code") == "kilocode"
+
+    def test_alias_kilo_gateway(self):
+        assert resolve_provider("kilo-gateway") == "kilocode"
+
+    def test_auto_detects_kilocode_key(self, monkeypatch):
+        monkeypatch.setenv("KILOCODE_API_KEY", "test-kilo-key")
+        assert resolve_provider("auto") == "kilocode"
 
     def test_openrouter_takes_priority_over_glm(self, monkeypatch):
         """OpenRouter API key should win over GLM in auto-detection."""
@@ -248,6 +272,19 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["api_key"] == "mmcn-secret-key"
         assert creds["base_url"] == "https://api.minimaxi.com/v1"
 
+    def test_resolve_kilocode_with_key(self, monkeypatch):
+        monkeypatch.setenv("KILOCODE_API_KEY", "kilo-secret-key")
+        creds = resolve_api_key_provider_credentials("kilocode")
+        assert creds["provider"] == "kilocode"
+        assert creds["api_key"] == "kilo-secret-key"
+        assert creds["base_url"] == "https://api.kilo.ai/api/gateway"
+
+    def test_resolve_kilocode_custom_base_url(self, monkeypatch):
+        monkeypatch.setenv("KILOCODE_API_KEY", "kilo-key")
+        monkeypatch.setenv("KILOCODE_BASE_URL", "https://custom.kilo.example/v1")
+        creds = resolve_api_key_provider_credentials("kilocode")
+        assert creds["base_url"] == "https://custom.kilo.example/v1"
+
     def test_resolve_with_custom_base_url(self, monkeypatch):
         monkeypatch.setenv("GLM_API_KEY", "glm-key")
         monkeypatch.setenv("GLM_BASE_URL", "https://custom.glm.example/v4")
@@ -308,6 +345,15 @@ class TestRuntimeProviderResolution:
         result = resolve_runtime_provider(requested="minimax")
         assert result["provider"] == "minimax"
         assert result["api_key"] == "mm-key"
+
+    def test_runtime_kilocode(self, monkeypatch):
+        monkeypatch.setenv("KILOCODE_API_KEY", "kilo-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="kilocode")
+        assert result["provider"] == "kilocode"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "kilo-key"
+        assert "kilo.ai" in result["base_url"]
 
     def test_runtime_auto_detects_api_key_provider(self, monkeypatch):
         monkeypatch.setenv("KIMI_API_KEY", "auto-kimi-key")

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -26,6 +26,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `MINIMAX_BASE_URL` | Override MiniMax base URL (default: `https://api.minimax.io/v1`) |
 | `MINIMAX_CN_API_KEY` | MiniMax API key — China endpoint ([minimaxi.com](https://www.minimaxi.com)) |
 | `MINIMAX_CN_BASE_URL` | Override MiniMax China base URL (default: `https://api.minimaxi.com/v1`) |
+| `KILOCODE_API_KEY` | Kilo Code API key ([kilo.ai](https://kilo.ai)) |
+| `KILOCODE_BASE_URL` | Override Kilo Code base URL (default: `https://api.kilo.ai/api/gateway`) |
 | `ANTHROPIC_API_KEY` | Anthropic Console API key ([console.anthropic.com](https://console.anthropic.com/)) |
 | `ANTHROPIC_TOKEN` | Manual or legacy Anthropic OAuth/setup-token override |
 | `CLAUDE_CODE_OAUTH_TOKEN` | Explicit Claude Code token override if you export one manually |
@@ -40,7 +42,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `anthropic`, `zai`, `kimi-coding`, `minimax`, `minimax-cn` (default: `auto`) |
+| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `anthropic`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode` (default: `auto`) |
 | `HERMES_PORTAL_BASE_URL` | Override Nous Portal URL (for development/testing) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference API URL |
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -69,6 +69,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
+| **Kilo Code** | `KILOCODE_API_KEY` in `~/.hermes/.env` (provider: `kilocode`) |
 | **Custom Endpoint** | `hermes model` (saved in `config.yaml`) or `OPENAI_BASE_URL` + `OPENAI_API_KEY` in `~/.hermes/.env` |
 
 :::info Codex Note

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -42,6 +42,7 @@ Both `provider` and `model` are **required**. If either is missing, the fallback
 | Kimi / Moonshot | `kimi-coding` | `KIMI_API_KEY` |
 | MiniMax | `minimax` | `MINIMAX_API_KEY` |
 | MiniMax (China) | `minimax-cn` | `MINIMAX_CN_API_KEY` |
+| Kilo Code | `kilocode` | `KILOCODE_API_KEY` |
 | Custom endpoint | `custom` | `base_url` + `api_key_env` (see below) |
 
 ### Custom Endpoint Fallback


### PR DESCRIPTION
## Summary

Adds [Kilo Gateway](https://kilo.ai/gateway) (`kilocode`) as a first-class inference provider in Hermes Agent. Kilo Gateway provides a unified, OpenAI-compatible API to access 500+ AI models from Anthropic, OpenAI, Google, xAI, Mistral, MiniMax, and more through a single endpoint and API key.

## Kilo Gateway Details

- **Base URL**: `https://api.kilo.ai/api/gateway`
- **API**: OpenAI-compatible (`/chat/completions` drop-in)
- **Auth**: Bearer token via `KILOCODE_API_KEY`
- **Streaming**: Supported (SSE)
- **Model format**: `provider/model-name` (e.g., `anthropic/claude-opus-4.6`)
- **Docs**: https://kilo.ai/docs/gateway

## Changes

### Core Integration
- **`hermes_cli/auth.py`** — Register `kilocode` in `PROVIDER_REGISTRY` with `KILOCODE_API_KEY` env var, aliases (`kilo`, `kilo-code`, `kilo-gateway`), and hardcoded base URL
- **`hermes_cli/models.py`** — Add model catalog with popular models (Claude, GPT, Gemini families) and wire into `hermes model` interactive CLI
- **`hermes_cli/main.py`** — Add `kilocode` to CLI provider choices
- **`hermes_cli/setup.py`** — Add Kilo Gateway to `hermes setup` wizard with API key prompt
- **`hermes_cli/doctor.py`** — Add Kilo Gateway health check in `hermes doctor`
- **`agent/auxiliary_client.py`** — Add `kilocode` as auxiliary provider option with default model `google/gemini-3-flash-preview`

### Documentation
- **`website/docs/user-guide/configuration.md`** — Add Kilo Gateway to provider table and config examples
- **`website/docs/reference/environment-variables.md`** — Document `KILOCODE_API_KEY`
- **`website/docs/user-guide/features/fallback-providers.md`** — Add `kilocode` to supported fallback providers

### Tests
- **`tests/test_api_key_providers.py`** — 12 new test cases covering registry, aliases, credential resolution, and runtime config

## Configuration

```yaml
model:
  provider: "kilocode"
  default: "anthropic/claude-opus-4.6"
```

```bash
# In ~/.hermes/.env
KILOCODE_API_KEY=your-api-key-here
```

Or interactively: `hermes model` → select "Kilo Gateway"

## Testing

All 75 tests pass (12 new + 63 existing).
