### PR TITLE
fix(honcho): correct seed_ai_identity to use session.add_messages()

### DIFF
--- a/honcho_integration/session.py
+++ b/honcho_integration/session.py
@@ -927,6 +927,11 @@ class HonchoSessionManager:
             return False
 
         assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
+        honcho_session = self._sessions_cache.get(session.honcho_session_id)
+        if not honcho_session:
+            logger.warning("No Honcho session cached for '%s', skipping AI seed", session_key)
+            return False
+
         try:
             wrapped = (
                 f"<ai_identity_seed>\n"
@@ -935,7 +940,7 @@ class HonchoSessionManager:
                 f"{content.strip()}\n"
                 f"</ai_identity_seed>"
             )
-            assistant_peer.add_message("assistant", wrapped)
+            honcho_session.add_messages([assistant_peer.message(wrapped)])
             logger.info("Seeded AI identity from '%s' into %s", source, session_key)
             return True
         except Exception as e:


### PR DESCRIPTION
## Summary
- fix `hermes honcho identity <file>` crashing because `Peer.add_message()` does not exist in the Honcho SDK
- use the same `session.add_messages([peer.message(...)])` pattern already used elsewhere in the integration
- add focused regression tests for both the happy path and missing-session-cache guard

## Notes
- salvages the substantive fix from PR #1350 onto current `main`
- preserves contributor authorship via cherry-pick

## Test plan
- `python -m py_compile honcho_integration/session.py tests/honcho_integration/test_session.py`
- `python -m pytest tests/honcho_integration/test_session.py -n0 -q`

Fixes #1349
Supersedes #1350
