### PR TITLE
fix(docker): map current cwd into /workspace

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,5 +1,7 @@
 import logging
 import subprocess
+import sys
+import types
 
 import pytest
 
@@ -18,8 +20,30 @@ def _make_dummy_env(**kwargs):
         persistent_filesystem=kwargs.get("persistent_filesystem", False),
         task_id=kwargs.get("task_id", "test-task"),
         volumes=kwargs.get("volumes", []),
+        host_cwd=kwargs.get("host_cwd", ""),
         network=kwargs.get("network", True),
     )
+
+
+def _install_fake_minisweagent(monkeypatch, captured):
+    """Install a fake mini-swe-agent docker module to capture constructor args."""
+
+    class _FakeDocker:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.container_id = "fake-container"
+
+        def cleanup(self):
+            return None
+
+    minisweagent_mod = types.ModuleType("minisweagent")
+    environments_mod = types.ModuleType("minisweagent.environments")
+    docker_mod = types.ModuleType("minisweagent.environments.docker")
+    docker_mod.DockerEnvironment = _FakeDocker
+
+    monkeypatch.setitem(sys.modules, "minisweagent", minisweagent_mod)
+    monkeypatch.setitem(sys.modules, "minisweagent.environments", environments_mod)
+    monkeypatch.setitem(sys.modules, "minisweagent.environments.docker", docker_mod)
 
 
 def test_ensure_docker_available_logs_and_raises_when_not_found(monkeypatch, caplog):
@@ -86,3 +110,36 @@ def test_ensure_docker_available_uses_resolved_executable(monkeypatch):
         })
     ]
 
+
+def test_host_cwd_is_bind_mounted_to_workspace(monkeypatch, tmp_path):
+    """A host cwd should be mounted at /workspace for Docker CLI sessions."""
+
+    captured = {}
+    _install_fake_minisweagent(monkeypatch, captured)
+    monkeypatch.setattr(docker_env, "_ensure_docker_available", lambda: None)
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+
+    env = _make_dummy_env(cwd="/workspace", host_cwd=str(tmp_path))
+
+    assert env.cwd == "/workspace"
+    assert captured["cwd"] == "/workspace"
+    assert f"{tmp_path}:/workspace" in captured["run_args"]
+
+
+def test_missing_host_cwd_falls_back_to_sandbox_workspace(monkeypatch, tmp_path):
+    """Invalid host cwd should not produce a broken bind mount."""
+
+    captured = {}
+    _install_fake_minisweagent(monkeypatch, captured)
+    monkeypatch.setattr(docker_env, "_ensure_docker_available", lambda: None)
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(
+        "tools.environments.base.get_sandbox_dir",
+        lambda: tmp_path / "sandboxes",
+    )
+
+    missing = tmp_path / "does-not-exist"
+    _make_dummy_env(cwd="/workspace", host_cwd=str(missing), persistent_filesystem=True)
+
+    assert f"{missing}:/workspace" not in captured["run_args"]
+    assert any(str(tmp_path / "sandboxes" / "docker" / "test-task" / "workspace") in arg for arg in captured["run_args"])

--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -91,17 +91,18 @@ class TestCwdHandling:
                 "/home/ paths should be replaced for modal backend."
             )
 
-    def test_users_path_replaced_for_docker(self):
-        """TERMINAL_CWD=/Users/... should be replaced with /root for docker."""
+    def test_users_path_maps_to_workspace_for_docker(self):
+        """Docker should bind-mount a host cwd into /workspace."""
         with patch.dict(os.environ, {
             "TERMINAL_ENV": "docker",
             "TERMINAL_CWD": "/Users/someone/projects",
         }):
             config = _tt_mod._get_env_config()
-            assert config["cwd"] == "/root", (
-                f"Expected /root, got {config['cwd']}. "
-                "/Users/ paths should be replaced for docker backend."
+            assert config["cwd"] == "/workspace", (
+                f"Expected /workspace, got {config['cwd']}. "
+                "Docker host paths should map into /workspace."
             )
+            assert config["docker_host_cwd"] == "/Users/someone/projects"
 
     def test_windows_path_replaced_for_modal(self):
         """TERMINAL_CWD=C:\\Users\\... should be replaced for modal."""
@@ -114,7 +115,7 @@ class TestCwdHandling:
 
     def test_default_cwd_is_root_for_container_backends(self):
         """Container backends should default to /root, not ~."""
-        for backend in ("modal", "docker", "singularity", "daytona"):
+        for backend in ("modal", "singularity", "daytona"):
             with patch.dict(os.environ, {"TERMINAL_ENV": backend}, clear=False):
                 # Remove TERMINAL_CWD so it uses default
                 env = os.environ.copy()
@@ -134,6 +135,19 @@ class TestCwdHandling:
                 config = _tt_mod._get_env_config()
                 assert config["cwd"] == os.getcwd()
 
+    def test_docker_default_cwd_maps_current_directory(self):
+        """Docker should auto-map the host current directory into /workspace."""
+        with (
+            patch("tools.terminal_tool.os.getcwd", return_value="/Users/someone/project"),
+            patch.dict(os.environ, {"TERMINAL_ENV": "docker"}, clear=False),
+        ):
+            env = os.environ.copy()
+            env.pop("TERMINAL_CWD", None)
+            with patch.dict(os.environ, env, clear=True):
+                config = _tt_mod._get_env_config()
+                assert config["cwd"] == "/workspace"
+                assert config["docker_host_cwd"] == "/Users/someone/project"
+
     def test_ssh_preserves_home_paths(self):
         """SSH backend should NOT replace /home/ paths (they're valid remotely)."""
         with patch.dict(os.environ, {
@@ -146,6 +160,29 @@ class TestCwdHandling:
             assert config["cwd"] == "/home/remote-user/work", (
                 "SSH backend should preserve /home/ paths"
             )
+
+    def test_create_environment_passes_docker_host_cwd(self, monkeypatch):
+        """Docker host cwd from config should reach DockerEnvironment."""
+        captured = {}
+        sentinel = object()
+
+        def _fake_docker_environment(**kwargs):
+            captured.update(kwargs)
+            return sentinel
+
+        monkeypatch.setattr(_tt_mod, "_DockerEnvironment", _fake_docker_environment)
+
+        env = _tt_mod._create_environment(
+            env_type="docker",
+            image="python:3.11",
+            cwd="/workspace",
+            timeout=60,
+            container_config={"docker_host_cwd": "/Users/someone/project"},
+        )
+
+        assert env is sentinel
+        assert captured["cwd"] == "/workspace"
+        assert captured["host_cwd"] == "/Users/someone/project"
 
 
 # =========================================================================

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -171,6 +171,7 @@ class DockerEnvironment(BaseEnvironment):
         persistent_filesystem: bool = False,
         task_id: str = "default",
         volumes: list = None,
+        host_cwd: str = "",
         network: bool = True,
     ):
         if cwd == "~":
@@ -216,7 +217,31 @@ class DockerEnvironment(BaseEnvironment):
 
         self._workspace_dir: Optional[str] = None
         self._home_dir: Optional[str] = None
-        if self._persistent:
+        host_cwd = os.path.expanduser((host_cwd or "").strip())
+        bind_host_cwd = bool(host_cwd)
+        if bind_host_cwd and not os.path.isdir(host_cwd):
+            logger.warning(
+                "Docker host cwd %r does not exist or is not a directory; falling back to the sandbox workspace.",
+                host_cwd,
+            )
+            bind_host_cwd = False
+
+        if bind_host_cwd:
+            if self._persistent:
+                sandbox = get_sandbox_dir() / "docker" / task_id
+                self._home_dir = str(sandbox / "home")
+                os.makedirs(self._home_dir, exist_ok=True)
+                writable_args = [
+                    "-v", f"{host_cwd}:/workspace",
+                    "-v", f"{self._home_dir}:/root",
+                ]
+            else:
+                writable_args = [
+                    "-v", f"{host_cwd}:/workspace",
+                    "--tmpfs", "/home:rw,exec,size=1g",
+                    "--tmpfs", "/root:rw,exec,size=1g",
+                ]
+        elif self._persistent:
             sandbox = get_sandbox_dir() / "docker" / task_id
             self._workspace_dir = str(sandbox / "workspace")
             self._home_dir = str(sandbox / "home")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -113,6 +113,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "container_disk": config.get("container_disk", 51200),
                     "container_persistent": config.get("container_persistent", True),
                     "docker_volumes": config.get("docker_volumes", []),
+                    "docker_host_cwd": config.get("docker_host_cwd", ""),
                 }
             terminal_env = _create_environment(
                 env_type=env_type,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -466,23 +466,25 @@ def _get_env_config() -> Dict[str, Any]:
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
     env_type = os.getenv("TERMINAL_ENV", "local")
     
-    # Default cwd: local uses the host's current directory, everything
-    # else starts in the user's home (~ resolves to whatever account
-    # is running inside the container/remote).
-    if env_type == "local":
+    # Default cwd: local uses the host's current directory. Docker also starts
+    # from the host cwd so the backend can auto-bind it into /workspace.
+    # Other backends still default to their own internal home directory.
+    if env_type in ("local", "docker"):
         default_cwd = os.getcwd()
     else:
         default_cwd = "/root"
     
-    # Read TERMINAL_CWD but sanity-check it for container backends.
-    # If the CWD looks like a host-local path that can't exist inside a
-    # container/sandbox, fall back to the backend's own default. This
-    # catches the case where cli.py (or .env) leaked the host's CWD.
-    # SSH is excluded since /home/ paths are valid on remote machines.
+    # Read TERMINAL_CWD but sanity-check it for non-Docker container backends.
+    # Docker is special: when given a host cwd, we bind-mount it into
+    # /workspace instead of discarding it.
     cwd = os.getenv("TERMINAL_CWD", default_cwd)
-    if env_type in ("modal", "docker", "singularity", "daytona") and cwd:
-        # Host paths that won't exist inside containers
-        host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
+    host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
+    docker_host_cwd = ""
+    if env_type == "docker" and cwd:
+        if any(cwd.startswith(p) for p in host_prefixes):
+            docker_host_cwd = cwd
+            cwd = "/workspace"
+    elif env_type in ("modal", "singularity", "daytona") and cwd:
         if any(cwd.startswith(p) for p in host_prefixes) and cwd != default_cwd:
             logger.info("Ignoring TERMINAL_CWD=%r for %s backend "
                         "(host path won't exist in sandbox). Using %r instead.",
@@ -509,6 +511,7 @@ def _get_env_config() -> Dict[str, Any]:
         "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
         "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in ("true", "1", "yes"),
         "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
+        "docker_host_cwd": docker_host_cwd,
     }
 
 
@@ -536,6 +539,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     disk = cc.get("container_disk", 51200)
     persistent = cc.get("container_persistent", True)
     volumes = cc.get("docker_volumes", [])
+    host_cwd = cc.get("docker_host_cwd", "")
 
     if env_type == "local":
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
@@ -545,7 +549,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             image=image, cwd=cwd, timeout=timeout,
             cpu=cpu, memory=memory, disk=disk,
             persistent_filesystem=persistent, task_id=task_id,
-            volumes=volumes,
+            volumes=volumes, host_cwd=host_cwd,
         )
     
     elif env_type == "singularity":
@@ -933,6 +937,7 @@ def terminal_tool(
                                 "container_disk": config.get("container_disk", 51200),
                                 "container_persistent": config.get("container_persistent", True),
                                 "docker_volumes": config.get("docker_volumes", []),
+                                "docker_host_cwd": config.get("docker_host_cwd", ""),
                             }
 
                         new_env = _create_environment(


### PR DESCRIPTION
## Summary
- auto-map the host current directory into /workspace for Docker terminal sessions instead of dropping back to /root
- thread the resolved host cwd through terminal and file environment creation into DockerEnvironment
- add regression tests for Docker cwd config mapping, environment creation, and bind-mount behavior

## Testing
- ./.venv/bin/python -m pytest tests/tools/test_modal_sandbox_fixes.py tests/tools/test_docker_environment.py -n0
- ./.venv/bin/python -m pytest tests/tools/test_modal_sandbox_fixes.py -k docker -n0 -q
- ./.venv/bin/python -m py_compile tools/terminal_tool.py tools/file_tools.py tools/environments/docker.py tests/tools/test_modal_sandbox_fixes.py tests/tools/test_docker_environment.py

Closes #1445