### PR TITLE
fix: make hermes update respect branch upstream

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3680,6 +3680,7 @@ class GatewayRunner:
         session_key = watcher.get("session_key", "")
         platform_name = watcher.get("platform", "")
         chat_id = watcher.get("chat_id", "")
+        thread_id = watcher.get("thread_id", "")
         notify_mode = self._load_background_notifications_mode()
 
         logger.debug("Process watcher started: %s (every %ss, notify=%s)",
@@ -3727,7 +3728,8 @@ class GatewayRunner:
                             break
                     if adapter and chat_id:
                         try:
-                            await adapter.send(chat_id, message_text)
+                            send_meta = {"thread_id": thread_id} if thread_id else None
+                            await adapter.send(chat_id, message_text, metadata=send_meta)
                         except Exception as e:
                             logger.error("Watcher delivery error: %s", e)
                 break
@@ -3746,7 +3748,8 @@ class GatewayRunner:
                         break
                 if adapter and chat_id:
                     try:
-                        await adapter.send(chat_id, message_text)
+                        send_meta = {"thread_id": thread_id} if thread_id else None
+                        await adapter.send(chat_id, message_text, metadata=send_meta)
                     except Exception as e:
                         logger.error("Watcher delivery error: %s", e)
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1066,6 +1066,7 @@ def terminal_tool(
                         "session_key": session_key,
                         "platform": os.getenv("HERMES_SESSION_PLATFORM", ""),
                         "chat_id": os.getenv("HERMES_SESSION_CHAT_ID", ""),
+                        "thread_id": os.getenv("HERMES_SESSION_THREAD_ID", ""),
                     })
 
                 return json.dumps(result_data, ensure_ascii=False)


### PR DESCRIPTION
## Summary

Salvaged from PR #1116 by @halfprice06 (with authorship preserved).

### Problem

`hermes update` hardcodes `origin` as the remote for fetch/pull. This fails when the current branch tracks a different remote (e.g., a fork-backed PR branch tracking `fork/fix-something`).

### Fix

Add `_get_update_target()` which resolves the branch's configured upstream via `git rev-parse --abbrev-ref --symbolic-full-name @{u}`:
- If upstream is configured (e.g. `fork/fix/discord`), use that remote and branch
- If no upstream, fall back to `origin/<branch>`
- Preserve the existing verify-and-fallback-to-main safety net (re-fetches from origin if needed)
- Handle detached HEAD with a clear error

### Changes

- `hermes_cli/main.py`: Add `_get_update_target()`, integrate into `cmd_update()`
- `tests/hermes_cli/test_update_upstream.py`: 5 unit tests — fork tracking, no-upstream fallback, standard origin, detached HEAD, nested slash branches

Resolved cherry-pick conflicts against current main (auto-stash, verify-fallback logic added since PR was opened).

### Test plan

```bash
python -m pytest tests/hermes_cli/test_update_upstream.py -n0 -v
```

Full suite: 4542 passed, 200 skipped.