### PR TITLE
fix(agent): skip reasoning extra_body for unsupported OpenRouter models

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3301,18 +3301,7 @@ class AIAgent:
             extra_body["provider"] = provider_preferences
         _is_nous = "nousresearch" in self.base_url.lower()
 
-        _is_mistral = "api.mistral.ai" in self.base_url.lower()
-        # Only send reasoning extra_body to providers/models known to support it.
-        # Sending unsupported fields (e.g. to MiniMax, Nvidia) causes 400 errors.
-        _REASONING_MODEL_PREFIXES = (
-            "deepseek/", "anthropic/", "openai/", "x-ai/",
-            "google/gemini-2", "qwen/qwen3",
-        )
-        _model_supports_reasoning = (
-            _is_nous
-            or any(self.model.lower().startswith(p) for p in _REASONING_MODEL_PREFIXES)
-        )
-        if (_is_openrouter or _is_nous) and not _is_mistral and _model_supports_reasoning:
+        if self._supports_reasoning_extra_body():
             if self.reasoning_config is not None:
                 rc = dict(self.reasoning_config)
                 # Nous Portal requires reasoning enabled — don't send
@@ -3335,6 +3324,32 @@ class AIAgent:
             api_kwargs["extra_body"] = extra_body
 
         return api_kwargs
+
+    def _supports_reasoning_extra_body(self) -> bool:
+        """Return True when reasoning extra_body is safe to send for this route/model.
+
+        OpenRouter forwards unknown extra_body fields to upstream providers.
+        Some providers/routes reject `reasoning` with 400s, so gate it to
+        known reasoning-capable model families and direct Nous Portal.
+        """
+        base_url = (self.base_url or "").lower()
+        if "nousresearch" in base_url:
+            return True
+        if "openrouter" not in base_url:
+            return False
+        if "api.mistral.ai" in base_url:
+            return False
+
+        model = (self.model or "").lower()
+        reasoning_model_prefixes = (
+            "deepseek/",
+            "anthropic/",
+            "openai/",
+            "x-ai/",
+            "google/gemini-2",
+            "qwen/qwen3",
+        )
+        return any(model.startswith(prefix) for prefix in reasoning_model_prefixes)
 
     def _build_assistant_message(self, assistant_message, finish_reason: str) -> dict:
         """Build a normalized assistant message dict from an API response message.
@@ -4290,17 +4305,8 @@ class AIAgent:
                     api_messages.insert(sys_offset + idx, pfm.copy())
 
             summary_extra_body = {}
-            _is_openrouter = "openrouter" in self.base_url.lower()
             _is_nous = "nousresearch" in self.base_url.lower()
-            _REASONING_MODEL_PREFIXES = (
-                "deepseek/", "anthropic/", "openai/", "x-ai/",
-                "google/gemini-2", "qwen/qwen3",
-            )
-            _model_supports_reasoning = (
-                _is_nous
-                or any(self.model.lower().startswith(p) for p in _REASONING_MODEL_PREFIXES)
-            )
-            if (_is_openrouter or _is_nous) and _model_supports_reasoning:
+            if self._supports_reasoning_extra_body():
                 if self.reasoning_config is not None:
                     summary_extra_body["reasoning"] = self.reasoning_config
                 else:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3302,7 +3302,17 @@ class AIAgent:
         _is_nous = "nousresearch" in self.base_url.lower()
 
         _is_mistral = "api.mistral.ai" in self.base_url.lower()
-        if (_is_openrouter or _is_nous) and not _is_mistral:
+        # Only send reasoning extra_body to providers/models known to support it.
+        # Sending unsupported fields (e.g. to MiniMax, Nvidia) causes 400 errors.
+        _REASONING_MODEL_PREFIXES = (
+            "deepseek/", "anthropic/", "openai/", "x-ai/",
+            "google/gemini-2", "qwen/qwen3",
+        )
+        _model_supports_reasoning = (
+            _is_nous
+            or any(self.model.lower().startswith(p) for p in _REASONING_MODEL_PREFIXES)
+        )
+        if (_is_openrouter or _is_nous) and not _is_mistral and _model_supports_reasoning:
             if self.reasoning_config is not None:
                 rc = dict(self.reasoning_config)
                 # Nous Portal requires reasoning enabled — don't send
@@ -4282,7 +4292,15 @@ class AIAgent:
             summary_extra_body = {}
             _is_openrouter = "openrouter" in self.base_url.lower()
             _is_nous = "nousresearch" in self.base_url.lower()
-            if _is_openrouter or _is_nous:
+            _REASONING_MODEL_PREFIXES = (
+                "deepseek/", "anthropic/", "openai/", "x-ai/",
+                "google/gemini-2", "qwen/qwen3",
+            )
+            _model_supports_reasoning = (
+                _is_nous
+                or any(self.model.lower().startswith(p) for p in _REASONING_MODEL_PREFIXES)
+            )
+            if (_is_openrouter or _is_nous) and _model_supports_reasoning:
                 if self.reasoning_config is not None:
                     summary_extra_body["reasoning"] = self.reasoning_config
                 else:

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -612,6 +612,25 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["extra_body"]["reasoning"] == {"enabled": False}
 
+    def test_reasoning_not_sent_for_unsupported_openrouter_model(self, agent):
+        agent.model = "minimax/minimax-m2.5"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "reasoning" not in kwargs.get("extra_body", {})
+
+    def test_reasoning_sent_for_supported_openrouter_model(self, agent):
+        agent.model = "qwen/qwen3.5-plus-02-15"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["extra_body"]["reasoning"]["effort"] == "medium"
+
+    def test_reasoning_sent_for_nous_route(self, agent):
+        agent.base_url = "https://inference-api.nousresearch.com/v1"
+        agent.model = "minimax/minimax-m2.5"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["extra_body"]["reasoning"]["effort"] == "medium"
+
     def test_max_tokens_injected(self, agent):
         agent.max_tokens = 4096
         messages = [{"role": "user", "content": "hi"}]
@@ -941,6 +960,19 @@ class TestHandleMaxIterations:
         assert isinstance(result, str)
         assert "error" in result.lower()
         assert "API down" in result
+
+    def test_summary_skips_reasoning_for_unsupported_openrouter_model(self, agent):
+        agent.model = "minimax/minimax-m2.5"
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert "reasoning" not in kwargs.get("extra_body", {})
 
 
 class TestRunConversation:


### PR DESCRIPTION
## Summary
- skip OpenRouter `extra_body.reasoning` for model families that reject it
- centralize the gating logic in a single helper instead of duplicating the allowlist in two paths
- add regression tests for both the main request path and the max-iterations summary path

## Notes
- salvages the substantive fix from PR #1089 onto current `main`
- preserves contributor authorship via cherry-pick, with a small follow-up test/refactor commit on top

## Test plan
- `python -m py_compile run_agent.py tests/test_run_agent.py`
- `python -m pytest tests/test_run_agent.py -n0 -q`

Fixes #1083
Supersedes #1089
