### PR TITLE
fix(gateway): null-coalesce mode in SessionResetPolicy.from_dict

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -97,10 +97,11 @@ class SessionResetPolicy:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionResetPolicy":
         # Handle both missing keys and explicit null values (YAML null → None)
+        mode = data.get("mode")
         at_hour = data.get("at_hour")
         idle_minutes = data.get("idle_minutes")
         return cls(
-            mode=data.get("mode", "both"),
+            mode=mode if mode is not None else "both",
             at_hour=at_hour if at_hour is not None else 4,
             idle_minutes=idle_minutes if idle_minutes is not None else 1440,
         )

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -83,6 +83,14 @@ class TestSessionResetPolicy:
         assert policy.at_hour == 4
         assert policy.idle_minutes == 1440
 
+    def test_from_dict_treats_null_values_as_defaults(self):
+        restored = SessionResetPolicy.from_dict(
+            {"mode": None, "at_hour": None, "idle_minutes": None}
+        )
+        assert restored.mode == "both"
+        assert restored.at_hour == 4
+        assert restored.idle_minutes == 1440
+
 
 class TestGatewayConfigRoundtrip:
     def test_full_roundtrip(self):


### PR DESCRIPTION
## Summary

Completes YAML null handling for `SessionResetPolicy.from_dict()`. The `at_hour` and `idle_minutes` fields already had null coalescing, but `mode` was still using `data.get('mode', 'both')` which returns `None` when the key exists with an explicit null value in YAML config.

Adds a regression test covering all-null input.

Based on PR #1120 by @stablegenius49 (partially redundant — two of three fields were already fixed on main).

## Test Plan

```bash
pytest tests/gateway/test_config.py -n0 -v  # 11/11 pass
```