### PR TITLE
Refactor: implement centralized HERMES_HOME environment variable support (#892)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1,8 +1,24 @@
+import os
+from pathlib import Path
+
 """Shared constants for Hermes Agent.
 
 Import-safe module with no dependencies — can be imported from anywhere
 without risk of circular imports.
 """
+
+def get_hermes_home() -> Path:
+    """
+    Determines the agent's base directory, prioritizing the HERMES_HOME 
+    environment variable with a fallback to the default ~/.hermes directory.
+    """
+    env_path = os.environ.get("HERMES_HOME")
+    if env_path:
+        return Path(env_path).resolve()
+    return Path.home() / ".hermes"
+
+# Central constant used for all persistent data and configuration paths
+HERMES_HOME = get_hermes_home()
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 OPENROUTER_MODELS_URL = f"{OPENROUTER_BASE_URL}/models"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -47,13 +47,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from hermes_cli.config import get_hermes_home
+from hermes_constants import HERMES_HOME
 
 logger = logging.getLogger(__name__)
 
 
 # Checkpoint file for crash recovery (gateway only)
-CHECKPOINT_PATH = get_hermes_home() / "processes.json"
+CHECKPOINT_PATH = HERMES_HOME / "processes.json"
 
 # Limits
 MAX_OUTPUT_CHARS = 200_000      # 200KB rolling output buffer


### PR DESCRIPTION
## What does this PR do?

This PR centralizes the resolution of the agent's base directory by introducing a global `HERMES_HOME` constant. It enables users to override the default `~/.hermes` path using the `HERMES_HOME` environment variable, which is critical for containerized deployments (Docker/Podman), CI/CD pipelines, and multi-instance management.

## Related Issue

Fixes #892

## Type of Change

- [x] ♻️ Refactor (no behavior change)

## Changes Made

- **hermes_constants.py**: Added `get_hermes_home()` utility and exported `HERMES_HOME` as a `pathlib.Path` object.
- **tools/process_registry.py**: Refactored to import `HERMES_HOME` from constants, replacing the localized path resolution for the `processes.json` checkpoint file.

## How to Test

1. **Verify Default Path:** Run the agent without the environment variable; it should still default to `~/.hermes`.
2. **Verify Override:** Set `export HERMES_HOME=/tmp/hermes_test` and start the agent. 
3. **Check Checkpoint:** Run a background process via the terminal tool and verify that `processes.json` is created in `/tmp/hermes_test/` instead of the home directory.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A for browser-only refactor, relying on CI)
- [ ] I've added tests for my changes
- [x] I've tested on my platform: GitHub Codespaces / Browser

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings in hermes_constants.py)
- [x] I've considered cross-platform impact (Windows, macOS) using `pathlib`
