### PR TITLE
fix: persist CLI token counts to session DB for /insights

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5069,6 +5069,22 @@ class AIAgent:
                         self.session_completion_tokens += completion_tokens
                         self.session_total_tokens += total_tokens
                         self.session_api_calls += 1
+
+                        # Persist token counts to session DB for /insights.
+                        # Gateway sessions persist via session_store.update_session()
+                        # after run_conversation returns, so only persist here for
+                        # CLI (and other non-gateway) platforms to avoid double-counting.
+                        if (self._session_db and self.session_id
+                                and getattr(self, 'platform', None) == 'cli'):
+                            try:
+                                self._session_db.update_token_counts(
+                                    self.session_id,
+                                    input_tokens=prompt_tokens,
+                                    output_tokens=completion_tokens,
+                                    model=self.model,
+                                )
+                            except Exception:
+                                pass  # never block the agent loop
                         
                         if self.verbose_logging:
                             logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")


### PR DESCRIPTION
## Problem

`/insights` shows 0 tokens and $0.00 cost for all sessions because CLI sessions never persist token counts to the SQLite DB.

The token tracking pipeline:
1. `run_agent.py` accumulates tokens in memory (`session_prompt_tokens` etc.) — works fine
2. `hermes_state.py` has `update_token_counts()` to persist to DB — works fine
3. `gateway/session.py` calls `update_token_counts()` after each conversation — **gateway sessions persist correctly**
4. `cli.py` **never calls** `update_token_counts()` — **CLI sessions always show 0**

Since most usage is CLI, `/insights` shows 0 across the board.

## Fix

After each API call in `run_agent.py`, persist the token delta to the session DB. Guarded to only run for CLI sessions (`platform == 'cli'`) since gateway sessions already persist via `session_store.update_session()` — without the guard, gateway tokens would be double-counted.

## Test plan

Full suite passes: 4522 passed, 2 pre-existing failures (unrelated)