### PR TITLE
fix(aux): add configurable timeouts for LLM providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -555,23 +555,40 @@ def _try_openrouter() -> Tuple[Optional[OpenAI], Optional[str]]:
     or_key = os.getenv("OPENROUTER_API_KEY")
     if not or_key:
         return None, None
+    
+    from hermes_cli.config import load_config
+    config = load_config()
+    timeout = float(os.getenv("OPENAI_LLM_TIMEOUT") or config.get("agent", {}).get("llm_timeout", 60))
+
     logger.debug("Auxiliary client: OpenRouter")
-    return OpenAI(api_key=or_key, base_url=OPENROUTER_BASE_URL,
-                   default_headers=_OR_HEADERS), _OPENROUTER_MODEL
+    return OpenAI(
+        api_key=or_key, 
+        base_url=OPENROUTER_BASE_URL,
+        timeout=timeout,
+        default_headers=_OR_HEADERS
+    ), _OPENROUTER_MODEL
 
 
 def _try_nous() -> Tuple[Optional[OpenAI], Optional[str]]:
     nous = _read_nous_auth()
     if not nous:
         return None, None
+    
+    from hermes_cli.config import load_config
+    config = load_config()
+    timeout = float(os.getenv("OPENAI_LLM_TIMEOUT") or config.get("agent", {}).get("llm_timeout", 60))
+
     global auxiliary_is_nous
     auxiliary_is_nous = True
     logger.debug("Auxiliary client: Nous Portal")
     return (
-        OpenAI(api_key=_nous_api_key(nous), base_url=_nous_base_url()),
+        OpenAI(
+            api_key=_nous_api_key(nous), 
+            base_url=_nous_base_url(),
+            timeout=timeout
+        ),
         _NOUS_MODEL,
     )
-
 
 def _read_main_model() -> str:
     """Read the user's configured main model from config/env.
@@ -639,18 +656,27 @@ def _try_custom_endpoint() -> Tuple[Optional[OpenAI], Optional[str]]:
     if not custom_base or not custom_key:
         return None, None
     model = _read_main_model() or "gpt-4o-mini"
+
+    from hermes_cli.config import load_config
+    config = load_config()
+    timeout = float(os.getenv("OPENAI_LLM_TIMEOUT") or config.get("agent", {}).get("llm_timeout", 60))
+
     logger.debug("Auxiliary client: custom endpoint (%s)", model)
-    return OpenAI(api_key=custom_key, base_url=custom_base), model
+    return OpenAI(api_key=custom_key, base_url=custom_base, timeout=timeout), model
 
 
 def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
     codex_token = _read_codex_access_token()
     if not codex_token:
         return None, None
-    logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", _CODEX_AUX_MODEL)
-    real_client = OpenAI(api_key=codex_token, base_url=_CODEX_AUX_BASE_URL)
-    return CodexAuxiliaryClient(real_client, _CODEX_AUX_MODEL), _CODEX_AUX_MODEL
 
+    from hermes_cli.config import load_config
+    config = load_config()
+    timeout = float(os.getenv("OPENAI_LLM_TIMEOUT") or config.get("agent", {}).get("llm_timeout", 60))
+
+    logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", _CODEX_AUX_MODEL)
+    real_client = OpenAI(api_key=codex_token, base_url=_CODEX_AUX_BASE_URL, timeout=timeout)
+    return CodexAuxiliaryClient(real_client, _CODEX_AUX_MODEL), _CODEX_AUX_MODEL
 
 def _try_anthropic() -> Tuple[Optional[Any], Optional[str]]:
     try:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -515,7 +515,10 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         extra = {}
         if "api.kimi.com" in base_url.lower():
             extra["default_headers"] = {"User-Agent": "KimiCLI/1.0"}
-        return OpenAI(api_key=api_key, base_url=base_url, **extra), model
+        from hermes_cli.config import load_config
+        config = load_config()
+        timeout = float(os.getenv("OPENAI_LLM_TIMEOUT") or config.get("agent", {}).get("llm_timeout", 60))
+        return OpenAI(api_key=api_key, base_url=base_url, timeout=timeout, **extra), model
 
     return None, None
 
@@ -733,6 +736,7 @@ def _to_async_client(sync_client, model: str):
     async_kwargs = {
         "api_key": sync_client.api_key,
         "base_url": str(sync_client.base_url),
+        "timeout": getattr(sync_client, "timeout", 60.0),
     }
     base_lower = str(sync_client.base_url).lower()
     if "openrouter" in base_lower:
@@ -1275,11 +1279,16 @@ def _build_call_kwargs(
     temperature: Optional[float] = None,
     max_tokens: Optional[int] = None,
     tools: Optional[list] = None,
-    timeout: float = 30.0,
+    timeout: float = None,
     extra_body: Optional[dict] = None,
     base_url: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
+  if timeout is None:
+    from hermes_cli.config import load_config
+    config = load_config()
+    # Priority: Env Var -> config.yaml -> Default (60s)
+    timeout = float(os.getenv("OPENAI_LLM_TIMEOUT") or config.get("agent", {}).get("llm_timeout", 60))
     kwargs: Dict[str, Any] = {
         "model": model,
         "messages": messages,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -99,6 +99,7 @@ DEFAULT_CONFIG = {
     "toolsets": ["hermes-cli"],
     "agent": {
         "max_turns": 90,
+        "llm_timeout": 60,
     },
     
     "terminal": {
@@ -346,6 +347,14 @@ OPTIONAL_ENV_VARS = {
         "url": "https://openrouter.ai/keys",
         "password": True,
         "tools": ["vision_analyze", "mixture_of_agents"],
+        "category": "provider",
+        "advanced": True,
+    },
+    "OPENAI_LLM_TIMEOUT": {
+        "description": "Timeout in seconds for OpenAI API requests",
+        "prompt": "OpenAI LLM Timeout (seconds)",
+        "url": None,
+        "password": False,
         "category": "provider",
         "advanced": True,
     },
@@ -1340,6 +1349,7 @@ def set_config_value(key: str, value: str):
         'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
         'GITHUB_TOKEN', 'HONCHO_API_KEY', 'WANDB_API_KEY',
         'TINKER_API_KEY',
+        'OPENAI_LLM_TIMEOUT',
     ]
     
     if key.upper() in api_keys or key.upper().endswith('_API_KEY') or key.upper().endswith('_TOKEN') or key.upper().startswith('TERMINAL_SSH'):

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -119,11 +119,16 @@ def _resolve_named_custom_runtime(
         or os.getenv("OPENROUTER_API_KEY", "").strip()
     )
 
+    config = load_config()
+    raw_timeout = os.getenv("OPENAI_LLM_TIMEOUT") or config.get("agent", {}).get("llm_timeout", 60)
+    timeout = float(raw_timeout)
+
     return {
         "provider": "openrouter",
         "api_mode": "chat_completions",
         "base_url": base_url,
         "api_key": api_key,
+        "timeout": timeout,
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
     }
 
@@ -191,11 +196,16 @@ def _resolve_openrouter_runtime(
 
     source = "explicit" if (explicit_api_key or explicit_base_url) else "env/config"
 
+    config = load_config()
+    raw_timeout = os.getenv("OPENAI_LLM_TIMEOUT") or config.get("agent", {}).get("llm_timeout", 60)
+    timeout = float(raw_timeout)
+
     return {
         "provider": "openrouter",
         "api_mode": "chat_completions",
         "base_url": base_url,
         "api_key": api_key,
+        "timeout": timeout,
         "source": source,
     }
 

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -352,6 +352,11 @@ class TrajectoryCompressor:
         """
         from agent.auxiliary_client import call_llm, async_call_llm
 
+        from hermes_cli.config import load_config
+        config_data = load_config()
+        timeout = float(os.getenv("OPENAI_LLM_TIMEOUT") or config_data.get("agent", {}).get("llm_timeout", 60))
+        # --------------------------------
+
         provider = self._detect_provider()
         if provider:
             # Store provider for use in _generate_summary calls
@@ -375,14 +380,21 @@ class TrajectoryCompressor:
                 raise RuntimeError(
                     f"Missing API key. Set {self.config.api_key_env} "
                     f"environment variable.")
+            
             from openai import OpenAI, AsyncOpenAI
             self.client = OpenAI(
-                api_key=api_key, base_url=self.config.base_url)
+                api_key=api_key, 
+                base_url=self.config.base_url,
+                timeout=timeout
+            )
             self.async_client = AsyncOpenAI(
-                api_key=api_key, base_url=self.config.base_url)
+                api_key=api_key, 
+                base_url=self.config.base_url,
+                timeout=timeout
+            )
 
         print(f"✅ Initialized summarizer client: {self.config.summarization_model}")
-        print(f"   Max concurrent requests: {self.config.max_concurrent_requests}")
+        print(f"    Max concurrent requests: {self.config.max_concurrent_requests}")
 
     def _detect_provider(self) -> str:
         """Detect the provider name from the configured base_url."""


### PR DESCRIPTION
What does this PR do?
Adds configurable timeouts to OpenAI/AsyncOpenAI clients in auxiliary tasks and trajectory compression to prevent the agent from hanging indefinitely.

Related Issue
Fixes #1010

Type of Change
[x] 🐛 Bug fix

Changes Made
agent/auxiliary_client.py: Added timeout to OpenRouter, Nous, Custom, and Codex providers.
trajectory_compressor.py: Added timeout to summarizer clients.
Clients now use OPENAI_LLM_TIMEOUT env or agent.llm_timeout from config (default 60s).

How to Test
Run export OPENAI_LLM_TIMEOUT=0.1.
Trigger any side task (e.g., web search).
Verify the agent errors out quickly instead of hanging.