### PR TITLE
feat: local Control API + /autoreply for autonomous agent loops

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -299,3 +299,11 @@ WANDB_API_KEY=
 # Override STT provider endpoints (for proxies or self-hosted instances)
 # GROQ_BASE_URL=https://api.groq.com/openai/v1
 # STT_OPENAI_BASE_URL=https://api.openai.com/v1
+
+# =============================================================================
+# CONTROL API (optional)
+# =============================================================================
+# Local HTTP API for external tools to inject messages/commands into a running session.
+# Binds to 127.0.0.1 only. Protected by CSRF header requirement.
+# HERMES_CONTROL_API=true
+# HERMES_CONTROL_PORT=47823

--- a/agent/autoreply.py
+++ b/agent/autoreply.py
@@ -1,0 +1,169 @@
+"""Auto-reply engine — shared logic for CLI and gateway.
+
+Handles config parsing, state management, prompt building, and LLM calls.
+Consumers (CLI, gateway) only handle injection into their respective message loops.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+_DEFAULT_MAX_TURNS = 20
+
+
+def parse_autoreply_args(args: str) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Parse /autoreply command arguments.
+
+    Returns (status_message, config_or_none).
+    - When enabling: returns (message, new_config_dict)
+    - When disabling/status/error: returns (message, None)
+
+    The caller is responsible for storing/clearing the config and
+    formatting the message for their platform (markdown vs plain text).
+    """
+    # /autoreply off
+    if args.lower() in ("off", "disable", "stop"):
+        return "off", None
+
+    # /autoreply max <N>
+    if args.lower() == "max" or (args.lower().startswith("max ") and len(args) > 4):
+        parts = args.split(None, 1)
+        if len(parts) == 2:
+            try:
+                n = int(parts[1])
+                if n < 1:
+                    return "error:Max turns must be at least 1.", None
+                return f"max:{n}", None
+            except ValueError:
+                return "error:Usage: /autoreply max <number>", None
+        return "error:Usage: /autoreply max <number>", None
+
+    # /autoreply (no args)
+    if not args:
+        return "status", None
+
+    # Extract flags from args: --literal, --max N, --forever
+    literal = False
+    max_turns = _DEFAULT_MAX_TURNS
+    remaining_parts = []
+
+    parts = args.split()
+    i = 0
+    while i < len(parts):
+        if parts[i] == "--literal":
+            literal = True
+        elif parts[i] == "--forever":
+            max_turns = 0  # 0 = unlimited
+        elif parts[i] == "--max" and i + 1 < len(parts):
+            i += 1
+            try:
+                n = int(parts[i])
+                if n < 1:
+                    return "error:--max must be at least 1.", None
+                max_turns = n
+            except ValueError:
+                return "error:--max requires a number.", None
+        else:
+            remaining_parts.append(parts[i])
+        i += 1
+
+    prompt = " ".join(remaining_parts).strip()
+
+    if literal:
+        if not prompt:
+            return "error:Usage: /autoreply --literal <message>", None
+        return "enabled", {
+            "prompt": prompt,
+            "model": None,
+            "max_turns": max_turns,
+            "turn_count": 0,
+            "literal": True,
+        }
+
+    if not prompt:
+        return "error:Usage: /autoreply <instructions>", None
+
+    return "enabled", {
+        "prompt": prompt,
+        "model": None,
+        "max_turns": max_turns,
+        "turn_count": 0,
+    }
+
+
+def build_autoreply_messages(config: Dict[str, Any],
+                             history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Build the message list for the auto-reply LLM call.
+
+    Filters history to recent user/assistant messages, prepends a system
+    prompt with the user's instructions, and appends the generation request.
+    """
+    recent = [
+        m for m in (history or [])
+        if m.get("role") in ("user", "assistant") and m.get("content")
+    ][-20:]
+
+    system_prompt = (
+        "You are generating a reply on behalf of the user in a conversation "
+        "with an AI assistant.\n\n"
+        "THE USER'S INSTRUCTIONS — follow these as your top priority:\n"
+        f"{config['prompt']}\n\n"
+        "Output ONLY the user's reply message. No labels, no meta-commentary, "
+        "no 'User:' prefix."
+    )
+
+    messages = [{"role": "system", "content": system_prompt}]
+    for m in recent:
+        content = m["content"]
+        # Flatten list-type content to plain text
+        if isinstance(content, list):
+            content = "\n".join(
+                p.get("text", "") for p in content
+                if isinstance(p, dict) and p.get("type") == "text"
+            )
+        messages.append({"role": m["role"], "content": content})
+    messages.append({
+        "role": "user",
+        "content": "Based on the conversation above and your instructions, "
+                   "generate the next user reply.",
+    })
+    return messages
+
+
+def check_and_advance(config: Dict[str, Any]) -> Tuple[Optional[str], bool]:
+    """Check turn cap and handle literal mode.
+
+    Returns (reply_text, cap_reached).
+    - (None, False): config is None / not applicable (caller didn't pass config)
+    - (None, True): turn cap reached, config should be removed
+    - (text, False): literal mode reply, turn_count incremented
+    - None for LLM mode: caller should proceed to call the LLM
+
+    For LLM mode, returns a sentinel to indicate the caller should proceed:
+    the return is (None, False) when turn_count < max_turns and not literal.
+    But we can't distinguish "no config" from "LLM needed" with just (None, False).
+
+    So the contract is: caller checks config existence first, then calls this.
+    If this returns (None, True) → cap reached. If it returns a string → use it.
+    If it returns (None, False) → proceed to LLM call.
+    """
+    if config["max_turns"] > 0 and config["turn_count"] >= config["max_turns"]:
+        return None, True
+
+    if config.get("literal"):
+        config["turn_count"] += 1
+        return config["prompt"], False
+
+    return None, False
+
+
+def format_status(config: Dict[str, Any]) -> str:
+    """Format the auto-reply status for display."""
+    mode = "literal" if config.get("literal") else "LLM-generated"
+    label = "Message" if config.get("literal") else "Prompt"
+    prompt_preview = config["prompt"][:100]
+    if len(config["prompt"]) > 100:
+        prompt_preview += "..."
+    return (
+        f"Auto-reply active ({mode})\n"
+        f"  {label}: {prompt_preview}\n"
+        f"  Turns: {config['turn_count']}/{'∞' if config['max_turns'] == 0 else config['max_turns']}"
+    )

--- a/agent/autoreply.py
+++ b/agent/autoreply.py
@@ -10,14 +10,10 @@ _DEFAULT_MAX_TURNS = 20
 
 
 def parse_autoreply_args(args: str) -> Tuple[str, Optional[Dict[str, Any]]]:
-    """Parse /autoreply command arguments.
+    """Parse /autoreply arguments into (action, config_or_none).
 
-    Returns (status_message, config_or_none).
-    - When enabling: returns (message, new_config_dict)
-    - When disabling/status/error: returns (message, None)
-
-    The caller is responsible for storing/clearing the config and
-    formatting the message for their platform (markdown vs plain text).
+    Actions: "off", "max:N", "error:msg", "status", "enabled".
+    Used internally by handle_command(); prefer that for full dispatch.
     """
     # /autoreply off
     if args.lower() in ("off", "disable", "stop"):
@@ -129,21 +125,12 @@ def build_autoreply_messages(config: Dict[str, Any],
 
 
 def check_and_advance(config: Dict[str, Any]) -> Tuple[Optional[str], bool]:
-    """Check turn cap and handle literal mode.
+    """Check turn cap and return literal text if applicable.
 
-    Returns (reply_text, cap_reached).
-    - (None, False): config is None / not applicable (caller didn't pass config)
-    - (None, True): turn cap reached, config should be removed
-    - (text, False): literal mode reply, turn_count incremented
-    - None for LLM mode: caller should proceed to call the LLM
-
-    For LLM mode, returns a sentinel to indicate the caller should proceed:
-    the return is (None, False) when turn_count < max_turns and not literal.
-    But we can't distinguish "no config" from "LLM needed" with just (None, False).
-
-    So the contract is: caller checks config existence first, then calls this.
-    If this returns (None, True) → cap reached. If it returns a string → use it.
-    If it returns (None, False) → proceed to LLM call.
+    Returns (reply_text, cap_reached):
+    - (None, True)  — cap hit, caller should remove config
+    - (text, False)  — literal mode reply
+    - (None, False) — caller should proceed to LLM call
     """
     if config["max_turns"] > 0 and config["turn_count"] >= config["max_turns"]:
         return None, True
@@ -167,3 +154,50 @@ def format_status(config: Dict[str, Any]) -> str:
         f"  {label}: {prompt_preview}\n"
         f"  Turns: {config['turn_count']}/{'∞' if config['max_turns'] == 0 else config['max_turns']}"
     )
+
+
+def handle_command(
+    args: str, current_config: Optional[Dict[str, Any]]
+) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Handle /autoreply command — full dispatch.
+
+    Returns (display_text, new_config).
+    - new_config is None when autoreply should be disabled/inactive.
+    - new_config is the (possibly mutated) config when active.
+    - display_text is ready to show to the user.
+    """
+    action, new_config = parse_autoreply_args(args)
+
+    if action == "off":
+        if current_config:
+            return "🔇 Auto-reply disabled.", None
+        return "Auto-reply is not active.", None
+
+    if action.startswith("max:"):
+        n = int(action.split(":")[1])
+        if current_config:
+            current_config["max_turns"] = n
+            return f"🔄 Auto-reply max turns set to {n}.", current_config
+        return "Auto-reply is not active. Use /autoreply <instructions> first.", None
+
+    if action.startswith("error:"):
+        return action[6:], current_config
+
+    if action == "status":
+        if current_config:
+            return "🔄 " + format_status(current_config), current_config
+        return "Auto-reply is not active. Use /autoreply <instructions> to enable.", None
+
+    # action == "enabled"
+    mode = "literal mode " if new_config.get("literal") else ""
+    label = "Message" if new_config.get("literal") else "Prompt"
+    max_t = new_config["max_turns"]
+    prompt_preview = new_config["prompt"][:100]
+    if len(new_config["prompt"]) > 100:
+        prompt_preview += "..."
+    text = (
+        f"🔄 Auto-reply enabled — {mode}({'forever' if max_t == 0 else f'max {max_t} turns'}).\n"
+        f"  {label}: {prompt_preview}\n"
+        f"  Send a message to start the loop. Use /autoreply off to stop."
+    )
+    return text, new_config

--- a/agent/autoreply.py
+++ b/agent/autoreply.py
@@ -178,8 +178,12 @@ def extract_reply(config: Dict[str, Any], response) -> Optional[str]:
     if not content:
         logger.warning("[AutoReply] LLM returned empty content")
         return None
+    text = content.strip()
+    if not text:
+        logger.warning("[AutoReply] LLM returned whitespace-only content")
+        return None
     config["turn_count"] += 1
-    return content.strip()
+    return text
 
 
 def session_info(config: Optional[Dict[str, Any]]) -> dict:

--- a/agent/autoreply.py
+++ b/agent/autoreply.py
@@ -4,9 +4,16 @@ Handles config parsing, state management, prompt building, and LLM calls.
 Consumers (CLI, gateway) only handle injection into their respective message loops.
 """
 
+import logging
 from typing import Any, Dict, List, Optional, Tuple
 
+logger = logging.getLogger(__name__)
+
 _DEFAULT_MAX_TURNS = 20
+
+# Marker constants used by CLI and gateway to tag auto-reply messages.
+GATEWAY_MSG_PREFIX = "autoreply-"
+CLI_INPUT_PREFIX = "[autoreply]"
 
 
 def parse_autoreply_args(args: str) -> Tuple[str, Optional[Dict[str, Any]]]:
@@ -140,6 +147,51 @@ def check_and_advance(config: Dict[str, Any]) -> Tuple[Optional[str], bool]:
         return config["prompt"], False
 
     return None, False
+
+
+def prepare_llm_call(config: Dict[str, Any],
+                     history: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Build call_llm kwargs from config and history."""
+    messages = build_autoreply_messages(config, history)
+    kwargs: Dict[str, Any] = {
+        "task": "autoreply",
+        "messages": messages,
+        "temperature": 0.7,
+        "max_tokens": 1024,
+    }
+    if config.get("model"):
+        kwargs["model"] = config["model"]
+    return kwargs
+
+
+def extract_reply(config: Dict[str, Any], response) -> Optional[str]:
+    """Extract reply text from LLM response, or None on empty/missing content.
+
+    Increments config["turn_count"] only on success.  Returns None (without
+    incrementing) when the LLM returns no choices or empty content, so the
+    caller can decide how to handle the gap.
+    """
+    if not response.choices:
+        logger.warning("[AutoReply] LLM returned no choices")
+        return None
+    content = response.choices[0].message.content
+    if not content:
+        logger.warning("[AutoReply] LLM returned empty content")
+        return None
+    config["turn_count"] += 1
+    return content.strip()
+
+
+def session_info(config: Optional[Dict[str, Any]]) -> dict:
+    """Build autoreply status dict for the control API."""
+    return {
+        "autoreply": {
+            "enabled": config is not None,
+            "prompt": config.get("prompt", "") if config else None,
+            "max_turns": config.get("max_turns", 0) if config else None,
+            "turn_count": config.get("turn_count", 0) if config else None,
+        },
+    }
 
 
 def format_status(config: Dict[str, Any]) -> str:

--- a/cli.py
+++ b/cli.py
@@ -3080,7 +3080,7 @@ class HermesCLI:
             self._toggle_verbose()
         elif cmd_lower.startswith("/reasoning"):
             self._handle_reasoning_command(cmd_original)
-        elif cmd_lower == "/compress":
+        elif cmd_lower in ("/compress", "/compact"):
             self._manual_compress()
         elif cmd_lower == "/usage":
             self._show_usage()

--- a/cli.py
+++ b/cli.py
@@ -1186,6 +1186,10 @@ class HermesCLI:
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
 
+        # Auto-reply config (ephemeral, in-memory only)
+        # {"prompt": str, "model": str|None, "max_turns": int, "turn_count": int, "literal": bool}
+        self._autoreply_config: Optional[Dict[str, Any]] = None
+
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
         import time as _time
@@ -1448,11 +1452,69 @@ class HermesCLI:
                 except (ValueError, Exception) as e:
                     _cprint(f"  Could not apply pending title: {e}")
                     self._pending_title = None
+
+            # Start local control API so external tools can switch models
+            self._start_control_api()
+
             return True
         except Exception as e:
             self.console.print(f"[bold red]Failed to initialize agent: {e}[/]")
             return False
-    
+
+    def _start_control_api(self):
+        """Start the control API in a background thread for external model switching."""
+        if not os.getenv("HERMES_CONTROL_API", "").lower() in ("1", "true", "yes"):
+            return
+        try:
+            import asyncio as _aio
+            import threading
+            from gateway.control_api import ControlAPI
+
+            # Lightweight shim so ControlAPI can find our agent
+            class _CLIRunner:
+                def __init__(self, agent, session_id, cli_instance):
+                    self._running_agents = {session_id: agent}
+                    self._cli = cli_instance
+
+                def inject_message(self, key: str, text: str, *, interrupt: bool = True):
+                    """Inject a message into the CLI's input queues."""
+                    if interrupt and self._cli._agent_running:
+                        self._cli._interrupt_queue.put(text)
+                    else:
+                        self._cli._pending_input.put(text)
+
+                def get_session_info(self, key: str) -> dict:
+                    """Return session state for the control API."""
+                    cfg = getattr(self._cli, "_autoreply_config", None)
+                    return {
+                        "autoreply": {
+                            "enabled": cfg is not None,
+                            "prompt": cfg.get("prompt", "") if cfg else None,
+                            "max_turns": cfg.get("max_turns", 0) if cfg else None,
+                            "turn_count": cfg.get("turn_count", 0) if cfg else None,
+                        },
+                    }
+
+            shim = _CLIRunner(self.agent, self.session_id, self)
+            api = ControlAPI(shim)
+
+            def _run():
+                try:
+                    loop = _aio.new_event_loop()
+                    _aio.set_event_loop(loop)
+                    loop.run_until_complete(api.start())
+                    loop.run_forever()
+                except Exception as e:
+                    logger.error("Control API thread crashed: %s", e)
+
+            t = threading.Thread(target=_run, daemon=True, name="control-api")
+            t.start()
+            # Give it a moment to bind
+            import time
+            time.sleep(0.3)
+        except Exception as e:
+            logger.debug("Control API failed to start: %s", e)
+
     def show_banner(self):
         """Display the welcome banner in Claude Code style."""
         self.console.clear()
@@ -2896,6 +2958,7 @@ class HermesCLI:
                 else:
                     _cprint("  Session database not available.")
         elif cmd_lower in ("/reset", "/new"):
+            self._autoreply_config = None
             self.new_session()
         elif cmd_lower.startswith("/model"):
             # Use original case so model names like "Anthropic/Claude-Opus-4" are preserved
@@ -3023,6 +3086,8 @@ class HermesCLI:
             self._handle_rollback_command(cmd_original)
         elif cmd_lower.startswith("/background"):
             self._handle_background_command(cmd_original)
+        elif cmd_lower.startswith("/autoreply"):
+            self._handle_autoreply_command(cmd_original)
         elif cmd_lower.startswith("/skin"):
             self._handle_skin_command(cmd_original)
         elif cmd_lower.startswith("/voice"):
@@ -3125,6 +3190,79 @@ class HermesCLI:
         else:
             self.console.print("[bold red]Plan mode unavailable: input queue not initialized[/]")
     
+    def _handle_autoreply_command(self, cmd: str):
+        """Handle /autoreply — enable, disable, or show auto-reply status."""
+        from agent.autoreply import parse_autoreply_args, format_status
+
+        args = cmd.split(None, 1)[1].strip() if len(cmd.split(None, 1)) > 1 else ""
+        action, new_config = parse_autoreply_args(args)
+
+        if action == "off":
+            if self._autoreply_config:
+                self._autoreply_config = None
+                _cprint("🔇 Auto-reply disabled.")
+            else:
+                _cprint("Auto-reply is not active.")
+        elif action.startswith("max:"):
+            n = int(action.split(":")[1])
+            if self._autoreply_config:
+                self._autoreply_config["max_turns"] = n
+                _cprint(f"🔄 Auto-reply max turns set to {n}.")
+            else:
+                _cprint("Auto-reply is not active. Use /autoreply <instructions> first.")
+        elif action.startswith("error:"):
+            _cprint(action[6:])
+        elif action == "status":
+            if self._autoreply_config:
+                _cprint("🔄 " + format_status(self._autoreply_config))
+            else:
+                _cprint("Auto-reply is not active. Use /autoreply <instructions> to enable.")
+        elif action == "enabled":
+            self._autoreply_config = new_config
+            mode = "literal mode " if new_config.get("literal") else ""
+            label = "Message" if new_config.get("literal") else "Prompt"
+            prompt_preview = new_config["prompt"][:80]
+            if len(new_config["prompt"]) > 80:
+                prompt_preview += "..."
+            limit = "forever" if new_config["max_turns"] == 0 else f"max {new_config['max_turns']} turns"
+            _cprint(f"🔄 Auto-reply enabled — {mode}({limit}).")
+            _cprint(f"  {label}: {prompt_preview}")
+            _cprint("  Send a message to start the loop. Use /autoreply off to stop.")
+
+    def _generate_autoreply_text(self) -> Optional[str]:
+        """Generate the next auto-reply text, or None if done."""
+        from agent.autoreply import check_and_advance, build_autoreply_messages
+
+        config = self._autoreply_config
+        if not config:
+            return None
+
+        text, cap_reached = check_and_advance(config)
+        if cap_reached:
+            self._autoreply_config = None
+            _cprint(f"\n{_DIM}[Auto-reply limit reached. Use /autoreply to re-enable.]{_RST}")
+            return None
+        if text:
+            return text
+
+        # LLM-generated: build prompt from conversation history and call sync LLM
+        from agent.auxiliary_client import call_llm
+
+        messages = build_autoreply_messages(config, self.conversation_history or [])
+        call_kwargs = {
+            "task": "autoreply",
+            "messages": messages,
+            "temperature": 0.7,
+            "max_tokens": 1024,
+        }
+        if config.get("model"):
+            call_kwargs["model"] = config["model"]
+
+        response = call_llm(**call_kwargs)
+        reply_text = response.choices[0].message.content.strip()
+        config["turn_count"] += 1
+        return reply_text
+
     def _handle_background_command(self, cmd: str):
         """Handle /background <prompt> — run a prompt in a separate background session.
 
@@ -5806,6 +5944,13 @@ class HermesCLI:
                         n = len(submit_images)
                         _cprint(f"  {_DIM}📎 {n} image{'s' if n > 1 else ''} attached{_RST}")
 
+                    # Real user messages reset auto-reply turn counter
+                    if self._autoreply_config and not user_input.startswith("[autoreply]"):
+                        self._autoreply_config["turn_count"] = 0
+                    # Strip the autoreply prefix before sending to agent
+                    if isinstance(user_input, str) and user_input.startswith("[autoreply]"):
+                        user_input = user_input[len("[autoreply]"):]
+
                     # Regular chat - run agent
                     self._agent_running = True
                     app.invalidate()  # Refresh status line
@@ -5832,7 +5977,20 @@ class HermesCLI:
                                 except Exception as e:
                                     _cprint(f"{_DIM}Voice auto-restart failed: {e}{_RST}")
                             threading.Thread(target=_restart_recording, daemon=True).start()
-                    
+
+                        # Auto-reply: generate and inject the next message
+                        if self._autoreply_config:
+                            try:
+                                reply = self._generate_autoreply_text()
+                                if reply:
+                                    cfg = self._autoreply_config
+                                    turn = cfg["turn_count"] if cfg else "?"
+                                    max_t = cfg["max_turns"] if cfg else "?"
+                                    _cprint(f"\n{_DIM}[Auto-reply {turn}/{max_t}]{_RST}")
+                                    self._pending_input.put(f"[autoreply]{reply}")
+                            except Exception as e:
+                                _cprint(f"\n{_DIM}[Auto-reply failed: {e}]{_RST}")
+
                 except Exception as e:
                     print(f"Error: {e}")
         

--- a/cli.py
+++ b/cli.py
@@ -3263,6 +3263,8 @@ class HermesCLI:
 
         try:
             response = call_llm(**call_kwargs)
+            if not response.choices:
+                return None
             content = response.choices[0].message.content
             if not content:
                 return None

--- a/cli.py
+++ b/cli.py
@@ -960,6 +960,36 @@ def save_config_value(key_path: str, value: any) -> bool:
 
 
 # ============================================================================
+# _CLIRunner — lightweight shim so ControlAPI can talk to the CLI
+# ============================================================================
+
+
+class _CLIRunner:
+    """Adapter between ControlAPI and HermesCLI.
+
+    Exposes the same interface that ControlAPI expects from GatewayRunner,
+    bridging the sync/single-session CLI with the async ControlAPI server.
+    """
+
+    def __init__(self, agent, session_id, cli_instance):
+        self._running_agents = {session_id: agent}
+        self._cli = cli_instance
+
+    def inject_message(self, key: str, text: str, *, interrupt: bool = True):
+        """Inject a message into the CLI's input queues."""
+        if interrupt and self._cli._agent_running:
+            self._cli._interrupt_queue.put(text)
+        else:
+            self._cli._pending_input.put(text)
+
+    def get_session_info(self, key: str) -> dict:
+        """Return session state for the control API."""
+        from agent.autoreply import session_info
+        cfg = getattr(self._cli, "_autoreply_config", None)
+        return session_info(cfg)
+
+
+# ============================================================================
 # HermesCLI Class
 # ============================================================================
 
@@ -1470,51 +1500,27 @@ class HermesCLI:
             import threading
             from gateway.control_api import ControlAPI
 
-            # Lightweight shim so ControlAPI can find our agent
-            class _CLIRunner:
-                def __init__(self, agent, session_id, cli_instance):
-                    self._running_agents = {session_id: agent}
-                    self._cli = cli_instance
-
-                def inject_message(self, key: str, text: str, *, interrupt: bool = True):
-                    """Inject a message into the CLI's input queues."""
-                    if interrupt and self._cli._agent_running:
-                        self._cli._interrupt_queue.put(text)
-                    else:
-                        self._cli._pending_input.put(text)
-
-                def get_session_info(self, key: str) -> dict:
-                    """Return session state for the control API."""
-                    cfg = getattr(self._cli, "_autoreply_config", None)
-                    return {
-                        "autoreply": {
-                            "enabled": cfg is not None,
-                            "prompt": cfg.get("prompt", "") if cfg else None,
-                            "max_turns": cfg.get("max_turns", 0) if cfg else None,
-                            "turn_count": cfg.get("turn_count", 0) if cfg else None,
-                        },
-                    }
-
             shim = _CLIRunner(self.agent, self.session_id, self)
             api = ControlAPI(shim)
+            ready = threading.Event()
 
             def _run():
                 try:
                     loop = _aio.new_event_loop()
                     _aio.set_event_loop(loop)
                     loop.run_until_complete(api.start())
+                    ready.set()
                     loop.run_forever()
                 except Exception as e:
                     logger.error("Control API thread crashed: %s", e)
+                    ready.set()  # Unblock caller even on failure
 
             t = threading.Thread(target=_run, daemon=True, name="control-api")
             t.start()
             # Clean up port file on exit (daemon thread won't call api.stop())
             import atexit
             atexit.register(ControlAPI._remove_port_file)
-            # Give it a moment to bind
-            import time
-            time.sleep(0.3)
+            ready.wait(timeout=5.0)
         except Exception as e:
             logger.debug("Control API failed to start: %s", e)
 
@@ -3203,7 +3209,7 @@ class HermesCLI:
 
     def _generate_autoreply_text(self) -> Optional[str]:
         """Generate the next auto-reply text, or None if done."""
-        from agent.autoreply import check_and_advance, build_autoreply_messages
+        from agent.autoreply import check_and_advance, prepare_llm_call, extract_reply
 
         config = self._autoreply_config
         if not config:
@@ -3220,29 +3226,13 @@ class HermesCLI:
         # LLM-generated: build prompt from conversation history and call sync LLM
         from agent.auxiliary_client import call_llm
 
-        messages = build_autoreply_messages(config, self.conversation_history or [])
-        call_kwargs = {
-            "task": "autoreply",
-            "messages": messages,
-            "temperature": 0.7,
-            "max_tokens": 1024,
-        }
-        if config.get("model"):
-            call_kwargs["model"] = config["model"]
-
+        call_kwargs = prepare_llm_call(config, self.conversation_history or [])
         try:
             response = call_llm(**call_kwargs)
-            if not response.choices:
-                return None
-            content = response.choices[0].message.content
-            if not content:
-                return None
-            reply_text = content.strip()
         except Exception as e:
             _cprint(f"\n{_DIM}[Auto-reply LLM error: {e}]{_RST}")
             return None
-        config["turn_count"] += 1
-        return reply_text
+        return extract_reply(config, response)
 
     def _handle_background_command(self, cmd: str):
         """Handle /background <prompt> — run a prompt in a separate background session.
@@ -5930,11 +5920,12 @@ class HermesCLI:
                         _cprint(f"  {_DIM}📎 {n} image{'s' if n > 1 else ''} attached{_RST}")
 
                     # Real user messages reset auto-reply turn counter
-                    if self._autoreply_config and not user_input.startswith("[autoreply]"):
+                    from agent.autoreply import CLI_INPUT_PREFIX
+                    if self._autoreply_config and not user_input.startswith(CLI_INPUT_PREFIX):
                         self._autoreply_config["turn_count"] = 0
                     # Strip the autoreply prefix before sending to agent
-                    if isinstance(user_input, str) and user_input.startswith("[autoreply]"):
-                        user_input = user_input[len("[autoreply]"):]
+                    if isinstance(user_input, str) and user_input.startswith(CLI_INPUT_PREFIX):
+                        user_input = user_input[len(CLI_INPUT_PREFIX):]
 
                     # Regular chat - run agent
                     self._agent_running = True
@@ -5972,7 +5963,10 @@ class HermesCLI:
                                     turn = cfg["turn_count"] if cfg else "?"
                                     max_t = cfg["max_turns"] if cfg else "?"
                                     _cprint(f"\n{_DIM}[Auto-reply {turn}/{max_t}]{_RST}")
-                                    self._pending_input.put(f"[autoreply]{reply}")
+                                    self._pending_input.put(f"{CLI_INPUT_PREFIX}{reply}")
+                                elif self._autoreply_config:
+                                    # LLM returned empty — loop pauses until next message
+                                    _cprint(f"\n{_DIM}[Auto-reply: LLM returned empty response]{_RST}")
                             except Exception as e:
                                 _cprint(f"\n{_DIM}[Auto-reply failed: {e}]{_RST}")
 

--- a/cli.py
+++ b/cli.py
@@ -1463,7 +1463,7 @@ class HermesCLI:
 
     def _start_control_api(self):
         """Start the control API in a background thread for external model switching."""
-        if not os.getenv("HERMES_CONTROL_API", "").lower() in ("1", "true", "yes"):
+        if os.getenv("HERMES_CONTROL_API", "").lower() not in ("1", "true", "yes"):
             return
         try:
             import asyncio as _aio
@@ -1509,6 +1509,9 @@ class HermesCLI:
 
             t = threading.Thread(target=_run, daemon=True, name="control-api")
             t.start()
+            # Clean up port file on exit (daemon thread won't call api.stop())
+            import atexit
+            atexit.register(ControlAPI._remove_port_file)
             # Give it a moment to bind
             import time
             time.sleep(0.3)
@@ -3221,8 +3224,8 @@ class HermesCLI:
             self._autoreply_config = new_config
             mode = "literal mode " if new_config.get("literal") else ""
             label = "Message" if new_config.get("literal") else "Prompt"
-            prompt_preview = new_config["prompt"][:80]
-            if len(new_config["prompt"]) > 80:
+            prompt_preview = new_config["prompt"][:100]
+            if len(new_config["prompt"]) > 100:
                 prompt_preview += "..."
             limit = "forever" if new_config["max_turns"] == 0 else f"max {new_config['max_turns']} turns"
             _cprint(f"🔄 Auto-reply enabled — {mode}({limit}).")
@@ -3258,8 +3261,15 @@ class HermesCLI:
         if config.get("model"):
             call_kwargs["model"] = config["model"]
 
-        response = call_llm(**call_kwargs)
-        reply_text = response.choices[0].message.content.strip()
+        try:
+            response = call_llm(**call_kwargs)
+            content = response.choices[0].message.content
+            if not content:
+                return None
+            reply_text = content.strip()
+        except Exception as e:
+            _cprint(f"\n{_DIM}[Auto-reply LLM error: {e}]{_RST}")
+            return None
         config["turn_count"] += 1
         return reply_text
 
@@ -4624,6 +4634,10 @@ class HermesCLI:
                             if self._clarify_state or self._clarify_freetext:
                                 continue
                             print(f"\n⚡ New message detected, interrupting...")
+                            # User interrupt clears autoreply loop
+                            if self._autoreply_config:
+                                self._autoreply_config = None
+                                _cprint(f"{_DIM}🔇 Auto-reply disabled by interrupt.{_RST}")
                             # Signal TTS to stop on interrupt
                             if stop_event is not None:
                                 stop_event.set()

--- a/cli.py
+++ b/cli.py
@@ -5958,13 +5958,13 @@ class HermesCLI:
                         if self._autoreply_config:
                             try:
                                 reply = self._generate_autoreply_text()
-                                if reply:
-                                    cfg = self._autoreply_config
-                                    turn = cfg["turn_count"] if cfg else "?"
-                                    max_t = cfg["max_turns"] if cfg else "?"
+                                cfg = self._autoreply_config
+                                if reply and cfg:
+                                    turn = cfg["turn_count"]
+                                    max_t = cfg["max_turns"]
                                     _cprint(f"\n{_DIM}[Auto-reply {turn}/{max_t}]{_RST}")
                                     self._pending_input.put(f"{CLI_INPUT_PREFIX}{reply}")
-                                elif self._autoreply_config:
+                                elif cfg:
                                     # LLM returned empty — loop pauses until next message
                                     _cprint(f"\n{_DIM}[Auto-reply: LLM returned empty response]{_RST}")
                             except Exception as e:

--- a/cli.py
+++ b/cli.py
@@ -3195,42 +3195,11 @@ class HermesCLI:
     
     def _handle_autoreply_command(self, cmd: str):
         """Handle /autoreply — enable, disable, or show auto-reply status."""
-        from agent.autoreply import parse_autoreply_args, format_status
+        from agent.autoreply import handle_command
 
         args = cmd.split(None, 1)[1].strip() if len(cmd.split(None, 1)) > 1 else ""
-        action, new_config = parse_autoreply_args(args)
-
-        if action == "off":
-            if self._autoreply_config:
-                self._autoreply_config = None
-                _cprint("🔇 Auto-reply disabled.")
-            else:
-                _cprint("Auto-reply is not active.")
-        elif action.startswith("max:"):
-            n = int(action.split(":")[1])
-            if self._autoreply_config:
-                self._autoreply_config["max_turns"] = n
-                _cprint(f"🔄 Auto-reply max turns set to {n}.")
-            else:
-                _cprint("Auto-reply is not active. Use /autoreply <instructions> first.")
-        elif action.startswith("error:"):
-            _cprint(action[6:])
-        elif action == "status":
-            if self._autoreply_config:
-                _cprint("🔄 " + format_status(self._autoreply_config))
-            else:
-                _cprint("Auto-reply is not active. Use /autoreply <instructions> to enable.")
-        elif action == "enabled":
-            self._autoreply_config = new_config
-            mode = "literal mode " if new_config.get("literal") else ""
-            label = "Message" if new_config.get("literal") else "Prompt"
-            prompt_preview = new_config["prompt"][:100]
-            if len(new_config["prompt"]) > 100:
-                prompt_preview += "..."
-            limit = "forever" if new_config["max_turns"] == 0 else f"max {new_config['max_turns']} turns"
-            _cprint(f"🔄 Auto-reply enabled — {mode}({limit}).")
-            _cprint(f"  {label}: {prompt_preview}")
-            _cprint("  Send a message to start the loop. Use /autoreply off to stop.")
+        text, self._autoreply_config = handle_command(args, self._autoreply_config)
+        _cprint(text)
 
     def _generate_autoreply_text(self) -> Optional[str]:
         """Generate the next auto-reply text, or None if done."""

--- a/gateway/control_api.py
+++ b/gateway/control_api.py
@@ -1,0 +1,228 @@
+"""
+Local-only HTTP control API for the Hermes gateway.
+
+Runs alongside the gateway as a background aiohttp server on 127.0.0.1.
+Provides programmatic control over live agent sessions — session listing,
+message injection, etc.
+
+External tools (e.g., desloppify) can call these endpoints to influence
+a running Hermes agent without needing direct process access.
+
+All mutations go through POST /sessions/{key}/message — inject any text
+(including /commands) as if the user typed it.
+
+Default port: 47823 (override with HERMES_CONTROL_PORT env var).
+"""
+
+import json
+import logging
+import os
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PORT = 47823
+
+# Commands available via /message injection.  This list is informational —
+# the message endpoint accepts any text, but GET /commands exposes these
+# so external tools know what's available.
+AVAILABLE_COMMANDS = [
+    {"command": "/reset", "description": "Reset conversation history"},
+    {"command": "/new", "description": "Start a new conversation"},
+    {"command": "/stop", "description": "Stop the running agent"},
+    {"command": "/compact", "description": "Compress conversation context"},
+    {"command": "/compress", "description": "Compress conversation context"},
+    {"command": "/status", "description": "Show session info"},
+    {"command": "/model <provider:model>", "description": "Switch model"},
+    {"command": "/personality <name>", "description": "Switch personality"},
+    {"command": "/autoreply <prompt>", "description": "Enable auto-reply loop (LLM generates replies from your prompt)"},
+    {"command": "/autoreply --literal <message>", "description": "Enable auto-reply loop (sends exact message each turn)"},
+    {"command": "/autoreply --forever <prompt>", "description": "Auto-reply with no turn limit (default: 20)"},
+    {"command": "/autoreply --max N <prompt>", "description": "Auto-reply with custom turn limit"},
+    {"command": "/autoreply off", "description": "Disable auto-reply loop"},
+    {"command": "/reasoning <level>", "description": "Set reasoning effort"},
+    {"command": "/rollback [number]", "description": "List or restore checkpoints"},
+    {"command": "/background <prompt>", "description": "Run prompt in background session"},
+    {"command": "/undo", "description": "Undo last assistant response"},
+    {"command": "/retry", "description": "Retry last message"},
+    {"command": "/usage", "description": "Show token usage"},
+    {"command": "/help", "description": "List commands"},
+]
+
+
+def _get_port() -> int:
+    return int(os.getenv("HERMES_CONTROL_PORT", str(DEFAULT_PORT)))
+
+
+def _json_response(data: dict, status: int = 200) -> web.Response:
+    return web.Response(
+        text=json.dumps(data, ensure_ascii=False),
+        content_type="application/json",
+        status=status,
+    )
+
+
+REQUIRED_HEADER = "X-Hermes-Control"
+
+
+class ControlAPI:
+    """Lightweight control API that holds a reference to the GatewayRunner."""
+
+    def __init__(self, gateway_runner):
+        self.runner = gateway_runner
+        self.app = web.Application(middlewares=[self._require_header])
+        self._setup_routes()
+        self._site = None
+
+    @web.middleware
+    async def _require_header(self, request: web.Request, handler):
+        """Reject requests missing the X-Hermes-Control header.
+
+        This blocks browser-based CSRF attacks: any non-standard header
+        forces a CORS preflight, which fails because we don't serve
+        Access-Control-Allow-* headers.  Non-browser callers just add
+        the header.
+        """
+        if request.headers.get(REQUIRED_HEADER) != "1":
+            return _json_response(
+                {"error": f"Missing required header: {REQUIRED_HEADER}: 1"},
+                status=403,
+            )
+        return await handler(request)
+
+    def _setup_routes(self):
+        self.app.router.add_get("/health", self.health)
+        self.app.router.add_get("/sessions", self.list_sessions)
+        self.app.router.add_get("/sessions/{key}", self.get_session)
+        self.app.router.add_get("/commands", self.list_commands)
+        self.app.router.add_post("/sessions/{key}/message", self.send_message)
+
+    # ── Helpers ─────────────────────────────────────────────────────────
+
+    def _resolve_agent(self, key: str):
+        """Look up a running agent by session key.  '_any' returns the first.
+        Returns (resolved_key, agent) or (key, None) if not found."""
+        if key == "_any":
+            if not self.runner._running_agents:
+                return key, None
+            key = next(iter(self.runner._running_agents))
+        return key, self.runner._running_agents.get(key)
+
+    # ── Endpoints ────────────────────────────────────────────────────────
+
+    async def health(self, request: web.Request) -> web.Response:
+        return _json_response({"status": "ok"})
+
+    async def list_sessions(self, request: web.Request) -> web.Response:
+        """List all sessions, marking which have a live (running) agent."""
+        sessions = []
+        for key, agent in self.runner._running_agents.items():
+            entry = {
+                "session_key": key,
+                "status": "running",
+                "model": getattr(agent, "model", None),
+                "provider": getattr(agent, "provider", None),
+                **self.runner.get_session_info(key),
+            }
+            sessions.append(entry)
+        return _json_response({"sessions": sessions})
+
+    async def get_session(self, request: web.Request) -> web.Response:
+        key = request.match_info["key"]
+        key, agent = self._resolve_agent(key)
+        if not agent:
+            return _json_response(
+                {"error": f"No running agent for '{key}'"},
+                status=404,
+            )
+        return _json_response({
+            "session_key": key,
+            "status": "running",
+            "model": getattr(agent, "model", None),
+            "provider": getattr(agent, "provider", None),
+            **self.runner.get_session_info(key),
+        })
+
+    async def list_commands(self, request: web.Request) -> web.Response:
+        """List available slash commands that can be sent via /message."""
+        return _json_response({"commands": AVAILABLE_COMMANDS})
+
+    async def send_message(self, request: web.Request) -> web.Response:
+        """Inject a message (or /command) into a session.
+
+        POST body: {"text": "...", "mode": "interrupt"|"queue"}
+
+        Modes:
+        - interrupt (default): cancel current agent run, process this message
+        - queue: let current run finish, then process this message next
+        """
+        key = request.match_info["key"]
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _json_response({"error": "Invalid JSON body"}, status=400)
+
+        text = body.get("text", "").strip()
+        if not text:
+            return _json_response({"error": "'text' is required"}, status=400)
+
+        mode = body.get("mode", "interrupt")
+        if mode not in ("interrupt", "queue"):
+            return _json_response(
+                {"error": f"Invalid mode '{mode}', must be 'interrupt' or 'queue'"},
+                status=400,
+            )
+
+        logger.info(
+            "Control API: send_message session=%s mode=%s text=%s",
+            key, mode, text[:80],
+        )
+
+        try:
+            result = self.runner.inject_message(key, text, interrupt=(mode != "queue"))
+            # await if coroutine (GatewayRunner is async, CLI shim is sync)
+            if hasattr(result, "__await__"):
+                await result
+        except LookupError as e:
+            return _json_response({"error": str(e)}, status=404)
+
+        return _json_response({"success": True, "message": "Message submitted"})
+
+    # ── Lifecycle ────────────────────────────────────────────────────────
+
+    async def start(self):
+        port = _get_port()
+        app_runner = web.AppRunner(self.app, access_log=None)
+        await app_runner.setup()
+        self._site = web.TCPSite(app_runner, "127.0.0.1", port)
+        try:
+            await self._site.start()
+            logger.info("Control API listening on http://127.0.0.1:%d", port)
+            self._write_port_file(port)
+        except OSError as e:
+            logger.warning("Control API failed to bind port %d: %s", port, e)
+
+    async def stop(self):
+        if self._site:
+            await self._site.stop()
+            self._remove_port_file()
+            logger.info("Control API stopped")
+
+    @staticmethod
+    def _write_port_file(port: int):
+        path = os.path.expanduser("~/.hermes/control_api.port")
+        try:
+            with open(path, "w") as f:
+                f.write(str(port))
+        except OSError:
+            pass
+
+    @staticmethod
+    def _remove_port_file():
+        path = os.path.expanduser("~/.hermes/control_api.port")
+        try:
+            os.remove(path)
+        except OSError:
+            pass

--- a/gateway/control_api.py
+++ b/gateway/control_api.py
@@ -74,6 +74,7 @@ class ControlAPI:
         self.app = web.Application(middlewares=[self._require_header])
         self._setup_routes()
         self._site = None
+        self._app_runner = None
 
     @web.middleware
     async def _require_header(self, request: web.Request, handler):
@@ -194,9 +195,9 @@ class ControlAPI:
 
     async def start(self):
         port = _get_port()
-        app_runner = web.AppRunner(self.app, access_log=None)
-        await app_runner.setup()
-        self._site = web.TCPSite(app_runner, "127.0.0.1", port)
+        self._app_runner = web.AppRunner(self.app, access_log=None)
+        await self._app_runner.setup()
+        self._site = web.TCPSite(self._app_runner, "127.0.0.1", port)
         try:
             await self._site.start()
             logger.info("Control API listening on http://127.0.0.1:%d", port)
@@ -207,8 +208,10 @@ class ControlAPI:
     async def stop(self):
         if self._site:
             await self._site.stop()
-            self._remove_port_file()
-            logger.info("Control API stopped")
+        if self._app_runner:
+            await self._app_runner.cleanup()
+        self._remove_port_file()
+        logger.info("Control API stopped")
 
     @staticmethod
     def _write_port_file(port: int):

--- a/gateway/control_api.py
+++ b/gateway/control_api.py
@@ -24,31 +24,13 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_PORT = 47823
 
-# Commands available via /message injection.  This list is informational —
-# the message endpoint accepts any text, but GET /commands exposes these
-# so external tools know what's available.
-AVAILABLE_COMMANDS = [
-    {"command": "/reset", "description": "Reset conversation history"},
-    {"command": "/new", "description": "Start a new conversation"},
-    {"command": "/stop", "description": "Stop the running agent"},
-    {"command": "/compact", "description": "Compress conversation context"},
-    {"command": "/compress", "description": "Compress conversation context"},
-    {"command": "/status", "description": "Show session info"},
-    {"command": "/model <provider:model>", "description": "Switch model"},
-    {"command": "/personality <name>", "description": "Switch personality"},
-    {"command": "/autoreply <prompt>", "description": "Enable auto-reply loop (LLM generates replies from your prompt)"},
-    {"command": "/autoreply --literal <message>", "description": "Enable auto-reply loop (sends exact message each turn)"},
-    {"command": "/autoreply --forever <prompt>", "description": "Auto-reply with no turn limit (default: 20)"},
-    {"command": "/autoreply --max N <prompt>", "description": "Auto-reply with custom turn limit"},
-    {"command": "/autoreply off", "description": "Disable auto-reply loop"},
-    {"command": "/reasoning <level>", "description": "Set reasoning effort"},
-    {"command": "/rollback [number]", "description": "List or restore checkpoints"},
-    {"command": "/background <prompt>", "description": "Run prompt in background session"},
-    {"command": "/undo", "description": "Undo last assistant response"},
-    {"command": "/retry", "description": "Retry last message"},
-    {"command": "/usage", "description": "Show token usage"},
-    {"command": "/help", "description": "List commands"},
-]
+def _get_available_commands():
+    """Pull command list from hermes_cli.commands (single source of truth)."""
+    try:
+        from hermes_cli.commands import COMMANDS
+        return [{"command": cmd, "description": desc} for cmd, desc in COMMANDS.items()]
+    except Exception:
+        return []
 
 
 def _get_port() -> int:
@@ -147,7 +129,7 @@ class ControlAPI:
 
     async def list_commands(self, request: web.Request) -> web.Response:
         """List available slash commands that can be sent via /message."""
-        return _json_response({"commands": AVAILABLE_COMMANDS})
+        return _json_response({"commands": _get_available_commands()})
 
     async def send_message(self, request: web.Request) -> web.Response:
         """Inject a message (or /command) into a session.

--- a/gateway/control_api.py
+++ b/gateway/control_api.py
@@ -30,6 +30,7 @@ def _get_available_commands():
         from hermes_cli.commands import COMMANDS
         return [{"command": cmd, "description": desc} for cmd, desc in COMMANDS.items()]
     except Exception:
+        logger.debug("Failed to load commands list", exc_info=True)
         return []
 
 
@@ -87,9 +88,10 @@ class ControlAPI:
         """Look up a running agent by session key.  '_any' returns the first.
         Returns (resolved_key, agent) or (key, None) if not found."""
         if key == "_any":
-            if not self.runner._running_agents:
+            try:
+                key = next(iter(self.runner._running_agents))
+            except StopIteration:
                 return key, None
-            key = next(iter(self.runner._running_agents))
         return key, self.runner._running_agents.get(key)
 
     # ── Endpoints ────────────────────────────────────────────────────────

--- a/gateway/hermes_control_client.py
+++ b/gateway/hermes_control_client.py
@@ -1,0 +1,141 @@
+"""
+Hermes control client — lightweight module for external tools to control
+a running Hermes instance (CLI or gateway).
+
+Usage:
+    from gateway.hermes_control_client import HermesControl
+
+    ctl = HermesControl()  # auto-discovers port from ~/.hermes/control_api.port
+
+    # Send a message (interrupt mode — stops current work)
+    ctl.send_message("Focus on this instead")
+
+    # Queue a message (processed after current work finishes)
+    ctl.send_message("When you're done, also check logs", mode="queue")
+
+    # Send a slash command
+    ctl.send_message("/reset")
+    ctl.send_message("/model openrouter:anthropic/claude-sonnet-4")
+
+    # List running sessions
+    sessions = ctl.list_sessions()
+
+    # List available commands
+    commands = ctl.list_commands()
+
+Zero dependencies beyond stdlib (uses urllib, not requests/aiohttp).
+"""
+
+import json
+import os
+import urllib.request
+import urllib.error
+from typing import Optional
+
+DEFAULT_PORT = 47823
+PORT_FILE = os.path.expanduser("~/.hermes/control_api.port")
+
+
+class HermesControl:
+    """Client for the Hermes control API."""
+
+    def __init__(self, host: str = "127.0.0.1", port: Optional[int] = None):
+        if port is None:
+            port = self._discover_port()
+        self.base_url = f"http://{host}:{port}"
+
+    @staticmethod
+    def _discover_port() -> int:
+        try:
+            with open(PORT_FILE) as f:
+                return int(f.read().strip())
+        except (OSError, ValueError):
+            return DEFAULT_PORT
+
+    def _request(self, method: str, path: str, body: dict = None) -> dict:
+        url = f"{self.base_url}{path}"
+        data = json.dumps(body).encode() if body else None
+        headers = {"X-Hermes-Control": "1"}
+        if data:
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers=headers,
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            return json.loads(e.read())
+        except urllib.error.URLError as e:
+            return {"error": f"Cannot reach Hermes control API: {e.reason}"}
+
+    # ── Read-only endpoints ────────────────────────────────────────────
+
+    def health(self) -> dict:
+        """Check if the control API is running."""
+        return self._request("GET", "/health")
+
+    def list_sessions(self) -> dict:
+        """List all running agent sessions."""
+        return self._request("GET", "/sessions")
+
+    def get_session(self, session_key: str = "_any") -> dict:
+        """Get info about a specific session."""
+        return self._request("GET", f"/sessions/{session_key}")
+
+    def list_commands(self) -> dict:
+        """List available slash commands."""
+        return self._request("GET", "/commands")
+
+    # ── Message injection ──────────────────────────────────────────────
+
+    def send_message(
+        self,
+        text: str,
+        session_key: str = "_any",
+        mode: str = "interrupt",
+    ) -> dict:
+        """Send a message (or /command) into a running session.
+
+        Args:
+            text: Message text or slash command (e.g., "hello", "/reset").
+            session_key: Session to target. "_any" targets the first running session.
+            mode: "interrupt" (default) stops current work; "queue" waits for it to finish.
+        """
+        return self._request("POST", f"/sessions/{session_key}/message", {
+            "text": text,
+            "mode": mode,
+        })
+
+    # ── Convenience methods ────────────────────────────────────────────
+
+    def switch_model(self, provider: str, model: str, **kw) -> dict:
+        """Switch model via /model command."""
+        return self.send_message(f"/model {provider}:{model}", **kw)
+
+    def compact_context(self, **kw) -> dict:
+        """Trigger context compaction."""
+        return self.send_message("/compact", **kw)
+
+    def reset(self, **kw) -> dict:
+        """Reset conversation history."""
+        return self.send_message("/reset", **kw)
+
+    def stop(self, **kw) -> dict:
+        """Stop the running agent."""
+        return self.send_message("/stop", **kw)
+
+    def is_autoreply_enabled(self, session_key: str = "_any") -> bool:
+        """Check if autoreply is enabled for a session."""
+        info = self.get_session(session_key)
+        return bool(info.get("autoreply", {}).get("enabled"))
+
+    def is_available(self) -> bool:
+        """Check if a Hermes instance with control API is reachable."""
+        try:
+            return self.health().get("status") == "ok"
+        except Exception:
+            return False

--- a/gateway/hermes_control_client.py
+++ b/gateway/hermes_control_client.py
@@ -1,29 +1,8 @@
 """
-Hermes control client — lightweight module for external tools to control
-a running Hermes instance (CLI or gateway).
+Hermes control client — zero-dependency stdlib client for the local control API.
 
-Usage:
-    from gateway.hermes_control_client import HermesControl
-
-    ctl = HermesControl()  # auto-discovers port from ~/.hermes/control_api.port
-
-    # Send a message (interrupt mode — stops current work)
-    ctl.send_message("Focus on this instead")
-
-    # Queue a message (processed after current work finishes)
-    ctl.send_message("When you're done, also check logs", mode="queue")
-
-    # Send a slash command
-    ctl.send_message("/reset")
-    ctl.send_message("/model openrouter:anthropic/claude-sonnet-4")
-
-    # List running sessions
-    sessions = ctl.list_sessions()
-
-    # List available commands
-    commands = ctl.list_commands()
-
-Zero dependencies beyond stdlib (uses urllib, not requests/aiohttp).
+Auto-discovers port from ~/.hermes/control_api.port.
+All mutations go through send_message() which accepts any text including /commands.
 """
 
 import json
@@ -32,7 +11,7 @@ import urllib.request
 import urllib.error
 from typing import Optional
 
-DEFAULT_PORT = 47823
+DEFAULT_PORT = 47823  # must match gateway.control_api.DEFAULT_PORT
 PORT_FILE = os.path.expanduser("~/.hermes/control_api.port")
 
 
@@ -58,12 +37,7 @@ class HermesControl:
         headers = {"X-Hermes-Control": "1"}
         if data:
             headers["Content-Type"] = "application/json"
-        req = urllib.request.Request(
-            url,
-            data=data,
-            method=method,
-            headers=headers,
-        )
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
         try:
             with urllib.request.urlopen(req, timeout=5) as resp:
                 return json.loads(resp.read())
@@ -72,70 +46,25 @@ class HermesControl:
         except urllib.error.URLError as e:
             return {"error": f"Cannot reach Hermes control API: {e.reason}"}
 
-    # ── Read-only endpoints ────────────────────────────────────────────
-
     def health(self) -> dict:
-        """Check if the control API is running."""
         return self._request("GET", "/health")
 
     def list_sessions(self) -> dict:
-        """List all running agent sessions."""
         return self._request("GET", "/sessions")
 
     def get_session(self, session_key: str = "_any") -> dict:
-        """Get info about a specific session."""
         return self._request("GET", f"/sessions/{session_key}")
 
     def list_commands(self) -> dict:
-        """List available slash commands."""
         return self._request("GET", "/commands")
 
-    # ── Message injection ──────────────────────────────────────────────
+    def send_message(self, text: str, session_key: str = "_any",
+                     mode: str = "interrupt") -> dict:
+        """Send a message or /command into a running session.
 
-    def send_message(
-        self,
-        text: str,
-        session_key: str = "_any",
-        mode: str = "interrupt",
-    ) -> dict:
-        """Send a message (or /command) into a running session.
-
-        Args:
-            text: Message text or slash command (e.g., "hello", "/reset").
-            session_key: Session to target. "_any" targets the first running session.
-            mode: "interrupt" (default) stops current work; "queue" waits for it to finish.
+        mode: "interrupt" (default) stops current work; "queue" waits.
         """
         return self._request("POST", f"/sessions/{session_key}/message", {
             "text": text,
             "mode": mode,
         })
-
-    # ── Convenience methods ────────────────────────────────────────────
-
-    def switch_model(self, provider: str, model: str, **kw) -> dict:
-        """Switch model via /model command."""
-        return self.send_message(f"/model {provider}:{model}", **kw)
-
-    def compact_context(self, **kw) -> dict:
-        """Trigger context compaction."""
-        return self.send_message("/compact", **kw)
-
-    def reset(self, **kw) -> dict:
-        """Reset conversation history."""
-        return self.send_message("/reset", **kw)
-
-    def stop(self, **kw) -> dict:
-        """Stop the running agent."""
-        return self.send_message("/stop", **kw)
-
-    def is_autoreply_enabled(self, session_key: str = "_any") -> bool:
-        """Check if autoreply is enabled for a session."""
-        info = self.get_session(session_key)
-        return bool(info.get("autoreply", {}).get("enabled"))
-
-    def is_available(self) -> bool:
-        """Check if a Hermes instance with control API is reachable."""
-        try:
-            return self.health().get("status") == "ok"
-        except Exception:
-            return False

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -741,13 +741,16 @@ class BasePlatformAdapter(ABC):
         except asyncio.CancelledError:
             pass  # Normal cancellation when handler completes
     
-    async def handle_message(self, event: MessageEvent) -> None:
+    async def handle_message(self, event: MessageEvent, *, interrupt: bool = True) -> None:
         """
         Process an incoming message.
-        
+
         This method returns quickly by spawning background tasks.
         This allows new messages to be processed even while an agent is running,
         enabling interruption support.
+
+        If interrupt=False, the message is queued for after the current run
+        finishes without signalling the agent to stop (queue mode).
         """
         if not self._message_handler:
             return
@@ -777,12 +780,14 @@ class BasePlatformAdapter(ABC):
                     self._pending_messages[session_key] = event
                 return  # Don't interrupt now - will run after current task completes
 
-            # Default behavior for non-photo follow-ups: interrupt the running agent
-            print(f"[{self.name}] ⚡ New message while session {session_key} is active - triggering interrupt")
+            # Store pending message for after current run finishes
             self._pending_messages[session_key] = event
-            # Signal the interrupt (the processing task checks this)
-            self._active_sessions[session_key].set()
-            return  # Don't process now - will be handled after current task finishes
+            if interrupt:
+                print(f"[{self.name}] ⚡ New message while session {session_key} is active - triggering interrupt")
+                self._active_sessions[session_key].set()
+            else:
+                print(f"[{self.name}] 📬 Message queued for session {session_key} (no interrupt)")
+            return
         
         # Spawn background task to process this message
         task = asyncio.create_task(self._process_message_background(event, session_key))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1272,7 +1272,7 @@ class GatewayRunner:
         # Emit command:* hook for any recognized slash command
         _known_commands = {"new", "reset", "help", "status", "stop", "model", "reasoning",
                           "personality", "plan", "retry", "undo", "sethome", "set-home",
-                          "compress", "usage", "insights", "reload-mcp", "reload_mcp",
+                          "compress", "compact", "usage", "insights", "reload-mcp", "reload_mcp",
                           "update", "title", "resume", "provider", "rollback",
                           "background", "reasoning", "voice", "autoreply"}
         if command and command in _known_commands:
@@ -1338,7 +1338,7 @@ class GatewayRunner:
         if command in ["sethome", "set-home"]:
             return await self._handle_set_home_command(event)
 
-        if command == "compress":
+        if command in ("compress", "compact"):
             return await self._handle_compress_command(event)
 
         if command == "usage":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2574,6 +2574,8 @@ class GatewayRunner:
             call_kwargs["model"] = config["model"]
 
         response = await async_call_llm(**call_kwargs)
+        if not response.choices:
+            return None, False
         content = response.choices[0].message.content
         if not content:
             return None, False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -372,6 +372,51 @@ class GatewayRunner:
         # Per-chat voice reply mode: "off" | "voice_only" | "all"
         self._voice_mode: Dict[str, str] = self._load_voice_modes()
 
+        # Auto-reply configs per session (ephemeral, in-memory only)
+        # Key: session_key, Value: {"prompt": str, "model": str|None, "max_turns": int, "turn_count": int}
+        self._autoreply_configs: Dict[str, Dict[str, Any]] = {}
+
+    def get_session_info(self, key: str) -> dict:
+        """Return session state for the control API."""
+        cfg = self._autoreply_configs.get(key)
+        return {
+            "autoreply": {
+                "enabled": cfg is not None,
+                "prompt": cfg.get("prompt", "") if cfg else None,
+                "max_turns": cfg.get("max_turns", 0) if cfg else None,
+                "turn_count": cfg.get("turn_count", 0) if cfg else None,
+            },
+        }
+
+    async def inject_message(self, key: str, text: str, *, interrupt: bool = True):
+        """Inject a synthetic message into a session via its platform adapter.
+
+        Resolves the session key ('_any' picks the first running session),
+        builds a MessageEvent from the session's stored origin, and hands it
+        to the adapter's handle_message with the requested interrupt mode.
+        """
+        if key == "_any":
+            if not self._running_agents:
+                raise LookupError("No running session to inject into")
+            key = next(iter(self._running_agents))
+
+        self.session_store._ensure_loaded()
+        entry = self.session_store._entries.get(key)
+        if not entry or not entry.origin:
+            raise LookupError(f"No session found for '{key}'")
+
+        source = entry.origin
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            raise LookupError(f"No adapter for platform '{source.platform}'")
+
+        event = MessageEvent(
+            text=text,
+            source=source,
+            message_id=f"control-{time.time()}",
+        )
+        await adapter.handle_message(event, interrupt=interrupt)
+
     def _get_or_create_gateway_honcho(self, session_key: str):
         """Return a persistent Honcho manager/config pair for this gateway session."""
         if not hasattr(self, "_honcho_managers"):
@@ -1235,7 +1280,7 @@ class GatewayRunner:
                           "personality", "plan", "retry", "undo", "sethome", "set-home",
                           "compress", "usage", "insights", "reload-mcp", "reload_mcp",
                           "update", "title", "resume", "provider", "rollback",
-                          "background", "reasoning", "voice"}
+                          "background", "reasoning", "voice", "autoreply"}
         if command and command in _known_commands:
             await self.hooks.emit(f"command:{command}", {
                 "platform": source.platform.value if source.platform else "",
@@ -1331,6 +1376,9 @@ class GatewayRunner:
 
         if command == "voice":
             return await self._handle_voice_command(event)
+
+        if command == "autoreply":
+            return await self._handle_autoreply_command(event)
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
@@ -1780,6 +1828,12 @@ class GatewayRunner:
                     )
                 message_text = f"{context_note}\n\n{message_text}"
 
+        # Real user messages reset auto-reply turn counter;
+        # auto-reply messages (injected by _process_autoreply) do not.
+        is_autoreply = (event.message_id or "").startswith("autoreply-")
+        if session_key in self._autoreply_configs and not is_autoreply:
+            self._autoreply_configs[session_key]["turn_count"] = 0
+
         try:
             # Emit agent:start hook
             hook_ctx = {
@@ -1911,6 +1965,21 @@ class GatewayRunner:
                 model=agent_result.get("model"),
             )
 
+            # Auto-reply: label the response and schedule next auto-reply
+            if is_autoreply and response:
+                ar_config = self._autoreply_configs.get(session_key)
+                if ar_config:
+                    cap = "∞" if ar_config["max_turns"] == 0 else ar_config["max_turns"]
+                    response = (
+                        f"**[Auto-reply {ar_config['turn_count']}/{cap}]:** "
+                        f"{event.text}\n\n---\n\n{response}"
+                    )
+
+            if session_key in self._autoreply_configs:
+                asyncio.create_task(
+                    self._process_autoreply(source, session_key, session_entry.session_id)
+                )
+
             # Auto voice reply: send TTS audio before the text response
             if self._should_send_voice_reply(event, response, agent_messages):
                 await self._send_voice_reply(event, response)
@@ -1947,7 +2016,8 @@ class GatewayRunner:
             logger.debug("Gateway memory flush on reset failed: %s", e)
 
         self._shutdown_gateway_honcho(session_key)
-        
+        self._autoreply_configs.pop(session_key, None)
+
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
         
@@ -1995,11 +2065,17 @@ class GatewayRunner:
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
-        
+
+        was_autoreply = self._autoreply_configs.pop(session_key, None)
         if session_key in self._running_agents:
             agent = self._running_agents[session_key]
             agent.interrupt()
-            return "⚡ Stopping the current task... The agent will finish its current step and respond."
+            msg = "⚡ Stopping the current task... The agent will finish its current step and respond."
+            if was_autoreply:
+                msg += "\n🔇 Auto-reply disabled."
+            return msg
+        elif was_autoreply:
+            return "🔇 Auto-reply disabled."
         else:
             return "No active task to stop."
     
@@ -2025,6 +2101,7 @@ class GatewayRunner:
             "`/reasoning [level|show|hide]` — Set reasoning effort or toggle display",
             "`/rollback [number]` — List or restore filesystem checkpoints",
             "`/background <prompt>` — Run a prompt in a separate background session",
+            "`/autoreply <instructions>` — Enable auto-reply loop with meta-prompt",
             "`/voice [on|off|tts|status]` — Toggle voice reply mode",
             "`/reload-mcp` — Reload MCP servers from config",
             "`/update` — Update Hermes Agent to the latest version",
@@ -2414,6 +2491,132 @@ class GatewayRunner:
         if hasattr(raw, "guild") and raw.guild:
             return raw.guild.id
         return None
+
+    # ── Auto-reply ────────────────────────────────────────────────────
+
+    async def _handle_autoreply_command(self, event: MessageEvent) -> str:
+        """Handle /autoreply command — enable, disable, or show auto-reply status."""
+        from agent.autoreply import parse_autoreply_args, format_status
+
+        source = event.source
+        session_key = build_session_key(source)
+        args = event.get_command_args().strip()
+
+        action, new_config = parse_autoreply_args(args)
+
+        if action == "off":
+            if self._autoreply_configs.pop(session_key, None):
+                return "🔇 Auto-reply disabled."
+            return "Auto-reply is not active."
+
+        if action.startswith("max:"):
+            n = int(action.split(":")[1])
+            cfg = self._autoreply_configs.get(session_key)
+            if cfg:
+                cfg["max_turns"] = n
+                return f"🔄 Auto-reply max turns set to **{n}**."
+            return "Auto-reply is not active. Use `/autoreply <instructions>` first."
+
+        if action.startswith("error:"):
+            return action[6:]
+
+        if action == "status":
+            cfg = self._autoreply_configs.get(session_key)
+            if cfg:
+                return "🔄 " + format_status(cfg)
+            return "Auto-reply is not active. Use `/autoreply <instructions>` to enable."
+
+        # action == "enabled"
+        self._autoreply_configs[session_key] = new_config
+        mode = "literal mode " if new_config.get("literal") else ""
+        label = "Message" if new_config.get("literal") else "Prompt"
+        max_t = new_config["max_turns"]
+        prompt_preview = new_config["prompt"][:100]
+        if len(new_config["prompt"]) > 100:
+            prompt_preview += "..."
+        return (
+            f"🔄 Auto-reply enabled — {mode}({'forever' if max_t == 0 else f'max {max_t} turns'}).\n"
+            f"**{label}:** {prompt_preview}\n\n"
+            f"_Send a message to start the loop. Use `/autoreply off` to stop._"
+        )
+
+    async def _generate_autoreply(self, session_key: str, session_id: str):
+        """Generate an auto-reply using the auxiliary LLM client.
+
+        Returns (reply_text, cap_reached).  reply_text is None when
+        auto-reply is inactive or the turn cap was just hit.
+        """
+        from agent.autoreply import check_and_advance, build_autoreply_messages
+
+        config = self._autoreply_configs.get(session_key)
+        if not config:
+            return None, False
+
+        text, cap_reached = check_and_advance(config)
+        if cap_reached:
+            del self._autoreply_configs[session_key]
+            return None, True
+        if text:
+            return text, False
+
+        # LLM-generated: build prompt from transcript and call async LLM
+        history = self.session_store.load_transcript(session_id)
+        messages = build_autoreply_messages(config, history)
+
+        from agent.auxiliary_client import async_call_llm
+        call_kwargs = {
+            "task": "autoreply",
+            "messages": messages,
+            "temperature": 0.7,
+            "max_tokens": 1024,
+        }
+        if config.get("model"):
+            call_kwargs["model"] = config["model"]
+
+        response = await async_call_llm(**call_kwargs)
+        reply_text = response.choices[0].message.content.strip()
+        config["turn_count"] += 1
+        return reply_text, False
+
+    async def _process_autoreply(self, source, session_key: str, session_id: str):
+        """Fire-and-forget task: generate an auto-reply and inject it via the adapter."""
+        try:
+            adapter = self.adapters.get(source.platform)
+            if not adapter:
+                return
+
+            autoreply_text, cap_reached = await self._generate_autoreply(
+                session_key, session_id)
+
+            if not autoreply_text:
+                if cap_reached:
+                    metadata = {"thread_id": source.thread_id} if source.thread_id else None
+                    await adapter.send(
+                        chat_id=source.chat_id,
+                        content="_[Auto-reply limit reached. Use `/autoreply` to re-enable.]_",
+                        metadata=metadata,
+                    )
+                return
+
+            synthetic_event = MessageEvent(
+                text=autoreply_text,
+                source=source,
+                message_id=f"autoreply-{time.time()}",
+            )
+            await adapter.handle_message(synthetic_event, interrupt=False)
+        except Exception as e:
+            logger.error("[AutoReply] Failed: %s", e)
+            try:
+                adapter = self.adapters.get(source.platform)
+                if adapter:
+                    metadata = {"thread_id": source.thread_id} if source.thread_id else None
+                    await adapter.send(
+                        chat_id=source.chat_id,
+                        content=f"_[Auto-reply error: {e}. Loop paused. Use `/autoreply` to check status.]_",
+                        metadata=metadata,
+                    )
+            except Exception:
+                pass
 
     async def _handle_voice_command(self, event: MessageEvent) -> str:
         """Handle /voice [on|off|tts|channel|leave|status] command."""
@@ -4597,7 +4800,18 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         if runner.exit_reason:
             logger.error("Gateway exiting cleanly: %s", runner.exit_reason)
         return True
-    
+
+    # Start local-only control API for external tools (e.g., desloppify)
+    # Opt-in via HERMES_CONTROL_API=true (new HTTP surface, off by default)
+    control_api = None
+    if os.getenv("HERMES_CONTROL_API", "").lower() in ("1", "true", "yes"):
+        try:
+            from gateway.control_api import ControlAPI
+            control_api = ControlAPI(runner)
+            await control_api.start()
+        except Exception as e:
+            logger.warning("Control API failed to start (non-fatal): %s", e)
+
     # Write PID file so CLI can detect gateway is running
     import atexit
     from gateway.status import write_pid_file, remove_pid_file
@@ -4617,7 +4831,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     
     # Wait for shutdown
     await runner.wait_for_shutdown()
-    
+
+    # Stop control API
+    if control_api:
+        await control_api.stop()
+
     # Stop cron ticker cleanly
     cron_stop.set()
     cron_thread.join(timeout=5)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -378,15 +378,9 @@ class GatewayRunner:
 
     def get_session_info(self, key: str) -> dict:
         """Return session state for the control API."""
+        from agent.autoreply import session_info
         cfg = self._autoreply_configs.get(key)
-        return {
-            "autoreply": {
-                "enabled": cfg is not None,
-                "prompt": cfg.get("prompt", "") if cfg else None,
-                "max_turns": cfg.get("max_turns", 0) if cfg else None,
-                "turn_count": cfg.get("turn_count", 0) if cfg else None,
-            },
-        }
+        return session_info(cfg)
 
     async def inject_message(self, key: str, text: str, *, interrupt: bool = True):
         """Inject a synthetic message into a session via its platform adapter.
@@ -1830,7 +1824,8 @@ class GatewayRunner:
 
         # Real user messages reset auto-reply turn counter;
         # auto-reply messages (injected by _process_autoreply) do not.
-        is_autoreply = (event.message_id or "").startswith("autoreply-")
+        from agent.autoreply import GATEWAY_MSG_PREFIX
+        is_autoreply = (event.message_id or "").startswith(GATEWAY_MSG_PREFIX)
         if session_key in self._autoreply_configs and not is_autoreply:
             self._autoreply_configs[session_key]["turn_count"] = 0
 
@@ -2513,7 +2508,7 @@ class GatewayRunner:
         Returns (reply_text, cap_reached).  reply_text is None when
         auto-reply is inactive or the turn cap was just hit.
         """
-        from agent.autoreply import check_and_advance, build_autoreply_messages
+        from agent.autoreply import check_and_advance, prepare_llm_call, extract_reply
 
         config = self._autoreply_configs.get(session_key)
         if not config:
@@ -2528,30 +2523,16 @@ class GatewayRunner:
 
         # LLM-generated: build prompt from transcript and call async LLM
         history = self.session_store.load_transcript(session_id)
-        messages = build_autoreply_messages(config, history)
+        call_kwargs = prepare_llm_call(config, history)
 
         from agent.auxiliary_client import async_call_llm
-        call_kwargs = {
-            "task": "autoreply",
-            "messages": messages,
-            "temperature": 0.7,
-            "max_tokens": 1024,
-        }
-        if config.get("model"):
-            call_kwargs["model"] = config["model"]
-
         response = await async_call_llm(**call_kwargs)
-        if not response.choices:
-            return None, False
-        content = response.choices[0].message.content
-        if not content:
-            return None, False
-        reply_text = content.strip()
-        config["turn_count"] += 1
+        reply_text = extract_reply(config, response)
         return reply_text, False
 
     async def _process_autoreply(self, source, session_key: str, session_id: str):
         """Fire-and-forget task: generate an auto-reply and inject it via the adapter."""
+        from agent.autoreply import GATEWAY_MSG_PREFIX
         try:
             adapter = self.adapters.get(source.platform)
             if not adapter:
@@ -2568,6 +2549,11 @@ class GatewayRunner:
                         content="_[Auto-reply limit reached. Use `/autoreply` to re-enable.]_",
                         metadata=metadata,
                     )
+                elif session_key in self._autoreply_configs:
+                    # LLM returned empty — config is still active but this
+                    # turn produced nothing.  Log it; the loop pauses until
+                    # the next real message triggers another attempt.
+                    logger.warning("[AutoReply] LLM returned empty response for %s", session_key)
                 return
 
             # Re-check: user may have disabled autoreply while LLM was running
@@ -2577,7 +2563,7 @@ class GatewayRunner:
             synthetic_event = MessageEvent(
                 text=autoreply_text,
                 source=source,
-                message_id=f"autoreply-{time.time()}",
+                message_id=f"{GATEWAY_MSG_PREFIX}{time.time()}",
             )
             await adapter.handle_message(synthetic_event, interrupt=False)
         except Exception as e:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2516,7 +2516,7 @@ class GatewayRunner:
 
         text, cap_reached = check_and_advance(config)
         if cap_reached:
-            del self._autoreply_configs[session_key]
+            self._autoreply_configs.pop(session_key, None)
             return None, True
         if text:
             return text, False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2574,7 +2574,10 @@ class GatewayRunner:
             call_kwargs["model"] = config["model"]
 
         response = await async_call_llm(**call_kwargs)
-        reply_text = response.choices[0].message.content.strip()
+        content = response.choices[0].message.content
+        if not content:
+            return None, False
+        reply_text = content.strip()
         config["turn_count"] += 1
         return reply_text, False
 
@@ -2598,6 +2601,10 @@ class GatewayRunner:
                     )
                 return
 
+            # Re-check: user may have disabled autoreply while LLM was running
+            if session_key not in self._autoreply_configs:
+                return
+
             synthetic_event = MessageEvent(
                 text=autoreply_text,
                 source=source,
@@ -2607,7 +2614,6 @@ class GatewayRunner:
         except Exception as e:
             logger.error("[AutoReply] Failed: %s", e)
             try:
-                adapter = self.adapters.get(source.platform)
                 if adapter:
                     metadata = {"thread_id": source.thread_id} if source.thread_id else None
                     await adapter.send(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2495,50 +2495,17 @@ class GatewayRunner:
     # ── Auto-reply ────────────────────────────────────────────────────
 
     async def _handle_autoreply_command(self, event: MessageEvent) -> str:
-        """Handle /autoreply command — enable, disable, or show auto-reply status."""
-        from agent.autoreply import parse_autoreply_args, format_status
+        """Handle /autoreply command - enable, disable, or show auto-reply status."""
+        from agent.autoreply import handle_command
 
-        source = event.source
-        session_key = build_session_key(source)
+        session_key = build_session_key(event.source)
         args = event.get_command_args().strip()
-
-        action, new_config = parse_autoreply_args(args)
-
-        if action == "off":
-            if self._autoreply_configs.pop(session_key, None):
-                return "🔇 Auto-reply disabled."
-            return "Auto-reply is not active."
-
-        if action.startswith("max:"):
-            n = int(action.split(":")[1])
-            cfg = self._autoreply_configs.get(session_key)
-            if cfg:
-                cfg["max_turns"] = n
-                return f"🔄 Auto-reply max turns set to **{n}**."
-            return "Auto-reply is not active. Use `/autoreply <instructions>` first."
-
-        if action.startswith("error:"):
-            return action[6:]
-
-        if action == "status":
-            cfg = self._autoreply_configs.get(session_key)
-            if cfg:
-                return "🔄 " + format_status(cfg)
-            return "Auto-reply is not active. Use `/autoreply <instructions>` to enable."
-
-        # action == "enabled"
-        self._autoreply_configs[session_key] = new_config
-        mode = "literal mode " if new_config.get("literal") else ""
-        label = "Message" if new_config.get("literal") else "Prompt"
-        max_t = new_config["max_turns"]
-        prompt_preview = new_config["prompt"][:100]
-        if len(new_config["prompt"]) > 100:
-            prompt_preview += "..."
-        return (
-            f"🔄 Auto-reply enabled — {mode}({'forever' if max_t == 0 else f'max {max_t} turns'}).\n"
-            f"**{label}:** {prompt_preview}\n\n"
-            f"_Send a message to start the loop. Use `/autoreply off` to stop._"
-        )
+        text, new_config = handle_command(args, self._autoreply_configs.get(session_key))
+        if new_config is None:
+            self._autoreply_configs.pop(session_key, None)
+        else:
+            self._autoreply_configs[session_key] = new_config
+        return text
 
     async def _generate_autoreply(self, session_key: str, session_id: str):
         """Generate an auto-reply using the auxiliary LLM client.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -27,6 +27,7 @@ COMMANDS_BY_CATEGORY = {
         "/compress": "Manually compress conversation context (flush memories + summarize)",
         "/rollback": "List or restore filesystem checkpoints (usage: /rollback [number])",
         "/background": "Run a prompt in the background (usage: /background <prompt>)",
+        "/autoreply": "Auto-reply loop (/autoreply <prompt> [--forever] [--max N] [--literal], /autoreply off)",
     },
     "Configuration": {
         "/config": "Show current configuration",

--- a/tests/agent/test_autoreply.py
+++ b/tests/agent/test_autoreply.py
@@ -1,0 +1,429 @@
+"""Unit tests for agent/autoreply.py — shared autoreply engine.
+
+Tests every public function in isolation, with focus on edge cases
+that the integration tests (test_cli_autoreply.py, test_autoreply_command.py)
+don't cover.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.autoreply import (
+    CLI_INPUT_PREFIX,
+    GATEWAY_MSG_PREFIX,
+    _DEFAULT_MAX_TURNS,
+    build_autoreply_messages,
+    check_and_advance,
+    extract_reply,
+    format_status,
+    parse_autoreply_args,
+    prepare_llm_call,
+    session_info,
+)
+
+
+# ── Constants ────────────────────────────────────────────────────────────
+
+
+class TestConstants:
+    def test_default_max_turns(self):
+        assert _DEFAULT_MAX_TURNS == 20
+
+    def test_gateway_msg_prefix(self):
+        assert GATEWAY_MSG_PREFIX == "autoreply-"
+
+    def test_cli_input_prefix(self):
+        assert CLI_INPUT_PREFIX == "[autoreply]"
+
+
+# ── parse_autoreply_args ─────────────────────────────────────────────────
+
+
+class TestParseAutoreplyArgs:
+    def test_empty_string_returns_status(self):
+        assert parse_autoreply_args("") == ("status", None)
+
+    def test_off(self):
+        assert parse_autoreply_args("off") == ("off", None)
+
+    def test_disable_aliases(self):
+        for word in ("off", "disable", "stop", "OFF", "Disable", "STOP"):
+            action, cfg = parse_autoreply_args(word)
+            assert action == "off"
+
+    def test_simple_instructions(self):
+        action, cfg = parse_autoreply_args("Ask follow-up questions")
+        assert action == "enabled"
+        assert cfg["prompt"] == "Ask follow-up questions"
+        assert cfg["max_turns"] == _DEFAULT_MAX_TURNS
+        assert cfg["turn_count"] == 0
+        assert cfg.get("literal") is None  # not set for LLM mode
+
+    def test_literal_flag(self):
+        action, cfg = parse_autoreply_args("--literal continue")
+        assert action == "enabled"
+        assert cfg["prompt"] == "continue"
+        assert cfg["literal"] is True
+
+    def test_literal_without_message(self):
+        action, cfg = parse_autoreply_args("--literal")
+        assert action.startswith("error:")
+        assert cfg is None
+
+    def test_forever_flag(self):
+        action, cfg = parse_autoreply_args("--forever Ask questions")
+        assert action == "enabled"
+        assert cfg["max_turns"] == 0
+
+    def test_max_flag(self):
+        action, cfg = parse_autoreply_args("--max 5 Ask questions")
+        assert action == "enabled"
+        assert cfg["max_turns"] == 5
+        assert cfg["prompt"] == "Ask questions"
+
+    def test_combined_flags(self):
+        action, cfg = parse_autoreply_args("--literal --max 10 continue")
+        assert action == "enabled"
+        assert cfg["literal"] is True
+        assert cfg["max_turns"] == 10
+        assert cfg["prompt"] == "continue"
+
+    def test_max_subcommand(self):
+        action, cfg = parse_autoreply_args("max 25")
+        assert action == "max:25"
+        assert cfg is None
+
+    def test_max_subcommand_without_number(self):
+        action, cfg = parse_autoreply_args("max")
+        assert action.startswith("error:")
+
+    def test_max_subcommand_invalid_number(self):
+        action, cfg = parse_autoreply_args("max abc")
+        assert action.startswith("error:")
+
+    def test_max_subcommand_zero_rejected(self):
+        action, cfg = parse_autoreply_args("max 0")
+        assert action.startswith("error:")
+        assert "at least 1" in action
+
+    def test_max_flag_zero_rejected(self):
+        action, cfg = parse_autoreply_args("--max 0 prompt")
+        assert action.startswith("error:")
+
+    def test_maximize_not_treated_as_max_subcommand(self):
+        """Words starting with 'max' that aren't 'max <N>' are instructions."""
+        action, cfg = parse_autoreply_args("maximize depth of investigation")
+        assert action == "enabled"
+        assert "maximize" in cfg["prompt"]
+
+    def test_whitespace_only_is_error(self):
+        action, cfg = parse_autoreply_args("   ")
+        # After stripping flags, empty prompt → error
+        assert action.startswith("error:") or action == "status"
+
+
+# ── build_autoreply_messages ─────────────────────────────────────────────
+
+
+class TestBuildAutoreplyMessages:
+    def _config(self, prompt="Test prompt"):
+        return {"prompt": prompt, "model": None, "max_turns": 20, "turn_count": 0}
+
+    def test_empty_history(self):
+        msgs = build_autoreply_messages(self._config(), [])
+        # Should have system + final user prompt, no history messages
+        assert len(msgs) == 2
+        assert msgs[0]["role"] == "system"
+        assert msgs[-1]["role"] == "user"
+        assert "generate the next user reply" in msgs[-1]["content"]
+
+    def test_none_history(self):
+        msgs = build_autoreply_messages(self._config(), None)
+        assert len(msgs) == 2
+
+    def test_system_prompt_contains_user_instructions(self):
+        msgs = build_autoreply_messages(self._config("Ask about Python"), [])
+        assert "Ask about Python" in msgs[0]["content"]
+
+    def test_filters_to_user_and_assistant_only(self):
+        history = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+            {"role": "tool", "content": "tool output"},
+        ]
+        msgs = build_autoreply_messages(self._config(), history)
+        roles = [m["role"] for m in msgs]
+        # system (ours) + user (Hello) + assistant (Hi) + user (generate prompt)
+        assert roles == ["system", "user", "assistant", "user"]
+
+    def test_filters_empty_content(self):
+        history = [
+            {"role": "user", "content": ""},
+            {"role": "user", "content": "Real message"},
+        ]
+        msgs = build_autoreply_messages(self._config(), history)
+        # Only "Real message" should appear (empty content filtered)
+        assert len(msgs) == 3  # system + 1 history + generate prompt
+
+    def test_truncates_to_20_messages(self):
+        history = [{"role": "user", "content": f"msg {i}"} for i in range(30)]
+        msgs = build_autoreply_messages(self._config(), history)
+        # system + 20 history + generate prompt = 22
+        assert len(msgs) == 22
+
+    def test_flattens_list_content(self):
+        history = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "Look at this"},
+                {"type": "image_url", "image_url": {"url": "http://example.com"}},
+            ]},
+        ]
+        msgs = build_autoreply_messages(self._config(), history)
+        user_msg = msgs[1]
+        assert user_msg["content"] == "Look at this"
+
+    def test_list_content_with_no_text_items(self):
+        history = [
+            {"role": "user", "content": [
+                {"type": "image_url", "image_url": {"url": "http://example.com"}},
+            ]},
+        ]
+        msgs = build_autoreply_messages(self._config(), history)
+        # The message has empty string content but still passes the filter
+        # because the original content (a list) is truthy
+        user_msg = msgs[1]
+        assert user_msg["content"] == ""
+
+    def test_list_content_with_non_dict_elements(self):
+        """Non-dict elements in list content are silently skipped."""
+        history = [
+            {"role": "user", "content": ["raw string", {"type": "text", "text": "ok"}]},
+        ]
+        msgs = build_autoreply_messages(self._config(), history)
+        assert msgs[1]["content"] == "ok"
+
+
+# ── check_and_advance ────────────────────────────────────────────────────
+
+
+class TestCheckAndAdvance:
+    def test_cap_reached(self):
+        config = {"max_turns": 5, "turn_count": 5}
+        text, cap = check_and_advance(config)
+        assert text is None
+        assert cap is True
+
+    def test_cap_exceeded(self):
+        config = {"max_turns": 5, "turn_count": 10}
+        text, cap = check_and_advance(config)
+        assert text is None
+        assert cap is True
+
+    def test_under_cap_llm_mode(self):
+        config = {"max_turns": 5, "turn_count": 2}
+        text, cap = check_and_advance(config)
+        assert text is None
+        assert cap is False
+
+    def test_unlimited_mode(self):
+        """max_turns=0 means unlimited — should never trigger cap."""
+        config = {"max_turns": 0, "turn_count": 1000}
+        text, cap = check_and_advance(config)
+        assert text is None
+        assert cap is False
+
+    def test_literal_mode_returns_prompt(self):
+        config = {"max_turns": 20, "turn_count": 0, "literal": True, "prompt": "continue"}
+        text, cap = check_and_advance(config)
+        assert text == "continue"
+        assert cap is False
+        assert config["turn_count"] == 1
+
+    def test_literal_mode_cap_takes_precedence(self):
+        """Cap check happens before literal check."""
+        config = {"max_turns": 3, "turn_count": 3, "literal": True, "prompt": "continue"}
+        text, cap = check_and_advance(config)
+        assert text is None
+        assert cap is True
+        # turn_count should NOT have been incremented
+        assert config["turn_count"] == 3
+
+    def test_boundary_turn_count_equals_max_minus_one(self):
+        """Last allowed turn."""
+        config = {"max_turns": 5, "turn_count": 4, "literal": True, "prompt": "go"}
+        text, cap = check_and_advance(config)
+        assert text == "go"
+        assert config["turn_count"] == 5
+
+
+# ── prepare_llm_call ─────────────────────────────────────────────────────
+
+
+class TestPrepareLlmCall:
+    def test_basic_kwargs(self):
+        config = {"prompt": "Ask questions", "model": None, "max_turns": 20, "turn_count": 0}
+        kwargs = prepare_llm_call(config, [])
+        assert kwargs["task"] == "autoreply"
+        assert kwargs["temperature"] == 0.7
+        assert kwargs["max_tokens"] == 1024
+        assert "model" not in kwargs
+        assert "messages" in kwargs
+
+    def test_model_override(self):
+        config = {"prompt": "test", "model": "openai/gpt-4o-mini", "max_turns": 20, "turn_count": 0}
+        kwargs = prepare_llm_call(config, [])
+        assert kwargs["model"] == "openai/gpt-4o-mini"
+
+    def test_empty_history(self):
+        config = {"prompt": "test", "model": None, "max_turns": 20, "turn_count": 0}
+        kwargs = prepare_llm_call(config, [])
+        # system + generate prompt only
+        assert len(kwargs["messages"]) == 2
+
+    def test_with_history(self):
+        config = {"prompt": "test", "model": None, "max_turns": 20, "turn_count": 0}
+        history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        kwargs = prepare_llm_call(config, history)
+        # system + 2 history + generate prompt
+        assert len(kwargs["messages"]) == 4
+
+
+# ── extract_reply ─────────────────────────────────────────────────────────
+
+
+class TestExtractReply:
+    def _config(self):
+        return {"turn_count": 0}
+
+    def test_normal_response(self):
+        config = self._config()
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "  A reply  "
+        result = extract_reply(config, resp)
+        assert result == "A reply"
+        assert config["turn_count"] == 1
+
+    def test_empty_choices(self):
+        config = self._config()
+        resp = MagicMock()
+        resp.choices = []
+        result = extract_reply(config, resp)
+        assert result is None
+        assert config["turn_count"] == 0
+
+    def test_none_content(self):
+        config = self._config()
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = None
+        result = extract_reply(config, resp)
+        assert result is None
+        assert config["turn_count"] == 0
+
+    def test_empty_string_content(self):
+        config = self._config()
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = ""
+        result = extract_reply(config, resp)
+        assert result is None
+        assert config["turn_count"] == 0
+
+    def test_whitespace_only_content(self):
+        config = self._config()
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "   \n  "
+        result = extract_reply(config, resp)
+        # content is truthy ("   \n  ") so turn_count increments,
+        # but strip() returns empty string
+        assert result == ""
+        assert config["turn_count"] == 1
+
+
+# ── session_info ──────────────────────────────────────────────────────────
+
+
+class TestSessionInfo:
+    def test_none_config(self):
+        info = session_info(None)
+        assert info["autoreply"]["enabled"] is False
+        assert info["autoreply"]["prompt"] is None
+        assert info["autoreply"]["max_turns"] is None
+        assert info["autoreply"]["turn_count"] is None
+
+    def test_with_config(self):
+        cfg = {"prompt": "test", "max_turns": 10, "turn_count": 3}
+        info = session_info(cfg)
+        assert info["autoreply"]["enabled"] is True
+        assert info["autoreply"]["prompt"] == "test"
+        assert info["autoreply"]["max_turns"] == 10
+        assert info["autoreply"]["turn_count"] == 3
+
+    def test_empty_dict_treated_as_disabled(self):
+        """An empty dict is falsy in Python, so it's treated as disabled."""
+        info = session_info({})
+        # {} is falsy → enabled is True (config is not None) but fields use None
+        # because `if config` is False for empty dict
+        assert info["autoreply"]["enabled"] is True
+        assert info["autoreply"]["prompt"] is None
+
+    def test_config_with_minimal_keys(self):
+        """Config with just the required keys works correctly."""
+        cfg = {"prompt": "test", "max_turns": 20, "turn_count": 0}
+        info = session_info(cfg)
+        assert info["autoreply"]["enabled"] is True
+        assert info["autoreply"]["prompt"] == "test"
+        assert info["autoreply"]["max_turns"] == 20
+        assert info["autoreply"]["turn_count"] == 0
+
+    def test_cli_and_gateway_parity(self):
+        """Both CLI and gateway should produce identical output for the same config."""
+        cfg = {"prompt": "test", "max_turns": 20, "turn_count": 5}
+        # Both paths now call session_info() directly
+        result = session_info(cfg)
+        assert result == {
+            "autoreply": {
+                "enabled": True,
+                "prompt": "test",
+                "max_turns": 20,
+                "turn_count": 5,
+            },
+        }
+
+
+# ── format_status ─────────────────────────────────────────────────────────
+
+
+class TestFormatStatus:
+    def test_llm_mode(self):
+        cfg = {"prompt": "Ask questions", "max_turns": 20, "turn_count": 3}
+        result = format_status(cfg)
+        assert "LLM-generated" in result
+        assert "Prompt:" in result
+        assert "3/20" in result
+        assert "Ask questions" in result
+
+    def test_literal_mode(self):
+        cfg = {"prompt": "continue", "max_turns": 20, "turn_count": 1, "literal": True}
+        result = format_status(cfg)
+        assert "literal" in result
+        assert "Message:" in result
+
+    def test_unlimited_mode(self):
+        cfg = {"prompt": "test", "max_turns": 0, "turn_count": 5}
+        result = format_status(cfg)
+        assert "5/∞" in result
+
+    def test_long_prompt_truncated(self):
+        cfg = {"prompt": "A" * 200, "max_turns": 20, "turn_count": 0}
+        result = format_status(cfg)
+        assert "..." in result
+        assert "A" * 200 not in result
+        assert "A" * 100 in result

--- a/tests/agent/test_autoreply.py
+++ b/tests/agent/test_autoreply.py
@@ -17,6 +17,7 @@ from agent.autoreply import (
     check_and_advance,
     extract_reply,
     format_status,
+    handle_command,
     parse_autoreply_args,
     prepare_llm_call,
     session_info,
@@ -341,10 +342,9 @@ class TestExtractReply:
         resp.choices = [MagicMock()]
         resp.choices[0].message.content = "   \n  "
         result = extract_reply(config, resp)
-        # content is truthy ("   \n  ") so turn_count increments,
-        # but strip() returns empty string
-        assert result == ""
-        assert config["turn_count"] == 1
+        # Whitespace-only content is treated as empty — returns None
+        assert result is None
+        assert config["turn_count"] == 0
 
 
 # ── session_info ──────────────────────────────────────────────────────────
@@ -427,3 +427,64 @@ class TestFormatStatus:
         assert "..." in result
         assert "A" * 200 not in result
         assert "A" * 100 in result
+
+
+# ── handle_command ────────────────────────────────────────────────────────
+
+
+class TestHandleCommand:
+    """Unit tests for the handle_command orchestrator."""
+
+    def test_enable_returns_config(self):
+        text, cfg = handle_command("Ask questions", None)
+        assert cfg is not None
+        assert cfg["prompt"] == "Ask questions"
+        assert "enabled" in text.lower()
+
+    def test_disable_active(self):
+        active = {"prompt": "test", "model": None, "max_turns": 20, "turn_count": 0}
+        text, cfg = handle_command("off", active)
+        assert cfg is None
+        assert "disabled" in text.lower()
+
+    def test_disable_inactive(self):
+        text, cfg = handle_command("off", None)
+        assert cfg is None
+        assert "not active" in text.lower()
+
+    def test_status_active(self):
+        active = {"prompt": "test", "model": None, "max_turns": 20, "turn_count": 3}
+        text, cfg = handle_command("", active)
+        assert cfg is active  # Same object returned
+        assert "3/20" in text
+
+    def test_status_inactive(self):
+        text, cfg = handle_command("", None)
+        assert cfg is None
+        assert "not active" in text.lower()
+
+    def test_max_mutates_config(self):
+        active = {"prompt": "test", "model": None, "max_turns": 20, "turn_count": 0}
+        text, cfg = handle_command("max 50", active)
+        assert cfg is active  # Same object, mutated
+        assert cfg["max_turns"] == 50
+
+    def test_max_without_active_config(self):
+        text, cfg = handle_command("max 50", None)
+        assert cfg is None
+        assert "not active" in text.lower()
+
+    def test_error_propagated(self):
+        text, cfg = handle_command("--literal", None)
+        assert "Usage" in text
+
+    def test_error_preserves_existing_config(self):
+        active = {"prompt": "test", "model": None, "max_turns": 20, "turn_count": 0}
+        text, cfg = handle_command("--max abc prompt", active)
+        assert cfg is active  # Config unchanged on error
+
+    def test_literal_mode(self):
+        text, cfg = handle_command("--literal continue", None)
+        assert cfg is not None
+        assert cfg["literal"] is True
+        assert "literal" in text.lower()

--- a/tests/gateway/test_autoreply_command.py
+++ b/tests/gateway/test_autoreply_command.py
@@ -1,0 +1,738 @@
+"""Tests for /autoreply gateway slash command.
+
+Tests the auto-reply loop: enabling/disabling via command, auto-reply
+generation, message injection, turn counting, cap notification, and
+cleanup on /reset and /stop.
+"""
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, SendResult
+from agent.autoreply import _DEFAULT_MAX_TURNS
+from gateway.session import SessionSource, build_session_key
+
+
+def _make_source(platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    return SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+
+
+def _make_event(text="/autoreply", platform=Platform.TELEGRAM,
+                user_id="12345", chat_id="67890", message_id=None):
+    """Build a MessageEvent for testing."""
+    source = _make_source(platform, user_id, chat_id)
+    return MessageEvent(text=text, source=source, message_id=message_id)
+
+
+def _make_runner():
+    """Create a bare GatewayRunner with minimal mocks."""
+    from gateway.run import GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._pending_approvals = {}
+    runner._autoreply_configs = {}
+    runner._honcho_managers = {}
+    runner._honcho_configs = {}
+
+    mock_store = MagicMock()
+    mock_store.get_or_create_session.return_value = MagicMock(
+        session_id="sess_123",
+        session_key="agent:main:telegram:dm:12345",
+        created_at=MagicMock(strftime=lambda f: "2026-01-01 00:00"),
+        updated_at=MagicMock(strftime=lambda f: "2026-01-01 00:00"),
+        total_tokens=0,
+        last_prompt_tokens=0,
+        was_auto_reset=False,
+    )
+    mock_store._generate_session_key.return_value = "agent:main:telegram:dm:12345"
+    mock_store.load_transcript.return_value = []
+    runner.session_store = mock_store
+
+    from gateway.hooks import HookRegistry
+    runner.hooks = HookRegistry()
+
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# _handle_autoreply_command
+# ---------------------------------------------------------------------------
+
+
+class TestHandleAutoreplyCommand:
+    """Tests for GatewayRunner._handle_autoreply_command."""
+
+    @pytest.mark.asyncio
+    async def test_no_args_shows_inactive_status(self):
+        runner = _make_runner()
+        event = _make_event(text="/autoreply")
+        result = await runner._handle_autoreply_command(event)
+        assert "not active" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_no_args_shows_active_status(self):
+        runner = _make_runner()
+        session_key = build_session_key(_make_source())
+        runner._autoreply_configs[session_key] = {
+            "prompt": "Ask follow-up questions",
+            "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS,
+            "turn_count": 3,
+        }
+        event = _make_event(text="/autoreply")
+        result = await runner._handle_autoreply_command(event)
+        assert "active" in result.lower()
+        assert f"3/{_DEFAULT_MAX_TURNS}" in result
+        assert "Ask follow-up" in result
+
+    @pytest.mark.asyncio
+    async def test_enable_with_instructions(self):
+        runner = _make_runner()
+        event = _make_event(text="/autoreply Ask follow-up questions about the topic")
+        result = await runner._handle_autoreply_command(event)
+        assert "enabled" in result.lower()
+        assert f"{_DEFAULT_MAX_TURNS} turns" in result
+
+        session_key = build_session_key(_make_source())
+        cfg = runner._autoreply_configs[session_key]
+        assert cfg["prompt"] == "Ask follow-up questions about the topic"
+        assert cfg["max_turns"] == 20
+        assert cfg["turn_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_disable(self):
+        runner = _make_runner()
+        session_key = build_session_key(_make_source())
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        event = _make_event(text="/autoreply off")
+        result = await runner._handle_autoreply_command(event)
+        assert "disabled" in result.lower()
+        assert session_key not in runner._autoreply_configs
+
+    @pytest.mark.asyncio
+    async def test_disable_when_not_active(self):
+        runner = _make_runner()
+        event = _make_event(text="/autoreply off")
+        result = await runner._handle_autoreply_command(event)
+        assert "not active" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_set_max_turns(self):
+        runner = _make_runner()
+        session_key = build_session_key(_make_source())
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        event = _make_event(text="/autoreply max 25")
+        result = await runner._handle_autoreply_command(event)
+        assert "25" in result
+        assert runner._autoreply_configs[session_key]["max_turns"] == 25
+
+    @pytest.mark.asyncio
+    async def test_max_without_active_config(self):
+        runner = _make_runner()
+        event = _make_event(text="/autoreply max 5")
+        result = await runner._handle_autoreply_command(event)
+        assert "not active" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_max_invalid_number(self):
+        runner = _make_runner()
+        session_key = build_session_key(_make_source())
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        event = _make_event(text="/autoreply max abc")
+        result = await runner._handle_autoreply_command(event)
+        assert "Usage" in result
+
+    @pytest.mark.asyncio
+    async def test_max_zero_rejected(self):
+        runner = _make_runner()
+        session_key = build_session_key(_make_source())
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        event = _make_event(text="/autoreply max 0")
+        result = await runner._handle_autoreply_command(event)
+        assert "at least 1" in result
+
+    @pytest.mark.asyncio
+    async def test_instructions_starting_with_max_not_treated_as_subcommand(self):
+        """'/autoreply maximize depth' should set instructions, not parse as /max."""
+        runner = _make_runner()
+        event = _make_event(text="/autoreply maximize the depth of investigation")
+        result = await runner._handle_autoreply_command(event)
+        assert "enabled" in result.lower()
+
+        session_key = build_session_key(_make_source())
+        assert "maximize" in runner._autoreply_configs[session_key]["prompt"]
+
+    @pytest.mark.asyncio
+    async def test_long_prompt_truncated_in_preview(self):
+        runner = _make_runner()
+        long_prompt = "A" * 200
+        event = _make_event(text=f"/autoreply {long_prompt}")
+        result = await runner._handle_autoreply_command(event)
+        assert "..." in result
+        assert long_prompt not in result
+
+    @pytest.mark.asyncio
+    async def test_literal_flag_enables_literal_mode(self):
+        """/autoreply --literal <msg> enables literal (no-LLM) mode."""
+        runner = _make_runner()
+        event = _make_event(text="/autoreply --literal continue")
+        result = await runner._handle_autoreply_command(event)
+        assert "literal" in result.lower()
+
+        session_key = build_session_key(_make_source())
+        cfg = runner._autoreply_configs[session_key]
+        assert cfg["prompt"] == "continue"
+        assert cfg["literal"] is True
+
+    @pytest.mark.asyncio
+    async def test_literal_flag_without_message_rejected(self):
+        runner = _make_runner()
+        event = _make_event(text="/autoreply --literal    ")
+        result = await runner._handle_autoreply_command(event)
+        assert "Usage" in result
+
+    @pytest.mark.asyncio
+    async def test_literal_status_shows_mode(self):
+        runner = _make_runner()
+        session_key = build_session_key(_make_source())
+        runner._autoreply_configs[session_key] = {
+            "prompt": "continue", "model": None, "max_turns": _DEFAULT_MAX_TURNS,
+            "turn_count": 2, "literal": True,
+        }
+        event = _make_event(text="/autoreply")
+        result = await runner._handle_autoreply_command(event)
+        assert "literal" in result.lower()
+        assert "Message:" in result
+
+    @pytest.mark.asyncio
+    async def test_disable_aliases(self):
+        """All disable aliases work: off, disable, stop."""
+        for word in ("off", "disable", "stop"):
+            runner = _make_runner()
+            session_key = build_session_key(_make_source())
+            runner._autoreply_configs[session_key] = {
+                "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+            }
+            event = _make_event(text=f"/autoreply {word}")
+            result = await runner._handle_autoreply_command(event)
+            assert "disabled" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# _generate_autoreply
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateAutoreply:
+    """Tests for GatewayRunner._generate_autoreply."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_configured(self):
+        runner = _make_runner()
+        text, cap = await runner._generate_autoreply("no_such_key", "sess_123")
+        assert text is None
+        assert cap is False
+
+    @pytest.mark.asyncio
+    async def test_returns_none_and_cap_when_limit_reached(self):
+        runner = _make_runner()
+        runner._autoreply_configs["key"] = {
+            "prompt": "test", "model": None, "max_turns": 5, "turn_count": 5,
+        }
+        text, cap = await runner._generate_autoreply("key", "sess_123")
+        assert text is None
+        assert cap is True
+        assert "key" not in runner._autoreply_configs
+
+    @pytest.mark.asyncio
+    async def test_literal_mode_skips_llm(self):
+        """Literal mode returns the prompt directly without calling the LLM."""
+        runner = _make_runner()
+        runner._autoreply_configs["key"] = {
+            "prompt": "continue", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0, "literal": True,
+        }
+        # No LLM mock needed — literal mode shouldn't call it
+        text, cap = await runner._generate_autoreply("key", "sess_123")
+        assert text == "continue"
+        assert cap is False
+        assert runner._autoreply_configs["key"]["turn_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_generates_reply_and_increments_counter(self):
+        runner = _make_runner()
+        runner._autoreply_configs["key"] = {
+            "prompt": "Ask follow-up questions",
+            "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS,
+            "turn_count": 2,
+        }
+        runner.session_store.load_transcript.return_value = [
+            {"role": "user", "content": "Tell me about Python"},
+            {"role": "assistant", "content": "Python is a programming language."},
+        ]
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "What about its type system?"
+
+        with patch("agent.auxiliary_client.async_call_llm", return_value=mock_response) as mock_llm:
+            text, cap = await runner._generate_autoreply("key", "sess_123")
+
+        assert text == "What about its type system?"
+        assert cap is False
+        assert runner._autoreply_configs["key"]["turn_count"] == 3
+
+        # Verify the LLM was called with task="autoreply"
+        call_kwargs = mock_llm.call_args[1]
+        assert call_kwargs["task"] == "autoreply"
+        assert call_kwargs["temperature"] == 0.7
+        # System prompt should contain the user's instructions
+        system_msg = call_kwargs["messages"][0]
+        assert system_msg["role"] == "system"
+        assert "Ask follow-up questions" in system_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_flattens_list_content(self):
+        """Messages with list-type content are flattened to text."""
+        runner = _make_runner()
+        runner._autoreply_configs["key"] = {
+            "prompt": "Continue", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        runner.session_store.load_transcript.return_value = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "Look at this image"},
+                {"type": "image_url", "image_url": {"url": "http://example.com/img.png"}},
+            ]},
+            {"role": "assistant", "content": "I see the image."},
+        ]
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "What else can you tell me?"
+
+        with patch("agent.auxiliary_client.async_call_llm", return_value=mock_response) as mock_llm:
+            await runner._generate_autoreply("key", "sess_123")
+
+        # The user message should have been flattened to text only
+        messages = mock_llm.call_args[1]["messages"]
+        user_msg = [m for m in messages if m["role"] == "user" and "Look at" in m.get("content", "")]
+        assert len(user_msg) == 1
+        assert user_msg[0]["content"] == "Look at this image"
+
+    @pytest.mark.asyncio
+    async def test_uses_model_override(self):
+        runner = _make_runner()
+        runner._autoreply_configs["key"] = {
+            "prompt": "test", "model": "openai/gpt-4o-mini",
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        runner.session_store.load_transcript.return_value = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "reply"
+
+        with patch("agent.auxiliary_client.async_call_llm", return_value=mock_response) as mock_llm:
+            await runner._generate_autoreply("key", "sess_123")
+
+        assert mock_llm.call_args[1]["model"] == "openai/gpt-4o-mini"
+
+
+# ---------------------------------------------------------------------------
+# _process_autoreply
+# ---------------------------------------------------------------------------
+
+
+class TestProcessAutoreply:
+    """Tests for GatewayRunner._process_autoreply."""
+
+    @pytest.mark.asyncio
+    async def test_injects_message_via_adapter(self):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        runner.session_store.load_transcript.return_value = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Generated reply"
+
+        mock_adapter = AsyncMock()
+        mock_adapter.handle_message = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        with patch("agent.auxiliary_client.async_call_llm", return_value=mock_response):
+            await runner._process_autoreply(source, session_key, "sess_123")
+
+        mock_adapter.handle_message.assert_called_once()
+        injected_event = mock_adapter.handle_message.call_args[0][0]
+        assert injected_event.text == "Generated reply"
+        assert injected_event.message_id.startswith("autoreply-")
+        assert injected_event.source is source
+
+    @pytest.mark.asyncio
+    async def test_sends_cap_notification(self):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": 3, "turn_count": 3,
+        }
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        await runner._process_autoreply(source, session_key, "sess_123")
+
+        mock_adapter.send.assert_called_once()
+        content = mock_adapter.send.call_args[1]["content"]
+        assert "limit reached" in content.lower()
+        # Should NOT have injected a message
+        mock_adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_notification_when_manually_disabled(self):
+        """If config was already removed (user ran /autoreply off), no cap notification."""
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        # Config is NOT present — simulates user having run /autoreply off
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        await runner._process_autoreply(source, session_key, "sess_123")
+
+        mock_adapter.send.assert_not_called()
+        mock_adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_adapter_returns_silently(self):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        # No adapter — should not raise
+        await runner._process_autoreply(source, session_key, "sess_123")
+
+    @pytest.mark.asyncio
+    async def test_handle_message_called_with_interrupt_false(self):
+        """Autoreply should queue (interrupt=False), not interrupt ongoing work."""
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        runner.session_store.load_transcript.return_value = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Follow-up question"
+
+        mock_adapter = AsyncMock()
+        mock_adapter.handle_message = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        with patch("agent.auxiliary_client.async_call_llm", return_value=mock_response):
+            await runner._process_autoreply(source, session_key, "sess_123")
+
+        mock_adapter.handle_message.assert_called_once()
+        call_kwargs = mock_adapter.handle_message.call_args
+        assert call_kwargs[1].get("interrupt") is False or (
+            len(call_kwargs[0]) > 1 and call_kwargs[0][1] is False
+        ), "handle_message must be called with interrupt=False"
+
+    @pytest.mark.asyncio
+    async def test_llm_error_sends_notification(self):
+        """LLM failures send an error message to the user."""
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        runner.session_store.load_transcript.return_value = []
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        with patch("agent.auxiliary_client.async_call_llm", side_effect=RuntimeError("LLM down")):
+            await runner._process_autoreply(source, session_key, "sess_123")
+
+        mock_adapter.send.assert_called_once()
+        content = mock_adapter.send.call_args[1]["content"]
+        assert "error" in content.lower()
+        assert "LLM down" in content
+
+    @pytest.mark.asyncio
+    async def test_llm_error_notification_includes_thread_id(self):
+        """Error notification respects thread_id for threaded platforms."""
+        runner = _make_runner()
+        source = SessionSource(
+            platform=Platform.SLACK,
+            user_id="U123",
+            chat_id="C456",
+            user_name="testuser",
+            thread_id="ts_789",
+        )
+        session_key = build_session_key(source)
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        runner.session_store.load_transcript.return_value = []
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+        runner.adapters[Platform.SLACK] = mock_adapter
+
+        with patch("agent.auxiliary_client.async_call_llm", side_effect=RuntimeError("fail")):
+            await runner._process_autoreply(source, session_key, "sess_123")
+
+        call_kwargs = mock_adapter.send.call_args[1]
+        assert call_kwargs["metadata"] == {"thread_id": "ts_789"}
+
+    @pytest.mark.asyncio
+    async def test_llm_error_is_caught(self):
+        """LLM failures are logged, not raised (even if send also fails)."""
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        runner.session_store.load_transcript.return_value = []
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(side_effect=RuntimeError("send also broken"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        with patch("agent.auxiliary_client.async_call_llm", side_effect=RuntimeError("LLM down")):
+            # Should not raise even if send fails
+            await runner._process_autoreply(source, session_key, "sess_123")
+
+    @pytest.mark.asyncio
+    async def test_cap_notification_includes_thread_id(self):
+        """Cap notification respects thread_id for threaded platforms."""
+        runner = _make_runner()
+        source = SessionSource(
+            platform=Platform.SLACK,
+            user_id="U123",
+            chat_id="C456",
+            user_name="testuser",
+            thread_id="ts_789",
+        )
+        session_key = build_session_key(source)
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": 1, "turn_count": 1,
+        }
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+        runner.adapters[Platform.SLACK] = mock_adapter
+
+        await runner._process_autoreply(source, session_key, "sess_123")
+
+        call_kwargs = mock_adapter.send.call_args[1]
+        assert call_kwargs["metadata"] == {"thread_id": "ts_789"}
+
+
+# ---------------------------------------------------------------------------
+# Turn counter reset & auto-reply label in _handle_message
+# ---------------------------------------------------------------------------
+
+
+class TestAutoreplyInHandleMessage:
+    """Tests for auto-reply wiring in _handle_message.
+
+    These test the auto-reply logic directly rather than going through the
+    full _handle_message pipeline, which requires too much setup. The
+    individual methods (_generate_autoreply, _process_autoreply) are
+    thoroughly tested above; here we verify the wiring code itself.
+    """
+
+    def test_autoreply_message_detected_by_message_id(self):
+        """Messages with autoreply- prefix in message_id are detected."""
+        event = _make_event(text="test", message_id="autoreply-123.456")
+        assert (event.message_id or "").startswith("autoreply-")
+
+        event2 = _make_event(text="test", message_id="regular-123")
+        assert not (event2.message_id or "").startswith("autoreply-")
+
+    def test_turn_counter_reset_logic(self):
+        """Real messages reset counter; autoreply messages don't."""
+        runner = _make_runner()
+        session_key = "agent:main:telegram:dm:12345"
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 7,
+        }
+
+        # Real message — should reset
+        is_autoreply = ("regular-msg" or "").startswith("autoreply-")
+        if session_key in runner._autoreply_configs and not is_autoreply:
+            runner._autoreply_configs[session_key]["turn_count"] = 0
+        assert runner._autoreply_configs[session_key]["turn_count"] == 0
+
+        # Restore and test autoreply message — should NOT reset
+        runner._autoreply_configs[session_key]["turn_count"] = 7
+        is_autoreply = ("autoreply-123.456" or "").startswith("autoreply-")
+        if session_key in runner._autoreply_configs and not is_autoreply:
+            runner._autoreply_configs[session_key]["turn_count"] = 0
+        assert runner._autoreply_configs[session_key]["turn_count"] == 7
+
+    def test_response_labeling_logic(self):
+        """Auto-reply responses get labeled with turn count."""
+        runner = _make_runner()
+        session_key = "test_key"
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 3,
+        }
+
+        # Simulate the labeling code from _handle_message
+        is_autoreply = True
+        response = "Agent response here"
+        event_text = "Generated question"
+
+        if is_autoreply and response:
+            ar_config = runner._autoreply_configs.get(session_key)
+            if ar_config:
+                response = (
+                    f"**[Auto-reply {ar_config['turn_count']}/{ar_config['max_turns']}]:** "
+                    f"{event_text}\n\n---\n\n{response}"
+                )
+
+        assert f"**[Auto-reply 3/{_DEFAULT_MAX_TURNS}]:**" in response
+        assert "Generated question" in response
+        assert "Agent response here" in response
+
+    def test_no_label_for_regular_messages(self):
+        """Regular messages are not labeled."""
+        response = "Agent response"
+        is_autoreply = False
+
+        if is_autoreply and response:
+            response = "SHOULD NOT HAPPEN"
+
+        assert response == "Agent response"
+
+
+# ---------------------------------------------------------------------------
+# Cleanup on /reset and /stop
+# ---------------------------------------------------------------------------
+
+
+class TestAutoreplyCleanup:
+    """Tests for auto-reply cleanup on /reset and /stop."""
+
+    @pytest.mark.asyncio
+    async def test_reset_clears_autoreply(self):
+        runner = _make_runner()
+        session_key = "agent:main:telegram:dm:12345"
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+
+        # Stub out honcho shutdown
+        runner._shutdown_gateway_honcho = MagicMock()
+
+        event = _make_event(text="/reset")
+        await runner._handle_reset_command(event)
+        assert session_key not in runner._autoreply_configs
+
+    @pytest.mark.asyncio
+    async def test_stop_clears_autoreply(self):
+        runner = _make_runner()
+        session_key = "agent:main:telegram:dm:12345"
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+
+        event = _make_event(text="/stop")
+        result = await runner._handle_stop_command(event)
+        assert session_key not in runner._autoreply_configs
+        assert "disabled" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_stop_with_running_agent_and_autoreply(self):
+        runner = _make_runner()
+        session_key = "agent:main:telegram:dm:12345"
+        runner._autoreply_configs[session_key] = {
+            "prompt": "test", "model": None, "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        mock_agent = MagicMock()
+        runner._running_agents[session_key] = mock_agent
+
+        event = _make_event(text="/stop")
+        result = await runner._handle_stop_command(event)
+
+        mock_agent.interrupt.assert_called_once()
+        assert session_key not in runner._autoreply_configs
+        assert "Auto-reply disabled" in result
+        assert "Stopping" in result
+
+    @pytest.mark.asyncio
+    async def test_stop_without_autoreply_or_agent(self):
+        runner = _make_runner()
+        event = _make_event(text="/stop")
+        result = await runner._handle_stop_command(event)
+        assert "No active task" in result
+
+
+# ---------------------------------------------------------------------------
+# /autoreply in help and known_commands
+# ---------------------------------------------------------------------------
+
+
+class TestAutoreplyInHelp:
+    """Verify /autoreply appears in help text and known commands."""
+
+    @pytest.mark.asyncio
+    async def test_autoreply_in_help_output(self):
+        runner = _make_runner()
+        event = _make_event(text="/help")
+        result = await runner._handle_help_command(event)
+        assert "/autoreply" in result
+
+    def test_autoreply_is_known_command(self):
+        from gateway.run import GatewayRunner
+        source = inspect.getsource(GatewayRunner._handle_message)
+        assert '"autoreply"' in source

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -38,6 +38,7 @@ def _make_runner():
     runner._provider_routing = {}
     runner._fallback_model = None
     runner._running_agents = {}
+    runner._autoreply_configs = {}
 
     mock_store = MagicMock()
     runner.session_store = mock_store

--- a/tests/gateway/test_control_api.py
+++ b/tests/gateway/test_control_api.py
@@ -1,0 +1,167 @@
+"""Tests for the control API."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.control_api import ControlAPI, REQUIRED_HEADER
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_control_api():
+    """Create a ControlAPI with a mock runner."""
+    runner = MagicMock()
+    runner._running_agents = {"sess1": MagicMock(model="test-model", provider="test")}
+    runner.inject_message = MagicMock(return_value=None)
+    api = ControlAPI(runner)
+    return api, runner
+
+
+def _make_request(key, body=None):
+    request = MagicMock()
+    request.match_info = {"key": key}
+    if body is not None:
+        request.json = AsyncMock(return_value=body)
+    return request
+
+
+# ── send_message tests ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_message_calls_inject_message():
+    """POST /message delegates to runner.inject_message."""
+    api, runner = _make_control_api()
+    request = _make_request("sess1", {"text": "hello", "mode": "interrupt"})
+
+    resp = await api.send_message(request)
+
+    assert resp.status == 200
+    runner.inject_message.assert_called_once_with("sess1", "hello", interrupt=True)
+
+
+@pytest.mark.asyncio
+async def test_send_message_queue_mode():
+    """Queue mode passes interrupt=False."""
+    api, runner = _make_control_api()
+    request = _make_request("sess1", {"text": "/compact", "mode": "queue"})
+
+    resp = await api.send_message(request)
+
+    assert resp.status == 200
+    runner.inject_message.assert_called_once_with("sess1", "/compact", interrupt=False)
+
+
+@pytest.mark.asyncio
+async def test_send_message_defaults_to_interrupt():
+    """Mode defaults to interrupt when not specified."""
+    api, runner = _make_control_api()
+    request = _make_request("_any", {"text": "stop"})
+
+    resp = await api.send_message(request)
+
+    assert resp.status == 200
+    runner.inject_message.assert_called_once_with("_any", "stop", interrupt=True)
+
+
+@pytest.mark.asyncio
+async def test_send_message_empty_text_returns_400():
+    """Empty text should return 400."""
+    api, runner = _make_control_api()
+    request = _make_request("sess1", {"text": "  "})
+
+    resp = await api.send_message(request)
+
+    assert resp.status == 400
+    runner.inject_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_message_invalid_mode_returns_400():
+    """Invalid mode should return 400."""
+    api, runner = _make_control_api()
+    request = _make_request("sess1", {"text": "hello", "mode": "bogus"})
+
+    resp = await api.send_message(request)
+
+    assert resp.status == 400
+    runner.inject_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_message_lookup_error_returns_404():
+    """LookupError from inject_message should return 404."""
+    api, runner = _make_control_api()
+    runner.inject_message = MagicMock(side_effect=LookupError("No session found"))
+    request = _make_request("bad_key", {"text": "hello"})
+
+    resp = await api.send_message(request)
+
+    assert resp.status == 404
+    body = json.loads(resp.text)
+    assert "No session found" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_send_message_awaits_coroutine():
+    """If inject_message returns a coroutine, it should be awaited."""
+    api, runner = _make_control_api()
+    runner.inject_message = MagicMock(return_value=AsyncMock()())
+    request = _make_request("sess1", {"text": "hello"})
+
+    resp = await api.send_message(request)
+
+    assert resp.status == 200
+
+
+# ── list_commands tests ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_commands_returns_commands():
+    """GET /commands should return the available commands list."""
+    api, _ = _make_control_api()
+    request = MagicMock()
+
+    resp = await api.list_commands(request)
+
+    assert resp.status == 200
+    body = json.loads(resp.text)
+    assert "commands" in body
+    commands = [c["command"] for c in body["commands"]]
+    assert "/reset" in commands
+    assert "/compact" in commands
+    assert "/stop" in commands
+
+
+# ── CSRF protection tests ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_missing_header_returns_403():
+    """Requests without X-Hermes-Control header should be rejected."""
+    api, _ = _make_control_api()
+
+    from aiohttp.test_utils import TestClient, TestServer
+    async with TestClient(TestServer(api.app)) as client:
+        resp = await client.get("/health")
+        assert resp.status == 403
+        body = await resp.json()
+        assert "Missing required header" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_valid_header_passes():
+    """Requests with the correct header should succeed."""
+    api, _ = _make_control_api()
+
+    from aiohttp.test_utils import TestClient, TestServer
+    async with TestClient(TestServer(api.app)) as client:
+        resp = await client.get("/health",
+                                headers={REQUIRED_HEADER: "1"})
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["status"] == "ok"

--- a/tests/gateway/test_control_api.py
+++ b/tests/gateway/test_control_api.py
@@ -133,8 +133,7 @@ async def test_list_commands_returns_commands():
     assert "commands" in body
     commands = [c["command"] for c in body["commands"]]
     assert "/reset" in commands
-    assert "/compact" in commands
-    assert "/stop" in commands
+    assert "/model" in commands
 
 
 # ── CSRF protection tests ─────────────────────────────────────────────

--- a/tests/test_cli_autoreply.py
+++ b/tests/test_cli_autoreply.py
@@ -1,0 +1,402 @@
+"""Tests for CLI /autoreply command, _generate_autoreply_text, and _CLIRunner shim."""
+
+import queue
+from unittest.mock import MagicMock, patch
+
+from tests.test_cli_init import _make_cli
+from agent.autoreply import _DEFAULT_MAX_TURNS
+
+
+# ---------------------------------------------------------------------------
+# _handle_autoreply_command
+# ---------------------------------------------------------------------------
+
+
+class TestCLIHandleAutoreplyCommand:
+    """Tests for HermesCLI._handle_autoreply_command."""
+
+    def test_enable_with_instructions(self):
+        cli = _make_cli()
+        cli._handle_autoreply_command("/autoreply Ask follow-up questions")
+        assert cli._autoreply_config is not None
+        assert cli._autoreply_config["prompt"] == "Ask follow-up questions"
+        assert cli._autoreply_config["max_turns"] == _DEFAULT_MAX_TURNS
+        assert cli._autoreply_config["turn_count"] == 0
+
+    def test_disable(self):
+        cli = _make_cli()
+        cli._autoreply_config = {
+            "prompt": "test", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        cli._handle_autoreply_command("/autoreply off")
+        assert cli._autoreply_config is None
+
+    def test_disable_when_not_active(self):
+        cli = _make_cli()
+        cli._autoreply_config = None
+        cli._handle_autoreply_command("/autoreply off")
+        assert cli._autoreply_config is None  # still None, no error
+
+    def test_set_max_turns(self):
+        cli = _make_cli()
+        cli._autoreply_config = {
+            "prompt": "test", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        cli._handle_autoreply_command("/autoreply max 25")
+        assert cli._autoreply_config["max_turns"] == 25
+
+    def test_max_without_active_config(self):
+        cli = _make_cli()
+        cli._autoreply_config = None
+        cli._handle_autoreply_command("/autoreply max 5")
+        assert cli._autoreply_config is None  # not enabled
+
+    def test_status_when_active_does_not_error(self):
+        cli = _make_cli()
+        cli._autoreply_config = {
+            "prompt": "Ask questions", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 3,
+        }
+        # Should not raise
+        cli._handle_autoreply_command("/autoreply")
+        # Config unchanged
+        assert cli._autoreply_config["turn_count"] == 3
+
+    def test_status_when_inactive_does_not_error(self):
+        cli = _make_cli()
+        cli._autoreply_config = None
+        cli._handle_autoreply_command("/autoreply")
+        assert cli._autoreply_config is None
+
+    def test_literal_mode(self):
+        cli = _make_cli()
+        cli._handle_autoreply_command("/autoreply --literal continue")
+        assert cli._autoreply_config is not None
+        assert cli._autoreply_config["prompt"] == "continue"
+        assert cli._autoreply_config["literal"] is True
+
+    def test_forever_mode(self):
+        cli = _make_cli()
+        cli._handle_autoreply_command("/autoreply --forever keep going")
+        assert cli._autoreply_config is not None
+        assert cli._autoreply_config["max_turns"] == 0
+
+    def test_disable_aliases(self):
+        """All disable aliases work: off, disable, stop."""
+        for word in ("off", "disable", "stop"):
+            cli = _make_cli()
+            cli._autoreply_config = {
+                "prompt": "test", "model": None,
+                "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+            }
+            cli._handle_autoreply_command(f"/autoreply {word}")
+            assert cli._autoreply_config is None, f"'{word}' did not disable autoreply"
+
+    def test_instructions_starting_with_max_not_treated_as_subcommand(self):
+        """'/autoreply maximize depth' should set instructions, not parse as /max."""
+        cli = _make_cli()
+        cli._handle_autoreply_command("/autoreply maximize the depth of investigation")
+        assert cli._autoreply_config is not None
+        assert "maximize" in cli._autoreply_config["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# _generate_autoreply_text
+# ---------------------------------------------------------------------------
+
+
+class TestCLIGenerateAutoreplyText:
+    """Tests for HermesCLI._generate_autoreply_text."""
+
+    def test_returns_none_when_not_configured(self):
+        cli = _make_cli()
+        assert cli._generate_autoreply_text() is None
+
+    def test_literal_mode_returns_prompt_directly(self):
+        cli = _make_cli()
+        cli._autoreply_config = {
+            "prompt": "continue", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0, "literal": True,
+        }
+        result = cli._generate_autoreply_text()
+        assert result == "continue"
+        assert cli._autoreply_config["turn_count"] == 1
+
+    def test_cap_reached_clears_config(self):
+        cli = _make_cli()
+        cli._autoreply_config = {
+            "prompt": "test", "model": None,
+            "max_turns": 3, "turn_count": 3,
+        }
+        result = cli._generate_autoreply_text()
+        assert result is None
+        assert cli._autoreply_config is None
+
+    def test_llm_mode_calls_call_llm(self):
+        cli = _make_cli()
+        cli._autoreply_config = {
+            "prompt": "Ask follow-up questions", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        cli.conversation_history = [
+            {"role": "user", "content": "Tell me about Python"},
+            {"role": "assistant", "content": "Python is great."},
+        ]
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "What about type hints?"
+
+        with patch("agent.auxiliary_client.call_llm", return_value=mock_response) as mock_llm:
+            result = cli._generate_autoreply_text()
+
+        assert result == "What about type hints?"
+        assert cli._autoreply_config["turn_count"] == 1
+        call_kwargs = mock_llm.call_args[1]
+        assert call_kwargs["task"] == "autoreply"
+        assert call_kwargs["temperature"] == 0.7
+        # System prompt should contain the user's instructions
+        system_msg = call_kwargs["messages"][0]
+        assert system_msg["role"] == "system"
+        assert "Ask follow-up questions" in system_msg["content"]
+
+    def test_model_override_passed_to_llm(self):
+        cli = _make_cli()
+        cli._autoreply_config = {
+            "prompt": "test", "model": "openai/gpt-4o-mini",
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        }
+        cli.conversation_history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "reply"
+
+        with patch("agent.auxiliary_client.call_llm", return_value=mock_response) as mock_llm:
+            cli._generate_autoreply_text()
+
+        assert mock_llm.call_args[1]["model"] == "openai/gpt-4o-mini"
+
+    def test_forever_mode_does_not_cap(self):
+        """max_turns=0 means forever — turn counting never stops."""
+        cli = _make_cli()
+        cli._autoreply_config = {
+            "prompt": "keep going", "model": None,
+            "max_turns": 0, "turn_count": 100, "literal": True,
+        }
+        result = cli._generate_autoreply_text()
+        assert result == "keep going"
+        assert cli._autoreply_config["turn_count"] == 101
+
+
+# ---------------------------------------------------------------------------
+# _CLIRunner shim
+# ---------------------------------------------------------------------------
+
+
+class TestCLIRunnerShim:
+    """Tests for the _CLIRunner shim used by ControlAPI in CLI mode."""
+
+    def _make_shim(self):
+        """Build a _CLIRunner matching the one defined in _start_control_api."""
+        cli = _make_cli()
+        cli._agent_running = False
+        cli._pending_input = queue.Queue()
+        cli._interrupt_queue = queue.Queue()
+        cli._autoreply_config = None
+        cli.agent = MagicMock()
+        cli.session_id = "test-session"
+
+        class _CLIRunner:
+            def __init__(self, agent, session_id, cli_instance):
+                self._running_agents = {session_id: agent}
+                self._cli = cli_instance
+
+            def inject_message(self, key, text, *, interrupt=True):
+                if interrupt and self._cli._agent_running:
+                    self._cli._interrupt_queue.put(text)
+                else:
+                    self._cli._pending_input.put(text)
+
+            def get_session_info(self, key):
+                cfg = getattr(self._cli, "_autoreply_config", None)
+                return {
+                    "autoreply": {
+                        "enabled": cfg is not None,
+                        "prompt": cfg.get("prompt", "") if cfg else None,
+                        "max_turns": cfg.get("max_turns", 0) if cfg else None,
+                        "turn_count": cfg.get("turn_count", 0) if cfg else None,
+                    },
+                }
+
+        shim = _CLIRunner(cli.agent, cli.session_id, cli)
+        return shim, cli
+
+    def test_inject_message_interrupt_mode(self):
+        """Interrupt mode puts message on _interrupt_queue when agent is running."""
+        shim, cli = self._make_shim()
+        cli._agent_running = True
+        shim.inject_message("_any", "/stop", interrupt=True)
+        assert cli._interrupt_queue.get_nowait() == "/stop"
+        assert cli._pending_input.empty()
+
+    def test_inject_message_queue_mode(self):
+        """Queue mode always puts message on _pending_input."""
+        shim, cli = self._make_shim()
+        cli._agent_running = True
+        shim.inject_message("_any", "/model cheap", interrupt=False)
+        assert cli._pending_input.get_nowait() == "/model cheap"
+        assert cli._interrupt_queue.empty()
+
+    def test_inject_message_interrupt_when_not_running(self):
+        """When agent is not running, interrupt falls through to _pending_input."""
+        shim, cli = self._make_shim()
+        cli._agent_running = False
+        shim.inject_message("_any", "hello", interrupt=True)
+        assert cli._pending_input.get_nowait() == "hello"
+        assert cli._interrupt_queue.empty()
+
+    def test_get_session_info_no_autoreply(self):
+        shim, cli = self._make_shim()
+        info = shim.get_session_info("_any")
+        assert info["autoreply"]["enabled"] is False
+        assert info["autoreply"]["prompt"] is None
+
+    def test_get_session_info_with_autoreply(self):
+        shim, cli = self._make_shim()
+        cli._autoreply_config = {
+            "prompt": "keep going", "model": None,
+            "max_turns": 10, "turn_count": 3,
+        }
+        info = shim.get_session_info("_any")
+        assert info["autoreply"]["enabled"] is True
+        assert info["autoreply"]["prompt"] == "keep going"
+        assert info["autoreply"]["max_turns"] == 10
+        assert info["autoreply"]["turn_count"] == 3
+
+    def test_running_agents_contains_session(self):
+        shim, cli = self._make_shim()
+        assert cli.session_id in shim._running_agents
+
+
+# ---------------------------------------------------------------------------
+# Reset clears autoreply
+# ---------------------------------------------------------------------------
+
+
+class TestCLIAutoreplyCleanup:
+    """Tests for autoreply cleanup on /reset and /new."""
+
+    def test_reset_clears_autoreply(self):
+        cli = _make_cli()
+        cli._autoreply_config = {
+            "prompt": "test", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 5,
+        }
+        cli.process_command("/reset")
+        assert cli._autoreply_config is None
+
+    def test_new_clears_autoreply(self):
+        cli = _make_cli()
+        cli._autoreply_config = {
+            "prompt": "test", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 5,
+        }
+        cli.process_command("/new")
+        assert cli._autoreply_config is None
+
+
+# ---------------------------------------------------------------------------
+# Chat loop autoreply wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCLIAutoreplyPrefix:
+    """Tests for the [autoreply] prefix stripping and turn counter reset logic."""
+
+    def test_autoreply_prefix_detected(self):
+        user_input = "[autoreply]What else can you tell me?"
+        assert user_input.startswith("[autoreply]")
+        stripped = user_input[len("[autoreply]"):]
+        assert stripped == "What else can you tell me?"
+
+    def test_regular_message_not_detected(self):
+        user_input = "Tell me more"
+        assert not user_input.startswith("[autoreply]")
+
+    def test_turn_counter_reset_on_real_message(self):
+        """Real user messages reset the turn counter."""
+        cli = _make_cli()
+        cli._autoreply_config = {
+            "prompt": "test", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 7,
+        }
+        user_input = "Tell me more"
+        if cli._autoreply_config and not user_input.startswith("[autoreply]"):
+            cli._autoreply_config["turn_count"] = 0
+        assert cli._autoreply_config["turn_count"] == 0
+
+    def test_turn_counter_not_reset_on_autoreply_message(self):
+        """Autoreply-injected messages do NOT reset the turn counter."""
+        cli = _make_cli()
+        cli._autoreply_config = {
+            "prompt": "test", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 7,
+        }
+        user_input = "[autoreply]Generated question"
+        if cli._autoreply_config and not user_input.startswith("[autoreply]"):
+            cli._autoreply_config["turn_count"] = 0
+        assert cli._autoreply_config["turn_count"] == 7
+
+    def test_autoreply_injection_into_pending_input(self):
+        """After agent response, autoreply text is pushed onto _pending_input."""
+        cli = _make_cli()
+        cli._pending_input = queue.Queue()
+        cli._autoreply_config = {
+            "prompt": "continue", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0, "literal": True,
+        }
+
+        reply = cli._generate_autoreply_text()
+        if reply:
+            cli._pending_input.put(f"[autoreply]{reply}")
+
+        assert not cli._pending_input.empty()
+        queued = cli._pending_input.get_nowait()
+        assert queued == "[autoreply]continue"
+
+
+# ---------------------------------------------------------------------------
+# _start_control_api gating
+# ---------------------------------------------------------------------------
+
+
+class TestCLIControlAPIGating:
+    """Tests for _start_control_api env var gating."""
+
+    def test_control_api_not_started_without_env_var(self):
+        """Without HERMES_CONTROL_API, _start_control_api does nothing."""
+        cli = _make_cli()
+        with patch.dict("os.environ", {"HERMES_CONTROL_API": ""}, clear=False):
+            with patch("gateway.control_api.ControlAPI") as mock_api:
+                cli._start_control_api()
+                mock_api.assert_not_called()
+
+    def test_control_api_started_with_env_var(self):
+        """With HERMES_CONTROL_API=1, ControlAPI is instantiated."""
+        cli = _make_cli()
+        cli.agent = MagicMock()
+        cli.session_id = "test-session"
+        with patch.dict("os.environ", {"HERMES_CONTROL_API": "1"}, clear=False):
+            with patch("gateway.control_api.ControlAPI") as mock_api, \
+                 patch("threading.Thread") as mock_thread, \
+                 patch("time.sleep"):
+                mock_thread.return_value.start = MagicMock()
+                cli._start_control_api()
+                mock_api.assert_called_once()
+                mock_thread.return_value.start.assert_called_once()

--- a/tests/test_cli_autoreply.py
+++ b/tests/test_cli_autoreply.py
@@ -1,177 +1,183 @@
-"""Tests for CLI /autoreply command, _generate_autoreply_text, and _CLIRunner shim."""
+"""Tests for CLI auto-reply: _CLIRunner shim, _generate_autoreply_text,
+and /autoreply command handling.
 
-import queue
+Mirrors tests/gateway/test_autoreply_command.py for the CLI code paths.
+"""
+
+from queue import Queue
 from unittest.mock import MagicMock, patch
 
-from tests.test_cli_init import _make_cli
-from agent.autoreply import _DEFAULT_MAX_TURNS
+import pytest
+
+from agent.autoreply import (
+    CLI_INPUT_PREFIX,
+    _DEFAULT_MAX_TURNS,
+)
+from cli import _CLIRunner
 
 
-# ---------------------------------------------------------------------------
-# _handle_autoreply_command
-# ---------------------------------------------------------------------------
+# ── Helpers ──────────────────────────────────────────────────────────────
 
 
-class TestCLIHandleAutoreplyCommand:
-    """Tests for HermesCLI._handle_autoreply_command."""
+def _make_cli_stub(autoreply_config=None, agent_running=False):
+    """Create a minimal HermesCLI-like stub for unit testing."""
+    cli = MagicMock()
+    cli._autoreply_config = autoreply_config
+    cli._agent_running = agent_running
+    cli._pending_input = Queue()
+    cli._interrupt_queue = Queue()
+    cli.conversation_history = []
+    return cli
 
-    def test_enable_with_instructions(self):
-        cli = _make_cli()
-        cli._handle_autoreply_command("/autoreply Ask follow-up questions")
-        assert cli._autoreply_config is not None
-        assert cli._autoreply_config["prompt"] == "Ask follow-up questions"
-        assert cli._autoreply_config["max_turns"] == _DEFAULT_MAX_TURNS
-        assert cli._autoreply_config["turn_count"] == 0
 
-    def test_disable(self):
-        cli = _make_cli()
-        cli._autoreply_config = {
-            "prompt": "test", "model": None,
-            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+# ── _CLIRunner tests ─────────────────────────────────────────────────────
+
+
+class TestCLIRunner:
+    """Tests for the _CLIRunner shim used by ControlAPI."""
+
+    def test_inject_message_interrupt_when_agent_running(self):
+        cli = _make_cli_stub(agent_running=True)
+        runner = _CLIRunner(MagicMock(), "sess1", cli)
+
+        runner.inject_message("sess1", "hello", interrupt=True)
+
+        assert cli._interrupt_queue.get_nowait() == "hello"
+        assert cli._pending_input.empty()
+
+    def test_inject_message_queue_when_agent_not_running(self):
+        cli = _make_cli_stub(agent_running=False)
+        runner = _CLIRunner(MagicMock(), "sess1", cli)
+
+        runner.inject_message("sess1", "hello", interrupt=True)
+
+        assert cli._pending_input.get_nowait() == "hello"
+        assert cli._interrupt_queue.empty()
+
+    def test_inject_message_queue_mode(self):
+        cli = _make_cli_stub(agent_running=True)
+        runner = _CLIRunner(MagicMock(), "sess1", cli)
+
+        runner.inject_message("sess1", "hello", interrupt=False)
+
+        assert cli._pending_input.get_nowait() == "hello"
+        assert cli._interrupt_queue.empty()
+
+    def test_get_session_info_no_config(self):
+        cli = _make_cli_stub(autoreply_config=None)
+        runner = _CLIRunner(MagicMock(), "sess1", cli)
+
+        info = runner.get_session_info("sess1")
+
+        assert info["autoreply"]["enabled"] is False
+        assert info["autoreply"]["prompt"] is None
+
+    def test_get_session_info_with_config(self):
+        cfg = {
+            "prompt": "Ask follow-up questions",
+            "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS,
+            "turn_count": 3,
         }
-        cli._handle_autoreply_command("/autoreply off")
-        assert cli._autoreply_config is None
+        cli = _make_cli_stub(autoreply_config=cfg)
+        runner = _CLIRunner(MagicMock(), "sess1", cli)
 
-    def test_disable_when_not_active(self):
-        cli = _make_cli()
-        cli._autoreply_config = None
-        cli._handle_autoreply_command("/autoreply off")
-        assert cli._autoreply_config is None  # still None, no error
+        info = runner.get_session_info("sess1")
 
-    def test_set_max_turns(self):
-        cli = _make_cli()
-        cli._autoreply_config = {
-            "prompt": "test", "model": None,
-            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
-        }
-        cli._handle_autoreply_command("/autoreply max 25")
-        assert cli._autoreply_config["max_turns"] == 25
+        assert info["autoreply"]["enabled"] is True
+        assert info["autoreply"]["prompt"] == "Ask follow-up questions"
+        assert info["autoreply"]["turn_count"] == 3
+        assert info["autoreply"]["max_turns"] == _DEFAULT_MAX_TURNS
 
-    def test_max_without_active_config(self):
-        cli = _make_cli()
-        cli._autoreply_config = None
-        cli._handle_autoreply_command("/autoreply max 5")
-        assert cli._autoreply_config is None  # not enabled
+    def test_running_agents_contains_session(self):
+        agent = MagicMock()
+        runner = _CLIRunner(agent, "sess1", MagicMock())
 
-    def test_status_when_active_does_not_error(self):
-        cli = _make_cli()
-        cli._autoreply_config = {
-            "prompt": "Ask questions", "model": None,
-            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 3,
-        }
-        # Should not raise
-        cli._handle_autoreply_command("/autoreply")
-        # Config unchanged
-        assert cli._autoreply_config["turn_count"] == 3
-
-    def test_status_when_inactive_does_not_error(self):
-        cli = _make_cli()
-        cli._autoreply_config = None
-        cli._handle_autoreply_command("/autoreply")
-        assert cli._autoreply_config is None
-
-    def test_literal_mode(self):
-        cli = _make_cli()
-        cli._handle_autoreply_command("/autoreply --literal continue")
-        assert cli._autoreply_config is not None
-        assert cli._autoreply_config["prompt"] == "continue"
-        assert cli._autoreply_config["literal"] is True
-
-    def test_forever_mode(self):
-        cli = _make_cli()
-        cli._handle_autoreply_command("/autoreply --forever keep going")
-        assert cli._autoreply_config is not None
-        assert cli._autoreply_config["max_turns"] == 0
-
-    def test_disable_aliases(self):
-        """All disable aliases work: off, disable, stop."""
-        for word in ("off", "disable", "stop"):
-            cli = _make_cli()
-            cli._autoreply_config = {
-                "prompt": "test", "model": None,
-                "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
-            }
-            cli._handle_autoreply_command(f"/autoreply {word}")
-            assert cli._autoreply_config is None, f"'{word}' did not disable autoreply"
-
-    def test_instructions_starting_with_max_not_treated_as_subcommand(self):
-        """'/autoreply maximize depth' should set instructions, not parse as /max."""
-        cli = _make_cli()
-        cli._handle_autoreply_command("/autoreply maximize the depth of investigation")
-        assert cli._autoreply_config is not None
-        assert "maximize" in cli._autoreply_config["prompt"]
+        assert "sess1" in runner._running_agents
+        assert runner._running_agents["sess1"] is agent
 
 
-# ---------------------------------------------------------------------------
-# _generate_autoreply_text
-# ---------------------------------------------------------------------------
+# ── _generate_autoreply_text tests ───────────────────────────────────────
 
 
-class TestCLIGenerateAutoreplyText:
+class TestGenerateAutoreplyText:
     """Tests for HermesCLI._generate_autoreply_text."""
 
+    def _make_cli_for_autoreply(self, config=None, history=None):
+        """Build a HermesCLI stub with just enough for _generate_autoreply_text."""
+        from cli import HermesCLI
+        cli = object.__new__(HermesCLI)
+        cli._autoreply_config = config
+        cli.conversation_history = history or []
+        return cli
+
     def test_returns_none_when_not_configured(self):
-        cli = _make_cli()
+        cli = self._make_cli_for_autoreply(config=None)
         assert cli._generate_autoreply_text() is None
 
-    def test_literal_mode_returns_prompt_directly(self):
-        cli = _make_cli()
-        cli._autoreply_config = {
-            "prompt": "continue", "model": None,
-            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0, "literal": True,
-        }
-        result = cli._generate_autoreply_text()
-        assert result == "continue"
-        assert cli._autoreply_config["turn_count"] == 1
-
-    def test_cap_reached_clears_config(self):
-        cli = _make_cli()
-        cli._autoreply_config = {
+    def test_returns_none_and_clears_config_when_cap_reached(self):
+        config = {
             "prompt": "test", "model": None,
-            "max_turns": 3, "turn_count": 3,
+            "max_turns": 5, "turn_count": 5,
         }
-        result = cli._generate_autoreply_text()
+        cli = self._make_cli_for_autoreply(config=config)
+
+        with patch("cli._cprint"):
+            result = cli._generate_autoreply_text()
+
         assert result is None
         assert cli._autoreply_config is None
 
-    def test_llm_mode_calls_call_llm(self):
-        cli = _make_cli()
-        cli._autoreply_config = {
-            "prompt": "Ask follow-up questions", "model": None,
-            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+    def test_literal_mode_returns_prompt(self):
+        config = {
+            "prompt": "continue", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0, "literal": True,
         }
-        cli.conversation_history = [
+        cli = self._make_cli_for_autoreply(config=config)
+
+        result = cli._generate_autoreply_text()
+
+        assert result == "continue"
+        assert cli._autoreply_config["turn_count"] == 1
+
+    def test_llm_mode_calls_prepare_and_extract(self):
+        config = {
+            "prompt": "Ask follow-up questions",
+            "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS,
+            "turn_count": 2,
+        }
+        history = [
             {"role": "user", "content": "Tell me about Python"},
             {"role": "assistant", "content": "Python is great."},
         ]
+        cli = self._make_cli_for_autoreply(config=config, history=history)
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "What about type hints?"
+        mock_response.choices[0].message.content = "What about its type system?"
 
         with patch("agent.auxiliary_client.call_llm", return_value=mock_response) as mock_llm:
             result = cli._generate_autoreply_text()
 
-        assert result == "What about type hints?"
-        assert cli._autoreply_config["turn_count"] == 1
+        assert result == "What about its type system?"
+        assert config["turn_count"] == 3
+
+        # Verify LLM was called with correct kwargs
         call_kwargs = mock_llm.call_args[1]
         assert call_kwargs["task"] == "autoreply"
         assert call_kwargs["temperature"] == 0.7
-        # System prompt should contain the user's instructions
-        system_msg = call_kwargs["messages"][0]
-        assert system_msg["role"] == "system"
-        assert "Ask follow-up questions" in system_msg["content"]
+        assert call_kwargs["max_tokens"] == 1024
 
     def test_model_override_passed_to_llm(self):
-        cli = _make_cli()
-        cli._autoreply_config = {
+        config = {
             "prompt": "test", "model": "openai/gpt-4o-mini",
             "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
         }
-        cli.conversation_history = [
+        cli = self._make_cli_for_autoreply(config=config, history=[
             {"role": "user", "content": "hi"},
             {"role": "assistant", "content": "hello"},
-        ]
+        ])
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
@@ -182,221 +188,143 @@ class TestCLIGenerateAutoreplyText:
 
         assert mock_llm.call_args[1]["model"] == "openai/gpt-4o-mini"
 
-    def test_forever_mode_does_not_cap(self):
-        """max_turns=0 means forever — turn counting never stops."""
-        cli = _make_cli()
-        cli._autoreply_config = {
-            "prompt": "keep going", "model": None,
-            "max_turns": 0, "turn_count": 100, "literal": True,
-        }
-        result = cli._generate_autoreply_text()
-        assert result == "keep going"
-        assert cli._autoreply_config["turn_count"] == 101
-
-
-# ---------------------------------------------------------------------------
-# _CLIRunner shim
-# ---------------------------------------------------------------------------
-
-
-class TestCLIRunnerShim:
-    """Tests for the _CLIRunner shim used by ControlAPI in CLI mode."""
-
-    def _make_shim(self):
-        """Build a _CLIRunner matching the one defined in _start_control_api."""
-        cli = _make_cli()
-        cli._agent_running = False
-        cli._pending_input = queue.Queue()
-        cli._interrupt_queue = queue.Queue()
-        cli._autoreply_config = None
-        cli.agent = MagicMock()
-        cli.session_id = "test-session"
-
-        class _CLIRunner:
-            def __init__(self, agent, session_id, cli_instance):
-                self._running_agents = {session_id: agent}
-                self._cli = cli_instance
-
-            def inject_message(self, key, text, *, interrupt=True):
-                if interrupt and self._cli._agent_running:
-                    self._cli._interrupt_queue.put(text)
-                else:
-                    self._cli._pending_input.put(text)
-
-            def get_session_info(self, key):
-                cfg = getattr(self._cli, "_autoreply_config", None)
-                return {
-                    "autoreply": {
-                        "enabled": cfg is not None,
-                        "prompt": cfg.get("prompt", "") if cfg else None,
-                        "max_turns": cfg.get("max_turns", 0) if cfg else None,
-                        "turn_count": cfg.get("turn_count", 0) if cfg else None,
-                    },
-                }
-
-        shim = _CLIRunner(cli.agent, cli.session_id, cli)
-        return shim, cli
-
-    def test_inject_message_interrupt_mode(self):
-        """Interrupt mode puts message on _interrupt_queue when agent is running."""
-        shim, cli = self._make_shim()
-        cli._agent_running = True
-        shim.inject_message("_any", "/stop", interrupt=True)
-        assert cli._interrupt_queue.get_nowait() == "/stop"
-        assert cli._pending_input.empty()
-
-    def test_inject_message_queue_mode(self):
-        """Queue mode always puts message on _pending_input."""
-        shim, cli = self._make_shim()
-        cli._agent_running = True
-        shim.inject_message("_any", "/model cheap", interrupt=False)
-        assert cli._pending_input.get_nowait() == "/model cheap"
-        assert cli._interrupt_queue.empty()
-
-    def test_inject_message_interrupt_when_not_running(self):
-        """When agent is not running, interrupt falls through to _pending_input."""
-        shim, cli = self._make_shim()
-        cli._agent_running = False
-        shim.inject_message("_any", "hello", interrupt=True)
-        assert cli._pending_input.get_nowait() == "hello"
-        assert cli._interrupt_queue.empty()
-
-    def test_get_session_info_no_autoreply(self):
-        shim, cli = self._make_shim()
-        info = shim.get_session_info("_any")
-        assert info["autoreply"]["enabled"] is False
-        assert info["autoreply"]["prompt"] is None
-
-    def test_get_session_info_with_autoreply(self):
-        shim, cli = self._make_shim()
-        cli._autoreply_config = {
-            "prompt": "keep going", "model": None,
-            "max_turns": 10, "turn_count": 3,
-        }
-        info = shim.get_session_info("_any")
-        assert info["autoreply"]["enabled"] is True
-        assert info["autoreply"]["prompt"] == "keep going"
-        assert info["autoreply"]["max_turns"] == 10
-        assert info["autoreply"]["turn_count"] == 3
-
-    def test_running_agents_contains_session(self):
-        shim, cli = self._make_shim()
-        assert cli.session_id in shim._running_agents
-
-
-# ---------------------------------------------------------------------------
-# Reset clears autoreply
-# ---------------------------------------------------------------------------
-
-
-class TestCLIAutoreplyCleanup:
-    """Tests for autoreply cleanup on /reset and /new."""
-
-    def test_reset_clears_autoreply(self):
-        cli = _make_cli()
-        cli._autoreply_config = {
+    def test_empty_response_returns_none(self):
+        config = {
             "prompt": "test", "model": None,
-            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 5,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
         }
-        cli.process_command("/reset")
+        cli = self._make_cli_for_autoreply(config=config, history=[
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ])
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = None
+
+        with patch("agent.auxiliary_client.call_llm", return_value=mock_response):
+            result = cli._generate_autoreply_text()
+
+        assert result is None
+        # turn_count should NOT have incremented
+        assert config["turn_count"] == 0
+
+
+# ── _handle_autoreply_command tests ──────────────────────────────────────
+
+
+class TestHandleAutoreplyCommand:
+    """Tests for HermesCLI._handle_autoreply_command."""
+
+    def _make_cli(self, config=None):
+        from cli import HermesCLI
+        cli = object.__new__(HermesCLI)
+        cli._autoreply_config = config
+        return cli
+
+    def test_enable_with_instructions(self):
+        cli = self._make_cli()
+        with patch("cli._cprint"):
+            cli._handle_autoreply_command("/autoreply Ask follow-up questions")
+
+        cfg = cli._autoreply_config
+        assert cfg is not None
+        assert cfg["prompt"] == "Ask follow-up questions"
+        assert cfg["max_turns"] == _DEFAULT_MAX_TURNS
+        assert cfg["turn_count"] == 0
+
+    def test_disable(self):
+        cli = self._make_cli(config={
+            "prompt": "test", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        })
+        with patch("cli._cprint"):
+            cli._handle_autoreply_command("/autoreply off")
+
         assert cli._autoreply_config is None
 
-    def test_new_clears_autoreply(self):
-        cli = _make_cli()
-        cli._autoreply_config = {
+    def test_disable_when_not_active(self):
+        cli = self._make_cli()
+        with patch("cli._cprint") as mock_print:
+            cli._handle_autoreply_command("/autoreply off")
+        assert "not active" in mock_print.call_args[0][0].lower()
+
+    def test_status_when_active(self):
+        cli = self._make_cli(config={
+            "prompt": "Ask questions", "model": None,
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 3,
+        })
+        with patch("cli._cprint") as mock_print:
+            cli._handle_autoreply_command("/autoreply")
+        output = mock_print.call_args[0][0]
+        assert "active" in output.lower() or "Active" in output
+
+    def test_status_when_not_active(self):
+        cli = self._make_cli()
+        with patch("cli._cprint") as mock_print:
+            cli._handle_autoreply_command("/autoreply")
+        assert "not active" in mock_print.call_args[0][0].lower()
+
+    def test_set_max_turns(self):
+        cli = self._make_cli(config={
             "prompt": "test", "model": None,
-            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 5,
-        }
-        cli.process_command("/new")
-        assert cli._autoreply_config is None
+            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0,
+        })
+        with patch("cli._cprint"):
+            cli._handle_autoreply_command("/autoreply max 25")
+        assert cli._autoreply_config["max_turns"] == 25
+
+    def test_literal_mode(self):
+        cli = self._make_cli()
+        with patch("cli._cprint"):
+            cli._handle_autoreply_command("/autoreply --literal continue")
+
+        cfg = cli._autoreply_config
+        assert cfg["literal"] is True
+        assert cfg["prompt"] == "continue"
+
+    def test_error_message(self):
+        cli = self._make_cli()
+        with patch("cli._cprint") as mock_print:
+            cli._handle_autoreply_command("/autoreply --literal")
+        assert "Usage" in mock_print.call_args[0][0]
 
 
-# ---------------------------------------------------------------------------
-# Chat loop autoreply wiring
-# ---------------------------------------------------------------------------
+# ── CLI_INPUT_PREFIX usage tests ─────────────────────────────────────────
 
 
-class TestCLIAutoreplyPrefix:
-    """Tests for the [autoreply] prefix stripping and turn counter reset logic."""
+class TestCLIInputPrefix:
+    """Tests for CLI_INPUT_PREFIX constant usage in the input loop."""
 
-    def test_autoreply_prefix_detected(self):
-        user_input = "[autoreply]What else can you tell me?"
-        assert user_input.startswith("[autoreply]")
-        stripped = user_input[len("[autoreply]"):]
-        assert stripped == "What else can you tell me?"
+    def test_prefix_value(self):
+        assert CLI_INPUT_PREFIX == "[autoreply]"
 
-    def test_regular_message_not_detected(self):
-        user_input = "Tell me more"
-        assert not user_input.startswith("[autoreply]")
+    def test_prefix_stripping(self):
+        """Simulate the prefix-stripping logic from the CLI input loop."""
+        user_input = f"{CLI_INPUT_PREFIX}What about types?"
+        if user_input.startswith(CLI_INPUT_PREFIX):
+            user_input = user_input[len(CLI_INPUT_PREFIX):]
+        assert user_input == "What about types?"
+
+    def test_real_message_does_not_strip(self):
+        user_input = "What about types?"
+        if user_input.startswith(CLI_INPUT_PREFIX):
+            user_input = user_input[len(CLI_INPUT_PREFIX):]
+        assert user_input == "What about types?"
 
     def test_turn_counter_reset_on_real_message(self):
-        """Real user messages reset the turn counter."""
-        cli = _make_cli()
-        cli._autoreply_config = {
-            "prompt": "test", "model": None,
-            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 7,
-        }
-        user_input = "Tell me more"
-        if cli._autoreply_config and not user_input.startswith("[autoreply]"):
-            cli._autoreply_config["turn_count"] = 0
-        assert cli._autoreply_config["turn_count"] == 0
+        """Real messages reset turn counter; prefixed messages don't."""
+        config = {"turn_count": 5}
 
-    def test_turn_counter_not_reset_on_autoreply_message(self):
-        """Autoreply-injected messages do NOT reset the turn counter."""
-        cli = _make_cli()
-        cli._autoreply_config = {
-            "prompt": "test", "model": None,
-            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 7,
-        }
-        user_input = "[autoreply]Generated question"
-        if cli._autoreply_config and not user_input.startswith("[autoreply]"):
-            cli._autoreply_config["turn_count"] = 0
-        assert cli._autoreply_config["turn_count"] == 7
+        # Real message resets
+        user_input = "hello"
+        if not user_input.startswith(CLI_INPUT_PREFIX):
+            config["turn_count"] = 0
+        assert config["turn_count"] == 0
 
-    def test_autoreply_injection_into_pending_input(self):
-        """After agent response, autoreply text is pushed onto _pending_input."""
-        cli = _make_cli()
-        cli._pending_input = queue.Queue()
-        cli._autoreply_config = {
-            "prompt": "continue", "model": None,
-            "max_turns": _DEFAULT_MAX_TURNS, "turn_count": 0, "literal": True,
-        }
-
-        reply = cli._generate_autoreply_text()
-        if reply:
-            cli._pending_input.put(f"[autoreply]{reply}")
-
-        assert not cli._pending_input.empty()
-        queued = cli._pending_input.get_nowait()
-        assert queued == "[autoreply]continue"
-
-
-# ---------------------------------------------------------------------------
-# _start_control_api gating
-# ---------------------------------------------------------------------------
-
-
-class TestCLIControlAPIGating:
-    """Tests for _start_control_api env var gating."""
-
-    def test_control_api_not_started_without_env_var(self):
-        """Without HERMES_CONTROL_API, _start_control_api does nothing."""
-        cli = _make_cli()
-        with patch.dict("os.environ", {"HERMES_CONTROL_API": ""}, clear=False):
-            with patch("gateway.control_api.ControlAPI") as mock_api:
-                cli._start_control_api()
-                mock_api.assert_not_called()
-
-    def test_control_api_started_with_env_var(self):
-        """With HERMES_CONTROL_API=1, ControlAPI is instantiated."""
-        cli = _make_cli()
-        cli.agent = MagicMock()
-        cli.session_id = "test-session"
-        with patch.dict("os.environ", {"HERMES_CONTROL_API": "1"}, clear=False):
-            with patch("gateway.control_api.ControlAPI") as mock_api, \
-                 patch("threading.Thread") as mock_thread, \
-                 patch("time.sleep"):
-                mock_thread.return_value.start = MagicMock()
-                cli._start_control_api()
-                mock_api.assert_called_once()
-                mock_thread.return_value.start.assert_called_once()
+        # Autoreply message does not reset
+        config["turn_count"] = 5
+        user_input = f"{CLI_INPUT_PREFIX}generated reply"
+        if not user_input.startswith(CLI_INPUT_PREFIX):
+            config["turn_count"] = 0
+        assert config["turn_count"] == 5


### PR DESCRIPTION
## What does this PR do?

Adds a local HTTP Control API and `/autoreply` command that allow external tools to programmatically interact with a running Hermes session — injecting messages, switching models, clearing context, and enabling autonomous conversation loops.

In building [desloppify](https://github.com/peteromallet/desloppify) (a codebase health tool), I needed the ability to programmatically switch models, clear context, and prompt the agent upon completion from an external harness. The simplest approach: a local HTTP API that accepts text — one endpoint that lets external tools do anything the user can do (same code path, same commands).

What this enables:
1. **A harness can switch models** — e.g. cheap model for execution, expensive for planning
2. **The agent can prompt itself** — via `/autoreply`, with a static or AI-generated meta-prompt
3. **Context management** — clear context to stay focused on long-running tasks
4. **Any slash command** — model switching, interrupt, queue mode, etc.

Real-world example: [desloppify uses the control API](https://github.com/peteromallet/desloppify/blob/0.9.10/desloppify/app/commands/helpers/transition_messages.py) to switch models between execution and review phases, enable autoreply so the agent keeps working autonomously, and reset context between tasks.

### Security

- **Opt-in only** — gated behind `HERMES_CONTROL_API=1` env var, off by default
- **Localhost only** — binds to `127.0.0.1`, not reachable from the network
- **CSRF protection** — all requests require an `X-Hermes-Control: 1` header, which blocks browser-based attacks (any non-standard header forces a CORS preflight, which fails because the server has no CORS headers)

Future hardening could include a per-session auth token (generated on startup, written alongside the port file), but the custom header is sufficient against the primary threat vector (malicious webpages making cross-origin requests to localhost).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/control_api.py`: New aiohttp server on `127.0.0.1`. Endpoints: `/health`, `/sessions`, `/sessions/{key}`, `/commands`, `/sessions/{key}/message`. Writes port to `~/.hermes/control_api.port` for discovery. CSRF protection via `X-Hermes-Control` header.
- `gateway/hermes_control_client.py`: Zero-dependency stdlib client (urllib only). Auto-discovers port from port file. Convenience methods: `health()`, `list_sessions()`, `send_message()`, `list_commands()`.
- `agent/autoreply.py`: Shared autoreply engine used by both CLI and gateway. Parses args (`--forever`, `--max N`, `--literal`), builds LLM prompts from conversation history, manages turn counter, formats status.
- `gateway/platforms/base.py`: Add `interrupt` kwarg to `handle_message()`. When `interrupt=False`, messages are queued without signaling the agent to stop (used by autoreply queue mode).
- `gateway/run.py`: Add `inject_message()` and `get_session_info()` methods. Add `/autoreply` command handler with scheduling, response labeling, and cleanup on `/stop` and `/reset`. Control API startup/shutdown in `start_gateway()`.
- `cli.py`: Add `_CLIRunner` shim class bridging ControlAPI to CLI input queues. Add `/autoreply` command handler with chat loop integration (turn reset, prefix stripping, auto-injection after agent response). Control API startup in `_init_agent()`.
- `hermes_cli/commands.py`: Register `/autoreply` in the commands list.
- `.env.example`: Document `HERMES_CONTROL_API` and `HERMES_CONTROL_PORT` env vars.
- `tests/gateway/test_control_api.py`: 8 tests covering message injection (interrupt/queue modes), command listing, CSRF protection, error handling.
- `tests/gateway/test_autoreply_command.py`: 42 tests covering parsing, turn limits, literal mode, cleanup on reset/stop, response labeling, help text integration.

## How to Test

1. **Control API**: `HERMES_CONTROL_API=1 hermes` → from another terminal: `python -c "from gateway.hermes_control_client import HermesControl; c = HermesControl(); print(c.send_message('/help'))"`
2. **Autoreply**: In a running session, type `/autoreply summarise what you just did` → agent responds, then auto-prompts itself with a summary request
3. **Queue mode**: `c.send_message("do this next", interrupt=False)` → message queued until current run finishes
4. **Off by default**: Without `HERMES_CONTROL_API=1`, no API starts, no port file written

## Validation

```
python -m pytest tests/gateway/test_control_api.py tests/gateway/test_autoreply_command.py -v
# 50 passed in 0.97s
```

## Notes

This PR does NOT include the `run_command` tool (agent self-commanding via tool use) — that will be a separate PR.

I'm very open to feedback — if there's a better approach to achieving the same thing, I'm all ears.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env var only)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — localhost HTTP + stdlib urllib, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A