### PR TITLE
fix: agent executes actions without user approval in Telegram gateway

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -91,7 +91,7 @@ SKILLS_GUIDANCE = (
 )
 
 _MESSAGING_CONFIRMATION_HINT = (
-    " When on this messaging platform, always describe what you plan to do "
+    "When on this messaging platform, always describe what you plan to do "
     "and ask for explicit user confirmation before executing any file-modifying "
     "or destructive action (write_file, patch_file, terminal commands that "
     "modify files, delete operations). Do not interpret conversational "
@@ -107,7 +107,7 @@ PLATFORM_HINTS = {
         "will be sent as a native WhatsApp attachment — images (.jpg, .png, "
         ".webp) appear as photos, videos (.mp4, .mov) play inline, and other "
         "files arrive as downloadable documents. You can also include image "
-        "URLs in markdown format ![alt](url) and they will be sent as photos."
+        "URLs in markdown format ![alt](url) and they will be sent as photos. "
         + _MESSAGING_CONFIRMATION_HINT
     ),
     "telegram": (
@@ -117,7 +117,7 @@ PLATFORM_HINTS = {
         "include MEDIA:/absolute/path/to/file in your response. Images "
         "(.png, .jpg, .webp) appear as photos, audio (.ogg) sends as voice "
         "bubbles, and videos (.mp4) play inline. You can also include image "
-        "URLs in markdown format ![alt](url) and they will be sent as native photos."
+        "URLs in markdown format ![alt](url) and they will be sent as native photos. "
         + _MESSAGING_CONFIRMATION_HINT
     ),
     "discord": (
@@ -125,7 +125,7 @@ PLATFORM_HINTS = {
         "You can send media files natively: include MEDIA:/absolute/path/to/file "
         "in your response. Images (.png, .jpg, .webp) are sent as photo "
         "attachments, audio as file attachments. You can also include image URLs "
-        "in markdown format ![alt](url) and they will be sent as attachments."
+        "in markdown format ![alt](url) and they will be sent as attachments. "
         + _MESSAGING_CONFIRMATION_HINT
     ),
     "slack": (
@@ -133,7 +133,7 @@ PLATFORM_HINTS = {
         "You can send media files natively: include MEDIA:/absolute/path/to/file "
         "in your response. Images (.png, .jpg, .webp) are uploaded as photo "
         "attachments, audio as file attachments. You can also include image URLs "
-        "in markdown format ![alt](url) and they will be uploaded as attachments."
+        "in markdown format ![alt](url) and they will be uploaded as attachments. "
         + _MESSAGING_CONFIRMATION_HINT
     ),
     "signal": (
@@ -143,7 +143,7 @@ PLATFORM_HINTS = {
         "include MEDIA:/absolute/path/to/file in your response. Images "
         "(.png, .jpg, .webp) appear as photos, audio as attachments, and other "
         "files arrive as downloadable documents. You can also include image "
-        "URLs in markdown format ![alt](url) and they will be sent as photos."
+        "URLs in markdown format ![alt](url) and they will be sent as photos. "
         + _MESSAGING_CONFIRMATION_HINT
     ),
     "email": (

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -90,6 +90,14 @@ SKILLS_GUIDANCE = (
     "skill with skill_manage so you can reuse it next time."
 )
 
+_MESSAGING_CONFIRMATION_HINT = (
+    " When on this messaging platform, always describe what you plan to do "
+    "and ask for explicit user confirmation before executing any file-modifying "
+    "or destructive action (write_file, patch_file, terminal commands that "
+    "modify files, delete operations). Do not interpret conversational "
+    "discussion as an instruction to execute."
+)
+
 PLATFORM_HINTS = {
     "whatsapp": (
         "You are on a text messaging communication platform, WhatsApp. "
@@ -100,6 +108,7 @@ PLATFORM_HINTS = {
         ".webp) appear as photos, videos (.mp4, .mov) play inline, and other "
         "files arrive as downloadable documents. You can also include image "
         "URLs in markdown format ![alt](url) and they will be sent as photos."
+        + _MESSAGING_CONFIRMATION_HINT
     ),
     "telegram": (
         "You are on a text messaging communication platform, Telegram. "
@@ -109,6 +118,7 @@ PLATFORM_HINTS = {
         "(.png, .jpg, .webp) appear as photos, audio (.ogg) sends as voice "
         "bubbles, and videos (.mp4) play inline. You can also include image "
         "URLs in markdown format ![alt](url) and they will be sent as native photos."
+        + _MESSAGING_CONFIRMATION_HINT
     ),
     "discord": (
         "You are in a Discord server or group chat communicating with your user. "
@@ -116,6 +126,7 @@ PLATFORM_HINTS = {
         "in your response. Images (.png, .jpg, .webp) are sent as photo "
         "attachments, audio as file attachments. You can also include image URLs "
         "in markdown format ![alt](url) and they will be sent as attachments."
+        + _MESSAGING_CONFIRMATION_HINT
     ),
     "slack": (
         "You are in a Slack workspace communicating with your user. "
@@ -123,6 +134,7 @@ PLATFORM_HINTS = {
         "in your response. Images (.png, .jpg, .webp) are uploaded as photo "
         "attachments, audio as file attachments. You can also include image URLs "
         "in markdown format ![alt](url) and they will be uploaded as attachments."
+        + _MESSAGING_CONFIRMATION_HINT
     ),
     "signal": (
         "You are on a text messaging communication platform, Signal. "
@@ -132,6 +144,7 @@ PLATFORM_HINTS = {
         "(.png, .jpg, .webp) appear as photos, audio as attachments, and other "
         "files arrive as downloadable documents. You can also include image "
         "URLs in markdown format ![alt](url) and they will be sent as photos."
+        + _MESSAGING_CONFIRMATION_HINT
     ),
     "email": (
         "You are communicating via email. Write clear, well-structured responses "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3587,6 +3587,7 @@ class GatewayRunner:
 
     def _set_session_env(self, context: SessionContext) -> None:
         """Set environment variables for the current session."""
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
         os.environ["HERMES_SESSION_PLATFORM"] = context.source.platform.value
         os.environ["HERMES_SESSION_CHAT_ID"] = context.source.chat_id
         if context.source.chat_name:
@@ -3596,7 +3597,7 @@ class GatewayRunner:
     
     def _clear_session_env(self) -> None:
         """Clear session environment variables."""
-        for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME", "HERMES_SESSION_THREAD_ID"]:
+        for var in ["HERMES_GATEWAY_SESSION", "HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME", "HERMES_SESSION_THREAD_ID"]:
             if var in os.environ:
                 del os.environ[var]
     

--- a/tests/gateway/test_gateway_approval.py
+++ b/tests/gateway/test_gateway_approval.py
@@ -1,0 +1,92 @@
+"""Tests for gateway session approval: env var setup and dangerous command guard."""
+
+import os
+
+import pytest
+
+from agent.prompt_builder import PLATFORM_HINTS
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionContext, SessionSource
+from tools.approval import check_dangerous_command, clear_session
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Ensure gateway session env var is clean before/after each test."""
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    key = os.getenv("HERMES_SESSION_KEY", "default")
+    clear_session(key)
+    yield
+    clear_session(key)
+
+
+def _make_runner_and_context():
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_name="TestGroup",
+        chat_type="group",
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+    return runner, context
+
+
+# ---------------------------------------------------------------------------
+# _set_session_env / _clear_session_env
+# ---------------------------------------------------------------------------
+
+class TestSessionEnvGatewayFlag:
+    def test_set_session_env_sets_gateway_session(self):
+        runner, context = _make_runner_and_context()
+        runner._set_session_env(context)
+        assert os.getenv("HERMES_GATEWAY_SESSION") == "1"
+
+    def test_clear_session_env_removes_gateway_session(self):
+        runner, context = _make_runner_and_context()
+        runner._set_session_env(context)
+        assert os.getenv("HERMES_GATEWAY_SESSION") == "1"
+
+        runner._clear_session_env()
+        assert os.getenv("HERMES_GATEWAY_SESSION") is None
+
+
+# ---------------------------------------------------------------------------
+# check_dangerous_command with HERMES_GATEWAY_SESSION
+# ---------------------------------------------------------------------------
+
+class TestDangerousCommandGateway:
+    def test_auto_approves_without_gateway_session(self):
+        """Without HERMES_GATEWAY_SESSION, dangerous commands are auto-approved."""
+        result = check_dangerous_command("rm -rf /tmp/test", "local")
+        assert result["approved"] is True
+
+    def test_requires_approval_with_gateway_session(self, monkeypatch):
+        """With HERMES_GATEWAY_SESSION=1, dangerous commands require approval."""
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        result = check_dangerous_command("rm -rf /tmp/test", "local")
+        # The command should match a dangerous pattern and require approval
+        if result.get("status") == "approval_required":
+            assert result["approved"] is False
+        else:
+            # If the command doesn't match any dangerous pattern, it's still approved
+            assert result["approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# Platform hints contain confirmation instruction
+# ---------------------------------------------------------------------------
+
+class TestPlatformHintsConfirmation:
+    @pytest.mark.parametrize("platform", ["telegram", "whatsapp", "discord", "slack", "signal"])
+    def test_messaging_hints_contain_confirmation(self, platform):
+        hint = PLATFORM_HINTS[platform]
+        assert "ask for explicit user confirmation" in hint
+        assert "Do not interpret conversational discussion as an instruction" in hint
+
+    def test_email_hint_does_not_contain_confirmation(self):
+        hint = PLATFORM_HINTS["email"]
+        assert "ask for explicit user confirmation" not in hint

--- a/tests/gateway/test_gateway_approval.py
+++ b/tests/gateway/test_gateway_approval.py
@@ -1,13 +1,10 @@
-"""Tests for gateway session approval: env var setup and dangerous command guard."""
+"""Tests for gateway approval: dangerous command guard and platform hints."""
 
 import os
 
 import pytest
 
 from agent.prompt_builder import PLATFORM_HINTS
-from gateway.config import Platform
-from gateway.run import GatewayRunner
-from gateway.session import SessionContext, SessionSource
 from tools.approval import check_dangerous_command, clear_session
 
 
@@ -23,57 +20,26 @@ def _clean_env(monkeypatch):
     clear_session(key)
 
 
-def _make_runner_and_context():
-    runner = object.__new__(GatewayRunner)
-    source = SessionSource(
-        platform=Platform.TELEGRAM,
-        chat_id="-1001",
-        chat_name="TestGroup",
-        chat_type="group",
-    )
-    context = SessionContext(source=source, connected_platforms=[], home_channels={})
-    return runner, context
-
-
-# ---------------------------------------------------------------------------
-# _set_session_env / _clear_session_env
-# ---------------------------------------------------------------------------
-
-class TestSessionEnvGatewayFlag:
-    def test_set_session_env_sets_gateway_session(self):
-        runner, context = _make_runner_and_context()
-        runner._set_session_env(context)
-        assert os.getenv("HERMES_GATEWAY_SESSION") == "1"
-
-    def test_clear_session_env_removes_gateway_session(self):
-        runner, context = _make_runner_and_context()
-        runner._set_session_env(context)
-        assert os.getenv("HERMES_GATEWAY_SESSION") == "1"
-
-        runner._clear_session_env()
-        assert os.getenv("HERMES_GATEWAY_SESSION") is None
-
-
 # ---------------------------------------------------------------------------
 # check_dangerous_command with HERMES_GATEWAY_SESSION
 # ---------------------------------------------------------------------------
 
 class TestDangerousCommandGateway:
     def test_auto_approves_without_gateway_session(self):
-        """Without HERMES_GATEWAY_SESSION, dangerous commands are auto-approved."""
+        """Without HERMES_GATEWAY_SESSION, dangerous commands are auto-approved
+        via the early return at lines 319-320 of approval.py."""
         result = check_dangerous_command("rm -rf /tmp/test", "local")
         assert result["approved"] is True
+        # Confirm this is the early-return auto-approve path (no status key),
+        # not the non-dangerous path.
+        assert "status" not in result
 
     def test_requires_approval_with_gateway_session(self, monkeypatch):
         """With HERMES_GATEWAY_SESSION=1, dangerous commands require approval."""
         monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
         result = check_dangerous_command("rm -rf /tmp/test", "local")
-        # The command should match a dangerous pattern and require approval
-        if result.get("status") == "approval_required":
-            assert result["approved"] is False
-        else:
-            # If the command doesn't match any dangerous pattern, it's still approved
-            assert result["approved"] is True
+        assert result["approved"] is False
+        assert result["status"] == "approval_required"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -43,3 +43,24 @@ def test_clear_session_env_removes_thread_id(monkeypatch):
     assert os.getenv("HERMES_SESSION_CHAT_ID") is None
     assert os.getenv("HERMES_SESSION_CHAT_NAME") is None
     assert os.getenv("HERMES_SESSION_THREAD_ID") is None
+
+
+def test_set_session_env_sets_gateway_session(monkeypatch):
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_name="Group",
+        chat_type="group",
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+    runner._set_session_env(context)
+    assert os.getenv("HERMES_GATEWAY_SESSION") == "1"
+
+
+def test_clear_session_env_removes_gateway_session(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    runner = object.__new__(GatewayRunner)
+    runner._clear_session_env()
+    assert os.getenv("HERMES_GATEWAY_SESSION") is None


### PR DESCRIPTION
Fixes #1444

## Problem

When using Hermes via Telegram (or other messaging gateways), the agent sometimes executes file edits and terminal commands without asking for user approval. This happens because:

1. `HERMES_GATEWAY_SESSION` env var is never set despite being checked by `check_dangerous_command()` in `tools/approval.py` — without it, dangerous commands auto-approve.
2. The LLM system prompt has no instruction telling it to distinguish casual conversation from explicit commands on messaging platforms.

## Changes

**gateway/run.py** — Set `HERMES_GATEWAY_SESSION=1` in `_set_session_env()` and clean it up in `_clear_session_env()`. This activates the existing approval gate in `check_dangerous_command()`.

**agent/prompt_builder.py** — Add a confirmation instruction to all messaging platform hints (Telegram, WhatsApp, Discord, Slack, Signal) telling the agent to describe planned actions and ask for explicit confirmation before executing file-modifying or destructive operations.

**tests/gateway/test_gateway_approval.py** — Tests verifying:
- `check_dangerous_command()` returns `approval_required` when `HERMES_GATEWAY_SESSION=1`
- Auto-approves without the env var (existing behavior preserved)
- All messaging platform hints contain the confirmation instruction

**tests/gateway/test_session_env.py** — Tests verifying `HERMES_GATEWAY_SESSION` is set/cleared in session lifecycle.

## Test plan

- All 4475 existing tests pass (1 pre-existing failure in unrelated `test_transcription_tools`, 4 pre-existing import errors in `acp/`)
- New gateway approval tests pass
- Manual verification: connect via Telegram gateway and confirm agent asks before executing actions