### PR TITLE
fix(terminal): add Singularity/Apptainer preflight check

### DIFF
--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -22,6 +22,20 @@ from tools.interrupt import is_interrupted
 
 logger = logging.getLogger(__name__)
 
+
+def _ensure_singularity_available() -> None:
+    """Check that Singularity or Apptainer is available before use."""
+    has_apptainer = shutil.which("apptainer")
+    has_singularity = shutil.which("singularity")
+    
+    if not has_apptainer and not has_singularity:
+        raise RuntimeError(
+            "Singularity/Apptainer is not installed. "
+            "Install Apptainer: https://apptainer.org/docs/admin/main/installation.html "
+            "or Singularity: https://sylabs.io/guides/latest/admin-guide/"
+        )
+
+
 _SNAPSHOT_STORE = get_hermes_home() / "singularity_snapshots.json"
 
 
@@ -169,6 +183,7 @@ class SingularityEnvironment(BaseEnvironment):
         task_id: str = "default",
     ):
         super().__init__(cwd=cwd, timeout=timeout)
+        _ensure_singularity_available()
         self.executable = "apptainer" if shutil.which("apptainer") else "singularity"
         self.image = _get_or_build_sif(image, self.executable)
         self.instance_id = f"hermes_{uuid.uuid4().hex[:12]}"


### PR DESCRIPTION
- Add _ensure_singularity_available() function that checks if either apptainer or singularity is installed
- Raises clear RuntimeError with install instructions if neither found
- Called in __init__ before attempting to use the backend
- Follows pattern from Docker's _ensure_docker_available()

Fixes #1511

   ## What does this PR do?

   Adds a preflight check for Singularity/Apptainer availability, similar to how Docker has `_ensure_docker_available()`. Provides a clear error message if neither is installed instead of cryptic FileNotFoundError later.

   ## Related Issue

   Fixes (similar pattern to #1458 - SSH preflight)

   ## Type of Change

   - [x] 🐛 Bug fix (non-breaking change that fixes an issue)

   ## Changes Made

   - Add `_ensure_singularity_available()` function that checks if either apptainer or singularity is installed
   - Raises clear RuntimeError with install instructions if neither found
   - Called in `__init__` before attempting to use the backend
   - Follows pattern from Docker's `_ensure_docker_available()` and SSH fix

   ## How to Test

   1. Try to use the Singularity terminal backend when neither apptainer nor singularity is installed
   2. Verify clear error message appears instead of cryptic FileNotFoundError

   ## Checklist

   - [x] Follows Contributing Guide
   - [x] Conventional commit format
