### PR TITLE
feat: add hermes tools disable/enable/list for toolsets and MCP tools

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3032,17 +3032,72 @@ For more help on a command:
     tools_parser = subparsers.add_parser(
         "tools",
         help="Configure which tools are enabled per platform",
-        description="Interactive tool configuration — enable/disable tools for CLI, Telegram, Discord, etc."
+        description=(
+            "Enable, disable, or list tools for CLI, Telegram, Discord, etc.\n\n"
+            "Built-in toolsets use plain names (e.g. web, memory).\n"
+            "MCP tools use server:tool notation (e.g. github:create_issue).\n\n"
+            "Run 'hermes tools config' for the interactive configuration UI."
+        ),
     )
     tools_parser.add_argument(
         "--summary",
         action="store_true",
         help="Print a summary of enabled tools per platform and exit"
     )
+    tools_sub = tools_parser.add_subparsers(dest="tools_action")
+
+    # hermes tools list [--platform cli]
+    tools_list_p = tools_sub.add_parser(
+        "list",
+        help="Show all tools and their enabled/disabled status",
+    )
+    tools_list_p.add_argument(
+        "--platform", default="cli",
+        help="Platform to show (default: cli)",
+    )
+
+    # hermes tools disable <name...> [--platform cli]
+    tools_disable_p = tools_sub.add_parser(
+        "disable",
+        help="Disable toolsets or MCP tools",
+    )
+    tools_disable_p.add_argument(
+        "names", nargs="+", metavar="NAME",
+        help="Toolset name (e.g. web) or MCP tool in server:tool form (e.g. github:create_issue)",
+    )
+    tools_disable_p.add_argument(
+        "--platform", default="cli",
+        help="Platform to apply to for built-in toolsets (default: cli)",
+    )
+
+    # hermes tools enable <name...> [--platform cli]
+    tools_enable_p = tools_sub.add_parser(
+        "enable",
+        help="Enable toolsets or MCP tools",
+    )
+    tools_enable_p.add_argument(
+        "names", nargs="+", metavar="NAME",
+        help="Toolset name or MCP tool in server:tool form",
+    )
+    tools_enable_p.add_argument(
+        "--platform", default="cli",
+        help="Platform to apply to for built-in toolsets (default: cli)",
+    )
+
+    # hermes tools config — existing interactive UI
+    tools_sub.add_parser(
+        "config",
+        help="Interactive tool configuration UI",
+    )
 
     def cmd_tools(args):
-        from hermes_cli.tools_config import tools_command
-        tools_command(args)
+        action = getattr(args, "tools_action", None)
+        if action in ("list", "disable", "enable"):
+            from hermes_cli.tools_config import tools_disable_enable_command
+            tools_disable_enable_command(args)
+        else:
+            from hermes_cli.tools_config import tools_command
+            tools_command(args)
 
     tools_parser.set_defaults(func=cmd_tools)
     # =========================================================================

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1053,3 +1053,132 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
     print(color("  Tool configuration saved to ~/.hermes/config.yaml", Colors.DIM))
     print(color("  Changes take effect on next 'hermes' or gateway restart.", Colors.DIM))
     print()
+
+
+# ─── Non-interactive disable/enable ───────────────────────────────────────────
+#
+# Visibility guarantee — disabled tools are completely invisible to the LLM:
+#
+# Built-in toolsets
+#   cli.py reads `platform_toolsets.cli` → passes it to HermesCLI as `toolsets`
+#   → forwarded to `get_tool_definitions(enabled_toolsets=...)` in model_tools.py
+#   → only those toolsets are resolved via `resolve_toolset()` → only matching
+#   tool names are sent to `registry.get_definitions()` → the result is the
+#   `tools` parameter in every LLM API call.
+#   A disabled toolset is simply absent; the model never sees it.
+#
+# MCP tools
+#   At session start, `mcp_tool._discover_and_register_server()` calls
+#   `_should_register()` for each discovered tool. Tools in
+#   `mcp_servers.<server>.tools.exclude` are skipped — `registry.register()`
+#   is never called, so they have no registry entry and can never appear in
+#   the `tools` list sent to the LLM.
+
+
+def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str], action: str):
+    """Add or remove built-in toolsets for a platform."""
+    enabled = _get_platform_tools(config, platform)
+    if action == "disable":
+        updated = enabled - set(toolset_names)
+    else:
+        updated = enabled | set(toolset_names)
+    _save_platform_tools(config, platform, updated)
+
+
+def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]:
+    """Add or remove specific MCP tools from a server's exclude list.
+
+    Returns the set of server names that were not found in config.
+    """
+    failed_servers: Set[str] = set()
+    mcp_servers = config.get("mcp_servers") or {}
+
+    for target in targets:
+        server_name, tool_name = target.split(":", 1)
+        if server_name not in mcp_servers:
+            failed_servers.add(server_name)
+            continue
+        tools_cfg = mcp_servers[server_name].setdefault("tools", {})
+        exclude = list(tools_cfg.get("exclude") or [])
+        if action == "disable":
+            if tool_name not in exclude:
+                exclude.append(tool_name)
+        else:
+            exclude = [t for t in exclude if t != tool_name]
+        tools_cfg["exclude"] = exclude
+
+    return failed_servers
+
+
+def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = "cli"):
+    """Print a summary of enabled/disabled toolsets and MCP tool filters."""
+    print(f"Built-in toolsets ({platform}):")
+    for ts_key, label, _ in CONFIGURABLE_TOOLSETS:
+        status = color("✓ enabled", Colors.GREEN) if ts_key in enabled_toolsets else color("✗ disabled", Colors.RED)
+        print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
+
+    if mcp_servers:
+        print()
+        print("MCP servers:")
+        for srv_name, srv_cfg in mcp_servers.items():
+            tools_cfg = srv_cfg.get("tools") or {}
+            exclude = tools_cfg.get("exclude") or []
+            include = tools_cfg.get("include") or []
+            if include:
+                _print_info(f"{srv_name}  [include only: {', '.join(include)}]")
+            elif exclude:
+                _print_info(f"{srv_name}  [excluded: {color(', '.join(exclude), Colors.YELLOW)}]")
+            else:
+                _print_info(f"{srv_name}  {color('all tools enabled', Colors.DIM)}")
+
+
+def tools_disable_enable_command(args):
+    """Enable, disable, or list tools for a platform.
+
+    Built-in toolsets use plain names (e.g. ``web``, ``memory``).
+    MCP tools use ``server:tool`` notation (e.g. ``github:create_issue``).
+    Disabled tools are completely invisible to the LLM — see module comment above.
+    """
+    action = args.tools_action
+    platform = args.platform
+    config = load_config()
+
+    if platform not in PLATFORMS:
+        _print_error(f"Unknown platform '{platform}'. Valid: {', '.join(PLATFORMS)}")
+        return
+
+    if action == "list":
+        _print_tools_list(_get_platform_tools(config, platform), config.get("mcp_servers") or {}, platform)
+        return
+
+    targets: List[str] = args.names
+    toolset_targets = [t for t in targets if ":" not in t]
+    mcp_targets = [t for t in targets if ":" in t]
+
+    valid_toolsets = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
+    unknown_toolsets = [t for t in toolset_targets if t not in valid_toolsets]
+    if unknown_toolsets:
+        for name in unknown_toolsets:
+            _print_error(f"Unknown toolset '{name}'")
+        toolset_targets = [t for t in toolset_targets if t in valid_toolsets]
+
+    if toolset_targets:
+        _apply_toolset_change(config, platform, toolset_targets, action)
+
+    failed_servers: Set[str] = set()
+    if mcp_targets:
+        failed_servers = _apply_mcp_change(config, mcp_targets, action)
+        for srv in failed_servers:
+            _print_error(f"MCP server '{srv}' not found in config")
+
+    save_config(config)
+
+    successful = [
+        t for t in targets
+        if t not in unknown_toolsets and (":" not in t or t.split(":")[0] not in failed_servers)
+    ]
+    if successful:
+        verb = "Disabled" if action == "disable" else "Enabled"
+        _print_success(f"{verb}: {', '.join(successful)}")
+        _print_info("Changes take effect on the next 'hermes chat' session.")
+        _print_info("Gateway users: run 'hermes gateway restart' to apply now.")

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -1,0 +1,233 @@
+"""Tests for hermes tools disable/enable/list command."""
+from argparse import Namespace
+from unittest.mock import patch
+
+from hermes_cli.tools_config import tools_disable_enable_command
+
+
+# ── Built-in toolset disable ───────────────────────────────────────────────────
+
+class TestToolsDisableBuiltin:
+
+    def test_disable_removes_toolset_from_platform(self):
+        config = {"platform_toolsets": {"cli": ["web", "memory", "terminal"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="disable", names=["web"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert "web" not in saved["platform_toolsets"]["cli"]
+        assert "memory" in saved["platform_toolsets"]["cli"]
+
+    def test_disable_multiple_toolsets(self):
+        config = {"platform_toolsets": {"cli": ["web", "memory", "terminal"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="disable", names=["web", "memory"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert "web" not in saved["platform_toolsets"]["cli"]
+        assert "memory" not in saved["platform_toolsets"]["cli"]
+        assert "terminal" in saved["platform_toolsets"]["cli"]
+
+    def test_disable_already_absent_is_idempotent(self):
+        config = {"platform_toolsets": {"cli": ["memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="disable", names=["web"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert "web" not in saved["platform_toolsets"]["cli"]
+
+
+# ── Built-in toolset enable ────────────────────────────────────────────────────
+
+class TestToolsEnableBuiltin:
+
+    def test_enable_adds_toolset_to_platform(self):
+        config = {"platform_toolsets": {"cli": ["memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="enable", names=["web"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert "web" in saved["platform_toolsets"]["cli"]
+
+    def test_enable_already_present_is_idempotent(self):
+        config = {"platform_toolsets": {"cli": ["web"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="enable", names=["web"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert saved["platform_toolsets"]["cli"].count("web") == 1
+
+
+# ── MCP tool disable ───────────────────────────────────────────────────────────
+
+class TestToolsDisableMcp:
+
+    def test_disable_adds_to_exclude_list(self):
+        config = {"mcp_servers": {"github": {"command": "npx"}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["github:create_issue"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert "create_issue" in saved["mcp_servers"]["github"]["tools"]["exclude"]
+
+    def test_disable_multiple_mcp_tools(self):
+        config = {"mcp_servers": {"github": {"command": "npx"}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(
+                tools_action="disable",
+                names=["github:create_issue", "github:delete_branch"],
+                platform="cli",
+            ))
+        saved = mock_save.call_args[0][0]
+        assert "create_issue" in saved["mcp_servers"]["github"]["tools"]["exclude"]
+        assert "delete_branch" in saved["mcp_servers"]["github"]["tools"]["exclude"]
+
+    def test_disable_already_excluded_is_idempotent(self):
+        config = {"mcp_servers": {"github": {"tools": {"exclude": ["create_issue"]}}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["github:create_issue"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert saved["mcp_servers"]["github"]["tools"]["exclude"].count("create_issue") == 1
+
+    def test_disable_unknown_server_prints_error(self, capsys):
+        config = {"mcp_servers": {}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config"):
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["unknown:tool"], platform="cli")
+            )
+        out = capsys.readouterr().out
+        assert "MCP server 'unknown' not found in config" in out
+
+
+# ── MCP tool enable ────────────────────────────────────────────────────────────
+
+class TestToolsEnableMcp:
+
+    def test_enable_removes_from_exclude_list(self):
+        config = {"mcp_servers": {"github": {"tools": {"exclude": ["create_issue", "delete_branch"]}}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["github:create_issue"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert "create_issue" not in saved["mcp_servers"]["github"]["tools"]["exclude"]
+        assert "delete_branch" in saved["mcp_servers"]["github"]["tools"]["exclude"]
+
+    def test_enable_tool_not_in_exclude_is_idempotent(self):
+        config = {"mcp_servers": {"github": {"tools": {"exclude": []}}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["github:create_issue"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert saved["mcp_servers"]["github"]["tools"]["exclude"] == []
+
+
+# ── Mixed targets ──────────────────────────────────────────────────────────────
+
+class TestToolsMixedTargets:
+
+    def test_disable_builtin_and_mcp_together(self):
+        config = {
+            "platform_toolsets": {"cli": ["web", "memory"]},
+            "mcp_servers": {"github": {"command": "npx"}},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(
+                tools_action="disable",
+                names=["web", "github:create_issue"],
+                platform="cli",
+            ))
+        saved = mock_save.call_args[0][0]
+        assert "web" not in saved["platform_toolsets"]["cli"]
+        assert "create_issue" in saved["mcp_servers"]["github"]["tools"]["exclude"]
+
+
+# ── List output ────────────────────────────────────────────────────────────────
+
+class TestToolsList:
+
+    def test_list_shows_enabled_toolsets(self, capsys):
+        config = {"platform_toolsets": {"cli": ["web", "memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config):
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cli"))
+        out = capsys.readouterr().out
+        assert "web" in out
+        assert "memory" in out
+
+    def test_list_shows_mcp_excluded_tools(self, capsys):
+        config = {
+            "mcp_servers": {"github": {"tools": {"exclude": ["create_issue"]}}},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config):
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cli"))
+        out = capsys.readouterr().out
+        assert "github" in out
+        assert "create_issue" in out
+
+    def test_list_shows_all_tools_enabled_when_no_exclude(self, capsys):
+        config = {
+            "mcp_servers": {"filesystem": {"command": "npx"}},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config):
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cli"))
+        out = capsys.readouterr().out
+        assert "filesystem" in out
+        assert "all tools enabled" in out
+
+
+# ── Validation ─────────────────────────────────────────────────────────────────
+
+class TestToolsValidation:
+
+    def test_unknown_platform_prints_error(self, capsys):
+        config = {}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config"):
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["web"], platform="invalid_platform")
+            )
+        out = capsys.readouterr().out
+        assert "Unknown platform 'invalid_platform'" in out
+
+    def test_unknown_toolset_prints_error(self, capsys):
+        config = {"platform_toolsets": {"cli": ["web"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config"):
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["nonexistent_toolset"], platform="cli")
+            )
+        out = capsys.readouterr().out
+        assert "Unknown toolset 'nonexistent_toolset'" in out
+
+    def test_unknown_toolset_does_not_corrupt_config(self):
+        config = {"platform_toolsets": {"cli": ["web", "memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["nonexistent_toolset"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert "web" in saved["platform_toolsets"]["cli"]
+        assert "memory" in saved["platform_toolsets"]["cli"]
+
+    def test_mixed_valid_and_invalid_toolsets_applies_valid_only(self):
+        config = {"platform_toolsets": {"cli": ["web", "memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["web", "bad_toolset"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert "web" not in saved["platform_toolsets"]["cli"]
+        assert "memory" in saved["platform_toolsets"]["cli"]


### PR DESCRIPTION
## Summary

Extends `hermes tools` with three non-interactive subcommands covering both built-in toolsets and individual MCP tools in a single unified interface.

## Motivation

Currently, disabling tools requires either the interactive curses UI (`hermes tools config`) or hand-editing `~/.hermes/config.yaml`. There is no CLI to disable individual MCP tools at all. This makes scripting, dotfiles management, and quick adjustments awkward.

## Usage

```bash
# List all tools with enabled/disabled status
hermes tools list
hermes tools list --platform telegram

# Disable a built-in toolset
hermes tools disable web
hermes tools disable web memory --platform telegram

# Disable a specific MCP tool
hermes tools disable github:create_issue
hermes tools disable github:create_issue github:delete_branch

# Mix built-in and MCP in one command
hermes tools disable web github:create_issue

# Re-enable
hermes tools enable web
hermes tools enable github:create_issue

# Existing interactive UI and --summary flag are unchanged
hermes tools config
hermes tools --summary
```

Changes take effect on the next `hermes chat` session. Gateway users run `hermes gateway restart`.

## Visibility guarantee

Disabled tools are **completely invisible to the LLM** — the model cannot see or call them.

**Built-in toolsets:** `cli.py` reads `platform_toolsets[platform]` and passes it to `get_tool_definitions(enabled_toolsets=...)` in `model_tools.py`. Only the listed toolsets are resolved via `resolve_toolset()`. The result is the `tools` parameter in every LLM API call — a disabled toolset is simply absent.

**MCP tools:** At session start, `mcp_tool._discover_and_register_server()` calls `_should_register()` for each discovered tool. Tools in `mcp_servers.<server>.tools.exclude` are skipped — `registry.register()` is never called, so they have no registry entry and cannot appear in the `tools` list sent to the LLM.

Both call chains are documented with inline comments in `tools_config.py`.

## Implementation

**`hermes_cli/tools_config.py`**
- Adds `tools_disable_enable_command(args)` — the command entry point
- Adds `_apply_toolset_change()` — mutates `platform_toolsets[platform]`
- Adds `_apply_mcp_change()` — mutates `mcp_servers.<server>.tools.exclude`; returns set of unknown server names
- Adds `_print_tools_list()` — formats the `list` output
- Uses existing helpers: `_get_platform_tools()`, `_save_platform_tools()`, `load_config()`, `save_config()`, `_print_success()`, `_print_error()`, `_print_info()`

**`hermes_cli/main.py`**
- Extends `hermes tools` with `list`, `disable`, `enable`, and `config` subparsers
- Preserves `--summary` flag for backward compatibility
- Follows the same routing pattern as `hermes skills` and `hermes cron`

**Validation**
- Unknown platforms are rejected immediately with a clear error
- Unknown toolset names are reported and skipped; valid names in the same command still apply
- Unknown MCP servers are reported without corrupting other changes in the same command

## Tests

19 unit tests in `tests/hermes_cli/test_tools_disable_enable.py`:

| Class | Coverage |
|-------|----------|
| `TestToolsDisableBuiltin` | single, multiple, idempotent |
| `TestToolsEnableBuiltin` | add toolset, idempotent |
| `TestToolsDisableMcp` | single, multiple, idempotent, unknown server error |
| `TestToolsEnableMcp` | remove from exclude, idempotent |
| `TestToolsMixedTargets` | built-in + MCP in one call |
| `TestToolsList` | toolsets shown, MCP exclude shown, all-enabled shown |
| `TestToolsValidation` | invalid platform, invalid toolset, no config corruption, partial apply |

All 26 tests pass (19 new + 7 existing `test_tools_config.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)