### PR TITLE
feat: support slash commands in ACP adapter (#1402)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1,6 +1,8 @@
 """ACP agent server — exposes Hermes Agent via the Agent Client Protocol."""
 
 from __future__ import annotations
+import io
+from contextlib import redirect_stdout
 
 import asyncio
 import logging
@@ -333,17 +335,40 @@ class HermesACPAgent(acp.Agent):
 
     async def _handle_slash_command(self, command_text: str, state: Any) -> str:
         """
-        Executes a slash command using the CLI command handlers.
+        Executes a slash command by capturing the TUI output from ChatConsole.
+        This allows ACP clients to use /help, /tools, /model, etc.
         """
-        try:
-            # You will need to import the command dispatcher from hermes_cli
-            # For example: from hermes_cli.main import dispatch_command
-            # return dispatch_command(command_text, state)
-            return f"Executed command: {command_text}\n(Note: Connect this to hermes_cli handlers)"
-        except Exception as e:
-            logger.error(f"Failed to execute slash command {command_text}: {e}")
-            return f"Error executing command: {e}"
-
+        from cli import ChatConsole
+        
+        # Create a string buffer to capture stdout
+        output_buffer = io.StringIO()
+        
+        # Redirect stdout to our buffer
+        with redirect_stdout(output_buffer):
+            try:
+                # Initialize the console. 
+                # We pass the existing agent instance so that commands (e.g., /model) 
+                # correctly affect the current session state.
+                console = ChatConsole(agent=state.agent)
+                
+                # Suppress interactive elements (progress bars, etc.) where possible
+                console.compact = True 
+                
+                # Process the command
+                console.process_command(command_text)
+                
+            except Exception as e:
+                logger.error(f"Error executing slash command {command_text}: {e}")
+                return f"Error executing command: {e}"
+        
+        # Retrieve the accumulated text from the buffer
+        result_text = output_buffer.getvalue()
+        
+        # If the command produced no output (e.g., /clear just resets the state silently)
+        if not result_text.strip():
+            return f"Command '{command_text}' executed successfully."
+            
+        return result_text.strip()
     # ---- Model switching ----------------------------------------------------
 
     async def set_session_model(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -226,9 +226,25 @@ class HermesACPAgent(acp.Agent):
             logger.error("prompt: session %s not found", session_id)
             return PromptResponse(stop_reason="refusal")
 
-        user_text = _extract_text(prompt)
-        if not user_text.strip():
+        user_text = _extract_text(prompt).strip()
+        if not user_text:
             return PromptResponse(stop_reason="end_turn")
+
+        # --- Issue #1402: Support Slash Commands via ACP ---
+        if user_text.startswith('/'):
+            logger.info("Slash command detected in session %s: %s", session_id, user_text)
+            
+            # Execute the command locally without calling the LLM
+            command_output = await self._handle_slash_command(user_text, state)
+            
+            # Send the command result back to the client via session_update
+            if self._conn and command_output:
+                update = acp.update_agent_message_text(command_output)
+                await self._conn.session_update(session_id, update)
+            
+            # Return early as we don't need the LLM to process this
+            return PromptResponse(stop_reason="end_turn")
+        # ----------------------------------------------------
 
         logger.info("Prompt on session %s: %s", session_id, user_text[:100])
 
@@ -314,6 +330,19 @@ class HermesACPAgent(acp.Agent):
 
         stop_reason = "cancelled" if state.cancel_event and state.cancel_event.is_set() else "end_turn"
         return PromptResponse(stop_reason=stop_reason, usage=usage)
+
+    async def _handle_slash_command(self, command_text: str, state: Any) -> str:
+        """
+        Executes a slash command using the CLI command handlers.
+        """
+        try:
+            # You will need to import the command dispatcher from hermes_cli
+            # For example: from hermes_cli.main import dispatch_command
+            # return dispatch_command(command_text, state)
+            return f"Executed command: {command_text}\n(Note: Connect this to hermes_cli handlers)"
+        except Exception as e:
+            logger.error(f"Failed to execute slash command {command_text}: {e}")
+            return f"Error executing command: {e}"
 
     # ---- Model switching ----------------------------------------------------
 


### PR DESCRIPTION
What does this PR do?
This PR adds support for slash commands (/help, /model, etc.) in the ACP adapter. It intercepts prompts starting with / and routes them to the existing CLI logic instead of the LLM.

Related Issue
Fixes #1402

Changes Made
acp_adapter/server.py:
Intercepts / commands in the prompt method.
Uses contextlib.redirect_stdout to capture output from ChatConsole.process_command (cli.py).
Passes the current agent instance to ensure state consistency (e.g., for /model).

How to Test
Run hermes acp.
Connect a client and send /help or /model.
Verify you receive formatted CLI output instead of an LLM response.

Checklist
[x] Read Contributing Guide
[x] Followed Conventional Commits
[x] PR contains only related changes
[x] Tested on Codespaces/Linux