### PR TITLE
feat: add scoped access controls for connected tools

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -231,6 +231,23 @@ def load_cli_config() -> Dict[str, Any]:
             "base_url": "",    # Direct OpenAI-compatible endpoint for subagents
             "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         },
+        "access_control": {
+            "enabled": True,
+            "default_scope": "full",
+            "platform_profiles": {
+                "cli": "full",
+                "cron": "read-only",
+                "telegram": "read-only",
+                "discord": "read-only",
+                "slack": "read-only",
+                "whatsapp": "read-only",
+                "signal": "read-only",
+                "email": "read-only",
+                "acp": "full",
+            },
+            "services": {},
+            "accounts": {},
+        },
     }
     
     # Track whether the config file explicitly set terminal config.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -306,8 +306,29 @@ DEFAULT_CONFIG = {
         "tirith_fail_open": True,
     },
 
+    # Connected-account scope controls. Toolsets answer "which classes of
+    # tools exist"; scoped access answers "what those connected tools may do"
+    # on each platform/account.
+    "access_control": {
+        "enabled": True,
+        "default_scope": "full",
+        "platform_profiles": {
+            "cli": "full",
+            "cron": "read-only",
+            "telegram": "read-only",
+            "discord": "read-only",
+            "slack": "read-only",
+            "whatsapp": "read-only",
+            "signal": "read-only",
+            "email": "read-only",
+            "acp": "full",
+        },
+        "services": {},
+        "accounts": {},
+    },
+
     # Config schema version - bump this when adding new required fields
-    "_config_version": 8,
+    "_config_version": 9,
 }
 
 # =============================================================================

--- a/model_tools.py
+++ b/model_tools.py
@@ -165,6 +165,7 @@ def get_tool_definitions(
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
     quiet_mode: bool = False,
+    platform: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -223,7 +224,7 @@ def get_tool_definitions(
             tools_to_include.update(resolve_toolset(ts_name))
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
-    filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+    filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode, platform=platform)
 
     # Rebuild execute_code schema to only list sandbox tools that are actually
     # enabled.  Without this, the model sees "web_search is available in
@@ -269,6 +270,7 @@ def handle_function_call(
     enabled_tools: Optional[List[str]] = None,
     honcho_manager: Optional[Any] = None,
     honcho_session_key: Optional[str] = None,
+    platform: Optional[str] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -310,6 +312,7 @@ def handle_function_call(
                 enabled_tools=sandbox_enabled,
                 honcho_manager=honcho_manager,
                 honcho_session_key=honcho_session_key,
+                platform=platform,
             )
 
         return registry.dispatch(
@@ -318,6 +321,7 @@ def handle_function_call(
             user_task=user_task,
             honcho_manager=honcho_manager,
             honcho_session_key=honcho_session_key,
+            platform=platform,
         )
 
     except Exception as e:

--- a/run_agent.py
+++ b/run_agent.py
@@ -598,6 +598,7 @@ class AIAgent:
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
+            platform=self.platform,
         )
         
         # Show tool configuration and store valid tool names for validation
@@ -1605,6 +1606,7 @@ class AIAgent:
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
             quiet_mode=True,
+            platform=self.platform,
         )
         self.valid_tool_names = {
             tool["function"]["name"] for tool in self.tools
@@ -3792,6 +3794,7 @@ class AIAgent:
                 enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                 honcho_manager=self._honcho,
                 honcho_session_key=self._honcho_session_key,
+                platform=self.platform,
             )
 
     def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
@@ -4136,6 +4139,7 @@ class AIAgent:
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                         honcho_manager=self._honcho,
                         honcho_session_key=self._honcho_session_key,
+                        platform=self.platform,
                     )
                     _spinner_result = function_result
                 except Exception as tool_error:
@@ -4152,6 +4156,7 @@ class AIAgent:
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                         honcho_manager=self._honcho,
                         honcho_session_key=self._honcho_session_key,
+                        platform=self.platform,
                     )
                 except Exception as tool_error:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -932,6 +932,7 @@ class TestConcurrentToolExecution:
                 enabled_tools=list(agent.valid_tool_names),
                 honcho_manager=None,
                 honcho_session_key=None,
+                platform=agent.platform,
             )
             assert result == "result"
 

--- a/tests/tools/test_access_control.py
+++ b/tests/tools/test_access_control.py
@@ -1,0 +1,127 @@
+"""Tests for scoped connected-account access control."""
+
+import json
+
+from model_tools import handle_function_call
+from tools.access_control import evaluate_access, infer_mcp_operation
+from tools.registry import registry
+
+
+def test_evaluate_access_uses_read_only_platform_profile_for_writes():
+    decision = evaluate_access(
+        "ha_call_service",
+        {"service": "homeassistant", "account": "homeassistant", "operation": "write"},
+        platform="cron",
+        config={
+            "access_control": {
+                "enabled": True,
+                "default_scope": "full",
+                "platform_profiles": {"cron": "read-only"},
+            }
+        },
+    )
+
+    assert decision.allowed is False
+    assert decision.scope == "read-only"
+    assert decision.platform == "cron"
+
+
+def test_evaluate_access_allows_account_override_for_write():
+    decision = evaluate_access(
+        "mcp_github_create_issue",
+        {"service": "mcp", "account": "mcp.github", "operation": "write"},
+        platform="cron",
+        config={
+            "access_control": {
+                "enabled": True,
+                "default_scope": "full",
+                "platform_profiles": {"cron": "read-only"},
+                "accounts": {"mcp.github": {"scope": "full"}},
+            }
+        },
+    )
+
+    assert decision.allowed is True
+    assert decision.scope == "full"
+
+
+def test_infer_mcp_operation_fails_closed_for_mutating_verbs():
+    assert infer_mcp_operation("mcp_github_create_issue") == "write"
+    assert infer_mcp_operation("mcp_docs_read_page") == "read"
+    assert infer_mcp_operation("mcp_unknown_sync") == "write"
+
+
+def test_registry_hides_static_tool_when_scope_denies_it(monkeypatch):
+    tool_name = "test_scope_hidden_tool"
+    original = registry._tools.copy()
+    try:
+        registry.register(
+            name=tool_name,
+            toolset="testing",
+            schema={
+                "name": tool_name,
+                "description": "test tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **kwargs: json.dumps({"ok": True}),
+            access_fn=lambda args, **kwargs: {
+                "service": "homeassistant",
+                "account": "homeassistant",
+                "operation": "write",
+            },
+            access_static=True,
+        )
+        monkeypatch.setattr(
+            "tools.access_control._get_access_control_config",
+            lambda config=None: {
+                "enabled": True,
+                "default_scope": "full",
+                "platform_profiles": {"cron": "read-only", "cli": "full"},
+            },
+        )
+
+        hidden = registry.get_definitions({tool_name}, quiet=True, platform="cron")
+        shown = registry.get_definitions({tool_name}, quiet=True, platform="cli")
+
+        assert hidden == []
+        assert shown[0]["function"]["name"] == tool_name
+    finally:
+        registry._tools = original
+
+
+def test_handle_function_call_returns_scope_violation_without_running_handler(monkeypatch):
+    tool_name = "test_scope_blocked_tool"
+    original = registry._tools.copy()
+    called = {"value": False}
+    try:
+        registry.register(
+            name=tool_name,
+            toolset="testing",
+            schema={
+                "name": tool_name,
+                "description": "blocked tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **kwargs: called.__setitem__("value", True) or json.dumps({"ok": True}),
+            access_fn=lambda args, **kwargs: {
+                "service": "mcp",
+                "account": "mcp.github",
+                "operation": "write",
+            },
+            access_static=True,
+        )
+        monkeypatch.setattr(
+            "tools.access_control._get_access_control_config",
+            lambda config=None: {
+                "enabled": True,
+                "default_scope": "full",
+                "platform_profiles": {"cron": "read-only"},
+            },
+        )
+
+        result = json.loads(handle_function_call(tool_name, {}, platform="cron"))
+
+        assert result["error_type"] == "scope_violation"
+        assert called["value"] is False
+    finally:
+        registry._tools = original

--- a/tests/tools/test_access_control.py
+++ b/tests/tools/test_access_control.py
@@ -125,3 +125,164 @@ def test_handle_function_call_returns_scope_violation_without_running_handler(mo
         assert called["value"] is False
     finally:
         registry._tools = original
+
+
+def test_send_message_access_denied_on_read_only_platform(monkeypatch):
+    """send_message access_fn derives operation from target arg; deny on read-only platform."""
+    from tools.send_message_tool import _send_message_access
+
+    monkeypatch.setattr(
+        "tools.access_control._get_access_control_config",
+        lambda config=None: {
+            "enabled": True,
+            "default_scope": "full",
+            "platform_profiles": {"telegram": "read-only"},
+        },
+    )
+
+    decision = evaluate_access(
+        "send_message",
+        _send_message_access({"target": "telegram:12345"}),
+        platform="telegram",
+    )
+
+    assert decision.allowed is False
+    assert decision.service == "messaging"
+    assert decision.operation == "write"
+    assert decision.scope == "read-only"
+
+
+def test_send_message_access_allowed_on_full_platform(monkeypatch):
+    """send_message should be allowed when platform has full scope."""
+    from tools.send_message_tool import _send_message_access
+
+    monkeypatch.setattr(
+        "tools.access_control._get_access_control_config",
+        lambda config=None: {
+            "enabled": True,
+            "default_scope": "full",
+            "platform_profiles": {"cli": "full"},
+        },
+    )
+
+    decision = evaluate_access(
+        "send_message",
+        _send_message_access({"target": "cli"}),
+        platform="cli",
+    )
+
+    assert decision.allowed is True
+
+
+def test_send_message_not_hidden_from_schema_without_access_static(monkeypatch):
+    """send_message has access_fn but not access_static, so it stays visible in schemas."""
+    from tools.send_message_tool import _send_message_access
+
+    # Register a temp tool mimicking send_message (access_fn without access_static)
+    tool_name = "test_send_msg_dynamic"
+    original = registry._tools.copy()
+    try:
+        registry.register(
+            name=tool_name,
+            toolset="testing",
+            schema={
+                "name": tool_name,
+                "description": "dynamic access tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **kwargs: json.dumps({"ok": True}),
+            access_fn=_send_message_access,
+            # access_static=False (default) — schema check skipped
+        )
+        monkeypatch.setattr(
+            "tools.access_control._get_access_control_config",
+            lambda config=None: {
+                "enabled": True,
+                "default_scope": "full",
+                "platform_profiles": {"telegram": "read-only"},
+            },
+        )
+
+        # Should appear in schema even on read-only platform (no access_static)
+        shown = registry.get_definitions({tool_name}, quiet=True, platform="telegram")
+        assert len(shown) == 1
+        assert shown[0]["function"]["name"] == tool_name
+    finally:
+        registry._tools = original
+
+
+def test_sandbox_tool_calls_inherit_platform_access(monkeypatch):
+    """Tools dispatched via execute_code sandbox should receive the originating platform."""
+    from tools.access_control import evaluate_access, _get_access_control_config
+
+    monkeypatch.setattr(
+        "tools.access_control._get_access_control_config",
+        lambda config=None: {
+            "enabled": True,
+            "default_scope": "full",
+            "platform_profiles": {"cron": "read-only"},
+        },
+    )
+
+    # Simulate what the sandbox RPC loop does: evaluate with the platform string
+    decision = evaluate_access(
+        "ha_call_service",
+        {"service": "homeassistant", "account": "homeassistant", "operation": "write"},
+        platform="cron",
+    )
+
+    assert decision.allowed is False
+    assert decision.platform == "cron"
+
+    # But same call from CLI should pass
+    decision_cli = evaluate_access(
+        "ha_call_service",
+        {"service": "homeassistant", "account": "homeassistant", "operation": "write"},
+        platform="cli",
+    )
+    assert decision_cli.allowed is True
+
+
+def test_access_control_disabled_allows_everything(monkeypatch):
+    """When enabled=False, all tools should be allowed regardless of scope."""
+    monkeypatch.setattr(
+        "tools.access_control._get_access_control_config",
+        lambda config=None: {
+            "enabled": False,
+            "default_scope": "read-only",
+            "platform_profiles": {},
+        },
+    )
+
+    decision = evaluate_access(
+        "ha_call_service",
+        {"service": "homeassistant", "account": "homeassistant", "operation": "write"},
+        platform="telegram",
+    )
+
+    assert decision.allowed is True
+    assert "disabled" in decision.reason.lower()
+
+
+def test_service_level_scope_override(monkeypatch):
+    """Service-level scope should override platform profile."""
+    monkeypatch.setattr(
+        "tools.access_control._get_access_control_config",
+        lambda config=None: {
+            "enabled": True,
+            "default_scope": "full",
+            "platform_profiles": {"telegram": "read-only"},
+            "services": {
+                "homeassistant": {"scope": "full"},
+            },
+        },
+    )
+
+    decision = evaluate_access(
+        "ha_call_service",
+        {"service": "homeassistant", "account": "homeassistant", "operation": "write"},
+        platform="telegram",
+    )
+
+    assert decision.allowed is True
+    assert decision.scope == "full"

--- a/tools/access_control.py
+++ b/tools/access_control.py
@@ -1,0 +1,236 @@
+"""Runtime scope enforcement for connected-account tools.
+
+This module adds a lightweight, config-driven access layer on top of the
+existing toolset enable/disable system. Tool authors can opt in by providing an
+``access_fn`` when registering a tool. The function returns a dict describing
+what external service/account the tool touches and whether the action is a
+read or write operation.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_READ_ONLY = "read-only"
+_FULL = "full"
+_NONE = "none"
+
+_READ_VERBS = (
+    "get",
+    "list",
+    "read",
+    "search",
+    "find",
+    "fetch",
+    "query",
+    "describe",
+    "inspect",
+    "view",
+    "show",
+    "preview",
+)
+
+_WRITE_VERBS = (
+    "create",
+    "update",
+    "delete",
+    "remove",
+    "set",
+    "send",
+    "write",
+    "edit",
+    "patch",
+    "post",
+    "put",
+    "call",
+    "invoke",
+    "run",
+    "execute",
+    "close",
+    "open",
+    "archive",
+    "approve",
+    "reject",
+    "resume",
+    "pause",
+    "trigger",
+)
+
+
+@dataclass(frozen=True)
+class AccessDecision:
+    allowed: bool
+    scope: str
+    platform: str
+    operation: str
+    service: str
+    account: str
+    reason: str
+
+
+def build_static_access_fn(service: str, operation: str, *, account: Optional[str] = None) -> Callable[..., dict[str, str]]:
+    """Build a simple access context function for a fixed service/action."""
+
+    def _access_fn(args: Optional[dict[str, Any]] = None, **_: Any) -> dict[str, str]:
+        return {
+            "service": service,
+            "account": account or service,
+            "operation": operation,
+        }
+
+    return _access_fn
+
+
+def infer_mcp_operation(tool_name: str) -> str:
+    """Best-effort read/write inference for MCP tool names.
+
+    MCP servers can expose arbitrary tools, so fail closed: ambiguous verbs are
+    treated as writes unless they clearly look read-only.
+    """
+    normalized = tool_name.lower().replace("-", "_").replace(".", "_")
+    parts = [part for part in normalized.split("_") if part and part != "mcp"]
+
+    for part in parts:
+        if part in _WRITE_VERBS:
+            return "write"
+    for part in parts:
+        if part in _READ_VERBS:
+            return "read"
+    return "write"
+
+
+def evaluate_access(
+    tool_name: str,
+    access_context: Optional[dict[str, Any]],
+    *,
+    platform: Optional[str] = None,
+    config: Optional[dict[str, Any]] = None,
+) -> AccessDecision:
+    """Return whether a tool call is allowed for the given platform/account."""
+    platform_key = _normalize_platform(platform)
+    service = str((access_context or {}).get("service") or "")
+    account = str((access_context or {}).get("account") or service or tool_name)
+    operation = _normalize_operation((access_context or {}).get("operation"))
+
+    if not access_context or not service:
+        return AccessDecision(
+            allowed=True,
+            scope=_FULL,
+            platform=platform_key,
+            operation=operation,
+            service=service,
+            account=account,
+            reason="No scoped access policy applies to this tool.",
+        )
+
+    settings = _get_access_control_config(config)
+    if not settings.get("enabled", True):
+        return AccessDecision(
+            allowed=True,
+            scope=_FULL,
+            platform=platform_key,
+            operation=operation,
+            service=service,
+            account=account,
+            reason="Scoped access control is disabled.",
+        )
+
+    scope = _resolve_scope(settings, platform_key, service, account, tool_name)
+    allowed = _scope_allows(scope, operation)
+    if allowed:
+        reason = f"Allowed by scope '{scope}'."
+    else:
+        reason = f"Scope '{scope}' does not permit '{operation}' operations."
+
+    return AccessDecision(
+        allowed=allowed,
+        scope=scope,
+        platform=platform_key,
+        operation=operation,
+        service=service,
+        account=account,
+        reason=reason,
+    )
+
+
+def _get_access_control_config(config: Optional[dict[str, Any]]) -> dict[str, Any]:
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = {}
+
+    return dict(config.get("access_control") or {})
+
+
+def _normalize_platform(platform: Optional[str]) -> str:
+    value = str(platform or "cli").strip().lower()
+    if value in {"", "local", "none"}:
+        return "cli"
+    return value
+
+
+def _normalize_scope(scope: Any) -> str:
+    value = str(scope or _FULL).strip().lower()
+    aliases = {
+        "allow": _FULL,
+        "all": _FULL,
+        "full-access": _FULL,
+        "read_only": _READ_ONLY,
+        "readonly": _READ_ONLY,
+        "read": _READ_ONLY,
+        "deny": _NONE,
+        "disabled": _NONE,
+        "off": _NONE,
+    }
+    return aliases.get(value, value if value in {_FULL, _READ_ONLY, _NONE} else _FULL)
+
+
+def _normalize_operation(operation: Any) -> str:
+    value = str(operation or "write").strip().lower()
+    return "read" if value == "read" else "write"
+
+
+def _scope_allows(scope: str, operation: str) -> bool:
+    if scope == _FULL:
+        return True
+    if scope == _READ_ONLY:
+        return operation == "read"
+    return False
+
+
+def _resolve_scope(settings: dict[str, Any], platform: str, service: str, account: str, tool_name: str) -> str:
+    scope = _normalize_scope(settings.get("default_scope", _FULL))
+    scope = _pick_scope(settings.get("platform_profiles"), platform, scope)
+
+    services = settings.get("services") or {}
+    service_cfg = services.get(service) or {}
+    scope = _pick_scope(service_cfg, None, scope)
+    scope = _pick_scope(service_cfg.get("platform_scopes"), platform, scope)
+    scope = _pick_scope(service_cfg.get("tool_scopes"), tool_name, scope)
+
+    accounts = settings.get("accounts") or {}
+    account_cfg = accounts.get(account) or {}
+    scope = _pick_scope(account_cfg, None, scope)
+    scope = _pick_scope(account_cfg.get("platform_scopes"), platform, scope)
+    scope = _pick_scope(account_cfg.get("tool_scopes"), tool_name, scope)
+    return scope
+
+
+def _pick_scope(source: Any, key: Optional[str], fallback: str) -> str:
+    if not source:
+        return fallback
+    if isinstance(source, str):
+        return _normalize_scope(source)
+    if isinstance(source, dict):
+        if key is not None and key in source:
+            return _normalize_scope(source.get(key))
+        if key is None and "scope" in source:
+            return _normalize_scope(source.get("scope"))
+    return fallback

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -304,7 +304,7 @@ def _rpc_server_loop(
                     sys.stderr = open(os.devnull, "w")
                     try:
                         result = handle_function_call(
-                            tool_name, tool_args, task_id=task_id
+                            tool_name, tool_args, task_id=task_id, platform=platform
                         )
                     finally:
                         sys.stdout.close()
@@ -347,6 +347,7 @@ def execute_code(
     code: str,
     task_id: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
+    platform: Optional[str] = None,
 ) -> str:
     """
     Run a Python script in a sandboxed child process with RPC access
@@ -774,7 +775,8 @@ registry.register(
     handler=lambda args, **kw: execute_code(
         code=args.get("code", ""),
         task_id=kw.get("task_id"),
-        enabled_tools=kw.get("enabled_tools")),
+        enabled_tools=kw.get("enabled_tools"),
+        platform=kw.get("platform")),
     check_fn=check_sandbox_requirements,
     emoji="🐍",
 )

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -226,6 +226,7 @@ def _rpc_server_loop(
     tool_call_counter: list,   # mutable [int] so the thread can increment
     max_tool_calls: int,
     allowed_tools: frozenset,
+    platform: Optional[str] = None,
 ):
     """
     Accept one client connection and dispatch tool-call requests until
@@ -419,6 +420,7 @@ def execute_code(
             args=(
                 server_sock, task_id, tool_call_log,
                 tool_call_counter, max_tool_calls, sandbox_tools,
+                platform,
             ),
             daemon=True,
         )

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -451,6 +451,7 @@ HA_CALL_SERVICE_SCHEMA = {
 # Registration
 # ---------------------------------------------------------------------------
 
+from tools.access_control import build_static_access_fn
 from tools.registry import registry
 
 registry.register(
@@ -460,6 +461,8 @@ registry.register(
     handler=_handle_list_entities,
     check_fn=_check_ha_available,
     emoji="🏠",
+    access_fn=build_static_access_fn("homeassistant", "read"),
+    access_static=True,
 )
 
 registry.register(
@@ -469,6 +472,8 @@ registry.register(
     handler=_handle_get_state,
     check_fn=_check_ha_available,
     emoji="🏠",
+    access_fn=build_static_access_fn("homeassistant", "read"),
+    access_static=True,
 )
 
 registry.register(
@@ -478,6 +483,8 @@ registry.register(
     handler=_handle_list_services,
     check_fn=_check_ha_available,
     emoji="🏠",
+    access_fn=build_static_access_fn("homeassistant", "read"),
+    access_static=True,
 )
 
 registry.register(
@@ -487,4 +494,6 @@ registry.register(
     handler=_handle_call_service,
     check_fn=_check_ha_available,
     emoji="🏠",
+    access_fn=build_static_access_fn("homeassistant", "write"),
+    access_static=True,
 )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -80,6 +80,8 @@ import threading
 import time
 from typing import Any, Dict, List, Optional
 
+from tools.access_control import infer_mcp_operation
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -1441,6 +1443,12 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
             check_fn=_make_check_fn(name),
             is_async=False,
             description=schema["description"],
+            access_fn=lambda args, tool_name=tool_name_prefixed, server_name=name, **_kwargs: {
+                "service": "mcp",
+                "account": f"mcp.{server_name}",
+                "operation": infer_mcp_operation(tool_name),
+            },
+            access_static=True,
         )
         registered_names.append(tool_name_prefixed)
 
@@ -1466,6 +1474,12 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
             check_fn=check_fn,
             is_async=False,
             description=schema["description"],
+            access_fn=lambda args, tool_name=schema["name"], server_name=name, **_kwargs: {
+                "service": "mcp",
+                "account": f"mcp.{server_name}",
+                "operation": infer_mcp_operation(tool_name),
+            },
+            access_static=True,
         )
         registered_names.append(schema["name"])
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -27,10 +27,11 @@ class ToolEntry:
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
+        "access_fn", "access_static",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
-                 requires_env, is_async, description, emoji):
+                 requires_env, is_async, description, emoji, access_fn, access_static):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -40,6 +41,8 @@ class ToolEntry:
         self.is_async = is_async
         self.description = description
         self.emoji = emoji
+        self.access_fn = access_fn
+        self.access_static = access_static
 
 
 class ToolRegistry:
@@ -64,6 +67,8 @@ class ToolRegistry:
         is_async: bool = False,
         description: str = "",
         emoji: str = "",
+        access_fn: Callable = None,
+        access_static: bool = False,
     ):
         """Register a tool.  Called at module-import time by each tool file."""
         self._tools[name] = ToolEntry(
@@ -76,6 +81,8 @@ class ToolRegistry:
             is_async=is_async,
             description=description or schema.get("description", ""),
             emoji=emoji,
+            access_fn=access_fn,
+            access_static=access_static,
         )
         if check_fn and toolset not in self._toolset_checks:
             self._toolset_checks[toolset] = check_fn
@@ -84,7 +91,7 @@ class ToolRegistry:
     # Schema retrieval
     # ------------------------------------------------------------------
 
-    def get_definitions(self, tool_names: Set[str], quiet: bool = False) -> List[dict]:
+    def get_definitions(self, tool_names: Set[str], quiet: bool = False, platform: Optional[str] = None) -> List[dict]:
         """Return OpenAI-format tool schemas for the requested tool names.
 
         Only tools whose ``check_fn()`` returns True (or have no check_fn)
@@ -105,6 +112,23 @@ class ToolRegistry:
                     if not quiet:
                         logger.debug("Tool %s check raised; skipping", name)
                     continue
+            if entry.access_fn and entry.access_static:
+                try:
+                    from tools.access_control import evaluate_access
+
+                    decision = evaluate_access(
+                        name,
+                        entry.access_fn({}, tool_name=name),
+                        platform=platform,
+                    )
+                    if not decision.allowed:
+                        if not quiet:
+                            logger.debug("Tool %s hidden by scoped access policy: %s", name, decision.reason)
+                        continue
+                except Exception:
+                    if not quiet:
+                        logger.debug("Tool %s access evaluation raised; skipping", name, exc_info=True)
+                    continue
             result.append({"type": "function", "function": entry.schema})
         return result
 
@@ -123,6 +147,38 @@ class ToolRegistry:
         if not entry:
             return json.dumps({"error": f"Unknown tool: {name}"})
         try:
+            if entry.access_fn:
+                from tools.access_control import evaluate_access
+
+                decision = evaluate_access(
+                    name,
+                    entry.access_fn(args, tool_name=name, **kwargs),
+                    platform=kwargs.get("platform"),
+                )
+                if not decision.allowed:
+                    logger.warning(
+                        "Scoped access denied tool=%s platform=%s service=%s account=%s operation=%s scope=%s",
+                        name,
+                        decision.platform,
+                        decision.service,
+                        decision.account,
+                        decision.operation,
+                        decision.scope,
+                    )
+                    return json.dumps({
+                        "error": (
+                            f"Tool '{name}' is outside the configured scope for platform "
+                            f"'{decision.platform}' (service='{decision.service}', "
+                            f"account='{decision.account}', scope='{decision.scope}', "
+                            f"required='{decision.operation}')."
+                        ),
+                        "error_type": "scope_violation",
+                        "platform": decision.platform,
+                        "service": decision.service,
+                        "account": decision.account,
+                        "scope": decision.scope,
+                        "required_operation": decision.operation,
+                    })
             if entry.is_async:
                 from model_tools import _run_async
                 return _run_async(entry.handler(args, **kwargs))

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -21,6 +21,17 @@ _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a"}
 _VOICE_EXTS = {".ogg", ".opus"}
 
 
+def _send_message_access(args, **_kwargs):
+    target = str((args or {}).get("target") or "").strip().lower()
+    platform = target.split(":", 1)[0] if ":" in target else target
+    platform = platform or os.getenv("HERMES_SESSION_PLATFORM", "").strip().lower() or "default"
+    return {
+        "service": "messaging",
+        "account": f"messaging.{platform}",
+        "operation": "write",
+    }
+
+
 SEND_MESSAGE_SCHEMA = {
     "name": "send_message",
     "description": (
@@ -513,4 +524,5 @@ registry.register(
     handler=send_message_tool,
     check_fn=_check_send_message,
     emoji="📨",
+    access_fn=_send_message_access,
 )


### PR DESCRIPTION
Closes #1154

## Summary
- add a config-driven scoped access control layer for connected-account tools
- enforce scopes in the tool registry before handler dispatch and hide statically denied tools from schemas
- classify Home Assistant and messaging tools explicitly, infer MCP read/write levels, and preserve scope enforcement through `execute_code`
- fix platform string threading through sandbox RPC loop so access control works for tools invoked from `execute_code`

## Config
```yaml
access_control:
  enabled: true
  default_scope: full
  platform_profiles:
    cli: full
    cron: read-only
    telegram: read-only
    discord: read-only
    slack: read-only
    whatsapp: read-only
    signal: read-only
    email: read-only
  services: {}
  accounts: {}
```

Examples:
- allow one MCP server to stay writable on cron:
  `accounts.mcp.github.scope: full`
- keep Home Assistant read-only everywhere except CLI:
  `services.homeassistant.scope: read-only`

## Changes
- `tools/access_control.py` — new module: scope evaluation, MCP operation inference, access decision dataclass
- `tools/registry.py` — `access_fn`/`access_static` on `ToolEntry`, schema hiding for static tools, dispatch-time enforcement
- `tools/homeassistant_tool.py` — static access_fn on all 4 HA tools (3 read, 1 write)
- `tools/mcp_tool.py` — static access_fn with MCP verb inference on all registered MCP tools
- `tools/send_message_tool.py` — dynamic access_fn (operation depends on target arg)
- `tools/code_execution_tool.py` — platform string threaded through sandbox RPC loop
- `model_tools.py` — platform parameter added to `get_tool_definitions` and `handle_function_call`
- `run_agent.py` — platform passed through at all tool dispatch points
- `hermes_cli/config.py` — `access_control` default config, `_config_version` bumped to 9
- `cli.py` — `access_control` defaults added to `load_cli_config()`

## Test plan
```
python -m pytest -o addopts=" tests/tools/test_access_control.py tests/tools/test_code_execution.py tests/test_model_tools.py tests/test_run_agent.py tests/tools/test_homeassistant_tool.py tests/tools/test_send_message_tool.py tests/tools/test_mcp_tool.py tests/hermes_cli/test_tools_config.py tests/test_cli_init.py -q
```
```
python -m pytest -o addopts=" tests/ -q
```
*(finishes with 4 unrelated existing failures in HA websocket integration, delegation credential resolution, and transcription env-sensitive tests)*

## Test coverage
- `test_access_control.py` — 11 tests covering: platform profiles, account overrides, MCP verb inference, static tool hiding, scope violation dispatch, send_message dynamic access, sandbox platform inheritance, disabled bypass, service-level overrides

## Notes
- full-suite unrelated failures observed:
  - `tests/integration/test_ha_integration.py::TestGatewayWebSocket::test_event_received_and_forwarded`
  - `tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_direct_endpoint_does_not_fall_back_to_openrouter_api_key_env`
  - `tests/tools/test_transcription.py::TestGetProvider::test_openai_fallback_to_local`
  - `tests/tools/test_transcription.py::TestTranscribeOpenAI::test_no_key`