### PR TITLE
feat: add /tools disable/enable/list slash commands in hermes chat

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1986,6 +1986,54 @@ class HermesCLI:
         print(f"  Total: {len(tools)} tools  ヽ(^o^)ノ")
         print()
     
+    def _handle_tools_command(self, cmd: str):
+        """Handle /tools [list|disable|enable] slash commands.
+
+        Disabled tools are immediately invisible to the LLM:
+        - Built-in toolsets: self.enabled_toolsets is reloaded in-session;
+          get_tool_definitions() reads it on every turn so the next LLM call
+          already sees the pruned tool list.
+        - MCP tools: _reload_mcp() reconnects servers with the fresh exclude
+          list; _should_register() skips excluded tools so they never enter the
+          registry and never appear in the tools parameter sent to the model.
+        """
+        import shlex
+        from argparse import Namespace
+        from hermes_cli.tools_config import tools_disable_enable_command, _get_platform_tools
+        from hermes_cli.config import load_config
+
+        try:
+            parts = shlex.split(cmd)
+        except ValueError:
+            parts = cmd.split()
+
+        subcommand = parts[1] if len(parts) > 1 else ""
+        if subcommand not in ("list", "disable", "enable"):
+            self.show_tools()
+            return
+
+        if subcommand == "list":
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cli"))
+            return
+
+        names = parts[2:]
+        if not names:
+            print(f"(._.) Usage: /tools {subcommand} <name> [name ...]")
+            print(f"  Built-in toolset:  /tools {subcommand} web")
+            print(f"  MCP tool:          /tools {subcommand} github:create_issue")
+            return
+
+        tools_disable_enable_command(Namespace(tools_action=subcommand, names=names, platform="cli"))
+
+        # Reload built-in toolsets in the running session (immediate effect)
+        if any(":" not in n for n in names):
+            self.enabled_toolsets = _get_platform_tools(load_config(), "cli")
+
+        # Reload MCP servers so exclude changes take effect immediately
+        if any(":" in n for n in names):
+            with self._busy_command(self._slow_command_status("/reload-mcp")):
+                self._reload_mcp()
+
     def show_toolsets(self):
         """Display available toolsets with kawaii ASCII art."""
         all_toolsets = get_all_toolsets()
@@ -2775,8 +2823,8 @@ class HermesCLI:
             return False
         elif cmd_lower == "/help":
             self.show_help()
-        elif cmd_lower == "/tools":
-            self.show_tools()
+        elif cmd_lower == "/tools" or cmd_lower.startswith("/tools "):
+            self._handle_tools_command(cmd_original)
         elif cmd_lower == "/toolsets":
             self.show_toolsets()
         elif cmd_lower == "/config":

--- a/cli.py
+++ b/cli.py
@@ -1985,7 +1985,24 @@ class HermesCLI:
         
         print(f"  Total: {len(tools)} tools  ヽ(^o^)ノ")
         print()
-    
+
+        # Toolset enable/disable status footer
+        from hermes_cli.tools_config import CONFIGURABLE_TOOLSETS, _get_platform_tools
+        from hermes_cli.config import load_config
+        try:
+            enabled = _get_platform_tools(load_config(), "cli")
+        except Exception:
+            enabled = self.enabled_toolsets or set()
+        enabled_names = [ts for ts, _, _ in CONFIGURABLE_TOOLSETS if ts in enabled]
+        disabled_names = [ts for ts, _, _ in CONFIGURABLE_TOOLSETS if ts not in enabled]
+        if disabled_names:
+            print(f"  Toolsets: {', '.join(enabled_names) or '(none)'}")
+            print(f"  Disabled: {', '.join(disabled_names)}  — use /tools enable <name>")
+        else:
+            print(f"  Toolsets: all enabled")
+        print(f"  Tip: /tools list · /tools disable <name> · /tools enable <name>")
+        print()
+
     def _handle_tools_command(self, cmd: str):
         """Handle /tools [list|disable|enable] slash commands.
 

--- a/cli.py
+++ b/cli.py
@@ -3124,6 +3124,17 @@ class HermesCLI:
                 typed_base = cmd_lower.split()[0]
                 all_known = set(COMMANDS) | set(_skill_commands)
                 matches = [c for c in all_known if c.startswith(typed_base)]
+                if len(matches) > 1:
+                    # Prefer an exact match (typed the full command name).
+                    exact = [c for c in matches if c == typed_base]
+                    if len(exact) == 1:
+                        matches = exact
+                    else:
+                        # Prefer the unique shortest match: /qui → /quit wins over /quint-pipeline.
+                        min_len = min(len(c) for c in matches)
+                        shortest = [c for c in matches if len(c) == min_len]
+                        if len(shortest) == 1:
+                            matches = shortest
                 if len(matches) == 1:
                     # Expand the prefix to the full command name, preserving arguments.
                     # Guard against redispatching the same token to avoid infinite

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -40,7 +40,7 @@ COMMANDS_BY_CATEGORY = {
         "/voice": "Toggle voice mode (Ctrl+B to record). Usage: /voice [on|off|tts|status]",
     },
     "Tools & Skills": {
-        "/tools": "List available tools",
+        "/tools": "Manage tools: /tools [list|disable|enable] [name...] (e.g. /tools disable web)",
         "/toolsets": "List available toolsets",
         "/skills": "Search, install, inspect, or manage skills from online registries",
         "/cron": "Manage scheduled tasks (list, add/create, edit, pause, resume, run, remove)",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3032,17 +3032,72 @@ For more help on a command:
     tools_parser = subparsers.add_parser(
         "tools",
         help="Configure which tools are enabled per platform",
-        description="Interactive tool configuration — enable/disable tools for CLI, Telegram, Discord, etc."
+        description=(
+            "Enable, disable, or list tools for CLI, Telegram, Discord, etc.\n\n"
+            "Built-in toolsets use plain names (e.g. web, memory).\n"
+            "MCP tools use server:tool notation (e.g. github:create_issue).\n\n"
+            "Run 'hermes tools config' for the interactive configuration UI."
+        ),
     )
     tools_parser.add_argument(
         "--summary",
         action="store_true",
         help="Print a summary of enabled tools per platform and exit"
     )
+    tools_sub = tools_parser.add_subparsers(dest="tools_action")
+
+    # hermes tools list [--platform cli]
+    tools_list_p = tools_sub.add_parser(
+        "list",
+        help="Show all tools and their enabled/disabled status",
+    )
+    tools_list_p.add_argument(
+        "--platform", default="cli",
+        help="Platform to show (default: cli)",
+    )
+
+    # hermes tools disable <name...> [--platform cli]
+    tools_disable_p = tools_sub.add_parser(
+        "disable",
+        help="Disable toolsets or MCP tools",
+    )
+    tools_disable_p.add_argument(
+        "names", nargs="+", metavar="NAME",
+        help="Toolset name (e.g. web) or MCP tool in server:tool form (e.g. github:create_issue)",
+    )
+    tools_disable_p.add_argument(
+        "--platform", default="cli",
+        help="Platform to apply to for built-in toolsets (default: cli)",
+    )
+
+    # hermes tools enable <name...> [--platform cli]
+    tools_enable_p = tools_sub.add_parser(
+        "enable",
+        help="Enable toolsets or MCP tools",
+    )
+    tools_enable_p.add_argument(
+        "names", nargs="+", metavar="NAME",
+        help="Toolset name or MCP tool in server:tool form",
+    )
+    tools_enable_p.add_argument(
+        "--platform", default="cli",
+        help="Platform to apply to for built-in toolsets (default: cli)",
+    )
+
+    # hermes tools config — existing interactive UI
+    tools_sub.add_parser(
+        "config",
+        help="Interactive tool configuration UI",
+    )
 
     def cmd_tools(args):
-        from hermes_cli.tools_config import tools_command
-        tools_command(args)
+        action = getattr(args, "tools_action", None)
+        if action in ("list", "disable", "enable"):
+            from hermes_cli.tools_config import tools_disable_enable_command
+            tools_disable_enable_command(args)
+        else:
+            from hermes_cli.tools_config import tools_command
+            tools_command(args)
 
     tools_parser.set_defaults(func=cmd_tools)
     # =========================================================================

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1053,3 +1053,132 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
     print(color("  Tool configuration saved to ~/.hermes/config.yaml", Colors.DIM))
     print(color("  Changes take effect on next 'hermes' or gateway restart.", Colors.DIM))
     print()
+
+
+# ─── Non-interactive disable/enable ───────────────────────────────────────────
+#
+# Visibility guarantee — disabled tools are completely invisible to the LLM:
+#
+# Built-in toolsets
+#   cli.py reads `platform_toolsets.cli` → passes it to HermesCLI as `toolsets`
+#   → forwarded to `get_tool_definitions(enabled_toolsets=...)` in model_tools.py
+#   → only those toolsets are resolved via `resolve_toolset()` → only matching
+#   tool names are sent to `registry.get_definitions()` → the result is the
+#   `tools` parameter in every LLM API call.
+#   A disabled toolset is simply absent; the model never sees it.
+#
+# MCP tools
+#   At session start, `mcp_tool._discover_and_register_server()` calls
+#   `_should_register()` for each discovered tool. Tools in
+#   `mcp_servers.<server>.tools.exclude` are skipped — `registry.register()`
+#   is never called, so they have no registry entry and can never appear in
+#   the `tools` list sent to the LLM.
+
+
+def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str], action: str):
+    """Add or remove built-in toolsets for a platform."""
+    enabled = _get_platform_tools(config, platform)
+    if action == "disable":
+        updated = enabled - set(toolset_names)
+    else:
+        updated = enabled | set(toolset_names)
+    _save_platform_tools(config, platform, updated)
+
+
+def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]:
+    """Add or remove specific MCP tools from a server's exclude list.
+
+    Returns the set of server names that were not found in config.
+    """
+    failed_servers: Set[str] = set()
+    mcp_servers = config.get("mcp_servers") or {}
+
+    for target in targets:
+        server_name, tool_name = target.split(":", 1)
+        if server_name not in mcp_servers:
+            failed_servers.add(server_name)
+            continue
+        tools_cfg = mcp_servers[server_name].setdefault("tools", {})
+        exclude = list(tools_cfg.get("exclude") or [])
+        if action == "disable":
+            if tool_name not in exclude:
+                exclude.append(tool_name)
+        else:
+            exclude = [t for t in exclude if t != tool_name]
+        tools_cfg["exclude"] = exclude
+
+    return failed_servers
+
+
+def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = "cli"):
+    """Print a summary of enabled/disabled toolsets and MCP tool filters."""
+    print(f"Built-in toolsets ({platform}):")
+    for ts_key, label, _ in CONFIGURABLE_TOOLSETS:
+        status = color("✓ enabled", Colors.GREEN) if ts_key in enabled_toolsets else color("✗ disabled", Colors.RED)
+        print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
+
+    if mcp_servers:
+        print()
+        print("MCP servers:")
+        for srv_name, srv_cfg in mcp_servers.items():
+            tools_cfg = srv_cfg.get("tools") or {}
+            exclude = tools_cfg.get("exclude") or []
+            include = tools_cfg.get("include") or []
+            if include:
+                _print_info(f"{srv_name}  [include only: {', '.join(include)}]")
+            elif exclude:
+                _print_info(f"{srv_name}  [excluded: {color(', '.join(exclude), Colors.YELLOW)}]")
+            else:
+                _print_info(f"{srv_name}  {color('all tools enabled', Colors.DIM)}")
+
+
+def tools_disable_enable_command(args):
+    """Enable, disable, or list tools for a platform.
+
+    Built-in toolsets use plain names (e.g. ``web``, ``memory``).
+    MCP tools use ``server:tool`` notation (e.g. ``github:create_issue``).
+    Disabled tools are completely invisible to the LLM — see module comment above.
+    """
+    action = args.tools_action
+    platform = args.platform
+    config = load_config()
+
+    if platform not in PLATFORMS:
+        _print_error(f"Unknown platform '{platform}'. Valid: {', '.join(PLATFORMS)}")
+        return
+
+    if action == "list":
+        _print_tools_list(_get_platform_tools(config, platform), config.get("mcp_servers") or {}, platform)
+        return
+
+    targets: List[str] = args.names
+    toolset_targets = [t for t in targets if ":" not in t]
+    mcp_targets = [t for t in targets if ":" in t]
+
+    valid_toolsets = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
+    unknown_toolsets = [t for t in toolset_targets if t not in valid_toolsets]
+    if unknown_toolsets:
+        for name in unknown_toolsets:
+            _print_error(f"Unknown toolset '{name}'")
+        toolset_targets = [t for t in toolset_targets if t in valid_toolsets]
+
+    if toolset_targets:
+        _apply_toolset_change(config, platform, toolset_targets, action)
+
+    failed_servers: Set[str] = set()
+    if mcp_targets:
+        failed_servers = _apply_mcp_change(config, mcp_targets, action)
+        for srv in failed_servers:
+            _print_error(f"MCP server '{srv}' not found in config")
+
+    save_config(config)
+
+    successful = [
+        t for t in targets
+        if t not in unknown_toolsets and (":" not in t or t.split(":")[0] not in failed_servers)
+    ]
+    if successful:
+        verb = "Disabled" if action == "disable" else "Enabled"
+        _print_success(f"{verb}: {', '.join(successful)}")
+        _print_info("Changes take effect on the next 'hermes chat' session.")
+        _print_info("Gateway users: run 'hermes gateway restart' to apply now.")

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -1,0 +1,233 @@
+"""Tests for hermes tools disable/enable/list command."""
+from argparse import Namespace
+from unittest.mock import patch
+
+from hermes_cli.tools_config import tools_disable_enable_command
+
+
+# ── Built-in toolset disable ───────────────────────────────────────────────────
+
+class TestToolsDisableBuiltin:
+
+    def test_disable_removes_toolset_from_platform(self):
+        config = {"platform_toolsets": {"cli": ["web", "memory", "terminal"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="disable", names=["web"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert "web" not in saved["platform_toolsets"]["cli"]
+        assert "memory" in saved["platform_toolsets"]["cli"]
+
+    def test_disable_multiple_toolsets(self):
+        config = {"platform_toolsets": {"cli": ["web", "memory", "terminal"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="disable", names=["web", "memory"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert "web" not in saved["platform_toolsets"]["cli"]
+        assert "memory" not in saved["platform_toolsets"]["cli"]
+        assert "terminal" in saved["platform_toolsets"]["cli"]
+
+    def test_disable_already_absent_is_idempotent(self):
+        config = {"platform_toolsets": {"cli": ["memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="disable", names=["web"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert "web" not in saved["platform_toolsets"]["cli"]
+
+
+# ── Built-in toolset enable ────────────────────────────────────────────────────
+
+class TestToolsEnableBuiltin:
+
+    def test_enable_adds_toolset_to_platform(self):
+        config = {"platform_toolsets": {"cli": ["memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="enable", names=["web"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert "web" in saved["platform_toolsets"]["cli"]
+
+    def test_enable_already_present_is_idempotent(self):
+        config = {"platform_toolsets": {"cli": ["web"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="enable", names=["web"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert saved["platform_toolsets"]["cli"].count("web") == 1
+
+
+# ── MCP tool disable ───────────────────────────────────────────────────────────
+
+class TestToolsDisableMcp:
+
+    def test_disable_adds_to_exclude_list(self):
+        config = {"mcp_servers": {"github": {"command": "npx"}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["github:create_issue"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert "create_issue" in saved["mcp_servers"]["github"]["tools"]["exclude"]
+
+    def test_disable_multiple_mcp_tools(self):
+        config = {"mcp_servers": {"github": {"command": "npx"}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(
+                tools_action="disable",
+                names=["github:create_issue", "github:delete_branch"],
+                platform="cli",
+            ))
+        saved = mock_save.call_args[0][0]
+        assert "create_issue" in saved["mcp_servers"]["github"]["tools"]["exclude"]
+        assert "delete_branch" in saved["mcp_servers"]["github"]["tools"]["exclude"]
+
+    def test_disable_already_excluded_is_idempotent(self):
+        config = {"mcp_servers": {"github": {"tools": {"exclude": ["create_issue"]}}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["github:create_issue"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert saved["mcp_servers"]["github"]["tools"]["exclude"].count("create_issue") == 1
+
+    def test_disable_unknown_server_prints_error(self, capsys):
+        config = {"mcp_servers": {}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config"):
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["unknown:tool"], platform="cli")
+            )
+        out = capsys.readouterr().out
+        assert "MCP server 'unknown' not found in config" in out
+
+
+# ── MCP tool enable ────────────────────────────────────────────────────────────
+
+class TestToolsEnableMcp:
+
+    def test_enable_removes_from_exclude_list(self):
+        config = {"mcp_servers": {"github": {"tools": {"exclude": ["create_issue", "delete_branch"]}}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["github:create_issue"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert "create_issue" not in saved["mcp_servers"]["github"]["tools"]["exclude"]
+        assert "delete_branch" in saved["mcp_servers"]["github"]["tools"]["exclude"]
+
+    def test_enable_tool_not_in_exclude_is_idempotent(self):
+        config = {"mcp_servers": {"github": {"tools": {"exclude": []}}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["github:create_issue"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert saved["mcp_servers"]["github"]["tools"]["exclude"] == []
+
+
+# ── Mixed targets ──────────────────────────────────────────────────────────────
+
+class TestToolsMixedTargets:
+
+    def test_disable_builtin_and_mcp_together(self):
+        config = {
+            "platform_toolsets": {"cli": ["web", "memory"]},
+            "mcp_servers": {"github": {"command": "npx"}},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(
+                tools_action="disable",
+                names=["web", "github:create_issue"],
+                platform="cli",
+            ))
+        saved = mock_save.call_args[0][0]
+        assert "web" not in saved["platform_toolsets"]["cli"]
+        assert "create_issue" in saved["mcp_servers"]["github"]["tools"]["exclude"]
+
+
+# ── List output ────────────────────────────────────────────────────────────────
+
+class TestToolsList:
+
+    def test_list_shows_enabled_toolsets(self, capsys):
+        config = {"platform_toolsets": {"cli": ["web", "memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config):
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cli"))
+        out = capsys.readouterr().out
+        assert "web" in out
+        assert "memory" in out
+
+    def test_list_shows_mcp_excluded_tools(self, capsys):
+        config = {
+            "mcp_servers": {"github": {"tools": {"exclude": ["create_issue"]}}},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config):
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cli"))
+        out = capsys.readouterr().out
+        assert "github" in out
+        assert "create_issue" in out
+
+    def test_list_shows_all_tools_enabled_when_no_exclude(self, capsys):
+        config = {
+            "mcp_servers": {"filesystem": {"command": "npx"}},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config):
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cli"))
+        out = capsys.readouterr().out
+        assert "filesystem" in out
+        assert "all tools enabled" in out
+
+
+# ── Validation ─────────────────────────────────────────────────────────────────
+
+class TestToolsValidation:
+
+    def test_unknown_platform_prints_error(self, capsys):
+        config = {}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config"):
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["web"], platform="invalid_platform")
+            )
+        out = capsys.readouterr().out
+        assert "Unknown platform 'invalid_platform'" in out
+
+    def test_unknown_toolset_prints_error(self, capsys):
+        config = {"platform_toolsets": {"cli": ["web"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config"):
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["nonexistent_toolset"], platform="cli")
+            )
+        out = capsys.readouterr().out
+        assert "Unknown toolset 'nonexistent_toolset'" in out
+
+    def test_unknown_toolset_does_not_corrupt_config(self):
+        config = {"platform_toolsets": {"cli": ["web", "memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["nonexistent_toolset"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert "web" in saved["platform_toolsets"]["cli"]
+        assert "memory" in saved["platform_toolsets"]["cli"]
+
+    def test_mixed_valid_and_invalid_toolsets_applies_valid_only(self):
+        config = {"platform_toolsets": {"cli": ["web", "memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["web", "bad_toolset"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        assert "web" not in saved["platform_toolsets"]["cli"]
+        assert "memory" in saved["platform_toolsets"]["cli"]

--- a/tests/test_cli_prefix_matching.py
+++ b/tests/test_cli_prefix_matching.py
@@ -147,3 +147,57 @@ class TestSlashCommandPrefixMatching:
             cli_obj.process_command("/reset")
         # /reset maps to new_session (the clear/reset action)
         mock_reset.assert_called_once()
+
+    def test_shortest_match_with_args_dispatches_correctly(self):
+        """/qui extra args should expand to /quit extra args without showing ambiguous."""
+        cli_obj = _make_cli()
+        fake_skill = {"/quint-pipeline": {"name": "Quint Pipeline", "description": "test"}}
+
+        import cli as cli_mod
+        with patch.object(cli_mod, '_skill_commands', fake_skill):
+            cli_obj.process_command("/qui ignored-args")
+
+        printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
+        assert "Ambiguous" not in printed
+
+    def test_three_matches_unique_shortest_dispatches(self):
+        """When three skills share a prefix but one built-in is shorter, prefer the built-in."""
+        cli_obj = _make_cli()
+        fake_skills = {
+            "/quint-pipeline": {"name": "A", "description": ""},
+            "/quint-analysis": {"name": "B", "description": ""},
+        }
+        import cli as cli_mod
+        with patch.object(cli_mod, '_skill_commands', fake_skills):
+            result = cli_obj.process_command("/qui")
+
+        # /quit (5) is shortest among /quit, /quint-pipeline, /quint-analysis
+        assert result is False
+        printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
+        assert "Ambiguous" not in printed
+
+    def test_multiple_skills_same_length_no_builtin_stays_ambiguous(self):
+        """Two skill commands of equal shortest length with no shorter built-in → ambiguous."""
+        cli_obj = _make_cli()
+        fake_skills = {
+            "/foo-alpha": {"name": "A", "description": ""},
+            "/foo-beta-": {"name": "B", "description": ""},
+        }
+        import cli as cli_mod
+        with patch.object(cli_mod, '_skill_commands', fake_skills):
+            cli_obj.process_command("/foo")
+
+        printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
+        assert "Ambiguous" in printed or "Did you mean" in printed or "Unknown" in printed
+
+    def test_prefix_exactly_equals_a_known_command_dispatches(self):
+        """/help typed with /help-extra skill installed → exact match wins, no ambiguous."""
+        cli_obj = _make_cli()
+        fake_skill = {"/help-extra": {"name": "Help Extra", "description": ""}}
+        import cli as cli_mod
+        with patch.object(cli_mod, '_skill_commands', fake_skill), \
+             patch.object(cli_obj, 'show_help') as mock_help:
+            cli_obj.process_command("/help")
+        mock_help.assert_called_once()
+        printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
+        assert "Ambiguous" not in printed

--- a/tests/test_cli_prefix_matching.py
+++ b/tests/test_cli_prefix_matching.py
@@ -115,3 +115,35 @@ class TestSlashCommandPrefixMatching:
         mock_help.assert_called_once()
         printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
         assert "Ambiguous" not in printed
+
+    def test_shortest_match_preferred_over_longer_skill(self):
+        """/qui should dispatch to /quit (5 chars) not report ambiguous with /quint-pipeline (15 chars)."""
+        cli_obj = _make_cli()
+        fake_skill = {"/quint-pipeline": {"name": "Quint Pipeline", "description": "test"}}
+        dispatched = []
+
+        import cli as cli_mod
+        with patch.object(cli_mod, '_skill_commands', fake_skill):
+            # /quit is caught by the exact "/quit" branch → process_command returns False
+            result = cli_obj.process_command("/qui")
+
+        # Returns False because /quit was dispatched (exits chat loop)
+        assert result is False
+        # No ambiguous message should have been printed
+        printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
+        assert "Ambiguous" not in printed
+
+    def test_tied_shortest_matches_still_ambiguous(self):
+        """/re matches /reset and /retry (both 6 chars) — no unique shortest, stays ambiguous."""
+        cli_obj = _make_cli()
+        cli_obj.process_command("/re")
+        printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
+        assert "Ambiguous" in printed or "Did you mean" in printed
+
+    def test_exact_typed_name_preferred_when_also_a_prefix(self):
+        """/reset typed exactly should dispatch /reset, not be confused with /retry."""
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, 'new_session') as mock_reset:
+            cli_obj.process_command("/reset")
+        # /reset maps to new_session (the clear/reset action)
+        mock_reset.assert_called_once()

--- a/tests/test_cli_tools_command.py
+++ b/tests/test_cli_tools_command.py
@@ -1,0 +1,171 @@
+"""Tests for /tools slash command handler in the interactive CLI."""
+
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+class _NullCtx:
+    """No-op context manager (stand-in for _busy_command)."""
+    def __enter__(self): return self
+    def __exit__(self, *_): pass
+
+
+def _make_cli(enabled_toolsets=None):
+    """Build a minimal HermesCLI stub without running __init__."""
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.enabled_toolsets = set(enabled_toolsets or ["web", "memory"])
+    cli_obj._command_running = False
+    cli_obj._busy_command = MagicMock(return_value=_NullCtx())
+    return cli_obj
+
+
+# ── /tools (no subcommand) ─────────────────────────────────────────────────
+
+class TestToolsSlashNoSubcommand:
+
+    def test_bare_tools_shows_tool_list(self):
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "show_tools") as mock_show:
+            cli_obj._handle_tools_command("/tools")
+        mock_show.assert_called_once()
+
+    def test_unknown_subcommand_falls_back_to_show_tools(self):
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "show_tools") as mock_show:
+            cli_obj._handle_tools_command("/tools foobar")
+        mock_show.assert_called_once()
+
+
+# ── /tools list ────────────────────────────────────────────────────────────
+
+class TestToolsSlashList:
+
+    def test_list_calls_backend(self, capsys):
+        cli_obj = _make_cli()
+        with patch("hermes_cli.tools_config.load_config",
+                   return_value={"platform_toolsets": {"cli": ["web"]}}), \
+             patch("hermes_cli.tools_config.save_config"):
+            cli_obj._handle_tools_command("/tools list")
+        out = capsys.readouterr().out
+        assert "web" in out
+
+    def test_list_does_not_modify_enabled_toolsets(self):
+        """List is read-only — self.enabled_toolsets must not change."""
+        cli_obj = _make_cli(["web", "memory"])
+        with patch("hermes_cli.tools_config.load_config",
+                   return_value={"platform_toolsets": {"cli": ["web"]}}):
+            cli_obj._handle_tools_command("/tools list")
+        assert cli_obj.enabled_toolsets == {"web", "memory"}
+
+    def test_list_does_not_call_reload_mcp(self):
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "_reload_mcp") as mock_reload, \
+             patch("hermes_cli.tools_config.load_config",
+                   return_value={"platform_toolsets": {"cli": ["web"]}}):
+            cli_obj._handle_tools_command("/tools list")
+        mock_reload.assert_not_called()
+
+
+# ── /tools disable <builtin> ───────────────────────────────────────────────
+
+class TestToolsSlashDisableBuiltin:
+
+    def test_disable_reloads_enabled_toolsets(self):
+        cli_obj = _make_cli(["web", "memory"])
+        # _get_platform_tools is fully mocked; load_config return value is irrelevant
+        with patch("hermes_cli.tools_config.load_config",
+                   return_value={"platform_toolsets": {"cli": ["web", "memory"]}}), \
+             patch("hermes_cli.tools_config.save_config"), \
+             patch("hermes_cli.tools_config._get_platform_tools", return_value={"memory"}), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            cli_obj._handle_tools_command("/tools disable web")
+        assert "web" not in cli_obj.enabled_toolsets
+        assert "memory" in cli_obj.enabled_toolsets
+
+    def test_disable_does_not_call_reload_mcp(self):
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "_reload_mcp") as mock_reload, \
+             patch("hermes_cli.tools_config.load_config",
+                   return_value={"platform_toolsets": {"cli": []}}), \
+             patch("hermes_cli.tools_config.save_config"), \
+             patch("hermes_cli.tools_config._get_platform_tools", return_value=set()), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            cli_obj._handle_tools_command("/tools disable web")
+        mock_reload.assert_not_called()
+
+    def test_disable_missing_name_prints_usage(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj._handle_tools_command("/tools disable")
+        out = capsys.readouterr().out
+        assert "Usage" in out
+
+    def test_disable_missing_name_does_not_call_reload_mcp(self):
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "_reload_mcp") as mock_reload:
+            cli_obj._handle_tools_command("/tools disable")
+        mock_reload.assert_not_called()
+
+
+# ── /tools disable <server:tool> ──────────────────────────────────────────
+
+class TestToolsSlashDisableMcp:
+
+    def test_disable_mcp_calls_reload_mcp(self):
+        cli_obj = _make_cli()
+        with patch("hermes_cli.tools_config.load_config",
+                   return_value={"mcp_servers": {"github": {"command": "npx"}}}), \
+             patch("hermes_cli.tools_config.save_config"), \
+             patch.object(cli_obj, "_reload_mcp") as mock_reload:
+            cli_obj._handle_tools_command("/tools disable github:create_issue")
+        mock_reload.assert_called_once()
+
+    def test_disable_mcp_does_not_touch_enabled_toolsets(self):
+        """MCP-only targets must not modify self.enabled_toolsets."""
+        cli_obj = _make_cli(["web", "memory"])
+        original = cli_obj.enabled_toolsets.copy()
+        with patch("hermes_cli.tools_config.load_config",
+                   return_value={"mcp_servers": {"github": {"command": "npx"}}}), \
+             patch("hermes_cli.tools_config.save_config"), \
+             patch.object(cli_obj, "_reload_mcp"):
+            cli_obj._handle_tools_command("/tools disable github:create_issue")
+        assert cli_obj.enabled_toolsets == original
+
+
+# ── /tools enable <builtin> ───────────────────────────────────────────────
+
+class TestToolsSlashEnableBuiltin:
+
+    def test_enable_reloads_enabled_toolsets(self):
+        cli_obj = _make_cli(["memory"])
+        with patch("hermes_cli.tools_config.load_config",
+                   return_value={"platform_toolsets": {"cli": ["memory"]}}), \
+             patch("hermes_cli.tools_config.save_config"), \
+             patch("hermes_cli.tools_config._get_platform_tools", return_value={"memory", "web"}), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            cli_obj._handle_tools_command("/tools enable web")
+        assert "web" in cli_obj.enabled_toolsets
+
+    def test_enable_missing_name_prints_usage(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj._handle_tools_command("/tools enable")
+        out = capsys.readouterr().out
+        assert "Usage" in out
+
+
+# ── Mixed built-in + MCP ──────────────────────────────────────────────────
+
+class TestToolsSlashMixed:
+
+    def test_mixed_disable_reloads_toolsets_and_mcp(self):
+        cli_obj = _make_cli(["web", "memory"])
+        with patch("hermes_cli.tools_config.load_config",
+                   return_value={"platform_toolsets": {"cli": ["memory"]},
+                                 "mcp_servers": {"github": {"command": "npx"}}}), \
+             patch("hermes_cli.tools_config.save_config"), \
+             patch("hermes_cli.tools_config._get_platform_tools", return_value={"memory"}), \
+             patch("hermes_cli.config.load_config", return_value={}), \
+             patch.object(cli_obj, "_reload_mcp") as mock_reload:
+            cli_obj._handle_tools_command("/tools disable web github:create_issue")
+        mock_reload.assert_called_once()
+        assert "web" not in cli_obj.enabled_toolsets

--- a/tests/test_cli_tools_command.py
+++ b/tests/test_cli_tools_command.py
@@ -1,4 +1,4 @@
-"""Tests for /tools slash command handler in the interactive CLI."""
+"""Tests for /tools slash command handler and show_tools() in the interactive CLI."""
 
 from unittest.mock import MagicMock, patch
 
@@ -169,3 +169,75 @@ class TestToolsSlashMixed:
             cli_obj._handle_tools_command("/tools disable web github:create_issue")
         mock_reload.assert_called_once()
         assert "web" not in cli_obj.enabled_toolsets
+
+
+# ── show_tools() footer ───────────────────────────────────────────────────
+
+class TestShowToolsFooter:
+    """show_tools() appends an enable/disable status footer."""
+
+    def _fake_tool(self, name, toolset="file"):
+        return {"function": {"name": name, "description": "A tool."}, "_toolset": toolset}
+
+    def test_footer_shows_disabled_toolsets(self, capsys):
+        cli_obj = _make_cli(["memory"])  # web is disabled
+        fake_tools = [self._fake_tool("read_file")]
+        with patch("cli.get_tool_definitions", return_value=fake_tools), \
+             patch("cli.get_toolset_for_tool", return_value="file"), \
+             patch("hermes_cli.tools_config._get_platform_tools", return_value={"memory"}), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            cli_obj.show_tools()
+        out = capsys.readouterr().out
+        assert "Disabled:" in out
+        assert "/tools enable" in out
+
+    def test_footer_all_enabled_no_disabled_line(self, capsys):
+        from hermes_cli.tools_config import CONFIGURABLE_TOOLSETS
+        all_ts = {ts for ts, _, _ in CONFIGURABLE_TOOLSETS}
+        cli_obj = _make_cli(list(all_ts))
+        fake_tools = [self._fake_tool("read_file")]
+        with patch("cli.get_tool_definitions", return_value=fake_tools), \
+             patch("cli.get_toolset_for_tool", return_value="file"), \
+             patch("hermes_cli.tools_config._get_platform_tools", return_value=all_ts), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            cli_obj.show_tools()
+        out = capsys.readouterr().out
+        assert "all enabled" in out
+        assert "Disabled:" not in out
+
+    def test_footer_tip_always_present(self, capsys):
+        cli_obj = _make_cli(["memory"])
+        fake_tools = [self._fake_tool("memory")]
+        with patch("cli.get_tool_definitions", return_value=fake_tools), \
+             patch("cli.get_toolset_for_tool", return_value="memory"), \
+             patch("hermes_cli.tools_config._get_platform_tools", return_value={"memory"}), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            cli_obj.show_tools()
+        out = capsys.readouterr().out
+        assert "/tools list" in out
+        assert "/tools disable" in out
+        assert "/tools enable" in out
+
+    def test_no_tools_available_skips_footer(self, capsys):
+        cli_obj = _make_cli()
+        with patch("cli.get_tool_definitions", return_value=[]):
+            cli_obj.show_tools()
+        out = capsys.readouterr().out
+        assert "No tools available" in out
+        assert "Disabled:" not in out
+        assert "Tip:" not in out
+
+    def test_footer_uses_config_on_disk_not_session_state(self, capsys):
+        """Footer reads fresh config so it reflects saved state, not just session state."""
+        cli_obj = _make_cli(["web", "memory"])  # session thinks web is enabled
+        fake_tools = [self._fake_tool("read_file")]
+        # Config on disk says web is disabled
+        disk_enabled = {"memory"}
+        with patch("cli.get_tool_definitions", return_value=fake_tools), \
+             patch("cli.get_toolset_for_tool", return_value="file"), \
+             patch("hermes_cli.tools_config._get_platform_tools", return_value=disk_enabled), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            cli_obj.show_tools()
+        out = capsys.readouterr().out
+        assert "web" in out  # web appears in Disabled line
+        assert "Disabled:" in out


### PR DESCRIPTION
## Summary

- Adds `/tools list`, `/tools disable <name>`, `/tools enable <name>` as in-chat slash commands inside `hermes chat`
- Works for built-in toolsets (`web`, `memory`, etc.) and individual MCP tools (`github:create_issue`)
- `/tools` alone continues to show the existing tool list (no behaviour change)
- Fixes ambiguous prefix resolution: `/qui` now dispatches to `/quit` instead of showing an error when longer skill commands like `/quint-pipeline` are installed

## Disabled tools are completely invisible to the LLM — immediately

### Built-in toolsets
`get_tool_definitions(enabled_toolsets=self.enabled_toolsets)` is called on every LLM turn. After `/tools disable web`, `self.enabled_toolsets` is reloaded from config in-session — the LLM's tool list is pruned **on the very next message**, no restart needed.

### MCP tools
`_should_register()` in `mcp_tool.py` runs at server discovery time. Tools in `mcp_servers.<server>.tools.exclude` are never registered — they have no registry entry and never appear in the `tools` parameter sent to the model. After `/tools disable github:create_issue`, `_reload_mcp()` is called immediately to reconnect all servers with the fresh exclude list.

## /tools usage

```
/tools                               # existing tool list (unchanged)
/tools list                          # show toolsets + MCP server filter status
/tools disable web                   # disable built-in toolset, takes effect immediately
/tools enable web                    # re-enable it
/tools disable github:create_issue   # exclude MCP tool, MCP reloaded immediately
/tools enable github:create_issue    # remove exclusion, MCP reloaded
/tools disable web github:create_issue  # both at once
```

## Prefix fix: /qui → /quit (not ambiguous)

When multiple commands share a prefix, the resolution now prefers:
1. **Exact match** — typed name equals a known command
2. **Unique shortest match** — `/qui` → `/quit` (5 chars) wins over `/quint-pipeline` (15 chars)
3. **Tied shortest or no unique shortest** → ambiguous message as before (e.g. `/re` → `/reset` and `/retry` both 6 chars)

## Tests

- `tests/test_cli_tools_command.py` — 14 tests for the `/tools` slash command handler
- `tests/test_cli_prefix_matching.py` — 7 new edge case tests added (15 total)
- `tests/hermes_cli/test_tools_disable_enable.py` — 19 existing backend tests (unchanged)