### PR TITLE
feat: add option to skip email attachments (#1137)

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -135,7 +135,7 @@ def _extract_email_address(raw: str) -> str:
     return raw.strip().lower()
 
 
-def _extract_attachments(msg: email_lib.message.Message) -> List[Dict[str, Any]]:
+def _extract_attachments(msg: email_lib.message.Message, skip_attachments: bool = False) -> List[Dict[str, Any]]:
     """Extract attachment metadata and cache files locally."""
     attachments = []
     if not msg.is_multipart():
@@ -143,6 +143,8 @@ def _extract_attachments(msg: email_lib.message.Message) -> List[Dict[str, Any]]
 
     for part in msg.walk():
         disposition = str(part.get("Content-Disposition", ""))
+        if skip_attachments and ("attachment" in disposition or "inline" in disposition):
+            continue
         if "attachment" not in disposition and "inline" not in disposition:
             continue
         # Skip text/plain and text/html body parts
@@ -195,6 +197,7 @@ class EmailAdapter(BasePlatformAdapter):
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
         self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
         self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        self._skip_attachments = os.getenv("EMAIL_SKIP_ATTACHMENTS", "false").lower() == "true"
 
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
@@ -306,7 +309,7 @@ class EmailAdapter(BasePlatformAdapter):
                 message_id = msg.get("Message-ID", "")
                 in_reply_to = msg.get("In-Reply-To", "")
                 body = _extract_text_body(msg)
-                attachments = _extract_attachments(msg)
+                attachments = _extract_attachments(msg, skip_attachments=self._skip_attachments)
 
                 results.append({
                     "uid": uid,


### PR DESCRIPTION
Adds EMAIL_SKIP_ATTACHMENTS environment variable to the Email adapter.

Why: Protects against malware and saves bandwidth by ignoring attachments before payload decoding.

Fixes: #1137

Changes:
gateway/platforms/email.py: Added config check and logic to bypass attachment/inline parts in _extract_attachments.

How to Test:
Set EMAIL_SKIP_ATTACHMENTS=true.
Send email with file; verify it's ignored in logs.
Set to false; verify attachments work as usual.

