### PR TITLE
fix(docker): mount current cwd into /workspace by default

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -86,3 +86,148 @@ def test_ensure_docker_available_uses_resolved_executable(monkeypatch):
         })
     ]
 
+
+def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
+    """When host_cwd is provided, it should be auto-mounted to /workspace."""
+    import os
+
+    # Create a temp directory to simulate user's project directory
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+
+    # Mock Docker availability
+    def _run_docker_version(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, stdout="Docker version", stderr="")
+
+    def _run_docker_create(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 1, stdout="", stderr="storage-opt not supported")
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env.subprocess, "run", _run_docker_version)
+
+    # Mock the inner _Docker class to capture run_args
+    captured_run_args = []
+
+    class MockInnerDocker:
+        container_id = "mock-container-123"
+        config = type("Config", (), {"executable": "/usr/bin/docker", "forward_env": [], "env": {}})()
+
+        def __init__(self, **kwargs):
+            captured_run_args.extend(kwargs.get("run_args", []))
+
+    monkeypatch.setattr(
+        "minisweagent.environments.docker.DockerEnvironment",
+        MockInnerDocker,
+    )
+
+    # Create environment with host_cwd
+    env = docker_env.DockerEnvironment(
+        image="python:3.11",
+        cwd="/workspace",
+        timeout=60,
+        persistent_filesystem=False,  # Non-persistent mode uses tmpfs, should be overridden
+        task_id="test-auto-mount",
+        volumes=[],
+        host_cwd=str(project_dir),
+        auto_mount_cwd=True,
+    )
+
+    # Check that the host_cwd was added as a volume mount
+    volume_mount = f"-v {project_dir}:/workspace"
+    run_args_str = " ".join(captured_run_args)
+    assert f"{project_dir}:/workspace" in run_args_str, f"Expected auto-mount in run_args: {run_args_str}"
+
+
+def test_auto_mount_disabled_via_env(monkeypatch, tmp_path):
+    """Auto-mount should be disabled when TERMINAL_DOCKER_NO_AUTO_MOUNT is set."""
+    import os
+
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+
+    monkeypatch.setenv("TERMINAL_DOCKER_NO_AUTO_MOUNT", "true")
+
+    def _run_docker_version(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, stdout="Docker version", stderr="")
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env.subprocess, "run", _run_docker_version)
+
+    captured_run_args = []
+
+    class MockInnerDocker:
+        container_id = "mock-container-456"
+        config = type("Config", (), {"executable": "/usr/bin/docker", "forward_env": [], "env": {}})()
+
+        def __init__(self, **kwargs):
+            captured_run_args.extend(kwargs.get("run_args", []))
+
+    monkeypatch.setattr(
+        "minisweagent.environments.docker.DockerEnvironment",
+        MockInnerDocker,
+    )
+
+    env = docker_env.DockerEnvironment(
+        image="python:3.11",
+        cwd="/workspace",
+        timeout=60,
+        persistent_filesystem=False,
+        task_id="test-no-auto-mount",
+        volumes=[],
+        host_cwd=str(project_dir),
+        auto_mount_cwd=True,
+    )
+
+    # Check that the host_cwd was NOT added (because env var disabled it)
+    run_args_str = " ".join(captured_run_args)
+    assert f"{project_dir}:/workspace" not in run_args_str, f"Auto-mount should be disabled: {run_args_str}"
+
+
+def test_auto_mount_skipped_when_workspace_already_mounted(monkeypatch, tmp_path):
+    """Auto-mount should be skipped if /workspace is already mounted via user volumes."""
+    import os
+
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+
+    def _run_docker_version(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, stdout="Docker version", stderr="")
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env.subprocess, "run", _run_docker_version)
+
+    captured_run_args = []
+
+    class MockInnerDocker:
+        container_id = "mock-container-789"
+        config = type("Config", (), {"executable": "/usr/bin/docker", "forward_env": [], "env": {}})()
+
+        def __init__(self, **kwargs):
+            captured_run_args.extend(kwargs.get("run_args", []))
+
+    monkeypatch.setattr(
+        "minisweagent.environments.docker.DockerEnvironment",
+        MockInnerDocker,
+    )
+
+    # User already configured a volume mount for /workspace
+    env = docker_env.DockerEnvironment(
+        image="python:3.11",
+        cwd="/workspace",
+        timeout=60,
+        persistent_filesystem=False,
+        task_id="test-workspace-exists",
+        volumes=[f"{other_dir}:/workspace"],  # User explicitly mounted something to /workspace
+        host_cwd=str(project_dir),
+        auto_mount_cwd=True,
+    )
+
+    # The user's explicit mount should be present
+    run_args_str = " ".join(captured_run_args)
+    assert f"{other_dir}:/workspace" in run_args_str
+
+    # But the auto-mount should NOT add a duplicate
+    assert run_args_str.count(":/workspace") == 1, f"Should only have one /workspace mount: {run_args_str}"
+

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -231,3 +231,44 @@ def test_auto_mount_skipped_when_workspace_already_mounted(monkeypatch, tmp_path
     # But the auto-mount should NOT add a duplicate
     assert run_args_str.count(":/workspace") == 1, f"Should only have one /workspace mount: {run_args_str}"
 
+
+def test_auto_mount_replaces_persistent_workspace_bind(monkeypatch, tmp_path):
+    """Persistent mode should still mount host cwd at /workspace when available."""
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+
+    def _run_docker_version(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, stdout="Docker version", stderr="")
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env.subprocess, "run", _run_docker_version)
+
+    captured_run_args = []
+
+    class MockInnerDocker:
+        container_id = "mock-container-persistent"
+        config = type("Config", (), {"executable": "/usr/bin/docker", "forward_env": [], "env": {}})()
+
+        def __init__(self, **kwargs):
+            captured_run_args.extend(kwargs.get("run_args", []))
+
+    monkeypatch.setattr(
+        "minisweagent.environments.docker.DockerEnvironment",
+        MockInnerDocker,
+    )
+
+    docker_env.DockerEnvironment(
+        image="python:3.11",
+        cwd="/workspace",
+        timeout=60,
+        persistent_filesystem=True,
+        task_id="test-persistent-auto-mount",
+        volumes=[],
+        host_cwd=str(project_dir),
+        auto_mount_cwd=True,
+    )
+
+    run_args_str = " ".join(captured_run_args)
+    assert f"{project_dir}:/workspace" in run_args_str
+    assert "/sandboxes/docker/test-persistent-auto-mount/workspace:/workspace" not in run_args_str
+

--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -91,17 +91,18 @@ class TestCwdHandling:
                 "/home/ paths should be replaced for modal backend."
             )
 
-    def test_users_path_replaced_for_docker(self):
-        """TERMINAL_CWD=/Users/... should be replaced with /root for docker."""
+    def test_users_path_maps_to_workspace_for_docker(self):
+        """TERMINAL_CWD=/Users/... should map into /workspace for docker."""
         with patch.dict(os.environ, {
             "TERMINAL_ENV": "docker",
             "TERMINAL_CWD": "/Users/someone/projects",
         }):
             config = _tt_mod._get_env_config()
-            assert config["cwd"] == "/root", (
-                f"Expected /root, got {config['cwd']}. "
-                "/Users/ paths should be replaced for docker backend."
+            assert config["cwd"] == "/workspace", (
+                f"Expected /workspace, got {config['cwd']}. "
+                "/Users/ paths should map into /workspace for docker backend."
             )
+            assert config["host_cwd"] == "/Users/someone/projects"
 
     def test_windows_path_replaced_for_modal(self):
         """TERMINAL_CWD=C:\\Users\\... should be replaced for modal."""
@@ -113,8 +114,8 @@ class TestCwdHandling:
             assert config["cwd"] == "/root"
 
     def test_default_cwd_is_root_for_container_backends(self):
-        """Container backends should default to /root, not ~."""
-        for backend in ("modal", "docker", "singularity", "daytona"):
+        """Non-docker container backends should default to /root, not ~."""
+        for backend in ("modal", "singularity", "daytona"):
             with patch.dict(os.environ, {"TERMINAL_ENV": backend}, clear=False):
                 # Remove TERMINAL_CWD so it uses default
                 env = os.environ.copy()
@@ -122,8 +123,20 @@ class TestCwdHandling:
                 with patch.dict(os.environ, env, clear=True):
                     config = _tt_mod._get_env_config()
                     assert config["cwd"] == "/root", (
-                        f"Backend {backend}: expected /root default, got {config['cwd']}"
+                        f"Expected /root, got {config['cwd']} for {backend}. "
+                        "Container backends should default to /root"
                     )
+
+    def test_docker_default_cwd_maps_current_directory(self):
+        """Docker should map the host cwd into /workspace by default."""
+        with patch("tools.terminal_tool.os.getcwd", return_value="/home/user/project"):
+            with patch.dict(os.environ, {"TERMINAL_ENV": "docker"}, clear=False):
+                env = os.environ.copy()
+                env.pop("TERMINAL_CWD", None)
+                with patch.dict(os.environ, env, clear=True):
+                    config = _tt_mod._get_env_config()
+                    assert config["cwd"] == "/workspace"
+                    assert config["host_cwd"] == "/home/user/project"
 
     def test_local_backend_uses_getcwd(self):
         """Local backend should use os.getcwd(), not /root."""
@@ -133,6 +146,30 @@ class TestCwdHandling:
             with patch.dict(os.environ, env, clear=True):
                 config = _tt_mod._get_env_config()
                 assert config["cwd"] == os.getcwd()
+
+    def test_create_environment_passes_docker_host_cwd(self, monkeypatch):
+        """Docker host cwd from config should reach DockerEnvironment."""
+        captured = {}
+        sentinel = object()
+
+        def _fake_docker_environment(**kwargs):
+            captured.update(kwargs)
+            return sentinel
+
+        monkeypatch.setattr(_tt_mod, "_DockerEnvironment", _fake_docker_environment)
+
+        env = _tt_mod._create_environment(
+            env_type="docker",
+            image="python:3.11",
+            cwd="/workspace",
+            timeout=60,
+            container_config={},
+            host_cwd="/home/user/project",
+        )
+
+        assert env is sentinel
+        assert captured["cwd"] == "/workspace"
+        assert captured["host_cwd"] == "/home/user/project"
 
     def test_ssh_preserves_home_paths(self):
         """SSH backend should NOT replace /home/ paths (they're valid remotely)."""

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -158,6 +158,10 @@ class DockerEnvironment(BaseEnvironment):
 
     Persistence: when enabled, bind mounts preserve /workspace and /root
     across container restarts.
+
+    Auto-mount: when host_cwd is provided (the user's original working directory),
+    it is automatically bind-mounted to /workspace unless auto_mount_cwd=False
+    or the path is already covered by an explicit volume mount.
     """
 
     def __init__(
@@ -172,6 +176,8 @@ class DockerEnvironment(BaseEnvironment):
         task_id: str = "default",
         volumes: list = None,
         network: bool = True,
+        host_cwd: str = None,
+        auto_mount_cwd: bool = True,
     ):
         if cwd == "~":
             cwd = "/root"
@@ -249,6 +255,29 @@ class DockerEnvironment(BaseEnvironment):
                 volume_args.extend(["-v", vol])
             else:
                 logger.warning(f"Docker volume '{vol}' missing colon, skipping")
+
+        # Auto-mount host CWD to /workspace when enabled (fixes #1445).
+        # This allows users to run `cd my-project && hermes` and have Docker
+        # automatically mount their project directory into the container.
+        # Disabled when: auto_mount_cwd=False, host_cwd is not a valid directory,
+        # or /workspace is already covered by writable_args or a user volume.
+        auto_mount_disabled = os.getenv("TERMINAL_DOCKER_NO_AUTO_MOUNT", "").lower() in ("1", "true", "yes")
+        if host_cwd and auto_mount_cwd and not auto_mount_disabled:
+            host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd))
+            if os.path.isdir(host_cwd_abs):
+                # Check if /workspace is already being mounted by persistence or user config
+                workspace_already_mounted = any(
+                    ":/workspace" in arg for arg in writable_args
+                ) or any(
+                    ":/workspace" in arg for arg in volume_args
+                )
+                if not workspace_already_mounted:
+                    logger.info(f"Auto-mounting host CWD to /workspace: {host_cwd_abs}")
+                    volume_args.extend(["-v", f"{host_cwd_abs}:/workspace"])
+                else:
+                    logger.debug(f"Skipping auto-mount: /workspace already mounted")
+            else:
+                logger.debug(f"Skipping auto-mount: host_cwd is not a valid directory: {host_cwd}")
 
         logger.info(f"Docker volume_args: {volume_args}")
         all_run_args = list(_SECURITY_ARGS) + writable_args + resource_args + volume_args

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -220,30 +220,12 @@ class DockerEnvironment(BaseEnvironment):
         # mode uses tmpfs (ephemeral, fast, gone on cleanup).
         from tools.environments.base import get_sandbox_dir
 
-        self._workspace_dir: Optional[str] = None
-        self._home_dir: Optional[str] = None
-        if self._persistent:
-            sandbox = get_sandbox_dir() / "docker" / task_id
-            self._workspace_dir = str(sandbox / "workspace")
-            self._home_dir = str(sandbox / "home")
-            os.makedirs(self._workspace_dir, exist_ok=True)
-            os.makedirs(self._home_dir, exist_ok=True)
-            writable_args = [
-                "-v", f"{self._workspace_dir}:/workspace",
-                "-v", f"{self._home_dir}:/root",
-            ]
-        else:
-            writable_args = [
-                "--tmpfs", "/workspace:rw,exec,size=10g",
-                "--tmpfs", "/home:rw,exec,size=1g",
-                "--tmpfs", "/root:rw,exec,size=1g",
-            ]
-
         # All containers get security hardening (capabilities dropped, no privilege
         # escalation, PID limits). The container filesystem is writable so agents
         # can install packages as needed.
         # User-configured volume mounts (from config.yaml docker_volumes)
         volume_args = []
+        workspace_explicitly_mounted = False
         for vol in (volumes or []):
             if not isinstance(vol, str):
                 logger.warning(f"Docker volume entry is not a string: {vol!r}")
@@ -253,31 +235,54 @@ class DockerEnvironment(BaseEnvironment):
                 continue
             if ":" in vol:
                 volume_args.extend(["-v", vol])
+                if ":/workspace" in vol:
+                    workspace_explicitly_mounted = True
             else:
                 logger.warning(f"Docker volume '{vol}' missing colon, skipping")
 
-        # Auto-mount host CWD to /workspace when enabled (fixes #1445).
-        # This allows users to run `cd my-project && hermes` and have Docker
-        # automatically mount their project directory into the container.
-        # Disabled when: auto_mount_cwd=False, host_cwd is not a valid directory,
-        # or /workspace is already covered by writable_args or a user volume.
+        host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
         auto_mount_disabled = os.getenv("TERMINAL_DOCKER_NO_AUTO_MOUNT", "").lower() in ("1", "true", "yes")
-        if host_cwd and auto_mount_cwd and not auto_mount_disabled:
-            host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd))
-            if os.path.isdir(host_cwd_abs):
-                # Check if /workspace is already being mounted by persistence or user config
-                workspace_already_mounted = any(
-                    ":/workspace" in arg for arg in writable_args
-                ) or any(
-                    ":/workspace" in arg for arg in volume_args
-                )
-                if not workspace_already_mounted:
-                    logger.info(f"Auto-mounting host CWD to /workspace: {host_cwd_abs}")
-                    volume_args.extend(["-v", f"{host_cwd_abs}:/workspace"])
-                else:
-                    logger.debug(f"Skipping auto-mount: /workspace already mounted")
-            else:
-                logger.debug(f"Skipping auto-mount: host_cwd is not a valid directory: {host_cwd}")
+        bind_host_cwd = (
+            bool(host_cwd_abs)
+            and auto_mount_cwd
+            and not auto_mount_disabled
+            and os.path.isdir(host_cwd_abs)
+            and not workspace_explicitly_mounted
+        )
+        if host_cwd and auto_mount_cwd and not auto_mount_disabled and not os.path.isdir(host_cwd_abs):
+            logger.debug(f"Skipping auto-mount: host_cwd is not a valid directory: {host_cwd}")
+
+        self._workspace_dir: Optional[str] = None
+        self._home_dir: Optional[str] = None
+        writable_args = []
+        if self._persistent:
+            sandbox = get_sandbox_dir() / "docker" / task_id
+            self._home_dir = str(sandbox / "home")
+            os.makedirs(self._home_dir, exist_ok=True)
+            writable_args.extend([
+                "-v", f"{self._home_dir}:/root",
+            ])
+            if not bind_host_cwd and not workspace_explicitly_mounted:
+                self._workspace_dir = str(sandbox / "workspace")
+                os.makedirs(self._workspace_dir, exist_ok=True)
+                writable_args.extend([
+                    "-v", f"{self._workspace_dir}:/workspace",
+                ])
+        else:
+            if not bind_host_cwd and not workspace_explicitly_mounted:
+                writable_args.extend([
+                    "--tmpfs", "/workspace:rw,exec,size=10g",
+                ])
+            writable_args.extend([
+                "--tmpfs", "/home:rw,exec,size=1g",
+                "--tmpfs", "/root:rw,exec,size=1g",
+            ])
+
+        if bind_host_cwd:
+            logger.info(f"Auto-mounting host CWD to /workspace: {host_cwd_abs}")
+            volume_args = ["-v", f"{host_cwd_abs}:/workspace", *volume_args]
+        elif workspace_explicitly_mounted:
+            logger.debug("Skipping docker cwd auto-mount: /workspace already mounted by user config")
 
         logger.info(f"Docker volume_args: {volume_args}")
         all_run_args = list(_SECURITY_ARGS) + writable_args + resource_args + volume_args

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -140,6 +140,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 container_config=container_config,
                 local_config=local_config,
                 task_id=task_id,
+                host_cwd=config.get("host_cwd"),
             )
 
             with _env_lock:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -481,7 +481,12 @@ def _get_env_config() -> Dict[str, Any]:
     # container/sandbox, fall back to the backend's own default. This
     # catches the case where cli.py (or .env) leaked the host's CWD.
     # SSH is excluded since /home/ paths are valid on remote machines.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    raw_cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = raw_cwd
+    # Capture original host CWD for auto-mounting into containers (fixes #1445).
+    # Even when the container's working directory falls back to /root, we still
+    # want to auto-mount the user's host project directory to /workspace.
+    host_cwd = raw_cwd if raw_cwd and os.path.isdir(raw_cwd) else os.getcwd()
     if env_type in ("modal", "docker", "singularity", "daytona") and cwd:
         # Host paths that won't exist inside containers
         host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
@@ -498,6 +503,7 @@ def _get_env_config() -> Dict[str, Any]:
         "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
         "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
         "cwd": cwd,
+        "host_cwd": host_cwd,  # Original host directory for auto-mounting into containers
         "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
         "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
         # SSH-specific config
@@ -525,7 +531,8 @@ def _get_env_config() -> Dict[str, Any]:
 def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
                         ssh_config: dict = None, container_config: dict = None,
                         local_config: dict = None,
-                        task_id: str = "default"):
+                        task_id: str = "default",
+                        host_cwd: str = None):
     """
     Create an execution environment from mini-swe-agent.
     
@@ -537,6 +544,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
         ssh_config: SSH connection config (for env_type="ssh")
         container_config: Resource config for container backends (cpu, memory, disk, persistent)
         task_id: Task identifier for environment reuse and snapshot keying
+        host_cwd: Original host working directory (for auto-mounting into containers)
         
     Returns:
         Environment instance with execute() method
@@ -559,6 +567,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             cpu=cpu, memory=memory, disk=disk,
             persistent_filesystem=persistent, task_id=task_id,
             volumes=volumes,
+            host_cwd=host_cwd,
         )
     
     elif env_type == "singularity":
@@ -965,6 +974,7 @@ def terminal_tool(
                             container_config=container_config,
                             local_config=local_config,
                             task_id=effective_task_id,
+                            host_cwd=config.get("host_cwd"),
                         )
                     except ImportError as e:
                         return json.dumps({

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -466,28 +466,34 @@ def _get_env_config() -> Dict[str, Any]:
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
     env_type = os.getenv("TERMINAL_ENV", "local")
     
-    # Default cwd: local uses the host's current directory, everything
-    # else starts in the user's home (~ resolves to whatever account
-    # is running inside the container/remote).
+    # Default cwd: local uses the host's current directory. Docker captures the
+    # host cwd and maps it into /workspace. Other backends keep their own
+    # internal defaults.
+    host_cwd = os.getcwd()
     if env_type == "local":
-        default_cwd = os.getcwd()
+        default_cwd = host_cwd
     elif env_type == "ssh":
         default_cwd = "~"
+    elif env_type == "docker":
+        default_cwd = host_cwd
     else:
         default_cwd = "/root"
-    
+
     # Read TERMINAL_CWD but sanity-check it for container backends.
-    # If the CWD looks like a host-local path that can't exist inside a
-    # container/sandbox, fall back to the backend's own default. This
-    # catches the case where cli.py (or .env) leaked the host's CWD.
-    # SSH is excluded since /home/ paths are valid on remote machines.
+    # Docker is special: if the cwd looks like a real host directory, we mount
+    # it into /workspace instead of discarding it.
     raw_cwd = os.getenv("TERMINAL_CWD", default_cwd)
     cwd = raw_cwd
-    # Capture original host CWD for auto-mounting into containers (fixes #1445).
-    # Even when the container's working directory falls back to /root, we still
-    # want to auto-mount the user's host project directory to /workspace.
-    host_cwd = raw_cwd if raw_cwd and os.path.isdir(raw_cwd) else os.getcwd()
-    if env_type in ("modal", "docker", "singularity", "daytona") and cwd:
+    if env_type == "docker" and cwd:
+        host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
+        candidate = os.path.abspath(os.path.expanduser(cwd))
+        if (
+            any(candidate.startswith(p) for p in host_prefixes)
+            or (os.path.isabs(candidate) and os.path.isdir(candidate) and not candidate.startswith(("/workspace", "/root")))
+        ):
+            host_cwd = candidate
+            cwd = "/workspace"
+    elif env_type in ("modal", "singularity", "daytona") and cwd:
         # Host paths that won't exist inside containers
         host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
         if any(cwd.startswith(p) for p in host_prefixes) and cwd != default_cwd:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -520,6 +520,42 @@ This is useful for:
 
 Can also be set via environment variable: `TERMINAL_DOCKER_VOLUMES='["/host:/container"]'` (JSON array).
 
+### Docker Auto-Mount Current Directory
+
+When using the Docker backend, Hermes **automatically mounts your current working directory** to `/workspace` inside the container. This means you can:
+
+```bash
+cd ~/projects/my-app
+hermes
+# The agent can now see and edit files in ~/projects/my-app via /workspace
+```
+
+No manual volume configuration needed — just `cd` to your project and run `hermes`.
+
+**How it works:**
+- If you're in `/home/user/projects/my-app`, that directory is mounted to `/workspace`
+- The container's working directory is set to `/workspace`
+- Files you edit on the host are immediately visible to the agent, and vice versa
+
+**Disabling auto-mount:**
+
+If you prefer the old behavior (empty `/workspace` with tmpfs or persistent sandbox), disable auto-mount:
+
+```bash
+export TERMINAL_DOCKER_NO_AUTO_MOUNT=true
+```
+
+**Precedence:**
+
+Auto-mount is skipped when:
+1. `TERMINAL_DOCKER_NO_AUTO_MOUNT=true` is set
+2. You've explicitly configured a volume mount to `/workspace` in `docker_volumes`
+3. `container_persistent: true` is set (persistent sandbox mode uses its own `/workspace`)
+
+:::tip
+Auto-mount is ideal for project-based work where you want the agent to operate on your actual files. For isolated sandboxing where the agent shouldn't access your filesystem, set `TERMINAL_DOCKER_NO_AUTO_MOUNT=true`.
+:::
+
 ### Persistent Shell
 
 By default, each terminal command runs in its own subprocess — working directory, environment variables, and shell variables reset between commands. When **persistent shell** is enabled, a single long-lived bash process is kept alive across `execute()` calls so that state survives between commands.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -550,7 +550,8 @@ export TERMINAL_DOCKER_NO_AUTO_MOUNT=true
 Auto-mount is skipped when:
 1. `TERMINAL_DOCKER_NO_AUTO_MOUNT=true` is set
 2. You've explicitly configured a volume mount to `/workspace` in `docker_volumes`
-3. `container_persistent: true` is set (persistent sandbox mode uses its own `/workspace`)
+
+If `container_persistent: true` is enabled, Hermes still auto-mounts your host cwd to `/workspace`; the persistent sandbox home continues to back `/root`.
 
 :::tip
 Auto-mount is ideal for project-based work where you want the agent to operate on your actual files. For isolated sandboxing where the agent shouldn't access your filesystem, set `TERMINAL_DOCKER_NO_AUTO_MOUNT=true`.


### PR DESCRIPTION
## Summary
- salvage Bartok9's fix from PR #1504 by auto-mounting the host cwd to `/workspace` for Docker backend sessions
- refine the behavior so Docker defaults to `/workspace`, file-tool-created environments get the same host cwd, and persistent mode still auto-mounts the host workspace while preserving `/root`
- keep explicit `/workspace` user volume mounts taking precedence and document the final behavior clearly

## Contributor credit
- cherry-picked Bartok9's substantive fix from PR #1504 and added follow-up fixes, tests, and docs on top

## Test plan
- source .venv/bin/activate && python -m pytest tests/tools/test_docker_environment.py tests/tools/test_modal_sandbox_fixes.py -n0 -q
- source .venv/bin/activate && python -m pytest tests/tools/ -n0 -q
- cd website && npx docusaurus build
- source .venv/bin/activate && python -m pytest tests/ -n0 -q  # one unrelated existing failure remains: tests/test_api_key_providers.py::TestResolveProvider::test_auto_detects_minimax_cn_key
