### PR TITLE
Improve error logging in skill manager tool

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -63,7 +63,7 @@ def _security_scan_skill(skill_dir: Path) -> Optional[str]:
             report = format_scan_report(result)
             return f"Security scan blocked this skill ({reason}):\n{report}"
     except Exception as e:
-        logger.warning("Security scan failed for %s: %s", skill_dir, e)
+        logger.warning("Security scan failed for %s: %s", skill_dir, e, exc_info=True)
     return None
 
 import yaml
@@ -219,7 +219,7 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
         try:
             os.unlink(temp_path)
         except OSError:
-            pass
+            logger.error("Failed to remove temporary file %s during atomic write", temp_path, exc_info=True)
         raise
 
 


### PR DESCRIPTION
Improves error observability in `skill_manager_tool.py` by enriching logging around security scans and atomic file writes. The `_security_scan_skill` helper now logs failures with `exc_info=True` so issues in `scan_skill`, `should_allow_install`, or `format_scan_report` include full stack traces, making it easier to debug skill-guard problems without changing the returned error text. Additionally, `_atomic_write_text` now emits a `logger.error` with `exc_info=True` when cleanup of the temporary file fails during an atomic write, preserving the existing behavior of re-raising the original exception while adding crucial diagnostics for filesystem issues that previously failed silently.