### PR TITLE
fix: resolve ambiguous slash command prefix when shorter built-in exists

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3076,6 +3076,17 @@ class HermesCLI:
                 typed_base = cmd_lower.split()[0]
                 all_known = set(COMMANDS) | set(_skill_commands)
                 matches = [c for c in all_known if c.startswith(typed_base)]
+                if len(matches) > 1:
+                    # Prefer an exact match (typed the full command name).
+                    exact = [c for c in matches if c == typed_base]
+                    if len(exact) == 1:
+                        matches = exact
+                    else:
+                        # Prefer the unique shortest match: /qui → /quit wins over /quint-pipeline.
+                        min_len = min(len(c) for c in matches)
+                        shortest = [c for c in matches if len(c) == min_len]
+                        if len(shortest) == 1:
+                            matches = shortest
                 if len(matches) == 1:
                     # Expand the prefix to the full command name, preserving arguments.
                     # Guard against redispatching the same token to avoid infinite

--- a/tests/test_cli_prefix_matching.py
+++ b/tests/test_cli_prefix_matching.py
@@ -147,3 +147,57 @@ class TestSlashCommandPrefixMatching:
             cli_obj.process_command("/reset")
         # /reset maps to new_session (the clear/reset action)
         mock_reset.assert_called_once()
+
+    def test_shortest_match_with_args_dispatches_correctly(self):
+        """/qui extra args should expand to /quit extra args without showing ambiguous."""
+        cli_obj = _make_cli()
+        fake_skill = {"/quint-pipeline": {"name": "Quint Pipeline", "description": "test"}}
+
+        import cli as cli_mod
+        with patch.object(cli_mod, '_skill_commands', fake_skill):
+            cli_obj.process_command("/qui ignored-args")
+
+        printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
+        assert "Ambiguous" not in printed
+
+    def test_three_matches_unique_shortest_dispatches(self):
+        """When three skills share a prefix but one built-in is shorter, prefer the built-in."""
+        cli_obj = _make_cli()
+        fake_skills = {
+            "/quint-pipeline": {"name": "A", "description": ""},
+            "/quint-analysis": {"name": "B", "description": ""},
+        }
+        import cli as cli_mod
+        with patch.object(cli_mod, '_skill_commands', fake_skills):
+            result = cli_obj.process_command("/qui")
+
+        # /quit (5) is shortest among /quit, /quint-pipeline, /quint-analysis
+        assert result is False
+        printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
+        assert "Ambiguous" not in printed
+
+    def test_multiple_skills_same_length_no_builtin_stays_ambiguous(self):
+        """Two skill commands of equal shortest length with no shorter built-in → ambiguous."""
+        cli_obj = _make_cli()
+        fake_skills = {
+            "/foo-alpha": {"name": "A", "description": ""},
+            "/foo-beta-": {"name": "B", "description": ""},
+        }
+        import cli as cli_mod
+        with patch.object(cli_mod, '_skill_commands', fake_skills):
+            cli_obj.process_command("/foo")
+
+        printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
+        assert "Ambiguous" in printed or "Did you mean" in printed or "Unknown" in printed
+
+    def test_prefix_exactly_equals_a_known_command_dispatches(self):
+        """/help typed with /help-extra skill installed → exact match wins, no ambiguous."""
+        cli_obj = _make_cli()
+        fake_skill = {"/help-extra": {"name": "Help Extra", "description": ""}}
+        import cli as cli_mod
+        with patch.object(cli_mod, '_skill_commands', fake_skill), \
+             patch.object(cli_obj, 'show_help') as mock_help:
+            cli_obj.process_command("/help")
+        mock_help.assert_called_once()
+        printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
+        assert "Ambiguous" not in printed

--- a/tests/test_cli_prefix_matching.py
+++ b/tests/test_cli_prefix_matching.py
@@ -115,3 +115,35 @@ class TestSlashCommandPrefixMatching:
         mock_help.assert_called_once()
         printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
         assert "Ambiguous" not in printed
+
+    def test_shortest_match_preferred_over_longer_skill(self):
+        """/qui should dispatch to /quit (5 chars) not report ambiguous with /quint-pipeline (15 chars)."""
+        cli_obj = _make_cli()
+        fake_skill = {"/quint-pipeline": {"name": "Quint Pipeline", "description": "test"}}
+        dispatched = []
+
+        import cli as cli_mod
+        with patch.object(cli_mod, '_skill_commands', fake_skill):
+            # /quit is caught by the exact "/quit" branch → process_command returns False
+            result = cli_obj.process_command("/qui")
+
+        # Returns False because /quit was dispatched (exits chat loop)
+        assert result is False
+        # No ambiguous message should have been printed
+        printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
+        assert "Ambiguous" not in printed
+
+    def test_tied_shortest_matches_still_ambiguous(self):
+        """/re matches /reset and /retry (both 6 chars) — no unique shortest, stays ambiguous."""
+        cli_obj = _make_cli()
+        cli_obj.process_command("/re")
+        printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
+        assert "Ambiguous" in printed or "Did you mean" in printed
+
+    def test_exact_typed_name_preferred_when_also_a_prefix(self):
+        """/reset typed exactly should dispatch /reset, not be confused with /retry."""
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, 'new_session') as mock_reset:
+            cli_obj.process_command("/reset")
+        # /reset maps to new_session (the clear/reset action)
+        mock_reset.assert_called_once()


### PR DESCRIPTION
## Problem

When a skill with a long name (e.g. `/quint-pipeline`) is installed, typing the prefix `/qui` triggers an ambiguous command error instead of dispatching to the built-in `/quit`:

```
⚙️  /qui
Ambiguous command: /qui
Did you mean: /quint-pipeline, /quit?
```

## Fix

When multiple commands match a typed prefix, resolve using this priority:

1. **Exact match** — if the typed text is itself a known command name, dispatch it immediately
2. **Unique shortest match** — prefer the match with the fewest characters when there is exactly one shortest candidate (`/qui` → `/quit` wins over `/quint-pipeline`)
3. **Tied shortest or no unique winner** → report ambiguous as before (e.g. `/re` matches `/reset` and `/retry`, both 6 chars — stays ambiguous)

## Tests

15 tests in `tests/test_cli_prefix_matching.py` (7 new, 8 existing):

- `/qui` dispatches to `/quit` when `/quint-pipeline` skill is installed
- Three-way ambiguity resolved when one candidate is uniquely shortest
- Tied shortest lengths still report ambiguous (`/re` → `/reset` vs `/retry`)
- Exact name wins even when a longer skill shares the prefix (`/help` + `/help-extra`)
- Prefix with trailing args dispatched without ambiguous message
- Multiple equal-length skills with no shorter built-in → ambiguous