### PR TITLE
fix(whatsapp): Support LID format in self-chat mode

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -53,6 +53,10 @@ const logger = pino({ level: 'warn' });
 const messageQueue = [];
 const MAX_QUEUE_SIZE = 100;
 
+// Track recently sent message IDs to prevent echo-back loops with media
+const recentlySentIds = new Set();
+const MAX_RECENT_IDS = 50;
+
 let sock = null;
 let connectionState = 'disconnected';
 
@@ -187,14 +191,23 @@ async function startSocket() {
       }
 
       // Ignore Hermes' own reply messages in self-chat mode to avoid loops.
-      if (msg.key.fromMe && body.startsWith('⚕ *Hermes Agent*')) {
-        try { console.log(JSON.stringify({ event: 'ignored', reason: 'agent_echo', chatId })); } catch {}
+      // Check both text prefix (for text messages) and message ID tracking (for media)
+      if (msg.key.fromMe && (body.startsWith('⚕ *Hermes Agent*') || recentlySentIds.has(msg.key.id))) {
+        try { 
+          console.log(JSON.stringify({ event: 'ignored', reason: 'agent_echo', chatId, messageId: msg.key.id })); 
+        } catch (err) {
+          console.error('Failed to log agent echo event:', err);
+        }
         continue;
       }
 
       // Skip empty messages
       if (!body && !hasMedia) {
-        try { console.log(JSON.stringify({ event: 'ignored', reason: 'empty', chatId, messageKeys: Object.keys(msg.message || {}) })); } catch {}
+        try { 
+          console.log(JSON.stringify({ event: 'ignored', reason: 'empty', chatId, messageKeys: Object.keys(msg.message || {}) })); 
+        } catch (err) {
+          console.error('Failed to log empty message event:', err);
+        }
         continue;
       }
 
@@ -243,9 +256,19 @@ app.post('/send', async (req, res) => {
 
   try {
     // Prefix responses so the user can distinguish agent replies from their
-    // own messages (especially in self-chat / "Message Yourself").
-    const prefixed = `⚕ *Hermes Agent*\n────────────\n${message}`;
+    // own messages (especially in self-chat / \"Message Yourself\").
+    const prefixed = `⚕ *Hermes Agent*\\n────────────\\n${message}`;
     const sent = await sock.sendMessage(chatId, { text: prefixed });
+    
+    // Track sent message ID to prevent echo-back loops
+    if (sent?.key?.id) {
+      recentlySentIds.add(sent.key.id);
+      if (recentlySentIds.size > MAX_RECENT_IDS) {
+        const firstId = recentlySentIds.values().next().value;
+        recentlySentIds.delete(firstId);
+      }
+    }
+    
     res.json({ success: true, messageId: sent?.key?.id });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -337,6 +360,16 @@ app.post('/send-media', async (req, res) => {
     }
 
     const sent = await sock.sendMessage(chatId, msgPayload);
+    
+    // Track sent message ID to prevent echo-back loops
+    if (sent?.key?.id) {
+      recentlySentIds.add(sent.key.id);
+      if (recentlySentIds.size > MAX_RECENT_IDS) {
+        const firstId = recentlySentIds.values().next().value;
+        recentlySentIds.delete(firstId);
+      }
+    }
+    
     res.json({ success: true, messageId: sent?.key?.id });
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -103,12 +103,25 @@ async function startSocket() {
   });
 
   sock.ev.on('messages.upsert', ({ messages, type }) => {
-    if (type !== 'notify') return;
+    // In self-chat mode, your own messages commonly arrive as 'append' rather
+    // than 'notify'. If we only accept 'notify', Hermes never sees the user's
+    // self-chat prompts. Accept both and filter agent echo-backs below.
+    if (type !== 'notify' && type !== 'append') return;
 
     for (const msg of messages) {
       if (!msg.message) continue;
 
       const chatId = msg.key.remoteJid;
+      try {
+        console.log(JSON.stringify({
+          event: 'upsert',
+          type,
+          fromMe: !!msg.key.fromMe,
+          chatId,
+          senderId: msg.key.participant || chatId,
+          messageKeys: Object.keys(msg.message || {}),
+        }));
+      } catch {}
       const senderId = msg.key.participant || chatId;
       const isGroup = chatId.endsWith('@g.us');
       const senderNumber = senderId.replace(/@.*/, '');
@@ -123,9 +136,13 @@ async function startSocket() {
         }
 
         // Self-chat mode: only allow messages in the user's own self-chat
+        // WhatsApp now uses LID (Linked Identity Device) format: 67427329167522@lid
+        // AND classic format: 34652029134@s.whatsapp.net
+        // sock.user has both: { id: "number:10@s.whatsapp.net", lid: "lid_number:10@lid" }
         const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
+        const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
         const chatNumber = chatId.replace(/@.*/, '');
-        const isSelfChat = myNumber && chatNumber === myNumber;
+        const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
         if (!isSelfChat) continue;
       }
 
@@ -161,8 +178,17 @@ async function startSocket() {
         mediaType = 'document';
       }
 
+      // Ignore Hermes' own reply messages in self-chat mode to avoid loops.
+      if (msg.key.fromMe && body.startsWith('⚕ *Hermes Agent*')) {
+        try { console.log(JSON.stringify({ event: 'ignored', reason: 'agent_echo', chatId })); } catch {}
+        continue;
+      }
+
       // Skip empty messages
-      if (!body && !hasMedia) continue;
+      if (!body && !hasMedia) {
+        try { console.log(JSON.stringify({ event: 'ignored', reason: 'empty', chatId, messageKeys: Object.keys(msg.message || {}) })); } catch {}
+        continue;
+      }
 
       const event = {
         messageId: msg.key.id,

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -203,10 +203,12 @@ async function startSocket() {
 
       // Skip empty messages
       if (!body && !hasMedia) {
-        try { 
-          console.log(JSON.stringify({ event: 'ignored', reason: 'empty', chatId, messageKeys: Object.keys(msg.message || {}) })); 
-        } catch (err) {
-          console.error('Failed to log empty message event:', err);
+        if (process.env.WHATSAPP_DEBUG) {
+          try { 
+            console.log(JSON.stringify({ event: 'ignored', reason: 'empty', chatId, messageKeys: Object.keys(msg.message || {}) })); 
+          } catch (err) {
+            console.error('Failed to log empty message event:', err);
+          }
         }
         continue;
       }

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -33,6 +33,12 @@ function getArg(name, defaultVal) {
   return idx !== -1 && args[idx + 1] ? args[idx + 1] : defaultVal;
 }
 
+const WHATSAPP_DEBUG =
+  typeof process !== 'undefined' &&
+  process.env &&
+  typeof process.env.WHATSAPP_DEBUG === 'string' &&
+  ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_DEBUG.toLowerCase());
+
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
 const PAIR_ONLY = args.includes('--pair-only');
@@ -112,16 +118,18 @@ async function startSocket() {
       if (!msg.message) continue;
 
       const chatId = msg.key.remoteJid;
-      try {
-        console.log(JSON.stringify({
-          event: 'upsert',
-          type,
-          fromMe: !!msg.key.fromMe,
-          chatId,
-          senderId: msg.key.participant || chatId,
-          messageKeys: Object.keys(msg.message || {}),
-        }));
-      } catch {}
+      if (WHATSAPP_DEBUG) {
+        try {
+          console.log(JSON.stringify({
+            event: 'upsert',
+            type,
+            fromMe: !!msg.key.fromMe,
+            chatId,
+            senderId: msg.key.participant || chatId,
+            messageKeys: Object.keys(msg.message || {}),
+          }));
+        } catch {}
+      }
       const senderId = msg.key.participant || chatId;
       const isGroup = chatId.endsWith('@g.us');
       const senderNumber = senderId.replace(/@.*/, '');


### PR DESCRIPTION
## Summary                                                                                                                                                                           
                                                                                                                                                                                        
   WhatsApp now uses LID (Linked Identity Device) format for user identification in addition to the classic phone number format. This PR fixes self-chat mode to recognize both         
   formats.                                                                                                                                                                             
                                                                                                                                                                                        
   **Before:**                                                                                                                                                                          
   - Only recognized: `15551234567@s.whatsapp.net` (user.id)                                                                                                                            
   - Self-chat messages with LID format were ignored                                                                                                                                    
                                                                                                                                                                                        
   **After:**                                                                                                                                                                           
   - Recognizes both formats:                                                                                                                                                           
     - Classic: `15551234567@s.whatsapp.net` (user.id)                                                                                                                                  
     - LID: `123456789012345@lid` (user.lid)                                                                                                                                            
   - Self-chat messages now work regardless of format                                                                                                                                   
                                                                                                                                                                                        
   **Additional improvements:**                                                                                                                                                         
   - Support for 'append' message type (used in self-chat)                                                                                                                              
   - Debug logging for message events                                                                                                                                                   
   - Filtering of Hermes' own reply messages to avoid loops                                                                                                                             
                                                                                                                                                                                        
   ## What does this PR do?                                                                                                                                                             
                                                                                                                                                                                        
   WhatsApp has migrated to a new LID (Linked Identity Device) identifier format alongside the classic phone number format. Users' self-chat messages now arrive with `chatId` like     
   `123456789012345@lid` instead of `15551234567@s.whatsapp.net`.                                                                                                                       
                                                                                                                                                                                        
   The WhatsApp bridge was only checking `sock.user.id` (classic format) to identify self-chat messages, causing all LID-format messages to be ignored. This broke self-chat            
   functionality for users with LID-enabled accounts.                                                                                                                                   
                                                                                                                                                                                        
   **Solution:** Check both `sock.user.id` AND `sock.user.lid` when identifying self-chat messages.                                                                                     
                                                                                                                                                                                        
   ## Related Issue                                                                                                                                                                     
                                                                                                                                                                                        
   No existing issue - bug discovered during real-world usage with LID-enabled WhatsApp account.                                                                                        
                                                                                                                                                                                        
   ## Type of Change                                                                                                                                                                    
                                                                                                                                                                                        
   - [x] 🐛 Bug fix (non-breaking change that fixes an issue)                                                                                                                           
   - [ ] ✨ New feature (non-breaking change that adds functionality)                                                                                                                   
   - [ ] 🔒 Security fix                                                                                                                                                                
   - [ ] 📝 Documentation update                                                                                                                                                        
   - [ ] ✅ Tests (adding or improving test coverage)                                                                                                                                   
   - [ ] ♻️ Refactor (no behavior change)                                                                                                                                               
   - [ ] 🎯 New skill (bundled or hub)                                                                                                                                                  
                                                                                                                                                                                        
   ## Changes Made                                                                                                                                                                      
                                                                                                                                                                                        
   **File:** `scripts/whatsapp-bridge/bridge.js`                                                                                                                                        
                                                                                                                                                                                        
   1. **LID format support (lines 139-142):**                                                                                                                                           
      - Added `myLid` variable to extract LID from `sock.user.lid`                                                                                                                      
      - Modified `isSelfChat` check to accept both formats                                                                                                                              
      - Added comments explaining WhatsApp's dual-format system                                                                                                                         
                                                                                                                                                                                        
   2. **'append' message type support (line 109):**                                                                                                                                     
      - Accept both 'notify' and 'append' message types                                                                                                                                 
      - Self-chat messages commonly arrive as 'append' rather than 'notify'                                                                                                             
                                                                                                                                                                                        
   3. **Debug logging (lines 116-124):**                                                                                                                                                
      - Log message events with type, fromMe status, chatId, and message keys                                                                                                           
      - Helps troubleshoot message processing issues                                                                                                                                    
                                                                                                                                                                                        
   4. **Echo-back filtering (lines 178-181):**                                                                                                                                          
      - Filter out Hermes' own replies (starting with "⚕ *Hermes Agent*")                                                                                                               
      - Prevents infinite loops in self-chat mode                                                                                                                                       
                                                                                                                                                                                        
   5. **Empty message handling (lines 184-187):**                                                                                                                                       
      - Added logging for ignored empty messages                                                                                                                                        
                                                                                                                                                                                        
   ## How to Test                                                                                                                                                                       
                                                                                                                                                                                        
   **Prerequisites:**                                                                                                                                                                   
   - WhatsApp account with LID enabled (most recent accounts)                                                                                                                           
   - Hermes Agent with WhatsApp bridge configured in self-chat mode                                                                                                                     
                                                                                                                                                                                        
   **Steps:**                                                                                                                                                                           
   1. Apply this PR and restart the gateway: `hermes gateway restart`                                                                                                                   
   2. Open WhatsApp on your phone                                                                                                                                                       
   3. Find your own contact and send yourself a message (e.g., "test")                                                                                                                  
   4. Verify Hermes responds in the WhatsApp self-chat                                                                                                                                  
   5. Check `~/.hermes/whatsapp/bridge.log` for debug events showing both LID and classic formats                                                                                       
                                                                                                                                                                                        
   **Expected result:** Self-chat messages are processed and Hermes responds correctly.                                                                                                 
                                                                                                                                                                                        
   ## Checklist                                                                                                                                                                         
                                                                                                                                                                                        
   ### Code                                                                                                                                                                             
   - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)                                                                     
   - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)                                                   
   - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate                                                          
   - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)                                                                                             
   - [ ] I've run `pytest tests/ -q` and all tests pass                                                                                                                                 
   - [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)                                                                                     
   - [x] I've tested on my platform: **macOS 26.4, Apple M4**                                                                                                                           
                                                                                                                                                                                        
   ### Documentation & Housekeeping                                                                                                                                                     
   - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or **N/A** (code comments added)                                                                           
   - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or **N/A**                                                                                             
   - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or **N/A**                                                                              
   - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility                                                                                                  
   guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or **N/A** (JavaScript code, platform-agnostic)                        
   - [x] I've updated tool descriptions/schemas if I changed tool behavior — or **N/A**                                                                                                 
                                                                                                                                                                                        
   ## Screenshots / Logs                                                                                                                                                                
                                                                                                                                                                                        
   **Before fix - LID messages ignored:**                                                                                                                                               
   ```json                                                                                                                                                                              
   {"event":"upsert","type":"notify","fromMe":true,"chatId":"123456789012345@lid","senderId":"123456789012345@lid","messageKeys":["conversation"]}                                      
   // Message silently dropped - no response                                                                                                                                            
   ```                                                                                                                                                                                  
                                                                                                                                                                                        
   **After fix - LID messages processed:**                                                                                                                                              
   ```json                                                                                                                                                                              
   {"event":"upsert","type":"notify","fromMe":true,"chatId":"123456789012345@lid","senderId":"123456789012345@lid","messageKeys":["conversation"]}                                      
   // Message added to queue and processed by gateway                                                                                                                                   
   // Hermes responds successfully    