### PR TITLE
fix(approval): show full command in dangerous command approval (Fixes #1553)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1740,9 +1740,12 @@ class DiscordAdapter(BasePlatformAdapter):
             if not channel:
                 channel = await self._client.fetch_channel(int(chat_id))
 
+            # Discord embed description limit is 4096; show full command up to that
+            max_desc = 4088
+            cmd_display = command if len(command) <= max_desc else command[: max_desc - 3] + "..."
             embed = discord.Embed(
                 title="Command Approval Required",
-                description=f"```\n{command[:500]}\n```",
+                description=f"```\n{cmd_display}\n```",
                 color=discord.Color.orange(),
             )
             embed.set_footer(text=f"Approval ID: {approval_id}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,11 @@ def _ensure_current_event_loop(request):
 
 @pytest.fixture(autouse=True)
 def _enforce_test_timeout():
-    """Kill any individual test that takes longer than 30 seconds."""
+    """Kill any individual test that takes longer than 30 seconds.
+    SIGALRM is Unix-only; skip on Windows."""
+    if sys.platform == "win32":
+        yield
+        return
     old = signal.signal(signal.SIGALRM, _timeout_handler)
     signal.alarm(30)
     yield

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -220,17 +220,15 @@ def prompt_dangerous_approval(command: str, description: str,
 
     os.environ["HERMES_SPINNER_PAUSE"] = "1"
     try:
-        is_truncated = len(command) > 80
         while True:
             print()
             print(f"  ⚠️  DANGEROUS COMMAND: {description}")
-            print(f"      {command[:80]}{'...' if is_truncated else ''}")
+            print(f"      {command}")
             print()
-            view_hint = "  |  [v]iew full" if is_truncated else ""
             if allow_permanent:
-                print(f"      [o]nce  |  [s]ession  |  [a]lways  |  [d]eny{view_hint}")
+                print("      [o]nce  |  [s]ession  |  [a]lways  |  [d]eny")
             else:
-                print(f"      [o]nce  |  [s]ession  |  [d]eny{view_hint}")
+                print("      [o]nce  |  [s]ession  |  [d]eny")
             print()
             sys.stdout.flush()
 
@@ -252,12 +250,6 @@ def prompt_dangerous_approval(command: str, description: str,
                 return "deny"
 
             choice = result["choice"]
-            if choice in ('v', 'view') and is_truncated:
-                print()
-                print("      Full command:")
-                print(f"      {command}")
-                is_truncated = False
-                continue
             if choice in ('o', 'once'):
                 print("      ✓ Allowed once")
                 return "once"
@@ -394,7 +386,10 @@ def check_dangerous_command(command: str, env_type: str,
             "status": "approval_required",
             "command": command,
             "description": description,
-            "message": f"⚠️ This command is potentially dangerous ({description}). Asking the user for approval...",
+            "message": (
+                f"⚠️ This command is potentially dangerous ({description}). "
+                f"Asking the user for approval.\n\n**Command:**\n```\n{command}\n```"
+            ),
         }
 
     choice = prompt_dangerous_approval(command, description,
@@ -542,7 +537,9 @@ def check_all_command_guards(command: str, env_type: str,
             "status": "approval_required",
             "command": command,
             "description": combined_desc,
-            "message": f"⚠️ {combined_desc}. Asking the user for approval...",
+            "message": (
+                f"⚠️ {combined_desc}. Asking the user for approval.\n\n**Command:**\n```\n{command}\n```"
+            ),
         }
 
     # CLI interactive: single combined prompt


### PR DESCRIPTION
## What does this PR do?

Fixes the dangerous command approval flow so the **full command** is shown when asking the user for approval. Previously the command was truncated (80 chars in CLI, 500 in Discord, and missing entirely in Telegram/Slack approval messages), making it hard to see what was being approved. Now the full command is displayed everywhere, with platform limits only where required (e.g. Discord embed 4096-char limit).

## Related Issue

Fixes #1553

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **tools/approval.py:** CLI prompt now shows the full command (removed 80-char truncation and `[v]iew full`). Gateway/Telegram/Slack: `approval_required` message now includes the full command in the body (`**Command:**\n```\n{command}\n````).
- **gateway/platforms/discord.py:** Embed description shows full command up to Discord’s limit (4088 chars) instead of truncating at 500.
- **tests/conftest.py:** Skip the SIGALRM-based test timeout fixture on Windows (SIGALRM is Unix-only), so the test suite runs on Windows.

## How to Test

1. **CLI:** Run `hermes`, trigger a dangerous command (e.g. `rm -rf /tmp/something`). Confirm the full command is shown in the approval prompt (not cut at 80 chars).
2. **Gateway (Telegram/Slack):** With gateway running, ask the agent to run a dangerous command. Confirm the approval message includes the full command in the text.
3. **Discord:** Same flow; confirm the approval embed shows the full command (up to ~4k chars), not only the first 500.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A