### PR TITLE
feat(telegram): auto-detect HTML tags and set parse_mode on send_message

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -323,8 +323,11 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         warnings = []
 
         if message.strip():
+            # Auto-detect HTML tags and set parse_mode accordingly
+            import re
+            parse_mode = "HTML" if re.search(r'<[a-zA-Z/][^>]*>', message) else None
             last_msg = await bot.send_message(
-                chat_id=int_chat_id, text=message, **thread_kwargs
+                chat_id=int_chat_id, text=message, parse_mode=parse_mode, **thread_kwargs
             )
 
         for media_path, is_voice in media_files:


### PR DESCRIPTION
## Summary

When sending messages via the Telegram Bot API, the `send_message` tool currently sends all messages as plain text. If an agent or cron job generates HTML-formatted output (`<b>`, `<i>`, `<code>`, `<pre>`, etc.), Telegram displays the raw tags instead of rendering them.

## Fix

Auto-detect HTML tags in the message body and set `parse_mode='HTML'` when they're present. Plain-text messages (no HTML tags) are sent without `parse_mode`, preserving backward compatibility.

## Details

- Uses a simple regex check: `re.search(r'<[a-zA-Z/][^>]*>', message)`
- Only activates for messages that actually contain HTML-like tags
- Zero impact on existing plain-text messages
- Enables cron jobs and agents to send rich formatted Telegram messages with bold, italic, code blocks, etc.

## Testing

Tested end-to-end with cron-driven health briefs sent to Telegram — bold headers, preformatted comparison tables, and inline formatting all render correctly.