### PR TITLE
fix(security): block sandbox backend creds from subprocess env

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -128,6 +128,9 @@ class TestProviderEnvBlocklist:
             "GH_TOKEN": "gh_alias_secret",
             "GATEWAY_ALLOW_ALL_USERS": "true",
             "GATEWAY_ALLOWED_USERS": "alice,bob",
+            "MODAL_TOKEN_ID": "modal-id",
+            "MODAL_TOKEN_SECRET": "modal-secret",
+            "DAYTONA_API_KEY": "daytona-key",
         }
         result_env = _run_with_env(extra_os_env=leaked_vars)
 
@@ -280,5 +283,8 @@ class TestBlocklistCoverage:
             "GITHUB_APP_ID",
             "GITHUB_APP_PRIVATE_KEY_PATH",
             "GITHUB_APP_INSTALLATION_ID",
+            "MODAL_TOKEN_ID",
+            "MODAL_TOKEN_SECRET",
+            "DAYTONA_API_KEY",
         }
         assert extras.issubset(_HERMES_PROVIDER_ENV_BLOCKLIST)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -117,6 +117,10 @@ def _build_provider_env_blocklist() -> frozenset:
         "GITHUB_APP_ID",
         "GITHUB_APP_PRIVATE_KEY_PATH",
         "GITHUB_APP_INSTALLATION_ID",
+        # Remote sandbox backend credentials.
+        "MODAL_TOKEN_ID",
+        "MODAL_TOKEN_SECRET",
+        "DAYTONA_API_KEY",
     })
     return frozenset(blocked)
 


### PR DESCRIPTION
## Summary

- Adds `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`, and `DAYTONA_API_KEY` to the subprocess env blocklist
- These remote sandbox backend credentials were not covered by the existing `OPTIONAL_ENV_VARS` dynamic loading because they are not registered there
- Extends existing tests to cover the three new variables (runtime leak test + coverage test)

Closes #1264

## Changes

| File | Change |
|------|--------|
| `tools/environments/local.py` | +3 vars to manual blocklist |
| `tests/tools/test_local_env_blocklist.py` | +3 vars in `test_tool_and_gateway_vars_are_stripped` and `test_gateway_runtime_vars_are_in_blocklist` |

## Verification

- Blocklist size: 84 → 87
- All 14 existing + updated tests pass
- Zero new ruff lint errors

## Test plan

- [x] Blocklist includes `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`, `DAYTONA_API_KEY`
- [x] Runtime test confirms these vars are stripped from subprocess env
- [x] Coverage test confirms these vars are in the blocklist
- [x] All pre-existing tests still pass