### PR TITLE
Allow remote self-hosted Honcho via HONCHO_URL base URL override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ environments/benchmarks/evals/
 
 # Release script temp files
 .release_notes.md
+
+# macOS Finder metadata
+.DS_Store
+**/.DS_Store

--- a/README.moe-local.md
+++ b/README.moe-local.md
@@ -1,0 +1,140 @@
+# MOE legal-writing quick commands
+
+Personal local notes for the Hermes setup on this machine.
+
+This file documents the legal-writing shortcuts and the intended workflow.
+It is written for personal use and assumes the local Hermes config in:
+- `~/.hermes/config.yaml`
+
+## Purpose
+
+These shortcuts are meant to make the legal thought-leadership workflow fast and consistent.
+
+They sit on top of the `legal-writing` skill suite and use Hermes quick-command aliases.
+
+## Installed quick commands
+
+### `/moe-review`
+Alias to:
+- `/legal-thought-leadership-review`
+
+Use when you want the full review flow:
+- structure
+- argument
+- style
+- domain framing
+- humanization
+- synthesis into a revision plan
+
+Example:
+- `/moe-review Review this LinkedIn draft for partner-level thought leadership.`
+
+### `/moe-revise`
+Alias to:
+- `/legal-thought-leadership-revise`
+
+Use when you want a full rewritten draft rather than critique only.
+
+Example:
+- `/moe-revise Turn this draft into a polished client alert.`
+
+### `/moe-style`
+Alias to:
+- `/law-style-editor`
+
+Use when the substance is mostly right and the main need is:
+- clarity
+- concision
+- rhythm
+- readability
+- voice preservation
+
+Example:
+- `/moe-style Tighten this piece without making it sound generic.`
+
+### `/moe-argument`
+Alias to:
+- `/law-argument-editor`
+
+Use when the main need is:
+- stronger thesis
+- tighter doctrinal reasoning
+- better use of authorities
+- sharper policy logic
+
+Example:
+- `/moe-argument Strengthen the thesis and legal reasoning.`
+
+## Recommended workflow
+
+### 1. First-pass diagnosis
+Start with:
+- `/moe-review`
+
+Use this when the draft is still taking shape or when you want the full set of expert lenses.
+
+### 2. Full rewrite
+If the review shows the piece needs a full rewrite, run:
+- `/moe-revise`
+
+This should produce a cleaner, publishable draft while preserving the core position.
+
+### 3. Focused follow-up passes
+After the big review or rewrite:
+- use `/moe-style` for polish
+- use `/moe-argument` for legal depth and thesis strength
+
+## Skill mapping
+
+Underlying skills currently installed in `legal-writing`:
+- `legal-thought-leadership-review`
+- `legal-thought-leadership-revise`
+- `law-draft-review-orchestrator`
+- `law-revision-synthesizer`
+- `law-structure-editor`
+- `law-argument-editor`
+- `law-style-editor`
+- `law-domain-editor`
+- `humanizer`
+
+## Implementation notes
+
+### Quick-command behavior
+Hermes now supports two quick-command types:
+- `exec` — run a shell command directly
+- `alias` — rewrite to another slash command
+
+The `/moe-*` commands are all `alias` commands.
+
+### Config location
+Aliases live in:
+- `~/.hermes/config.yaml`
+
+Current entries:
+- `moe-review -> /legal-thought-leadership-review`
+- `moe-revise -> /legal-thought-leadership-revise`
+- `moe-style -> /law-style-editor`
+- `moe-argument -> /law-argument-editor`
+
+## Guardrails
+
+Use these tools as drafting and editorial support, not as a substitute for authority verification.
+
+Working assumptions for this workflow:
+- do not fabricate cases, statutes, guidance, or speeches
+- preserve the intended commercial/legal audience
+- prefer crisp, publishable prose over bloated academic prose
+- keep Canadian/US legal framing explicit when relevant
+
+## Verification
+
+Related Hermes test file:
+- `tests/test_quick_commands.py`
+
+Last verified locally with:
+- `/Users/rhx/.hermes/hermes-agent/venv/bin/pytest tests/test_quick_commands.py -q`
+
+## Local-only note
+
+This setup is intended for personal local use.
+Do not open a public PR with these personal shortcut choices unless they are deliberately generalized first.

--- a/cli.py
+++ b/cli.py
@@ -3555,7 +3555,7 @@ class HermesCLI:
         elif cmd_lower.startswith("/voice"):
             self._handle_voice_command(cmd_original)
         else:
-            # Check for user-defined quick commands (bypass agent loop, no LLM call)
+            # Check for user-defined quick commands (exec or alias)
             base_cmd = cmd_lower.split()[0]
             quick_commands = self.config.get("quick_commands", {})
             if base_cmd.lstrip("/") in quick_commands:
@@ -3580,8 +3580,17 @@ class HermesCLI:
                             self.console.print(f"[bold red]Quick command error: {e}[/]")
                     else:
                         self.console.print(f"[bold red]Quick command '{base_cmd}' has no command defined[/]")
+                elif qcmd.get("type") == "alias":
+                    target = qcmd.get("target", "").strip()
+                    if target:
+                        target = target if target.startswith("/") else f"/{target}"
+                        user_args = cmd_original[len(base_cmd):].strip()
+                        aliased_command = f"{target} {user_args}".strip()
+                        return self.process_command(aliased_command)
+                    else:
+                        self.console.print(f"[bold red]Quick command '{base_cmd}' has no target defined[/]")
                 else:
-                    self.console.print(f"[bold red]Quick command '{base_cmd}' has unsupported type (only 'exec' is supported)[/]")
+                    self.console.print(f"[bold red]Quick command '{base_cmd}' has unsupported type (supported: 'exec', 'alias')[/]")
             # Check for skill slash commands (/gif-search, /axolotl, etc.)
             elif base_cmd in _skill_commands:
                 user_instruction = cmd_original[len(base_cmd):].strip()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -261,6 +261,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             if delivery_target.get("thread_id") is not None:
                 os.environ["HERMES_CRON_AUTO_DELIVER_THREAD_ID"] = str(delivery_target["thread_id"])
 
+
         model = job.get("model") or os.getenv("HERMES_MODEL") or "anthropic/claude-opus-4.6"
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
@@ -322,12 +323,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             format_runtime_provider_error,
         )
         try:
-            runtime_kwargs = {
-                "requested": job.get("provider") or os.getenv("HERMES_INFERENCE_PROVIDER"),
-            }
-            if job.get("base_url"):
-                runtime_kwargs["explicit_base_url"] = job.get("base_url")
-            runtime = resolve_runtime_provider(**runtime_kwargs)
+            runtime = resolve_runtime_provider(
+                requested=job.get("provider") or os.getenv("HERMES_INFERENCE_PROVIDER"),
+                explicit_api_key=job.get("api_key"),
+                explicit_base_url=job.get("base_url"),
+            )
         except Exception as exc:
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -260,8 +260,6 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             os.environ["HERMES_CRON_AUTO_DELIVER_CHAT_ID"] = str(delivery_target["chat_id"])
             if delivery_target.get("thread_id") is not None:
                 os.environ["HERMES_CRON_AUTO_DELIVER_THREAD_ID"] = str(delivery_target["thread_id"])
-
-
         model = job.get("model") or os.getenv("HERMES_MODEL") or "anthropic/claude-opus-4.6"
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1388,7 +1388,6 @@ class GatewayRunner:
             return await self._handle_voice_command(event)
 
         # User-defined quick commands (exec or alias)
-
         if command:
             if isinstance(self.config, dict):
                 quick_commands = self.config.get("quick_commands", {}) or {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1387,7 +1387,8 @@ class GatewayRunner:
         if command == "voice":
             return await self._handle_voice_command(event)
 
-        # User-defined quick commands (bypass agent loop, no LLM call)
+        # User-defined quick commands (exec or alias)
+
         if command:
             if isinstance(self.config, dict):
                 quick_commands = self.config.get("quick_commands", {}) or {}
@@ -1415,8 +1416,18 @@ class GatewayRunner:
                             return f"Quick command error: {e}"
                     else:
                         return f"Quick command '/{command}' has no command defined."
+                elif qcmd.get("type") == "alias":
+                    target = qcmd.get("target", "").strip()
+                    if target:
+                        target = target if target.startswith("/") else f"/{target}"
+                        target_command = target.lstrip("/")
+                        user_args = event.get_command_args().strip()
+                        event.text = f"{target} {user_args}".strip()
+                        command = target_command
+                    else:
+                        return f"Quick command '/{command}' has no target defined."
                 else:
-                    return f"Quick command '/{command}' has unsupported type (only 'exec' is supported)."
+                    return f"Quick command '/{command}' has unsupported type (supported: 'exec', 'alias')."
 
         # Skill slash commands: /skill-name loads the skill and sends to agent
         if command:
@@ -1427,7 +1438,7 @@ class GatewayRunner:
                 if cmd_key in skill_cmds:
                     user_instruction = event.get_command_args().strip()
                     msg = build_skill_invocation_message(
-                        cmd_key, user_instruction, task_id=session_key
+                        cmd_key, user_instruction, task_id=build_session_key(source)
                     )
                     if msg:
                         event.text = msg

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -320,7 +320,8 @@ DEFAULT_CONFIG = {
 
     # Permanently allowed dangerous command patterns (added via "always" approval)
     "command_allowlist": [],
-    # User-defined quick commands that bypass the agent loop (type: exec only)
+    # User-defined quick commands that either run shell commands (type: exec)
+    # or alias to another slash command/skill (type: alias, target: /some-command)
     "quick_commands": {},
     # Custom personalities — add your own entries here
     # Supports string format: {"name": "system prompt"}

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -782,7 +782,7 @@ def cmd_model(args):
         ("openrouter", "OpenRouter (100+ models, pay-per-use)"),
         ("nous", "Nous Portal (Nous Research subscription)"),
         ("openai-codex", "OpenAI Codex"),
-        ("anthropic", "Anthropic (Claude models — API key or Claude Code)"),
+        ("anthropic", "Anthropic / Claude Code Max (Claude models — API key or Claude Code)"),
         ("zai", "Z.AI / GLM (Zhipu AI direct API)"),
         ("kimi-coding", "Kimi / Moonshot (Moonshot AI direct API)"),
         ("minimax", "MiniMax (global direct API)"),

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -145,6 +145,7 @@ def list_available_providers() -> list[dict[str, str]]:
     _PROVIDER_ORDER = [
         "openrouter", "nous", "openai-codex",
         "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic", "deepseek",
+        "custom",  # Custom OpenAI-compatible endpoints
     ]
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}
@@ -158,9 +159,12 @@ def list_available_providers() -> list[dict[str, str]]:
         # Check if this provider has credentials available
         has_creds = False
         try:
-            from hermes_cli.runtime_provider import resolve_runtime_provider
-            runtime = resolve_runtime_provider(requested=pid)
-            has_creds = bool(runtime.get("api_key"))
+            if pid == "custom":
+                has_creds = bool(_get_custom_base_url())
+            else:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+                runtime = resolve_runtime_provider(requested=pid)
+                has_creds = bool(runtime.get("api_key"))
         except Exception:
             pass
         result.append({
@@ -199,6 +203,19 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     return (current_provider, stripped)
 
 
+def _get_custom_base_url() -> str:
+    """Get the custom endpoint base_url from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        model_cfg = config.get("model", {})
+        if isinstance(model_cfg, dict):
+            return str(model_cfg.get("base_url", "")).strip()
+    except Exception:
+        pass
+    return ""
+
+
 def curated_models_for_provider(provider: Optional[str]) -> list[tuple[str, str]]:
     """Return ``(model_id, description)`` tuples for a provider's model list.
 
@@ -208,6 +225,10 @@ def curated_models_for_provider(provider: Optional[str]) -> list[tuple[str, str]
     """
     normalized = normalize_provider(provider)
     if normalized == "openrouter":
+        # If base_url points to a custom endpoint, don't show OpenRouter models
+        base_url = _get_custom_base_url()
+        if base_url and "openrouter.ai" not in base_url:
+            return []
         return list(OPENROUTER_MODELS)
 
     # Try live API first (Codex, Nous, etc. all support /models)
@@ -374,6 +395,15 @@ def provider_model_ids(provider: Optional[str]) -> list[str]:
         live = _fetch_anthropic_models()
         if live:
             return live
+    if normalized == "custom":
+        # Probe the custom endpoint's /models API
+        base_url = _get_custom_base_url()
+        if base_url:
+            import os
+            api_key = os.getenv("OPENAI_API_KEY", "") or os.getenv("OPENROUTER_API_KEY", "")
+            live = fetch_api_models(api_key, base_url)
+            if live:
+                return live
     return list(_PROVIDER_MODELS.get(normalized, []))
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -92,7 +92,7 @@ _PROVIDER_LABELS = {
     "kimi-coding": "Kimi / Moonshot",
     "minimax": "MiniMax",
     "minimax-cn": "MiniMax (China)",
-    "anthropic": "Anthropic",
+    "anthropic": "Anthropic / Claude Code Max",
     "deepseek": "DeepSeek",
     "custom": "Custom endpoint",
 }
@@ -109,6 +109,8 @@ _PROVIDER_ALIASES = {
     "claude": "anthropic",
     "claude-code": "anthropic",
     "deep-seek": "deepseek",
+    "claude-max": "anthropic",
+    "claude-code-max": "anthropic",
 }
 
 

--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -363,10 +363,17 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
 
     logger.info("Initializing Honcho client (host: %s, workspace: %s)", config.host, config.workspace_id)
 
+    # Allow an explicit local/self-hosted Honcho URL to override the SDK's
+    # environment mapping (e.g. production/local). This makes it possible to
+    # point Hermes at a remote self-hosted Honcho instance without requiring
+    # the server to live on localhost.
+    resolved_base_url = os.environ.get("HONCHO_URL") or None
+
     _honcho_client = Honcho(
         workspace_id=config.workspace_id,
         api_key=config.api_key,
         environment=config.environment,
+        base_url=resolved_base_url,
     )
 
     return _honcho_client

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import types
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
@@ -354,6 +355,7 @@ class TestRunJobPerJobOverrides:
         assert "ok" in output
         runtime_mock.assert_called_once_with(
             requested="custom",
+            explicit_api_key=None,
             explicit_base_url="http://127.0.0.1:4000/v1",
         )
         assert mock_agent_cls.call_args.kwargs["model"] == "perplexity/sonar-pro"

--- a/tests/test_quick_commands.py
+++ b/tests/test_quick_commands.py
@@ -23,6 +23,7 @@ class TestCLIQuickCommands:
         cli.console = MagicMock()
         cli.agent = None
         cli.conversation_history = []
+        cli.session_id = "test-session"
         return cli
 
     def test_exec_command_runs_and_prints_output(self):
@@ -46,6 +47,20 @@ class TestCLIQuickCommands:
         cli.console.print.assert_called_once()
         args = cli.console.print.call_args[0][0]
         assert "no output" in args.lower()
+
+    def test_alias_command_routes_to_target_command(self):
+        cli = self._make_cli({"moe-review": {"type": "alias", "target": "/legal-thought-leadership-review"}})
+        with patch("cli._skill_commands", {"/legal-thought-leadership-review": {"name": "legal-thought-leadership-review"}}), \
+             patch("cli.build_skill_invocation_message", return_value="expanded-skill-message"):
+            result = cli.process_command("/moe-review tighten this draft")
+        assert result is True
+
+    def test_alias_command_supports_other_skill_targets(self):
+        cli = self._make_cli({"moe-argument": {"type": "alias", "target": "/law-argument-editor"}})
+        with patch("cli._skill_commands", {"/law-argument-editor": {"name": "law-argument-editor"}}), \
+             patch("cli.build_skill_invocation_message", return_value="argument-skill-message"):
+            result = cli.process_command("/moe-argument sharpen the thesis")
+        assert result is True
 
     def test_unsupported_type_shows_error(self):
         cli = self._make_cli({"bad": {"type": "prompt", "command": "echo hi"}})
@@ -116,6 +131,46 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_alias_command_rewrites_to_skill_command(self):
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"moe-review": {"type": "alias", "target": "/legal-thought-leadership-review"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+        runner.session_store = MagicMock()
+        runner.session_store.get_or_create_session.side_effect = RuntimeError("stop after rewrite")
+
+        event = self._make_event("moe-review", "tighten this draft")
+        with patch("gateway.run.build_session_key", return_value="sess"), \
+             patch("agent.skill_commands.get_skill_commands", return_value={"/legal-thought-leadership-review": {"name": "legal-thought-leadership-review"}}), \
+             patch("agent.skill_commands.build_skill_invocation_message", return_value="expanded-skill-message"), \
+             pytest.raises(RuntimeError, match="stop after rewrite"):
+            await runner._handle_message(event)
+        assert event.text == "expanded-skill-message"
+
+    @pytest.mark.asyncio
+    async def test_alias_command_rewrites_to_other_skill_targets(self):
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"moe-style": {"type": "alias", "target": "/law-style-editor"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+        runner.session_store = MagicMock()
+        runner.session_store.get_or_create_session.side_effect = RuntimeError("stop after rewrite")
+
+        event = self._make_event("moe-style", "polish this post")
+        with patch("gateway.run.build_session_key", return_value="sess"), \
+             patch("agent.skill_commands.get_skill_commands", return_value={"/law-style-editor": {"name": "law-style-editor"}}), \
+             patch("agent.skill_commands.build_skill_invocation_message", return_value="style-skill-message"), \
+             pytest.raises(RuntimeError, match="stop after rewrite"):
+            await runner._handle_message(event)
+        assert event.text == "style-skill-message"
 
     @pytest.mark.asyncio
     async def test_unsupported_type_returns_error(self):

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -976,7 +976,7 @@ For the behavior details and examples, see [Sessions](/docs/user-guide/sessions)
 
 ## Quick Commands
 
-Define custom commands that run shell commands without invoking the LLM — zero token usage, instant execution. Especially useful from messaging platforms (Telegram, Discord, etc.) for quick server checks or utility scripts.
+Define custom commands that either run shell commands without invoking the LLM or alias to another slash command. This is useful from the CLI and messaging platforms (Telegram, Discord, etc.) for quick server checks, utility scripts, or shorter names for complex skill commands.
 
 ```yaml
 quick_commands:
@@ -992,14 +992,22 @@ quick_commands:
   gpu:
     type: exec
     command: nvidia-smi --query-gpu=name,utilization.gpu,memory.used,memory.total --format=csv,noheader
+  moe-review:
+    type: alias
+    target: /legal-thought-leadership-review
+  moe-style:
+    type: alias
+    target: /law-style-editor
 ```
 
-Usage: type `/status`, `/disk`, `/update`, or `/gpu` in the CLI or any messaging platform. The command runs locally on the host and returns the output directly — no LLM call, no tokens consumed.
+Usage:
+- `exec` commands like `/status`, `/disk`, `/update`, or `/gpu` run locally on the host and return output directly — no LLM call, no tokens consumed.
+- `alias` commands like `/moe-review` or `/moe-style` rewrite to another slash command before normal processing, so they can target built-in commands or installed skills.
 
-- **30-second timeout** — long-running commands are killed with an error message
-- **Priority** — quick commands are checked before skill commands, so you can override skill names
+- **30-second timeout** — applies to `exec` quick commands; long-running commands are killed with an error message
+- **Priority** — quick commands are checked before skill commands, so you can override skill names or add shorter aliases
 - **Autocomplete** — quick commands are resolved at dispatch time and are not shown in the built-in slash-command autocomplete tables
-- **Type** — only `exec` is supported (runs a shell command); other types show an error
+- **Types** — `exec` runs a shell command; `alias` rewrites to another slash command via `target`
 - **Works everywhere** — CLI, Telegram, Discord, Slack, WhatsApp, Signal, Email, Home Assistant
 
 ## Human Delay


### PR DESCRIPTION
Summary
This PR allows Hermes’ Honcho integration to respect `HONCHO_URL` and pass it through to the Honcho SDK as `base_url`.

Problem
Today Hermes can initialize Honcho in two practical modes:
- hosted Honcho via the SDK production default
- “local” Honcho via the SDK’s `environment="local"` mapping to `http://localhost:8000`

That works if Honcho is running on the same machine as Hermes, but breaks for a common self-hosting pattern:
- Hermes on one machine
- self-hosted Honcho on another machine on the LAN / VPN / internal network

In that setup, `environment="local"` is not sufficient because the SDK maps it to localhost rather than the actual self-hosted Honcho URL.

Change
If `HONCHO_URL` is set, Hermes now passes it to the Honcho SDK as `base_url` when constructing the client.

Behavior:
- no change when `HONCHO_URL` is unset
- explicit self-hosted override when `HONCHO_URL` is set

Why this is useful
This enables remote self-hosted Honcho deployments without:
- pretending the server is local
- patching SDK environment mappings
- using workarounds tied only to localhost

Example use case
- Hermes running on a workstation
- Honcho self-hosted on a Proxmox VM or internal server
- `HONCHO_URL=http://192.168.x.x:8000` or `https://honcho.example.com`

Risk
Low.
The change is additive and opt-in.

Validation
Tested against a self-hosted Honcho deployment running on a separate LAN VM.
Verified:
- `hermes honcho status` succeeds
- Hermes session manager can save messages
- dialectic retrieval works against the remote self-hosted instance