### PR TITLE
feat: add real-time cost estimation to session token tracking

### DIFF
--- a/agent/pricing.py
+++ b/agent/pricing.py
@@ -1,0 +1,62 @@
+"""Model pricing helpers for session cost estimation."""
+
+from __future__ import annotations
+
+
+MODEL_PRICING = {
+    "claude-sonnet-4-20250514": (3.00, 15.00, 0.30),
+    "claude-opus-4-20250514": (15.00, 75.00, 1.50),
+    "claude-haiku-3-5-20241022": (0.80, 4.00, 0.08),
+    "gpt-4o": (2.50, 10.00, 1.25),
+    "gpt-4o-mini": (0.15, 0.60, 0.075),
+    "o3-mini": (1.10, 4.40, 0.55),
+    "deepseek-chat": (0.27, 1.10, 0.07),
+    "deepseek-reasoner": (0.55, 2.19, 0.14),
+    "meta-llama/llama-4-maverick": (0.20, 0.60, 0.05),
+}
+
+
+def _resolve_pricing(model: str) -> tuple[float, float, float] | None:
+    """Resolve pricing with loose model-name matching."""
+    if not model:
+        return None
+
+    if model in MODEL_PRICING:
+        return MODEL_PRICING[model]
+
+    model_name = model.split("/", 1)[-1]
+    if model_name in MODEL_PRICING:
+        return MODEL_PRICING[model_name]
+
+    for name, pricing in MODEL_PRICING.items():
+        if (
+            model in name
+            or name in model
+            or model_name in name
+            or name.split("/", 1)[-1] in model_name
+        ):
+            return pricing
+
+    return None
+
+
+def estimate_cost(
+    model: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    cached_tokens: int = 0,
+) -> float:
+    """Estimate USD cost for one model call."""
+    pricing = _resolve_pricing(model)
+    if pricing is None:
+        return 0.0
+
+    input_rate, output_rate, cached_input_rate = pricing
+    cached_tokens = max(0, cached_tokens)
+    billable_prompt_tokens = max(0, prompt_tokens - cached_tokens)
+
+    return (
+        (billable_prompt_tokens / 1_000_000) * input_rate
+        + (completion_tokens / 1_000_000) * output_rate
+        + (cached_tokens / 1_000_000) * cached_input_rate
+    )

--- a/cli.py
+++ b/cli.py
@@ -3437,6 +3437,8 @@ class HermesCLI:
         print(f"  Completion tokens (output): {completion:>9,}")
         print(f"  Total tokens:              {total:>10,}")
         print(f"  API calls:                 {calls:>10,}")
+        print(f"  Estimated cost:            ${agent.session_estimated_cost:.4f}")
+        print(f"  Cached tokens:             {agent.session_cached_tokens:>10,}")
         print(f"  {'─' * 40}")
         print(f"  Current context:  {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")
         print(f"  Messages:         {msg_count}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3160,6 +3160,8 @@ class GatewayRunner:
                 f"Completion (output): {agent.session_completion_tokens:,}",
                 f"Total: {agent.session_total_tokens:,}",
                 f"API calls: {agent.session_api_calls}",
+                f"Estimated cost: ${agent.session_estimated_cost:.4f}",
+                f"Cached tokens: {agent.session_cached_tokens:,}",
             ]
             ctx = agent.context_compressor
             if ctx.last_prompt_tokens:

--- a/run_agent.py
+++ b/run_agent.py
@@ -817,6 +817,8 @@ class AIAgent:
         self.session_completion_tokens = 0
         self.session_total_tokens = 0
         self.session_api_calls = 0
+        self.session_estimated_cost = 0.0
+        self.session_cached_tokens = 0
         
         if not self.quiet_mode:
             if compression_enabled:
@@ -5044,11 +5046,8 @@ class AIAgent:
                         self.session_completion_tokens += completion_tokens
                         self.session_total_tokens += total_tokens
                         self.session_api_calls += 1
-                        
-                        if self.verbose_logging:
-                            logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
-                        
-                        # Log cache hit stats when prompt caching is active
+                        cached = 0
+                        written = 0
                         if self._use_prompt_caching:
                             if self.api_mode == "anthropic_messages":
                                 # Anthropic uses cache_read_input_tokens / cache_creation_input_tokens
@@ -5059,6 +5058,21 @@ class AIAgent:
                                 details = getattr(response.usage, 'prompt_tokens_details', None)
                                 cached = getattr(details, 'cached_tokens', 0) or 0 if details else 0
                                 written = getattr(details, 'cache_write_tokens', 0) or 0 if details else 0
+                        self.session_cached_tokens += cached
+                        from agent.pricing import estimate_cost
+                        call_cost = estimate_cost(
+                            self.model,
+                            prompt_tokens,
+                            completion_tokens,
+                            cached_tokens=cached,
+                        )
+                        self.session_estimated_cost += call_cost
+                        
+                        if self.verbose_logging:
+                            logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
+                        
+                        # Log cache hit stats when prompt caching is active
+                        if self._use_prompt_caching:
                             prompt = usage_dict["prompt_tokens"]
                             hit_pct = (cached / prompt * 100) if prompt > 0 else 0
                             if not self.quiet_mode:


### PR DESCRIPTION
## Summary

Adds real-time cost estimation to Hermes's existing token tracking. Every API call already counts tokens — this PR multiplies them by model pricing to show estimated USD cost.

## Changes

### New: `agent/pricing.py` (62 lines)
- `MODEL_PRICING` dict mapping model names → `(input_rate, output_rate, cached_rate)` per 1M tokens
- `estimate_cost()` — calculates USD cost accounting for prompt cache savings
- `_resolve_pricing()` — fuzzy model name matching (strips provider prefixes, partial substring)
- Models: Claude Sonnet/Opus/Haiku, GPT-4o/4o-mini, o3-mini, DeepSeek Chat/Reasoner, Llama 4 Maverick

### Modified: `run_agent.py`
- Added `session_estimated_cost` and `session_cached_tokens` counters to AIAgent
- After each API call, computes cost from actual token usage + cache data
- Lazy import of `agent.pricing` (inside the hot path, not at module level)
- Restructured cache token extraction to happen before cost calculation (shared with existing cache hit logging)

### Modified: `gateway/run.py` + `cli.py`
- `/usage` command now shows `Estimated cost: $X.XXXX` and `Cached tokens: N`

## Design Decisions
- **Zero new dependencies** — pure Python stdlib
- **Backward compatible** — new attributes on AIAgent, existing behavior unchanged
- **Lazy import** — `agent.pricing` only loaded when first API response arrives
- **Cache-aware** — cached tokens billed at reduced rate (e.g., 90% discount for Anthropic)

## Testing
- `python -m py_compile` passes on all 4 files
- `pytest tests/test_model_tools.py tests/test_cli_init.py` — 24/24 passed
- Manual verification of pricing calculations with known rates