### PR TITLE
fix: hide Honcho session line on CLI load when no API key

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5353,7 +5353,7 @@ class HermesCLI:
             from honcho_integration.client import HonchoClientConfig
             from agent.display import honcho_session_line, write_tty
             hcfg = HonchoClientConfig.from_global_config()
-            if hcfg.enabled:
+            if hcfg.enabled and hcfg.api_key:
                 sname = hcfg.resolve_session_name(session_id=self.session_id)
                 if sname:
                     write_tty(honcho_session_line(hcfg.workspace_id, sname) + "\n")

--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -114,11 +114,12 @@ class HonchoClientConfig:
     @classmethod
     def from_env(cls, workspace_id: str = "hermes") -> HonchoClientConfig:
         """Create config from environment variables (fallback)."""
+        api_key = os.environ.get("HONCHO_API_KEY")
         return cls(
             workspace_id=workspace_id,
-            api_key=os.environ.get("HONCHO_API_KEY"),
+            api_key=api_key,
             environment=os.environ.get("HONCHO_ENVIRONMENT", "production"),
-            enabled=True,
+            enabled=bool(api_key),
         )
 
     @classmethod


### PR DESCRIPTION
## What this PR does

Stops the Honcho session indicator from displaying on CLI launch when the user hasn't configured Honcho.

### Root Cause

`HonchoClientConfig.from_env()` set `enabled=True` unconditionally. When `~/.honcho/config.json` didn't exist, `from_global_config()` fell back to `from_env()` which returned `enabled=True` with a null `api_key`. The CLI display code checked `if hcfg.enabled:` and showed the Honcho session line even with no Honcho setup.

### Fix

- `from_env()` now sets `enabled=bool(api_key)`, matching the auto-enable logic already used in `from_global_config()` (line 181: `enabled = bool(api_key)`)
- Added `and hcfg.api_key` guard to the CLI display check as defense-in-depth (matches the pattern already used in `honcho_integration/cli.py` line 258)

### Files Changed

- `honcho_integration/client.py` — `from_env()` respects missing API key
- `cli.py` — display guard