### PR TITLE
improve error logging in code_execution_tool

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -593,7 +593,14 @@ def execute_code(
 
     except Exception as exc:
         duration = round(time.monotonic() - exec_start, 2)
-        logging.exception("execute_code failed")
+        logger.error(
+            "execute_code failed after %ss with %d tool calls: %s: %s",
+            duration,
+            tool_call_counter[0],
+            type(exc).__name__,
+            exc,
+            exc_info=True,
+        )
         return json.dumps({
             "status": "error",
             "error": str(exc),
@@ -606,7 +613,7 @@ def execute_code(
         try:
             server_sock.close()
         except Exception as e:
-            logger.debug("Server socket close error: %s", e)
+            logger.debug("Server socket close error: %s", e, exc_info=True)
         try:
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
This PR improves observability in `code_execution_tool.py` by routing top-level `execute_code` failures through the module logger with `exc_info=True` (including execution duration and tool-call count) and by adding stack traces when the RPC server socket cleanup fails, making sandbox execution issues significantly easier to debug without changing existing behavior or response formats.