### PR TITLE
fix(setup): install anthropic SDK when Anthropic provider is selected

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1136,6 +1136,33 @@ def setup_model_provider(config: dict):
         from hermes_cli.config import save_anthropic_api_key, save_anthropic_oauth_token
         pconfig = PROVIDER_REGISTRY["anthropic"]
 
+        # Check if anthropic SDK is installed
+        try:
+            __import__("anthropic")
+        except ImportError:
+            print_info("Installing anthropic SDK...")
+            import subprocess
+
+            uv_bin = shutil.which("uv")
+            if uv_bin:
+                result = subprocess.run(
+                    [uv_bin, "pip", "install", "--python", sys.executable, "anthropic>=0.39.0"],
+                    capture_output=True,
+                    text=True,
+                )
+            else:
+                result = subprocess.run(
+                    [sys.executable, "-m", "pip", "install", "anthropic>=0.39.0"],
+                    capture_output=True,
+                    text=True,
+                )
+            if result.returncode == 0:
+                print_success("anthropic SDK installed")
+            else:
+                print_warning("Install failed — run manually: pip install 'anthropic>=0.39.0'")
+                if result.stderr:
+                    print_info(f"  Error: {result.stderr.strip().splitlines()[-1]}")
+
         # Check ALL credential sources
         import os as _os
         from agent.anthropic_adapter import (


### PR DESCRIPTION
## Problem

Selecting the Anthropic provider in `hermes setup` configures credentials but never checks whether the `anthropic` Python package is installed. On first launch after switching providers, `build_anthropic_client()` raises `ImportError` because `anthropic_adapter.py` lazy-imports the SDK (sets `_anthropic_sdk=None` on miss) and only raises at client construction time, not at import time.

The user sees a cryptic error on their very first message, with no indication that a simple `pip install anthropic` would fix it.

## Fix

At the point in `setup_model_provider()` where the Anthropic provider branch is entered, check importability of `anthropic` and install it if missing:

- Uses `uv pip install` when `uv` is available (preferred)
- Falls back to `pip install` otherwise
- Prints a clear manual-install hint if installation fails

Follows the same pattern as the `daytona` and `swe-rex[modal]` dependency installs already present in `setup.py`.

## Testing

Verified by temporarily removing the `anthropic` package and running `hermes setup` with the Anthropic provider — the SDK is installed automatically before credential prompts begin.