### PR TITLE
fix(claw): warn when API keys are skipped during OpenClaw migration

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -294,3 +294,18 @@ def _print_migration_report(report: dict, dry_run: bool):
     elif migrated:
         print()
         print_success("Migration complete!")
+        # Warn if API keys were skipped (migrate_secrets not enabled)
+        skipped_keys = [
+            i for i in report.get("items", [])
+            if i.get("kind") == "provider-keys" and i.get("status") == "skipped"
+        ]
+        if skipped_keys:
+            print()
+            print(color("  ⚠ API keys were NOT migrated (secrets migration is disabled by default).", Colors.YELLOW))
+            print(color("  Your OPENROUTER_API_KEY and other provider keys must be added manually.", Colors.YELLOW))
+            print()
+            print_info("To migrate API keys, re-run with:")
+            print_info("  hermes claw migrate --migrate-secrets")
+            print()
+            print_info("Or add your key manually:")
+            print_info("  hermes config set OPENROUTER_API_KEY sk-or-v1-...")


### PR DESCRIPTION
Fixes #1580

## Problem
After running `hermes claw migrate`, the OPENROUTER_API_KEY was silently skipped because `--migrate-secrets` is disabled by default. Users had no indication that their API key wasn't migrated, leading to confusing 401 errors in Telegram.

## Fix
After migration completes, if any provider keys were skipped, display a clear warning with actionable next steps:
- How to re-run with `--migrate-secrets`
- How to add the key manually via `hermes config set`

## Before
Migration completes silently, agent fails with misleading 401 error.

## After
✓ Migration complete!
⚠ API keys were NOT migrated (secrets migration is disabled by default).
Your OPENROUTER_API_KEY and other provider keys must be added manually.
To migrate API keys, re-run with:
hermes claw migrate --migrate-secrets
Or add your key manually:
hermes config set OPENROUTER_API_KEY sk-or-v1-...