### PR TITLE
fix: add --yes flag to bypass confirmation in TUI mode

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -304,7 +304,7 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
 
 
 def do_install(identifier: str, category: str = "", force: bool = False,
-               console: Optional[Console] = None) -> None:
+               console: Optional[Console] = None, skip_confirm: bool = False) -> None:
     """Fetch, quarantine, scan, confirm, and install a skill."""
     from tools.skills_hub import (
         GitHubAuth, create_source_router, ensure_hub_dirs,
@@ -378,7 +378,8 @@ def do_install(identifier: str, category: str = "", force: bool = False,
             c.print(Panel("\n".join(metadata_lines), title="Upstream Metadata", border_style="blue"))
 
     # Confirm with user — show appropriate warning based on source
-    if not force:
+    # Skip confirmation in TUI mode or if explicitly bypassed
+    if not force and not skip_confirm:
         c.print()
         if bundle.source == "official":
             c.print(Panel(
@@ -407,11 +408,11 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         if answer not in ("y", "yes"):
             c.print("[dim]Installation cancelled.[/]\n")
             shutil.rmtree(q_path, ignore_errors=True)
+            from tools.skills_hub import append_audit_log
+            append_audit_log("CANCELLED", bundle.name, bundle.source,
+                             bundle.trust_level, result.verdict,
+                             f"{len(result.findings)}_findings")
             return
-
-    # Install
-    install_dir = install_from_quarantine(q_path, bundle.name, category, bundle, result)
-    from tools.skills_hub import SKILLS_DIR
     c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
 
@@ -598,20 +599,22 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None) -> N
         c.print()
 
 
-def do_uninstall(name: str, console: Optional[Console] = None) -> None:
+def do_uninstall(name: str, force: bool = False, console: Optional[Console] = None) -> None:
     """Remove a hub-installed skill with confirmation."""
     from tools.skills_hub import uninstall_skill
 
     c = console or _console
 
-    c.print(f"\n[bold]Uninstall '{name}'?[/]")
-    try:
-        answer = input("Confirm [y/N]: ").strip().lower()
-    except (EOFError, KeyboardInterrupt):
-        answer = "n"
-    if answer not in ("y", "yes"):
-        c.print("[dim]Cancelled.[/]\n")
-        return
+    # Skip confirmation if force=True (e.g., TUI mode or --yes flag)
+    if not force:
+        c.print(f"\n[bold]Uninstall '{name}'?[/]")
+        try:
+            answer = input("Confirm [y/N]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = "n"
+        if answer not in ("y", "yes"):
+            c.print("[dim]Cancelled.[/]\n")
+            return
 
     success, msg = uninstall_skill(name)
     if success:
@@ -1054,11 +1057,13 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
             return
         identifier = args[0]
         category = ""
-        force = any(flag in args for flag in ("--force", "--yes", "-y"))
+        # --yes / -y bypasses confirmation, --force handles reinstall
+        skip_confirm = any(flag in args for flag in ("--yes", "-y"))
+        force = any(flag in args for flag in ("--force",))
         for i, a in enumerate(args):
             if a == "--category" and i + 1 < len(args):
                 category = args[i + 1]
-        do_install(identifier, category=category, force=force, console=c)
+        do_install(identifier, category=category, force=force, skip_confirm=skip_confirm, console=c)
 
     elif action == "inspect":
         if not args:
@@ -1088,9 +1093,11 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
 
     elif action == "uninstall":
         if not args:
-            c.print("[bold red]Usage:[/] /skills uninstall <name>\n")
+            c.print("[bold red]Usage:[/] /skills uninstall <name> [--yes]\n")
             return
-        do_uninstall(args[0], console=c)
+        # Check for --yes / -y flag to bypass confirmation (needed for TUI mode)
+        force = any(flag in args for flag in ("--yes", "-y", "--force"))
+        do_uninstall(args[0], force=force, console=c)
 
     elif action == "publish":
         if not args:


### PR DESCRIPTION
**What does this PR do?** 
Fixes hanging when using `/skills install` or `/skills uninstall` commands from the  Hermes TUI by adding `--yes` flag support to bypass confirmation prompts that hang on Python's `input()` in prompt_toolkit.                                                   

**Related Issue** 
No issue exists, this is a spontaneous fix.                                             

**Type of Change**
 - [x] 🐛 Bug fix (non-breaking change that fixes an issue) 

**Changes Made**                                                                        
- hermes_cli/skills_hub.py: Added `--yes` / `-y` / `--force` flags to `/skills  install` and `/skills uninstall`                                                        
- Separated `--force` (reinstall override) from `--yes` (confirmation bypass)           
- Fixed hanging confirmation prompts in TUI mode

**How to Test**                                                                         
1. In Hermes TUI: `/skills install some-skill --yes` should install without  hanging
2. In Hermes TUI: `/skills uninstall some-skill --yes` should uninstall without    hanging                                                                                 
3. Commands without `--yes` should still show confirmation (for CLI usage)

