### PR TITLE
fix(tools): remove unnecessary crontab dependency from cronjob tools

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -62,19 +62,31 @@ class TestScanCronPrompt:
 
 
 class TestCronjobRequirements:
-    def test_requires_crontab_binary_even_in_interactive_mode(self, monkeypatch):
-        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    def test_requires_interactive_mode(self, monkeypatch):
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
-        monkeypatch.setattr("shutil.which", lambda name: None)
 
         assert check_cronjob_requirements() is False
 
-    def test_accepts_interactive_mode_when_crontab_exists(self, monkeypatch):
+    def test_accepts_interactive_mode(self, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
-        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/crontab")
+
+        assert check_cronjob_requirements() is True
+
+    def test_accepts_gateway_session(self, monkeypatch):
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+        assert check_cronjob_requirements() is True
+
+    def test_accepts_exec_ask(self, monkeypatch):
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
 
         assert check_cronjob_requirements() is True
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -8,7 +8,6 @@ Compatibility wrappers remain for direct Python callers and legacy tests.
 import json
 import os
 import re
-import shutil
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -414,13 +413,10 @@ def check_cronjob_requirements() -> bool:
     """
     Check if cronjob tools can be used.
 
-    Requires 'crontab' executable to be present in the system PATH.
+    Cron jobs are managed internally by Hermes (stored in ~/.hermes/cron/jobs.json
+    and executed by the gateway's scheduler). No system crontab is required.
     Available in interactive CLI mode and gateway/messaging platforms.
     """
-    # Ensure the system can actually install and manage cron entries.
-    if not shutil.which("crontab"):
-        return False
-
     return bool(
         os.getenv("HERMES_INTERACTIVE")
         or os.getenv("HERMES_GATEWAY_SESSION")


### PR DESCRIPTION
## What does this PR do?

Removes the unnecessary check for the system 'crontab' binary in the cronjob tools. The cronjob system is entirely internal to Hermes — jobs are stored in ~/.hermes/cron/jobs.json and executed by the gateway's in-process scheduler. The crontab binary was never actually used.

## Related Issue

Fixes #1589

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Removed `shutil.which('crontab')` check from `check_cronjob_requirements()`
- Updated docstring to clarify internal cron implementation
- Removed unused `shutil` import
- Updated tests to reflect new behavior

## How to Test

1. Run Hermes in a container without crontab installed (e.g., `docker run --rm -it ubuntu`)
2. Verify the cronjob tool is now available
3. Create a test cron job and verify it schedules correctly

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] My PR contains only changes related to this fix
- [x] I've considered cross-platform impact
