### PR TITLE
fix(gateway): strip MEDIA: and [[audio_as_voice]] tags from message body

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -838,8 +838,7 @@ class BasePlatformAdapter(ABC):
                 images, text_content = self.extract_images(response)
                 # Strip any remaining internal directives from message body (fixes #1561)
                 text_content = text_content.replace("[[audio_as_voice]]", "").strip()
-                import re as _re
-                text_content = _re.sub(r"MEDIA:\s*\S+", "", text_content).strip()
+                text_content = re.sub(r"MEDIA:\s*\S+", "", text_content).strip()
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
                 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -836,6 +836,10 @@ class BasePlatformAdapter(ABC):
                 
                 # Extract image URLs and send them as native platform attachments
                 images, text_content = self.extract_images(response)
+                # Strip any remaining internal directives from message body (fixes #1561)
+                text_content = text_content.replace("[[audio_as_voice]]", "").strip()
+                import re as _re
+                text_content = _re.sub(r"MEDIA:\s*\S+", "", text_content).strip()
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
                 


### PR DESCRIPTION
Closes #1561

## What does this PR do?

In the current Gateway logic, MEDIA: and [[audio_as_voice]] tags were leaking into the final message output after extract_images() processing.

After extract_media() strips these tags from the response, extract_images() returns a text_content that still contains [[audio_as_voice]] directives. This causes raw technical text to appear in Telegram chat bubbles.

Fix: strip [[audio_as_voice]] and MEDIA: tags from text_content immediately after extract_images() returns.

Closes #1561

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [✅] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- gateway/platforms/base.py: strip [[audio_as_voice]] and MEDIA: tags from text_content after extract_images() returns 

## How to Test

1. Set up gateway with Telegram
2. Send a TTS command that generates audio
3. Verify [[audio_as_voice]] and MEDIA: tags no longer appear in the chat bubble

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [✅] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [✅ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [✅ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ✅] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

