### PR TITLE
fix: improve systemd gateway service resilience

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -168,19 +168,28 @@ def generate_systemd_unit() -> str:
     return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network.target
+# Cap rapid crash loops — 5 failures within 2 minutes triggers cooldown
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 [Service]
 Type=simple
 ExecStart={python_path} -m hermes_cli.main gateway run --replace
 ExecStop={hermes_cli} gateway stop
+# Kill leaked browser processes (chrome, chromium) from browser automation tools
+ExecStopPost=/bin/bash -c 'pkill -9 -f "chrom.*remote-debugging-port" 2>/dev/null || true'
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
-Restart=on-failure
-RestartSec=10
-KillMode=mixed
+# Restart on any exit — not just failure codes — so the gateway self-heals
+Restart=always
+RestartSec=15
+# Kill the entire cgroup so orphan browser processes die with the service
+KillMode=control-group
 KillSignal=SIGTERM
-TimeoutStopSec=15
+# Give Python time to gracefully disconnect messaging platforms, then SIGKILL
+TimeoutStopSec=20
+SendSIGKILL=yes
 StandardOutput=journal
 StandardError=journal
 
@@ -412,8 +421,8 @@ def run_gateway(verbose: bool = False, replace: bool = False):
     print("└─────────────────────────────────────────────────────────┘")
     print()
     
-    # Exit with code 1 if gateway fails to connect any platform,
-    # so systemd Restart=on-failure will retry on transient errors
+    # Exit with code 1 if gateway fails to connect any platform.
+    # systemd Restart=always will auto-restart regardless of exit code.
     success = asyncio.run(start_gateway(replace=replace))
     if not success:
         sys.exit(1)


### PR DESCRIPTION
Fixes #1617

## Changes

Updates the systemd unit template in `hermes_cli/gateway.py` to handle browser process orphaning and improve auto-restart reliability.

### Service Unit Changes

| Setting | Before | After | Why |
|---------|--------|-------|-----|
| `Restart` | `on-failure` | `always` | Self-heal on any exit, not just error codes |
| `RestartSec` | `10` | `15` | Avoid rapid restart churn |
| `KillMode` | `mixed` | `control-group` | Kill orphan Chrome processes in cgroup |
| `TimeoutStopSec` | `15` | `20` | More time for graceful platform disconnect |
| `SendSIGKILL` | (default) | `yes` | Ensure cleanup after timeout |
| `ExecStopPost` | — | force-kill chrome | Clean leaked browser processes |
| `StartLimitIntervalSec` | — | `120` | Crash loop protection (5 per 2min) |
| `StartLimitBurst` | — | `5` | Crash loop protection |

### What was happening

Browser automation tools spawn Chrome with `--remote-debugging-port`. Those Chrome processes join the service's cgroup. On stop, `KillMode=mixed` only SIGKILL'd the main Python process — Chrome children stayed alive, preventing clean cgroup teardown. systemd timed out, marked the service as failed, and `Restart=on-failure` didn't always trigger recovery.

### Migration

Existing installations need `hermes gateway install --force` to regenerate the unit file.