### PR TITLE
fix: apply MarkdownV2 formatting in _send_telegram for proper message rendering

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -308,9 +308,23 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
 
 async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None):
-    """Send via Telegram Bot API (one-shot, no polling needed)."""
+    """Send via Telegram Bot API (one-shot, no polling needed).
+
+    Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
+    so that bold, links, and headers render correctly.
+    """
     try:
         from telegram import Bot
+        from telegram.constants import ParseMode
+
+        # Reuse the gateway adapter's format_message for markdown→MarkdownV2
+        try:
+            from gateway.platforms.telegram import TelegramAdapter, _escape_mdv2, _strip_mdv2
+            _adapter = TelegramAdapter.__new__(TelegramAdapter)
+            formatted = _adapter.format_message(message)
+        except Exception:
+            # Fallback: send as-is if formatting unavailable
+            formatted = message
 
         bot = Bot(token=token)
         int_chat_id = int(chat_id)
@@ -322,10 +336,27 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         last_msg = None
         warnings = []
 
-        if message.strip():
-            last_msg = await bot.send_message(
-                chat_id=int_chat_id, text=message, **thread_kwargs
-            )
+        if formatted.strip():
+            try:
+                last_msg = await bot.send_message(
+                    chat_id=int_chat_id, text=formatted,
+                    parse_mode=ParseMode.MARKDOWN_V2, **thread_kwargs
+                )
+            except Exception as md_error:
+                # MarkdownV2 failed, fall back to plain text
+                if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
+                    logger.warning("MarkdownV2 parse failed in _send_telegram, falling back to plain text: %s", md_error)
+                    try:
+                        from gateway.platforms.telegram import _strip_mdv2
+                        plain = _strip_mdv2(formatted)
+                    except Exception:
+                        plain = message
+                    last_msg = await bot.send_message(
+                        chat_id=int_chat_id, text=plain,
+                        parse_mode=None, **thread_kwargs
+                    )
+                else:
+                    raise
 
         for media_path, is_voice in media_files:
             if not os.path.exists(media_path):


### PR DESCRIPTION
## Problem

The `_send_telegram()` function in `tools/send_message_tool.py` sends messages as raw markdown text without setting `parse_mode`. According to the [Telegram Bot API `sendMessage` documentation](https://core.telegram.org/bots/api#sendmessage), when `parse_mode` is omitted, the message is sent as **plain text** — all markdown syntax characters (``*``, ``_``, ``[``, etc.) are rendered literally instead of as formatting.

This means bold headers, inline links, and emphasis in cron reports, notifications, and other messages delivered via the direct Telegram path render as raw markdown garbage (e.g., ``**Portfolio Update**`` instead of **Portfolio Update**).

## Context from Telegram Documentation

The [Telegram Bot API](https://core.telegram.org/bots/api#formatting-options) defines three formatting modes for `sendMessage`:

| `parse_mode` | Status | Notes |
|---|---|---|
| ``MarkdownV2`` | **Current standard** | Full formatting support; requires escaping special characters |
| ``Markdown`` | **Legacy** | Deprecated; limited escaping rules, kept for backward compatibility |
| ``HTML`` | Supported | Uses HTML tags instead of markdown syntax |
| *(omitted)* | Plain text | All formatting characters rendered literally |

Per the [python-telegram-bot library docs](https://docs.python-telegram-bot.org/en/stable/telegram.constants.html#telegram.constants.ParseMode) (which tracks the official Bot API spec), ``MARKDOWN`` is explicitly marked as **legacy** — ``MARKDOWN_V2`` is the correct current standard.

The gateway adapter already implements proper markdown→MarkdownV2 conversion in `TelegramAdapter.format_message()` (`gateway/platforms/telegram.py:733`), which:

1. Protects fenced code blocks (`` ``` ``) and inline code (`` ` ``) from escaping
2. Converts standard markdown links `[text](url)` to escaped MarkdownV2 format
3. Translates headers (``#``) and bold (``**``) to MarkdownV2 syntax (``*text*``)
4. Escapes all [MarkdownV2 special characters](https://core.telegram.org/bots/api#markdownv2-style): ``_``, ``*``, ``[``, ``]``, ``(``, ``)``, ``~``, ``\``, ``>``, ``#``, ``+``, ``-``, ``=``, ``|``, ``{``, ``}``, ``.``, ``!``

The fix reuses this existing adapter logic instead of duplicating it.

## Fix

- Calls `TelegramAdapter.format_message()` to convert standard markdown to Telegram MarkdownV2
- Sets `parse_mode=ParseMode.MARKDOWN_V2` when sending via `bot.send_message()`
- Falls back to plain text (with `parse_mode=None`) if MarkdownV2 parsing fails, ensuring messages are always delivered

## Testing

I have tested this in scheduled jobs and direct DMs. Before the fix, I would get just un-rendered markdown while after the fix, the markdown is properly rendered.

**Before**
<img width="718" height="752" alt="image" src="https://github.com/user-attachments/assets/ab37937c-9b4d-4527-b7cc-e98364ecd6a4" />

**After**
<img width="333" height="365" alt="image" src="https://github.com/user-attachments/assets/79e5a8b3-92eb-4861-9029-f2e0aea2b789" />


## Disclaimer
Everything in this PR was done by my Hermes Agent. I, the human, have verified that it works and wrote myself the testing and this disclaimer sections.