### PR TITLE
fix: MiniMax Anthropic API + execute_code logging improvements

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -395,6 +395,7 @@ def execute_code(
     tool_call_log: list = []
     tool_call_counter = [0]  # mutable so the RPC thread can increment
     exec_start = time.monotonic()
+    server_sock = None
 
     try:
         # Write the auto-generated hermes_tools module
@@ -615,19 +616,17 @@ def execute_code(
 
     finally:
         # Cleanup temp dir and socket
-        try:
-            server_sock.close()
-        except Exception as e:
-            logger.debug("Server socket close error: %s", e, exc_info=True)
-        try:
-            import shutil
-            shutil.rmtree(tmpdir, ignore_errors=True)
-        except Exception as e:
-            logger.debug("Could not clean temp dir: %s", e, exc_info=True)
+        if server_sock is not None:
+            try:
+                server_sock.close()
+            except OSError as e:
+                logger.debug("Server socket close error: %s", e)
+        import shutil
+        shutil.rmtree(tmpdir, ignore_errors=True)
         try:
             os.unlink(sock_path)
-        except OSError as e:
-            logger.debug("Could not remove socket file: %s", e, exc_info=True)
+        except OSError:
+            pass  # already cleaned up or never created
 
 
 def _kill_process_group(proc, escalate: bool = False):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -598,7 +598,14 @@ def execute_code(
 
     except Exception as exc:
         duration = round(time.monotonic() - exec_start, 2)
-        logging.exception("execute_code failed")
+        logger.error(
+            "execute_code failed after %ss with %d tool calls: %s: %s",
+            duration,
+            tool_call_counter[0],
+            type(exc).__name__,
+            exc,
+            exc_info=True,
+        )
         return json.dumps({
             "status": "error",
             "error": str(exc),
@@ -611,7 +618,7 @@ def execute_code(
         try:
             server_sock.close()
         except Exception as e:
-            logger.debug("Server socket close error: %s", e)
+            logger.debug("Server socket close error: %s", e, exc_info=True)
         try:
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
## Summary

Two changes in one PR:

### 1. Switch MiniMax to Anthropic Messages API (feat)

MiniMax's OpenAI-compatible endpoint has a known issue where tool calls are sometimes returned as XML content (`<minimax:tool_call>...`) instead of structured `tool_calls`. Their team confirmed this and recommended using their Anthropic Messages API endpoint instead.

**Changes across 8 files:**

- **`hermes_cli/auth.py`** — Switch MiniMax/MiniMax-CN inference base URLs from `/v1` (OpenAI) to `/anthropic` (Anthropic Messages)
- **`hermes_cli/runtime_provider.py`** — Return `api_mode='anthropic_messages'` for MiniMax providers instead of `chat_completions`
- **`agent/anthropic_adapter.py`** — Add `third_party` flag to `build_anthropic_client()` to skip OAuth detection, Anthropic beta headers, and Claude Code user-agent. Guard `normalize_model_name()` to not mangle non-Claude names (MiniMax-M2.5 → MiniMax-M2-5 was wrong)
- **`run_agent.py`** — Detect MiniMax as third-party Anthropic provider: skip OAuth credential refresh, use plain API key auth, show provider-appropriate 401 diagnostics
- **`agent/model_metadata.py` + `hermes_cli/models.py`** — Add missing MiniMax models (M2.1-highspeed, M2)

MiniMax's Anthropic compat layer supports: tool calling, interleaved thinking, explicit prompt caching (`cache_control` with 5min TTL), streaming, 204,800 token context.

Ref: https://platform.minimax.io/docs/api-reference/text-anthropic-api

### 2. Improve execute_code error logging (cherry-pick + follow-up)

Salvages PR #1588 by @aydnOktay:
- Fix root `logging.exception()` → module `logger.error()` with structured context
- Harden cleanup: init `server_sock = None`, guard close, narrow to `OSError`, remove debug noise

## Test plan
- Full suite: 4684 passed, 200 skipped, 3 pre-existing unrelated failures
- MiniMax URL and api_mode tests updated

Closes #1588