### PR TITLE
fix(cli): invalidate update-check cache after hermes update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2122,7 +2122,17 @@ def _restore_stashed_changes(
     print("  Review `git diff` / `git status` if Hermes behaves unexpectedly.")
     return True
 
-
+def _invalidate_update_cache():
+    """Delete the update-check cache so ``hermes --version`` doesn't
+    report a stale "commits behind" count after a successful update."""
+    try:
+        cache_file = Path(os.getenv(
+            "HERMES_HOME", Path.home() / ".hermes"
+        )) / ".update_check"
+        if cache_file.exists():
+            cache_file.unlink()
+    except Exception:
+        pass
 
 def cmd_update(args):
     """Update Hermes Agent to the latest version."""
@@ -2195,6 +2205,7 @@ def cmd_update(args):
         commit_count = int(result.stdout.strip())
         
         if commit_count == 0:
+            _invalidate_update_cache()
             print("✓ Already up to date!")
             return
         
@@ -2214,6 +2225,8 @@ def cmd_update(args):
                     auto_stash_ref,
                     prompt_user=prompt_for_restore,
                 )
+        
+        _invalidate_update_cache()
         
         # Reinstall Python dependencies (prefer uv for speed, fall back to pip)
         print("→ Updating Python dependencies...")


### PR DESCRIPTION
## What does this PR do?

   ## Problem

   `hermes --version` shows a stale "X commits behind" banner even after
   running `hermes update` successfully. The banner persists for up to 6 hours
   (the cache TTL).

   ## Root Cause

   `hermes update` (cmd_update in hermes_cli/main.py) does not invalidate the
   cached update-check file at `~/.hermes/.update_check` after a successful
   git pull. The version banner reads from this cache (banner.py:159), so it
   keeps serving the old commit count.


## Related Issue



<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes # https://github.com/NousResearch/hermes-agent/issues/1620

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

  - `hermes_cli/main.py` — add `_invalidate_update_cache()` helper that deletes `~/.hermes/.update_check`
   - Call it on the "already up to date" early return (line 2199) — covers the case where user ran `git pull`
   manually first, but stale cache still says N commits behind
   - Call it after successful `git pull` + dependency install (after line 2242) — covers the normal update path
   where cache was written before the pull
   - Wrapped in try/except so a failed cache delete never breaks the update flow

## How to Test

   1. Run `hermes --version` — note it shows the current status (or trigger a stale cache by running `hermes
   --version` while behind, then `git pull` manually)
   2. Run `hermes update` — should say "Already up to date!" or pull new commits
   3. Run `hermes --version` again — should immediately show correct status, no stale "X commits behind" banner
   4. Verify `~/.hermes/.update_check` has been deleted after step 2

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian (aarch64, Raspberry Pi)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

