### PR TITLE
fix: auto-detect local file paths in telegram gateway for small models

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -621,6 +621,40 @@ class BasePlatformAdapter(ABC):
         
         return media, cleaned
     
+
+    @staticmethod
+    def extract_local_files(content: str):
+        """
+        Detect bare local file paths in response text and extract them
+        for native media delivery.
+
+        Matches absolute paths (starting with /) ending in common image
+        or video extensions. Skips paths already wrapped in MEDIA: or IMAGE: tags.
+        """
+        _LOCAL_MEDIA_EXTS = (
+            '.png', '.jpg', '.jpeg', '.gif', '.webp',
+            '.mp4', '.mov', '.avi', '.mkv', '.webm',
+        )
+        ext_pattern = '|'.join(ext.lstrip('.') for ext in _LOCAL_MEDIA_EXTS)
+        pattern = r'(~?(?:/[\w.\-]+)+\.(?:' + ext_pattern + r'))\b'
+
+        paths = []
+        cleaned = content
+        for match in re.finditer(pattern, content):
+            path = match.group(1)
+            expanded = os.path.expanduser(path)
+            if os.path.isfile(expanded):
+                paths.append(expanded)
+
+        paths = list(dict.fromkeys(paths))
+
+        if paths:
+            for path in paths:
+                cleaned = cleaned.replace(path, '')
+            cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
+
+        return paths, cleaned
+
     async def _keep_typing(self, chat_id: str, interval: float = 2.0, metadata=None) -> None:
         """
         Continuously send typing indicator until cancelled.
@@ -704,6 +738,9 @@ class BasePlatformAdapter(ABC):
                 
                 # Extract image URLs and send them as native platform attachments
                 images, text_content = self.extract_images(response)
+
+                # Extract bare local file paths for native media delivery
+                local_files, text_content = self.extract_local_files(text_content)
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
                 
@@ -801,6 +838,23 @@ class BasePlatformAdapter(ABC):
                     except Exception as media_err:
                         print(f"[{self.name}] Error sending media: {media_err}")
             
+                # Send auto-detected local files as native attachments
+                for file_path in local_files:
+                    try:
+                        ext = Path(file_path).suffix.lower()
+                        if ext in _IMAGE_EXTS:
+                            await self.send_image_file(
+                                chat_id=event.source.chat_id,
+                                image_path=file_path,
+                            )
+                        elif ext in _VIDEO_EXTS:
+                            await self.send_video(
+                                chat_id=event.source.chat_id,
+                                video_path=file_path,
+                            )
+                    except Exception as file_err:
+                        logger.error("[%s] Error sending local file: %s", self.name, file_err)
+
             # Check if there's a pending message that was queued during our processing
             if session_key in self._pending_messages:
                 pending_event = self._pending_messages.pop(session_key)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -380,6 +380,31 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return await super().send_image_file(chat_id, image_path, caption, reply_to)
 
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a local video file natively as a Telegram video."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            if not os.path.exists(video_path):
+                return SendResult(success=False, error=f"Video not found: {video_path}")
+            with open(video_path, "rb") as vf:
+                msg = await self._bot.send_video(
+                    chat_id=int(chat_id),
+                    video=vf,
+                    reply_to_message_id=int(reply_to) if reply_to else None,
+                )
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.error("[%s] Failed to send video: %s", self.name, e, exc_info=True)
+            return await super().send_video(chat_id, video_path, caption, reply_to)
+
     async def send_image(
         self,
         chat_id: str,


### PR DESCRIPTION
## problem

small models (7B-14B) running through hermes agent on telegram can't reliably send images. they output raw file paths as text instead of using the MEDIA: or IMAGE: syntax the gateway expects. big models learn these patterns from training data. small models don't. they just output the path naturally and nothing catches it.

## what this fixes

the gateway now auto-detects bare local file paths in any response text. if a model mentions `/root/screenshots/game.png` or `~/cat-image.jpg` and that file exists on disk, it gets sent as a native telegram photo or video. no special syntax needed from the model.

## changes

- add `extract_local_files()` static method to `BasePlatformAdapter` that regex-detects absolute and tilde file paths ending in image/video extensions
- integrate into `_process_message_background()` pipeline after `extract_images()`
- add delivery loop that routes detected files by extension to `send_image_file()` or `send_video()`
- add `send_video()` override to `TelegramAdapter` for native video delivery
- `os.path.expanduser()` handles tilde paths, `os.path.isfile()` guards against false positives
- supported extensions: png, jpg, jpeg, gif, webp, mp4, mov, avi, mkv, webm

## before (9B model outputs path as text)

model says "both images should be visible" but they arrive as plain text file paths. the user sees strings not images.

## after (gateway auto-detects and delivers natively)

the same 9B model outputs a path in its response. the gateway intercepts it, checks the file exists, and sends it as a native telegram photo. text and image arrive separately.

## how it works

1. `extract_media()` runs first and strips any MEDIA: tagged paths (existing behavior unchanged)
2. `extract_images()` runs and strips markdown image URLs (existing behavior unchanged)
3. `extract_local_files()` runs on remaining text, detects bare file paths, validates with `os.path.isfile()`
4. detected files are sent as native telegram attachments (photos for images, videos for video files)
5. remaining text is sent as a regular message

no changes to existing MEDIA: or IMAGE: flows. this is purely additive for models that don't use those conventions.

## tested on

- qwen 3.5 9B Q4 on RTX 3060 12GB via telegram gateway
- absolute paths (/root/screenshots/homepage.png) confirmed working
- tilde paths (~/cat-image.jpg) confirmed working
- URL false positives (https://example.com/img.png) correctly filtered by isfile check

## future improvements (not in this PR)

- skip paths inside fenced code blocks
- file size check for telegram's 50MB video limit
- send_document fallback for non-media files