### PR TITLE
fix(cli): invalidate update-check cache after hermes update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2124,7 +2124,17 @@ def _restore_stashed_changes(
     print("  Review `git diff` / `git status` if Hermes behaves unexpectedly.")
     return True
 
-
+def _invalidate_update_cache():
+    """Delete the update-check cache so ``hermes --version`` doesn't
+    report a stale "commits behind" count after a successful update."""
+    try:
+        cache_file = Path(os.getenv(
+            "HERMES_HOME", Path.home() / ".hermes"
+        )) / ".update_check"
+        if cache_file.exists():
+            cache_file.unlink()
+    except Exception:
+        pass
 
 def cmd_update(args):
     """Update Hermes Agent to the latest version."""
@@ -2197,6 +2207,7 @@ def cmd_update(args):
         commit_count = int(result.stdout.strip())
         
         if commit_count == 0:
+            _invalidate_update_cache()
             print("✓ Already up to date!")
             return
         
@@ -2216,6 +2227,8 @@ def cmd_update(args):
                     auto_stash_ref,
                     prompt_user=prompt_for_restore,
                 )
+        
+        _invalidate_update_cache()
         
         # Reinstall Python dependencies (prefer uv for speed, fall back to pip)
         print("→ Updating Python dependencies...")


### PR DESCRIPTION
## Summary

Cherry-picked from PR #1627 by @nidhi-singh02 onto current main.

After `hermes update` completes, deletes the `~/.hermes/.update_check` cache file so `hermes --version` immediately shows the correct status instead of a stale "X commits behind" banner (cached for up to 6 hours).

**Changes:**
- Adds `_invalidate_update_cache()` helper in `hermes_cli/main.py`
- Called on "already up to date" early return (covers manual `git pull` first)
- Called after successful `git pull` + stash restore (covers normal update path)

Fixes #1620