### PR TITLE
fix(tools): remove unnecessary crontab requirement from cronjob tool

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -62,21 +62,36 @@ class TestScanCronPrompt:
 
 
 class TestCronjobRequirements:
-    def test_requires_crontab_binary_even_in_interactive_mode(self, monkeypatch):
+    def test_requires_no_crontab_binary(self, monkeypatch):
+        """Cron is internal (JSON-based scheduler), no system crontab needed."""
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
-        monkeypatch.setattr("shutil.which", lambda name: None)
+        # Even with no crontab in PATH, the cronjob tool should be available
+        # because hermes uses an internal scheduler, not system crontab.
+        assert check_cronjob_requirements() is True
 
-        assert check_cronjob_requirements() is False
-
-    def test_accepts_interactive_mode_when_crontab_exists(self, monkeypatch):
+    def test_accepts_interactive_mode(self, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
-        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/crontab")
 
         assert check_cronjob_requirements() is True
+
+    def test_accepts_gateway_session(self, monkeypatch):
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+        assert check_cronjob_requirements() is True
+
+    def test_rejects_when_no_session_env(self, monkeypatch):
+        """Without any session env vars, cronjob tool should not be available."""
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+        assert check_cronjob_requirements() is False
 
 
 # =========================================================================

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -85,6 +85,13 @@ class TestCronjobRequirements:
 
         assert check_cronjob_requirements() is True
 
+    def test_accepts_exec_ask(self, monkeypatch):
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+
+        assert check_cronjob_requirements() is True
+
     def test_rejects_when_no_session_env(self, monkeypatch):
         """Without any session env vars, cronjob tool should not be available."""
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -8,7 +8,6 @@ Compatibility wrappers remain for direct Python callers and legacy tests.
 import json
 import os
 import re
-import shutil
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -414,13 +413,10 @@ def check_cronjob_requirements() -> bool:
     """
     Check if cronjob tools can be used.
 
-    Requires 'crontab' executable to be present in the system PATH.
     Available in interactive CLI mode and gateway/messaging platforms.
+    The cron system is internal (JSON file-based scheduler ticked by the gateway),
+    so no external crontab executable is required.
     """
-    # Ensure the system can actually install and manage cron entries.
-    if not shutil.which("crontab"):
-        return False
-
     return bool(
         os.getenv("HERMES_INTERACTIVE")
         or os.getenv("HERMES_GATEWAY_SESSION")


### PR DESCRIPTION
## Summary

Salvage of PR #1633 (by @Bartok9) and PR #1610 (by @BillionClaw), both fixing #1589.

The cronjob tool's `check_cronjob_requirements()` was gating on `shutil.which('crontab')`, but the cron system is entirely internal — jobs stored in `~/.hermes/cron/jobs.json`, ticked by the gateway's in-process scheduler. The system `crontab` binary was never used.

## Changes

- **Cherry-picked from #1633 (@Bartok9):** Remove `shutil.which('crontab')` check, remove unused `shutil` import, update docstring, update tests
- **Follow-up:** Added `test_accepts_exec_ask` test from #1610 (@BillionClaw) for complete session mode coverage

## Test plan

All 5 tests in `TestCronjobRequirements` pass, covering:
- No crontab binary needed (explicit)
- Interactive mode
- Gateway session
- Exec ask mode
- No session env → rejected

Fixes #1589