### PR TITLE
fix(gateway): strip MEDIA: and [[audio_as_voice]] tags from message body

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -840,6 +840,10 @@ class BasePlatformAdapter(ABC):
                 
                 # Extract image URLs and send them as native platform attachments
                 images, text_content = self.extract_images(response)
+                # Strip any remaining internal directives from message body (fixes #1561)
+                text_content = text_content.replace("[[audio_as_voice]]", "").strip()
+                import re as _re
+                text_content = _re.sub(r"MEDIA:\s*\S+", "", text_content).strip()
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
                 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -842,8 +842,7 @@ class BasePlatformAdapter(ABC):
                 images, text_content = self.extract_images(response)
                 # Strip any remaining internal directives from message body (fixes #1561)
                 text_content = text_content.replace("[[audio_as_voice]]", "").strip()
-                import re as _re
-                text_content = _re.sub(r"MEDIA:\s*\S+", "", text_content).strip()
+                text_content = re.sub(r"MEDIA:\s*\S+", "", text_content).strip()
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
                 


### PR DESCRIPTION
## Summary

Cherry-picked from PR #1611 by @mettin4 onto current main.

Adds defensive stripping of `[[audio_as_voice]]` and `MEDIA:<path>` tags from `text_content` after `extract_images()` returns. While `extract_media()` already handles these tags earlier in the pipeline, this provides a safety net for edge cases where tags survive (e.g. unusual LLM formatting that doesn't match the extraction regex).

Fixes #1561