### PR TITLE
fix: show custom endpoint models in /model via live API probe

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -162,7 +162,7 @@ def list_available_providers() -> list[dict[str, str]]:
     _PROVIDER_ORDER = [
         "openrouter", "nous", "openai-codex",
         "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic",
-        "ai-gateway", "deepseek",
+        "ai-gateway", "deepseek", "custom",
     ]
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}
@@ -176,9 +176,12 @@ def list_available_providers() -> list[dict[str, str]]:
         # Check if this provider has credentials available
         has_creds = False
         try:
-            from hermes_cli.runtime_provider import resolve_runtime_provider
-            runtime = resolve_runtime_provider(requested=pid)
-            has_creds = bool(runtime.get("api_key"))
+            if pid == "custom":
+                has_creds = bool(_get_custom_base_url())
+            else:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+                runtime = resolve_runtime_provider(requested=pid)
+                has_creds = bool(runtime.get("api_key"))
         except Exception:
             pass
         result.append({
@@ -215,6 +218,19 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
         if provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES:
             return (normalize_provider(provider_part), model_part)
     return (current_provider, stripped)
+
+
+def _get_custom_base_url() -> str:
+    """Get the custom endpoint base_url from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        model_cfg = config.get("model", {})
+        if isinstance(model_cfg, dict):
+            return str(model_cfg.get("base_url", "")).strip()
+    except Exception:
+        pass
+    return ""
 
 
 def curated_models_for_provider(provider: Optional[str]) -> list[tuple[str, str]]:
@@ -396,6 +412,18 @@ def provider_model_ids(provider: Optional[str]) -> list[str]:
         live = _fetch_ai_gateway_models()
         if live:
             return live
+    if normalized == "custom":
+        base_url = _get_custom_base_url()
+        if base_url:
+            # Try common API key env vars for custom endpoints
+            api_key = (
+                os.getenv("CUSTOM_API_KEY", "")
+                or os.getenv("OPENAI_API_KEY", "")
+                or os.getenv("OPENROUTER_API_KEY", "")
+            )
+            live = fetch_api_models(api_key, base_url)
+            if live:
+                return live
     return list(_PROVIDER_MODELS.get(normalized, []))
 
 


### PR DESCRIPTION
## Summary

Salvage of PR #1612 by @aashizpoudel. The original PR had the right idea but was 25 commits behind main and included stale branch damage (ai-gateway removal, deepseek removal).

When a user has a custom OpenAI-compatible endpoint configured via `model.base_url`, the `/model` list command showed nothing for it. This adds `custom` to the provider listing flow with live model discovery.

## Changes

- Add `custom` to `_PROVIDER_ORDER` so it appears in `/model` list
- Add `_get_custom_base_url()` helper to read `model.base_url` from config
- Add `custom` branch in `provider_model_ids()` that probes the endpoint's `/models` API via `fetch_api_models()`
- Custom-aware credential check in `list_available_providers()` (uses base_url presence)
- API key resolution tries `CUSTOM_API_KEY`, `OPENAI_API_KEY`, then `OPENROUTER_API_KEY`

## What was skipped from original PR

- ai-gateway provider removal (stale branch damage, not intentional)
- OpenRouter curated list filter (could break `/model` for OpenRouter users who also have a custom base_url)
- `import os` removal (still needed by existing code)

## Test plan

- All 4606 tests pass (`python -m pytest tests/ -n0 -q`)
- Verified `list_available_providers()` includes `custom` with correct auth detection
- Model validation and provider resolution tests pass

Closes #1612 (original PR)