### PR TITLE
fix: remove ANTHROPIC_BASE_URL env var to avoid collisions

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -138,7 +138,6 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="api_key",
         inference_base_url="https://api.anthropic.com",
         api_key_env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
-        base_url_env_var="ANTHROPIC_BASE_URL",
     ),
     "alibaba": ProviderConfig(
         id="alibaba",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -492,14 +492,6 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "provider",
     },
-    "ANTHROPIC_BASE_URL": {
-        "description": "Custom Anthropic-compatible API base URL (e.g. Alibaba Cloud DashScope)",
-        "prompt": "Anthropic Base URL",
-        "url": "",
-        "password": False,
-        "category": "provider",
-        "advanced": True,
-    },
     "DASHSCOPE_API_KEY": {
         "description": "Alibaba Cloud DashScope API key for Qwen models",
         "prompt": "DashScope API Key",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -276,12 +276,10 @@ def resolve_runtime_provider(
                 "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
                 "run 'claude setup-token', or authenticate with 'claude /login'."
             )
-        # Support custom Anthropic-compatible endpoints via ANTHROPIC_BASE_URL
-        base_url = os.getenv("ANTHROPIC_BASE_URL", "").strip() or "https://api.anthropic.com"
         return {
             "provider": "anthropic",
             "api_mode": "anthropic_messages",
-            "base_url": base_url,
+            "base_url": "https://api.anthropic.com",
             "api_key": token,
             "source": "env",
             "requested_provider": requested_provider,


### PR DESCRIPTION
Removes the `ANTHROPIC_BASE_URL` env var added in #1673. It collides with Claude Code and other Anthropic tooling that use the same variable.

Base URL overrides for Anthropic-compatible endpoints should go through `config.yaml` (`model.base_url`) instead of environment variables.

The Alibaba/DashScope provider is unaffected — it has its own dedicated `DASHSCOPE_API_KEY` and hardcoded base URL that don't collide with anything.