### PR TITLE
fix: make _is_write_denied robust to Path objects

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -94,7 +94,7 @@ def _get_safe_write_root() -> Optional[str]:
 
 def _is_write_denied(path: str) -> bool:
     """Return True if path is on the write deny list."""
-    resolved = os.path.realpath(os.path.expanduser(path))
+    resolved = os.path.realpath(os.path.expanduser(str(path)))
 
     # 1) Static deny list
     if resolved in WRITE_DENIED_PATHS:


### PR DESCRIPTION
One-line fix from PR #1051 by @JackTheGit — cast `path` to `str()` before `os.path.expanduser()` so `pathlib.Path` inputs are handled safely.

Skipped the unrelated skill doc typo fixes from the original PR (axolotl, pytorch-fsdp, unsloth reference files).

Closes #1051