### PR TITLE
feat(gateway): wire DingTalk into gateway setup and platform maps

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1177,7 +1177,8 @@ class GatewayRunner:
             Platform.SLACK: "SLACK_ALLOWED_USERS",
             Platform.SIGNAL: "SIGNAL_ALLOWED_USERS",
             Platform.EMAIL: "EMAIL_ALLOWED_USERS",
-            Platform.SMS: "SMS_ALLOWED_USERS",
+Platform.SMS: "SMS_ALLOWED_USERS",
+Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
         }
         platform_allow_all_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",
@@ -1186,7 +1187,8 @@ class GatewayRunner:
             Platform.SLACK: "SLACK_ALLOW_ALL_USERS",
             Platform.SIGNAL: "SIGNAL_ALLOW_ALL_USERS",
             Platform.EMAIL: "EMAIL_ALLOW_ALL_USERS",
-            Platform.SMS: "SMS_ALLOW_ALL_USERS",
+Platform.SMS: "SMS_ALLOW_ALL_USERS",
+Platform.DINGTALK: "DINGTALK_ALLOW_ALL_USERS",
         }
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
@@ -3046,6 +3048,7 @@ class GatewayRunner:
                 Platform.SIGNAL: "hermes-signal",
                 Platform.HOMEASSISTANT: "hermes-homeassistant",
                 Platform.EMAIL: "hermes-email",
+                Platform.DINGTALK: "hermes-dingtalk",
             }
             platform_toolsets_config = {}
             try:
@@ -3067,6 +3070,7 @@ class GatewayRunner:
                 Platform.SIGNAL: "signal",
                 Platform.HOMEASSISTANT: "homeassistant",
                 Platform.EMAIL: "email",
+                Platform.DINGTALK: "dingtalk",
             }.get(source.platform, "telegram")
 
             config_toolsets = platform_toolsets_config.get(platform_config_key)
@@ -4064,6 +4068,7 @@ class GatewayRunner:
             Platform.SIGNAL: "hermes-signal",
             Platform.HOMEASSISTANT: "hermes-homeassistant",
             Platform.EMAIL: "hermes-email",
+            Platform.DINGTALK: "hermes-dingtalk",
         }
 
         # Try to load platform_toolsets from config
@@ -4088,6 +4093,7 @@ class GatewayRunner:
             Platform.SIGNAL: "signal",
             Platform.HOMEASSISTANT: "homeassistant",
             Platform.EMAIL: "email",
+            Platform.DINGTALK: "dingtalk",
         }.get(source.platform, "telegram")
         
         # Use config override if present (list of toolsets), otherwise hardcoded default

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1066,6 +1066,24 @@ _PLATFORMS = [
              "help": "Phone number to deliver cron job results and notifications to."},
         ],
     },
+    {
+        "key": "dingtalk",
+        "label": "DingTalk",
+        "emoji": "💬",
+        "token_var": "DINGTALK_CLIENT_ID",
+        "setup_instructions": [
+            "1. Go to https://open-dev.dingtalk.com → Create Application",
+            "2. Under 'Credentials', copy the AppKey (Client ID) and AppSecret (Client Secret)",
+            "3. Enable 'Stream Mode' under the bot settings",
+            "4. Add the bot to a group chat or message it directly",
+        ],
+        "vars": [
+            {"name": "DINGTALK_CLIENT_ID", "prompt": "AppKey (Client ID)", "password": False,
+             "help": "The AppKey from your DingTalk application credentials."},
+            {"name": "DINGTALK_CLIENT_SECRET", "prompt": "AppSecret (Client Secret)", "password": True,
+             "help": "The AppSecret from your DingTalk application credentials."},
+        ],
+    },
 ]
 
 


### PR DESCRIPTION
Completes the DingTalk integration by adding it to all the gateway registration points that were missed in #1685.

## Changes

**`hermes_cli/gateway.py`** — Added DingTalk to `_PLATFORMS` list:
- Setup instructions for creating a DingTalk app and enabling Stream Mode
- Prompts for AppKey (Client ID) and AppSecret (Client Secret)
- Available in `hermes gateway setup` interactive wizard

**`gateway/run.py`** — Added `Platform.DINGTALK` to all platform maps:
- Allowed users map (`DINGTALK_ALLOWED_USERS`)
- Allow-all users map (`DINGTALK_ALLOW_ALL_USERS`)  
- Default toolset maps (2 locations) → `hermes-dingtalk`
- Platform config key maps (2 locations) → `dingtalk`

## Test plan
All 1013 gateway tests pass.