### PR TITLE
fix(gateway): NameError on skill slash commands — wrong variable reference

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1481,7 +1481,7 @@ class GatewayRunner:
                 if cmd_key in skill_cmds:
                     user_instruction = event.get_command_args().strip()
                     msg = build_skill_invocation_message(
-                        cmd_key, user_instruction, task_id=session_key
+                        cmd_key, user_instruction, task_id=_quick_key
                     )
                     if msg:
                         event.text = msg


### PR DESCRIPTION
## Summary

Skill slash commands in the gateway (e.g. `/deploy`, any user-defined skill command) always silently fail with a `NameError`.

**Root cause:** Line 1482 of `gateway/run.py` passes `session_key` as `task_id` to `build_skill_invocation_message()`, but `session_key` is not defined until line 1519. The `try/except Exception` block on line 1487 silently swallows the error, so the skill content is never injected and the message falls through to normal processing.

**Fix:** Replace `session_key` with `_quick_key`, which is the session key variable defined at line 1292 — the same variable used by the `/plan` handler on line 1379.

## What changed
- `gateway/run.py`: One-line fix — `task_id=session_key` → `task_id=_quick_key`

## Test plan
- Send a skill slash command (e.g. `/plan write a hello world`) via Telegram/Discord
- Verify the skill content is injected and the agent receives it
- Previously: skill commands silently fell through to normal chat