### PR TITLE
fix(cli): fetch_nous_models called with positional args — always TypeError

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -473,7 +473,7 @@ def provider_model_ids(provider: Optional[str]) -> list[str]:
             from hermes_cli.auth import fetch_nous_models, resolve_nous_runtime_credentials
             creds = resolve_nous_runtime_credentials()
             if creds:
-                live = fetch_nous_models(creds.get("api_key", ""), creds.get("base_url", ""))
+                live = fetch_nous_models(api_key=creds.get("api_key", ""), inference_base_url=creds.get("base_url", ""))
                 if live:
                     return live
         except Exception:


### PR DESCRIPTION
## Summary

`fetch_nous_models()` in `hermes_cli/auth.py` uses keyword-only parameters (the `*` separator), but `hermes_cli/models.py:476` called it with positional args:

```python
# Before (broken):
live = fetch_nous_models(creds.get("api_key", ""), creds.get("base_url", ""))

# After (fixed):
live = fetch_nous_models(api_key=creds.get("api_key", ""), inference_base_url=creds.get("base_url", ""))
```

Two issues in one line:
1. Positional args to a keyword-only function → always `TypeError`
2. Argument order was reversed (api_key first, but signature expects inference_base_url first)

The `except Exception: pass` silently swallowed the error, so the Nous provider model list always fell back to the static catalog. Live model fetching from the Nous Portal `/models` endpoint was completely broken.

## What changed
- `hermes_cli/models.py`: One-line fix — use keyword arguments in correct order

## Test plan
- `hermes model` → select Nous provider → verify live models are fetched (not just static list)
- `provider_model_ids('nous')` returns live model list