### PR TITLE
fix(core): RedactingFormatter NameError when verbose_logging=True

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -457,8 +457,8 @@ class AIAgent:
             and Path(getattr(handler, "baseFilename", "")).resolve() == resolved_error_log_path
             for handler in root_logger.handlers
         )
+        from agent.redact import RedactingFormatter
         if not has_errors_log_handler:
-            from agent.redact import RedactingFormatter
             error_log_dir.mkdir(parents=True, exist_ok=True)
             error_file_handler = RotatingFileHandler(
                 error_log_path, maxBytes=2 * 1024 * 1024, backupCount=2,


### PR DESCRIPTION
## Summary

`RedactingFormatter` was imported conditionally inside `if not has_errors_log_handler:` (line 461), but used unconditionally in the `verbose_logging` block (line 479).

When the error log handler already exists (second `AIAgent` instantiation in the same process, common in gateway and batch_runner) AND `verbose_logging=True`, the import was skipped and line 479 crashed with `NameError: name 'RedactingFormatter' is not defined`.

## What changed
- `run_agent.py`: Moved `from agent.redact import RedactingFormatter` one level up, before the `if not has_errors_log_handler:` block, so it's always available.

## Test plan
- Set `verbose_logging: true` in config
- Start a second agent session in the same process (or use gateway)
- Verify no NameError — verbose log handlers get RedactingFormatter applied correctly