### PR TITLE
fix(gateway): PII redaction config never read — missing yaml import

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1542,8 +1542,9 @@ class GatewayRunner:
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
         try:
+            import yaml as _pii_yaml
             with open(_config_path, encoding="utf-8") as _pf:
-                _pcfg = yaml.safe_load(_pf) or {}
+                _pcfg = _pii_yaml.safe_load(_pf) or {}
             _redact_pii = bool((_pcfg.get("privacy") or {}).get("redact_pii", False))
         except Exception:
             pass


### PR DESCRIPTION
## Summary

The `privacy.redact_pii` config reader in `gateway/run.py` line 1546 used bare `yaml.safe_load()`, but `yaml` is not in scope at that point — the module-level import is `import yaml as _yaml` (line 93), and other methods use local `import yaml as _y`.

The `NameError` was silently caught by the `try/except Exception: pass` block, so `_redact_pii` always defaulted to `False`. Users who configured `privacy.redact_pii: true` got no PII redaction in the gateway.

## What changed
- `gateway/run.py`: Added local `import yaml as _pii_yaml` before the safe_load call, consistent with the aliased-import pattern used throughout the file.

## Test plan
- Set `privacy.redact_pii: true` in config.yaml
- Send a message via gateway containing PII
- Verify redaction is applied (previously: always skipped)