### PR TITLE
feat(compression): add summary_base_url for custom provider endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1252,6 +1252,7 @@ def _resolve_task_provider_model(
             if isinstance(comp, dict):
                 cfg_provider = comp.get("summary_provider", "").strip() or None
                 cfg_model = cfg_model or comp.get("summary_model", "").strip() or None
+                cfg_base_url = cfg_base_url or comp.get("summary_base_url", "").strip() or None
 
     env_model = _get_auxiliary_env_override(task, "MODEL") if task else None
     resolved_model = model or env_model or cfg_model

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -162,6 +162,7 @@ DEFAULT_CONFIG = {
         "threshold": 0.50,
         "summary_model": "google/gemini-3-flash-preview",
         "summary_provider": "auto",
+        "summary_base_url": None,
     },
     "smart_model_routing": {
         "enabled": False,


### PR DESCRIPTION
Closes #1591

## What
Adds `summary_base_url` config option to the `compression` block, allowing users to specify a custom OpenAI-compatible endpoint for the compression summarizer (e.g. zai, DeepSeek, Ollama).

## Changes
- `hermes_cli/config.py`: Added `summary_base_url: null` to DEFAULT_CONFIG
- `agent/auxiliary_client.py`: `_resolve_task_provider_model()` now reads `summary_base_url` from the compression config block (backwards compat)

## Usage
```yaml
compression:
  enabled: true
  summary_model: glm-4.7
  summary_provider: zai
  summary_base_url: https://api.z.ai/api/coding/paas/v4
```

## Backward Compatibility
Fully backward compatible — existing configs without `summary_base_url` work unchanged.