### PR TITLE
fix(anthropic): consecutive assistant message merge drops content on mixed types

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -963,8 +963,12 @@ def convert_messages_to_anthropic(
                 elif isinstance(prev_blocks, str) and isinstance(curr_blocks, str):
                     fixed[-1]["content"] = prev_blocks + "\n" + curr_blocks
                 else:
-                    # Keep the later message
-                    fixed[-1] = m
+                    # Mixed types — normalize both to list and merge
+                    if isinstance(prev_blocks, str):
+                        prev_blocks = [{"type": "text", "text": prev_blocks}]
+                    if isinstance(curr_blocks, str):
+                        curr_blocks = [{"type": "text", "text": curr_blocks}]
+                    fixed[-1]["content"] = prev_blocks + curr_blocks
         else:
             fixed.append(m)
     result = fixed


### PR DESCRIPTION
## Summary

In `agent/anthropic_adapter.py`, when merging consecutive assistant messages (required by Anthropic's API which rejects consecutive same-role messages), the mixed-types case (one message has string content, the other has list content) simply replaced the earlier message with the later one:

```python
# Before (line 967):
fixed[-1] = m  # Earlier message content silently dropped
```

This caused data loss when the conversation had consecutive assistant messages with different content formats.

## What changed

Applied the same normalize-and-merge pattern already used in the tool_use merge path (lines 952-956): convert both to `[{"type": "text", "text": ...}]` list format before concatenating.

```python
# After:
if isinstance(prev_blocks, str):
    prev_blocks = [{"type": "text", "text": prev_blocks}]
if isinstance(curr_blocks, str):
    curr_blocks = [{"type": "text", "text": curr_blocks}]
fixed[-1]["content"] = prev_blocks + curr_blocks
```

## Test plan
- Trigger consecutive assistant messages with mixed content types (e.g. tool call producing list content followed by text response)
- Verify both messages' content is preserved in the merged result