### PR TITLE
fix(dingtalk): requirements check passes with only one credential set

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -60,7 +60,7 @@ def check_dingtalk_requirements() -> bool:
     """Check if DingTalk dependencies are available and configured."""
     if not DINGTALK_STREAM_AVAILABLE or not HTTPX_AVAILABLE:
         return False
-    if not os.getenv("DINGTALK_CLIENT_ID") and not os.getenv("DINGTALK_CLIENT_SECRET"):
+    if not os.getenv("DINGTALK_CLIENT_ID") or not os.getenv("DINGTALK_CLIENT_SECRET"):
         return False
     return True
 


### PR DESCRIPTION
## Summary

`check_dingtalk_requirements()` in `gateway/platforms/dingtalk.py` used `and` instead of `or`:

```python
# Before (wrong): only fails when BOTH missing
if not os.getenv("DINGTALK_CLIENT_ID") and not os.getenv("DINGTALK_CLIENT_SECRET"):

# After (correct): fails when EITHER missing
if not os.getenv("DINGTALK_CLIENT_ID") or not os.getenv("DINGTALK_CLIENT_SECRET"):
```

With the old logic, setting only `DINGTALK_CLIENT_ID` (without `CLIENT_SECRET`) would pass the check, and `connect()` would fail later with a cryptic SDK error instead of the clear warning message.

## What changed
- `gateway/platforms/dingtalk.py`: `and` → `or` in credential check

## Test plan
- Set only DINGTALK_CLIENT_ID (without SECRET), start gateway
- Verify: clear warning "DingTalk: ... not set" instead of cryptic connect error