### PR TITLE
fix(gateway): Matrix and Mattermost never report as connected

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -220,6 +220,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Start the sync loop.
         self._sync_task = asyncio.create_task(self._sync_loop())
+        self._mark_connected()
         return True
 
     async def disconnect(self) -> None:

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -222,6 +222,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Start WebSocket in background.
         self._ws_task = asyncio.create_task(self._ws_loop())
+        self._mark_connected()
         return True
 
     async def disconnect(self) -> None:


### PR DESCRIPTION
## Summary

Neither the Matrix nor Mattermost adapter called `_mark_connected()` after successful `connect()`. This meant:
- `_running` stayed `False` → `is_connected` always returned `False`
- Runtime status file never showed "connected" for these platforms
- `/status` command reported them as offline even while actively processing messages

## What changed
- `gateway/platforms/matrix.py`: Added `self._mark_connected()` after sync loop starts
- `gateway/platforms/mattermost.py`: Added `self._mark_connected()` after WS loop starts

Matches the pattern used by Telegram (line 264) and DingTalk (line 122).