### PR TITLE
fix(aux): auxiliary_is_nous flag never resets — leaks Nous tags to other providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -706,6 +706,8 @@ def _resolve_forced_provider(forced: str) -> Tuple[Optional[OpenAI], Optional[st
 
 def _resolve_auto() -> Tuple[Optional[OpenAI], Optional[str]]:
     """Full auto-detection chain: OpenRouter → Nous → custom → Codex → API-key → None."""
+    global auxiliary_is_nous
+    auxiliary_is_nous = False  # Reset — _try_nous() will set True if it wins
     for try_fn in (_try_openrouter, _try_nous, _try_custom_endpoint,
                    _try_codex, _resolve_api_key_provider):
         client, model = try_fn()


### PR DESCRIPTION
## Summary

`auxiliary_is_nous` is a module-level global set to `True` by `_try_nous()` and never reset. In long-running gateway processes, once Nous Portal was ever resolved as the auxiliary provider, the flag stayed `True` forever — even when subsequent calls resolved to OpenRouter, Anthropic, or any other provider.

This caused `get_auxiliary_extra_body()` and `call_llm()` to send Nous-specific product tags (`tags: ["product=hermes-agent"]`) to non-Nous providers, which at best is confusing metadata and at worst could cause API rejections.

## What changed
- `agent/auxiliary_client.py`: Reset `auxiliary_is_nous = False` at the start of `_resolve_auto()` before the provider loop. `_try_nous()` still sets it to `True` if it wins.