### PR TITLE
fix(anthropic): tool_choice 'none' still allows tool calls

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1053,7 +1053,8 @@ def build_anthropic_kwargs(
         elif tool_choice == "required":
             kwargs["tool_choice"] = {"type": "any"}
         elif tool_choice == "none":
-            pass  # Don't send tool_choice — Anthropic will use tools if needed
+            # Anthropic has no tool_choice "none" — omit tools entirely to prevent use
+            kwargs.pop("tools", None)
         elif isinstance(tool_choice, str):
             # Specific tool name
             kwargs["tool_choice"] = {"type": "tool", "name": tool_choice}


### PR DESCRIPTION
## Summary

When `tool_choice="none"` was passed to `build_anthropic_kwargs()`, the handler did `pass` — no `tool_choice` was set, but tools were still included in the request. Anthropic's API defaults to `"auto"` when tools are present, so the model could still call tools despite the caller explicitly requesting no tool use.

Anthropic doesn't support a `tool_choice: none` equivalent. The only way to prevent tool use is to omit tools entirely.

## What changed
- `agent/anthropic_adapter.py`: When `tool_choice == "none"`, remove `tools` from kwargs via `kwargs.pop("tools", None)`