### PR TITLE
feat: add file reference support for custom personalities (salvaged #1564)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -114,6 +114,29 @@ def _load_prefill_messages(file_path: str) -> List[Dict[str, Any]]:
         return []
 
 
+def _load_personality_file(file_path: str) -> str | None:
+    """Load personality content from a file path.
+
+    Supports:
+    - Absolute paths: /path/to/file.md
+    - User home: ~/path/to/file.md
+    - Relative: path/to/file.md (resolved from HERMES_HOME)
+    """
+    if not file_path:
+        return None
+    path = Path(file_path).expanduser()
+    if not path.is_absolute():
+        path = _hermes_home / path
+    if not path.exists():
+        logger.warning("Personality file not found: %s", path)
+        return None
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception as e:
+        logger.warning("Failed to load personality file %s: %s", path, e)
+        return None
+
+
 def _parse_reasoning_config(effort: str) -> dict | None:
     """Parse a reasoning effort level into an OpenRouter reasoning config dict.
     
@@ -2935,13 +2958,23 @@ class HermesCLI:
 
     @staticmethod
     def _resolve_personality_prompt(value) -> str:
-        """Accept string or dict personality value; return system prompt string."""
+        """Accept string, dict, or file reference; return system prompt string."""
         if isinstance(value, dict):
+            if "file" in value:
+                loaded = _load_personality_file(value["file"])
+                if loaded is None:
+                    return ""
+                parts = [loaded]
+                if value.get("tone"):
+                    parts.append(f'Tone: {value["tone"]}')
+                if value.get("style"):
+                    parts.append(f'Style: {value["style"]}')
+                return "\n".join(p for p in parts if p)
             parts = [value.get("system_prompt", "")]
             if value.get("tone"):
-                parts.append(f'Tone: {value["tone"]}' )
+                parts.append(f'Tone: {value["tone"]}')
             if value.get("style"):
-                parts.append(f'Style: {value["style"]}' )
+                parts.append(f'Style: {value["style"]}')
             return "\n".join(p for p in parts if p)
         return str(value)
 
@@ -2962,13 +2995,22 @@ class HermesCLI:
                     print("(^_^) Personality cleared (session only)")
                 print("  No personality overlay — using base agent behavior.")
             elif personality_name in self.personalities:
-                self.system_prompt = self._resolve_personality_prompt(self.personalities[personality_name])
+                personality_config = self.personalities[personality_name]
+                is_file_reference = (
+                    isinstance(personality_config, dict) 
+                    and "file" in personality_config
+                )
+                self.system_prompt = self._resolve_personality_prompt(personality_config)
                 self.agent = None  # Force re-init
-                if save_config_value("agent.system_prompt", self.system_prompt):
+                if is_file_reference:
+                    print(f"(^_^) Personality set to '{personality_name}' (session only)")
+                    print(f"  Using file reference, not saved to config")
+                    print(f"  \"{self.system_prompt[:60]}{'...' if len(self.system_prompt) > 60 else ''}\"")
+                elif save_config_value("agent.system_prompt", self.system_prompt):
                     print(f"(^_^)b Personality set to '{personality_name}' (saved to config)")
                 else:
                     print(f"(^_^) Personality set to '{personality_name}' (session only)")
-                print(f"  \"{self.system_prompt[:60]}{'...' if len(self.system_prompt) > 60 else ''}\"")
+                    print(f"  \"{self.system_prompt[:60]}{'...' if len(self.system_prompt) > 60 else ''}\"")
             else:
                 print(f"(._.) Unknown personality: {personality_name}")
                 print(f"  Available: none, {', '.join(self.personalities.keys())}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2503,6 +2503,25 @@ class GatewayRunner:
 
         def _resolve_prompt(value):
             if isinstance(value, dict):
+                if "file" in value:
+                    file_path = value["file"]
+                    path = Path(file_path).expanduser()
+                    if not path.is_absolute():
+                        path = _hermes_home / path
+                    loaded = None
+                    if path.exists():
+                        try:
+                            loaded = path.read_text(encoding="utf-8")
+                        except Exception:
+                            pass
+                    if loaded is None:
+                        return ""
+                    parts = [loaded]
+                    if value.get("tone"):
+                        parts.append(f'Tone: {value["tone"]}')
+                    if value.get("style"):
+                        parts.append(f'Style: {value["style"]}')
+                    return "\n".join(p for p in parts if p)
                 parts = [value.get("system_prompt", "")]
                 if value.get("tone"):
                     parts.append(f'Tone: {value["tone"]}')

--- a/tests/test_personality_none.py
+++ b/tests/test_personality_none.py
@@ -210,3 +210,120 @@ class TestPersonalityDictFormat:
         from cli import HermesCLI
         result = HermesCLI._resolve_personality_prompt("You are helpful.")
         assert result == "You are helpful."
+
+
+class TestPersonalityFileReference:
+    """Test file reference for custom personalities."""
+
+    def _make_cli(self, personalities):
+        from cli import HermesCLI
+        cli = HermesCLI.__new__(HermesCLI)
+        cli.personalities = personalities
+        cli.system_prompt = ""
+        cli.agent = None
+        cli.console = MagicMock()
+        return cli
+
+    def test_file_reference_loads_content(self, tmp_path):
+        personality_file = tmp_path / "verbose.md"
+        personality_file.write_text("You are verbose and detailed.")
+
+        cli = self._make_cli({"verbose": {"file": str(personality_file)}})
+        with patch("cli.save_config_value", return_value=True):
+            cli._handle_personality_command("/personality verbose")
+        assert cli.system_prompt == "You are verbose and detailed."
+
+    def test_file_reference_with_relative_path(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cli._hermes_home", tmp_path)
+        personality_file = tmp_path / "test.md"
+        personality_file.write_text("Content from relative path.")
+
+        cli = self._make_cli({"test": {"file": "test.md"}})
+        with patch("cli.save_config_value", return_value=True):
+            cli._handle_personality_command("/personality test")
+        assert cli.system_prompt == "Content from relative path."
+
+    def test_file_reference_missing_file_returns_empty(self, tmp_path):
+        cli = self._make_cli({"missing": {"file": str(tmp_path / "nonexistent.md")}})
+        with patch("cli.save_config_value", return_value=True):
+            cli._handle_personality_command("/personality missing")
+        assert cli.system_prompt == ""
+
+    def test_file_plus_supplemental_fields(self, tmp_path):
+        personality_file = tmp_path / "base.md"
+        personality_file.write_text("You are a base personality.")
+
+        cli = self._make_cli({
+            "hybrid": {
+                "file": str(personality_file),
+                "tone": "friendly",
+                "style": "conversational"
+            }
+        })
+        with patch("cli.save_config_value", return_value=True):
+            cli._handle_personality_command("/personality hybrid")
+        assert "You are a base personality." in cli.system_prompt
+        assert "Tone: friendly" in cli.system_prompt
+        assert "Style: conversational" in cli.system_prompt
+
+    def test_file_reference_with_home_path(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cli._hermes_home", tmp_path)
+        personality_file = tmp_path / "test.md"
+        personality_file.write_text("Content from home-relative path.")
+
+        cli = self._make_cli({"test": {"file": "test.md"}})
+        with patch("cli.save_config_value", return_value=True):
+            cli._handle_personality_command("/personality test")
+        assert cli.system_prompt == "Content from home-relative path."
+
+    def test_resolve_prompt_file_reference_directly(self, tmp_path):
+        from cli import HermesCLI
+        personality_file = tmp_path / "direct.md"
+        personality_file.write_text("Direct file content.")
+
+        result = HermesCLI._resolve_personality_prompt({
+            "file": str(personality_file)
+        })
+        assert result == "Direct file content."
+
+    def test_file_reference_not_saved_to_config(self, tmp_path, capsys):
+        """File references should be session-only, not saved to config."""
+        personality_file = tmp_path / "verbose.md"
+        personality_file.write_text("You are verbose and detailed.")
+
+        cli = self._make_cli({"verbose": {"file": str(personality_file)}})
+        
+        with patch("cli.save_config_value", return_value=True) as mock_save:
+            cli._handle_personality_command("/personality verbose")
+        
+        # Verify save was NOT called for file references
+        mock_save.assert_not_called()
+        # Verify content was loaded
+        assert cli.system_prompt == "You are verbose and detailed."
+
+    def test_inline_dict_still_saved_to_config(self, tmp_path, capsys):
+        """Inline dict personalities should still be saved to config."""
+        cli = self._make_cli({
+            "inline": {
+                "system_prompt": "You are inline.",
+                "tone": "friendly"
+            }
+        })
+        
+        with patch("cli.save_config_value", return_value=True) as mock_save:
+            cli._handle_personality_command("/personality inline")
+        
+        # Verify save WAS called for inline personalities
+        mock_save.assert_called_once_with("agent.system_prompt", "You are inline.\nTone: friendly")
+        assert cli.system_prompt == "You are inline.\nTone: friendly"
+
+    def test_inline_string_still_saved_to_config(self, tmp_path, capsys):
+        """Inline string personalities should still be saved to config."""
+        cli = self._make_cli({"helpful": "You are helpful."})
+        
+        with patch("cli.save_config_value", return_value=True) as mock_save:
+            cli._handle_personality_command("/personality helpful")
+        
+        # Verify save WAS called for inline string personalities
+        mock_save.assert_called_once_with("agent.system_prompt", "You are helpful.")
+        assert cli.system_prompt == "You are helpful."


### PR DESCRIPTION
## Summary

Salvaged from PR #1564 by @dafunction. Cherry-picked cleanly onto current main with authorship preserved.

Adds `file:` reference support for personality definitions in config.yaml, allowing verbose personality profiles to live in separate `.md` files instead of being inlined in the config.

## Example

```yaml
agent:
  personalities:
    verbose:
      file: "~/.hermes/personalities/verbose_profile.md"
      tone: friendly
      style: conversational
```

## What changed

- `_load_personality_file()` helper in cli.py — resolves absolute, `~/`, and relative (from HERMES_HOME) paths
- `_resolve_personality_prompt()` checks for `file` key, loads content, appends tone/style if present
- File-referenced personalities are session-only (not saved to config) — preserves config.yaml as clean source of truth
- Gateway gets equivalent file-loading logic in its `_resolve_prompt()`
- 10 new tests covering file loading, relative paths, missing files, supplemental fields, and config save behavior

## Test plan

- All 27 personality tests pass (`tests/test_personality_none.py`)

## Attribution

Original work by @dafunction (Alec G) in PR #1564.