### PR TITLE
fix(cron): get_due_jobs reads jobs.json twice — race condition

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -5,6 +5,7 @@ Jobs are stored in ~/.hermes/cron/jobs.json
 Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
 """
 
+import copy
 import json
 import logging
 import tempfile
@@ -539,8 +540,8 @@ def get_due_jobs() -> List[Dict[str, Any]]:
     immediately.  This prevents a burst of missed jobs on gateway restart.
     """
     now = _hermes_now()
-    jobs = [_apply_skill_fields(j) for j in load_jobs()]
-    raw_jobs = load_jobs()  # For saving updates
+    raw_jobs = load_jobs()
+    jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
     due = []
     needs_save = False
 


### PR DESCRIPTION
## Summary

`get_due_jobs()` called `load_jobs()` twice (lines 542-543): once for filtering with `_apply_skill_fields()`, once to get raw jobs for saving updates. Between the two reads, another process could modify `jobs.json`, causing the filtering and saving to use inconsistent data — a job could be identified as "due" from the first read but its fast-forward update applied to a different version from the second read.

## What changed
- `cron/jobs.py`: Load once, `copy.deepcopy()` for the skill-applied working list
- Added `import copy`

## Test plan
- `python -m pytest tests/cron/ -n0 -q` → 54 passed, 3 skipped ✔