### PR TITLE
fix(core): length_continue_retries never resets — later truncations get fewer retries

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6169,6 +6169,8 @@ class AIAgent:
 
                     if truncated_response_prefix:
                         final_response = truncated_response_prefix + final_response
+                        truncated_response_prefix = ""
+                        length_continue_retries = 0
                     
                     # Strip <think> blocks from user-facing response (keep raw in messages for trajectory)
                     final_response = self._strip_think_blocks(final_response).strip()


### PR DESCRIPTION
## Summary

`length_continue_retries` and `truncated_response_prefix` were initialized once before the outer conversation loop and never reset after a successful continuation. If the model hit length truncation, succeeded on continuation, then later hit length again in the same `run_conversation()` call, the counter started from its previous value instead of 0 — giving fewer retries for the second event. The stale prefix text from the first event would also bleed into the second response.

## What changed
- `run_agent.py`: Reset both `truncated_response_prefix` and `length_continue_retries` after the prefix is successfully consumed into the final response (line ~6171).

## Test plan
- Trigger two separate length truncations within one conversation (e.g. ask for a very long response, let it continue, do a tool call, ask for another long response)
- Verify the second truncation gets the full 3 retries