### PR TITLE
fix(toolsets): add missing 'messaging' toolset — can't enable/disable send_message

### DIFF
--- a/toolsets.py
+++ b/toolsets.py
@@ -130,6 +130,12 @@ TOOLSETS = {
         "includes": []
     },
     
+    "messaging": {
+        "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
+        "tools": ["send_message"],
+        "includes": []
+    },
+    
     "rl": {
         "description": "RL training tools for running reinforcement learning on Tinker-Atropos",
         "tools": [


### PR DESCRIPTION
## Summary

`send_message_tool.py` registers under `toolset="messaging"`, but no `"messaging"` entry existed in the `TOOLSETS` dict in `toolsets.py`. This meant:
- `--disable-toolset messaging` silently failed
- `--enable-toolset messaging` silently failed  
- `hermes tools` config UI couldn't toggle messaging tools independently

The tool was still discoverable through composite toolsets (`_HERMES_CORE_TOOLS`), but couldn't be controlled by its own toolset name.

## What changed
- `toolsets.py`: Added `"messaging"` toolset with `send_message` tool