### PR TITLE
fix(core): compression_attempts resets each iteration — allows unlimited compressions

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4884,6 +4884,7 @@ class AIAgent:
         codex_ack_continuations = 0
         length_continue_retries = 0
         truncated_response_prefix = ""
+        compression_attempts = 0
         
         # Clear any stale interrupt state at start
         self.clear_interrupt()
@@ -5029,7 +5030,6 @@ class AIAgent:
             api_start_time = time.time()
             retry_count = 0
             max_retries = 3
-            compression_attempts = 0
             max_compression_attempts = 3
             codex_auth_retry_attempted = False
             anthropic_auth_retry_attempted = False


### PR DESCRIPTION
## Summary

`compression_attempts` was initialized to 0 inside the outer while loop (line 5032), which resets every iteration. Since a successful compression sets `restart_with_compressed_messages = True` and `continue`s the outer loop, the counter was always 1 when checked — the cap of 3 was never enforceable.

## What changed
- `run_agent.py`: Moved `compression_attempts = 0` initialization before the outer while loop (alongside the other per-conversation counters like `length_continue_retries`), so the cap of 3 applies across the entire conversation.

## Test plan
- Trigger repeated context-length errors → verify the agent stops after 3 compression attempts instead of looping