### PR TITLE
fix(metadata): fuzzy context length match can return wrong model's value

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -266,8 +266,10 @@ def get_model_context_length(model: str, base_url: str = "") -> int:
     if model in metadata:
         return metadata[model].get("context_length", 128000)
 
-    # 3. Hardcoded defaults (fuzzy match)
-    for default_model, length in DEFAULT_CONTEXT_LENGTHS.items():
+    # 3. Hardcoded defaults (fuzzy match — longest key first for specificity)
+    for default_model, length in sorted(
+        DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
+    ):
         if default_model in model or model in default_model:
             return length
 


### PR DESCRIPTION
## Summary

The fuzzy match in `get_model_context_length()` iterated `DEFAULT_CONTEXT_LENGTHS` in dict insertion order, using bidirectional substring matching. Shorter model names (e.g. `gpt-5`) could match before more specific ones (e.g. `gpt-5.4-pro`), returning the wrong context window size.

## What changed
- `agent/model_metadata.py`: Sort the dict items by key length (longest first) before fuzzy matching, so more specific model names always match before less specific ones.

## Test plan
- Query context length for a model with both short and long variants in the catalog
- Verify the most specific match wins