### PR TITLE
fix(cron): naive ISO timestamps stored without timezone — jobs fire at wrong time

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -168,6 +168,10 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         try:
             # Parse and validate
             dt = datetime.fromisoformat(schedule.replace('Z', '+00:00'))
+            # Make naive timestamps timezone-aware at parse time so the stored
+            # value doesn't depend on the system timezone matching at check time.
+            if dt.tzinfo is None:
+                dt = dt.astimezone()  # Interpret as local timezone
             return {
                 "kind": "once",
                 "run_at": dt.isoformat(),


### PR DESCRIPTION
## Summary

User-provided ISO timestamps like `2026-02-03T14:00` (no timezone) were stored as naive datetimes. At check time, `_ensure_aware()` interprets them using the *current* system timezone. If the system timezone changes between job creation and checking (e.g., server migration, DST change), the job fires at the wrong wall-clock time.

## What changed
- `cron/jobs.py`: In `parse_schedule()`, call `dt.astimezone()` on naive datetimes to immediately stamp them with the local timezone. The stored `run_at` value is now always timezone-aware (e.g., `2026-02-03T14:00:00-08:00`), so it's stable regardless of later timezone changes.

Timestamps that already include timezone info (e.g., `2026-02-03T14:00+02:00` or `Z`) are unaffected.

## Test plan
- `python -m pytest tests/cron/ -n0 -q` → 54 passed, 3 skipped ✔
- Create a job with `2026-06-01T09:00` → verify stored `run_at` includes timezone offset