### PR TITLE
feat: eager fallback to backup model on rate-limit errors

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5132,6 +5132,13 @@ class AIAgent:
                         # This is often rate limiting or provider returning malformed response
                         retry_count += 1
                         
+                        # Eager fallback: empty/malformed responses are a common
+                        # rate-limit symptom.  Switch to fallback immediately
+                        # rather than retrying with extended backoff.
+                        if not self._fallback_activated and self._try_activate_fallback():
+                            retry_count = 0
+                            continue
+
                         # Check for error field in response (some providers include this)
                         error_msg = "Unknown"
                         provider_name = "Unknown"
@@ -5485,6 +5492,24 @@ class AIAgent:
                     # A 413 is a payload-size error — the correct response is to
                     # compress history and retry, not abort immediately.
                     status_code = getattr(api_error, "status_code", None)
+
+                    # Eager fallback for rate-limit errors (429 or quota exhaustion).
+                    # When a fallback model is configured, switch immediately instead
+                    # of burning through retries with exponential backoff -- the
+                    # primary provider won't recover within the retry window.
+                    is_rate_limited = (
+                        status_code == 429
+                        or "rate limit" in error_msg
+                        or "too many requests" in error_msg
+                        or "rate_limit" in error_msg
+                        or "usage limit" in error_msg
+                        or "quota" in error_msg
+                    )
+                    if is_rate_limited and not self._fallback_activated:
+                        if self._try_activate_fallback():
+                            retry_count = 0
+                            continue
+
                     is_payload_too_large = (
                         status_code == 413
                         or 'request entity too large' in error_msg


### PR DESCRIPTION
## Summary

Salvage of PR #1413 by @usvimal, cherry-picked onto current main.

When a fallback model is configured, the agent now switches to it **immediately** upon detecting rate-limit conditions instead of exhausting all retries with exponential backoff.

Two eager-fallback checks added to `run_agent.py`:

1. **Invalid/empty API responses** — common rate-limit symptom. Fallback attempted immediately after first failure, before retry loop.
2. **HTTP 429 / rate-limit errors** — detected via status code and error message keywords (rate limit, too many requests, quota, usage limit). Fallback attempted before backoff.

Both paths guarded by `_fallback_activated` to preserve one-shot semantics.

## Test results

5130 passed, 5 pre-existing failures (unrelated `test_anthropic_adapter.py`), 200 skipped.

Closes #1413.