### PR TITLE
fix(tools): browser handlers TypeError on unexpected LLM params + fuzzy_match docstring

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1734,7 +1734,7 @@ registry.register(
     name="browser_click",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_click"],
-    handler=lambda args, **kw: browser_click(**args, task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_click(ref=args.get("ref", ""), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="👆",
 )
@@ -1742,7 +1742,7 @@ registry.register(
     name="browser_type",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_type"],
-    handler=lambda args, **kw: browser_type(**args, task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_type(ref=args.get("ref", ""), text=args.get("text", ""), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="⌨️",
 )
@@ -1750,7 +1750,7 @@ registry.register(
     name="browser_scroll",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_scroll"],
-    handler=lambda args, **kw: browser_scroll(**args, task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_scroll(direction=args.get("direction", "down"), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="📜",
 )

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -6,16 +6,17 @@ Implements a multi-strategy matching chain to robustly find and replace text,
 accommodating variations in whitespace, indentation, and escaping common
 in LLM-generated code.
 
-The 9-strategy chain (inspired by OpenCode):
+The 8-strategy chain (inspired by OpenCode), tried in order:
 1. Exact match - Direct string comparison
 2. Line-trimmed - Strip leading/trailing whitespace per line
-3. Block anchor - Match first+last lines, use similarity for middle
-4. Whitespace normalized - Collapse multiple spaces/tabs to single space
-5. Indentation flexible - Ignore indentation differences entirely
-6. Escape normalized - Convert \\n literals to actual newlines
-7. Trimmed boundary - Trim first/last line whitespace only
+3. Whitespace normalized - Collapse multiple spaces/tabs to single space
+4. Indentation flexible - Ignore indentation differences entirely
+5. Escape normalized - Convert \\n literals to actual newlines
+6. Trimmed boundary - Trim first/last line whitespace only
+7. Block anchor - Match first+last lines, use similarity for middle
 8. Context-aware - 50% line similarity threshold
-9. Multi-occurrence - For replace_all flag
+
+Multi-occurrence matching is handled via the replace_all flag.
 
 Usage:
     from tools.fuzzy_match import fuzzy_find_and_replace


### PR DESCRIPTION
## Summary

### 1. Browser tool handler safety (browser_tool.py)
`browser_click`, `browser_type`, and `browser_scroll` handlers used `**args` spread which passed ALL dict keys as keyword arguments. If the LLM sent unexpected parameters (e.g. `{"ref": "@e5", "timeout": 10}`), the spread would cause a `TypeError: unexpected keyword argument`.

**Fix:** Extract only the expected parameters with `.get()` and safe defaults, matching the pattern used by all other browser tool handlers (navigate, snapshot, vision, etc.).

### 2. Fuzzy match docstring (fuzzy_match.py)
The module docstring listed block_anchor as strategy #3, but it's actually #7 in the code. Multi-occurrence was listed as strategy #9 but is just the `replace_all` flag. Updated to match actual code order.

## Test plan
- `python -m pytest tests/tools/test_fuzzy_match.py -n0 -q` → 9 passed ✔