### PR TITLE
fix(gateway): SMS session-per-send + Matrix bare media types break downstream processing

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -662,17 +662,24 @@ class MatrixAdapter(BasePlatformAdapter):
             http_url = self._mxc_to_http(url)
 
         # Determine message type from event class.
-        media_type = "document"
+        # Use the MIME type from the event's content info when available,
+        # falling back to category-level MIME types for downstream matching
+        # (gateway/run.py checks startswith("image/"), startswith("audio/"), etc.)
+        content_info = getattr(event, "content", {}) if isinstance(getattr(event, "content", None), dict) else {}
+        event_mimetype = (content_info.get("info") or {}).get("mimetype", "")
+        media_type = "application/octet-stream"
         msg_type = MessageType.DOCUMENT
         if isinstance(event, nio.RoomMessageImage):
             msg_type = MessageType.PHOTO
-            media_type = "image"
+            media_type = event_mimetype or "image/png"
         elif isinstance(event, nio.RoomMessageAudio):
             msg_type = MessageType.AUDIO
-            media_type = "audio"
+            media_type = event_mimetype or "audio/ogg"
         elif isinstance(event, nio.RoomMessageVideo):
             msg_type = MessageType.VIDEO
-            media_type = "video"
+            media_type = event_mimetype or "video/mp4"
+        elif event_mimetype:
+            media_type = event_mimetype
 
         is_dm = self._dm_rooms.get(room.room_id, False)
         if not is_dm and room.member_count == 2:

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -79,6 +79,7 @@ class SmsAdapter(BasePlatformAdapter):
             os.getenv("SMS_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))
         )
         self._runner = None
+        self._http_session: Optional["aiohttp.ClientSession"] = None
 
     def _basic_auth_header(self) -> str:
         """Build HTTP Basic auth header value for Twilio."""
@@ -106,6 +107,7 @@ class SmsAdapter(BasePlatformAdapter):
         await self._runner.setup()
         site = web.TCPSite(self._runner, "0.0.0.0", self._webhook_port)
         await site.start()
+        self._http_session = aiohttp.ClientSession()
         self._running = True
 
         logger.info(
@@ -116,6 +118,9 @@ class SmsAdapter(BasePlatformAdapter):
         return True
 
     async def disconnect(self) -> None:
+        if self._http_session:
+            await self._http_session.close()
+            self._http_session = None
         if self._runner:
             await self._runner.cleanup()
             self._runner = None
@@ -140,7 +145,8 @@ class SmsAdapter(BasePlatformAdapter):
             "Authorization": self._basic_auth_header(),
         }
 
-        async with aiohttp.ClientSession() as session:
+        session = self._http_session or aiohttp.ClientSession()
+        try:
             for chunk in chunks:
                 form_data = aiohttp.FormData()
                 form_data.add_field("From", self._from_number)
@@ -167,6 +173,10 @@ class SmsAdapter(BasePlatformAdapter):
                 except Exception as e:
                     logger.error("[sms] send error to %s: %s", _redact_phone(chat_id), e)
                     return SendResult(success=False, error=str(e))
+        finally:
+            # Close session only if we created a fallback (no persistent session)
+            if not self._http_session and session:
+                await session.close()
 
         return last_result
 


### PR DESCRIPTION
## Summary

### 1. SMS adapter: persistent HTTP session (sms.py)
Each outbound SMS created and destroyed a new `aiohttp.ClientSession`, paying TCP+TLS handshake costs every time. Now uses a persistent session created in `connect()` and closed in `disconnect()`, matching the pattern used by Mattermost and HomeAssistant adapters.

### 2. Matrix adapter: MIME-type media types (matrix.py)
Media types were set to bare category words (`"image"`, `"audio"`, `"video"`) instead of proper MIME types. The gateway's media processing in `run.py` checks `mtype.startswith("image/")` and `mtype.startswith("audio/")`, so bare words caused:
- Matrix images to **skip vision enrichment** (the `MessageType.PHOTO` fallback saved it, but only for the image path)
- Matrix audio to **skip transcription** entirely

Now extracts the actual MIME type from the nio event's `content.info.mimetype` field when available, falling back to sensible defaults (`image/png`, `audio/ogg`, `video/mp4`).

## Test plan
- `python -m pytest tests/gateway/test_sms.py tests/gateway/test_matrix.py -n0 -q` → 61 passed ✔