### PR TITLE
docs: add macOS automation guide via macos-mcp Python MCP server

### DIFF
--- a/website/docs/guides/macos-automation.md
+++ b/website/docs/guides/macos-automation.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 9
+title: 'macOS Automation with Hermes'
+description: 'Give Hermes full macOS desktop automation via AppleScript, JXA, screenshots, clipboard, and system controls using the macos-mcp Python MCP server'
+---
+
+# macOS Automation with Hermes
+
+This guide shows how to give Hermes native macOS automation capabilities: run AppleScript,
+control apps (Messages, Mail, Safari, Finder, Calendar, Xcode, and more), take screenshots,
+manage the clipboard, and control system settings.
+
+## How it works
+
+[`macos-mcp`](https://github.com/YanSte/macos-mcp) is a Python MCP server that ports
+[`@steipete/macos-automator-mcp`](https://github.com/steipete/macos-automator-mcp)
+(TypeScript, MIT) to Python. It exposes 7 tools and a 498-script AppleScript/JXA knowledge base
+over the MCP stdio protocol.
+
+Hermes connects to it like any other MCP server — no code changes required.
+
+## Installation
+
+### 1. Install the server
+
+```bash
+pip install macos-mcp
+# or with uv:
+uv tool install macos-mcp
+```
+
+### 2. Enable MCP support in Hermes
+
+```bash
+pip install hermes-agent[mcp]
+```
+
+### 3. Add to `~/.hermes/config.yaml`
+
+```yaml
+mcp_servers:
+  macos:
+    command: python
+    args: ['-m', 'macos_automator_mcp']
+```
+
+Or with `uvx` if you installed via `uv tool`:
+
+```yaml
+mcp_servers:
+  macos:
+    command: uvx
+    args: ['macos-mcp']
+```
+
+### 4. Grant macOS permissions
+
+The process running Hermes (usually Terminal or iTerm2) needs two permissions:
+
+**System Settings → Privacy & Security → Automation**
+Enable the parent terminal app. macOS also shows an automatic Allow/Deny prompt
+the first time each target app (e.g. Messages, Safari) is scripted.
+
+**System Settings → Privacy & Security → Screen Recording**
+Enable the parent terminal app. Required only for `macos_screenshot`.
+
+## Available tools
+
+| Tool | What it does |
+|---|---|
+| `macos_run_script` | Run inline AppleScript or JXA; or run any of the 498 pre-built scripts by ID |
+| `macos_scripting_tips` | Fuzzy-search the knowledge base: "send imessage", "safari screenshot", etc. |
+| `macos_screenshot` | Take a screenshot — returns base64 PNG |
+| `macos_open` | Open any app, file, or URL (`open` command) |
+| `macos_clipboard` | Read or write the clipboard |
+| `macos_notify` | Send a macOS system notification |
+| `macos_system` | Volume, brightness, dark mode, lock screen, list/quit apps, TTS |
+
+## What Hermes can do on macOS
+
+**Messaging & email**
+- Send and read iMessages
+- Compose and send emails, count unread, search inbox
+- Create group chats, send file attachments
+
+**Browser control**
+- Open URLs in Safari/Chrome/Firefox, execute JavaScript, take page screenshots
+- Manage bookmarks, fill forms, inspect DOM
+
+**Calendar & productivity**
+- Create calendar events, list today's meetings
+- Add reminders, search notes, look up contacts
+
+**Developer tools**
+- Build, run, and test Xcode projects
+- Boot iOS Simulators, set location, install apps, send push notifications
+- Run commands in Terminal/iTerm2/Ghostty, open VS Code/Cursor projects
+
+**System**
+- Control volume, brightness, dark mode
+- Lock screen, sleep display, list/quit running apps
+- Speak text (TTS), send notifications
+
+## Usage examples
+
+Once configured, talk to Hermes naturally:
+
+> "Take a screenshot and show me what's on screen"
+
+> "Send an iMessage to Mom: I'll be home by 7"
+
+> "What do I have on my calendar today?"
+
+> "Open Safari and go to github.com/NousResearch/hermes-agent"
+
+> "Set the volume to 30%"
+
+> "Build my Xcode project in ~/dev/MyApp"
+
+For advanced use, reference script IDs directly:
+
+> "Run the script `messages_get_chat_history` for my conversation with Alice"
+
+Or discover available scripts:
+
+> "What scripts do you know for controlling Spotify?"
+
+## Security notes
+
+- `macos_run_script` executes arbitrary AppleScript/JXA. The same trust model
+  applies as any other code execution tool — Hermes's normal confirmation flow
+  applies for sensitive operations.
+- The server only runs on macOS; on other platforms all tools return an error.
+- No network calls are made by the server itself — all operations are local.
+
+## Source
+
+- Server: https://github.com/YanSte/macos-mcp (MIT)
+- Knowledge base: adapted from https://github.com/steipete/macos-automator-mcp (MIT)

--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -398,6 +398,7 @@ Good first servers for most users:
 - GitHub
 - fetch / documentation MCP servers
 - one narrow internal API
+- [macos-mcp](./macos-automation) — if you are on macOS and want Hermes to control your desktop
 
 Not-great first servers:
 - giant business systems with lots of destructive actions and no filtering


### PR DESCRIPTION
## Summary

Hermes currently has no native macOS automation capability — only Markdown skill files that tell the agent to use CLIs. This PR adds documentation and integration guide for [`macos-mcp`](https://github.com/YanSte/macos-mcp), a Python MCP server that gives Hermes full macOS desktop automation.

**What `macos-mcp` provides:**
- 7 MCP tools: `macos_run_script`, `macos_scripting_tips`, `macos_screenshot`, `macos_open`, `macos_clipboard`, `macos_notify`, `macos_system`
- 498-script AppleScript/JXA knowledge base covering: Messages, Mail, Safari, Chrome, Firefox, Calendar, Reminders, Contacts, Finder, Terminal/iTerm2/Ghostty, VS Code, Cursor, Xcode, iOS Simulator (30 scripts), Music, Spotify, and more
- Full `--MCP_INPUT:key` placeholder substitution for dynamic inputs
- Python port of [`@steipete/macos-automator-mcp`](https://github.com/steipete/macos-automator-mcp) (MIT, 719 stars) — trusted, pure TypeScript original, no pre-compiled binaries
- Zero new Hermes dependencies — uses the existing `mcp` optional extra

**Changes:**
- `website/docs/guides/macos-automation.md` — new dedicated guide with install steps, permissions setup, tool reference, and usage examples
- `website/docs/guides/use-mcp-with-hermes.md` — adds `macos-mcp` to the recommended first servers list

**Configuration is one YAML snippet:**
```yaml
mcp_servers:
  macos:
    command: python
    args: ['-m', 'macos_automator_mcp']
```

## Test plan

- [ ] Read `website/docs/guides/macos-automation.md` — verify accuracy and completeness
- [ ] Install `macos-mcp` on macOS: `pip install macos-mcp`
- [ ] Add to `~/.hermes/config.yaml` per the guide
- [ ] Ask Hermes: "Take a screenshot", "Send an iMessage to [contact]", "What meetings do I have today?"
- [ ] Verify tools work as documented

## Source

- `macos-mcp` server: https://github.com/YanSte/macos-mcp (MIT)
- Original TypeScript inspiration: https://github.com/steipete/macos-automator-mcp (MIT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)