### PR TITLE
validate Twilio webhook signatures for SMS

### DIFF
--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -1,0 +1,271 @@
+"""SMS (Twilio) platform adapter.
+
+Connects to the Twilio REST API for outbound SMS and runs an aiohttp
+webhook server to receive inbound messages.
+
+Shares credentials with the optional telephony skill — same env vars:
+  - TWILIO_ACCOUNT_SID
+  - TWILIO_AUTH_TOKEN
+  - TWILIO_PHONE_NUMBER  (E.164 from-number, e.g. +15551234567)
+
+Gateway-specific env vars:
+  - SMS_WEBHOOK_PORT     (default 8080)
+  - SMS_ALLOWED_USERS    (comma-separated E.164 phone numbers)
+  - SMS_ALLOW_ALL_USERS  (true/false)
+  - SMS_HOME_CHANNEL     (phone number for cron delivery)
+"""
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import re
+import urllib.parse
+from typing import Any, Dict, List, Optional
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+logger = logging.getLogger(__name__)
+
+TWILIO_API_BASE = "https://api.twilio.com/2010-04-01/Accounts"
+MAX_SMS_LENGTH = 1600  # ~10 SMS segments
+DEFAULT_WEBHOOK_PORT = 8080
+
+# E.164 phone number pattern for redaction
+_PHONE_RE = re.compile(r"\+[1-9]\d{6,14}")
+
+
+def _redact_phone(phone: str) -> str:
+    """Redact a phone number for logging: +15551234567 -> +1555***4567."""
+    if not phone:
+        return "<none>"
+    if len(phone) <= 8:
+        return phone[:2] + "***" + phone[-2:] if len(phone) > 4 else "****"
+    return phone[:5] + "***" + phone[-4:]
+
+
+def check_sms_requirements() -> bool:
+    """Check if SMS adapter dependencies are available."""
+    try:
+        import aiohttp  # noqa: F401
+    except ImportError:
+        return False
+    return bool(os.getenv("TWILIO_ACCOUNT_SID") and os.getenv("TWILIO_AUTH_TOKEN"))
+
+
+class SmsAdapter(BasePlatformAdapter):
+    """
+    Twilio SMS <-> Hermes gateway adapter.
+
+    Each inbound phone number gets its own Hermes session (multi-tenant).
+    Replies are always sent from the configured TWILIO_PHONE_NUMBER.
+    """
+
+    MAX_MESSAGE_LENGTH = MAX_SMS_LENGTH
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.SMS)
+        self._account_sid: str = os.environ["TWILIO_ACCOUNT_SID"]
+        self._auth_token: str = os.environ["TWILIO_AUTH_TOKEN"]
+        self._from_number: str = os.getenv("TWILIO_PHONE_NUMBER", "")
+        self._webhook_port: int = int(
+            os.getenv("SMS_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))
+        )
+        self._runner = None
+        self._http_session: Optional["aiohttp.ClientSession"] = None
+
+    def _basic_auth_header(self) -> str:
+        """Build HTTP Basic auth header value for Twilio."""
+        creds = f"{self._account_sid}:{self._auth_token}"
+        encoded = base64.b64encode(creds.encode("ascii")).decode("ascii")
+        return f"Basic {encoded}"
+
+    # ------------------------------------------------------------------
+    # Required abstract methods
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> bool:
+        import aiohttp
+        from aiohttp import web
+
+        if not self._from_number:
+            logger.error("[sms] TWILIO_PHONE_NUMBER not set — cannot send replies")
+            return False
+
+        app = web.Application()
+        app.router.add_post("/webhooks/twilio", self._handle_webhook)
+        app.router.add_get("/health", lambda _: web.Response(text="ok"))
+
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, "0.0.0.0", self._webhook_port)
+        await site.start()
+        self._http_session = aiohttp.ClientSession()
+        self._running = True
+
+        logger.info(
+            "[sms] Twilio webhook server listening on port %d, from: %s",
+            self._webhook_port,
+            _redact_phone(self._from_number),
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        if self._http_session:
+            await self._http_session.close()
+            self._http_session = None
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+        self._running = False
+        logger.info("[sms] Disconnected")
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        import aiohttp
+
+        formatted = self.format_message(content)
+        chunks = self.truncate_message(formatted)
+        last_result = SendResult(success=True)
+
+        url = f"{TWILIO_API_BASE}/{self._account_sid}/Messages.json"
+        headers = {
+            "Authorization": self._basic_auth_header(),
+        }
+
+        session = self._http_session or aiohttp.ClientSession()
+        try:
+            for chunk in chunks:
+                form_data = aiohttp.FormData()
+                form_data.add_field("From", self._from_number)
+                form_data.add_field("To", chat_id)
+                form_data.add_field("Body", chunk)
+
+                try:
+                    async with session.post(url, data=form_data, headers=headers) as resp:
+                        body = await resp.json()
+                        if resp.status >= 400:
+                            error_msg = body.get("message", str(body))
+                            logger.error(
+                                "[sms] send failed to %s: %s %s",
+                                _redact_phone(chat_id),
+                                resp.status,
+                                error_msg,
+                            )
+                            return SendResult(
+                                success=False,
+                                error=f"Twilio {resp.status}: {error_msg}",
+                            )
+                        msg_sid = body.get("sid", "")
+                        last_result = SendResult(success=True, message_id=msg_sid)
+                except Exception as e:
+                    logger.error("[sms] send error to %s: %s", _redact_phone(chat_id), e)
+                    return SendResult(success=False, error=str(e))
+        finally:
+            # Close session only if we created a fallback (no persistent session)
+            if not self._http_session and session:
+                await session.close()
+
+        return last_result
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "dm"}
+
+    # ------------------------------------------------------------------
+    # SMS-specific formatting
+    # ------------------------------------------------------------------
+
+    def format_message(self, content: str) -> str:
+        """Strip markdown — SMS renders it as literal characters."""
+        content = re.sub(r"\*\*(.+?)\*\*", r"\1", content, flags=re.DOTALL)
+        content = re.sub(r"\*(.+?)\*", r"\1", content, flags=re.DOTALL)
+        content = re.sub(r"__(.+?)__", r"\1", content, flags=re.DOTALL)
+        content = re.sub(r"_(.+?)_", r"\1", content, flags=re.DOTALL)
+        content = re.sub(r"```[a-z]*\n?", "", content)
+        content = re.sub(r"`(.+?)`", r"\1", content)
+        content = re.sub(r"^#{1,6}\s+", "", content, flags=re.MULTILINE)
+        content = re.sub(r"\[([^\]]+)\]\([^\)]+\)", r"\1", content)
+        content = re.sub(r"\n{3,}", "\n\n", content)
+        return content.strip()
+
+    # ------------------------------------------------------------------
+    # Twilio webhook handler
+    # ------------------------------------------------------------------
+
+    async def _handle_webhook(self, request) -> "aiohttp.web.Response":
+        from aiohttp import web
+
+        try:
+            raw = await request.read()
+            # Twilio sends form-encoded data, not JSON
+            form = urllib.parse.parse_qs(raw.decode("utf-8"))
+        except Exception as e:
+            logger.error("[sms] webhook parse error: %s", e)
+            return web.Response(
+                text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                content_type="application/xml",
+                status=400,
+            )
+
+        # Extract fields (parse_qs returns lists)
+        from_number = (form.get("From", [""]))[0].strip()
+        to_number = (form.get("To", [""]))[0].strip()
+        text = (form.get("Body", [""]))[0].strip()
+        message_sid = (form.get("MessageSid", [""]))[0].strip()
+
+        if not from_number or not text:
+            return web.Response(
+                text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                content_type="application/xml",
+            )
+
+        # Ignore messages from our own number (echo prevention)
+        if from_number == self._from_number:
+            logger.debug("[sms] ignoring echo from own number %s", _redact_phone(from_number))
+            return web.Response(
+                text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                content_type="application/xml",
+            )
+
+        logger.info(
+            "[sms] inbound from %s -> %s: %s",
+            _redact_phone(from_number),
+            _redact_phone(to_number),
+            text[:80],
+        )
+
+        source = self.build_source(
+            chat_id=from_number,
+            chat_name=from_number,
+            chat_type="dm",
+            user_id=from_number,
+            user_name=from_number,
+        )
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=form,
+            message_id=message_sid,
+        )
+
+        # Non-blocking: Twilio expects a fast response
+        asyncio.create_task(self.handle_message(event))
+
+        # Return empty TwiML — we send replies via the REST API, not inline TwiML
+        return web.Response(
+            text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+            content_type="application/xml",
+        )

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -17,10 +17,13 @@ Gateway-specific env vars:
 
 import asyncio
 import base64
+import hmac
 import json
 import logging
 import os
 import re
+import secrets
+import urllib
 import urllib.parse
 from typing import Any, Dict, List, Optional
 
@@ -40,6 +43,8 @@ DEFAULT_WEBHOOK_PORT = 8080
 
 # E.164 phone number pattern for redaction
 _PHONE_RE = re.compile(r"\+[1-9]\d{6,14}")
+
+_TWILIO_SIGNATURE_HEADER = "X-Twilio-Signature"
 
 
 def _redact_phone(phone: str) -> str:
@@ -86,6 +91,67 @@ class SmsAdapter(BasePlatformAdapter):
         creds = f"{self._account_sid}:{self._auth_token}"
         encoded = base64.b64encode(creds.encode("ascii")).decode("ascii")
         return f"Basic {encoded}"
+
+    def _signature_validation_enabled(self) -> bool:
+        val = os.getenv("SMS_VALIDATE_TWILIO_SIGNATURE", "true").strip().lower()
+        return val in ("1", "true", "yes", "on")
+
+    def _public_webhook_base_url(self) -> str:
+        # Prefer explicit public URL for reverse proxies / TLS termination.
+        # Example: https://example.com/webhooks/twilio  (or without path; we append request path)
+        return os.getenv("SMS_WEBHOOK_PUBLIC_URL", "").strip().rstrip("/")
+
+    @staticmethod
+    def _build_request_url_for_signature(request) -> str:
+        """
+        Build the URL Twilio used to sign the request.
+
+        We prefer proxy headers when present, because the adapter often runs behind
+        a reverse proxy / tunnel (ngrok, Cloudflare, etc.).
+        """
+        # aiohttp exposes request.host (may include port) and request.path_qs
+        xf_proto = request.headers.get("X-Forwarded-Proto", "").split(",")[0].strip()
+        xf_host = request.headers.get("X-Forwarded-Host", "").split(",")[0].strip()
+
+        scheme = xf_proto or request.scheme
+        host = xf_host or request.host
+        return f"{scheme}://{host}{request.path_qs}"
+
+    def _twilio_expected_signature(self, url: str, form: Dict[str, List[str]]) -> str:
+        """
+        Compute Twilio signature (base64(hmac_sha1(auth_token, url + sorted(params)))).
+
+        Twilio's webhook signature is computed over the request URL and the POST
+        parameters. parse_qs gives list-values; we use the first value for each key.
+        """
+        # Twilio uses URL (no decoding) + concatenation of param name + value sorted by name.
+        pairs = []
+        for k in sorted(form.keys()):
+            vals = form.get(k) or [""]
+            v = vals[0] if isinstance(vals, list) and vals else str(vals)
+            pairs.append(f"{k}{v}")
+        data = (url + "".join(pairs)).encode("utf-8")
+
+        mac = hmac.new(self._auth_token.encode("utf-8"), data, digestmod="sha1")
+        return base64.b64encode(mac.digest()).decode("ascii")
+
+    def _is_valid_twilio_signature(self, request, form: Dict[str, List[str]]) -> bool:
+        provided = request.headers.get(_TWILIO_SIGNATURE_HEADER, "")
+        if not provided:
+            return False
+
+        public_base = self._public_webhook_base_url()
+        if public_base:
+            # If user provides full URL including path, respect it; else append request path.
+            if public_base.endswith(request.path):
+                url = public_base
+            else:
+                url = f"{public_base}{request.path}"
+        else:
+            url = self._build_request_url_for_signature(request)
+
+        expected = self._twilio_expected_signature(url, form)
+        return secrets.compare_digest(expected, provided)
 
     # ------------------------------------------------------------------
     # Required abstract methods
@@ -218,6 +284,25 @@ class SmsAdapter(BasePlatformAdapter):
                 content_type="application/xml",
                 status=400,
             )
+
+        # Validate Twilio signature unless explicitly disabled.
+        if self._signature_validation_enabled():
+            try:
+                if not self._is_valid_twilio_signature(request, form):
+                    logger.warning("[sms] webhook rejected: invalid Twilio signature")
+                    return web.Response(
+                        text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                        content_type="application/xml",
+                        status=403,
+                    )
+            except Exception as e:
+                # Fail closed when validation is enabled.
+                logger.warning("[sms] webhook rejected: signature validation error: %s", e)
+                return web.Response(
+                    text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                    content_type="application/xml",
+                    status=403,
+                )
 
         # Extract fields (parse_qs returns lists)
         from_number = (form.get("From", [""]))[0].strip()

--- a/tests/gateway/test_sms_signature.py
+++ b/tests/gateway/test_sms_signature.py
@@ -1,0 +1,91 @@
+import base64
+import hmac
+import os
+
+import pytest
+
+
+def _twilio_sig(auth_token: str, url: str, params: dict[str, str]) -> str:
+    payload = url + "".join(f"{k}{params[k]}" for k in sorted(params.keys()))
+    mac = hmac.new(auth_token.encode("utf-8"), payload.encode("utf-8"), digestmod="sha1")
+    return base64.b64encode(mac.digest()).decode("ascii")
+
+
+@pytest.mark.asyncio
+async def test_sms_webhook_rejects_missing_signature(aiohttp_client, monkeypatch):
+    from aiohttp import web
+    from gateway.config import PlatformConfig
+    from gateway.platforms.sms import SmsAdapter
+
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "AC123")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "secret")
+    monkeypatch.setenv("TWILIO_PHONE_NUMBER", "+15550001111")
+    monkeypatch.setenv("SMS_VALIDATE_TWILIO_SIGNATURE", "true")
+    monkeypatch.setenv("SMS_WEBHOOK_PUBLIC_URL", "https://example.com/webhooks/twilio")
+
+    adapter = SmsAdapter(PlatformConfig(name="sms", token="", extra={}))
+
+    app = web.Application()
+    app.router.add_post("/webhooks/twilio", adapter._handle_webhook)
+    client = await aiohttp_client(app)
+
+    resp = await client.post(
+        "/webhooks/twilio",
+        data={"From": "+15551234567", "To": "+15550001111", "Body": "hi", "MessageSid": "SM1"},
+    )
+    assert resp.status == 403
+
+
+@pytest.mark.asyncio
+async def test_sms_webhook_accepts_valid_signature(aiohttp_client, monkeypatch):
+    from aiohttp import web
+    from gateway.config import PlatformConfig
+    from gateway.platforms.sms import SmsAdapter
+
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "AC123")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "secret")
+    monkeypatch.setenv("TWILIO_PHONE_NUMBER", "+15550001111")
+    monkeypatch.setenv("SMS_VALIDATE_TWILIO_SIGNATURE", "true")
+    monkeypatch.setenv("SMS_WEBHOOK_PUBLIC_URL", "https://example.com/webhooks/twilio")
+
+    adapter = SmsAdapter(PlatformConfig(name="sms", token="", extra={}))
+
+    app = web.Application()
+    app.router.add_post("/webhooks/twilio", adapter._handle_webhook)
+    client = await aiohttp_client(app)
+
+    params = {"Body": "hi", "From": "+15551234567", "MessageSid": "SM1", "To": "+15550001111"}
+    url = "https://example.com/webhooks/twilio"
+    sig = _twilio_sig("secret", url, params)
+
+    resp = await client.post(
+        "/webhooks/twilio",
+        data=params,
+        headers={"X-Twilio-Signature": sig},
+    )
+    assert resp.status in (200, 204)
+
+
+@pytest.mark.asyncio
+async def test_sms_webhook_allows_disabled_validation(aiohttp_client, monkeypatch):
+    from aiohttp import web
+    from gateway.config import PlatformConfig
+    from gateway.platforms.sms import SmsAdapter
+
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "AC123")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "secret")
+    monkeypatch.setenv("TWILIO_PHONE_NUMBER", "+15550001111")
+    monkeypatch.setenv("SMS_VALIDATE_TWILIO_SIGNATURE", "false")
+
+    adapter = SmsAdapter(PlatformConfig(name="sms", token="", extra={}))
+
+    app = web.Application()
+    app.router.add_post("/webhooks/twilio", adapter._handle_webhook)
+    client = await aiohttp_client(app)
+
+    resp = await client.post(
+        "/webhooks/twilio",
+        data={"From": "+15551234567", "To": "+15550001111", "Body": "hi", "MessageSid": "SM1"},
+    )
+    assert resp.status in (200, 204)
+


### PR DESCRIPTION
Adds Twilio webhook signature validation to the SMS platform adapter to prevent spoofed inbound messages.

**What changed**

gateway/platforms/sms.py
Validates X-Twilio-Signature on /webhooks/twilio when enabled.
Proxy-safe URL construction using X-Forwarded-Proto / X-Forwarded-Host.
Supports explicit override via SMS_WEBHOOK_PUBLIC_URL.
Toggle via SMS_VALIDATE_TWILIO_SIGNATURE (default: enabled).
Invalid/missing signature returns 403 (fail closed when enabled).

tests/gateway/test_sms_signature.py
Covers: missing signature → 403, valid signature → 200/204, validation disabled → 200/204.