### PR TITLE
fix(telegram): cancel pending text batch tasks on disconnect

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -310,6 +310,12 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_photo_batch_tasks.clear()
         self._pending_photo_batches.clear()
 
+        for task in self._pending_text_batch_tasks.values():
+            if task and not task.done():
+                task.cancel()
+        self._pending_text_batch_tasks.clear()
+        self._pending_text_batches.clear()
+
         self._mark_disconnected()
         self._app = None
         self._bot = None

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -119,3 +119,31 @@ class TestTextBatching:
 
         assert len(adapter._pending_text_batches) == 0
         assert len(adapter._pending_text_batch_tasks) == 0
+
+
+class TestTextBatchDisconnect:
+    @pytest.mark.asyncio
+    async def test_disconnect_cancels_pending_text_batch_tasks(self):
+        from gateway.platforms.telegram import TelegramAdapter
+
+        config = PlatformConfig(enabled=True, token="fake-token")
+        adapter = TelegramAdapter(config)
+        adapter.handle_message = AsyncMock()
+
+        task = MagicMock()
+        task.done.return_value = False
+        adapter._pending_text_batch_tasks["session:text-burst"] = task
+        adapter._pending_text_batches["session:text-burst"] = _make_event("buffered text")
+
+        adapter._app = MagicMock()
+        adapter._app.updater.running = True
+        adapter._app.updater.stop = AsyncMock()
+        adapter._app.running = True
+        adapter._app.stop = AsyncMock()
+        adapter._app.shutdown = AsyncMock()
+
+        await adapter.disconnect()
+
+        task.cancel.assert_called_once()
+        assert adapter._pending_text_batch_tasks == {}
+        assert adapter._pending_text_batches == {}

--- a/tests/test_tool_call_parsers.py
+++ b/tests/test_tool_call_parsers.py
@@ -209,3 +209,66 @@ class TestDeepSeekV3Parser:
         content, tool_calls = parser.parse(text)
         assert tool_calls is not None
         assert len(tool_calls) == 1
+
+
+# ─── Mistral parser tests ───────────────────────────────────────────────
+
+class TestMistralParser:
+    @pytest.fixture
+    def parser(self):
+        return get_parser("mistral")
+
+    def test_no_tool_call(self, parser):
+        text = "Hello, how can I help you?"
+        content, tool_calls = parser.parse(text)
+        assert content == text
+        assert tool_calls is None
+
+    def test_pre_v11_single_tool_call(self, parser):
+        text = '[TOOL_CALLS] [{"name": "func", "arguments": {"key": "val"}}]'
+        content, tool_calls = parser.parse(text)
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "func"
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["key"] == "val"
+
+    def test_pre_v11_nested_json(self, parser):
+        text = '[TOOL_CALLS] [{"name": "func", "arguments": {"nested": {"deep": true}}}]'
+        content, tool_calls = parser.parse(text)
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "func"
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["nested"]["deep"] is True
+
+    def test_v11_single_tool_call(self, parser):
+        text = '[TOOL_CALLS]get_weather{"city": "London"}'
+        content, tool_calls = parser.parse(text)
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get_weather"
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["city"] == "London"
+
+    def test_v11_multiple_tool_calls(self, parser):
+        text = '[TOOL_CALLS]func1{"a": 1}[TOOL_CALLS]func2{"b": 2}'
+        content, tool_calls = parser.parse(text)
+        assert tool_calls is not None
+        assert len(tool_calls) == 2
+        names = [tc.function.name for tc in tool_calls]
+        assert "func1" in names
+        assert "func2" in names
+
+    def test_preceding_text_preserved(self, parser):
+        text = 'Hello[TOOL_CALLS]func{"a": 1}'
+        content, tool_calls = parser.parse(text)
+        assert content == "Hello"
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "func"
+
+    def test_malformed_json_fallback(self, parser):
+        text = "[TOOL_CALLS] not valid json"
+        content, tool_calls = parser.parse(text)
+        assert tool_calls is None


### PR DESCRIPTION
Photo and media group tasks are cancelled during `disconnect()`, but `_pending_text_batch_tasks` are not. This leaves orphaned asyncio tasks after shutdown.

Adds the same cancellation pattern used for photo batches, clearing both `_pending_text_batch_tasks` and `_pending_text_batches` on disconnect.

Includes a test modeled after `test_disconnect_cancels_pending_photo_batch_tasks`.