### PR TITLE
PII: redact emails and IPv4 addresses in redaction pipeline

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -81,6 +81,17 @@ _DB_CONNSTR_RE = re.compile(
 # Negative lookahead prevents matching hex strings or identifiers
 _SIGNAL_PHONE_RE = re.compile(r"(\+[1-9]\d{6,14})(?![A-Za-z0-9])")
 
+# Email addresses (conservative; avoids matching inside longer tokens)
+_EMAIL_RE = re.compile(
+    r"(?<![A-Za-z0-9._%+-])([A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,255}\.[A-Za-z]{2,63})(?![A-Za-z0-9._%+-])"
+)
+
+# IPv4 addresses (common in logs; avoids matching inside longer digit sequences)
+_IPV4_RE = re.compile(
+    r"(?<!\d)(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}"
+    r"(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?!\d)"
+)
+
 # Compile known prefix patterns into one alternation
 _PREFIX_RE = re.compile(
     r"(?<![A-Za-z0-9_-])(" + "|".join(_PREFIX_PATTERNS) + r")(?![A-Za-z0-9_-])"
@@ -146,6 +157,12 @@ def redact_sensitive_text(text: str) -> str:
             return phone[:2] + "****" + phone[-2:]
         return phone[:4] + "****" + phone[-4:]
     text = _SIGNAL_PHONE_RE.sub(_redact_phone, text)
+
+    # Email addresses
+    text = _EMAIL_RE.sub("[REDACTED EMAIL]", text)
+
+    # IPv4 addresses
+    text = _IPV4_RE.sub("[REDACTED IP]", text)
 
     return text
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -187,3 +187,26 @@ class TestSecretCapturePayloadRedaction:
         text = '{"raw_secret": "ghp_abc123def456ghi789jkl"}'
         result = redact_sensitive_text(text)
         assert "abc123def456" not in result
+
+
+class TestEmailRedaction:
+    def test_email_redacted(self):
+        text = "Contact me at john.doe+test@example.com ASAP"
+        result = redact_sensitive_text(text)
+        assert "john.doe" not in result
+        assert "example.com" not in result
+        assert "[REDACTED EMAIL]" in result
+
+
+class TestIpRedaction:
+    def test_ipv4_redacted(self):
+        text = "Client connected from 192.168.1.23"
+        result = redact_sensitive_text(text)
+        assert "192.168.1.23" not in result
+        assert "[REDACTED IP]" in result
+
+    def test_ipv4_invalid_not_redacted(self):
+        # Not a valid IPv4; should pass through.
+        text = "Not an IP: 999.999.999.999"
+        result = redact_sensitive_text(text)
+        assert result == text


### PR DESCRIPTION
This PR extends Hermes’s redaction pipeline to mask common PII found in logs and tool output by redacting email addresses and IPv4 addresses. The change adds conservative regex patterns to agent/redact.py and applies them after existing secret/phone redaction steps, returning [REDACTED EMAIL] and [REDACTED IP] placeholders. New unit tests cover typical email/IP cases and ensure invalid IPv4-like strings are not redacte