### PR TITLE
fix(gateway): honor streaming config and ignore Telegram no-op edits

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -403,6 +403,20 @@ def load_gateway_config() -> GatewayConfig:
                     True,
                 )
 
+            # Bridge gateway streaming config from the user-facing config source.
+            # This is the documented location for Telegram/Discord/Slack
+            # progressive message editing, so it should override gateway.json.
+            streaming_cfg = yaml_cfg.get("streaming")
+            if streaming_cfg is not None:
+                if isinstance(streaming_cfg, dict):
+                    config.streaming = StreamingConfig.from_dict(streaming_cfg)
+                else:
+                    logger.warning(
+                        "Ignoring invalid streaming config in config.yaml "
+                        "(expected mapping, got %s)",
+                        type(streaming_cfg).__name__,
+                    )
+
             # Bridge discord settings from config.yaml to env vars
             # (env vars take precedence — only set if not already defined)
             discord_cfg = yaml_cfg.get("discord", {})

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -414,13 +414,22 @@ class TelegramAdapter(BasePlatformAdapter):
                     text=formatted,
                     parse_mode=ParseMode.MARKDOWN_V2,
                 )
-            except Exception:
+            except Exception as md_err:
+                err_text = str(md_err).lower()
+                if "message is not modified" in err_text:
+                    return SendResult(success=True, message_id=message_id)
                 # Fallback: retry without markdown formatting
-                await self._bot.edit_message_text(
-                    chat_id=int(chat_id),
-                    message_id=int(message_id),
-                    text=content,
-                )
+                try:
+                    await self._bot.edit_message_text(
+                        chat_id=int(chat_id),
+                        message_id=int(message_id),
+                        text=content,
+                    )
+                except Exception as plain_err:
+                    plain_err_text = str(plain_err).lower()
+                    if "message is not modified" in plain_err_text:
+                        return SendResult(success=True, message_id=message_id)
+                    raise
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             logger.error(

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -106,6 +106,10 @@ class TelegramAdapter(BasePlatformAdapter):
     # Telegram message limits
     MAX_MESSAGE_LENGTH = 4096
     MEDIA_GROUP_WAIT_SECONDS = 0.8
+    # Telegram progressive edits are rate-limited more aggressively than the
+    # generic gateway default. Keep a platform-specific floor and still honor
+    # explicit RetryAfter values from the Bot API when they occur.
+    STREAM_EDIT_INTERVAL_FLOOR = 0.4
     
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.TELEGRAM)
@@ -125,6 +129,20 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._token_lock_identity: Optional[str] = None
         self._polling_error_task: Optional[asyncio.Task] = None
+
+    @staticmethod
+    def _is_message_not_modified(error: Exception) -> bool:
+        return "message is not modified" in str(error).lower()
+
+    @staticmethod
+    def _retry_after_seconds(error: Exception) -> Optional[float]:
+        retry_after = getattr(error, "retry_after", None)
+        if retry_after is None:
+            return None
+        try:
+            return max(float(retry_after), 0.0)
+        except (TypeError, ValueError):
+            return None
 
     @staticmethod
     def _looks_like_polling_conflict(error: Exception) -> bool:
@@ -344,9 +362,10 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id = metadata.get("thread_id") if metadata else None
             
             try:
-                from telegram.error import NetworkError as _NetErr
+                from telegram.error import NetworkError as _NetErr, RetryAfter as _RetryAfter
             except ImportError:
                 _NetErr = OSError  # type: ignore[misc,assignment]
+                _RetryAfter = TimeoutError  # type: ignore[misc,assignment]
 
             for i, chunk in enumerate(chunks):
                 msg = None
@@ -376,6 +395,22 @@ class TelegramAdapter(BasePlatformAdapter):
                             else:
                                 raise
                         break  # success
+                    except _RetryAfter as send_err:
+                        if _send_attempt < 2:
+                            wait = self._retry_after_seconds(send_err)
+                            if wait is None:
+                                wait = 2 ** _send_attempt
+                            wait = max(wait, self.STREAM_EDIT_INTERVAL_FLOOR)
+                            logger.warning(
+                                "[%s] Telegram flood control on send (attempt %d/3), retrying in %.2fs: %s",
+                                self.name,
+                                _send_attempt + 1,
+                                wait,
+                                send_err,
+                            )
+                            await asyncio.sleep(wait)
+                        else:
+                            raise
                     except _NetErr as send_err:
                         if _send_attempt < 2:
                             wait = 2 ** _send_attempt
@@ -406,31 +441,70 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
         try:
-            formatted = self.format_message(content)
             try:
-                await self._bot.edit_message_text(
-                    chat_id=int(chat_id),
-                    message_id=int(message_id),
-                    text=formatted,
-                    parse_mode=ParseMode.MARKDOWN_V2,
-                )
-            except Exception as md_err:
-                err_text = str(md_err).lower()
-                if "message is not modified" in err_text:
-                    return SendResult(success=True, message_id=message_id)
-                # Fallback: retry without markdown formatting
+                from telegram.error import NetworkError as _NetErr, RetryAfter as _RetryAfter
+            except ImportError:
+                _NetErr = OSError  # type: ignore[misc,assignment]
+                _RetryAfter = TimeoutError  # type: ignore[misc,assignment]
+
+            formatted = self.format_message(content)
+            for _edit_attempt in range(3):
                 try:
-                    await self._bot.edit_message_text(
-                        chat_id=int(chat_id),
-                        message_id=int(message_id),
-                        text=content,
-                    )
-                except Exception as plain_err:
-                    plain_err_text = str(plain_err).lower()
-                    if "message is not modified" in plain_err_text:
-                        return SendResult(success=True, message_id=message_id)
+                    try:
+                        await self._bot.edit_message_text(
+                            chat_id=int(chat_id),
+                            message_id=int(message_id),
+                            text=formatted,
+                            parse_mode=ParseMode.MARKDOWN_V2,
+                        )
+                    except Exception as md_err:
+                        if self._retry_after_seconds(md_err) is not None:
+                            raise
+                        if self._is_message_not_modified(md_err):
+                            return SendResult(success=True, message_id=message_id)
+                        # Fallback: retry without markdown formatting
+                        try:
+                            await self._bot.edit_message_text(
+                                chat_id=int(chat_id),
+                                message_id=int(message_id),
+                                text=content,
+                            )
+                        except Exception as plain_err:
+                            if self._retry_after_seconds(plain_err) is not None:
+                                raise
+                            if self._is_message_not_modified(plain_err):
+                                return SendResult(success=True, message_id=message_id)
+                            raise
+                    return SendResult(success=True, message_id=message_id)
+                except _RetryAfter as edit_err:
+                    if _edit_attempt < 2:
+                        wait = self._retry_after_seconds(edit_err)
+                        if wait is None:
+                            wait = 2 ** _edit_attempt
+                        wait = max(wait, self.STREAM_EDIT_INTERVAL_FLOOR)
+                        logger.warning(
+                            "[%s] Telegram flood control on edit (attempt %d/3), retrying in %.2fs: %s",
+                            self.name,
+                            _edit_attempt + 1,
+                            wait,
+                            edit_err,
+                        )
+                        await asyncio.sleep(wait)
+                        continue
                     raise
-            return SendResult(success=True, message_id=message_id)
+                except _NetErr as edit_err:
+                    if _edit_attempt < 2:
+                        wait = 2 ** _edit_attempt
+                        logger.warning(
+                            "[%s] Network error on edit (attempt %d/3), retrying in %ds: %s",
+                            self.name,
+                            _edit_attempt + 1,
+                            wait,
+                            edit_err,
+                        )
+                        await asyncio.sleep(wait)
+                        continue
+                    raise
         except Exception as e:
             logger.error(
                 "[%s] Failed to edit Telegram message %s: %s",

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -61,6 +61,9 @@ class GatewayStreamConsumer:
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
+        interval_floor = getattr(adapter, "STREAM_EDIT_INTERVAL_FLOOR", 0.0)
+        if interval_floor:
+            self.cfg.edit_interval = max(self.cfg.edit_interval, float(interval_floor))
         self.metadata = metadata
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1,0 +1,15 @@
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+class _Adapter:
+    STREAM_EDIT_INTERVAL_FLOOR = 0.4
+
+
+def test_stream_consumer_applies_adapter_edit_interval_floor():
+    consumer = GatewayStreamConsumer(
+        _Adapter(),
+        "123",
+        StreamConsumerConfig(edit_interval=0.1, buffer_threshold=40, cursor=" ▉"),
+    )
+
+    assert consumer.cfg.edit_interval == 0.4

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -28,8 +28,22 @@ def _ensure_telegram_mock():
     mod.constants.ChatType.SUPERGROUP = "supergroup"
     mod.constants.ChatType.CHANNEL = "channel"
     mod.constants.ChatType.PRIVATE = "private"
-    for name in ("telegram", "telegram.ext", "telegram.constants"):
+
+    class _MockNetworkError(Exception):
+        pass
+
+    class _MockRetryAfter(Exception):
+        def __init__(self, retry_after):
+            self.retry_after = retry_after
+            super().__init__(f"Flood control exceeded. Retry in {retry_after} seconds")
+
+    error_mod = MagicMock()
+    error_mod.NetworkError = _MockNetworkError
+    error_mod.RetryAfter = _MockRetryAfter
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.error"):
         sys.modules.setdefault(name, mod)
+    sys.modules["telegram.error"] = error_mod
 
 
 _ensure_telegram_mock()
@@ -416,3 +430,49 @@ async def test_send_escapes_chunk_indicator_for_markdownv2(adapter):
     assert len(sent_texts) > 1
     assert re.search(r" \\\([0-9]+/[0-9]+\\\)$", sent_texts[0])
     assert re.search(r" \\\([0-9]+/[0-9]+\\\)$", sent_texts[-1])
+
+
+@pytest.mark.asyncio
+async def test_send_retries_retry_after_then_succeeds(adapter, monkeypatch):
+    from telegram.error import RetryAfter
+
+    adapter._bot = MagicMock()
+    msg = MagicMock()
+    msg.message_id = 42
+    adapter._bot.send_message = AsyncMock(side_effect=[RetryAfter(0.2), msg])
+
+    sleep_calls = []
+
+    async def _fake_sleep(delay):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr("gateway.platforms.telegram.asyncio.sleep", _fake_sleep)
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is True
+    assert result.message_id == "42"
+    assert adapter._bot.send_message.await_count == 2
+    assert sleep_calls == [adapter.STREAM_EDIT_INTERVAL_FLOOR]
+
+
+@pytest.mark.asyncio
+async def test_edit_message_retries_retry_after_then_succeeds(adapter, monkeypatch):
+    from telegram.error import RetryAfter
+
+    adapter._bot = MagicMock()
+    adapter._bot.edit_message_text = AsyncMock(side_effect=[RetryAfter(0.2), MagicMock()])
+
+    sleep_calls = []
+
+    async def _fake_sleep(delay):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr("gateway.platforms.telegram.asyncio.sleep", _fake_sleep)
+
+    result = await adapter.edit_message("123", "77", "hello")
+
+    assert result.success is True
+    assert result.message_id == "77"
+    assert adapter._bot.edit_message_text.await_count == 2
+    assert sleep_calls == [adapter.STREAM_EDIT_INTERVAL_FLOOR]


### PR DESCRIPTION
## Summary

This fixes Telegram gateway streaming end-to-end for the documented `streaming:` config path.

- Bridge the documented top-level `streaming:` block from `~/.hermes/config.yaml` into the live gateway runtime
- Treat Telegram `message is not modified` responses as successful no-op edits during progressive message updates
- Handle Telegram flood control during streaming by honoring `RetryAfter` and retrying send/edit calls
- Apply a Telegram-specific streaming edit cadence floor so the generic gateway default does not hammer `editMessageText`

## Root Cause

The CLI already reads `display.streaming` directly from `config.yaml`, but the gateway runtime was not importing the top-level `streaming:` config into `GatewayConfig`. That meant CLI streaming could work while Telegram gateway turns still behaved as if streaming were disabled.

After fixing that, Telegram streaming could still stop after the first visible update because:

- Telegram may return `Bad Request: message is not modified` for benign duplicate edits during rapid progressive updates, and Hermes treated that as a hard failure instead of a harmless no-op
- Telegram may return `RetryAfter` flood-control errors during progressive edits, and Hermes did not wait and retry those edits

## Changes

### 1. Honor documented gateway streaming config

`gateway/config.py`

- read the top-level `streaming:` mapping from `config.yaml`
- if present and valid, apply it to `config.streaming`
- warn and ignore invalid non-mapping values

This makes the gateway honor the documented configuration surface for Telegram/Discord/Slack streaming:

```yaml
streaming:
  enabled: true
  edit_interval: 0.3
  buffer_threshold: 40
  cursor: " ▉"
```

### 2. Ignore Telegram no-op edit failures

`gateway/platforms/telegram.py`

- treat `message is not modified` as a successful edit in both the MarkdownV2 path and the plain-text fallback path

This prevents harmless duplicate edits from terminating streaming early.

### 3. Respect Telegram flood control during streaming

`gateway/platforms/telegram.py`

- catch `telegram.error.RetryAfter` on both `send_message` and `edit_message_text`
- honor Telegram's `retry_after` delay and retry instead of failing the stream
- keep network-error retries for the same paths

`gateway/stream_consumer.py`

- apply a Telegram-specific minimum edit interval floor of `0.4s`
- preserve the generic configured `edit_interval` for other adapters

This keeps Telegram streaming responsive while avoiding overly aggressive edit cadence.

## Verification

- `pytest tests/ -v` on Linux
- `python3 -m py_compile gateway/config.py gateway/platforms/telegram.py`
- `git diff --check`
- full-suite result matches current `main` baseline: 3 unrelated failures in `tests/tools/test_delegate.py` and `tests/tools/test_transcription.py`
- isolated reruns of those failing tests passed on both `main` and this PR branch
- focused Telegram verification:
  - `pytest tests/gateway/test_telegram_format.py tests/gateway/test_stream_consumer.py -v`

## How to test

1. Configure Telegram gateway streaming in `~/.hermes/config.yaml`:

```yaml
streaming:
  enabled: true
  edit_interval: 0.3
  buffer_threshold: 40
  cursor: " ▉"
```

2. Start the gateway and send a plain text Telegram prompt that produces a multi-line response.
3. Verify the bot progressively edits a single Telegram message instead of only sending the final full response.
4. Verify duplicate edit attempts do not terminate streaming early.

## Platforms tested

- Linux
- CLI
- Telegram gateway

## Notes

- This PR is intentionally scoped to the runtime fixes only.
- It does not include the temporary instrumentation/debugging used during diagnosis.
