### PR TITLE
feat(whatsapp): make reply prefix configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -35,7 +35,7 @@ _EXTRA_ENV_KEYS = frozenset({
     "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
     "DINGTALK_CLIENT_ID", "DINGTALK_CLIENT_SECRET",
     "TERMINAL_ENV", "TERMINAL_SSH_KEY", "TERMINAL_SSH_PORT",
-    "WHATSAPP_MODE", "WHATSAPP_ENABLED",
+    "WHATSAPP_MODE", "WHATSAPP_ENABLED", "WHATSAPP_REPLY_PREFIX",
     "MATTERMOST_HOME_CHANNEL", "MATTERMOST_REPLY_MODE",
     "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_HOME_ROOM",
 })
@@ -365,7 +365,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 9,
+    "_config_version": 11,
 }
 
 # =============================================================================
@@ -380,6 +380,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
     5: ["WHATSAPP_ENABLED", "WHATSAPP_MODE", "WHATSAPP_ALLOWED_USERS",
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
+    11: ["WHATSAPP_REPLY_PREFIX"],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -763,6 +764,14 @@ OPTIONAL_ENV_VARS = {
     "GATEWAY_ALLOW_ALL_USERS": {
         "description": "Allow all users to interact with messaging bots (true/false). Default: false.",
         "prompt": "Allow all users (true/false)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "WHATSAPP_REPLY_PREFIX": {
+        "description": "Optional WhatsApp reply prefix. Use an empty value to disable it. Supports \\n escapes.",
+        "prompt": "WhatsApp reply prefix",
         "url": None,
         "password": False,
         "category": "messaging",

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -44,6 +44,14 @@ const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.herme
 const PAIR_ONLY = args.includes('--pair-only');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const ALLOWED_USERS = (process.env.WHATSAPP_ALLOWED_USERS || '').split(',').map(s => s.trim()).filter(Boolean);
+const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
+const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
+  ? DEFAULT_REPLY_PREFIX
+  : process.env.WHATSAPP_REPLY_PREFIX.replace(/\\n/g, '\n');
+
+function formatOutgoingMessage(message) {
+  return REPLY_PREFIX ? `${REPLY_PREFIX}${message}` : message;
+}
 
 mkdirSync(SESSION_DIR, { recursive: true });
 
@@ -188,7 +196,7 @@ async function startSocket() {
       }
 
       // Ignore Hermes' own reply messages in self-chat mode to avoid loops.
-      if (msg.key.fromMe && (body.startsWith('⚕ *Hermes Agent*') || recentlySentIds.has(msg.key.id))) {
+      if (msg.key.fromMe && ((REPLY_PREFIX && body.startsWith(REPLY_PREFIX)) || recentlySentIds.has(msg.key.id))) {
         if (WHATSAPP_DEBUG) {
           try { console.log(JSON.stringify({ event: 'ignored', reason: 'agent_echo', chatId, messageId: msg.key.id })); } catch {}
         }
@@ -251,10 +259,7 @@ app.post('/send', async (req, res) => {
   }
 
   try {
-    // Prefix responses so the user can distinguish agent replies from their
-    // own messages (especially in self-chat / "Message Yourself").
-    const prefixed = `⚕ *Hermes Agent*\n────────────\n${message}`;
-    const sent = await sock.sendMessage(chatId, { text: prefixed });
+    const sent = await sock.sendMessage(chatId, { text: formatOutgoingMessage(message) });
 
     // Track sent message ID to prevent echo-back loops
     if (sent?.key?.id) {
@@ -282,9 +287,8 @@ app.post('/edit', async (req, res) => {
   }
 
   try {
-    const prefixed = `⚕ *Hermes Agent*\n────────────\n${message}`;
     const key = { id: messageId, fromMe: true, remoteJid: chatId };
-    await sock.sendMessage(chatId, { text: prefixed, edit: key });
+    await sock.sendMessage(chatId, { text: formatOutgoingMessage(message), edit: key });
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -347,6 +347,34 @@ class TestOptionalEnvVarsRegistry:
             all_vars.extend(vars_list)
         assert "TAVILY_API_KEY" in all_vars
 
+    def test_whatsapp_reply_prefix_registered(self):
+        """WHATSAPP_REPLY_PREFIX is listed in OPTIONAL_ENV_VARS."""
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+        assert "WHATSAPP_REPLY_PREFIX" in OPTIONAL_ENV_VARS
+
+    def test_whatsapp_reply_prefix_is_messaging_category(self):
+        """WHATSAPP_REPLY_PREFIX is a messaging setting."""
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+        assert OPTIONAL_ENV_VARS["WHATSAPP_REPLY_PREFIX"]["category"] == "messaging"
+
+    def test_whatsapp_reply_prefix_is_advanced(self):
+        """WHATSAPP_REPLY_PREFIX is marked as advanced."""
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+        assert OPTIONAL_ENV_VARS["WHATSAPP_REPLY_PREFIX"]["advanced"] is True
+
+    def test_whatsapp_reply_prefix_in_env_vars_by_version(self):
+        """WHATSAPP_REPLY_PREFIX is listed in ENV_VARS_BY_VERSION."""
+        from hermes_cli.config import ENV_VARS_BY_VERSION
+        all_vars = []
+        for vars_list in ENV_VARS_BY_VERSION.values():
+            all_vars.extend(vars_list)
+        assert "WHATSAPP_REPLY_PREFIX" in all_vars
+
+    def test_default_config_version_covers_env_var_versions(self):
+        """Latest config version is at least the newest env-var migration version."""
+        from hermes_cli.config import DEFAULT_CONFIG, ENV_VARS_BY_VERSION
+        assert DEFAULT_CONFIG["_config_version"] >= max(ENV_VARS_BY_VERSION)
+
 
 class TestAnthropicTokenMigration:
     """Test that config version 8→9 clears ANTHROPIC_TOKEN."""

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -263,6 +263,7 @@ class TestBlocklistCoverage:
             "WHATSAPP_ENABLED",
             "WHATSAPP_MODE",
             "WHATSAPP_ALLOWED_USERS",
+            "WHATSAPP_REPLY_PREFIX",
             "SIGNAL_HTTP_URL",
             "SIGNAL_ACCOUNT",
             "SIGNAL_ALLOWED_USERS",

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -99,6 +99,7 @@ def _build_provider_env_blocklist() -> frozenset:
         "WHATSAPP_ENABLED",
         "WHATSAPP_MODE",
         "WHATSAPP_ALLOWED_USERS",
+        "WHATSAPP_REPLY_PREFIX",
         "SIGNAL_HTTP_URL",
         "SIGNAL_ACCOUNT",
         "SIGNAL_ALLOWED_USERS",

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -149,6 +149,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `WHATSAPP_ENABLED` | Enable the WhatsApp bridge (`true`/`false`) |
 | `WHATSAPP_MODE` | `bot` (separate number) or `self-chat` (message yourself) |
 | `WHATSAPP_ALLOWED_USERS` | Comma-separated phone numbers (with country code, no `+`) |
+| `WHATSAPP_REPLY_PREFIX` | Optional WhatsApp reply prefix. Supports `\n` escapes. Set to an empty value to disable the header entirely |
 | `SIGNAL_HTTP_URL` | signal-cli daemon HTTP endpoint (for example `http://127.0.0.1:8080`) |
 | `SIGNAL_ACCOUNT` | Bot phone number in E.164 format |
 | `SIGNAL_ALLOWED_USERS` | Comma-separated E.164 phone numbers or UUIDs |

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -95,6 +95,10 @@ Add the following to your `~/.hermes/.env` file:
 WHATSAPP_ENABLED=true
 WHATSAPP_MODE=bot                          # "bot" or "self-chat"
 WHATSAPP_ALLOWED_USERS=15551234567         # Comma-separated phone numbers (with country code, no +)
+
+# Optional
+WHATSAPP_REPLY_PREFIX=                     # Empty disables the default "Hermes Agent" header
+# WHATSAPP_REPLY_PREFIX=Susie\\n\\n        # Example custom prefix with newlines
 ```
 
 Then start the gateway:
@@ -140,7 +144,8 @@ Hermes supports voice on WhatsApp:
 
 - **Incoming:** Voice messages (`.ogg` opus) are automatically transcribed using the configured STT provider: local `faster-whisper`, Groq Whisper (`GROQ_API_KEY`), or OpenAI Whisper (`VOICE_TOOLS_OPENAI_KEY`)
 - **Outgoing:** TTS responses are sent as MP3 audio file attachments
-- Agent responses are prefixed with "⚕ **Hermes Agent**" for easy identification
+- Agent responses use a configurable prefix. By default Hermes sends `⚕ **Hermes Agent**` with a divider for easy identification.
+- Set `WHATSAPP_REPLY_PREFIX=` to disable the header entirely, or set a custom value (supports `\n` escapes)
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds a configurable `WHATSAPP_REPLY_PREFIX` env var for the WhatsApp bridge so users can customize or disable the default `⚕ Hermes Agent` header without editing `bridge.js` directly.

This keeps the current header as the default, preserves the self-chat echo suppression behavior, and fixes the config-version bookkeeping so existing installs can surface newly introduced env vars correctly.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `WHATSAPP_REPLY_PREFIX` handling to `scripts/whatsapp-bridge/bridge.js`
- Keep the existing WhatsApp header as the default when the env var is unset
- Treat an empty `WHATSAPP_REPLY_PREFIX` value as "no header"
- Reuse the configured prefix in self-chat echo suppression so disabling the header does not reintroduce loops
- Register `WHATSAPP_REPLY_PREFIX` in CLI config metadata and env migration tracking
- Bump `_config_version` and add a regression test so env-var version tracking cannot get ahead of the config version again
- Update docs for the new WhatsApp env var and add targeted tests

## How to Test

1. Set `WHATSAPP_ENABLED=true` and configure either:
   - `WHATSAPP_REPLY_PREFIX=` to disable the header, or
   - `WHATSAPP_REPLY_PREFIX=Susie\\n\\n` for a custom prefix
2. Start the gateway and send a WhatsApp message.
3. Verify replies use the expected prefix behavior and self-chat mode still ignores Hermes' own outgoing messages.
4. Run `node --check scripts/whatsapp-bridge/bridge.js`.
5. Run `pytest tests/hermes_cli/test_config.py tests/tools/test_local_env_blocklist.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (local dev env + tests) and Ubuntu server (manual WhatsApp bridge behavior)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `node --check scripts/whatsapp-bridge/bridge.js` passes.
- `pytest tests/hermes_cli/test_config.py tests/tools/test_local_env_blocklist.py -q` passes locally (`54 passed`).
- `pytest tests/ -q` was also run locally, but the suite is red in this environment well beyond this PR (`190 failed, 4942 passed, 175 skipped, 137 errors`). The dominant error class is unrelated sandbox/home-directory permission failures when tests try to write to `/Users/welkin/.hermes/logs/errors.log`.
