### PR TITLE
Fix: Preserve parent agent's tool list after subagent delegation

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -171,6 +171,17 @@ def _build_child_agent(
     model on OpenRouter while the parent runs on Nous Portal).
     """
     from run_agent import AIAgent
+    import model_tools  # ADD THIS
+
+    # FIX: Save parent's resolved tool names before subagent can clobber them.
+    # Note: This fix assumes delegation is sequential (not parallel/async).
+    # Parallel batch delegation runs subagents in threads but each thread
+    # gets its own _run_single_child call, so this works correctly.
+    _original_tool_names = None  # Guard against import failures
+    try:
+        _original_tool_names = model_tools._last_resolved_tool_names
+    except Exception:
+        pass  # model_tools may not be fully loaded yet
 
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
@@ -365,6 +376,11 @@ def _run_single_child(
         }
 
     finally:
+        # FIX: Restore parent's resolved tool names after subagent completes.
+        # Guard ensures we don't restore None if save failed above.
+        if _original_tool_names is not None:
+            model_tools._last_resolved_tool_names = _original_tool_names
+
         # Unregister child from interrupt propagation
         if hasattr(parent_agent, '_active_children'):
             try:


### PR DESCRIPTION
## Problem

`_last_resolved_tool_names` in model_tools.py is a process-global variable. When a subagent runs via `delegate_task`, it calls `get_tool_definitions()` which overwrites this global with the subagent's restricted tool list. After the subagent completes, the parent agent's tool list is lost, causing `execute_code` to generate sandbox code with missing tool imports.

## Solution

Save and restore `_last_resolved_tool_names` around subagent execution in `delegate_tool.py`. The save/restore is wrapped in try/except and guarded in the finally block to handle edge cases.

## Concurrency Note

This fix assumes delegation runs sequentially. Each subagent in batch mode runs in its own `_run_single_child()` call with its own save/restore, so the pattern works correctly.

---

@NousResearch