### PR TITLE
fix(gateway): include resolved node path in systemd unit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6,6 +6,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 
 import asyncio
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -377,8 +378,14 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     venv_bin = str(PROJECT_ROOT / "venv" / "bin")
     node_bin = str(PROJECT_ROOT / "node_modules" / ".bin")
 
-    # Build a PATH that includes the venv, node_modules, and standard system dirs
-    sane_path = f"{venv_bin}:{node_bin}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    path_entries = [venv_bin, node_bin]
+    resolved_node = shutil.which("node")
+    if resolved_node:
+        resolved_node_dir = str(Path(resolved_node).resolve().parent)
+        if resolved_node_dir not in path_entries:
+            path_entries.append(resolved_node_dir)
+    path_entries.extend(["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"])
+    sane_path = ":".join(path_entries)
 
     hermes_home = str(Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")).resolve())
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -61,6 +61,13 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "TimeoutStopSec=60" in unit
 
+    def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/home/test/.nvm/versions/node/v24.14.0/bin/node" if cmd == "node" else None)
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "/home/test/.nvm/versions/node/v24.14.0/bin" in unit
+
     def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
         unit = gateway_cli.generate_systemd_unit(system=True)
 


### PR DESCRIPTION
## Summary
- include the directory of the resolved `node` binary when generating the gateway systemd unit PATH
- keep the existing venv and `node_modules/.bin` entries unchanged
- add a regression test covering Node installed under `~/.nvm/.../bin`

## Problem
On Linux, if Node is installed via `nvm`, `hermes gateway install` can generate a systemd unit whose PATH omits the actual Node binary directory. When WhatsApp is enabled, the gateway service then fails the WhatsApp bridge requirement check and can enter a restart loop.

## Reproduction
This was reproduced on a fresh Ubuntu 24.04 install with upstream `main`, Node installed only through `nvm`, and:
```bash
WHATSAPP_ENABLED=true
WHATSAPP_MODE=bot
```
Then:
```bash
hermes gateway install
systemctl --user restart hermes-gateway
```
The generated unit PATH omitted `~/.nvm/.../bin`, `node` was missing under the service environment, and the gateway crash-looped.

## Fix
When generating the systemd unit, resolve `node` from the current install environment and append its parent directory to the service PATH if present.

## Test plan
- `./venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py -q`
- verified the clean repro separately on Ubuntu 24.04 before the fix

Closes #1766
