### PR TITLE
fix(tools): add outbound WhatsApp send_message routing

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -400,20 +400,21 @@ class TestSendToPlatformChunking:
 
 class TestSendToPlatformWhatsapp:
     def test_whatsapp_routes_via_local_bridge_sender(self):
-        async_mock = AsyncMock(return_value={"success": True, "platform": "whatsapp", "chat_id": "43121572348102@lid", "message_id": "abc123"})
+        chat_id = "test-user@lid"
+        async_mock = AsyncMock(return_value={"success": True, "platform": "whatsapp", "chat_id": chat_id, "message_id": "abc123"})
 
         with patch("tools.send_message_tool._send_whatsapp", async_mock):
             result = asyncio.run(
                 _send_to_platform(
                     Platform.WHATSAPP,
                     SimpleNamespace(enabled=True, token=None, extra={"bridge_port": 3000}),
-                    "43121572348102@lid",
+                    chat_id,
                     "hello from hermes",
                 )
             )
 
         assert result["success"] is True
-        async_mock.assert_awaited_once_with({"bridge_port": 3000}, "43121572348102@lid", "hello from hermes")
+        async_mock.assert_awaited_once_with({"bridge_port": 3000}, chat_id, "hello from hermes")
 
 
 class TestSendTelegramHtmlDetection:

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -398,6 +398,24 @@ class TestSendToPlatformChunking:
 # ---------------------------------------------------------------------------
 
 
+class TestSendToPlatformWhatsapp:
+    def test_whatsapp_routes_via_local_bridge_sender(self):
+        async_mock = AsyncMock(return_value={"success": True, "platform": "whatsapp", "chat_id": "43121572348102@lid", "message_id": "abc123"})
+
+        with patch("tools.send_message_tool._send_whatsapp", async_mock):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.WHATSAPP,
+                    SimpleNamespace(enabled=True, token=None, extra={"bridge_port": 3000}),
+                    "43121572348102@lid",
+                    "hello from hermes",
+                )
+            )
+
+        assert result["success"] is True
+        async_mock.assert_awaited_once_with({"bridge_port": 3000}, "43121572348102@lid", "hello from hermes")
+
+
 class TestSendTelegramHtmlDetection:
     """Verify that messages containing HTML tags are sent with parse_mode=HTML
     and that plain / markdown messages use MarkdownV2."""

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -331,6 +331,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_discord(pconfig.token, chat_id, chunk)
         elif platform == Platform.SLACK:
             result = await _send_slack(pconfig.token, chat_id, chunk)
+        elif platform == Platform.WHATSAPP:
+            result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
             result = await _send_signal(pconfig.extra, chat_id, chunk)
         elif platform == Platform.EMAIL:
@@ -512,6 +514,34 @@ async def _send_slack(token, chat_id, message):
                 return {"error": f"Slack API error: {data.get('error', 'unknown')}"}
     except Exception as e:
         return {"error": f"Slack send failed: {e}"}
+
+
+async def _send_whatsapp(extra, chat_id, message):
+    """Send via the local WhatsApp bridge HTTP API."""
+    try:
+        import aiohttp
+    except ImportError:
+        return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+    try:
+        bridge_port = extra.get("bridge_port", 3000)
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"http://localhost:{bridge_port}/send",
+                json={"chatId": chat_id, "message": message},
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status == 200:
+                    data = await resp.json()
+                    return {
+                        "success": True,
+                        "platform": "whatsapp",
+                        "chat_id": chat_id,
+                        "message_id": data.get("messageId"),
+                    }
+                body = await resp.text()
+                return {"error": f"WhatsApp bridge error ({resp.status}): {body}"}
+    except Exception as e:
+        return {"error": f"WhatsApp send failed: {e}"}
 
 
 async def _send_signal(extra, chat_id, message):


### PR DESCRIPTION
## Summary
- add outbound WhatsApp routing to `tools/send_message_tool.py`
- implement `_send_whatsapp(...)` using the existing local bridge `/send` endpoint
- add a regression test covering WhatsApp routing through `_send_to_platform(...)`

## Problem
`send_message` already accepts `whatsapp` as a platform target, but `_send_to_platform(...)` had no `Platform.WHATSAPP` branch. That meant outbound WhatsApp sends failed immediately with:

```text
Direct sending not yet implemented for whatsapp
```

This breaks proactive delivery paths that rely on `send_message`, including reminder / cron delivery flows.

## Reproduction
Verified on upstream `main` before this change with:

```python
import sys, asyncio
sys.path.insert(0, '/path/to/hermes-agent')
from tools.send_message_tool import _send_to_platform
from gateway.config import Platform
from types import SimpleNamespace

pconfig = SimpleNamespace(token=None, extra={})
print(asyncio.run(_send_to_platform(Platform.WHATSAPP, pconfig, '12345@lid', 'hello')))
```

Actual result before fix:
```python
{'error': 'Direct sending not yet implemented for whatsapp'}
```

## Fix
Route `Platform.WHATSAPP` through a new `_send_whatsapp(...)` helper that posts to the existing local bridge `/send` endpoint.

## Test plan
- added regression test in `tests/tools/test_send_message_tool.py`
- ran:
  ```bash
  ~/hermes-agent/venv/bin/python -m pytest tests/tools/test_send_message_tool.py -q
  ```

Closes #1768
