### PR TITLE
fix(search): handle hyphenated queries and preserve quoted literals in FTS5

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -15,6 +15,7 @@ Key design decisions:
 """
 
 import json
+import logging
 import os
 import re
 import sqlite3
@@ -22,6 +23,8 @@ import threading
 import time
 from pathlib import Path
 from typing import Dict, Any, List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 DEFAULT_DB_PATH = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
@@ -689,13 +692,30 @@ class SessionDB:
         ``NOT``) have special meaning.  Passing raw user input directly to
         MATCH can cause ``sqlite3.OperationalError``.
 
-        Strategy: strip characters that are only meaningful as FTS5 operators
-        and would otherwise cause syntax errors.  This preserves normal keyword
-        search while preventing crashes on inputs like ``C++``, ``"unterminated``,
-        or ``hello AND``.
+        Strategy: split query into balanced-quoted and unquoted segments.
+        Balanced quoted phrases (e.g. ``"exact phrase"``) are preserved for
+        FTS5 phrase search.  Unquoted segments are sanitized: FTS5 operators
+        are stripped, and inter-word hyphens are converted to spaces so that
+        terms like ``chat-send`` match content tokenized by unicode61.
         """
-        # Remove FTS5-special characters that are not useful in keyword search
-        sanitized = re.sub(r'[+{}()"^]', " ", query)
+        # Split into balanced-quoted vs unquoted segments
+        segments = re.split(r'("(?:[^"]*)")', query)
+
+        result_parts = []
+        for seg in segments:
+            if seg.startswith('"') and seg.endswith('"') and len(seg) >= 2:
+                # Balanced quoted phrase — preserve for FTS5 phrase search
+                result_parts.append(seg)
+            else:
+                # Unquoted text — full sanitization
+                part = seg
+                part = part.replace('"', ' ')           # strip unbalanced quotes
+                part = re.sub(r'[+{}()^]', " ", part)   # strip FTS5 operators
+                part = re.sub(r'(?<=\w)-(?=\w)', ' ', part)  # inter-word hyphens → space
+                result_parts.append(part)
+
+        sanitized = ''.join(result_parts)
+
         # Collapse repeated * (e.g. "***") into a single one, and remove
         # leading * (prefix-only matching requires at least one char before *)
         sanitized = re.sub(r"\*+", "*", sanitized)
@@ -729,6 +749,7 @@ class SessionDB:
         if not query or not query.strip():
             return []
 
+        raw_query = query
         query = self._sanitize_fts5_query(query)
         if not query:
             return []
@@ -777,6 +798,9 @@ class SessionDB:
                 cursor = self._conn.execute(sql, params)
             except sqlite3.OperationalError:
                 # FTS5 query syntax error despite sanitization — return empty
+                logger.debug(
+                    "FTS5 query failed: raw=%r sanitized=%r", raw_query, query
+                )
                 return []
             matches = [dict(row) for row in cursor.fetchall()]
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -278,6 +278,68 @@ class TestFTS5Search:
         # Valid prefix kept
         assert s('deploy*') == 'deploy*'
 
+    def test_sanitize_preserves_balanced_quotes(self):
+        """Balanced quoted phrases must be preserved for FTS5 phrase search."""
+        from hermes_state import SessionDB
+        s = SessionDB._sanitize_fts5_query
+        assert s('"exact phrase"') == '"exact phrase"'
+        assert s('"deploy docker"') == '"deploy docker"'
+
+    def test_sanitize_replaces_inter_word_hyphens(self):
+        """Inter-word hyphens should become spaces so FTS5 matches tokenized content."""
+        from hermes_state import SessionDB
+        s = SessionDB._sanitize_fts5_query
+        assert s('chat-send') == 'chat send'
+        assert s('real-time-sync') == 'real time sync'
+
+    def test_sanitize_mixed_quoted_and_unquoted(self):
+        """Quoted phrases stay intact while unquoted hyphens are converted."""
+        from hermes_state import SessionDB
+        s = SessionDB._sanitize_fts5_query
+        result = s('find "chat-send" in logs')
+        assert '"chat-send"' in result
+        assert 'find' in result
+        assert 'logs' in result
+
+    def test_sanitize_leading_hyphen_untouched(self):
+        """A leading hyphen (no word char before) is not an inter-word hyphen."""
+        from hermes_state import SessionDB
+        s = SessionDB._sanitize_fts5_query
+        # -test has no word character before the hyphen, so regex (?<=\w)- won't match
+        assert '-test' in s('-test')
+
+    def test_search_hyphenated_content(self, db):
+        """Searching for a hyphenated term should find messages containing it."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="Run the chat-send command to send messages.")
+
+        results = db.search_messages("chat-send")
+        assert len(results) >= 1
+        snippets = [r.get("snippet", "") for r in results]
+        assert any("chat" in s.lower() for s in snippets)
+
+    def test_search_quoted_phrase(self, db):
+        """A balanced quoted query should perform FTS5 phrase search."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="We need to deploy docker containers today.")
+        db.append_message("s1", role="user", content="Docker is great for deploy tasks.")
+
+        # Phrase search: "deploy docker" should only match the first message
+        results = db.search_messages('"deploy docker"')
+        assert len(results) >= 1
+        snippets = [r.get("snippet", "") for r in results]
+        assert any("deploy docker" in s.lower() for s in snippets)
+
+    def test_search_quoted_hyphenated_phrase(self, db):
+        """Regression for #1770: quoted hyphenated term must reach FTS5 intact."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="Use the chat-send command.")
+
+        results = db.search_messages('"chat-send"')
+        assert len(results) >= 1
+        snippets = [r.get("snippet", "") for r in results]
+        assert any("chat" in s.lower() for s in snippets)
+
 
 # =========================================================================
 # Session search and listing


### PR DESCRIPTION
## Summary
- **Fixes #1770**: `session_search` now correctly handles hyphenated terms (`chat-send`) and preserves user-provided quoted literals (`"exact phrase"`) for FTS5 phrase search.
- Rewrote `_sanitize_fts5_query()` to split queries into balanced-quoted vs unquoted segments — quoted phrases pass through intact, while unquoted inter-word hyphens are converted to spaces to match unicode61 tokenizer behavior.
- Added `logger.debug` on FTS5 `OperationalError` for diagnosability.

## Changes
| File | What |
|------|------|
| `hermes_state.py` | Quote-aware FTS5 sanitization + debug logging |
| `tests/test_hermes_state.py` | 7 new tests (4 unit + 3 integration) |

## Test plan
- [x] All 116 existing + new tests pass (`pytest tests/test_hermes_state.py`)
- [x] `chat-send` query finds hyphenated content (integration test)
- [x] `"deploy docker"` phrase search works (integration test)
- [x] `"chat-send"` quoted-hyphen regression covered (integration test)
- [x] Existing dangerous-query tests still pass (no regression)