### PR TITLE
fix: NameError in OpenCode provider setup (prompt_text -> prompt)

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1327,12 +1327,12 @@ def setup_model_provider(config: dict):
         if existing_key:
             print_info(f"Current: {existing_key[:8]}... (configured)")
             if prompt_yes_no("Update API key?", False):
-                api_key = prompt_text("OpenCode Zen API key", password=True)
+                api_key = prompt("  OpenCode Zen API key", password=True)
                 if api_key:
                     save_env_value("OPENCODE_ZEN_API_KEY", api_key)
                     print_success("OpenCode Zen API key updated")
         else:
-            api_key = prompt_text("OpenCode Zen API key", password=True)
+            api_key = prompt("  OpenCode Zen API key", password=True)
             if api_key:
                 save_env_value("OPENCODE_ZEN_API_KEY", api_key)
                 print_success("OpenCode Zen API key saved")
@@ -1360,12 +1360,12 @@ def setup_model_provider(config: dict):
         if existing_key:
             print_info(f"Current: {existing_key[:8]}... (configured)")
             if prompt_yes_no("Update API key?", False):
-                api_key = prompt_text("OpenCode Go API key", password=True)
+                api_key = prompt("  OpenCode Go API key", password=True)
                 if api_key:
                     save_env_value("OPENCODE_GO_API_KEY", api_key)
                     print_success("OpenCode Go API key updated")
         else:
-            api_key = prompt_text("OpenCode Go API key", password=True)
+            api_key = prompt("  OpenCode Go API key", password=True)
             if api_key:
                 save_env_value("OPENCODE_GO_API_KEY", api_key)
                 print_success("OpenCode Go API key saved")


### PR DESCRIPTION
## Summary

The OpenCode Zen and OpenCode Go provider setup sections in `hermes_cli/setup.py` used `prompt_text()` to collect API keys, but that function doesn't exist. Every other provider correctly uses the local `prompt()` function defined at line 211 of setup.py. This caused a `NameError` crash during `hermes setup` when selecting either OpenCode provider.

**Fix:** Changed all 4 occurrences of `prompt_text(...)` to `prompt("  ...", ...)` — matching the formatting pattern used by all other providers (two-space indent in the prompt string).

## Test plan
- Full test suite passes (4957 passed; 15 pre-existing failures unrelated to this change)
- Visual: the fix matches the exact pattern used by OpenRouter, Kilo Code, AI Gateway, GLM, Kimi, MiniMax, and all other providers