### PR TITLE
feat: add hermes config backup command with git-based auto-save

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1749,6 +1749,186 @@ def set_config_value(key: str, value: str):
 # Command handler
 # =============================================================================
 
+BACKUP_TRACKED = ["config.yaml", "SOUL.md", "skills", "cron", "memories", ".gitignore"]
+BACKUP_GITIGNORE = """.env
+auth.json
+auth.lock
+logs/
+audio_cache/
+images/
+sandboxes/
+sessions/
+pairing/
+migration/
+bin/
+workspace/
+*.pid
+*.lock
+gateway_state.json
+channel_directory.json
+interrupt_debug.log
+state.db
+state.db-shm
+state.db-wal
+"""
+BACKUP_CRON_MARKER = "# hermes-config-backup"
+BACKUP_CRON_LINE = "0 * * * * /bin/zsh -lc 'hermes config backup push' >> ~/.hermes/logs/backup.log 2>&1"
+
+
+def _git(args: list, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(["git"] + args, cwd=cwd, capture_output=True, text=True)
+
+
+def backup_command(args):
+    """Handle hermes config backup subcommands."""
+    import datetime
+    home = get_hermes_home()
+    git_dir = home / ".git"
+    subcmd = getattr(args, "backup_command", None) or "status"
+
+    if subcmd == "init":
+        # Init git repo
+        if not git_dir.exists():
+            r = _git(["init"], cwd=home)
+            if r.returncode != 0:
+                print(color(f"  ✗ git init failed: {r.stderr.strip()}", Colors.RED))
+                sys.exit(1)
+            print(color("  ✓ Initialized git repo in ~/.hermes/", Colors.GREEN))
+        else:
+            print("  Git repo already initialized")
+
+        # Write .gitignore
+        gi_path = home / ".gitignore"
+        if not gi_path.exists():
+            gi_path.write_text(BACKUP_GITIGNORE)
+            print(color("  ✓ Created .gitignore (secrets excluded)", Colors.GREEN))
+
+        # Initial commit
+        existing = [f for f in BACKUP_TRACKED if (home / f).exists()]
+        _git(["add"] + existing, cwd=home)
+        diff = _git(["diff", "--cached", "--quiet"], cwd=home)
+        if diff.returncode != 0:
+            _git(["commit", "-m", "initial hermes config snapshot"], cwd=home)
+            print(color("  ✓ Created initial snapshot", Colors.GREEN))
+
+        # Add remote if provided
+        remote = getattr(args, "remote", None)
+        if remote:
+            existing_remote = _git(["remote", "get-url", "origin"], cwd=home)
+            if existing_remote.returncode == 0:
+                _git(["remote", "set-url", "origin", remote], cwd=home)
+                print(color(f"  ✓ Updated remote: {remote}", Colors.GREEN))
+            else:
+                _git(["remote", "add", "origin", remote], cwd=home)
+                print(color(f"  ✓ Remote added: {remote}", Colors.GREEN))
+
+        print()
+        print("  Next steps:")
+        print("    hermes config backup auto on   — enable hourly auto-backup")
+        if not remote:
+            print("    hermes config backup init <url> — add a remote for off-machine backup")
+
+    elif subcmd == "push":
+        if not git_dir.exists():
+            print(color("  ✗ No backup repo. Run: hermes config backup init", Colors.RED))
+            sys.exit(1)
+
+        existing = [f for f in BACKUP_TRACKED if (home / f).exists()]
+        _git(["add"] + existing, cwd=home)
+        diff = _git(["diff", "--cached", "--quiet"], cwd=home)
+        if diff.returncode == 0:
+            print("  Nothing to commit — config unchanged")
+            sys.exit(0)
+
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+        _git(["commit", "-m", f"auto: config snapshot {timestamp}"], cwd=home)
+        print(color(f"  ✓ Committed snapshot ({timestamp})", Colors.GREEN))
+
+        remote = _git(["remote", "get-url", "origin"], cwd=home)
+        if remote.returncode == 0:
+            branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=home).stdout.strip() or "main"
+            r = _git(["push", "origin", branch], cwd=home)
+            if r.returncode == 0:
+                print(color(f"  ✓ Pushed to {remote.stdout.strip()}", Colors.GREEN))
+            else:
+                print(color(f"  ⚠ Push failed: {r.stderr.strip()}", Colors.YELLOW))
+
+    elif subcmd == "pull":
+        if not git_dir.exists():
+            print(color("  ✗ No backup repo. Run: hermes config backup init", Colors.RED))
+            sys.exit(1)
+        remote = _git(["remote", "get-url", "origin"], cwd=home)
+        if remote.returncode != 0:
+            print(color("  ✗ No remote configured. Run: hermes config backup init <url>", Colors.RED))
+            sys.exit(1)
+        branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=home).stdout.strip() or "main"
+        r = _git(["pull", "origin", branch], cwd=home)
+        if r.returncode == 0:
+            print(color("  ✓ Pulled latest config from remote", Colors.GREEN))
+            print(f"  {r.stdout.strip()}")
+        else:
+            print(color(f"  ✗ Pull failed: {r.stderr.strip()}", Colors.RED))
+            sys.exit(1)
+
+    elif subcmd == "auto":
+        state = getattr(args, "state", None)
+        try:
+            result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+            lines = result.stdout.splitlines() if result.returncode == 0 else []
+        except Exception:
+            lines = []
+
+        lines = [l for l in lines if BACKUP_CRON_MARKER not in l]
+
+        if state == "on":
+            lines.append(f"{BACKUP_CRON_LINE}  {BACKUP_CRON_MARKER}")
+            subprocess.run(["crontab", "-"], input="\n".join(lines) + "\n", text=True)
+            print(color("  ✓ Auto-backup enabled (hourly)", Colors.GREEN))
+            print("    Logs: ~/.hermes/logs/backup.log")
+        else:
+            subprocess.run(["crontab", "-"], input="\n".join(lines) + "\n", text=True)
+            print(color("  ✓ Auto-backup disabled", Colors.GREEN))
+
+    else:  # status
+        if not git_dir.exists():
+            print("  No backup repo. Run: hermes config backup init")
+            return
+
+        print()
+        print(color("  Config Backup Status", Colors.CYAN, Colors.BOLD))
+        print()
+
+        last = _git(["log", "-1", "--format=%h %s (%ar)"], cwd=home)
+        if last.returncode == 0 and last.stdout.strip():
+            print(f"  Last commit:  {last.stdout.strip()}")
+        else:
+            print("  Last commit:  none yet")
+
+        remote = _git(["remote", "get-url", "origin"], cwd=home)
+        if remote.returncode == 0:
+            print(f"  Remote:       {remote.stdout.strip()}")
+        else:
+            print(color("  Remote:       none (local only)", Colors.DIM))
+
+        # Check cron
+        cron = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+        auto_on = cron.returncode == 0 and BACKUP_CRON_MARKER in cron.stdout
+        status_str = color("on (hourly)", Colors.GREEN) if auto_on else color("off", Colors.DIM)
+        print(f"  Auto-backup:  {status_str}")
+
+        # Dirty files
+        existing = [f for f in BACKUP_TRACKED if (home / f).exists()]
+        dirty = _git(["status", "--short"] + existing, cwd=home)
+        if dirty.stdout.strip():
+            print()
+            print(color("  Uncommitted changes:", Colors.YELLOW))
+            for line in dirty.stdout.strip().splitlines():
+                print(f"    {line}")
+        else:
+            print("  Changes:      none (clean)")
+        print()
+
+
 def config_command(args):
     """Handle config subcommands."""
     subcmd = getattr(args, 'config_command', None)
@@ -1872,15 +2052,19 @@ def config_command(args):
         
         print()
     
+    elif subcmd == "backup":
+        backup_command(args)
+
     else:
         print(f"Unknown config command: {subcmd}")
         print()
         print("Available commands:")
-        print("  hermes config           Show current configuration")
-        print("  hermes config edit      Open config in editor")
+        print("  hermes config                     Show current configuration")
+        print("  hermes config edit                Open config in editor")
         print("  hermes config set <key> <value>   Set a config value")
-        print("  hermes config check     Check for missing/outdated config")
-        print("  hermes config migrate   Update config with new options")
-        print("  hermes config path      Show config file path")
-        print("  hermes config env-path  Show .env file path")
+        print("  hermes config check               Check for missing/outdated config")
+        print("  hermes config migrate             Update config with new options")
+        print("  hermes config path                Show config file path")
+        print("  hermes config env-path            Show .env file path")
+        print("  hermes config backup              Git-based config backup (init/push/pull/status/auto)")
         sys.exit(1)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2986,7 +2986,18 @@ For more help on a command:
     
     # config migrate
     config_migrate = config_subparsers.add_parser("migrate", help="Update config with new options")
-    
+
+    # config backup
+    config_backup = config_subparsers.add_parser("backup", help="Git-based config backup")
+    config_backup_sub = config_backup.add_subparsers(dest="backup_command")
+    config_backup_sub.add_parser("status", help="Show backup status")
+    config_backup_init = config_backup_sub.add_parser("init", help="Initialize backup repo")
+    config_backup_init.add_argument("remote", nargs="?", help="Optional remote URL (e.g. git@github.com:you/hermes-config)")
+    config_backup_sub.add_parser("push", help="Commit and push config changes")
+    config_backup_sub.add_parser("pull", help="Pull latest config from remote")
+    config_backup_auto = config_backup_sub.add_parser("auto", help="Enable/disable hourly auto-backup")
+    config_backup_auto.add_argument("state", choices=["on", "off"], help="on or off")
+
     config_parser.set_defaults(func=cmd_config)
     
     # =========================================================================

--- a/tests/hermes_cli/test_config_backup.py
+++ b/tests/hermes_cli/test_config_backup.py
@@ -1,0 +1,512 @@
+"""Tests for hermes config backup — git-based config auto-save feature."""
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch, call
+
+import pytest
+
+from hermes_cli.config import (
+    backup_command,
+    BACKUP_TRACKED,
+    BACKUP_GITIGNORE,
+    BACKUP_CRON_MARKER,
+    BACKUP_CRON_LINE,
+    get_hermes_home,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_args(backup_command_name, **kwargs):
+    """Build a minimal args namespace for backup_command()."""
+    class Args:
+        pass
+    a = Args()
+    a.backup_command = backup_command_name
+    for k, v in kwargs.items():
+        setattr(a, k, v)
+    return a
+
+
+def _seed_hermes_home(home: Path):
+    """Create minimal tracked files so git add has something to commit."""
+    (home / "config.yaml").write_text("model:\n  default: test-model\n")
+    (home / "SOUL.md").write_text("# Soul\n")
+    for d in ("skills", "cron", "memories"):
+        (home / d).mkdir(exist_ok=True)
+
+
+def _git(args, cwd):
+    return subprocess.run(
+        ["git"] + args, cwd=cwd, capture_output=True, text=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestBackupInit
+# ---------------------------------------------------------------------------
+
+class TestBackupInit:
+
+    def test_init_creates_git_repo(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+        # Ensure git identity for CI environments
+        _git(["config", "--global", "user.email", "test@test.com"], cwd=tmp_path)
+        _git(["config", "--global", "user.name", "Test"], cwd=tmp_path)
+
+        backup_command(_make_args("init", remote=None))
+
+        assert (tmp_path / ".git").is_dir()
+
+    def test_init_writes_gitignore(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+
+        backup_command(_make_args("init", remote=None))
+
+        gi = tmp_path / ".gitignore"
+        assert gi.exists()
+        content = gi.read_text()
+        assert ".env" in content
+        assert "auth.json" in content
+        assert "logs/" in content
+        assert "state.db" in content
+
+    def test_init_does_not_overwrite_existing_gitignore(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+        custom = "# my custom gitignore\n"
+        (tmp_path / ".gitignore").write_text(custom)
+
+        backup_command(_make_args("init", remote=None))
+
+        assert (tmp_path / ".gitignore").read_text() == custom
+
+    def test_init_creates_initial_commit(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+
+        backup_command(_make_args("init", remote=None))
+
+        result = _git(["log", "--oneline"], cwd=tmp_path)
+        assert result.returncode == 0
+        assert "initial hermes config snapshot" in result.stdout
+
+    def test_init_only_commits_gitignore_when_no_tracked_files_exist(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # No config.yaml / SOUL.md seeded — only .gitignore will be staged
+
+        backup_command(_make_args("init", remote=None))
+
+        result = _git(["log", "--oneline"], cwd=tmp_path)
+        # .gitignore itself gets committed (it's in BACKUP_TRACKED)
+        assert result.returncode == 0
+        assert "initial hermes config snapshot" in result.stdout
+
+    def test_init_adds_remote(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+        remote_url = "https://github.com/YanSte/hermes-config"
+
+        backup_command(_make_args("init", remote=remote_url))
+
+        result = _git(["remote", "get-url", "origin"], cwd=tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == remote_url
+
+    def test_init_updates_existing_remote(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+        _git(["init"], cwd=tmp_path)
+        _git(["remote", "add", "origin", "https://old-url.com"], cwd=tmp_path)
+
+        new_url = "https://github.com/YanSte/hermes-config-new"
+        backup_command(_make_args("init", remote=new_url))
+
+        result = _git(["remote", "get-url", "origin"], cwd=tmp_path)
+        assert result.stdout.strip() == new_url
+
+    def test_init_idempotent_when_repo_already_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+
+        backup_command(_make_args("init", remote=None))
+        backup_command(_make_args("init", remote=None))  # second call
+
+        assert (tmp_path / ".git").is_dir()
+        result = _git(["log", "--oneline"], cwd=tmp_path)
+        # Only one initial commit
+        assert result.stdout.count("\n") <= 1
+
+    def test_init_env_file_excluded(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+        (tmp_path / ".env").write_text("OPENAI_API_KEY=sk-secret\n")
+
+        backup_command(_make_args("init", remote=None))
+
+        result = _git(["show", "HEAD:.env"], cwd=tmp_path)
+        assert result.returncode != 0  # .env must NOT be in commit
+
+
+# ---------------------------------------------------------------------------
+# TestBackupPush
+# ---------------------------------------------------------------------------
+
+class TestBackupPush:
+
+    def _init(self, home):
+        _seed_hermes_home(home)
+        backup_command(_make_args("init", remote=None))
+
+    def test_push_commits_changed_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._init(tmp_path)
+
+        # Modify a tracked file
+        (tmp_path / "config.yaml").write_text("model:\n  default: changed-model\n")
+
+        backup_command(_make_args("push"))
+
+        result = _git(["log", "--oneline"], cwd=tmp_path)
+        lines = result.stdout.strip().splitlines()
+        assert len(lines) == 2
+        assert "auto: config snapshot" in lines[0]
+
+    def test_push_noop_when_nothing_changed(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._init(tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            backup_command(_make_args("push"))
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "nothing to commit" in captured.out.lower()
+
+    def test_push_without_init_prints_error(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        with pytest.raises(SystemExit):
+            backup_command(_make_args("push"))
+
+        captured = capsys.readouterr()
+        assert "init" in captured.out.lower()
+
+    def test_push_skips_remote_when_none_configured(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._init(tmp_path)
+        (tmp_path / "config.yaml").write_text("model:\n  default: new\n")
+
+        git_calls = []
+        original_run = subprocess.run
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "git" and "push" in cmd:
+                git_calls.append(cmd)
+            return original_run(cmd, **kwargs)
+
+        with patch("hermes_cli.config.subprocess.run", side_effect=fake_run):
+            backup_command(_make_args("push"))
+
+        assert not any("push" in c for c in git_calls)
+
+    def test_push_with_remote_calls_git_push(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._init(tmp_path)
+        # Add a fake remote
+        _git(["remote", "add", "origin", "https://github.com/YanSte/hermes-config"], cwd=tmp_path)
+        (tmp_path / "config.yaml").write_text("model:\n  default: pushed\n")
+
+        push_calls = []
+        original_git = __import__("hermes_cli.config", fromlist=["_git"])._git
+
+        def fake_git(args, cwd):
+            if "push" in args:
+                push_calls.append(args)
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return original_git(args, cwd)
+
+        with patch("hermes_cli.config._git", side_effect=fake_git):
+            backup_command(_make_args("push"))
+
+        assert any("push" in c for c in push_calls)
+
+    def test_push_warn_on_remote_failure(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._init(tmp_path)
+        _git(["remote", "add", "origin", "https://github.com/YanSte/hermes-config"], cwd=tmp_path)
+        (tmp_path / "config.yaml").write_text("model:\n  default: fail-push\n")
+
+        original_git = __import__("hermes_cli.config", fromlist=["_git"])._git
+
+        def fake_git(args, cwd):
+            if "push" in args:
+                return SimpleNamespace(returncode=1, stdout="", stderr="Authentication failed")
+            return original_git(args, cwd)
+
+        with patch("hermes_cli.config._git", side_effect=fake_git):
+            backup_command(_make_args("push"))
+
+        captured = capsys.readouterr()
+        assert "push failed" in captured.out.lower() or "authentication" in captured.out.lower()
+
+    def test_push_excludes_env_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._init(tmp_path)
+        (tmp_path / ".env").write_text("SECRET=should-not-be-committed\n")
+        (tmp_path / "config.yaml").write_text("model:\n  default: updated\n")
+
+        backup_command(_make_args("push"))
+
+        result = _git(["show", "HEAD:.env"], cwd=tmp_path)
+        assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# TestBackupPull
+# ---------------------------------------------------------------------------
+
+class TestBackupPull:
+
+    def test_pull_without_repo_prints_error(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        with pytest.raises(SystemExit):
+            backup_command(_make_args("pull"))
+
+        captured = capsys.readouterr()
+        assert "init" in captured.out.lower()
+
+    def test_pull_without_remote_prints_error(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+        backup_command(_make_args("init", remote=None))
+
+        with pytest.raises(SystemExit):
+            backup_command(_make_args("pull"))
+
+        captured = capsys.readouterr()
+        assert "remote" in captured.out.lower()
+
+    def test_pull_calls_git_pull(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+        backup_command(_make_args("init", remote=None))
+        _git(["remote", "add", "origin", "https://github.com/YanSte/hermes-config"], cwd=tmp_path)
+
+        pull_calls = []
+        original_git = __import__("hermes_cli.config", fromlist=["_git"])._git
+
+        def fake_git(args, cwd):
+            if "pull" in args:
+                pull_calls.append(args)
+                return SimpleNamespace(returncode=0, stdout="Already up to date.", stderr="")
+            return original_git(args, cwd)
+
+        with patch("hermes_cli.config._git", side_effect=fake_git):
+            backup_command(_make_args("pull"))
+
+        assert any("pull" in c for c in pull_calls)
+
+
+# ---------------------------------------------------------------------------
+# TestBackupStatus
+# ---------------------------------------------------------------------------
+
+class TestBackupStatus:
+
+    def test_status_without_repo(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        backup_command(_make_args("status"))
+
+        captured = capsys.readouterr()
+        assert "init" in captured.out.lower()
+
+    def test_status_shows_last_commit(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+        backup_command(_make_args("init", remote=None))
+
+        backup_command(_make_args("status"))
+
+        captured = capsys.readouterr()
+        assert "initial hermes config snapshot" in captured.out
+
+    def test_status_shows_no_remote_when_local_only(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+        backup_command(_make_args("init", remote=None))
+
+        backup_command(_make_args("status"))
+
+        captured = capsys.readouterr()
+        assert "local only" in captured.out.lower() or "none" in captured.out.lower()
+
+    def test_status_shows_remote_url(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+        remote_url = "https://github.com/YanSte/hermes-config"
+        backup_command(_make_args("init", remote=remote_url))
+
+        backup_command(_make_args("status"))
+
+        captured = capsys.readouterr()
+        assert remote_url in captured.out
+
+    def test_status_shows_dirty_files(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+        backup_command(_make_args("init", remote=None))
+        (tmp_path / "config.yaml").write_text("model:\n  default: dirty\n")
+
+        backup_command(_make_args("status"))
+
+        captured = capsys.readouterr()
+        assert "config.yaml" in captured.out
+
+    def test_status_shows_auto_on(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_hermes_home(tmp_path)
+        backup_command(_make_args("init", remote=None))
+
+        fake_cron = f"{BACKUP_CRON_LINE}  {BACKUP_CRON_MARKER}\n"
+
+        original_run = subprocess.run
+
+        def fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd == ["crontab", "-l"]:
+                return SimpleNamespace(returncode=0, stdout=fake_cron, stderr="")
+            return original_run(cmd, **kwargs)
+
+        with patch("hermes_cli.config.subprocess.run", side_effect=fake_run):
+            backup_command(_make_args("status"))
+
+        captured = capsys.readouterr()
+        assert "on" in captured.out.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestBackupAuto
+# ---------------------------------------------------------------------------
+
+class TestBackupAuto:
+
+    def _run_auto(self, state, existing_cron=""):
+        cron_written = []
+
+        def fake_run(cmd, **kwargs):
+            if cmd == ["crontab", "-l"]:
+                return SimpleNamespace(returncode=0, stdout=existing_cron, stderr="")
+            if cmd[0] == "crontab" and cmd[1] == "-":
+                cron_written.append(kwargs.get("input", ""))
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return subprocess.run(cmd, **kwargs)
+
+        with patch("hermes_cli.config.subprocess.run", side_effect=fake_run):
+            backup_command(_make_args("auto", state=state))
+
+        return cron_written
+
+    def test_auto_on_adds_cron_entry(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        written = self._run_auto("on")
+        assert written
+        assert BACKUP_CRON_MARKER in written[0]
+        assert "hermes config backup push" in written[0]
+
+    def test_auto_on_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        existing = f"{BACKUP_CRON_LINE}  {BACKUP_CRON_MARKER}\n"
+        written = self._run_auto("on", existing_cron=existing)
+        # Should appear exactly once
+        assert written[0].count(BACKUP_CRON_MARKER) == 1
+
+    def test_auto_off_removes_cron_entry(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        existing = f"0 5 * * * /other/job\n{BACKUP_CRON_LINE}  {BACKUP_CRON_MARKER}\n"
+        written = self._run_auto("off", existing_cron=existing)
+        assert BACKUP_CRON_MARKER not in written[0]
+        assert "/other/job" in written[0]  # other entries preserved
+
+    def test_auto_off_noop_when_not_set(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        existing = "0 5 * * * /other/job\n"
+        written = self._run_auto("off", existing_cron=existing)
+        assert BACKUP_CRON_MARKER not in written[0]
+        assert "/other/job" in written[0]
+
+    def test_auto_on_prints_confirmation(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._run_auto("on")
+        captured = capsys.readouterr()
+        assert "enabled" in captured.out.lower()
+
+    def test_auto_off_prints_confirmation(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._run_auto("off")
+        captured = capsys.readouterr()
+        assert "disabled" in captured.out.lower()
+
+    def test_auto_on_empty_existing_crontab(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        cron_written = []
+
+        def fake_run(cmd, **kwargs):
+            if cmd == ["crontab", "-l"]:
+                return SimpleNamespace(returncode=1, stdout="", stderr="no crontab for user")
+            if cmd[0] == "crontab" and cmd[1] == "-":
+                cron_written.append(kwargs.get("input", ""))
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return subprocess.run(cmd, **kwargs)
+
+        with patch("hermes_cli.config.subprocess.run", side_effect=fake_run):
+            backup_command(_make_args("auto", state="on"))
+
+        assert cron_written
+        assert BACKUP_CRON_MARKER in cron_written[0]
+
+
+# ---------------------------------------------------------------------------
+# TestBackupConstants
+# ---------------------------------------------------------------------------
+
+class TestBackupConstants:
+
+    def test_env_in_gitignore_template(self):
+        assert ".env" in BACKUP_GITIGNORE
+
+    def test_auth_json_in_gitignore_template(self):
+        assert "auth.json" in BACKUP_GITIGNORE
+
+    def test_state_db_in_gitignore_template(self):
+        assert "state.db" in BACKUP_GITIGNORE
+
+    def test_logs_in_gitignore_template(self):
+        assert "logs/" in BACKUP_GITIGNORE
+
+    def test_tracked_includes_config_yaml(self):
+        assert "config.yaml" in BACKUP_TRACKED
+
+    def test_tracked_includes_soul_md(self):
+        assert "SOUL.md" in BACKUP_TRACKED
+
+    def test_tracked_includes_skills(self):
+        assert "skills" in BACKUP_TRACKED
+
+    def test_tracked_includes_memories(self):
+        assert "memories" in BACKUP_TRACKED
+
+    def test_cron_line_has_correct_command(self):
+        assert "hermes config backup push" in BACKUP_CRON_LINE
+
+    def test_cron_line_has_hourly_schedule(self):
+        assert BACKUP_CRON_LINE.startswith("0 * * * *")

--- a/website/docs/user-guide/config-backup.md
+++ b/website/docs/user-guide/config-backup.md
@@ -1,0 +1,198 @@
+---
+sidebar_position: 3
+title: "Config Backup"
+description: "Version-control your Hermes config with git — local snapshots or remote push to GitHub/GitLab"
+---
+
+# Config Backup
+
+`hermes config backup` keeps your `~/.hermes/` config under git version control. Every change to
+`config.yaml`, `SOUL.md`, skills, cron jobs, and memories is automatically committed — hourly or on
+demand — with full history and optional remote push to GitHub, GitLab, or any git host.
+
+Your secrets (`.env`, `auth.json`) are **always excluded** and never committed.
+
+---
+
+## Quick start
+
+```bash
+# 1. Initialize a local backup repo
+hermes config backup init
+
+# 2. Enable hourly auto-backup
+hermes config backup auto on
+
+# 3. Check status any time
+hermes config backup status
+```
+
+That's it. From this point every config change is automatically captured once per hour.
+
+---
+
+## Commands
+
+### `hermes config backup init [remote]`
+
+Initializes a git repository in `~/.hermes/`, creates a `.gitignore` that excludes secrets, and
+takes the first snapshot. Optionally adds a remote for off-machine backup.
+
+```bash
+# Local only
+hermes config backup init
+
+# With remote (GitHub, GitLab, self-hosted, etc.)
+hermes config backup init git@github.com:you/hermes-config.git
+hermes config backup init https://github.com/you/hermes-config
+```
+
+Safe to run multiple times — re-running on an existing repo is a no-op.
+
+---
+
+### `hermes config backup push`
+
+Commits any changed tracked files and pushes to remote (if configured). Does nothing if config
+is unchanged.
+
+```bash
+hermes config backup push
+```
+
+```
+  ✓ Committed snapshot (2026-03-17 18:30)
+  ✓ Pushed to https://github.com/you/hermes-config
+```
+
+---
+
+### `hermes config backup pull`
+
+Pulls the latest config from your remote. Useful when switching machines or restoring after a
+reinstall.
+
+```bash
+hermes config backup pull
+```
+
+Requires a remote to be configured (`hermes config backup init <url>`).
+
+---
+
+### `hermes config backup status`
+
+Shows a snapshot of your backup state at a glance.
+
+```bash
+hermes config backup status
+```
+
+```
+  Config Backup Status
+
+  Last commit:  a87640c auto: config snapshot 2026-03-17 18:30 (2 hours ago)
+  Remote:       https://github.com/you/hermes-config
+  Auto-backup:  on (hourly)
+  Changes:      none (clean)
+```
+
+If there are uncommitted changes:
+
+```
+  Uncommitted changes:
+     M config.yaml
+     M memories/MEMORY.md
+```
+
+---
+
+### `hermes config backup auto on|off`
+
+Enables or disables an hourly cron job that runs `hermes config backup push` automatically.
+
+```bash
+hermes config backup auto on    # commits every hour if anything changed
+hermes config backup auto off   # stops auto-backup
+```
+
+Logs are written to `~/.hermes/logs/backup.log`.
+
+---
+
+## What gets tracked
+
+| Path | Tracked |
+|---|---|
+| `config.yaml` | ✅ |
+| `SOUL.md` | ✅ |
+| `skills/` | ✅ |
+| `cron/` | ✅ |
+| `memories/` | ✅ |
+| `.env` | ❌ never (API keys) |
+| `auth.json` | ❌ never (OAuth tokens) |
+| `logs/` | ❌ |
+| `sessions/` | ❌ |
+| `state.db` | ❌ |
+
+---
+
+## Setting up a remote
+
+Create a **private** repository on GitHub (or any git host), then:
+
+```bash
+hermes config backup init git@github.com:you/hermes-config.git
+hermes config backup push
+hermes config backup auto on
+```
+
+To change the remote URL later, just run `init` again with the new URL:
+
+```bash
+hermes config backup init git@gitlab.com:you/hermes-config.git
+```
+
+---
+
+## Restoring config on a new machine
+
+```bash
+# 1. Install Hermes
+# 2. Clone your config repo into ~/.hermes/
+git clone git@github.com:you/hermes-config.git ~/.hermes
+
+# 3. Re-add your secrets (.env is not in the repo)
+hermes setup
+
+# 4. Re-enable auto-backup
+hermes config backup auto on
+```
+
+---
+
+## Viewing history
+
+Since `~/.hermes/` is a standard git repo, all git commands work:
+
+```bash
+# See full history
+git -C ~/.hermes log --oneline
+
+# See what changed in the last commit
+git -C ~/.hermes show
+
+# Diff current state vs yesterday
+git -C ~/.hermes diff HEAD~5
+
+# Restore a previous config.yaml
+git -C ~/.hermes checkout HEAD~2 -- config.yaml
+```
+
+---
+
+## Security
+
+- `.env` and `auth.json` are in `.gitignore` and will never be staged or committed
+- If using a remote, use a **private** repository
+- The `.gitignore` is written on `init` and covers all known secrets and runtime files

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -31,6 +31,7 @@ hermes config edit         # Open config.yaml in your editor
 hermes config set KEY VAL  # Set a specific value
 hermes config check        # Check for missing options (after updates)
 hermes config migrate      # Interactively add missing options
+hermes config backup       # Git-based config backup (see Config Backup)
 
 # Examples:
 hermes config set model anthropic/claude-opus-4


### PR DESCRIPTION
## Summary

Adds `hermes config backup` — a git-based version control system for `~/.hermes/` config files, with optional remote push to GitHub/GitLab and hourly auto-commit via cron.

Secrets (`.env`, `auth.json`) are always excluded and never committed.

## New commands

```bash
hermes config backup init [remote]  # init git repo, optional remote URL
hermes config backup push           # commit changed files and push
hermes config backup pull           # pull latest from remote
hermes config backup status         # show last commit, remote, cron state
hermes config backup auto on|off    # toggle hourly cron auto-backup
```

## What gets tracked

| Path | Tracked |
|---|---|
| `config.yaml` | ✅ |
| `SOUL.md` | ✅ |
| `skills/` | ✅ |
| `cron/` | ✅ |
| `memories/` | ✅ |
| `.env` | ❌ never |
| `auth.json` | ❌ never |
| `logs/`, `sessions/`, `state.db` | ❌ |

## Example usage

```bash
# Local only
hermes config backup init
hermes config backup auto on

# With remote
hermes config backup init git@github.com:you/hermes-config.git
hermes config backup push

# Restore on a new machine
git clone git@github.com:you/hermes-config.git ~/.hermes
hermes setup
hermes config backup auto on
```

## Changes

| File | Description |
|---|---|
| `hermes_cli/config.py` | `backup_command()` function + constants + dispatcher hook |
| `hermes_cli/main.py` | `backup` subparser registration under `config` |
| `tests/hermes_cli/test_config_backup.py` | 42 tests covering all subcommands |
| `website/docs/user-guide/config-backup.md` | Full documentation page |
| `website/docs/user-guide/configuration.md` | Added `backup` to command reference |

## Test plan

- [x] `hermes config backup init` — creates git repo and initial snapshot
- [x] `hermes config backup init <url>` — adds/updates remote
- [x] `hermes config backup push` — commits only when files changed
- [x] `hermes config backup push` — no-op when config is clean
- [x] `hermes config backup pull` — pulls from remote
- [x] `hermes config backup status` — shows commit, remote, dirty files, auto state
- [x] `hermes config backup auto on` — adds hourly cron entry
- [x] `hermes config backup auto off` — removes cron entry
- [x] `.env` and `auth.json` never appear in git history
- [x] 42 unit tests passing