### PR TITLE
fix: streaming message length overflow + Telegram error handling

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -430,6 +430,20 @@ class TelegramAdapter(BasePlatformAdapter):
             # "Message is not modified" — content identical, treat as success
             if "not modified" in err_str:
                 return SendResult(success=True, message_id=message_id)
+            # Message too long — content exceeded 4096 chars (e.g. during
+            # streaming).  Truncate and succeed so the stream consumer can
+            # split the overflow into a new message instead of dying.
+            if "message_too_long" in err_str or "too long" in err_str:
+                truncated = content[: self.MAX_MESSAGE_LENGTH - 20] + "…"
+                try:
+                    await self._bot.edit_message_text(
+                        chat_id=int(chat_id),
+                        message_id=int(message_id),
+                        text=truncated,
+                    )
+                except Exception:
+                    pass  # best-effort truncation
+                return SendResult(success=True, message_id=message_id)
             # Flood control / RetryAfter — back off and retry once
             retry_after = getattr(e, "retry_after", None)
             if retry_after is not None or "retry after" in err_str:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -87,6 +87,10 @@ class GatewayStreamConsumer:
 
     async def run(self) -> None:
         """Async task that drains the queue and edits the platform message."""
+        # Platform message length limit — leave room for cursor + formatting
+        _raw_limit = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
+        _safe_limit = max(500, _raw_limit - len(self.cfg.cursor) - 100)
+
         try:
             while True:
                 # Drain all available items from the queue
@@ -112,6 +116,21 @@ class GatewayStreamConsumer:
                 )
 
                 if should_edit and self._accumulated:
+                    # Split overflow: if accumulated text exceeds the platform
+                    # limit, finalize the current message and start a new one.
+                    while (
+                        len(self._accumulated) > _safe_limit
+                        and self._message_id is not None
+                    ):
+                        split_at = self._accumulated.rfind("\n", 0, _safe_limit)
+                        if split_at < _safe_limit // 2:
+                            split_at = _safe_limit
+                        chunk = self._accumulated[:split_at]
+                        await self._send_or_edit(chunk)
+                        self._accumulated = self._accumulated[split_at:].lstrip("\n")
+                        self._message_id = None
+                        self._last_sent_text = ""
+
                     display_text = self._accumulated
                     if not got_done:
                         display_text += self.cfg.cursor


### PR DESCRIPTION
## Summary

When a streamed response grows past Telegram's 4096-char limit (or Discord's 2000, etc.), `editMessageText` fails with `MESSAGE_TOO_LONG` and the stream consumer treats it as an edit failure — killing streaming entirely. Normal sends chunk long responses, but streaming didn't.

### Fix: Stream consumer overflow splitting

The `run()` loop now checks accumulated text against `adapter.MAX_MESSAGE_LENGTH` before each edit. When the text exceeds the safe limit:

1. Finalizes the current message at a clean line break (or at the limit if no good break exists)
2. Resets `_message_id` so the next edit sends a fresh message
3. Continues streaming into the new message

Works for all platforms — reads the adapter's `MAX_MESSAGE_LENGTH` at runtime (Telegram 4096, Discord 2000, Slack 39000, etc.).

### Safety net: Telegram adapter

If `editMessageText` still hits `MESSAGE_TOO_LONG` (e.g. markdown formatting expanding the text), the adapter truncates and returns `success=True` instead of killing the stream.

## Files changed
- `gateway/stream_consumer.py` — Overflow split loop in `run()`
- `gateway/platforms/telegram.py` — `MESSAGE_TOO_LONG` handler in `edit_message()`

## Test plan
- 1035 gateway + streaming tests pass