### PR TITLE
docs: fix MDX build error in api-server.md

### DIFF
--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -136,11 +136,11 @@ Use the `conversation` parameter instead of tracking response IDs:
 
 The server automatically chains to the latest response in that conversation. Like the `/title` command for gateway sessions.
 
-### GET /v1/responses/{id}
+### GET /v1/responses/\{id\}
 
 Retrieve a previously stored response by ID.
 
-### DELETE /v1/responses/{id}
+### DELETE /v1/responses/\{id\}
 
 Delete a stored response.
 


### PR DESCRIPTION
The headings `GET /v1/responses/{id}` and `DELETE /v1/responses/{id}` caused `ReferenceError: id is not defined` during Docusaurus SSG. MDX v2+ interprets `{id}` in regular markdown as a JSX expression. Escaped with backslashes: `\{id\}`.