### PR TITLE
Add xgate provider surface

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -72,6 +72,7 @@ DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+DEFAULT_XGATE_BASE_URL = "https://ai.xgate.run/v1"
 
 
 # =============================================================================
@@ -187,6 +188,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://ai-gateway.vercel.sh/v1",
         api_key_env_vars=("AI_GATEWAY_API_KEY",),
         base_url_env_var="AI_GATEWAY_BASE_URL",
+    ),
+    "xgate": ProviderConfig(
+        id="xgate",
+        name="xgate",
+        auth_type="api_key",
+        inference_base_url=DEFAULT_XGATE_BASE_URL,
+        api_key_env_vars=("XGATE_API_KEY",),
+        base_url_env_var="XGATE_BASE_URL",
     ),
     "opencode-zen": ProviderConfig(
         id="opencode-zen",
@@ -684,6 +693,7 @@ def resolve_provider(
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
+        "daydreams": "xgate",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -544,6 +544,22 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "provider",
     },
+    "XGATE_API_KEY": {
+        "description": "xgate API key",
+        "prompt": "xgate API Key",
+        "url": "https://ai.xgate.run/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "XGATE_BASE_URL": {
+        "description": "Custom xgate base URL (advanced)",
+        "prompt": "xgate Base URL",
+        "url": "https://ai.xgate.run/v1",
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
     "DASHSCOPE_API_KEY": {
         "description": "Alibaba Cloud DashScope API key for Qwen models",
         "prompt": "DashScope API Key",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -790,6 +790,7 @@ def cmd_model(args):
         "opencode-go": "OpenCode Go",
         "ai-gateway": "AI Gateway",
         "kilocode": "Kilo Code",
+        "xgate": "xgate",
         "alibaba": "Alibaba Cloud (DashScope)",
         "custom": "Custom endpoint",
     }
@@ -812,6 +813,7 @@ def cmd_model(args):
         ("kimi-coding", "Kimi / Moonshot (Moonshot AI direct API)"),
         ("minimax", "MiniMax (global direct API)"),
         ("minimax-cn", "MiniMax China (domestic direct API)"),
+        ("xgate", "xgate (ai.xgate.run inference endpoint)"),
         ("kilocode", "Kilo Code (Kilo Gateway API)"),
         ("opencode-zen", "OpenCode Zen (35+ curated models, pay-as-you-go)"),
         ("opencode-go", "OpenCode Go (open models, $10/month subscription)"),
@@ -889,7 +891,7 @@ def cmd_model(args):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba"):
+    elif selected_provider in ("zai", "minimax", "minimax-cn", "xgate", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
 
@@ -3107,7 +3109,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "zai", "kimi-coding", "minimax", "minimax-cn", "xgate", "kilocode"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -286,7 +286,7 @@ def list_available_providers() -> list[dict[str, str]]:
     # Canonical providers in display order
     _PROVIDER_ORDER = [
         "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
-        "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
+        "zai", "kimi-coding", "minimax", "minimax-cn", "xgate", "kilocode", "anthropic", "alibaba",
         "opencode-zen", "opencode-go",
         "ai-gateway", "deepseek", "custom",
     ]

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1532,11 +1532,13 @@ def setup_model_provider(config: dict):
     elif provider_idx == 16:  # xgate
         selected_provider = "xgate"
         print()
-        print_header("xgate API Key")
+        print_header("xgate (Surface Only)")
         pconfig = PROVIDER_REGISTRY["xgate"]
         print_info(f"Provider: {pconfig.name}")
         print_info(f"Base URL: {pconfig.inference_base_url}")
-        print_info("Configure an API key if your xgate deployment requires one.")
+        print_info("This PR only adds the named provider surface and default base URL.")
+        print_info("Header-based auth lands in follow-up PR 2 and is required for the default hosted xgate flow.")
+        print_info("Only configure an API key here if your xgate deployment already accepts one directly.")
         print()
 
         existing_key = get_env_value("XGATE_API_KEY")
@@ -1553,7 +1555,7 @@ def setup_model_provider(config: dict):
                 save_env_value("XGATE_API_KEY", api_key)
                 print_success("xgate API key saved")
             else:
-                print_warning("Skipped - agent won't work without an API key")
+                print_info("Skipped - the hosted xgate auth path is added in follow-up PR 2")
 
         if existing_custom:
             save_env_value("OPENAI_BASE_URL", "")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -884,6 +884,7 @@ def setup_model_provider(config: dict):
         "OpenCode Go (open models, $10/month subscription)",
         "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)",
         "GitHub Copilot ACP (spawns `copilot --acp --stdio`)",
+        "xgate (ai.xgate.run inference endpoint)",
     ]
     if keep_label:
         provider_choices.append(keep_label)
@@ -1528,7 +1529,39 @@ def setup_model_provider(config: dict):
         _set_model_provider(config, "copilot-acp", pconfig.inference_base_url)
         selected_base_url = pconfig.inference_base_url
 
-    # else: provider_idx == 16 (Keep current) — only shown when a provider already exists
+    elif provider_idx == 16:  # xgate
+        selected_provider = "xgate"
+        print()
+        print_header("xgate API Key")
+        pconfig = PROVIDER_REGISTRY["xgate"]
+        print_info(f"Provider: {pconfig.name}")
+        print_info(f"Base URL: {pconfig.inference_base_url}")
+        print_info("Configure an API key if your xgate deployment requires one.")
+        print()
+
+        existing_key = get_env_value("XGATE_API_KEY")
+        if existing_key:
+            print_info(f"Current: {existing_key[:8]}... (configured)")
+            if prompt_yes_no("Update API key?", False):
+                api_key = prompt_text("xgate API key", password=True)
+                if api_key:
+                    save_env_value("XGATE_API_KEY", api_key)
+                    print_success("xgate API key updated")
+        else:
+            api_key = prompt_text("xgate API key", password=True)
+            if api_key:
+                save_env_value("XGATE_API_KEY", api_key)
+                print_success("xgate API key saved")
+            else:
+                print_warning("Skipped - agent won't work without an API key")
+
+        if existing_custom:
+            save_env_value("OPENAI_BASE_URL", "")
+            save_env_value("OPENAI_API_KEY", "")
+        _set_model_provider(config, "xgate", pconfig.inference_base_url)
+        selected_base_url = pconfig.inference_base_url
+
+    # else: provider_idx == 17 (Keep current) — only shown when a provider already exists
     # Normalize "keep current" to an explicit provider so downstream logic
     # doesn't fall back to the generic OpenRouter/static-model path.
     if selected_provider is None:
@@ -1709,7 +1742,7 @@ def setup_model_provider(config: dict):
             model_cfg = _model_config_dict(config)
             model_cfg["api_mode"] = "chat_completions"
             config["model"] = model_cfg
-        elif selected_provider in ("copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "ai-gateway", "opencode-zen", "opencode-go", "alibaba"):
+        elif selected_provider in ("copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "xgate", "kilocode", "ai-gateway", "opencode-zen", "opencode-go", "alibaba"):
             _setup_provider_model_selection(
                 config, selected_provider, current_model,
                 prompt_choice, prompt,
@@ -1770,7 +1803,7 @@ def setup_model_provider(config: dict):
     # Write provider+base_url to config.yaml only after model selection is complete.
     # This prevents a race condition where the gateway picks up a new provider
     # before the model name has been updated to match.
-    if selected_provider in ("copilot-acp", "copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic") and selected_base_url is not None:
+    if selected_provider in ("copilot-acp", "copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "xgate", "kilocode", "anthropic") and selected_base_url is not None:
         _update_config_for_provider(selected_provider, selected_base_url)
 
     save_config(config)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -119,6 +119,7 @@ def show_status(args):
         "Kimi": "KIMI_API_KEY",
         "MiniMax": "MINIMAX_API_KEY",
         "MiniMax-CN": "MINIMAX_CN_API_KEY",
+        "xgate": "XGATE_API_KEY",
         "Firecrawl": "FIRECRAWL_API_KEY",
         "Tavily": "TAVILY_API_KEY",
         "Browserbase": "BROWSERBASE_API_KEY",  # Optional — local browser works without this
@@ -197,6 +198,7 @@ def show_status(args):
         "Kimi / Moonshot":  ("KIMI_API_KEY",),
         "MiniMax":          ("MINIMAX_API_KEY",),
         "MiniMax (China)":  ("MINIMAX_CN_API_KEY",),
+        "xgate":            ("XGATE_API_KEY",),
     }
     for pname, env_vars in apikey_providers.items():
         key_val = ""

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -42,6 +42,7 @@ class TestProviderRegistry:
         ("kimi-coding", "Kimi / Moonshot", "api_key"),
         ("minimax", "MiniMax", "api_key"),
         ("minimax-cn", "MiniMax (China)", "api_key"),
+        ("xgate", "xgate", "api_key"),
         ("ai-gateway", "AI Gateway", "api_key"),
         ("kilocode", "Kilo Code", "api_key"),
     ])
@@ -82,6 +83,11 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("AI_GATEWAY_API_KEY",)
         assert pconfig.base_url_env_var == "AI_GATEWAY_BASE_URL"
 
+    def test_xgate_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["xgate"]
+        assert pconfig.api_key_env_vars == ("XGATE_API_KEY",)
+        assert pconfig.base_url_env_var == "XGATE_BASE_URL"
+
     def test_kilocode_env_vars(self):
         pconfig = PROVIDER_REGISTRY["kilocode"]
         assert pconfig.api_key_env_vars == ("KILOCODE_API_KEY",)
@@ -94,6 +100,7 @@ class TestProviderRegistry:
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["minimax"].inference_base_url == "https://api.minimax.io/anthropic"
         assert PROVIDER_REGISTRY["minimax-cn"].inference_base_url == "https://api.minimaxi.com/anthropic"
+        assert PROVIDER_REGISTRY["xgate"].inference_base_url == "https://ai.xgate.run/v1"
         assert PROVIDER_REGISTRY["ai-gateway"].inference_base_url == "https://ai-gateway.vercel.sh/v1"
         assert PROVIDER_REGISTRY["kilocode"].inference_base_url == "https://api.kilo.ai/api/gateway"
 
@@ -171,6 +178,9 @@ class TestResolveProvider:
 
     def test_alias_vercel(self):
         assert resolve_provider("vercel") == "ai-gateway"
+
+    def test_alias_daydreams(self):
+        assert resolve_provider("daydreams") == "xgate"
 
     def test_explicit_kilocode(self):
         assert resolve_provider("kilocode") == "kilocode"
@@ -285,6 +295,14 @@ class TestApiKeyProviderStatus:
         assert status["logged_in"] is True
         assert status["key_source"] == "gh auth token"
         assert status["base_url"] == "https://api.githubcopilot.com"
+
+    def test_xgate_status_uses_env_key(self, monkeypatch):
+        monkeypatch.setenv("XGATE_API_KEY", "test-xgate-key")
+        monkeypatch.setenv("XGATE_BASE_URL", "https://ai.xgate.run/v1")
+        status = get_api_key_provider_status("xgate")
+        assert status["configured"] is True
+        assert status["key_source"] == "XGATE_API_KEY"
+        assert status["base_url"] == "https://ai.xgate.run/v1"
 
     def test_get_auth_status_dispatches_to_api_key(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")


### PR DESCRIPTION
## What does this PR do?

Adds `xgate` as a named inference provider surface in Hermes, with default routing to `https://ai.xgate.run/v1`, config/env support, CLI/setup/status visibility, and provider-resolution tests. This PR is intentionally passive: it does **not** make the hosted xgate auth path work by itself. Follow-up PR 2 is required to add the provider request-header auth mechanism that xgate depends on.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Register `xgate` as a named provider with `XGATE_API_KEY` / `XGATE_BASE_URL` support and default routing to `https://ai.xgate.run/v1`.
- Expose `xgate` in model/provider labels, CLI provider choices, setup, and status output.
- Add provider-resolution coverage for explicit selection, auto-detection, env/config handling, and runtime resolution.
- Add the `daydreams` alias to map to `xgate`.
- Clarify in setup copy that hosted auth lands in follow-up PR 2.

## How to Test

1. `source .venv/bin/activate && python -m pytest -o addopts='' tests/test_api_key_providers.py tests/test_cli_provider_resolution.py tests/test_cli_init.py -q`
2. Run `hermes model` or `hermes setup model` and verify `xgate` appears as a provider option.
3. Export `XGATE_API_KEY` and confirm `--provider xgate` resolves to `https://ai.xgate.run/v1`.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused verification passed: `116 passed` across `tests/test_api_key_providers.py`, `tests/test_cli_provider_resolution.py`, and `tests/test_cli_init.py`.
- This PR only adds the provider surface. PR 2 in the split stack adds the request-header auth mechanism the hosted xgate path needs.