### PR TITLE
feat(telegram): add interactive inline keyboard for /model command

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -16,9 +16,10 @@ from typing import Dict, List, Optional, Any
 logger = logging.getLogger(__name__)
 
 try:
-    from telegram import Update, Bot, Message
+    from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup
     from telegram.ext import (
         Application,
+        CallbackQueryHandler,
         CommandHandler,
         MessageHandler as TelegramMessageHandler,
         ContextTypes,
@@ -206,7 +207,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
             ))
-            
+            self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+
             # Start polling — retry initialize() for transient TLS resets
             try:
                 from telegram.error import NetworkError, TimedOut
@@ -1317,3 +1319,67 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             timestamp=message.date,
         )
+
+    async def send_keyboard(
+        self,
+        chat_id: str,
+        text: str,
+        buttons: List[List[Dict]],
+        message_id: Optional[str] = None,
+    ) -> SendResult:
+        """Send or edit a message with inline keyboard buttons."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            keyboard = InlineKeyboardMarkup([
+                [InlineKeyboardButton(btn["text"], callback_data=btn["callback_data"])
+                 for btn in row]
+                for row in buttons
+            ]) if buttons else None
+            if message_id:
+                msg = await self._bot.edit_message_text(
+                    chat_id=int(chat_id),
+                    message_id=int(message_id),
+                    text=text,
+                    reply_markup=keyboard,
+                    parse_mode=None,
+                )
+            else:
+                msg = await self._bot.send_message(
+                    chat_id=int(chat_id),
+                    text=text,
+                    reply_markup=keyboard,
+                    parse_mode=None,
+                )
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def _handle_callback_query(
+        self,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,
+    ) -> None:
+        """Handle inline keyboard button callbacks."""
+        query = update.callback_query
+        if not query or not self._message_handler:
+            return
+        await query.answer()
+
+        chat = query.message.chat
+        user = query.from_user
+        source = self.build_source(
+            chat_id=str(chat.id),
+            chat_name=chat.title or getattr(chat, "full_name", None),
+            chat_type="dm" if chat.type == "private" else "group",
+            user_id=str(user.id) if user else None,
+            user_name=user.full_name if user else None,
+        )
+        event = MessageEvent(
+            text=query.data or "",
+            message_type=MessageType.COMMAND,
+            source=source,
+            raw_message=query,
+            message_id=str(query.message.message_id) if query.message else None,
+        )
+        await self._message_handler(event)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1364,7 +1364,12 @@ class TelegramAdapter(BasePlatformAdapter):
         query = update.callback_query
         if not query or not self._message_handler:
             return
-        await query.answer()
+        if not query.message:
+            return
+        try:
+            await query.answer()
+        except Exception:
+            pass  # already answered or timed out
 
         chat = query.message.chat
         user = query.from_user

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -80,7 +80,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 _hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
 
 # UUID action map for inline keyboard callbacks (chat_id, action_id) -> action dict
-_keyboard_actions: Dict[tuple[str, str], Dict] = {}
+_keyboard_actions: Dict[tuple[str, str, str], Dict] = {}
 
 # Load environment variables from ~/.hermes/.env first.
 # User-managed env files should override stale shell exports on restart.
@@ -276,14 +276,14 @@ def _resolve_gateway_model() -> str:
 _MODELS_PER_PAGE = 8
 
 
-def _model_providers_keyboard(chat_id: str, current_model: str) -> tuple[str, List[List[Dict]]]:
+def _model_providers_keyboard(chat_id: str, user_id: str, current_model: str) -> tuple[str, List[List[Dict]]]:
     """Build provider selection keyboard."""
     from hermes_cli.models import providers
     rows: List[List[Dict]] = []
     pair: List[Dict] = []
     for prov in providers():
         action_id = uuid.uuid4().hex[:16]
-        _keyboard_actions[(chat_id, action_id)] = {
+        _keyboard_actions[(chat_id, user_id, action_id)] = {
             "type": "model_provider", "provider": prov, "current_model": current_model
         }
         btn_label = f"* {prov}" if prov in current_model else prov
@@ -294,12 +294,12 @@ def _model_providers_keyboard(chat_id: str, current_model: str) -> tuple[str, Li
     if pair:
         rows.append(pair)
     cancel_id = uuid.uuid4().hex[:16]
-    _keyboard_actions[(chat_id, cancel_id)] = {"type": "model_cancel"}
+    _keyboard_actions[(chat_id, user_id, cancel_id)] = {"type": "model_cancel"}
     rows.append([{"text": "Cancel", "callback_data": cancel_id}])
     return f"Current: {current_model}\n\nSelect provider:", rows
 
 
-def _model_list_keyboard(chat_id: str, provider: str, current_model: str, page: int = 0) -> tuple[str, List[List[Dict]]]:
+def _model_list_keyboard(chat_id: str, user_id: str, provider: str, current_model: str, page: int = 0) -> tuple[str, List[List[Dict]]]:
     """Build paginated model list keyboard."""
     from hermes_cli.models import models_for_provider
     all_models = models_for_provider(provider)
@@ -311,7 +311,7 @@ def _model_list_keyboard(chat_id: str, provider: str, current_model: str, page: 
     pair: List[Dict] = []
     for mid in page_models:
         action_id = uuid.uuid4().hex[:16]
-        _keyboard_actions[(chat_id, action_id)] = {"type": "model_select", "model_id": mid}
+        _keyboard_actions[(chat_id, user_id, action_id)] = {"type": "model_select", "model_id": mid}
         label = f"* {mid}" if mid == current_model else mid
         display = label[:30] + "…" if len(label) > 30 else label
         pair.append({"text": display, "callback_data": action_id})
@@ -323,16 +323,16 @@ def _model_list_keyboard(chat_id: str, provider: str, current_model: str, page: 
     nav: List[Dict] = []
     if page > 0:
         pid = uuid.uuid4().hex[:16]
-        _keyboard_actions[(chat_id, pid)] = {"type": "model_page", "provider": provider, "current_model": current_model, "page": page - 1}
+        _keyboard_actions[(chat_id, user_id, pid)] = {"type": "model_page", "provider": provider, "current_model": current_model, "page": page - 1}
         nav.append({"text": "< Prev", "callback_data": pid})
     if (page + 1) * _MODELS_PER_PAGE < total:
         nid = uuid.uuid4().hex[:16]
-        _keyboard_actions[(chat_id, nid)] = {"type": "model_page", "provider": provider, "current_model": current_model, "page": page + 1}
+        _keyboard_actions[(chat_id, user_id, nid)] = {"type": "model_page", "provider": provider, "current_model": current_model, "page": page + 1}
         nav.append({"text": "Next >", "callback_data": nid})
     if nav:
         rows.append(nav)
     back_id = uuid.uuid4().hex[:16]
-    _keyboard_actions[(chat_id, back_id)] = {"type": "model_back", "current_model": current_model}
+    _keyboard_actions[(chat_id, user_id, back_id)] = {"type": "model_back", "current_model": current_model}
     rows.append([{"text": "<< Providers", "callback_data": back_id}])
     total_pages = max(1, (total + _MODELS_PER_PAGE - 1) // _MODELS_PER_PAGE)
     return f"Provider: {provider} ({total} models) — page {page+1}/{total_pages}\nCurrent: {current_model}", rows
@@ -1407,7 +1407,7 @@ class GatewayRunner:
         command = event.get_command()
 
         # Inline keyboard callback — text is a uuid hex with no "/" prefix
-        if not command and event.text and (event.source.chat_id, event.text.strip()) in _keyboard_actions:
+        if not command and event.text and (event.source.chat_id, event.source.user_id or "", event.text.strip()) in _keyboard_actions:
             return await self._handle_model_callback(event)
 
         # Emit command:* hook for any recognized slash command.
@@ -2388,7 +2388,7 @@ class GatewayRunner:
             adapter = self.adapters.get(source.platform) if source.platform else None
             if adapter and hasattr(adapter, "send_keyboard"):
                 try:
-                    text, rows = _model_providers_keyboard(source.chat_id, current)
+                    text, rows = _model_providers_keyboard(source.chat_id, source.user_id or "", current)
                     await adapter.send_keyboard(source.chat_id, text, rows)
                     return None
                 except Exception:
@@ -2501,7 +2501,8 @@ class GatewayRunner:
         """Handle inline keyboard callbacks for model selection."""
         import yaml
         chat_id = event.source.chat_id
-        action = _keyboard_actions.pop((chat_id, event.text.strip()), None)
+        user_id = event.source.user_id or ""
+        action = _keyboard_actions.pop((chat_id, user_id, event.text.strip()), None)
         if not action:
             return
         adapter = self.adapters.get(event.source.platform) if event.source.platform else None
@@ -2509,15 +2510,15 @@ class GatewayRunner:
 
         t = action.get("type")
         if t == "model_provider":
-            text, rows = _model_list_keyboard(chat_id, action["provider"], action["current_model"])
+            text, rows = _model_list_keyboard(chat_id, user_id, action["provider"], action["current_model"])
             if adapter:
                 await adapter.send_keyboard(chat_id, text, rows, message_id=msg_id)
         elif t == "model_page":
-            text, rows = _model_list_keyboard(chat_id, action["provider"], action["current_model"], action["page"])
+            text, rows = _model_list_keyboard(chat_id, user_id, action["provider"], action["current_model"], action["page"])
             if adapter:
                 await adapter.send_keyboard(chat_id, text, rows, message_id=msg_id)
         elif t == "model_back":
-            text, rows = _model_providers_keyboard(chat_id, action["current_model"])
+            text, rows = _model_providers_keyboard(chat_id, user_id, action["current_model"])
             if adapter:
                 await adapter.send_keyboard(chat_id, text, rows, message_id=msg_id)
         elif t == "model_select":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -79,7 +79,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # Resolve Hermes home directory (respects HERMES_HOME override)
 _hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
 
-# UUID action map for inline keyboard callbacks (chat_id, action_id) -> action dict
+# UUID action map for inline keyboard callbacks (chat_id, user_id, action_id) -> action dict
 _keyboard_actions: Dict[tuple[str, str, str], Dict] = {}
 
 # Load environment variables from ~/.hermes/.env first.
@@ -274,17 +274,27 @@ def _resolve_gateway_model() -> str:
 
 
 _MODELS_PER_PAGE = 8
+_KEYBOARD_ACTION_TTL = 900  # 15 minutes
+
+
+def _prune_keyboard_actions() -> None:
+    """Remove expired keyboard action entries."""
+    cutoff = time.time() - _KEYBOARD_ACTION_TTL
+    expired = [k for k, v in _keyboard_actions.items() if v.get("_ts", 0) < cutoff]
+    for k in expired:
+        del _keyboard_actions[k]
 
 
 def _model_providers_keyboard(chat_id: str, user_id: str, current_model: str) -> tuple[str, List[List[Dict]]]:
     """Build provider selection keyboard."""
     from hermes_cli.models import providers
+    ts = time.time()
     rows: List[List[Dict]] = []
     pair: List[Dict] = []
     for prov in providers():
         action_id = uuid.uuid4().hex[:16]
         _keyboard_actions[(chat_id, user_id, action_id)] = {
-            "type": "model_provider", "provider": prov, "current_model": current_model
+            "type": "model_provider", "provider": prov, "current_model": current_model, "_ts": ts,
         }
         btn_label = f"* {prov}" if prov in current_model else prov
         pair.append({"text": btn_label, "callback_data": action_id})
@@ -294,7 +304,7 @@ def _model_providers_keyboard(chat_id: str, user_id: str, current_model: str) ->
     if pair:
         rows.append(pair)
     cancel_id = uuid.uuid4().hex[:16]
-    _keyboard_actions[(chat_id, user_id, cancel_id)] = {"type": "model_cancel"}
+    _keyboard_actions[(chat_id, user_id, cancel_id)] = {"type": "model_cancel", "_ts": ts}
     rows.append([{"text": "Cancel", "callback_data": cancel_id}])
     return f"Current: {current_model}\n\nSelect provider:", rows
 
@@ -302,6 +312,7 @@ def _model_providers_keyboard(chat_id: str, user_id: str, current_model: str) ->
 def _model_list_keyboard(chat_id: str, user_id: str, provider: str, current_model: str, page: int = 0) -> tuple[str, List[List[Dict]]]:
     """Build paginated model list keyboard."""
     from hermes_cli.models import models_for_provider
+    ts = time.time()
     all_models = models_for_provider(provider)
     if not all_models:
         return f"No models for {provider}", []
@@ -311,7 +322,7 @@ def _model_list_keyboard(chat_id: str, user_id: str, provider: str, current_mode
     pair: List[Dict] = []
     for mid in page_models:
         action_id = uuid.uuid4().hex[:16]
-        _keyboard_actions[(chat_id, user_id, action_id)] = {"type": "model_select", "model_id": mid}
+        _keyboard_actions[(chat_id, user_id, action_id)] = {"type": "model_select", "model_id": mid, "_ts": ts}
         label = f"* {mid}" if mid == current_model else mid
         display = label[:30] + "…" if len(label) > 30 else label
         pair.append({"text": display, "callback_data": action_id})
@@ -323,16 +334,16 @@ def _model_list_keyboard(chat_id: str, user_id: str, provider: str, current_mode
     nav: List[Dict] = []
     if page > 0:
         pid = uuid.uuid4().hex[:16]
-        _keyboard_actions[(chat_id, user_id, pid)] = {"type": "model_page", "provider": provider, "current_model": current_model, "page": page - 1}
+        _keyboard_actions[(chat_id, user_id, pid)] = {"type": "model_page", "provider": provider, "current_model": current_model, "page": page - 1, "_ts": ts}
         nav.append({"text": "< Prev", "callback_data": pid})
     if (page + 1) * _MODELS_PER_PAGE < total:
         nid = uuid.uuid4().hex[:16]
-        _keyboard_actions[(chat_id, user_id, nid)] = {"type": "model_page", "provider": provider, "current_model": current_model, "page": page + 1}
+        _keyboard_actions[(chat_id, user_id, nid)] = {"type": "model_page", "provider": provider, "current_model": current_model, "page": page + 1, "_ts": ts}
         nav.append({"text": "Next >", "callback_data": nid})
     if nav:
         rows.append(nav)
     back_id = uuid.uuid4().hex[:16]
-    _keyboard_actions[(chat_id, user_id, back_id)] = {"type": "model_back", "current_model": current_model}
+    _keyboard_actions[(chat_id, user_id, back_id)] = {"type": "model_back", "current_model": current_model, "_ts": ts}
     rows.append([{"text": "<< Providers", "callback_data": back_id}])
     total_pages = max(1, (total + _MODELS_PER_PAGE - 1) // _MODELS_PER_PAGE)
     return f"Provider: {provider} ({total} models) — page {page+1}/{total_pages}\nCurrent: {current_model}", rows
@@ -2471,8 +2482,10 @@ class GatewayRunner:
                 user_config["model"]["default"] = new_model
                 if provider_changed:
                     user_config["model"]["provider"] = target_provider
-                with open(config_path, 'w', encoding="utf-8") as f:
+                tmp = config_path.with_suffix(".tmp")
+                with open(tmp, "w", encoding="utf-8") as f:
                     yaml.dump(user_config, f, default_flow_style=False, sort_keys=False)
+                os.replace(tmp, config_path)
             except Exception as e:
                 return f"⚠️ Failed to save model change: {e}"
 
@@ -2500,6 +2513,7 @@ class GatewayRunner:
     async def _handle_model_callback(self, event: MessageEvent) -> None:
         """Handle inline keyboard callbacks for model selection."""
         import yaml
+        _prune_keyboard_actions()
         chat_id = event.source.chat_id
         user_id = event.source.user_id or ""
         action = _keyboard_actions.pop((chat_id, user_id, event.text.strip()), None)
@@ -2523,24 +2537,34 @@ class GatewayRunner:
                 await adapter.send_keyboard(chat_id, text, rows, message_id=msg_id)
         elif t == "model_select":
             new_model = action["model_id"]
+            from hermes_cli.models import OPENROUTER_MODELS
+            known = {mid for mid, _ in OPENROUTER_MODELS}
+            if new_model not in known:
+                logger.warning("[keyboard] Rejected unknown model_id from action dict: %s", new_model)
+                if adapter:
+                    await adapter.send_keyboard(chat_id, "Unknown model — selection rejected.", [], message_id=msg_id)
+                return
             config_path = _hermes_home / "config.yaml"
             try:
                 user_config = {}
                 if config_path.exists():
-                    with open(config_path) as f:
+                    with open(config_path, encoding="utf-8") as f:
                         user_config = yaml.safe_load(f) or {}
                 if not isinstance(user_config.get("model"), dict):
                     user_config["model"] = {}
                 user_config["model"]["default"] = new_model
-                with open(config_path, "w") as f:
+                tmp = config_path.with_suffix(".tmp")
+                with open(tmp, "w", encoding="utf-8") as f:
                     yaml.dump(user_config, f, default_flow_style=False, sort_keys=False)
+                os.replace(tmp, config_path)
                 os.environ["HERMES_MODEL"] = new_model
                 confirm = f"✓ Switched to: {new_model}\n(takes effect on next message)"
                 if adapter:
                     await adapter.send_keyboard(chat_id, confirm, [], message_id=msg_id)
             except Exception as e:
+                logger.warning("[keyboard] Failed to write model config: %s", e)
                 if adapter:
-                    await adapter.send_keyboard(chat_id, f"Failed to save: {e}", [], message_id=msg_id)
+                    await adapter.send_keyboard(chat_id, "Failed to save model choice.", [], message_id=msg_id)
         elif t == "model_cancel":
             if adapter:
                 await adapter.send_keyboard(chat_id, "Cancelled.", [], message_id=msg_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24,6 +24,7 @@ import signal
 import tempfile
 import threading
 import time
+import uuid
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from datetime import datetime
@@ -77,6 +78,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 _hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+
+# UUID action map for inline keyboard callbacks (chat_id, action_id) -> action dict
+_keyboard_actions: Dict[tuple[str, str], Dict] = {}
 
 # Load environment variables from ~/.hermes/.env first.
 # User-managed env files should override stale shell exports on restart.
@@ -267,6 +271,71 @@ def _resolve_gateway_model() -> str:
     except Exception:
         pass
     return model
+
+
+_MODELS_PER_PAGE = 8
+
+
+def _model_providers_keyboard(chat_id: str, current_model: str) -> tuple[str, List[List[Dict]]]:
+    """Build provider selection keyboard."""
+    from hermes_cli.models import providers
+    rows: List[List[Dict]] = []
+    pair: List[Dict] = []
+    for prov in providers():
+        action_id = uuid.uuid4().hex[:16]
+        _keyboard_actions[(chat_id, action_id)] = {
+            "type": "model_provider", "provider": prov, "current_model": current_model
+        }
+        btn_label = f"* {prov}" if prov in current_model else prov
+        pair.append({"text": btn_label, "callback_data": action_id})
+        if len(pair) == 2:
+            rows.append(pair)
+            pair = []
+    if pair:
+        rows.append(pair)
+    cancel_id = uuid.uuid4().hex[:16]
+    _keyboard_actions[(chat_id, cancel_id)] = {"type": "model_cancel"}
+    rows.append([{"text": "Cancel", "callback_data": cancel_id}])
+    return f"Current: {current_model}\n\nSelect provider:", rows
+
+
+def _model_list_keyboard(chat_id: str, provider: str, current_model: str, page: int = 0) -> tuple[str, List[List[Dict]]]:
+    """Build paginated model list keyboard."""
+    from hermes_cli.models import models_for_provider
+    all_models = models_for_provider(provider)
+    if not all_models:
+        return f"No models for {provider}", []
+    total = len(all_models)
+    page_models = all_models[page * _MODELS_PER_PAGE:(page + 1) * _MODELS_PER_PAGE]
+    rows: List[List[Dict]] = []
+    pair: List[Dict] = []
+    for mid in page_models:
+        action_id = uuid.uuid4().hex[:16]
+        _keyboard_actions[(chat_id, action_id)] = {"type": "model_select", "model_id": mid}
+        label = f"* {mid}" if mid == current_model else mid
+        display = label[:30] + "…" if len(label) > 30 else label
+        pair.append({"text": display, "callback_data": action_id})
+        if len(pair) == 2:
+            rows.append(pair)
+            pair = []
+    if pair:
+        rows.append(pair)
+    nav: List[Dict] = []
+    if page > 0:
+        pid = uuid.uuid4().hex[:16]
+        _keyboard_actions[(chat_id, pid)] = {"type": "model_page", "provider": provider, "current_model": current_model, "page": page - 1}
+        nav.append({"text": "< Prev", "callback_data": pid})
+    if (page + 1) * _MODELS_PER_PAGE < total:
+        nid = uuid.uuid4().hex[:16]
+        _keyboard_actions[(chat_id, nid)] = {"type": "model_page", "provider": provider, "current_model": current_model, "page": page + 1}
+        nav.append({"text": "Next >", "callback_data": nid})
+    if nav:
+        rows.append(nav)
+    back_id = uuid.uuid4().hex[:16]
+    _keyboard_actions[(chat_id, back_id)] = {"type": "model_back", "current_model": current_model}
+    rows.append([{"text": "<< Providers", "callback_data": back_id}])
+    total_pages = max(1, (total + _MODELS_PER_PAGE - 1) // _MODELS_PER_PAGE)
+    return f"Provider: {provider} ({total} models) — page {page+1}/{total_pages}\nCurrent: {current_model}", rows
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:
@@ -1336,7 +1405,11 @@ class GatewayRunner:
         
         # Check for commands
         command = event.get_command()
-        
+
+        # Inline keyboard callback — text is a uuid hex with no "/" prefix
+        if not command and event.text and (event.source.chat_id, event.text.strip()) in _keyboard_actions:
+            return await self._handle_model_callback(event)
+
         # Emit command:* hook for any recognized slash command.
         # GATEWAY_KNOWN_COMMANDS is derived from the central COMMAND_REGISTRY
         # in hermes_cli/commands.py — no hardcoded set to maintain here.
@@ -2310,6 +2383,16 @@ class GatewayRunner:
                 lines.append("Switch provider: `/model provider:model-name`")
                 return "\n".join(lines)
 
+            # Try to show interactive keyboard if adapter supports it
+            source = event.source
+            adapter = self.adapters.get(source.platform) if source.platform else None
+            if adapter and hasattr(adapter, "send_keyboard"):
+                try:
+                    text, rows = _model_providers_keyboard(source.chat_id, current)
+                    await adapter.send_keyboard(source.chat_id, text, rows)
+                    return None
+                except Exception:
+                    pass  # Fall back to text response
             provider_label = _PROVIDER_LABELS.get(current_provider, current_provider)
             lines = [
                 f"🤖 **Current model:** `{current}`",
@@ -2413,6 +2496,53 @@ class GatewayRunner:
         self._effective_model = None
         self._effective_provider = None
         return f"🤖 Model changed to `{new_model}` ({persist_note}){provider_note}{warning}\n_(takes effect on next message)_"
+
+    async def _handle_model_callback(self, event: MessageEvent) -> None:
+        """Handle inline keyboard callbacks for model selection."""
+        import yaml
+        chat_id = event.source.chat_id
+        action = _keyboard_actions.pop((chat_id, event.text.strip()), None)
+        if not action:
+            return
+        adapter = self.adapters.get(event.source.platform) if event.source.platform else None
+        msg_id = event.message_id
+
+        t = action.get("type")
+        if t == "model_provider":
+            text, rows = _model_list_keyboard(chat_id, action["provider"], action["current_model"])
+            if adapter:
+                await adapter.send_keyboard(chat_id, text, rows, message_id=msg_id)
+        elif t == "model_page":
+            text, rows = _model_list_keyboard(chat_id, action["provider"], action["current_model"], action["page"])
+            if adapter:
+                await adapter.send_keyboard(chat_id, text, rows, message_id=msg_id)
+        elif t == "model_back":
+            text, rows = _model_providers_keyboard(chat_id, action["current_model"])
+            if adapter:
+                await adapter.send_keyboard(chat_id, text, rows, message_id=msg_id)
+        elif t == "model_select":
+            new_model = action["model_id"]
+            config_path = _hermes_home / "config.yaml"
+            try:
+                user_config = {}
+                if config_path.exists():
+                    with open(config_path) as f:
+                        user_config = yaml.safe_load(f) or {}
+                if not isinstance(user_config.get("model"), dict):
+                    user_config["model"] = {}
+                user_config["model"]["default"] = new_model
+                with open(config_path, "w") as f:
+                    yaml.dump(user_config, f, default_flow_style=False, sort_keys=False)
+                os.environ["HERMES_MODEL"] = new_model
+                confirm = f"✓ Switched to: {new_model}\n(takes effect on next message)"
+                if adapter:
+                    await adapter.send_keyboard(chat_id, confirm, [], message_id=msg_id)
+            except Exception as e:
+                if adapter:
+                    await adapter.send_keyboard(chat_id, f"Failed to save: {e}", [], message_id=msg_id)
+        elif t == "model_cancel":
+            if adapter:
+                await adapter.send_keyboard(chat_id, "Cancelled.", [], message_id=msg_id)
 
     async def _handle_provider_command(self, event: MessageEvent) -> str:
         """Handle /provider command - show available providers."""

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -217,6 +217,23 @@ def menu_labels() -> list[str]:
     return labels
 
 
+def providers() -> list[str]:
+    """Return unique provider prefixes in definition order. Models without '/' → 'local'."""
+    seen: list[str] = []
+    for mid, _ in OPENROUTER_MODELS:
+        prefix = mid.split("/")[0] if "/" in mid else "local"
+        if prefix not in seen:
+            seen.append(prefix)
+    return seen
+
+
+def models_for_provider(provider: str) -> list[str]:
+    """Return model ids belonging to provider. 'local' = all ids without '/'."""
+    if provider == "local":
+        return [mid for mid, _ in OPENROUTER_MODELS if "/" not in mid]
+    return [mid for mid, _ in OPENROUTER_MODELS if mid.startswith(f"{provider}/")]
+
+
 # All provider IDs and aliases that are valid for the provider:model syntax.
 _KNOWN_PROVIDER_NAMES: set[str] = (
     set(_PROVIDER_LABELS.keys())


### PR DESCRIPTION
## Summary

- Adds `InlineKeyboardButton`/`InlineKeyboardMarkup`/`CallbackQueryHandler` support to `TelegramAdapter`
- Adds `send_keyboard()` method to send or edit messages with inline keyboard buttons
- Adds `_handle_callback_query()` to route Telegram button presses back through the message handler
- Adds `_model_providers_keyboard()` and `_model_list_keyboard()` (paginated, 8 models/page) in `gateway/run.py`
- `/model` command now shows an interactive provider-then-model picker when the adapter supports `send_keyboard`; falls back to the existing text response on unsupported platforms
- Adds `providers()` and `models_for_provider()` generic helpers in `hermes_cli/models.py`

## Design notes

- The keyboard state is stored in `_keyboard_actions: Dict[tuple[chat_id, action_id], action]` using short UUID hex tokens as callback data, so no secrets or full model names pass through Telegram's callback payload limit
- Selecting a model persists immediately to `~/.hermes/config.yaml` and sets `HERMES_MODEL` in the current process — same behaviour as `/model <name>`
- All keyboard logic is gated on `hasattr(adapter, "send_keyboard")` so it degrades gracefully on CLI / WhatsApp / other adapters

## Test plan

- [ ] `/model` in Telegram shows provider keyboard
- [ ] Tapping a provider shows paginated model list; Next/Prev pages work
- [ ] Tapping a model writes config.yaml and confirms the switch
- [ ] Cancel returns "Cancelled." and removes the keyboard
- [ ] `providers()` and `models_for_provider()` return consistent results from `OPENROUTER_MODELS`
- [ ] `/model` on CLI still returns the plain-text response (no keyboard)