### PR TITLE
Feat(mcp)/mcp dynamic tool discovery

### DIFF
--- a/tests/tools/test_mcp_dynamic_discovery.py
+++ b/tests/tools/test_mcp_dynamic_discovery.py
@@ -1,0 +1,123 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools.mcp_tool import MCPServerTask, _register_server_tools
+from tools.registry import ToolRegistry
+
+
+def _make_mcp_tool(name: str, desc: str = ""):
+    return SimpleNamespace(name=name, description=desc, inputSchema=None)
+
+class TestDynamicToolDiscovery:
+    
+    @pytest.fixture
+    def mock_registry(self):
+        return ToolRegistry()
+
+    @pytest.fixture
+    def mock_toolsets(self):
+        return {
+            "hermes-cli": {"tools": ["terminal"], "description": "CLI", "includes": []},
+            "hermes-telegram": {"tools": ["terminal"], "description": "TG", "includes": []},
+            "custom-toolset": {"tools": [], "description": "Other", "includes": []},
+        }
+
+    def test_register_server_tools_injects_hermes_toolsets(self, mock_registry, mock_toolsets):
+        """Validates the extracted _register_server_tools handles hermes-* injection."""
+        server = MCPServerTask("my_srv")
+        server._tools = [_make_mcp_tool("my_tool", "desc")]
+        server.session = MagicMock()
+        
+        with patch("tools.registry.registry", mock_registry), \
+            patch("toolsets.create_custom_toolset") as mock_create, \
+            patch.dict("toolsets.TOOLSETS", mock_toolsets, clear=True):
+            
+            registered = _register_server_tools("my_srv", server, {})
+            
+        assert "mcp_my_srv_my_tool" in registered
+        assert "mcp_my_srv_my_tool" in mock_registry.get_all_tool_names()
+        
+        # Verify TOOLSETS injection
+        assert "mcp_my_srv_my_tool" in mock_toolsets["hermes-cli"]["tools"]
+        assert "mcp_my_srv_my_tool" in mock_toolsets["hermes-telegram"]["tools"]
+        assert "mcp_my_srv_my_tool" not in mock_toolsets["custom-toolset"]["tools"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_tools_nuke_and_repave(self, mock_registry, mock_toolsets):
+        """Verifies _refresh_tools removes old tools and registers new ones."""
+        server = MCPServerTask("live_srv")
+        server._refresh_lock = asyncio.Lock()
+        server._config = {}
+        
+        # New State reported by MCP
+        new_tool = _make_mcp_tool("new_tool", "new behavior")
+        
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(tools=[new_tool])
+            )
+        )
+        
+        # Initial State
+        server._registered_tool_names = ["mcp_live_srv_old_tool"]
+        mock_registry.register(
+            name="mcp_live_srv_old_tool", toolset="mcp-live_srv", schema={}, 
+            handler=lambda x: x, check_fn=lambda: True, is_async=False, description="", emoji=""
+        )
+        mock_toolsets["hermes-cli"]["tools"].append("mcp_live_srv_old_tool")
+        
+        # New State reported by MCP
+        
+        server.session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[new_tool])
+        )
+        
+        with patch("tools.registry.registry", mock_registry), \
+            patch("toolsets.create_custom_toolset"), \
+            patch.dict("toolsets.TOOLSETS", mock_toolsets, clear=True):
+                 
+            await server._refresh_tools()
+            
+        # Assert Old Tool is COMPLETELY gone
+        assert "mcp_live_srv_old_tool" not in mock_registry.get_all_tool_names()
+        assert "mcp_live_srv_old_tool" not in mock_toolsets["hermes-cli"]["tools"]
+        
+        # Assert New Tool is registered
+        assert "mcp_live_srv_new_tool" in mock_registry.get_all_tool_names()
+        assert "mcp_live_srv_new_tool" in mock_toolsets["hermes-cli"]["tools"]
+        assert server._registered_tool_names == ["mcp_live_srv_new_tool"]
+
+    @pytest.mark.asyncio
+    async def test_message_handler_dispatches_tool_list_changed(self):
+        from tools.mcp_tool import _MCP_NOTIFICATION_TYPES
+        if not _MCP_NOTIFICATION_TYPES:
+            pytest.skip("MCP SDK ToolListChangedNotification is not installed")
+
+        from mcp.types import ServerNotification, ToolListChangedNotification
+
+        server = MCPServerTask("notif_srv")
+
+        with patch.object(MCPServerTask, '_refresh_tools', new_callable=AsyncMock) as mock_refresh:
+            handler = server._make_message_handler()
+
+            notification = ServerNotification(
+                root=ToolListChangedNotification(method="notifications/tools/list_changed")
+            )
+
+            await handler(notification)
+            mock_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_message_handler_ignores_exceptions_and_other_messages(self):
+        server = MCPServerTask("notif_srv")
+
+        with patch.object(MCPServerTask, '_refresh_tools', new_callable=AsyncMock) as mock_refresh:
+            handler = server._make_message_handler()
+            
+            await handler(RuntimeError("connection dead"))
+            await handler({"jsonrpc": "2.0", "result": "ok"})
+            
+            mock_refresh.assert_not_awaited()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -83,9 +83,9 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-# Import the tool registry singleton
-from tools.registry import registry
-from toolsets import create_custom_toolset, TOOLSETS
+# Need lazy import for tools because registry singleton is patched during tests
+# from tools.registry import registry
+# from toolsets import create_custom_toolset, TOOLSETS
 
 # ---------------------------------------------------------------------------
 # Graceful import -- MCP SDK is an optional dependency
@@ -724,7 +724,7 @@ class MCPServerTask:
     __slots__ = (
         "name", "session", "tool_timeout",
         "_task", "_ready", "_shutdown_event", "_tools", "_error", "_config",
-        "_sampling", "_registered_tool_names",
+        "_sampling", "_registered_tool_names", "_refresh_lock"
     )
 
     def __init__(self, name: str):
@@ -739,6 +739,7 @@ class MCPServerTask:
         self._config: dict = {}
         self._sampling: Optional[SamplingHandler] = None
         self._registered_tool_names: list[str] = []
+        self._refresh_lock = asyncio.Lock()
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
@@ -858,18 +859,32 @@ class MCPServerTask:
 
     async def _refresh_tools(self):
         """Rediscover tools from the connected session, called by message_handler"""
+        from tools.registry import registry
+        from toolsets import TOOLSETS
+        
         async with self._refresh_lock:
-            # Step 1: fetch (async)
+            # Step 1: fetch new tool list (async)
             tools_result = await self.session.list_tools()
             new_mcp_tools = tools_result.tools if hasattr(tools_result, 'tools') else []
-            
-            # Step 2-6: deregister + re-register (all sync, no await)
+
+            # Step 2: remove old tool names from hermes-* toolsets (sync, no await)
+            for ts_name, ts in TOOLSETS.items():
+                if ts_name.startswith("hermes-"):
+                    ts["tools"] = [t for t in ts["tools"] if t not in self._registered_tool_names]
+
+            # Step 3: deregister old tools from registry
             for prefixed_name in self._registered_tool_names:
                 registry.deregister(prefixed_name)
-            
+
+            # Step 4: update state and re-register
             self._tools = new_mcp_tools
             self._registered_tool_names = _register_server_tools(
                 self.name, self, self._config
+            )
+
+            logger.info(
+                "MCP server '%s': dynamically refreshed %d tools",
+                self.name, len(self._registered_tool_names),
             )
     
     async def run(self, config: dict):
@@ -1494,6 +1509,9 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     Returns:
         List of registered prefixed tool names.
     """
+    
+    from tools.registry import registry
+    from toolsets import create_custom_toolset, TOOLSETS
     
     registered_names: List[str] = []
     toolset_name = f"mcp-{name}"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -70,6 +70,7 @@ Thread safety:
 """
 
 import asyncio
+import inspect
 import json
 import logging
 import math
@@ -82,6 +83,10 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+# Import the tool registry singleton
+from tools.registry import registry
+from toolsets import create_custom_toolset, TOOLSETS
+
 # ---------------------------------------------------------------------------
 # Graceful import -- MCP SDK is an optional dependency
 # ---------------------------------------------------------------------------
@@ -89,6 +94,8 @@ logger = logging.getLogger(__name__)
 _MCP_AVAILABLE = False
 _MCP_HTTP_AVAILABLE = False
 _MCP_SAMPLING_TYPES = False
+_MCP_NOTIFICATION_TYPES = False
+_MCP_MESSAGE_HANDLER_SUPPORTED = False
 try:
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
@@ -112,8 +119,37 @@ try:
         _MCP_SAMPLING_TYPES = True
     except ImportError:
         logger.debug("MCP sampling types not available -- sampling disabled")
+    try:
+        from mcp.types import (
+            ServerNotification,
+            ServerRequest,
+            ToolListChangedNotification,
+            PromptListChangedNotification,
+            ResourceListChangedNotification,
+        )
+        _MCP_NOTIFICATION_TYPES = True
+    except ImportError:
+        logger.debug("MCP Notification types not availiable -- Dynamic Tool change disabled ")
 except ImportError:
     logger.debug("mcp package not installed -- MCP tool support disabled")
+    
+
+# Check if client session supports message handler, done For backwards compatibility
+# This is ugly, but I have no idea what "older SDK version" needs to be supported, sorry
+def _client_session_supports_message_handler() -> bool:
+    try:
+        return "message_handler" in inspect.signature(ClientSession).parameters
+    except (TypeError, ValueError):
+        return False
+
+# Should only check if MCP imported successfully
+
+_MCP_MESSAGE_HANDLER_SUPPORTED = _MCP_AVAILABLE and _client_session_supports_message_handler()
+    
+if not _MCP_MESSAGE_HANDLER_SUPPORTED:
+    logger.debug("Current MCP sdk version does not support message handlers, dynamic mcp tool discovery not enabled")
+
+    
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -707,6 +743,42 @@ class MCPServerTask:
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
         return "url" in self._config
+    
+    # Need to guarentee handler to not block garbage collection if Clientsession
+    # outlives Server Task for some reason, it shouldn't, but use factory method
+    # just to be safe here (defensive programming)
+    def _make_message_handler(self):
+        server = self  # explicit closure reference
+        
+        # Refer to see mcp.client.session.MessageHandlerFnT
+        async def _handler(message: 'ServerRequest | ServerNotification | Exception'):
+            try:
+                if isinstance(message, Exception):
+                    logger.debug("MCP message handler saw exception: %s", message)
+                    return
+
+                if isinstance(message, ServerNotification):
+                    match message.root:
+                        case ToolListChangedNotification():
+                            logger.info(
+                                "MCP server '%s': received tools/list_changed notification",
+                                self.name,
+                            )
+                            await self._refresh_tools()
+                        
+                        # Deal with Resources/ prompt change notification later, low prio
+                        case PromptListChangedNotification():
+                            pass
+                        
+                        case ResourceListChangedNotification():
+                            pass
+                        
+                        case _:
+                            pass
+
+            except Exception:
+                logger.exception("Error in MCP message handler")
+        return _handler
 
     async def _run_stdio(self, config: dict):
         """Run the server using stdio transport."""
@@ -728,8 +800,13 @@ class MCPServerTask:
         )
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
+        message_handler = self._make_message_handler() if _MCP_NOTIFICATION_TYPES and _MCP_MESSAGE_HANDLER_SUPPORTED else None
+        kwargs = {**sampling_kwargs}
+        if message_handler is not None:
+            kwargs["message_handler"] = message_handler
+        
         async with stdio_client(server_params) as (read_stream, write_stream):
-            async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+            async with ClientSession(read_stream, write_stream, **kwargs) as session:
                 await session.initialize()
                 self.session = session
                 await self._discover_tools()
@@ -750,18 +827,24 @@ class MCPServerTask:
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
+        
+        message_handler = self._make_message_handler() if _MCP_NOTIFICATION_TYPES and _MCP_MESSAGE_HANDLER_SUPPORTED else None
+        kwargs = {**sampling_kwargs}
+        if message_handler is not None:
+            kwargs["message_handler"] = message_handler
+            
         async with streamablehttp_client(
             url,
             headers=headers,
             timeout=float(connect_timeout),
         ) as (read_stream, write_stream, _get_session_id):
-            async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+            async with ClientSession(read_stream, write_stream, **kwargs) as session:
                 await session.initialize()
                 self.session = session
                 await self._discover_tools()
                 self._ready.set()
                 await self._shutdown_event.wait()
-
+    
     async def _discover_tools(self):
         """Discover tools from the connected session."""
         if self.session is None:
@@ -773,6 +856,22 @@ class MCPServerTask:
             else []
         )
 
+    async def _refresh_tools(self):
+        """Rediscover tools from the connected session, called by message_handler"""
+        async with self._refresh_lock:
+            # Step 1: fetch (async)
+            tools_result = await self.session.list_tools()
+            new_mcp_tools = tools_result.tools if hasattr(tools_result, 'tools') else []
+            
+            # Step 2-6: deregister + re-register (all sync, no await)
+            for prefixed_name in self._registered_tool_names:
+                registry.deregister(prefixed_name)
+            
+            self._tools = new_mcp_tools
+            self._registered_tool_names = _register_server_tools(
+                self.name, self, self._config
+            )
+    
     async def run(self, config: dict):
         """Long-lived coroutine: connect, discover tools, wait, disconnect.
 
@@ -1386,35 +1485,19 @@ def _existing_tool_names() -> List[str]:
             names.append(schema["name"])
     return names
 
-
-async def _discover_and_register_server(name: str, config: dict) -> List[str]:
-    """Connect to a single MCP server, discover tools, and register them.
-
-    Also registers utility tools for MCP Resources and Prompts support
-    (list_resources, read_resource, list_prompts, get_prompt).
-
-    Returns list of registered tool names.
+def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> List[str]:
+    """Register tools from an already-connected server into the registry.
+    
+    Handles include/exclude filtering, utility tools, toolset creation,
+    and hermes-* injection.
+    
+    Returns:
+        List of registered prefixed tool names.
     """
-    from tools.registry import registry
-    from toolsets import create_custom_toolset
-
-    connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
-    server = await asyncio.wait_for(
-        _connect_server(name, config),
-        timeout=connect_timeout,
-    )
-    with _lock:
-        _servers[name] = server
-
+    
     registered_names: List[str] = []
     toolset_name = f"mcp-{name}"
 
-    # Selective tool loading: honour include/exclude lists from config.
-    # Rules (matching issue #690 spec):
-    #   tools.include — whitelist: only these tool names are registered
-    #   tools.exclude — blacklist: all tools EXCEPT these are registered
-    #   include takes precedence over exclude
-    #   Neither set → register all tools (backward-compatible default)
     tools_filter = config.get("tools") or {}
     include_set = _normalize_name_filter(tools_filter.get("include"), f"mcp_servers.{name}.tools.include")
     exclude_set = _normalize_name_filter(tools_filter.get("exclude"), f"mcp_servers.{name}.tools.exclude")
@@ -1430,6 +1513,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         if not _should_register(mcp_tool.name):
             logger.debug("MCP server '%s': skipping tool '%s' (filtered by config)", name, mcp_tool.name)
             continue
+        
         schema = _convert_mcp_schema(name, mcp_tool)
         tool_name_prefixed = schema["name"]
 
@@ -1444,8 +1528,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         )
         registered_names.append(tool_name_prefixed)
 
-    # Register MCP Resources & Prompts utility tools, filtered by config and
-    # only when the server actually supports the corresponding capability.
+    # Register MCP Resources & Prompts utility tools
     _handler_factories = {
         "list_resources": _make_list_resources_handler,
         "read_resource": _make_read_resource_handler,
@@ -1469,8 +1552,6 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         )
         registered_names.append(schema["name"])
 
-    server._registered_tool_names = list(registered_names)
-
     # Create a custom toolset so these tools are discoverable
     if registered_names:
         create_custom_toolset(
@@ -1478,6 +1559,29 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
             description=f"MCP tools from {name} server",
             tools=registered_names,
         )
+        
+        # Dynamically inject into all hermes-* platform toolsets
+        for ts_name, ts in TOOLSETS.items():
+            if ts_name.startswith("hermes-"):
+                for tool_name in registered_names:
+                    if tool_name not in ts["tools"]:
+                        ts["tools"].append(tool_name)
+
+    return registered_names
+
+async def _discover_and_register_server(name: str, config: dict) -> List[str]:
+    """Connect to a single MCP server, discover tools, and register them."""
+    connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+    server = await asyncio.wait_for(
+        _connect_server(name, config),
+        timeout=connect_timeout,
+    )
+    with _lock:
+        _servers[name] = server
+        
+    # Delegate the synchronous registration logic
+    registered_names = _register_server_tools(name, server, config)
+    server._registered_tool_names = list(registered_names)
 
     transport_type = "HTTP" if "url" in config else "stdio"
     logger.info(
@@ -1486,7 +1590,6 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         ", ".join(registered_names),
     )
     return registered_names
-
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -1570,7 +1673,8 @@ def discover_mcp_tools() -> List[str]:
                 for tool_name in all_tools:
                     if tool_name not in ts["tools"]:
                         ts["tools"].append(tool_name)
-
+    # Moved Dynamic injection of platform toolsets to _register_server_tools
+    
     # Print summary
     total_servers = len(new_servers)
     ok_servers = total_servers - failed_count

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -80,9 +80,24 @@ class ToolRegistry:
         if check_fn and toolset not in self._toolset_checks:
             self._toolset_checks[toolset] = check_fn
 
+    
+    # ------------------------------------------------------------------
+    # Deregister tools (for dynamic tool discovery)
+    # ------------------------------------------------------------------
+    
+    def deregister(self, name: str):
+        """Remove a tool from the registry."""
+        if name in self._tools:
+            entry = self._tools.pop(name)
+            # Also remove from toolset check if it was the last tool
+            if entry.toolset not in [e.toolset for e in self._tools.values()]:
+                self._toolset_checks.pop(entry.toolset, None)
+            logger.debug("Deregistered tool: %s", name)
+    
     # ------------------------------------------------------------------
     # Schema retrieval
     # ------------------------------------------------------------------
+    
 
     def get_definitions(self, tool_names: Set[str], quiet: bool = False) -> List[dict]:
         """Return OpenAI-format tool schemas for the requested tool names.
@@ -152,6 +167,10 @@ class ToolRegistry:
     def get_tool_to_toolset_map(self) -> Dict[str, str]:
         """Return ``{tool_name: toolset_name}`` for every registered tool."""
         return {name: e.toolset for name, e in self._tools.items()}
+    
+    def has_tool(self, name: str) -> bool:
+        """Checks whether or not a tool exists"""
+        return name in self._tools
 
     def is_toolset_available(self, toolset: str) -> bool:
         """Check if a toolset's requirements are met.


### PR DESCRIPTION
## What does this PR do?

Implements dynamic MCP tool discovery. 

Previously, tools from MCP servers were registered once at startup and never updated. 
If a server's tool list changed mid-session, the agent had no way to see the additions or removals until it was restarted.

This PR adds support for the MCP `notifications/tools/list_changed` notification ([defined in the MCP spec](https://modelcontextprotocol.info/specification/draft/server/tools/#list-changed-notification)). 

When a connected server sends this notification, Hermes will now
- Re-fetch the tool list from that server
- Remove any tools that are no longer present from the registry and all active toolsets,
- Registers any newly available tools, 

Without the need to restart.

Backwards-compatible: if the installed MCP SDK version does not support `message_handler` or the notification types, the feature silently degrades to the existing static-discovery behavior. No polling is involved.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [X] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`tools/registry.py`**
- Added `ToolRegistry.deregister(name)`: removes a tool from `_tools` and
  cleans up its toolset entry from `_toolset_checks` if it was the last tool
  in that toolset. Required for the nuke-and-repave refresh strategy.
- Added `ToolRegistry.has_tool(name) -> bool`: simple existence check by
  name, used internally during refresh.

**`tools/mcp_tool.py`**
- Added two new import guards: 
    - `_MCP_NOTIFICATION_TYPES` 
        - (controls whether `ToolListChangedNotification` and `ServerNotification` are available from the SDK)
    - `_MCP_MESSAGE_HANDLER_SUPPORTED` 
        - (inspects `ClientSession`'s constructor signature to determine if the installed SDK version accepts a `message_handler` kwarg). 
    - Both degrade gracefully to `False` on older SDK versions.
  
- Extracted `_register_server_tools(name, server, config) -> List[str]`: a 
  synchronous helper that encapsulates all post-connection registration 
  logic previously duplicated inside `_discover_and_register_server`. 
  
  Handles include/exclude filtering, utility tool registration, custom toolset
  creation, and injection into `hermes-*` platform toolsets. 

  Both the initial discovery path and the refresh path now call this single function, 
  ensuring they stay in sync.
- Simplified `_discover_and_register_server`: now just connects to the server
  and delegates to `_register_server_tools`, removing the duplicated
  registration logic.
- Added `_refresh_lock: asyncio.Lock` to `MCPServerTask.__slots__` and
  `__init__`: prevents overlapping refresh coroutines when a server sends
  multiple `list_changed` notifications in rapid succession.
- Added `MCPServerTask._make_message_handler()`: factory method that returns
  a `MessageHandlerFnT`-compatible coroutine. Dispatches on notification type
  using a `match` statement. Triggers `_refresh_tools()` on
  `ToolListChangedNotification`. `PromptListChangedNotification` and
  `ResourceListChangedNotification` are handled as no-ops for now (stubs for
  future work). Uses a factory rather than a bound method to make the closure
  explicit and avoid any GC dependency on the session outliving the task.
- Added `MCPServerTask._refresh_tools()`: the core refresh coroutine. Under
  `_refresh_lock`, fetches the new tool list, removes old tool names from
  all `hermes-*` toolsets, calls `registry.deregister()` for each previously
  registered tool, then calls `_register_server_tools()` to register the
  current tool list from scratch. All mutations after the initial `await` are
  synchronous, making the update atomic from the event loop's perspective.
- Wired `message_handler` into both `_run_stdio` and `_run_http`: the kwarg
  is only included in the `ClientSession` constructor call when both
  `_MCP_NOTIFICATION_TYPES` and `_MCP_MESSAGE_HANDLER_SUPPORTED` are `True`.

**`tests/tools/test_mcp_dynamic_discovery.py`** *(new file)*
- `test_register_server_tools_injects_hermes_toolsets`: verifies that
  `_register_server_tools` writes into `hermes-*` toolsets and skips
  non-hermes ones.
- `test_refresh_tools_nuke_and_repave`: verifies the full refresh cycle —
  old tools are removed from both the registry and `hermes-*` toolsets, new
  tools are registered in both, and `_registered_tool_names` reflects the
  new state.
- `test_message_handler_dispatches_tool_list_changed`: verifies that a
  `ToolListChangedNotification` arriving via the message handler triggers
  `_refresh_tools`. Skipped automatically if the MCP SDK does not export the
  required notification types.
- `test_message_handler_ignores_exceptions_and_other_messages`: verifies the
  handler does not call `_refresh_tools` on exceptions or unrecognized
  message types, and does not raise.

## How to Test

Run the new test file:
```
pytest tests/tools/test_mcp_dynamic_discovery.py -v
```

Or test end-to-end with the GitHub MCP server, which uses deferred/dynamic
toolsets and is a real-world case that triggered this feature:

```yaml
# ~/.hermes/config.yaml
mcp_servers:
  github:
    command: "docker"
    args:
      - "run"
      - "-i"
      - "--rm"
      - "-e"
      - "GITHUB_PERSONAL_ACCESS_TOKEN"
      - "-e"
      - "GITHUB_DYNAMIC_TOOLSETS"
      - "ghcr.io/github/github-mcp-server"
    env:
      GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_YOUR_TOKEN_HERE"
      GITHUB_DYNAMIC_TOOLSETS: "1"
```

With `GITHUB_DYNAMIC_TOOLSETS=1`, the GitHub MCP server starts with a minimal
tool set and sends `notifications/tools/list_changed` as the agent interacts
with it. Without this PR, those additional tools are never registered.

## Checklist

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

This change is not user-visible in a way that requires documentation updates. `mcp_servers` config format is unchanged. 

The feature activates automatically when the server sends the appropriate notification; no new config keys are needed. If a server does not send `notifications/tools/list_changed`, behavior is identical to before this PR.


