### PR TITLE
fix: allow agent-created skills with caution-level findings

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -154,6 +154,34 @@ class TestShouldAllowInstall:
         assert allowed is True
         assert "Force-installed" in reason
 
+    # -- agent-created policy --
+
+    def test_safe_agent_created_allowed(self):
+        allowed, _ = should_allow_install(self._result("agent-created", "safe"))
+        assert allowed is True
+
+    def test_caution_agent_created_allowed(self):
+        """Agent-created skills with caution verdict (e.g. docker refs) should pass."""
+        f = [Finding("docker_pull", "medium", "supply_chain", "SKILL.md", 1, "docker pull img", "pulls Docker image")]
+        allowed, reason = should_allow_install(self._result("agent-created", "caution", f))
+        assert allowed is True
+        assert "agent-created" in reason
+
+    def test_dangerous_agent_created_blocked(self):
+        """Agent-created skills with dangerous verdict (critical findings) stay blocked."""
+        f = [Finding("env_exfil_curl", "critical", "exfiltration", "SKILL.md", 1, "curl $TOKEN", "exfiltration")]
+        allowed, reason = should_allow_install(self._result("agent-created", "dangerous", f))
+        assert allowed is False
+        assert "Blocked" in reason
+
+    def test_force_overrides_dangerous_for_agent_created(self):
+        f = [Finding("x", "critical", "c", "f", 1, "m", "d")]
+        allowed, reason = should_allow_install(
+            self._result("agent-created", "dangerous", f), force=True
+        )
+        assert allowed is True
+        assert "Force-installed" in reason
+
 
 # ---------------------------------------------------------------------------
 # scan_file — pattern detection

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -43,7 +43,7 @@ INSTALL_POLICY = {
     "builtin":       ("allow",  "allow",   "allow"),
     "trusted":       ("allow",  "allow",   "block"),
     "community":     ("allow",  "block",   "block"),
-    "agent-created": ("allow",  "block",   "block"),
+    "agent-created": ("allow",  "allow",   "block"),
 }
 
 VERDICT_INDEX = {"safe": 0, "caution": 1, "dangerous": 2}


### PR DESCRIPTION
## Problem

Agent-created skills (via skill_manage) were blocked by the security scanner whenever they contained references to Docker, pip install, git clone, or similar common tools. The agent-created trust level had the same restrictive policy as community hub installs: any finding at medium severity or above -> caution verdict -> blocked.

## Fix

Changed the agent-created install policy from (allow, block, block) to (allow, allow, block) -- matching the trusted policy. Caution-level findings are now allowed through while dangerous findings (critical severity like exfiltration, prompt injection, reverse shells) remain blocked.

## Tests

Added 4 tests for agent-created policy coverage. All 61 guard tests pass.