### PR TITLE
fix: delegate_task NameError — _saved_tool_names scope

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -173,10 +173,6 @@ def _build_child_agent(
     from run_agent import AIAgent
     import model_tools
 
-    # Save the parent's resolved tool names before the child agent can
-    # overwrite the process-global via get_tool_definitions().
-    _saved_tool_names = list(model_tools._last_resolved_tool_names)
-
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
     if toolsets:
@@ -258,7 +254,13 @@ def _run_single_child(
     Run a pre-built child agent. Called from within a thread.
     Returns a structured result dict.
     """
+    import model_tools
+
     child_start = time.monotonic()
+
+    # Save the parent's resolved tool names before the child agent can
+    # overwrite the process-global via get_tool_definitions().
+    _saved_tool_names = list(model_tools._last_resolved_tool_names)
 
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, 'tool_progress_callback', None)


### PR DESCRIPTION
## Summary
Fixes #1802. Moves the save/restore of `_last_resolved_tool_names` into `_run_single_child()` where it belongs.

## Problem
`_saved_tool_names` was defined as a local variable in `_build_child_agent()` (line 178) but referenced in `_run_single_child()` (line 375) — a completely separate function scope. Every `delegate_task` call hit a `NameError` in the `finally` block. 100% reproducible, not intermittent.

## Fix
Move the save into `_run_single_child()` at the top of the function, so it shares scope with the `finally` restore. Remove the orphaned save from `_build_child_agent()`. Two-line change.

## Why tests missed it
The test suite mocks `_run_single_child` in most integration tests, so the real `finally` block never fires.