### PR TITLE
fix(security): sanitize env and redact output in quick commands + remove write-only _pending_messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1328,10 +1328,9 @@ class GatewayRunner:
             running_agent = self._running_agents[_quick_key]
             logger.debug("PRIORITY interrupt for session %s", _quick_key[:20])
             running_agent.interrupt(event.text)
-            if _quick_key in self._pending_messages:
-                self._pending_messages[_quick_key] += "\n" + event.text
-            else:
-                self._pending_messages[_quick_key] = event.text
+            # NOTE: self._pending_messages was write-only (never consumed).
+            # The actual interrupt message is delivered via adapter._pending_messages
+            # which is read by _run_agent. Removed to prevent unbounded growth.
             return None
         
         # Check for commands
@@ -1452,13 +1451,23 @@ class GatewayRunner:
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            # Sanitize env to prevent credential leakage —
+                            # quick commands run in the gateway process which
+                            # has all API keys in os.environ.
+                            from tools.environments.local import _sanitize_subprocess_env
+                            sanitized_env = _sanitize_subprocess_env(os.environ.copy())
                             proc = await asyncio.create_subprocess_shell(
                                 exec_cmd,
                                 stdout=asyncio.subprocess.PIPE,
                                 stderr=asyncio.subprocess.PIPE,
+                                env=sanitized_env,
                             )
                             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
                             output = (stdout or stderr).decode().strip()
+                            # Redact any remaining sensitive patterns in output
+                            if output:
+                                from agent.redact import redact_sensitive_text
+                                output = redact_sensitive_text(output)
                             return output if output else "Command returned no output."
                         except asyncio.TimeoutError:
                             return "Quick command timed out (30s)."

--- a/tests/test_quick_commands.py
+++ b/tests/test_quick_commands.py
@@ -1,4 +1,5 @@
 """Tests for user-defined quick commands that bypass the agent loop."""
+import os
 import subprocess
 from unittest.mock import MagicMock, patch, AsyncMock
 from rich.text import Text
@@ -139,6 +140,41 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_exec_command_does_not_leak_credentials(self):
+        """Quick command exec must sanitize env — API keys must not appear in output."""
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"leak": {"type": "exec", "command": "env"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("leak")
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-secret-12345"}):
+            result = await runner._handle_message(event)
+
+        assert "sk-or-secret-12345" not in result, \
+            "Quick command leaked OPENROUTER_API_KEY — exec runs without env sanitization"
+
+    @pytest.mark.asyncio
+    async def test_exec_command_output_is_redacted(self):
+        """Quick command output must redact sensitive patterns before returning."""
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"token": {"type": "exec", "command": "echo sk-ant-api03-supersecretkey1234567890"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("token")
+        result = await runner._handle_message(event)
+
+        assert "supersecretkey1234567890" not in result, \
+            "Quick command output not redacted — raw API key returned to user"
 
     @pytest.mark.asyncio
     async def test_unsupported_type_returns_error(self):


### PR DESCRIPTION
## Summary

1. **Quick command exec leaks credentials** — `type: exec` quick commands ran via `create_subprocess_shell()` in the gateway process's full environment. Unlike terminal_tool (which uses `_sanitize_subprocess_env`), quick commands had no env filtering or output redaction. A command like `env` would return all API keys and bot tokens to the chat.

   Fix: apply `_sanitize_subprocess_env()` before exec and `redact_sensitive_text()` on output.

2. **`_pending_messages` write-only memory leak** — `GatewayRunner._pending_messages` was appended on every interrupt but never read. The actual interrupt delivery uses `adapter._pending_messages` (separate dict). Removed the dead writes to prevent unbounded growth.

## Test plan

- [x] `test_exec_command_does_not_leak_credentials` — sets OPENROUTER_API_KEY in env, runs `env`, verifies key not in output
- [x] `test_exec_command_output_is_redacted` — command outputs API key pattern, verifies redacted
- [x] 19 existing quick command + gateway tests pass, 0 regressions