### PR TITLE
fix: add /browser to COMMAND_REGISTRY for help + autocomplete

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3560,7 +3560,7 @@ class HermesCLI:
         elif canonical == "reload-mcp":
             with self._busy_command(self._slow_command_status(cmd_original)):
                 self._reload_mcp()
-        elif _base_word == "browser":
+        elif canonical == "browser":
             self._handle_browser_command(cmd_original)
         elif canonical == "plugins":
             try:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -104,6 +104,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove")),
     CommandDef("reload-mcp", "Reload MCP servers from config", "Tools & Skills",
                aliases=("reload_mcp",)),
+    CommandDef("browser", "Connect browser tools to your live Chrome via CDP", "Tools & Skills",
+               cli_only=True, args_hint="[connect|disconnect|status]",
+               subcommands=("connect", "disconnect", "status")),
     CommandDef("plugins", "List installed plugins and their status",
                "Tools & Skills", cli_only=True),
 


### PR DESCRIPTION
The /browser command handler existed in cli.py (from PR #1549) but was never added to COMMAND_REGISTRY after the centralized command registry refactor (#1603). This meant /browser didn't appear in /help, had no tab-completion, and dispatched via _base_word fallback.

Adds CommandDef with connect/disconnect/status subcommands and switches dispatch to canonical.