### PR TITLE
Improve gateway error handling for 429 usage limits and 500 context overflow

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2122,23 +2122,41 @@ class GatewayRunner:
             error_detail = str(e)[:300] if str(e) else "no details available"
             status_hint = ""
             status_code = getattr(e, "status_code", None)
+            _hist_len = len(history) if 'history' in locals() else 0
             if status_code == 401:
                 status_hint = " Check your API key or run `claude /login` to refresh OAuth credentials."
             elif status_code == 429:
-                status_hint = " You are being rate-limited. Please wait a moment and try again."
+                # Check if this is a plan usage limit (resets on a schedule) vs a transient rate limit
+                _err_body = getattr(e, "response", None)
+                _err_json = {}
+                try:
+                    if _err_body is not None:
+                        _err_json = _err_body.json().get("error", {})
+                except Exception:
+                    pass
+                if _err_json.get("type") == "usage_limit_reached":
+                    _resets_in = _err_json.get("resets_in_seconds")
+                    if _resets_in and _resets_in > 0:
+                        import math
+                        _hours = math.ceil(_resets_in / 3600)
+                        status_hint = f" Your plan's usage limit has been reached. It resets in ~{_hours}h."
+                    else:
+                        status_hint = " Your plan's usage limit has been reached. Please wait until it resets."
+                else:
+                    status_hint = " You are being rate-limited. Please wait a moment and try again."
             elif status_code == 529:
                 status_hint = " The API is temporarily overloaded. Please try again shortly."
-            elif status_code == 400:
-                # 400 with a large session is almost always a context overflow.
-                # Give specific guidance instead of a generic error. (#1630)
-                _hist_len = len(history) if 'history' in locals() else 0
+            elif status_code in (400, 500):
+                # 400 with a large session is context overflow.
+                # 500 with a large session often means the payload is too large
+                # for the API to process — treat it the same way.
                 if _hist_len > 50:
                     return (
                         "⚠️ Session too large for the model's context window.\n"
                         "Use /compact to compress the conversation, or "
                         "/reset to start fresh."
                     )
-                else:
+                elif status_code == 400:
                     status_hint = " The request was rejected by the API."
             return (
                 f"Sorry, I encountered an error ({error_type}).\n"


### PR DESCRIPTION
- Distinguish plan usage limits (429 with usage_limit_reached) from transient rate limits
- Show approximate reset time in hours for plan limits
- Treat HTTP 500 with large sessions as context overflow (same as 400)
- Move history length check earlier for reuse across status codes

What does this PR do?

Improves error handling in the gateway's main exception handler for two common failure modes that currently give users unhelpful messages:

1. When users hit their API plan's usage limit (e.g. Anthropic's monthly token cap), they get a generic "You are being rate-limited" message. This is misleading — transient rate limits resolve in seconds, but plan limits reset on a schedule (hours). This PR parses the 429 response body for the usage_limit_reached error type and shows a specific message with approximate reset time.

2. Some API providers return HTTP 500 instead of 400 when the conversation payload is too large. The existing code only handled 400 for the "session too large" suggestion (/compact or /reset), so 500 errors on large sessions gave a generic unhelpful message. This extends the large-session detection to cover 500 as well.

Related Issue

No existing upstream issue found. Searched for: 429, rate limit, usage limit, 500 context overflow, gateway error handling.

Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

Changes Made

- gateway/run.py: Parse 429 response body for usage_limit_reached error type, extract resets_in_seconds, show human-friendly reset time
- gateway/run.py: Extend large-session context overflow detection (history > 50) to HTTP 500 in addition to 400
- gateway/run.py: Move _hist_len computation before status code checks so it's available for both 400 and 500 handlers

How to Test

1. Trigger a plan usage limit 429 (e.g. exceed Anthropic monthly cap) — should see "Your plan's usage limit has been reached. It resets in ~Xh." instead of generic rate limit message
2. Trigger a transient 429 — should still see "You are being rate-limited. Please wait a moment and try again."
3. Build up a conversation with 50+ messages and trigger a 500 from the API — should see the /compact or /reset suggestion instead of a generic error

Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A