### PR TITLE
fix: include ACP sessions in default session_search sources

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -758,7 +758,7 @@ class SessionDB:
             return []
 
         if source_filter is None:
-            source_filter = ["cli", "telegram", "discord", "whatsapp", "slack"]
+            source_filter = ["cli", "telegram", "discord", "whatsapp", "slack", "acp"]
 
         # Build WHERE clauses dynamically
         where_clauses = ["messages_fts MATCH ?"]

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -210,6 +210,14 @@ class TestFTS5Search:
         sources = [r["source"] for r in results]
         assert all(s == "telegram" for s in sources)
 
+    def test_search_default_sources_include_acp(self, db):
+        db.create_session(session_id="s1", source="acp")
+        db.append_message("s1", role="user", content="ACP question about Python")
+
+        results = db.search_messages("Python")
+        sources = [r["source"] for r in results]
+        assert "acp" in sources
+
     def test_search_with_role_filter(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="What is FastAPI?")


### PR DESCRIPTION
## Summary
- add `acp` to the default source filter for session message search
- add a regression test covering ACP sessions in default search results

## Test Plan
- [x] \.venv/bin/pytest tests/test_hermes_state.py -q

This fixes `session_search` excluding ACP sessions by default.