### PR TITLE
feat(audit): structured JSONL + SQLite audit log (closes #1155)

### DIFF
--- a/agent/audit.py
+++ b/agent/audit.py
@@ -1,0 +1,981 @@
+"""Structured audit log for Hermes Agent.
+
+Writes JSONL (one JSON object per line) to ~/.hermes/logs/audit/ with
+per-session files.  Designed for ``tail -f`` in a second terminal:
+
+    tail -f ~/.hermes/logs/audit/latest.jsonl | jq .
+
+Events are categorized by type using a dotted namespace convention:
+
+    session.start    -- session created (model, provider, platform, tools)
+    session.end      -- session ended (duration, token totals, cost)
+    api.request      -- LLM API call (model, provider, tokens, cost, duration)
+    tool.call        -- tool invoked (name, detail, result summary, duration)
+    tool.error       -- tool execution failed (name, error)
+    cli.launch       -- CLI started (model, session, toolsets)
+    context.*        -- context assembly and compression events
+    memory.*         -- local memory operations
+    honcho.*         -- honcho/memory operations
+    cron.*           -- cron job executions
+    mcp.*            -- MCP server/tool events
+    skill.*          -- skill load/manage events
+    plugin.*         -- external plugin events
+
+The source is derived from the event type prefix (text before the first
+dot).  Each source can be independently enabled/disabled via the
+``audit.sources`` config block:
+
+    audit:
+      sources:
+        core: true      # session, api, tool, cli, context events
+        honcho: true    # honcho.* events
+        memory: true    # memory.* events
+        cron: true      # cron.* events
+        mcp: true       # MCP tool/server events
+        skill: true     # skill load/manage events
+        plugin: true    # external plugin events
+
+Writes are async (background thread with queue) to avoid blocking the agent.
+
+Config (config.yaml):
+
+    audit:
+      enabled: true              # master switch (default: true)
+      redact: true               # redact sensitive args (default: true)
+      retention_days: 30         # auto-clean logs older than N days (0 = keep forever)
+      jsonl: true                # write JSONL files for hermes tail
+      sources: {...}             # per-source enable/disable (all true by default)
+"""
+
+import json
+import os
+import queue
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+_HERMES_HOME = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+_AUDIT_DIR = _HERMES_HOME / "logs" / "audit"
+_LATEST_LINK = _AUDIT_DIR / "latest.jsonl"
+
+# Module-level state
+_log_file = None
+_log_path: Optional[Path] = None
+_session_id: Optional[str] = None
+_enabled: Optional[bool] = None
+_redact: bool = True
+_retention_days: int = 30
+
+# SQLite audit DB (SessionDB instance, shared with hermes_state)
+_db = None  # type: Any  # SessionDB | None
+_user_id: Optional[str] = None
+_platform: Optional[str] = None
+
+# Per-source enable/disable (all True by default).
+# Keys are source names; values are booleans.
+_sources: Dict[str, bool] = {}
+
+# Async write queue + worker
+_write_queue: queue.Queue = queue.Queue()
+_writer_thread: Optional[threading.Thread] = None
+_writer_stop = threading.Event()
+
+# Prefixes that map to the "core" source.  Everything else uses its own
+# prefix as the source name (honcho.* → "honcho", cron.* → "cron", etc.).
+_CORE_PREFIXES = frozenset({
+    "session", "api", "tool", "cli", "context", "user",
+})
+
+
+# Keys whose values should be redacted when audit_log_redact is true
+_SENSITIVE_KEYS = frozenset({
+    "password", "secret", "token", "api_key", "apikey",
+    "authorization", "credential", "private_key",
+})
+
+
+def _resolve_source(event_type: str) -> str:
+    """Derive the audit source from an event type string.
+
+    Core events (session.*, api.*, tool.*, cli.*, context.*) map to
+    ``"core"``.  Everything else uses the prefix before the first dot
+    (e.g. ``"honcho.operation"`` → ``"honcho"``).
+
+    Unknown or un-dotted types default to ``"core"``.
+    """
+    prefix = event_type.split(".", 1)[0] if "." in event_type else event_type
+    if prefix in _CORE_PREFIXES:
+        return "core"
+    return prefix
+
+
+def _source_enabled(event_type: str) -> bool:
+    """Return True if the source for *event_type* is enabled.
+
+    When no sources dict is configured (the default), everything is
+    enabled.  When a sources dict is present, missing keys default True
+    so new sources are opt-out rather than opt-in.
+    """
+    if not _sources:
+        return True
+    source = _resolve_source(event_type)
+    return _sources.get(source, True)
+
+
+def _matches_source_filter(event_type: str, source: Optional[str]) -> bool:
+    """Return True if *event_type* matches the requested *source* filter.
+
+    ``source=None`` means no filtering.  The matching logic uses the same
+    source derivation as ``_resolve_source`` so old records without an
+    explicit ``source`` field still filter correctly.
+    """
+    if not source:
+        return True
+    return _resolve_source(event_type) == source
+
+
+def _should_redact(key: str) -> bool:
+    return _redact and key.lower() in _SENSITIVE_KEYS
+
+
+def _sanitize_args(args: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of args with sensitive values replaced."""
+    if not _redact or not isinstance(args, dict):
+        return args
+    out = {}
+    for k, v in args.items():
+        if _should_redact(k):
+            out[k] = "[REDACTED]"
+        elif isinstance(v, str) and len(v) > 2000:
+            out[k] = v[:2000] + f"... ({len(v)} chars)"
+        else:
+            out[k] = v
+    return out
+
+
+def _sanitize_result(result: str, max_len: int = 2000) -> str:
+    """Truncate long results for readability."""
+    if not isinstance(result, str):
+        result = str(result)
+    if len(result) > max_len:
+        return result[:max_len] + f"... ({len(result)} chars)"
+    return result
+
+
+def is_enabled() -> bool:
+    """Return True if audit logging is active."""
+    return _enabled is True and _log_file is not None
+
+
+def emit(event_type: str, **kwargs) -> None:
+    """General-purpose audit event emitter.
+
+    Any subsystem can call this to log an event.  The event_type is a
+    dotted string (e.g. 'memory.loaded', 'honcho.operation',
+    'mcp.tool_call') and kwargs become the JSON payload.
+
+    The source is derived from the event type prefix (see
+    ``_resolve_source``).  If the source is disabled via the
+    ``audit.sources`` config block, the event is silently dropped.
+
+    Values that look sensitive are auto-redacted.  Long strings are
+    truncated.  This is the primary interface — the specialised
+    log_*() helpers are thin wrappers around this.
+    """
+    if not is_enabled():
+        return
+    if not _source_enabled(event_type):
+        return
+    # Light sanitisation: redact known-sensitive keys, truncate long values
+    safe = {}
+    for k, v in kwargs.items():
+        if _should_redact(k):
+            safe[k] = "[REDACTED]"
+        elif isinstance(v, str) and len(v) > 2000:
+            safe[k] = v[:2000] + f"... ({len(v)} chars)"
+        elif isinstance(v, dict):
+            safe[k] = _sanitize_args(v)
+        else:
+            safe[k] = v
+    _write(event_type, **safe)
+
+
+def configure(*, enabled: bool = False, redact: bool = True, retention_days: int = 30,
+              user_id: Optional[str] = None, platform: Optional[str] = None,
+              sources: Optional[Dict[str, bool]] = None) -> None:
+    """Set module-level config.  Called once at session start.
+
+    ``sources`` is an optional dict mapping source names to booleans.
+    When provided, only events whose source is enabled will be written.
+    Missing keys default to ``True`` (opt-out, not opt-in).  Example::
+
+        configure(enabled=True, sources={"core": True, "mcp": False})
+    """
+    global _enabled, _redact, _retention_days, _user_id, _platform, _db, _sources
+    _enabled = enabled
+    _redact = redact
+    _retention_days = retention_days
+    if user_id is not None:
+        _user_id = user_id
+    if platform is not None:
+        _platform = platform
+    if sources is not None and isinstance(sources, dict):
+        _sources = sources
+    else:
+        _sources = {}
+    # Reset DB reference when disabled so tests/reconfigure get clean state
+    if not enabled:
+        _db = None
+
+
+def start_session(session_id: str, *, user_id: Optional[str] = None,
+                  platform: Optional[str] = None, **metadata) -> None:
+    """Open the audit log file for a new session.
+
+    Idempotent: if the log file is already open for this session_id, this
+    is a no-op.  This allows both the CLI (early init) and AIAgent.__init__
+    to call start_session without double-opening files or writer threads.
+    """
+    global _log_file, _log_path, _session_id, _writer_thread, _db
+
+    if not _enabled:
+        return
+
+    # Already running for this session — nothing to do.
+    if _log_file is not None and _session_id == session_id:
+        return
+
+    _session_id = session_id
+    _AUDIT_DIR.mkdir(parents=True, exist_ok=True)
+
+    _rotate_logs()
+
+    log_path = _AUDIT_DIR / f"{session_id}.jsonl"
+    _log_path = log_path
+    _log_file = open(log_path, "a", encoding="utf-8", buffering=1)
+
+    # Update the "latest" symlink
+    try:
+        if _LATEST_LINK.is_symlink() or _LATEST_LINK.exists():
+            _LATEST_LINK.unlink()
+        _LATEST_LINK.symlink_to(log_path.name)
+    except OSError:
+        pass
+
+    # Initialize SQLite audit DB (in the audit dir alongside JSONL files)
+    try:
+        if _db is None:
+            from hermes_state import SessionDB
+            audit_db_path = _AUDIT_DIR / "audit.db"
+            _db = SessionDB(audit_db_path)
+    except Exception:
+        pass  # SQLite unavailable — JSONL-only mode
+
+    # Store user_id / platform from params or module defaults
+    if user_id is not None:
+        metadata["user_id"] = user_id
+    elif _user_id is not None:
+        metadata["user_id"] = _user_id
+    if platform is not None:
+        metadata["platform"] = platform
+    elif _platform is not None:
+        metadata["platform"] = _platform
+
+    # Start async writer thread
+    _writer_stop.clear()
+    _writer_thread = threading.Thread(target=_writer_loop, daemon=True)
+    _writer_thread.start()
+
+    _write("session.start", session_id=session_id, **metadata)
+
+
+def end_session(**metadata) -> Optional[Path]:
+    """Close the audit log for the current session.  Returns the log file path."""
+    global _log_file, _writer_thread
+    if not is_enabled():
+        return None
+    _write("session.end", log_path=str(_log_path) if _log_path else "", **metadata)
+    # Drain the queue before closing
+    _writer_stop.set()
+    if _writer_thread and _writer_thread.is_alive():
+        _writer_thread.join(timeout=2.0)
+    # Flush remaining
+    _drain_queue()
+    path = _log_path
+    try:
+        _log_file.close()
+    except Exception:
+        pass
+    _log_file = None
+    # If another session is still running, repoint the symlink to it
+    # so that hermes tail doesn't go dead
+    try:
+        if path and _AUDIT_DIR.exists():
+            candidates = [
+                f for f in _AUDIT_DIR.glob("*.jsonl")
+                if f.name != "latest.jsonl" and f.name != path.name
+            ]
+            if candidates:
+                newest = max(candidates, key=lambda f: f.stat().st_mtime)
+                # Only repoint if the candidate was modified very recently (likely still active)
+                if time.time() - newest.stat().st_mtime < 10:
+                    try:
+                        if _LATEST_LINK.is_symlink() or _LATEST_LINK.exists():
+                            _LATEST_LINK.unlink()
+                        _LATEST_LINK.symlink_to(newest.name)
+                    except OSError:
+                        pass
+    except Exception:
+        pass
+    # Prune old audit events in SQLite
+    try:
+        if _db is not None and _retention_days > 0:
+            _db.prune_audit_events(retention_days=_retention_days)
+    except Exception:
+        pass
+    return path
+
+
+def log_api_request(
+    *,
+    model: str = "",
+    provider: str = "",
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+    total_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    reasoning_tokens: int = 0,
+    cost_usd: Optional[float] = None,
+    duration_ms: Optional[float] = None,
+    finish_reason: str = "",
+    tool_calls_count: int = 0,
+) -> None:
+    """Log an LLM API request/response."""
+    if not is_enabled():
+        return
+    _write(
+        "api.request",
+        model=model,
+        provider=provider,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        cache_read_tokens=cache_read_tokens,
+        reasoning_tokens=reasoning_tokens,
+        cost_usd=cost_usd,
+        duration_ms=duration_ms,
+        finish_reason=finish_reason,
+        tool_calls_count=tool_calls_count,
+    )
+
+
+def log_tool_call(
+    *,
+    tool_name: str,
+    args: Optional[Dict[str, Any]] = None,
+    result: str = "",
+    duration_ms: Optional[float] = None,
+    error: Optional[str] = None,
+) -> None:
+    """Log a tool call with rich per-tool detail extracted from args/result."""
+    if not is_enabled():
+        return
+    event_type = "tool.error" if error else "tool.call"
+    safe_args = _sanitize_args(args or {})
+    detail = _extract_tool_detail(tool_name, safe_args, result)
+
+    payload = {
+        "tool": tool_name,
+        "args": safe_args,
+        "detail": detail,
+        "duration_ms": duration_ms,
+    }
+    if error:
+        payload["error"] = str(error)
+    else:
+        payload["result_summary"] = _sanitize_result(result)
+    _write(event_type, **payload)
+
+
+def log_honcho_operation(
+    *,
+    operation: str,
+    payload: Optional[Dict[str, Any]] = None,
+    result: str = "",
+) -> None:
+    """Log a honcho/memory operation.  Thin wrapper around emit()."""
+    emit(
+        "honcho.operation",
+        operation=operation,
+        payload=payload or {},
+        result_summary=_sanitize_result(result, max_len=500),
+    )
+
+
+def log_cron_run(
+    *,
+    job_id: str,
+    job_name: str,
+    success: bool,
+    duration_s: Optional[float] = None,
+    error: Optional[str] = None,
+) -> None:
+    """Log a cron job execution.  Thin wrapper around emit()."""
+    emit(
+        "cron.run",
+        job_id=job_id,
+        job_name=job_name,
+        success=success,
+        duration_s=duration_s,
+        error=error,
+    )
+
+
+# -- Rich tool detail extraction --------------------------------------------
+
+def _extract_tool_detail(tool_name: str, args: dict, result: str) -> dict:
+    """Extract structured detail per tool type for display in hermes tail."""
+    detail = {}
+    try:
+        if tool_name == "terminal":
+            detail["command"] = args.get("command", "")[:200]
+            # Parse exit code from result
+            _parse_terminal_result(result, detail)
+
+        elif tool_name == "execute_code":
+            code = args.get("code", "")
+            detail["language"] = args.get("language", "python")
+            detail["code_preview"] = code[:150] + ("..." if len(code) > 150 else "")
+            _parse_terminal_result(result, detail)
+
+        elif tool_name == "read_file":
+            detail["path"] = args.get("file_path", args.get("path", ""))
+            detail["offset"] = args.get("offset")
+            detail["limit"] = args.get("limit")
+            # Extract size from result
+            if result:
+                detail["result_bytes"] = len(result)
+
+        elif tool_name == "write_file":
+            detail["path"] = args.get("file_path", args.get("path", ""))
+            content = args.get("content", "")
+            detail["content_bytes"] = len(content) if isinstance(content, str) else 0
+
+        elif tool_name in ("patch", "patch_file"):
+            detail["path"] = args.get("path", args.get("file_path", ""))
+            mode = args.get("mode", "replace")
+            detail["mode"] = mode
+            if mode == "replace":
+                old = args.get("old_string", "")
+                new = args.get("new_string", "")
+                detail["old_bytes"] = len(old) if isinstance(old, str) else 0
+                detail["new_bytes"] = len(new) if isinstance(new, str) else 0
+            else:
+                diff = args.get("patch", "")
+                detail["diff_bytes"] = len(diff) if isinstance(diff, str) else 0
+
+        elif tool_name == "search_files":
+            detail["query"] = args.get("query", args.get("pattern", ""))[:100]
+            detail["path"] = args.get("path", args.get("directory", ""))
+
+        elif tool_name in ("fetch_url", "url_fetch"):
+            detail["url"] = args.get("url", "")[:200]
+            if result:
+                detail["result_bytes"] = len(result)
+
+        elif tool_name in ("browser_navigate", "browser_snapshot"):
+            detail["url"] = args.get("url", "")[:200]
+            detail["action"] = args.get("action", "")
+
+        elif tool_name == "web_search":
+            detail["query"] = args.get("query", "")[:100]
+            # Extract URLs from result
+            if result:
+                import re as _re
+                urls = _re.findall(r'https?://[^\s"\'<>\]]+', result[:2000])
+                if urls:
+                    detail["result_urls"] = urls[:10]
+
+        elif tool_name.startswith("honcho_"):
+            detail["query"] = args.get("query", args.get("question", ""))[:200]
+            detail["conclusion"] = args.get("conclusion", "")[:200]
+
+        elif tool_name.startswith("mcp_"):
+            # MCP tool calls -- extract server and method + sanitized args
+            detail["mcp_tool"] = tool_name
+            # Parse server/method from mcp__server__method pattern
+            parts = tool_name.split("__")
+            if len(parts) >= 3:
+                detail["mcp_server"] = parts[1]
+                detail["mcp_method"] = "__".join(parts[2:])
+            detail["args"] = {k: str(v)[:200] for k, v in list(args.items())[:10]}
+
+        elif tool_name == "send_message":
+            detail["platform"] = args.get("platform", "")
+            detail["chat_id"] = args.get("chat_id", "")
+
+        elif tool_name == "delegate_task":
+            detail["task"] = args.get("task", "")[:150]
+
+        elif tool_name == "memory":
+            detail["action"] = args.get("action", "")
+            detail["content"] = args.get("content", "")[:150]
+
+        elif tool_name == "todo":
+            detail["action"] = args.get("action", "")
+            detail["item"] = args.get("item", args.get("text", ""))[:100]
+
+        elif tool_name == "skill_manage":
+            detail["action"] = args.get("action", "")
+            detail["skill"] = args.get("name", "")
+            detail["category"] = args.get("category", "")
+            if args.get("file_path"):
+                detail["file_path"] = args.get("file_path", "")
+
+    except Exception:
+        pass
+    return detail
+
+
+def _parse_terminal_result(result: str, detail: dict) -> None:
+    """Extract exit code and output summary from terminal/execute_code result."""
+    try:
+        if not result:
+            return
+        parsed = json.loads(result) if isinstance(result, str) else result
+        if isinstance(parsed, dict):
+            detail["exit_code"] = parsed.get("exit_code", parsed.get("returncode"))
+            output = parsed.get("output", parsed.get("stdout", ""))
+            stderr = parsed.get("stderr", "")
+            if output:
+                detail["output_preview"] = output[:200]
+            if stderr:
+                detail["stderr_preview"] = stderr[:200]
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+
+# -- Log rotation -----------------------------------------------------------
+
+def _rotate_logs() -> None:
+    """Remove audit log files older than retention_days."""
+    if _retention_days <= 0:
+        return
+    try:
+        cutoff = time.time() - (_retention_days * 86400)
+        for f in _AUDIT_DIR.glob("*.jsonl"):
+            if f.name == "latest.jsonl":
+                continue
+            try:
+                if f.stat().st_mtime < cutoff:
+                    f.unlink()
+            except OSError:
+                pass
+    except Exception:
+        pass
+
+
+# -- Query API (for /audit gateway command) ----------------------------------
+
+def get_audit_dir() -> Path:
+    """Return the audit log directory path."""
+    return _AUDIT_DIR
+
+
+def list_sessions() -> List[Dict[str, Any]]:
+    """List all audit log sessions with metadata."""
+    sessions = []
+    if not _AUDIT_DIR.exists():
+        return sessions
+    for f in sorted(_AUDIT_DIR.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True):
+        if f.name == "latest.jsonl":
+            continue
+        session_id = f.stem
+        stat = f.stat()
+        meta = {}
+        try:
+            with open(f, "r", encoding="utf-8") as fh:
+                first = fh.readline().strip()
+                if first:
+                    rec = json.loads(first)
+                    meta = {k: v for k, v in rec.items() if k not in ("ts", "iso", "type", "session")}
+        except Exception:
+            pass
+        sessions.append({
+            "session_id": session_id,
+            "file": str(f),
+            "size_kb": round(stat.st_size / 1024, 1),
+            "modified": time.strftime("%Y-%m-%d %H:%M", time.localtime(stat.st_mtime)),
+            **meta,
+        })
+    return sessions
+
+
+def query_events(
+    *,
+    session_id: Optional[str] = None,
+    event_type: Optional[str] = None,
+    tool_name: Optional[str] = None,
+    source: Optional[str] = None,
+    keyword: Optional[str] = None,
+    user_id: Optional[str] = None,
+    after: Optional[float] = None,
+    before: Optional[float] = None,
+    limit: int = 50,
+) -> List[Dict[str, Any]]:
+    """Query audit events across sessions with optional filters."""
+    # Prefer SQLite when available
+    if _db is not None:
+        try:
+            return _db.query_audit_events(
+                session_id=session_id,
+                event_type=event_type,
+                tool_name=tool_name,
+                source=source,
+                user_id=user_id,
+                keyword=keyword,
+                after=after,
+                before=before,
+                limit=limit,
+            )
+        except Exception:
+            pass  # fall through to JSONL
+    # Fallback to JSONL file scanning
+    if not _AUDIT_DIR.exists():
+        return []
+    if session_id:
+        files = list(_AUDIT_DIR.glob(f"*{session_id}*.jsonl"))
+    else:
+        files = sorted(
+            [f for f in _AUDIT_DIR.glob("*.jsonl") if f.name != "latest.jsonl"],
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    results = []
+    for f in files:
+        if len(results) >= limit:
+            break
+        try:
+            with open(f, "r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if event_type and rec.get("type") != event_type:
+                        continue
+                    if tool_name and rec.get("tool") != tool_name:
+                        continue
+                    if not _matches_source_filter(rec.get("type", ""), source):
+                        continue
+                    if keyword and keyword.lower() not in line.lower():
+                        continue
+                    if "source" not in rec:
+                        rec["source"] = _resolve_source(rec.get("type", ""))
+                    if user_id and rec.get("user_id") != user_id:
+                        continue
+                    if after is not None and rec.get("ts", 0) < after:
+                        continue
+                    if before is not None and rec.get("ts", float("inf")) > before:
+                        continue
+                    results.append(rec)
+                    if len(results) >= limit:
+                        break
+        except Exception:
+            continue
+    return results
+
+
+def export_events(
+    *,
+    session_id: Optional[str] = None,
+    format: str = "jsonl",
+) -> str:
+    """Export audit events as JSONL or CSV string."""
+    events = query_events(session_id=session_id, limit=100_000)
+    if format == "csv":
+        import csv
+        import io
+        if not events:
+            return ""
+        buf = io.StringIO()
+        all_keys = []
+        for e in events:
+            for k in e:
+                if k not in all_keys:
+                    all_keys.append(k)
+        writer = csv.DictWriter(buf, fieldnames=all_keys, extrasaction="ignore")
+        writer.writeheader()
+        for e in events:
+            flat = {}
+            for k, v in e.items():
+                flat[k] = json.dumps(v, ensure_ascii=False) if isinstance(v, (dict, list)) else v
+            writer.writerow(flat)
+        return buf.getvalue()
+    else:
+        return "\n".join(json.dumps(e, ensure_ascii=False, default=str) for e in events)
+
+
+# -- Summary & problems -----------------------------------------------------
+
+def audit_summary(
+    *,
+    session_id: Optional[str] = None,
+    after: Optional[float] = None,
+    before: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Aggregate stats across audit events.  Returns a dict of metrics."""
+    events = query_events(
+        session_id=session_id, after=after, before=before, limit=100_000,
+    )
+    if not events:
+        return {"total": 0}
+
+    api_calls = [e for e in events if e.get("type") == "api.request"]
+    tool_calls = [e for e in events if e.get("type") == "tool.call"]
+    errors = [e for e in events if e.get("type") == "tool.error" or e.get("error")]
+    sessions = {e.get("session", "") for e in events if e.get("session")}
+
+    total_tokens = sum(e.get("total_tokens", 0) or 0 for e in api_calls)
+    total_cost = sum(e.get("cost_usd", 0) or 0 for e in api_calls)
+    prompt_tokens = sum(e.get("prompt_tokens", 0) or 0 for e in api_calls)
+    completion_tokens = sum(e.get("completion_tokens", 0) or 0 for e in api_calls)
+
+    # Top tools by frequency
+    tool_freq: Dict[str, int] = {}
+    tool_dur: Dict[str, List[float]] = {}
+    for e in tool_calls:
+        t = e.get("tool", "?")
+        tool_freq[t] = tool_freq.get(t, 0) + 1
+        dur = e.get("duration_ms")
+        if dur is not None:
+            tool_dur.setdefault(t, []).append(dur)
+
+    top_tools = sorted(tool_freq.items(), key=lambda x: x[1], reverse=True)[:5]
+    top_tools_detail = [
+        {"tool": t, "count": c, "avg_ms": round(sum(tool_dur.get(t, [0])) / max(len(tool_dur.get(t, [1])), 1))}
+        for t, c in top_tools
+    ]
+
+    # Top errors by frequency
+    err_freq: Dict[str, int] = {}
+    for e in errors:
+        msg = (e.get("error") or "")[:80]
+        if msg:
+            err_freq[msg] = err_freq.get(msg, 0) + 1
+    top_errors = sorted(err_freq.items(), key=lambda x: x[1], reverse=True)[:3]
+
+    operational = len(api_calls) + len(tool_calls)
+    error_rate = round(len(errors) / max(operational, 1) * 100, 1)
+
+    ts_vals = [e.get("ts", 0) for e in events if e.get("ts")]
+    return {
+        "total": len(events),
+        "sessions": len(sessions),
+        "api_calls": len(api_calls),
+        "tool_calls": len(tool_calls),
+        "errors": len(errors),
+        "error_rate": error_rate,
+        "total_tokens": total_tokens,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_cost_usd": round(total_cost, 4),
+        "top_tools": top_tools_detail,
+        "top_errors": [{"error": e, "count": c} for e, c in top_errors],
+        "first_event": min(ts_vals) if ts_vals else None,
+        "last_event": max(ts_vals) if ts_vals else None,
+    }
+
+
+def audit_problems(
+    *,
+    session_id: Optional[str] = None,
+    after: Optional[float] = None,
+    before: Optional[float] = None,
+) -> List[Dict[str, str]]:
+    """Auto-detect anomalies in audit events.  Returns list of findings."""
+    events = query_events(
+        session_id=session_id, after=after, before=before, limit=100_000,
+    )
+    if not events:
+        return []
+
+    findings: List[Dict[str, str]] = []
+
+    # Repeated API errors (same message 3+ times)
+    api_errors: Dict[str, int] = {}
+    for e in events:
+        if e.get("type") in ("api.request",) and e.get("error"):
+            msg = (e.get("error") or "")[:80]
+            api_errors[msg] = api_errors.get(msg, 0) + 1
+    for msg, count in api_errors.items():
+        if count >= 3:
+            findings.append({"rule": "repeated_api_error", "message": f"\"{msg}\" occurred {count} times"})
+
+    # High error rate (>25%)
+    operational = sum(1 for e in events if e.get("type") in ("api.request", "tool.call"))
+    error_count = sum(1 for e in events if e.get("type") == "tool.error" or e.get("error"))
+    if operational > 0 and (error_count / operational) > 0.25:
+        rate = round(error_count / operational * 100, 1)
+        findings.append({"rule": "high_error_rate", "message": f"{rate}% error rate ({error_count}/{operational} events)"})
+
+    # Rate limiting (429)
+    rate_limited = sum(1 for e in events if "429" in str(e.get("error", "")))
+    if rate_limited > 0:
+        findings.append({"rule": "rate_limiting", "message": f"{rate_limited} rate-limited requests (429)"})
+
+    # Auth failures (401/403)
+    auth_fails = sum(1 for e in events if any(c in str(e.get("error", "")) for c in ("401", "403")))
+    if auth_fails > 0:
+        findings.append({"rule": "auth_failure", "message": f"{auth_fails} auth failures (401/403)"})
+
+    # Slow tools (avg > 10s)
+    tool_dur: Dict[str, List[float]] = {}
+    for e in events:
+        if e.get("type") == "tool.call" and e.get("duration_ms"):
+            tool_dur.setdefault(e.get("tool", "?"), []).append(e["duration_ms"])
+    for tool, durs in tool_dur.items():
+        avg = sum(durs) / len(durs)
+        if avg > 10000:
+            findings.append({"rule": "slow_tools", "message": f"{tool} avg {avg:.0f}ms ({len(durs)} calls)"})
+
+    # Repeated tool failures (same tool errors 3+ times)
+    tool_errors: Dict[str, int] = {}
+    for e in events:
+        if e.get("type") == "tool.error":
+            tool_errors[e.get("tool", "?")] = tool_errors.get(e.get("tool", "?"), 0) + 1
+    for tool, count in tool_errors.items():
+        if count >= 3:
+            findings.append({"rule": "repeated_tool_failure", "message": f"{tool} failed {count} times"})
+
+    return findings
+
+
+# -- Async writer -----------------------------------------------------------
+
+def _write_to_sqlite(line: str) -> None:
+    """Write a JSONL line to the SQLite audit_events table.  Best-effort."""
+    if _db is None:
+        return
+    try:
+        rec = json.loads(line)
+        ts = rec.get("ts", time.time())
+        iso = rec.get("iso", "")
+        event_type = rec.get("type", "")
+        session_id = rec.get("session", _session_id)
+
+        # Extract indexed columns from the record
+        tool = rec.get("tool")
+        user_id = rec.get("user_id", _user_id)
+        platform_val = rec.get("platform", _platform)
+        detail = rec.get("detail")
+        if isinstance(detail, dict):
+            detail = json.dumps(detail, ensure_ascii=False, default=str)
+        duration_ms = rec.get("duration_ms")
+        error = rec.get("error")
+
+        _db.insert_audit_event(
+            session_id=session_id,
+            ts=ts,
+            iso=iso,
+            event_type=event_type,
+            tool=tool,
+            user_id=user_id,
+            platform=platform_val,
+            detail=detail,
+            duration_ms=duration_ms,
+            error=error,
+            payload_json=line,
+            commit=False,
+        )
+    except Exception:
+        pass  # SQLite failure must never crash the agent
+
+_BATCH_SIZE = 10          # commit after this many events
+_BATCH_INTERVAL = 2.0     # or after this many seconds, whichever first
+
+
+def _writer_loop():
+    """Background thread that drains the write queue to disk.
+
+    Batches SQLite commits: flushes every ``_BATCH_SIZE`` events or every
+    ``_BATCH_INTERVAL`` seconds, whichever comes first.  JSONL writes are
+    immediate (OS-buffered via line-buffered file handle).
+    """
+    pending = 0
+    last_commit = time.monotonic()
+    while not _writer_stop.is_set():
+        try:
+            line = _write_queue.get(timeout=0.1)
+            if _log_file and not _log_file.closed:
+                _log_file.write(line + "\n")
+            _write_to_sqlite(line)
+            pending += 1
+            if pending >= _BATCH_SIZE:
+                _commit_sqlite_batch()
+                pending = 0
+                last_commit = time.monotonic()
+        except queue.Empty:
+            # Flush on idle if there are pending writes
+            if pending > 0 and (time.monotonic() - last_commit) >= _BATCH_INTERVAL:
+                _commit_sqlite_batch()
+                pending = 0
+                last_commit = time.monotonic()
+            continue
+        except Exception:
+            pass
+
+
+def _commit_sqlite_batch():
+    """Commit pending SQLite inserts.  Best-effort."""
+    try:
+        if _db is not None:
+            _db.commit_audit_batch()
+    except Exception:
+        pass
+
+
+def _drain_queue():
+    """Flush remaining items in the queue (called on session end)."""
+    while not _write_queue.empty():
+        try:
+            line = _write_queue.get_nowait()
+            if _log_file and not _log_file.closed:
+                _log_file.write(line + "\n")
+            _write_to_sqlite(line)
+        except queue.Empty:
+            break
+        except Exception:
+            pass
+    _commit_sqlite_batch()
+
+
+def _write(event_type: str, **data) -> None:
+    """Enqueue a JSONL record for async writing.
+
+    Source filtering is applied here so that specialised helpers
+    (``log_tool_call``, ``log_api_request``) that bypass ``emit()``
+    still respect the per-source config.
+    """
+    if _log_file is None:
+        return
+    if not _source_enabled(event_type):
+        return
+    record = {
+        "ts": time.time(),
+        "iso": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "type": event_type,
+        "source": _resolve_source(event_type),
+        "session": _session_id,
+        **data,
+    }
+    try:
+        line = json.dumps(record, ensure_ascii=False, default=str)
+        _write_queue.put_nowait(line)
+    except Exception:
+        pass  # audit logging must never crash the agent

--- a/cli.py
+++ b/cli.py
@@ -5602,6 +5602,13 @@ class HermesCLI:
             print(f"Session:        {self.session_id}")
             print(f"Duration:       {duration_str}")
             print(f"Messages:       {msg_count} ({user_msgs} user, {tool_calls} tool calls)")
+            try:
+                from agent.audit import end_session as _audit_end
+                _audit_path = _audit_end(duration_s=elapsed.total_seconds())
+                if _audit_path:
+                    print(f"Audit log:      {_audit_path}")
+            except Exception:
+                pass
         else:
             try:
                 from hermes_cli.skin_engine import get_active_goodbye
@@ -5710,6 +5717,55 @@ class HermesCLI:
                 sname = hcfg.resolve_session_name(session_id=self.session_id)
                 if sname:
                     write_tty(honcho_session_line(hcfg.workspace_id, sname) + "\n")
+        except Exception:
+            pass
+
+        # ── Early audit log init ─────────────────────────────────────
+        # Start the structured audit log NOW so session.start and cli.launch
+        # events are captured during banner/init, not deferred until the
+        # first user message (which lazily creates AIAgent).  AIAgent.__init__
+        # also calls start_session, but audit.start_session is idempotent for
+        # the same session_id, so the second call is a harmless no-op.
+        try:
+            from agent.audit import configure as _audit_configure, start_session as _audit_start, emit as _audit_emit
+            _audit_cfg = {}
+            try:
+                from hermes_cli.config import load_config as _load_audit_config
+                _audit_cfg = _load_audit_config()
+            except Exception:
+                pass
+            _audit_block = _audit_cfg.get("audit", {})
+            if isinstance(_audit_block, dict) and _audit_block:
+                _audit_enabled = _audit_block.get("enabled", True)
+                _audit_redact = _audit_block.get("redact", True)
+                _audit_retention = _audit_block.get("retention_days", 30)
+                _audit_sources = _audit_block.get("sources")
+            else:
+                _audit_enabled = _audit_cfg.get("audit_log", True)
+                _audit_redact = _audit_cfg.get("audit_log_redact", True)
+                _audit_retention = _audit_cfg.get("audit_log_retention_days", 30)
+                _audit_sources = None
+            _audit_configure(
+                enabled=_audit_enabled,
+                redact=_audit_redact,
+                retention_days=_audit_retention,
+                platform="cli",
+                sources=_audit_sources,
+            )
+            _audit_start(
+                self.session_id,
+                platform="cli",
+                model=self.model,
+            )
+            # Emit a cli.launch event with startup context
+            _audit_emit(
+                "cli.launch",
+                model=self.model,
+                session_id=self.session_id,
+                resumed=self._resumed,
+                toolsets=self.enabled_toolsets or [],
+                provider=self.requested_provider or "",
+            )
         except Exception:
             pass
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -420,11 +420,21 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 """
         
         logger.info("Job '%s' completed successfully", job_name)
+        try:
+            from agent.audit import log_cron_run
+            log_cron_run(job_id=job_id, job_name=job_name, success=True)
+        except Exception:
+            pass
         return True, output, final_response, None
-        
+
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.error("Job '%s' failed: %s", job_name, error_msg)
+        try:
+            from agent.audit import log_cron_run
+            log_cron_run(job_id=job_id, job_name=job_name, success=False, error=error_msg)
+        except Exception:
+            pass
         
         output = f"""# Cron Job: {job_name} (FAILED)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1438,6 +1438,9 @@ class GatewayRunner:
         if canonical == "insights":
             return await self._handle_insights_command(event)
 
+        if canonical == "audit":
+            return await self._handle_audit_command(event)
+
         if canonical == "reload-mcp":
             return await self._handle_reload_mcp_command(event)
 
@@ -3627,6 +3630,216 @@ class GatewayRunner:
         except Exception as e:
             logger.error("Insights command error: %s", e, exc_info=True)
             return f"Error generating insights: {e}"
+
+    async def _handle_audit_command(self, event: MessageEvent) -> str:
+        """Handle /audit command -- query the structured audit log.
+
+        Usage:
+            /audit                    -- last 20 events
+            /audit 50                 -- last 50 events
+            /audit --type tool.call   -- filter by event type
+            /audit --tool terminal    -- filter by tool name
+            /audit --source core      -- filter by source (core/honcho/mcp/...)
+            /audit --session <id>     -- filter by session ID
+            /audit --after 2026-03-17T12:00:00   -- only events after this time
+            /audit --before 2026-03-17T18:00:00  -- only events before this time
+            /audit --keyword <text>   -- full-text search in payloads
+            /audit sessions           -- list recent audit sessions
+        """
+        import asyncio as _asyncio
+        from datetime import datetime as _datetime
+
+        args_str = event.get_command_args().strip()
+        limit = 20
+        event_type = None
+        tool_name = None
+        source_filter = None
+        session_id = None
+        keyword = None
+        after_epoch = None
+        before_epoch = None
+        show_sessions = False
+
+        if args_str:
+            parts = args_str.split()
+            # Check for sub-action first
+            if parts[0] == "sessions":
+                show_sessions = True
+            elif parts[0] in ("summary", "problems"):
+                # Handled below after parsing remaining flags
+                pass
+            else:
+                i = 0
+                while i < len(parts):
+                    p = parts[i]
+                    if p == "--type" and i + 1 < len(parts):
+                        event_type = parts[i + 1]; i += 2
+                    elif p == "--tool" and i + 1 < len(parts):
+                        tool_name = parts[i + 1]; i += 2
+                    elif p == "--source" and i + 1 < len(parts):
+                        source_filter = parts[i + 1]; i += 2
+                    elif p == "--session" and i + 1 < len(parts):
+                        session_id = parts[i + 1]; i += 2
+                    elif p == "--keyword" and i + 1 < len(parts):
+                        keyword = parts[i + 1]; i += 2
+                    elif p == "--after" and i + 1 < len(parts):
+                        try:
+                            after_epoch = _datetime.fromisoformat(parts[i + 1]).timestamp()
+                        except ValueError:
+                            return f"Cannot parse date: {parts[i + 1]}"
+                        i += 2
+                    elif p == "--before" and i + 1 < len(parts):
+                        try:
+                            before_epoch = _datetime.fromisoformat(parts[i + 1]).timestamp()
+                        except ValueError:
+                            return f"Cannot parse date: {parts[i + 1]}"
+                        i += 2
+                    elif p.isdigit():
+                        limit = int(p); i += 1
+                    else:
+                        i += 1
+
+        try:
+            from agent.audit import query_events, list_sessions as _audit_list_sessions, audit_summary, audit_problems
+
+            loop = _asyncio.get_event_loop()
+
+            def _format_gateway_tool_detail(tool: str, detail: dict) -> str:
+                """Compact tool detail for messaging output."""
+                if not detail:
+                    return ""
+                if tool == "terminal":
+                    cmd = detail.get("command", "")
+                    return cmd[:60] if cmd else ""
+                elif tool in ("read_file", "write_file", "patch_file"):
+                    return detail.get("path", "")[:60]
+                elif tool == "web_search":
+                    return detail.get("query", "")[:60]
+                elif tool == "search_files":
+                    return detail.get("query", "")[:60]
+                elif tool == "browser_navigate":
+                    return detail.get("url", "")[:60]
+                elif tool == "delegate_task":
+                    return detail.get("task", "")[:60]
+                # Fallback: show first non-empty value
+                for v in detail.values():
+                    if v:
+                        return str(v)[:60]
+                return ""
+
+            def _run_query():
+                _parts = args_str.split() if args_str else []
+                _sub = _parts[0] if _parts else ""
+
+                # Sub-action: summary
+                if _sub == "summary":
+                    s = audit_summary(session_id=session_id, after=after_epoch, before=before_epoch)
+                    if s.get("total", 0) == 0:
+                        return "No audit events found."
+                    lines = [f"**Audit Summary** ({s['sessions']} sessions)\n"]
+                    lines.append(f"Events: {s['total']}  API: {s['api_calls']}  Tools: {s['tool_calls']}  Errors: {s['errors']} ({s['error_rate']}%)")
+                    lines.append(f"Tokens: {s['total_tokens']:,}  Cost: ${s['total_cost_usd']:.4f}")
+                    if s.get("top_tools"):
+                        lines.append("\nTop tools:")
+                        for t in s["top_tools"]:
+                            lines.append(f"  `{t['tool']}` {t['count']} calls, avg {t['avg_ms']}ms")
+                    if s.get("top_errors"):
+                        lines.append("\nTop errors:")
+                        for e in s["top_errors"]:
+                            lines.append(f"  {e['error'][:60]} x{e['count']}")
+                    return "\n".join(lines)
+
+                # Sub-action: problems
+                if _sub == "problems":
+                    findings = audit_problems(session_id=session_id, after=after_epoch, before=before_epoch)
+                    if not findings:
+                        return "No problems detected."
+                    lines = [f"**{len(findings)} problem{'s' if len(findings) != 1 else ''} detected**\n"]
+                    for f in findings:
+                        lines.append(f"`{f['rule']}` {f['message']}")
+                    return "\n".join(lines)
+
+                # Sub-action: list sessions
+                if show_sessions:
+                    sessions = _audit_list_sessions()
+                    if not sessions:
+                        return "No audit sessions found."
+                    lines = ["**Audit Sessions**\n"]
+                    import time as _time
+                    for s in sessions[:20]:
+                        sid = s.get("session_id", "?")
+                        size = s.get("size_kb", 0)
+                        modified = s.get("modified", "?")
+                        lines.append(f"`{sid}` {size}kb {modified}")
+                    return "\n".join(lines)
+
+                events = query_events(
+                    event_type=event_type,
+                    tool_name=tool_name,
+                    source=source_filter,
+                    session_id=session_id,
+                    keyword=keyword,
+                    after=after_epoch,
+                    before=before_epoch,
+                    limit=limit,
+                )
+
+                if not events:
+                    return "No audit events found. Enable with `audit.enabled: true` in config.yaml"
+
+                lines = [f"**Audit Log** ({len(events)} events)\n"]
+                for e in events:
+                    ts = e.get("iso", "")[:19]
+                    etype = e.get("type", "?")
+                    src = e.get("source", "")
+                    src_tag = f"[{src}] " if src else ""
+
+                    if etype == "api.request":
+                        model = e.get("model", "")
+                        tokens = e.get("total_tokens", 0)
+                        cost = e.get("cost_usd")
+                        cost_str = f"${cost:.4f}" if cost else ""
+                        lines.append(f"`{ts}` {src_tag}**{etype}** {model} {tokens} tok {cost_str}")
+                    elif etype in ("tool.call", "tool.error"):
+                        tool = e.get("tool", "")
+                        dur = e.get("duration_ms")
+                        dur_str = f"{dur:.0f}ms" if dur else ""
+                        err = e.get("error", "")
+                        if err:
+                            lines.append(f"`{ts}` {src_tag}**{etype}** {tool} {dur_str} ERR: {err[:40]}")
+                        else:
+                            detail = e.get("detail", {})
+                            info = _format_gateway_tool_detail(tool, detail)
+                            lines.append(f"`{ts}` {src_tag}**{etype}** {tool} {dur_str} {info}")
+                    elif etype.startswith("honcho."):
+                        op = e.get("operation", etype.split(".", 1)[1])
+                        lines.append(f"`{ts}` {src_tag}**{etype}** {op}")
+                    elif etype.startswith("memory."):
+                        action = e.get("action", etype.split(".", 1)[1])
+                        lines.append(f"`{ts}` {src_tag}**{etype}** {action}")
+                    elif etype == "cron.run":
+                        job = e.get("job_name", "")
+                        ok = "OK" if e.get("success") else "FAIL"
+                        lines.append(f"`{ts}` {src_tag}**{etype}** {job} {ok}")
+                    elif etype == "cli.launch":
+                        model = e.get("model", "")
+                        lines.append(f"`{ts}` {src_tag}**{etype}** {model}")
+                    elif etype.startswith("mcp."):
+                        mcp_tool = e.get("mcp_tool", etype)
+                        lines.append(f"`{ts}` {src_tag}**{etype}** {mcp_tool}")
+                    elif etype.startswith("skill."):
+                        skill = e.get("skill", e.get("name", ""))
+                        lines.append(f"`{ts}` {src_tag}**{etype}** {skill}")
+                    elif etype.startswith("plugin."):
+                        lines.append(f"`{ts}` {src_tag}**{etype}**")
+                    else:
+                        lines.append(f"`{ts}` {src_tag}**{etype}**")
+                return "\n".join(lines)
+
+            return await loop.run_in_executor(None, _run_query)
+        except Exception as e:
+            logger.error("Audit command error: %s", e, exc_info=True)
+            return f"Error querying audit log: {e}"
 
     async def _handle_reload_mcp_command(self, event: MessageEvent) -> str:
         """Handle /reload-mcp command -- disconnect and reconnect all MCP servers."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -119,6 +119,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     # Info
     CommandDef("help", "Show available commands", "Info"),
     CommandDef("usage", "Show token usage for the current session", "Info"),
+    CommandDef("audit", "Query the structured audit log", "Info",
+               args_hint="[sessions|summary|problems|--type|--tool|--source|--session|--keyword] [count]",
+               subcommands=("sessions", "summary", "problems")),
     CommandDef("insights", "Show usage insights and analytics", "Info",
                args_hint="[days]"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -371,8 +371,29 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # Audit log settings
+    "audit": {
+        "enabled": True,
+        "redact": True,
+        "retention_days": 7,
+        "jsonl": True,  # also write JSONL files for hermes tail
+        # Per-source filtering.  Source is derived from the event type prefix.
+        # Core events (session.*, api.*, tool.*, cli.*, context.*) map to "core".
+        # Everything else uses its own prefix (honcho.*, cron.*, mcp.*, etc.).
+        # Missing keys default to True (opt-out, not opt-in).
+        "sources": {
+            "core": True,       # session, api, tool, cli, context events
+            "honcho": True,     # honcho.* events
+            "memory": True,     # memory.* events
+            "cron": True,       # cron.* events
+            "mcp": True,        # MCP tool/server events
+            "skill": True,      # skill load/manage events
+            "plugin": True,     # external plugin events
+        },
+    },
+
     # Config schema version - bump this when adding new required fields
-    "_config_version": 10,
+    "_config_version": 11,
 }
 
 # =============================================================================
@@ -1015,6 +1036,54 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     print("  ✓ Cleared ANTHROPIC_TOKEN from .env (no longer used)")
         except Exception:
             pass
+
+    # ── Version 9 → 10: migrate flat audit keys to nested audit block ──
+    if current_ver < 10:
+        config = load_config()
+        audit_block = config.get("audit", {})
+        if not isinstance(audit_block, dict):
+            audit_block = {}
+        # Migrate old flat keys into the new nested block
+        if "audit_log" in config:
+            audit_block.setdefault("enabled", config.pop("audit_log"))
+            results["config_added"].append("audit.enabled (migrated from audit_log)")
+        if "audit_log_redact" in config:
+            audit_block.setdefault("redact", config.pop("audit_log_redact"))
+            results["config_added"].append("audit.redact (migrated from audit_log_redact)")
+        if "audit_log_retention_days" in config:
+            audit_block.setdefault("retention_days", config.pop("audit_log_retention_days"))
+            results["config_added"].append("audit.retention_days (migrated from audit_log_retention_days)")
+        # Ensure defaults
+        audit_block.setdefault("enabled", True)
+        audit_block.setdefault("redact", True)
+        audit_block.setdefault("retention_days", 7)
+        audit_block.setdefault("jsonl", True)
+        config["audit"] = audit_block
+        save_config(config)
+        if not quiet:
+            print("  ✓ Migrated audit config to nested audit block")
+
+    # ── Version 10 → 11: add audit.sources for per-source filtering ──
+    if current_ver < 11:
+        config = load_config()
+        audit_block = config.get("audit", {})
+        if not isinstance(audit_block, dict):
+            audit_block = {}
+        if "sources" not in audit_block:
+            audit_block["sources"] = {
+                "core": True,
+                "honcho": True,
+                "memory": True,
+                "cron": True,
+                "mcp": True,
+                "skill": True,
+                "plugin": True,
+            }
+            results["config_added"].append("audit.sources (per-source filtering)")
+        config["audit"] = audit_block
+        save_config(config)
+        if not quiet:
+            print("  ✓ Added audit.sources for per-source event filtering")
 
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3847,6 +3847,428 @@ For more help on a command:
     sessions_parser.set_defaults(func=cmd_sessions)
 
     # =========================================================================
+    # tail command
+    # =========================================================================
+    tail_parser = subparsers.add_parser(
+        "tail",
+        help="Live-tail the audit log (tool calls, API requests, honcho ops)",
+        description="Stream the structured audit log for the current or latest session"
+    )
+    tail_parser.add_argument("--raw", action="store_true", help="Print raw JSONL instead of formatted output")
+    tail_parser.add_argument("--type", dest="event_type", help="Filter by event type (api.request, tool.call, etc.)")
+    tail_parser.add_argument("--session", dest="tail_session", help="Show events for a specific session (from SQLite or JSONL file)")
+
+    def _format_tool_detail(tool: str, d: dict) -> str:
+        """Format rich detail from audit tool.call events for tail output."""
+        if not d:
+            return ""
+        if tool == "terminal":
+            cmd = d.get("command", "")[:60]
+            ec = d.get("exit_code")
+            ec_str = f" exit={ec}" if ec is not None else ""
+            return f"{cmd}{ec_str}"
+        if tool == "execute_code":
+            preview = d.get("code_preview", "")[:50]
+            ec = d.get("exit_code")
+            ec_str = f" exit={ec}" if ec is not None else ""
+            return f"{preview}{ec_str}"
+        if tool == "read_file":
+            path = d.get("path", "")
+            sz = d.get("result_bytes")
+            sz_str = f" {sz}b" if sz else ""
+            return f"{path}{sz_str}"
+        if tool == "write_file":
+            path = d.get("path", "")
+            sz = d.get("content_bytes", 0)
+            return f"{path} {sz}b"
+        if tool in ("patch", "patch_file"):
+            path = d.get("path", "")
+            mode = d.get("mode", "replace")
+            if mode == "replace":
+                old_b = d.get("old_bytes", 0)
+                new_b = d.get("new_bytes", 0)
+                return f"{path} -{old_b}b +{new_b}b"
+            else:
+                diff_b = d.get("diff_bytes", 0)
+                return f"{path} patch {diff_b}b"
+        if tool == "search_files":
+            return d.get("query", "") or d.get("path", "")
+        if tool in ("fetch_url", "browser_navigate", "web_search"):
+            return d.get("url", "") or d.get("query", "")
+        if tool.startswith("honcho_"):
+            return d.get("query", "") or d.get("conclusion", "")
+        if tool.startswith("mcp_"):
+            server = d.get("mcp_server", "")
+            method = d.get("mcp_method", "")
+            args_d = d.get("args", {})
+            arg_preview = " ".join(f"{k}={v[:30]}" for k, v in list(args_d.items())[:3]) if args_d else ""
+            label = f"{server}.{method}" if server and method else d.get("mcp_tool", "")
+            return f"{label}  {arg_preview}".strip()
+        if tool == "send_message":
+            return f"{d.get('platform', '')} {d.get('chat_id', '')}"
+        if tool == "memory":
+            return f"{d.get('action', '')} {d.get('content', '')}"[:60]
+        if tool == "todo":
+            return f"{d.get('action', '')} {d.get('item', '')}"[:60]
+        # Fallback: show first non-empty value
+        for v in d.values():
+            if v:
+                return str(v)[:60]
+        return ""
+
+    _last_session_tag = [None]  # mutable to allow closure update
+
+    def _format_audit_line(e: dict) -> str:
+        """Format a single audit event dict into a terminal-friendly line."""
+        etype = e.get("type", "?")
+        ts = e.get("iso", "")[11:19]  # HH:MM:SS only
+        # Short session tag (last 6 chars of session ID)
+        sid_full = e.get("session", e.get("session_id", ""))
+        stag = sid_full[-6:] if sid_full else "------"
+        # Separator when session changes
+        prefix = ""
+        if _last_session_tag[0] is not None and stag != _last_session_tag[0]:
+            prefix = f"--- {sid_full} ---\n"
+        _last_session_tag[0] = stag
+
+        if etype == "api.request":
+            model = e.get("model", "")
+            tokens = e.get("total_tokens", 0)
+            cost = e.get("cost_usd")
+            dur = e.get("duration_ms")
+            cost_str = f"${cost:.4f}" if cost else ""
+            dur_str = f"{dur:.0f}ms" if dur else ""
+            body = f"api      {model:<26} {tokens:>6} tok  {cost_str:>8}  {dur_str}"
+        elif etype == "tool.call":
+            tool = e.get("tool", "")
+            dur = e.get("duration_ms")
+            dur_str = f"{dur:.0f}ms" if dur else ""
+            d = e.get("detail", {})
+            info = _format_tool_detail(tool, d)
+            body = f"tool     {tool:<20} {dur_str:>6}  {info}"
+        elif etype == "tool.error":
+            tool = e.get("tool", "")
+            err = e.get("error", "")[:60]
+            body = f"error    {tool:<20}         {err}"
+        elif etype == "honcho.operation":
+            op = e.get("operation", "")
+            body = f"honcho   {op}"
+        elif etype == "honcho.init":
+            ws = e.get("workspace", "")
+            mode = e.get("memory_mode", "")
+            recall = e.get("recall_mode", "")
+            ok = "enabled" if e.get("enabled") else "disabled"
+            body = f"honcho   init {ok}  ws={ws} mode={mode} recall={recall}"
+        elif etype == "honcho.context_injected":
+            sections = e.get("sections", [])
+            total = e.get("total_chars", 0)
+            body = f"honcho   context injected  {total} chars  [{', '.join(sections)}]"
+        elif etype == "honcho.tool_call":
+            tool = e.get("tool", "")
+            preview = e.get("result_preview", "")[:80]
+            body = f"honcho   {tool}  {preview}"
+        elif etype == "memory.loaded":
+            mc = e.get("memory_chars", 0)
+            uc = e.get("user_profile_chars", 0)
+            body = f"memory   loaded  memory={mc} chars  user={uc} chars"
+        elif etype == "memory.tool_call":
+            action = e.get("action", "")
+            target = e.get("target", "")
+            preview = e.get("content_preview", "")[:60]
+            body = f"memory   {action} ({target})  {preview}"
+        elif etype == "context.assembled":
+            layers = e.get("layers", [])
+            total = e.get("total_chars", 0)
+            body = f"context  assembled  {total} chars  [{', '.join(layers)}]"
+        elif etype == "context.compression":
+            phase = e.get("phase", "")
+            if phase == "start":
+                msgs = e.get("message_count", 0)
+                tok = e.get("approx_tokens_before", "?")
+                body = f"context  compression start  {msgs} msgs  ~{tok} tok"
+            else:
+                before = e.get("messages_before", 0)
+                after = e.get("messages_after", 0)
+                body = f"context  compression end  {before} \u2192 {after} msgs"
+        elif etype == "session.search":
+            query = e.get("query", "")[:60]
+            body = f"session  search  q={query}"
+        elif etype == "cron.run":
+            job = e.get("job_name", "")
+            ok = "ok" if e.get("success") else "FAIL"
+            body = f"cron     {job:<26} {ok}"
+        elif etype == "user.message":
+            chars = e.get("chars", 0)
+            turn = e.get("turn", 0)
+            body = f"user     turn {turn}  {chars} chars"
+        elif etype.startswith("honcho."):
+            sub = etype.split(".", 1)[1]
+            if sub == "write" and e.get("operation"):
+                sub = e["operation"]
+            parts = []
+            if e.get("user_chars"):
+                parts.append(f"user={e['user_chars']} chars")
+            if e.get("assistant_chars"):
+                parts.append(f"assistant={e['assistant_chars']} chars")
+            if e.get("message_count"):
+                parts.append(f"msgs={e['message_count']}")
+            if e.get("content_chars"):
+                parts.append(f"{e['content_chars']} chars")
+            if e.get("source_dir") or e.get("mem_dir"):
+                parts.append(e.get("source_dir") or e.get("mem_dir", ""))
+            detail = "  ".join(parts)
+            body = f"honcho   {sub:<16} {detail}"
+        elif etype == "session.start":
+            model = e.get("model", "")
+            platform = e.get("platform", "")
+            body = f"start    {sid_full}  {model} ({platform})"
+        elif etype == "session.end":
+            log_path = e.get("log_path", "")
+            suffix = f"  {log_path}" if log_path else ""
+            body = f"end      {sid_full}{suffix}"
+        else:
+            body = f"{etype:<9}"
+
+        return f"{prefix}{ts}  {stag}  {body}"
+
+    def cmd_tail(args):
+        import subprocess
+        import sys
+        from agent.audit import get_audit_dir
+
+        # --session mode: show historical events for a session
+        if getattr(args, "tail_session", None):
+            from agent.audit import query_events
+            events = query_events(session_id=args.tail_session, event_type=args.event_type, limit=10000)
+            if not events:
+                print(f"No events found for session {args.tail_session}")
+                return
+            # SQLite returns reverse-chronological; flip for display
+            events.reverse()
+            for e in events:
+                if args.raw:
+                    print(json.dumps(e, ensure_ascii=False, default=str))
+                else:
+                    print(_format_audit_line(e))
+            return
+
+        audit_dir = get_audit_dir()
+        latest = audit_dir / "latest.jsonl"
+
+        if not latest.exists():
+            audit_dir.mkdir(parents=True, exist_ok=True)
+            print("Waiting for a hermes session to start...")
+            import time as _time
+            try:
+                while not latest.exists():
+                    _time.sleep(0.3)
+            except KeyboardInterrupt:
+                return
+
+        if args.raw:
+            # Raw JSONL -- pipe-friendly
+            if args.event_type:
+                cmd = ["tail", "-n", "0", "-F", str(latest)]
+                print(f"Filtering for {args.event_type} events...\n", file=sys.stderr)
+            else:
+                cmd = ["tail", "-n", "0", "-F", str(latest)]
+            try:
+                proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True)
+                for line in proc.stdout:
+                    if args.event_type:
+                        try:
+                            rec = json.loads(line)
+                            if rec.get("type") != args.event_type:
+                                continue
+                        except Exception:
+                            continue
+                    sys.stdout.write(line)
+                    sys.stdout.flush()
+            except KeyboardInterrupt:
+                pass
+            return
+
+        # Formatted output
+        try:
+            proc = subprocess.Popen(
+                ["tail", "-n", "0", "-F", str(latest)],
+                stdout=subprocess.PIPE, text=True,
+            )
+            for line in proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    e = json.loads(line)
+                except Exception:
+                    continue
+
+                etype = e.get("type", "?")
+                if args.event_type and etype != args.event_type:
+                    continue
+
+                print(_format_audit_line(e))
+                sys.stdout.flush()
+        except KeyboardInterrupt:
+            pass
+
+    import json
+    tail_parser.set_defaults(func=cmd_tail)
+
+    # =========================================================================
+    # audit command
+    # =========================================================================
+    audit_parser = subparsers.add_parser(
+        "audit",
+        help="Query and explore the structured audit log",
+        description="Search, filter, and export audit events across all sessions"
+    )
+    audit_parser.add_argument("action", nargs="?", default=None, help="Sub-action: 'sessions' to list sessions")
+    audit_parser.add_argument("--type", dest="event_type", help="Filter by event type (api.request, tool.call, etc.)")
+    audit_parser.add_argument("--tool", dest="tool_name", help="Filter by tool name (terminal, read_file, etc.)")
+    audit_parser.add_argument("--source", dest="source_filter", help="Filter by source (core, honcho, mcp, cron, skill, plugin)")
+    audit_parser.add_argument("--session", dest="session_id", help="Filter by session ID")
+    audit_parser.add_argument("--after", help="Show events after this date (ISO format, e.g. 2024-01-01)")
+    audit_parser.add_argument("--before", help="Show events before this date (ISO format, e.g. 2024-12-31)")
+    audit_parser.add_argument("--keyword", help="Full-text search in event payloads")
+    audit_parser.add_argument("--user", dest="user_id", help="Filter by user ID")
+    audit_parser.add_argument("-n", "--limit", type=int, default=20, help="Number of results to show (default: 20)")
+    audit_parser.add_argument("--export", choices=["json", "csv"], help="Export as JSONL or CSV")
+
+    def cmd_audit(args):
+        import sys
+        from datetime import datetime
+        from agent.audit import query_events, list_sessions, export_events, audit_summary, audit_problems
+
+        # Sub-action: summary
+        if args.action == "summary":
+            after_epoch = None
+            before_epoch = None
+            if args.after:
+                try:
+                    after_epoch = datetime.fromisoformat(args.after).timestamp()
+                except ValueError:
+                    pass
+            if args.before:
+                try:
+                    before_epoch = datetime.fromisoformat(args.before).timestamp()
+                except ValueError:
+                    pass
+            s = audit_summary(session_id=args.session_id, after=after_epoch, before=before_epoch)
+            if s.get("total", 0) == 0:
+                print("No audit events found.")
+                return
+            import time as _time
+            first = _time.strftime("%Y-%m-%d %H:%M", _time.localtime(s["first_event"])) if s.get("first_event") else "?"
+            last = _time.strftime("%Y-%m-%d %H:%M", _time.localtime(s["last_event"])) if s.get("last_event") else "?"
+            print(f"Audit summary  {first} -- {last}  ({s['sessions']} sessions)")
+            print(f"  Events: {s['total']}  API: {s['api_calls']}  Tools: {s['tool_calls']}  Errors: {s['errors']} ({s['error_rate']}%)")
+            print(f"  Tokens: {s['total_tokens']:,}  (prompt {s['prompt_tokens']:,}  completion {s['completion_tokens']:,})")
+            if s["total_cost_usd"] > 0:
+                print(f"  Cost: ${s['total_cost_usd']:.4f}")
+            if s.get("top_tools"):
+                print("  Top tools:")
+                for t in s["top_tools"]:
+                    print(f"    {t['tool']:<24} {t['count']:>4} calls  avg {t['avg_ms']}ms")
+            if s.get("top_errors"):
+                print("  Top errors:")
+                for e in s["top_errors"]:
+                    print(f"    {e['error']:<60} x{e['count']}")
+            return
+
+        # Sub-action: problems
+        if args.action == "problems":
+            after_epoch = None
+            before_epoch = None
+            if args.after:
+                try:
+                    after_epoch = datetime.fromisoformat(args.after).timestamp()
+                except ValueError:
+                    pass
+            if args.before:
+                try:
+                    before_epoch = datetime.fromisoformat(args.before).timestamp()
+                except ValueError:
+                    pass
+            findings = audit_problems(session_id=args.session_id, after=after_epoch, before=before_epoch)
+            if not findings:
+                print("No problems detected.")
+                return
+            print(f"{len(findings)} problem{'s' if len(findings) != 1 else ''} detected:\n")
+            for f in findings:
+                print(f"  {f['rule']:<26} {f['message']}")
+            return
+
+        # Sub-action: list sessions
+        if args.action == "sessions":
+            sessions = list_sessions()
+            if not sessions:
+                print("No audit sessions found.")
+                return
+            # Format as table
+            print(f"{'Session ID':<40} {'Events':>7} {'First Event':<20} {'Last Event':<20}")
+            print("-" * 90)
+            import time as _time
+            for s in sessions:
+                sid = s.get("session_id", "?")
+                count = s.get("event_count", 0)
+                first = s.get("first_event")
+                last = s.get("last_event")
+                first_str = _time.strftime("%Y-%m-%d %H:%M", _time.localtime(first)) if first else "?"
+                last_str = _time.strftime("%Y-%m-%d %H:%M", _time.localtime(last)) if last else "?"
+                print(f"{sid:<40} {count:>7} {first_str:<20} {last_str:<20}")
+            return
+
+        # Export mode
+        if args.export:
+            fmt = "csv" if args.export == "csv" else "jsonl"
+            output = export_events(session_id=args.session_id, format=fmt)
+            if output:
+                print(output)
+            else:
+                print("No events to export.", file=sys.stderr)
+            return
+
+        # Parse date filters
+        after_epoch = None
+        before_epoch = None
+        for attr, name in [(args.after, "after"), (args.before, "before")]:
+            if not attr:
+                continue
+            try:
+                ts = datetime.fromisoformat(attr).timestamp()
+                if name == "after":
+                    after_epoch = ts
+                else:
+                    before_epoch = ts
+            except ValueError:
+                print(f"Cannot parse date: {attr}", file=sys.stderr)
+                return
+
+        # Query events
+        events = query_events(
+            session_id=args.session_id,
+            event_type=args.event_type,
+            tool_name=args.tool_name,
+            source=getattr(args, "source_filter", None),
+            keyword=args.keyword,
+            user_id=args.user_id,
+            after=after_epoch,
+            before=before_epoch,
+            limit=args.limit,
+        )
+
+        if not events:
+            print("No matching audit events found.")
+            return
+
+        # Display events (most recent first from SQLite, reverse for chronological)
+        for e in events:
+            print(_format_audit_line(e))
+
+    audit_parser.set_defaults(func=cmd_audit)
+
+    # =========================================================================
     # insights command
     # =========================================================================
     insights_parser = subparsers.add_parser(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -26,7 +26,7 @@ from typing import Dict, Any, List, Optional
 
 DEFAULT_DB_PATH = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -76,10 +76,29 @@ CREATE TABLE IF NOT EXISTS messages (
     finish_reason TEXT
 );
 
+CREATE TABLE IF NOT EXISTS audit_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT,
+    ts REAL NOT NULL,
+    iso TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    tool TEXT,
+    user_id TEXT,
+    platform TEXT,
+    detail TEXT,
+    duration_ms REAL,
+    error TEXT,
+    payload TEXT NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_events(ts DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_session ON audit_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_audit_type ON audit_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_audit_tool ON audit_events(tool);
 """
 
 FTS_SQL = """
@@ -102,7 +121,6 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages BEGIN
     INSERT INTO messages_fts(rowid, content) VALUES (new.id, new.content);
 END;
 """
-
 
 class SessionDB:
     """
@@ -189,6 +207,25 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass
                 cursor.execute("UPDATE schema_version SET version = 5")
+            if current_version < 6:
+                # v6: add audit_events table
+                for stmt in [
+                    """CREATE TABLE IF NOT EXISTS audit_events (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        session_id TEXT, ts REAL NOT NULL, iso TEXT NOT NULL,
+                        event_type TEXT NOT NULL, tool TEXT, user_id TEXT,
+                        platform TEXT, detail TEXT, duration_ms REAL,
+                        error TEXT, payload TEXT NOT NULL)""",
+                    "CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_events(ts DESC)",
+                    "CREATE INDEX IF NOT EXISTS idx_audit_session ON audit_events(session_id)",
+                    "CREATE INDEX IF NOT EXISTS idx_audit_type ON audit_events(event_type)",
+                    "CREATE INDEX IF NOT EXISTS idx_audit_tool ON audit_events(tool)",
+                ]:
+                    try:
+                        cursor.execute(stmt)
+                    except sqlite3.OperationalError:
+                        pass
+                cursor.execute("UPDATE schema_version SET version = 6")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -950,3 +987,162 @@ class SessionDB:
 
             self._conn.commit()
         return len(session_ids)
+
+    # =========================================================================
+    # Audit events
+    # =========================================================================
+
+    def insert_audit_event(
+        self,
+        session_id: str,
+        ts: float,
+        iso: str,
+        event_type: str,
+        tool: Optional[str],
+        user_id: Optional[str],
+        platform: Optional[str],
+        detail: Optional[str],
+        duration_ms: Optional[float],
+        error: Optional[str],
+        payload_json: str,
+        *,
+        commit: bool = True,
+    ) -> None:
+        """Insert a single audit event.
+
+        Set ``commit=False`` when batching multiple inserts — the caller
+        is responsible for calling :meth:`commit_audit_batch` afterwards.
+        """
+        with self._lock:
+            self._conn.execute(
+                """INSERT INTO audit_events
+                   (session_id, ts, iso, event_type, tool, user_id, platform,
+                    detail, duration_ms, error, payload)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    session_id, ts, iso, event_type, tool, user_id, platform,
+                    detail, duration_ms, error, payload_json,
+                ),
+            )
+            if commit:
+                self._conn.commit()
+
+    def commit_audit_batch(self) -> None:
+        """Commit a batch of audit events inserted with ``commit=False``."""
+        with self._lock:
+            self._conn.commit()
+
+    def count_audit_events(self, session_id: Optional[str] = None) -> int:
+        """Return the total number of audit events, optionally filtered by session."""
+        with self._lock:
+            if session_id:
+                cursor = self._conn.execute(
+                    "SELECT COUNT(*) FROM audit_events WHERE session_id = ?",
+                    (session_id,),
+                )
+            else:
+                cursor = self._conn.execute("SELECT COUNT(*) FROM audit_events")
+            return cursor.fetchone()[0]
+
+    def query_audit_events(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        event_type: Optional[str] = None,
+        tool_name: Optional[str] = None,
+        source: Optional[str] = None,
+        user_id: Optional[str] = None,
+        keyword: Optional[str] = None,
+        after: Optional[float] = None,
+        before: Optional[float] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """Query audit events with optional filters.
+
+        Returns list of dicts (parsed payload with id/ts overlay).
+        """
+        with self._lock:
+            where_clauses: list = []
+            params: list = []
+
+            if session_id:
+                where_clauses.append("session_id = ?")
+                params.append(session_id)
+            if event_type:
+                where_clauses.append("event_type = ?")
+                params.append(event_type)
+            if tool_name:
+                where_clauses.append("tool = ?")
+                params.append(tool_name)
+            if source:
+                if source == "core":
+                    where_clauses.append(
+                        "(" + " OR ".join([
+                            "event_type LIKE 'session.%'",
+                            "event_type LIKE 'api.%'",
+                            "event_type LIKE 'tool.%'",
+                            "event_type LIKE 'cli.%'",
+                            "event_type LIKE 'context.%'",
+                        ]) + ")"
+                    )
+                else:
+                    where_clauses.append("event_type LIKE ?")
+                    params.append(f"{source}.%")
+            if user_id:
+                where_clauses.append("user_id = ?")
+                params.append(user_id)
+            if keyword:
+                where_clauses.append("payload LIKE ?")
+                params.append(f"%{keyword}%")
+            if after is not None:
+                where_clauses.append("ts >= ?")
+                params.append(after)
+            if before is not None:
+                where_clauses.append("ts <= ?")
+                params.append(before)
+
+            where_sql = (" WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+            params.append(limit)
+
+            sql = f"SELECT * FROM audit_events{where_sql} ORDER BY ts DESC LIMIT ?"
+            try:
+                cursor = self._conn.execute(sql, params)
+                rows = cursor.fetchall()
+            except sqlite3.OperationalError:
+                return []
+
+        results = []
+        core_prefixes = ("session.", "api.", "tool.", "cli.", "context.")
+        for row in rows:
+            try:
+                rec = json.loads(row["payload"])
+            except (json.JSONDecodeError, TypeError):
+                rec = {"payload": row["payload"]}
+            rec["id"] = row["id"]
+            rec["ts"] = row["ts"]
+            rec["iso"] = row["iso"]
+            rec["type"] = row["event_type"]
+            rec["session"] = row["session_id"]
+            if "source" not in rec:
+                event_type_val = row["event_type"] or ""
+                if event_type_val.startswith(core_prefixes):
+                    rec["source"] = "core"
+                else:
+                    rec["source"] = event_type_val.split(".", 1)[0] if "." in event_type_val else event_type_val
+            results.append(rec)
+        return results
+
+    def prune_audit_events(self, retention_days: int = 30) -> int:
+        """Delete audit events older than retention_days. Returns count deleted."""
+        if retention_days <= 0:
+            return 0
+        cutoff = time.time() - (retention_days * 86400)
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT COUNT(*) FROM audit_events WHERE ts < ?", (cutoff,)
+            )
+            count = cursor.fetchone()[0]
+            if count > 0:
+                self._conn.execute("DELETE FROM audit_events WHERE ts < ?", (cutoff,))
+                self._conn.commit()
+        return count

--- a/model_tools.py
+++ b/model_tools.py
@@ -24,6 +24,7 @@ import json
 import asyncio
 import os
 import logging
+import time
 from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import registry
@@ -95,6 +96,7 @@ def _discover_tools():
         "tools.send_message_tool",
         "tools.honcho_tools",
         "tools.homeassistant_tool",
+        "tools.audit_tool",
     ]
     import importlib
     for mod_name in _modules:
@@ -350,6 +352,8 @@ def handle_function_call(
         except Exception:
             pass
 
+        _t0 = time.monotonic()
+
         if function_name == "execute_code":
             # Prefer the caller-provided list so subagents can't overwrite
             # the parent's tool set via the process-global.
@@ -370,9 +374,44 @@ def handle_function_call(
                 honcho_session_key=honcho_session_key,
             )
 
+        _elapsed_ms = (time.monotonic() - _t0) * 1000
+
         try:
             from hermes_cli.plugins import invoke_hook
             invoke_hook("post_tool_call", tool_name=function_name, args=function_args, result=result, task_id=task_id or "")
+        except Exception:
+            pass
+
+        # Audit log: record every tool call with timing
+        try:
+            from agent.audit import log_tool_call, emit
+            log_tool_call(
+                tool_name=function_name,
+                args=function_args,
+                result=result,
+                duration_ms=round(_elapsed_ms, 1),
+            )
+            # Also emit a subsystem-specific event for honcho/memory tools
+            if function_name.startswith("honcho_"):
+                emit(
+                    "honcho.tool_call",
+                    tool=function_name,
+                    args=function_args,
+                    result_preview=result[:500] if result else "",
+                )
+            elif function_name == "memory":
+                emit(
+                    "memory.tool_call",
+                    action=function_args.get("action", ""),
+                    target=function_args.get("target", ""),
+                    content_preview=(function_args.get("content", "") or "")[:200],
+                )
+            elif function_name == "session_search":
+                emit(
+                    "session.search",
+                    query=function_args.get("query", ""),
+                    result_preview=result[:300] if result else "",
+                )
         except Exception:
             pass
 
@@ -381,6 +420,12 @@ def handle_function_call(
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"
         logger.error(error_msg)
+        # Audit log: record tool errors
+        try:
+            from agent.audit import log_tool_call
+            log_tool_call(tool_name=function_name, args=function_args, error=error_msg)
+        except Exception:
+            pass
         return json.dumps({"error": error_msg}, ensure_ascii=False)
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -845,7 +845,48 @@ class AIAgent:
                 )
             except Exception as e:
                 logger.debug("Session DB create_session failed: %s", e)
-        
+
+        # Structured audit log (JSONL + SQLite, tailable via hermes tail)
+        try:
+            from agent.audit import configure as _audit_configure, start_session as _audit_start
+            _audit_cfg = {}
+            try:
+                from hermes_cli.config import load_config as _load_audit_config
+                _audit_cfg = _load_audit_config()
+            except Exception:
+                pass
+            # Read from nested audit block (v10+), fall back to old flat keys
+            _audit_platform = self.platform or "cli"
+            _audit_block = _audit_cfg.get("audit", {})
+            if isinstance(_audit_block, dict) and _audit_block:
+                _audit_enabled = _audit_block.get("enabled", True)
+                _audit_redact = _audit_block.get("redact", True)
+                _audit_retention = _audit_block.get("retention_days", 7)
+                _audit_sources = _audit_block.get("sources")
+            else:
+                _audit_enabled = _audit_cfg.get("audit_log", True)
+                _audit_redact = _audit_cfg.get("audit_log_redact", True)
+                _audit_retention = _audit_cfg.get("audit_log_retention_days", 7)
+                _audit_sources = None
+            _audit_configure(
+                enabled=_audit_enabled,
+                redact=_audit_redact,
+                retention_days=_audit_retention,
+                user_id=None,
+                platform=_audit_platform,
+                sources=_audit_sources,
+            )
+            _audit_start(
+                self.session_id,
+                model=self.model,
+                provider=self.provider or "",
+                platform=_audit_platform,
+                base_url=self.base_url or "",
+                tools=sorted(self.valid_tool_names) if hasattr(self, 'valid_tool_names') else [],
+            )
+        except Exception:
+            pass
+
         # In-memory todo list for task planning (one per agent/session)
         from tools.todo_tool import TodoStore
         self._todo_store = TodoStore()
@@ -879,6 +920,22 @@ class AIAgent:
                         user_char_limit=mem_config.get("user_char_limit", 1375),
                     )
                     self._memory_store.load_from_disk()
+                    # Audit: log memory loaded
+                    try:
+                        from agent.audit import emit
+                        _mem_chars = len(self._memory_store.format_for_system_prompt("memory") or "")
+                        _user_chars = len(self._memory_store.format_for_system_prompt("user") or "")
+                        emit(
+                            "memory.loaded",
+                            memory_enabled=self._memory_enabled,
+                            user_profile_enabled=self._user_profile_enabled,
+                            memory_chars=_mem_chars,
+                            user_profile_chars=_user_chars,
+                            memory_char_limit=mem_config.get("memory_char_limit", 2200),
+                            user_char_limit=mem_config.get("user_char_limit", 1375),
+                        )
+                    except Exception:
+                        pass
             except Exception:
                 pass  # Memory is optional -- don't break agent init
         
@@ -931,6 +988,32 @@ class AIAgent:
                 print(f"  Honcho init failed: {e}")
                 print("  Run 'hermes honcho setup' to reconfigure.")
                 self._honcho = None
+
+        # Audit: log honcho/memory state after init
+        try:
+            from agent.audit import emit
+            _honcho_enabled = self._honcho is not None
+            _honcho_ws = ""
+            _honcho_session = ""
+            _honcho_mode = ""
+            _honcho_recall = ""
+            if _honcho_enabled and hasattr(self, '_honcho_config'):
+                _honcho_ws = getattr(self._honcho_config, 'workspace_id', '') or ''
+                _honcho_session = getattr(self._honcho_config, 'session_name', '') or ''
+                _honcho_mode = getattr(self._honcho_config, 'memory_mode', '') or ''
+                _honcho_recall = getattr(self._honcho_config, 'recall_mode', '') or ''
+            emit(
+                "honcho.init",
+                enabled=_honcho_enabled,
+                workspace=_honcho_ws,
+                session=_honcho_session,
+                memory_mode=_honcho_mode,
+                recall_mode=_honcho_recall,
+                memory_enabled=getattr(self, '_memory_enabled', False),
+                user_profile_enabled=getattr(self, '_user_profile_enabled', False),
+            )
+        except Exception:
+            pass
 
         # Tools are initially discovered before Honcho activation. If Honcho
         # stays inactive, remove any stale honcho_* tools from prior process state.
@@ -1799,6 +1882,11 @@ class AIAgent:
                     self._honcho_session_key,
                     mem_dir,
                 )
+                try:
+                    from agent.audit import emit
+                    emit("honcho.migrate", source_dir=mem_dir)
+                except Exception:
+                    pass
             except Exception as exc:
                 logger.debug("Memory files migration failed (non-fatal): %s", exc)
 
@@ -1915,7 +2003,31 @@ class AIAgent:
                 "and what you were working on together. Do not call tools to "
                 "look up information that is already present here.\n"
             )
-            return header + "\n\n".join(parts)
+            full_block = header + "\n\n".join(parts)
+
+            # Audit: log what honcho context was injected
+            try:
+                from agent.audit import emit
+                sections = []
+                if ctx:
+                    if ctx.get("representation"):
+                        sections.append(f"user_representation({len(ctx['representation'])} chars)")
+                    if ctx.get("card"):
+                        sections.append(f"peer_card({len(ctx['card'])} chars)")
+                    if ctx.get("ai_representation"):
+                        sections.append(f"ai_representation({len(ctx['ai_representation'])} chars)")
+                if dialectic:
+                    sections.append(f"dialectic({len(dialectic)} chars)")
+                emit(
+                    "honcho.context_injected",
+                    sections=sections,
+                    total_chars=len(full_block),
+                    session_key=self._honcho_session_key or "",
+                )
+            except Exception:
+                pass
+
+            return full_block
         except Exception as e:
             logger.debug("Honcho prefetch failed (non-fatal): %s", e)
             return ""
@@ -1932,6 +2044,11 @@ class AIAgent:
             session = self._honcho.get_or_create(self._honcho_session_key)
             session.add_message("user", f"[observation] {content.strip()}")
             self._honcho.save(session)
+            try:
+                from agent.audit import emit
+                emit("honcho.observe", content_chars=len(content.strip()))
+            except Exception:
+                pass
             return json.dumps({
                 "success": True,
                 "target": "user",
@@ -1950,6 +2067,13 @@ class AIAgent:
             session.add_message("user", user_content)
             session.add_message("assistant", assistant_content)
             self._honcho.save(session)
+            try:
+                from agent.audit import emit
+                emit("honcho.sync", user_chars=len(user_content),
+                     assistant_chars=len(assistant_content),
+                     message_count=len(session.messages))
+            except Exception:
+                pass
             logger.info("Honcho sync queued for session %s (%d messages)",
                         self._honcho_session_key, len(session.messages))
         except Exception as e:
@@ -2112,7 +2236,41 @@ class AIAgent:
         if platform_key in PLATFORM_HINTS:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
 
-        return "\n\n".join(prompt_parts)
+        full_prompt = "\n\n".join(prompt_parts)
+
+        # Audit: log what was assembled into the system prompt
+        try:
+            from agent.audit import emit
+            layers = []
+            if system_message is not None:
+                layers.append("system_message")
+            if self._memory_store and self._memory_enabled:
+                mem_block = self._memory_store.format_for_system_prompt("memory")
+                if mem_block:
+                    layers.append(f"memory({len(mem_block)} chars)")
+            if self._memory_store and self._user_profile_enabled:
+                user_block = self._memory_store.format_for_system_prompt("user")
+                if user_block:
+                    layers.append(f"user_profile({len(user_block)} chars)")
+            if self._honcho and self._honcho_session_key:
+                layers.append("honcho")
+            if skills_prompt:
+                layers.append(f"skills({len(skills_prompt)} chars)")
+            if not self.skip_context_files:
+                if context_files_prompt:
+                    layers.append(f"context_files({len(context_files_prompt)} chars)")
+            if platform_key in PLATFORM_HINTS:
+                layers.append(f"platform_hint({platform_key})")
+            emit(
+                "context.assembled",
+                layers=layers,
+                total_chars=len(full_prompt),
+                model=self.model or "",
+            )
+        except Exception:
+            pass
+
+        return full_prompt
 
     # =========================================================================
     # Pre/post-call guardrails (inspired by PR #1321 — @alireza78a)
@@ -4242,6 +4400,18 @@ class AIAgent:
         Returns:
             (compressed_messages, new_system_prompt) tuple
         """
+        # Audit: log compression start
+        try:
+            from agent.audit import emit
+            emit(
+                "context.compression",
+                phase="start",
+                message_count=len(messages),
+                approx_tokens_before=approx_tokens,
+            )
+        except Exception:
+            pass
+
         # Pre-compression memory flush: let the model save memories before they're lost
         self.flush_memories(messages, min_turns=0)
 
@@ -4299,6 +4469,19 @@ class AIAgent:
                 self._last_flushed_db_idx = 0
             except Exception as e:
                 logger.debug("Session DB compression split failed: %s", e)
+
+        # Audit: log compression result
+        try:
+            from agent.audit import emit
+            emit(
+                "context.compression",
+                phase="end",
+                messages_before=len(messages),
+                messages_after=len(compressed),
+                new_prompt_chars=len(new_system_prompt),
+            )
+        except Exception:
+            pass
 
         return compressed, new_system_prompt
 
@@ -5099,6 +5282,14 @@ class AIAgent:
         # Honcho should receive the actual user input, not system nudges.
         original_user_message = persist_user_message if persist_user_message is not None else user_message
 
+        # Audit: log user message received
+        try:
+            from agent.audit import emit
+            emit("user.message", chars=len(original_user_message),
+                 turn=self._user_turn_count)
+        except Exception:
+            pass
+
         # Periodic memory nudge: remind the model to consider saving memories.
         # Counter resets whenever the memory tool is actually used.
         if (self._memory_nudge_interval > 0
@@ -5706,6 +5897,36 @@ class AIAgent:
                             self.session_estimated_cost_usd += float(cost_result.amount_usd)
                         self.session_cost_status = cost_result.status
                         self.session_cost_source = cost_result.source
+
+                        # Audit log: record every API request with tokens and cost
+                        try:
+                            from agent.audit import log_api_request
+                            _finish = ""
+                            _tc_count = 0
+                            try:
+                                _choice = response.choices[0] if response.choices else None
+                                if _choice:
+                                    _finish = getattr(_choice, "finish_reason", "") or ""
+                                    _tc = getattr(_choice.message, "tool_calls", None)
+                                    _tc_count = len(_tc) if _tc else 0
+                            except Exception:
+                                pass
+                            log_api_request(
+                                model=self.model,
+                                provider=self.provider or "",
+                                prompt_tokens=prompt_tokens,
+                                completion_tokens=completion_tokens,
+                                total_tokens=total_tokens,
+                                cache_read_tokens=canonical_usage.cache_read_tokens,
+                                reasoning_tokens=canonical_usage.reasoning_tokens,
+                                cost_usd=float(cost_result.amount_usd)
+                                if cost_result.amount_usd is not None else None,
+                                duration_ms=round(api_duration * 1000, 1),
+                                finish_reason=_finish,
+                                tool_calls_count=_tc_count,
+                            )
+                        except Exception:
+                            pass
 
                         # Persist token counts to session DB for /insights.
                         # Gateway sessions persist via session_store.update_session()

--- a/tests/agent/test_audit.py
+++ b/tests/agent/test_audit.py
@@ -1,0 +1,482 @@
+"""Tests for the structured audit log module."""
+
+import json
+import tempfile
+import time
+import os
+from pathlib import Path
+
+from agent.audit import (
+    configure,
+    start_session,
+    end_session,
+    log_api_request,
+    log_tool_call,
+    log_honcho_operation,
+    log_cron_run,
+    is_enabled,
+    list_sessions,
+    query_events,
+    export_events,
+    emit,
+    _sanitize_args,
+    _rotate_logs,
+)
+
+
+class TestAuditSanitize:
+    def test_redacts_sensitive_keys(self):
+        args = {"query": "hello", "password": "secret123", "api_key": "sk-12345"}
+        result = _sanitize_args(args)
+        assert result["query"] == "hello"
+        assert result["password"] == "[REDACTED]"
+        assert result["api_key"] == "[REDACTED]"
+
+    def test_truncates_long_values(self):
+        args = {"content": "x" * 3000}
+        result = _sanitize_args(args)
+        assert len(result["content"]) < 3000
+        assert "3000 chars" in result["content"]
+
+    def test_passthrough_when_redact_disabled(self):
+        import agent.audit as audit
+        old = audit._redact
+        audit._redact = False
+        try:
+            args = {"password": "secret123"}
+            result = _sanitize_args(args)
+            assert result["password"] == "secret123"
+        finally:
+            audit._redact = old
+
+
+def _setup_tmpdir(tmpdir):
+    """Patch audit module to use a temp directory."""
+    import agent.audit as audit
+    old_dir = audit._AUDIT_DIR
+    old_link = audit._LATEST_LINK
+    audit._AUDIT_DIR = Path(tmpdir)
+    audit._LATEST_LINK = Path(tmpdir) / "latest.jsonl"
+    return old_dir, old_link
+
+
+def _teardown(old_dir, old_link):
+    import agent.audit as audit
+    end_session()
+    configure(enabled=False)
+    audit._AUDIT_DIR = old_dir
+    audit._LATEST_LINK = old_link
+
+
+class TestAuditLifecycle:
+    def test_disabled_by_default(self):
+        configure(enabled=False)
+        assert not is_enabled()
+
+    def test_writes_all_event_types(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True, redact=True)
+                start_session("test-001", model="test-model", provider="test")
+
+                log_api_request(
+                    model="test-model", provider="test",
+                    prompt_tokens=100, completion_tokens=50, total_tokens=150,
+                    cost_usd=0.001, duration_ms=1234.5, finish_reason="stop",
+                )
+                log_tool_call(
+                    tool_name="read_file",
+                    args={"path": "/tmp/test.txt"},
+                    result='{"content": "hello"}',
+                    duration_ms=12.3,
+                )
+                log_tool_call(
+                    tool_name="execute_code",
+                    args={"code": "print('hi')"},
+                    error="SandboxError: denied",
+                )
+                log_honcho_operation(
+                    operation="honcho_conclude",
+                    payload={"conclusion": "user prefers dark mode"},
+                    result="ok",
+                )
+                log_cron_run(
+                    job_id="cron-001", job_name="daily-report",
+                    success=True, duration_s=45.2,
+                )
+                end_session(duration_s=60.0, total_tokens=500)
+
+                log_path = Path(tmpdir) / "test-001.jsonl"
+                assert log_path.exists()
+                lines = log_path.read_text().strip().split("\n")
+                events = [json.loads(line) for line in lines]
+
+                assert len(events) == 7
+                types = [e["type"] for e in events]
+                assert types == [
+                    "session.start", "api.request", "tool.call",
+                    "tool.error", "honcho.operation", "cron.run", "session.end",
+                ]
+
+                # Verify specific fields
+                assert events[1]["prompt_tokens"] == 100
+                assert events[1]["cost_usd"] == 0.001
+                assert events[2]["tool"] == "read_file"
+                assert events[3]["error"] == "SandboxError: denied"
+                assert events[4]["operation"] == "honcho_conclude"
+                assert events[5]["job_name"] == "daily-report"
+                assert events[5]["success"] is True
+
+                # Symlink created
+                latest = Path(tmpdir) / "latest.jsonl"
+                assert latest.is_symlink()
+            finally:
+                _teardown(old_dir, old_link)
+
+
+class TestAuditQuery:
+    def test_list_sessions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("sess-a", model="gpt-4", platform="cli")
+                log_tool_call(tool_name="read_file", args={}, result="ok")
+                end_session()
+
+                sessions = list_sessions()
+                assert len(sessions) >= 1
+                # Find our session in the results
+                our = [s for s in sessions if s["session_id"] == "sess-a"]
+                assert len(our) == 1
+                assert our[0]["session_id"] == "sess-a"
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_query_by_type(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("sess-b", model="test")
+                log_api_request(model="test", total_tokens=100)
+                log_tool_call(tool_name="read_file", args={}, result="ok")
+                log_tool_call(tool_name="write_file", args={}, result="ok")
+                end_session()
+
+                api_events = query_events(event_type="api.request")
+                assert len(api_events) == 1
+                tool_events = query_events(event_type="tool.call")
+                assert len(tool_events) == 2
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_query_by_tool_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("sess-c", model="test")
+                log_tool_call(tool_name="read_file", args={}, result="ok")
+                log_tool_call(tool_name="write_file", args={}, result="ok")
+                end_session()
+
+                events = query_events(tool_name="write_file")
+                assert len(events) == 1
+                assert events[0]["tool"] == "write_file"
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_query_keyword(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("sess-d", model="test")
+                log_tool_call(tool_name="search_files", args={"query": "foobar"}, result="found")
+                log_tool_call(tool_name="read_file", args={"path": "/tmp/x"}, result="ok")
+                end_session()
+
+                events = query_events(keyword="foobar")
+                assert len(events) == 1
+                assert events[0]["tool"] == "search_files"
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_query_by_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("sess-source", model="test")
+                log_tool_call(tool_name="read_file", args={}, result="ok")
+                emit("honcho.operation", operation="search", payload={"query": "q"}, result_summary="ok")
+                emit("mcp.tool_call", mcp_tool="obsidian.search", query="vault")
+                end_session()
+
+                core_events = query_events(source="core")
+                assert len(core_events) >= 3
+                assert all(e["type"].startswith(("session.", "tool.")) for e in core_events)
+
+                honcho_events = query_events(source="honcho")
+                assert len(honcho_events) == 1
+                assert honcho_events[0]["type"] == "honcho.operation"
+                assert honcho_events[0]["source"] == "honcho"
+
+                mcp_events = query_events(source="mcp")
+                assert len(mcp_events) == 1
+                assert mcp_events[0]["type"] == "mcp.tool_call"
+                assert mcp_events[0]["source"] == "mcp"
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_export_csv(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("sess-e", model="test")
+                log_tool_call(tool_name="read_file", args={}, result="ok")
+                end_session()
+
+                csv_str = export_events(session_id="sess-e", format="csv")
+                assert "tool" in csv_str or "type" in csv_str
+                assert "read_file" in csv_str
+            finally:
+                _teardown(old_dir, old_link)
+
+
+class TestAuditRotation:
+    def test_rotation_removes_old_files(self):
+        import agent.audit as audit
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            old_retention = audit._retention_days
+            try:
+                audit._retention_days = 1
+                # Create an old file
+                old_file = Path(tmpdir) / "old-session.jsonl"
+                old_file.write_text('{"type":"session.start"}\n')
+                # Set mtime to 3 days ago
+                old_time = time.time() - (3 * 86400)
+                os.utime(old_file, (old_time, old_time))
+
+                # Create a recent file
+                new_file = Path(tmpdir) / "new-session.jsonl"
+                new_file.write_text('{"type":"session.start"}\n')
+
+                _rotate_logs()
+
+                assert not old_file.exists()
+                assert new_file.exists()
+            finally:
+                audit._retention_days = old_retention
+                _teardown(old_dir, old_link)
+
+
+# =========================================================================
+# SQLite audit integration tests
+# =========================================================================
+
+class TestAuditSQLite:
+    """Integration tests for SQLite-backed audit storage."""
+
+    def test_dual_write_and_query(self):
+        """Events written via audit.py appear in both JSONL and SQLite."""
+        import agent.audit as audit
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True, user_id="alice", platform="cli")
+                start_session("dual-001", model="test", user_id="alice", platform="cli")
+                log_tool_call(tool_name="terminal", args={"command": "ls"}, result='{"output":"ok"}', duration_ms=50.0)
+                emit("custom.event", data="test-data")
+                end_session()
+
+                # JSONL exists
+                jsonl_path = Path(tmpdir) / "dual-001.jsonl"
+                assert jsonl_path.exists()
+                lines = jsonl_path.read_text().strip().split("\n")
+                assert len(lines) >= 4  # start, tool, custom, end
+
+                # SQLite query by session
+                events = query_events(session_id="dual-001")
+                types = {e.get("type") for e in events}
+                assert "session.start" in types
+                assert "tool.call" in types
+                assert "custom.event" in types
+
+                # Query by user
+                assert len(query_events(user_id="alice")) >= 1
+                assert len(query_events(user_id="bob")) == 0
+
+                # Query by tool
+                assert len(query_events(tool_name="terminal")) >= 1
+
+                # Keyword search
+                assert len(query_events(keyword="ls")) >= 1
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_date_range_filter(self):
+        """Date range filtering works through query_events."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                before_ts = time.time()
+                configure(enabled=True)
+                start_session("range-001", model="test")
+                log_tool_call(tool_name="read_file", args={}, result="ok")
+                end_session()
+
+                # Nothing before session start
+                assert len(query_events(before=before_ts)) == 0
+                # Everything after session start
+                assert len(query_events(after=before_ts)) >= 1
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_graceful_degradation(self):
+        """JSONL still works if SQLite is unavailable."""
+        import agent.audit as audit
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                audit._db = None
+                start_session("fallback-001", model="test")
+                audit._db = None  # clear again after start_session creates it
+                log_tool_call(tool_name="read_file", args={}, result="ok")
+                end_session()
+
+                jsonl_path = Path(tmpdir) / "fallback-001.jsonl"
+                assert jsonl_path.exists()
+                lines = jsonl_path.read_text().strip().split("\n")
+                assert len(lines) >= 2
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_query_by_source_in_jsonl_fallback(self):
+        """Source filtering works in JSONL fallback mode too."""
+        import agent.audit as audit
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("fallback-source", model="test")
+                audit._db = None  # force query_events to use JSONL fallback
+                log_tool_call(tool_name="read_file", args={}, result="ok")
+                emit("plugin.action", plugin="radio", action="play")
+                end_session()
+
+                plugin_events = query_events(session_id="fallback-source", source="plugin")
+                assert len(plugin_events) == 1
+                assert plugin_events[0]["type"] == "plugin.action"
+                assert plugin_events[0]["source"] == "plugin"
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_skill_manage_detail_extraction(self):
+        """skill_manage tool calls get rich detail extraction."""
+        from agent.audit import _extract_tool_detail
+        detail = _extract_tool_detail(
+            "skill_manage",
+            {"action": "create", "name": "my-skill", "category": "devops"},
+            '{"success": true}',
+        )
+        assert detail["action"] == "create"
+        assert detail["skill"] == "my-skill"
+
+
+class TestAuditSummary:
+    def test_summary_aggregates_events(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("sum-001", model="test")
+                from agent.audit import log_api_request, audit_summary
+                log_api_request(model="test", total_tokens=500, prompt_tokens=300,
+                                completion_tokens=200, cost_usd=0.01)
+                log_api_request(model="test", total_tokens=800, prompt_tokens=500,
+                                completion_tokens=300, cost_usd=0.02)
+                log_tool_call(tool_name="terminal", args={"command": "ls"}, result="ok", duration_ms=50)
+                log_tool_call(tool_name="terminal", args={"command": "pwd"}, result="ok", duration_ms=30)
+                log_tool_call(tool_name="read_file", args={}, result="ok", duration_ms=10)
+                end_session()
+
+                s = audit_summary(session_id="sum-001")
+                assert s["total"] >= 5
+                assert s["api_calls"] == 2
+                assert s["tool_calls"] == 3
+                assert s["total_tokens"] == 1300
+                assert s["total_cost_usd"] == 0.03
+                assert len(s["top_tools"]) >= 1
+                assert s["top_tools"][0]["tool"] == "terminal"
+                assert s["top_tools"][0]["count"] == 2
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_summary_empty_returns_zero(self):
+        from agent.audit import audit_summary
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                s = audit_summary()
+                assert s["total"] == 0
+            finally:
+                _teardown(old_dir, old_link)
+
+
+class TestAuditProblems:
+    def test_detects_repeated_tool_failure(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("prob-001", model="test")
+                for _ in range(4):
+                    log_tool_call(tool_name="terminal", args={}, error="SandboxError: denied")
+                end_session()
+
+                from agent.audit import audit_problems
+                findings = audit_problems(session_id="prob-001")
+                rules = [f["rule"] for f in findings]
+                assert "repeated_tool_failure" in rules
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_no_problems_when_clean(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("prob-002", model="test")
+                log_tool_call(tool_name="read_file", args={}, result="ok", duration_ms=50)
+                end_session()
+
+                from agent.audit import audit_problems
+                findings = audit_problems(session_id="prob-002")
+                assert len(findings) == 0
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_detects_high_error_rate(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("prob-003", model="test")
+                log_tool_call(tool_name="read_file", args={}, result="ok")
+                for _ in range(5):
+                    log_tool_call(tool_name="terminal", args={}, error="fail")
+                end_session()
+
+                from agent.audit import audit_problems
+                findings = audit_problems(session_id="prob-003")
+                rules = [f["rule"] for f in findings]
+                assert "high_error_rate" in rules
+            finally:
+                _teardown(old_dir, old_link)

--- a/tests/gateway/test_audit_command.py
+++ b/tests/gateway/test_audit_command.py
@@ -1,0 +1,181 @@
+"""Tests for gateway /audit command filtering behavior."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/audit", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    """Build a MessageEvent for testing."""
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    """Create a bare GatewayRunner with minimal mocks."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.session_store = SimpleNamespace()
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    return runner
+
+
+class TestHandleAuditCommand:
+    """Tests for GatewayRunner._handle_audit_command."""
+
+    @pytest.mark.asyncio
+    async def test_parses_after_before_and_passes_timestamps(self, monkeypatch):
+        runner = _make_runner()
+        event = _make_event(
+            text="/audit --after 2026-03-17T12:00:00 --before 2026-03-17T18:00:00 --source core 5"
+        )
+
+        captured = {}
+
+        def fake_query_events(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr("agent.audit.query_events", fake_query_events)
+        monkeypatch.setattr("agent.audit.list_sessions", lambda: [])
+
+        result = await runner._handle_audit_command(event)
+
+        assert result == "No audit events found. Enable with `audit.enabled: true` in config.yaml"
+        assert captured["source"] == "core"
+        assert captured["limit"] == 5
+        # fromisoformat on naive string is local-tz-dependent; just verify
+        # the gateway parsed both timestamps and they're 6 hours apart.
+        expected_after = datetime.fromisoformat("2026-03-17T12:00:00").timestamp()
+        expected_before = datetime.fromisoformat("2026-03-17T18:00:00").timestamp()
+        assert captured["after"] == pytest.approx(expected_after)
+        assert captured["before"] == pytest.approx(expected_before)
+
+    @pytest.mark.asyncio
+    async def test_invalid_after_date_returns_error(self, monkeypatch):
+        runner = _make_runner()
+        event = _make_event(text="/audit --after not-a-date")
+
+        monkeypatch.setattr("agent.audit.query_events", lambda **kwargs: [])
+        monkeypatch.setattr("agent.audit.list_sessions", lambda: [])
+
+        result = await runner._handle_audit_command(event)
+
+        assert result == "Cannot parse date: not-a-date"
+
+    @pytest.mark.asyncio
+    async def test_sessions_lists_recent_sessions_and_caps_at_20(self, monkeypatch):
+        runner = _make_runner()
+        event = _make_event(text="/audit sessions")
+
+        sessions = [
+            {
+                "session_id": f"sess-{i:02d}",
+                "size_kb": i + 1,
+                "modified": f"2026-03-17 1{i % 10}:00",
+            }
+            for i in range(25)
+        ]
+
+        monkeypatch.setattr("agent.audit.list_sessions", lambda: sessions)
+        monkeypatch.setattr("agent.audit.query_events", lambda **kwargs: [])
+
+        result = await runner._handle_audit_command(event)
+
+        assert "**Audit Sessions**" in result
+        assert "`sess-00` 1kb" in result
+        assert "`sess-19` 20kb" in result
+        assert "sess-20" not in result
+        assert "sess-24" not in result
+
+    @pytest.mark.asyncio
+    async def test_formats_source_tags_and_tool_detail_previews(self, monkeypatch):
+        runner = _make_runner()
+        event = _make_event(text="/audit 3")
+
+        events = [
+            {
+                "iso": "2026-03-17T12:00:00+0000",
+                "type": "tool.call",
+                "source": "core",
+                "tool": "terminal",
+                "detail": {"command": "echo hello from terminal"},
+                "duration_ms": 12.0,
+            },
+            {
+                "iso": "2026-03-17T12:01:00+0000",
+                "type": "tool.call",
+                "source": "core",
+                "tool": "read_file",
+                "detail": {"path": "/tmp/example.txt"},
+                "duration_ms": 8.0,
+            },
+            {
+                "iso": "2026-03-17T12:02:00+0000",
+                "type": "honcho.operation",
+                "source": "honcho",
+                "operation": "search",
+            },
+        ]
+
+        monkeypatch.setattr("agent.audit.query_events", lambda **kwargs: events)
+        monkeypatch.setattr("agent.audit.list_sessions", lambda: [])
+
+        result = await runner._handle_audit_command(event)
+
+        assert "[core] **tool.call** terminal 12ms echo hello from terminal" in result
+        assert "[core] **tool.call** read_file 8ms /tmp/example.txt" in result
+        assert "[honcho] **honcho.operation** search" in result
+
+    @pytest.mark.asyncio
+    async def test_mixed_flags_unknown_tokens_and_repeated_source_parse_cleanly(self, monkeypatch):
+        runner = _make_runner()
+        event = _make_event(
+            text=(
+                "/audit --type tool.call junk --tool terminal --source honcho "
+                "--source core --session sess-1 --keyword foo "
+                "--after 2026-03-17T12:00:00 --before 2026-03-17T18:00:00 7 extra"
+            )
+        )
+
+        captured = {}
+
+        def fake_query_events(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr("agent.audit.query_events", fake_query_events)
+        monkeypatch.setattr("agent.audit.list_sessions", lambda: [])
+
+        result = await runner._handle_audit_command(event)
+
+        assert result == "No audit events found. Enable with `audit.enabled: true` in config.yaml"
+        assert captured["event_type"] == "tool.call"
+        assert captured["tool_name"] == "terminal"
+        assert captured["source"] == "core"
+        assert captured["session_id"] == "sess-1"
+        assert captured["keyword"] == "foo"
+        assert captured["limit"] == 7
+        expected_after = datetime.fromisoformat("2026-03-17T12:00:00").timestamp()
+        expected_before = datetime.fromisoformat("2026-03-17T18:00:00").timestamp()
+        assert captured["after"] == pytest.approx(expected_after)
+        assert captured["before"] == pytest.approx(expected_before)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -737,7 +737,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 5
+        assert version == 6
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -793,12 +793,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v5
+        # Open with SessionDB — should migrate to latest version
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 5
+        assert cursor.fetchone()[0] == 6
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")

--- a/tests/tools/test_audit_tool.py
+++ b/tests/tools/test_audit_tool.py
@@ -41,7 +41,7 @@ class TestAuditQueryTool:
                 log_tool_call(tool_name="terminal", args={"command": "ls"}, result="ok")
                 end_session()
 
-                result = _handle_audit_query(action="query", session="aq-001")
+                result = _handle_audit_query({"action": "query", "session": "aq-001"})
                 assert "terminal" in result
                 assert "tool.call" in result
             finally:
@@ -58,7 +58,7 @@ class TestAuditQueryTool:
                 log_tool_call(tool_name="read_file", args={}, result="ok")
                 end_session()
 
-                result = _handle_audit_query(action="summary", session="aq-002")
+                result = _handle_audit_query({"action": "summary", "session": "aq-002"})
                 assert "Audit summary" in result
                 assert "100" in result
             finally:
@@ -74,7 +74,7 @@ class TestAuditQueryTool:
                 log_tool_call(tool_name="read_file", args={}, result="ok")
                 end_session()
 
-                result = _handle_audit_query(action="problems", session="aq-003")
+                result = _handle_audit_query({"action": "problems", "session": "aq-003"})
                 assert "No problems" in result
             finally:
                 _teardown(old_dir, old_link)
@@ -82,5 +82,5 @@ class TestAuditQueryTool:
     def test_query_empty_returns_no_match(self):
         from tools.audit_tool import _handle_audit_query
         configure(enabled=False)
-        result = _handle_audit_query(action="query", tool="nonexistent")
+        result = _handle_audit_query({"action": "query", "tool": "nonexistent"})
         assert "No matching" in result or "No audit" in result

--- a/tests/tools/test_audit_tool.py
+++ b/tests/tools/test_audit_tool.py
@@ -1,0 +1,86 @@
+"""Tests for the audit_query tool handler."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from agent.audit import (
+    configure,
+    start_session,
+    end_session,
+    log_tool_call,
+    log_api_request,
+)
+
+
+def _setup_tmpdir(tmpdir):
+    import agent.audit as audit
+    old_dir = audit._AUDIT_DIR
+    old_link = audit._LATEST_LINK
+    audit._AUDIT_DIR = Path(tmpdir)
+    audit._LATEST_LINK = Path(tmpdir) / "latest.jsonl"
+    return old_dir, old_link
+
+
+def _teardown(old_dir, old_link):
+    import agent.audit as audit
+    end_session()
+    configure(enabled=False)
+    audit._AUDIT_DIR = old_dir
+    audit._LATEST_LINK = old_link
+
+
+class TestAuditQueryTool:
+    def test_query_action_returns_events(self):
+        from tools.audit_tool import _handle_audit_query
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("aq-001", model="test")
+                log_tool_call(tool_name="terminal", args={"command": "ls"}, result="ok")
+                end_session()
+
+                result = _handle_audit_query(action="query", session="aq-001")
+                assert "terminal" in result
+                assert "tool.call" in result
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_summary_action(self):
+        from tools.audit_tool import _handle_audit_query
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("aq-002", model="test")
+                log_api_request(model="test", total_tokens=100, cost_usd=0.005)
+                log_tool_call(tool_name="read_file", args={}, result="ok")
+                end_session()
+
+                result = _handle_audit_query(action="summary", session="aq-002")
+                assert "Audit summary" in result
+                assert "100" in result
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_problems_action_clean(self):
+        from tools.audit_tool import _handle_audit_query
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_dir, old_link = _setup_tmpdir(tmpdir)
+            try:
+                configure(enabled=True)
+                start_session("aq-003", model="test")
+                log_tool_call(tool_name="read_file", args={}, result="ok")
+                end_session()
+
+                result = _handle_audit_query(action="problems", session="aq-003")
+                assert "No problems" in result
+            finally:
+                _teardown(old_dir, old_link)
+
+    def test_query_empty_returns_no_match(self):
+        from tools.audit_tool import _handle_audit_query
+        configure(enabled=False)
+        result = _handle_audit_query(action="query", tool="nonexistent")
+        assert "No matching" in result or "No audit" in result

--- a/tools/audit_tool.py
+++ b/tools/audit_tool.py
@@ -1,0 +1,129 @@
+"""Audit query tool — lets the agent inspect its own audit trail.
+
+Registered as ``audit_query`` in the ``audit`` toolset.  Always available
+when audit logging is enabled (no check_fn gate — the module gracefully
+returns empty results when disabled).
+"""
+
+import json
+
+from tools.registry import registry
+
+_SCHEMA = {
+    "name": "audit_query",
+    "description": (
+        "Query the audit log for recent agent actions, errors, tool usage, "
+        "and system health. Use when the user asks about what happened, what "
+        "errors occurred, recent tool usage, or overall system status."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["query", "summary", "problems"],
+                "description": (
+                    "query: list recent events with optional filters. "
+                    "summary: aggregate stats (tokens, cost, error rate, top tools). "
+                    "problems: auto-detect anomalies (repeated errors, rate limits, slow tools)."
+                ),
+            },
+            "type": {
+                "type": "string",
+                "description": "Filter by event type: tool.call, api.request, tool.error, honcho.sync, etc.",
+            },
+            "tool": {
+                "type": "string",
+                "description": "Filter by tool name: terminal, read_file, patch, etc.",
+            },
+            "keyword": {
+                "type": "string",
+                "description": "Text search across event payloads.",
+            },
+            "session": {
+                "type": "string",
+                "description": "Scope to a specific session ID.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max events to return (default 20, max 100).",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+def _handle_audit_query(**kwargs) -> str:
+    """Handle audit_query tool calls."""
+    try:
+        from agent.audit import query_events, audit_summary, audit_problems
+    except ImportError:
+        return json.dumps({"error": "Audit module not available"})
+
+    action = kwargs.get("action", "query")
+    session_id = kwargs.get("session")
+    limit = min(kwargs.get("limit") or 20, 100)
+
+    try:
+        if action == "summary":
+            s = audit_summary(session_id=session_id)
+            if s.get("total", 0) == 0:
+                return "No audit events found."
+            lines = [f"Audit summary: {s['total']} events, {s['sessions']} sessions"]
+            lines.append(f"API: {s['api_calls']} calls, {s['total_tokens']:,} tokens, ${s['total_cost_usd']:.4f}")
+            lines.append(f"Tools: {s['tool_calls']} calls, Errors: {s['errors']} ({s['error_rate']}%)")
+            if s.get("top_tools"):
+                lines.append("Top tools: " + ", ".join(f"{t['tool']}({t['count']})" for t in s["top_tools"]))
+            if s.get("top_errors"):
+                lines.append("Top errors: " + ", ".join(f"{e['error'][:40]}(x{e['count']})" for e in s["top_errors"]))
+            return "\n".join(lines)
+
+        elif action == "problems":
+            findings = audit_problems(session_id=session_id)
+            if not findings:
+                return "No problems detected."
+            lines = [f"{len(findings)} problem(s) detected:"]
+            for f in findings:
+                lines.append(f"  [{f['rule']}] {f['message']}")
+            return "\n".join(lines)
+
+        else:  # query
+            events = query_events(
+                session_id=session_id,
+                event_type=kwargs.get("type"),
+                tool_name=kwargs.get("tool"),
+                keyword=kwargs.get("keyword"),
+                limit=limit,
+            )
+            if not events:
+                return "No matching audit events."
+            lines = [f"{len(events)} events:"]
+            for e in events:
+                ts = e.get("iso", "")[:19]
+                etype = e.get("type", "?")
+                tool = e.get("tool", "")
+                err = e.get("error", "")
+                dur = e.get("duration_ms")
+                detail = ""
+                if tool:
+                    detail = f" {tool}"
+                if dur:
+                    detail += f" {dur:.0f}ms"
+                if err:
+                    detail += f" ERR: {err[:60]}"
+                lines.append(f"  {ts} {etype}{detail}")
+            # Truncate to avoid context bloat
+            result = "\n".join(lines)
+            return result[:4000]
+
+    except Exception as e:
+        return f"Audit query failed: {e}"
+
+
+registry.register(
+    name="audit_query",
+    toolset="audit",
+    schema=_SCHEMA,
+    handler=_handle_audit_query,
+)

--- a/tools/audit_tool.py
+++ b/tools/audit_tool.py
@@ -54,16 +54,16 @@ _SCHEMA = {
 }
 
 
-def _handle_audit_query(**kwargs) -> str:
+def _handle_audit_query(args: dict, **kwargs) -> str:
     """Handle audit_query tool calls."""
     try:
         from agent.audit import query_events, audit_summary, audit_problems
     except ImportError:
         return json.dumps({"error": "Audit module not available"})
 
-    action = kwargs.get("action", "query")
-    session_id = kwargs.get("session")
-    limit = min(kwargs.get("limit") or 20, 100)
+    action = args.get("action", "query")
+    session_id = args.get("session")
+    limit = min(args.get("limit") or 20, 100)
 
     try:
         if action == "summary":
@@ -91,9 +91,9 @@ def _handle_audit_query(**kwargs) -> str:
         else:  # query
             events = query_events(
                 session_id=session_id,
-                event_type=kwargs.get("type"),
-                tool_name=kwargs.get("tool"),
-                keyword=kwargs.get("keyword"),
+                event_type=args.get("type"),
+                tool_name=args.get("tool"),
+                keyword=args.get("keyword"),
                 limit=limit,
             )
             if not events:

--- a/toolsets.py
+++ b/toolsets.py
@@ -64,6 +64,8 @@ _HERMES_CORE_TOOLS = [
     "honcho_context", "honcho_profile", "honcho_search", "honcho_conclude",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+    # Audit self-inspection
+    "audit_query",
 ]
 
 
@@ -199,6 +201,12 @@ TOOLSETS = {
     "honcho": {
         "description": "Honcho AI-native memory for persistent cross-session user modeling",
         "tools": ["honcho_context", "honcho_profile", "honcho_search", "honcho_conclude"],
+        "includes": []
+    },
+
+    "audit": {
+        "description": "Agent self-inspection of audit trail, errors, and system health",
+        "tools": ["audit_query"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary

Structured audit log for observability across CLI and gateway sessions. Every tool call, API request, honcho write, and user message is recorded to JSONL + SQLite with async background writes that never block the agent. Closes #1155.

- **agent/audit.py** -- core module: async queue-based writer, per-source event filtering, field redaction, JSONL rotation, batch SQLite commits (every 10 events or 2s), summary aggregation, problem auto-detection
- **hermes tail** -- live event stream via `tail -F` on latest.jsonl symlink, with `--raw`, `--type`, `--session` filters, 6-char session tags, separator on session change
- **hermes audit** -- retrospective SQLite query: `--type`, `--tool`, `--source`, `--session`, `--after`, `--before`, `--keyword`, `--user`, `-n`, `--export`. Sub-actions: `sessions`, `summary`, `problems`
- **/audit** gateway command -- same filter set + summary/problems, works across Telegram/Discord/Slack/Matrix
- **audit_query tool** -- agent can self-inspect its audit trail ("any errors?", "what happened last session?")
- **hermes_state.py** -- schema v5->v6: `audit_events` table with batch insert, count, query, prune
- **config v9->v11** -- nested `audit` block with `sources` dict for per-namespace filtering

## What reviewers should know

**Additive only.** No existing functionality modified or removed. All audit injection points are wrapped in `try/except: pass` -- audit failures cannot crash the agent.

**Schema migration.** v5->v6 adds one table (`audit_events`). Existing tables untouched. Migration runs automatically on first session with new code.

**Config migration.** v9->v10 migrates flat `audit_log` keys to nested `audit` block. v10->v11 adds `audit.sources` dict. Both are additive with `setdefault` -- existing user values preserved.

**Always on, 7-day retention.** Audit is enabled by default for all platforms (CLI + gateway). Retention is 7 days. Users can override via `audit.enabled: false` or `audit.retention_days: N` in config.

**Performance.** The hot path is `queue.put_nowait()` (non-blocking, microseconds). Background writer thread batches SQLite commits every 10 events or 2 seconds. JSONL writes are OS-buffered via line-buffered file handle. SessionDB uses WAL mode.

**Concurrent sessions.** `latest.jsonl` symlink is repointed on session start. On session end, if another session is still active (file modified within 10s), the symlink is repointed back so `hermes tail` continues following the surviving session.

**Relation to #1944.** Overlapping PR opened 18h after this one. Different architecture (pure SQLite, per-event commits, no JSONL/tail). The `summary`, `problems`, and `audit_query` features here were inspired by ideas from that PR, implemented on our JSONL+SQLite dual-storage foundation.

**Scope coverage:**
- Terminal commands: command, exit code, output summary
- File ops: read (path + bytes), write (path + bytes), patch (path + old/new byte diff)
- Web: fetch_url (URL + result bytes), web_search (query + result URLs)
- Browser: navigate/snapshot (URL + action), MCP browser tools (server.method + args)
- MCP tools: parsed server/method from `mcp__server__method`, sanitized args (10 keys, 200 char cap)
- Cron: job_id, job_name, success, duration
- Honcho: sync (user/assistant chars + msg count), observe (content chars), migrate (source dir), init, context injection
- User messages: char count + turn number per message
- API requests: model, tokens, cost, duration, finish reason

## Test plan

- [x] `pytest tests/agent/test_audit.py` -- 24 tests (sanitize, lifecycle, query, rotation, SQLite, source filtering, summary, problems)
- [x] `pytest tests/gateway/test_audit_command.py` -- 5 tests (gateway /audit parsing + response)
- [x] `pytest tests/tools/test_audit_tool.py` -- 4 tests (audit_query tool handler)
- [x] `pytest tests/test_hermes_state.py` -- schema version assertion
- [x] Manual: `hermes tail` live output during a session
- [x] Manual: `hermes audit summary` / `hermes audit problems`
- [x] Manual: ask agent "any errors recently?" (triggers audit_query tool)