### PR TITLE
feat(agent): set claude-sonnet-4.6 and claude-opus-4.6 context to 1M tokens

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -35,17 +35,20 @@ CONTEXT_PROBE_TIERS = [
 ]
 
 DEFAULT_CONTEXT_LENGTHS = {
+    # Claude 4.6 (Opus + Sonnet) natively support 1M context window via Anthropic API
+    # Other Claude 4.x models are limited to 200K (1M requires a feature flag or is unavailable)
+    # https://docs.anthropic.com/en/docs/about-claude/models
     "anthropic/claude-opus-4": 200000,
     "anthropic/claude-opus-4.5": 200000,
-    "anthropic/claude-opus-4.6": 200000,
+    "anthropic/claude-opus-4.6": 1_000_000,
     "anthropic/claude-sonnet-4": 200000,
     "anthropic/claude-sonnet-4-20250514": 200000,
     "anthropic/claude-sonnet-4.5": 200000,
-    "anthropic/claude-sonnet-4.6": 200000,
+    "anthropic/claude-sonnet-4.6": 1_000_000,
     "anthropic/claude-haiku-4.5": 200000,
     # Bare Anthropic model IDs (for native API provider)
-    "claude-opus-4-6": 200000,
-    "claude-sonnet-4-6": 200000,
+    "claude-opus-4-6": 1_000_000,
+    "claude-sonnet-4-6": 1_000_000,
     "claude-opus-4-5-20251101": 200000,
     "claude-sonnet-4-5-20250929": 200000,
     "claude-opus-4-1-20250805": 200000,


### PR DESCRIPTION
Claude Sonnet 4.6 and Claude Opus 4.6 natively support a 1M token context window via the Anthropic API without any feature flag.

Other Claude 4.x models (4, 4.1, 4.5) remain at 200K — 1M context is either behind a flag or not available for those versions.

Updated entries in agent/model_metadata.py:
- anthropic/claude-opus-4.6: 200_000 -> 1_000_000
- anthropic/claude-sonnet-4.6: 200_000 -> 1_000_000
- claude-opus-4-6 (bare model ID): 200_000 -> 1_000_000
- claude-sonnet-4-6 (bare model ID): 200_000 -> 1_000_000

Ref: https://docs.anthropic.com/en/docs/about-claude/models