### PR TITLE
feat(tts): add base_url support to openai provider for custom endpoints

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -259,6 +259,7 @@ DEFAULT_CONFIG = {
             "model": "gpt-4o-mini-tts",
             "voice": "alloy",
             # Voices: alloy, echo, fable, onyx, nova, shimmer
+            "base_url": "",
         },
         "neutts": {
             "ref_audio": "",  # Path to reference voice audio (empty = bundled default)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -73,6 +73,7 @@ DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2"
 DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 DEFAULT_OPENAI_VOICE = "alloy"
+DEFAULT_OPENAI_BASE_URL = os.getenv("TTS_OPENAI_BASE_URL", "https://api.openai.com/v1")
 DEFAULT_OUTPUT_DIR = str(Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "audio_cache")
 MAX_TEXT_LENGTH = 4000
 
@@ -233,10 +234,11 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         Path to the saved audio file.
     """
     api_key = os.getenv("VOICE_TOOLS_OPENAI_KEY", "")
-    if not api_key:
+    if not api_key and DEFAULT_OPENAI_BASE_URL.startswith("https://api.openai.com"):
         raise ValueError("VOICE_TOOLS_OPENAI_KEY not set. Get one at https://platform.openai.com/api-keys")
 
     oai_config = tts_config.get("openai", {})
+    base_url = oai_config.get("base_url") or DEFAULT_OPENAI_BASE_URL
     model = oai_config.get("model", DEFAULT_OPENAI_MODEL)
     voice = oai_config.get("voice", DEFAULT_OPENAI_VOICE)
 
@@ -247,7 +249,7 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         response_format = "mp3"
 
     OpenAIClient = _import_openai_client()
-    client = OpenAIClient(api_key=api_key, base_url="https://api.openai.com/v1")
+    client = OpenAIClient(api_key=api_key, base_url=base_url)
     response = client.audio.speech.create(
         model=model,
         voice=voice,


### PR DESCRIPTION
# hermes-agent TTS base_url openai endpoint PR

Branch: `taogaetz/hermes-agent:feat/tts-openai-base-url`

## Commit message

The openai TTS provider had a hardcoded base_url of https://api.openai.com/v1 with no way to override it, making it impossible to use OpenAI-compatible self-hosted TTS endpoints (e.g. Kokoro, anything local).

STT already handles this correctly via STT_OPENAI_BASE_URL. This mirrors that pattern for TTS:

- Add TTS_OPENAI_BASE_URL env var support
- Add tts.openai.base_url config key (takes precedence over env var)
- Add base_url default to config.py
- Relax api_key requirement for non-openai.com endpoints

related - #127 

## PR description

### What does this PR do?

allows for easy config of an openai-compatible tts endpoint by changing the openai tts baseurl to an env var & config field.

### Related Issue

related to #127

### Type of Change

- ✨ New feature (non-breaking change that adds functionality)

### Changes Made

- `tools/tts_tool.py` — read `base_url` from config or `TTS_OPENAI_BASE_URL` env var; relax api_key requirement for non-openai.com endpoints
- `hermes_cli/config.py` — add `base_url: ""` default under `tts.openai`

### How to Test

1. Set `tts.provider: openai` in `~/.hermes/config.yaml`
2. Set `tts.openai.base_url: 'http://<HOST>:<PORT>/'` and `tts.openai.model: <MODEL>`
3. Send a message triggering tts - it should use your endpoint. 

Or via env var: `TTS_OPENAI_BASE_URL=http://<HOST>:<PORT>/v1`

### Checklist

- [x] Follows Conventional Commits
- [x] No duplicate PRs found (checked — related issue #127 open, no existing PR)
- [x] Tested on Ubuntu 24.04
- [x] `I've run pytest tests/ -q and all tests pass`
- [x] `I've added tests for my changes` - N/A
- [x] `cli-config.yaml.example` — N/A (base_url already shown as empty string in defaults)
- [x] Cross-platform impact — none (pure Python, no OS-specific calls)