### PR TITLE
fix(file_tools): include pagination args in repeated search key

### DIFF
--- a/tests/tools/test_read_loop_detection.py
+++ b/tests/tools/test_read_loop_detection.py
@@ -442,6 +442,14 @@ class TestSearchLoopDetection(unittest.TestCase):
         self.assertNotIn("error", result)
 
     @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
+    def test_pagination_offset_does_not_count_as_repeat(self, _mock_ops):
+        """Paginating truncated results should not be blocked as a repeat search."""
+        for offset in (0, 50, 100, 150):
+            result = json.loads(search_tool("def main", task_id="t1", offset=offset, limit=50))
+            self.assertNotIn("_warning", result)
+            self.assertNotIn("error", result)
+
+    @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
     def test_read_between_searches_resets_consecutive(self, _mock_ops):
         """A read_file call between searches resets search consecutive counter."""
         search_tool("def main", task_id="t1")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -337,7 +337,17 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
     """Search for content or files."""
     try:
         # Track searches to detect *consecutive* repeated search loops.
-        search_key = ("search", pattern, target, str(path), file_glob or "")
+        # Include pagination args so users can page through truncated
+        # results without tripping the repeated-search guard.
+        search_key = (
+            "search",
+            pattern,
+            target,
+            str(path),
+            file_glob or "",
+            limit,
+            offset,
+        )
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
                 "last_key": None, "consecutive": 0, "read_history": set(),


### PR DESCRIPTION
## Summary

`search_files` repeated-search detection keyed searches on `pattern`, `target`, `path`, and `file_glob` only, omitting `limit` and `offset`.

As a result, paginating through truncated results could incorrectly trigger the consecutive-search guard:

```python
search_files(pattern="def main", offset=0,   limit=50)  # ok
search_files(pattern="def main", offset=50,  limit=50)  # ok
search_files(pattern="def main", offset=100, limit=50)  # warning
search_files(pattern="def main", offset=150, limit=50)  # BLOCKED
```

This also differs from `read_file`, where the repeated-read key already includes pagination parameters.

## Fix

Added `limit` and `offset` to the `search_key` tuple in `tools/file_tools.py`, so paginated `search_files` calls are treated as distinct searches. Truly identical repeated searches are still blocked as before.

## Tests

Added `test_pagination_offset_does_not_count_as_repeat` to `tests/tools/test_read_loop_detection.py`.

```bash
pytest -o addopts='' tests/tools/test_read_loop_detection.py -q
# 36 passed
```

Also verified under Python 3.11:

```bash
python3.11 -m pytest -o addopts='' tests/tools/test_read_loop_detection.py -q
# 36 passed
```