### PR TITLE
fix(discord): remove bugged follow up messages from discord slash commmands

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1364,16 +1364,17 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         interaction: discord.Interaction,
         command_text: str,
-        followup_msg: str = "Done~",
+        followup_msg: str | None = None,
     ) -> None:
         """Common handler for simple slash commands that dispatch a command string."""
         await interaction.response.defer(ephemeral=True)
         event = self._build_slash_event(interaction, command_text)
         await self.handle_message(event)
-        try:
-            await interaction.followup.send(followup_msg, ephemeral=True)
-        except Exception as e:
-            logger.debug("Discord followup failed: %s", e)
+        if followup_msg:
+            try:
+                await interaction.followup.send(followup_msg, ephemeral=True)
+            except Exception as e:
+                logger.debug("Discord followup failed: %s", e)
 
     def _register_slash_commands(self) -> None:
         """Register Discord slash commands on the command tree."""
@@ -1388,12 +1389,6 @@ class DiscordAdapter(BasePlatformAdapter):
             await interaction.response.defer()
             event = self._build_slash_event(interaction, question)
             await self.handle_message(event)
-            # The response is sent via the normal send() flow
-            # Send a followup to close the interaction if needed
-            try:
-                await interaction.followup.send("Processing complete~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
 
         @tree.command(name="new", description="Start a new conversation")
         async def slash_new(interaction: discord.Interaction):
@@ -1414,10 +1409,6 @@ class DiscordAdapter(BasePlatformAdapter):
             await interaction.response.defer(ephemeral=True)
             event = self._build_slash_event(interaction, f"/reasoning {effort}".strip())
             await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
 
         @tree.command(name="personality", description="Set a personality")
         @discord.app_commands.describe(name="Personality name. Leave empty to list available.")
@@ -1493,10 +1484,6 @@ class DiscordAdapter(BasePlatformAdapter):
             await interaction.response.defer(ephemeral=True)
             event = self._build_slash_event(interaction, f"/voice {mode}".strip())
             await self.handle_message(event)
-            try:
-                await interaction.followup.send("Done~", ephemeral=True)
-            except Exception as e:
-                logger.debug("Discord followup failed: %s", e)
 
         @tree.command(name="update", description="Update Hermes Agent to the latest version")
         async def slash_update(interaction: discord.Interaction):


### PR DESCRIPTION
## Summary
  - Discord slash commands (/ask, /reasoning, /voice) were sending unnecessary "Done~" or "Processing
  complete~" followup messages, even though the actual agent response is sent separately via the normal
  adapter flow
 - Sometimes these messages would replace the actual agent response, resulting in a completely broken discord gateway.
  - Changed _run_simple_slash default followup_msg from "Done~" to None so only commands that explicitly
   pass a message (e.g. /new, /reset, /update) send a followup
  - Removed redundant followup sends from slash_ask, slash_reasoning, and slash_voice

## Test plan
  - Run /ask (or any slash command) in Discord and verify only the agent's response appears (no "Processing complete~" or "Done~")