### PR TITLE
fix: normalize gateway voice transcripts before command handling

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -291,6 +291,13 @@ class MessageEvent:
     # media_urls: local file paths (for vision tool access)
     media_urls: List[str] = field(default_factory=list)
     media_types: List[str] = field(default_factory=list)
+
+    # Optional normalized transcription metadata for voice/audio inputs.
+    # ``text`` may be promoted to the transcript for command/interrupt parity,
+    # while these fields preserve that the content originated from STT.
+    transcription_text: Optional[str] = None
+    transcription_backend: Optional[str] = None
+    transcription_origin: Optional[str] = None
     
     # Reply context
     reply_to_message_id: Optional[str] = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1247,6 +1247,80 @@ class GatewayRunner:
         if "@" in user_id:
             check_ids.add(user_id.split("@")[0])
         return bool(check_ids & allowed_ids)
+
+    async def _prepare_event_for_control_flow(self, event: MessageEvent) -> MessageEvent:
+        """Normalize voice/audio inputs before interrupt and command parsing.
+
+        If a voice/audio message has no explicit text, promote the transcript into
+        ``event.text`` so it behaves like a normal text message in gateway control
+        flows. Preserve STT metadata separately so downstream code can still see
+        that the content originated from transcription.
+        """
+        if not event.media_urls or not getattr(self.config, "stt_enabled", True):
+            return event
+
+        audio_paths = []
+        for i, path in enumerate(event.media_urls):
+            mtype = event.media_types[i] if i < len(event.media_types) else ""
+            is_audio = (
+                mtype.startswith("audio/")
+                or event.message_type in (MessageType.VOICE, MessageType.AUDIO)
+            )
+            if is_audio:
+                audio_paths.append(path)
+
+        if not audio_paths:
+            return event
+
+        from tools.transcription_tools import transcribe_audio, get_stt_model_from_config
+
+        transcript_parts = []
+        backend = ""
+        stt_model = get_stt_model_from_config()
+        for path in audio_paths:
+            try:
+                result = await asyncio.to_thread(transcribe_audio, path, model=stt_model)
+            except Exception as e:
+                logger.error("Transcription preprocessing error: %s", e, exc_info=True)
+                continue
+            if result.get("success") and result.get("transcript"):
+                transcript_parts.append(str(result["transcript"]).strip())
+                if not backend:
+                    backend = str(result.get("provider") or result.get("backend") or "").strip()
+            else:
+                logger.warning("Audio transcription preprocessing failed: %s", result.get("error", "unknown error"))
+
+        transcript_text = "\n\n".join(part for part in transcript_parts if part).strip()
+        if not transcript_text:
+            return event
+
+        event.transcription_text = transcript_text
+        event.transcription_backend = backend or None
+        event.transcription_origin = "voice" if event.message_type == MessageType.VOICE else "audio"
+
+        if not (event.text or "").strip():
+            event.text = transcript_text
+        return event
+
+    def _build_agent_message_text(self, event: MessageEvent) -> str:
+        """Build the agent input while preserving voice/STT provenance.
+
+        Keep the main user text natural. Add a compact note about transcription
+        uncertainty instead of a narrated wrapper around the transcript.
+        """
+        explicit_text = (event.text or "").strip()
+        transcript_text = (getattr(event, "transcription_text", None) or "").strip()
+        origin = (getattr(event, "transcription_origin", None) or "voice").strip()
+
+        if not transcript_text:
+            return explicit_text
+
+        note = f"[Source note: transcribed from a {origin} message; minor transcription errors are possible.]"
+        if explicit_text and explicit_text == transcript_text:
+            return f"{explicit_text}\n\n{note}"
+        if explicit_text:
+            return f"{explicit_text}\n\n[Transcript]\n{transcript_text}\n\n{note}"
+        return f"{transcript_text}\n\n{note}"
     
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
@@ -1291,6 +1365,9 @@ class GatewayRunner:
                             "Please try again later!"
                         )
             return None
+
+        # Normalize voice/audio into text before any pre-agent control flow.
+        event = await self._prepare_event_for_control_flow(event)
         
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
@@ -1836,7 +1913,7 @@ class GatewayRunner:
         # attachments (documents, audio, etc.) are not sent to the vision
         # tool even when they appear in the same message.
         # -----------------------------------------------------------------
-        message_text = event.text or ""
+        message_text = self._build_agent_message_text(event)
         if event.media_urls:
             image_paths = []
             for i, path in enumerate(event.media_urls):
@@ -1853,24 +1930,6 @@ class GatewayRunner:
                     message_text, image_paths
                 )
         
-        # -----------------------------------------------------------------
-        # Auto-transcribe voice/audio messages sent by the user
-        # -----------------------------------------------------------------
-        if event.media_urls:
-            audio_paths = []
-            for i, path in enumerate(event.media_urls):
-                mtype = event.media_types[i] if i < len(event.media_types) else ""
-                is_audio = (
-                    mtype.startswith("audio/")
-                    or event.message_type in (MessageType.VOICE, MessageType.AUDIO)
-                )
-                if is_audio:
-                    audio_paths.append(path)
-            if audio_paths:
-                message_text = await self._enrich_message_with_transcription(
-                    message_text, audio_paths
-                )
-
         # -----------------------------------------------------------------
         # Enrich document messages with context notes for the agent
         # -----------------------------------------------------------------

--- a/tests/gateway/test_voice_transcription_parity.py
+++ b/tests/gateway/test_voice_transcription_parity.py
@@ -1,0 +1,121 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="u1",
+        user_name="Pol",
+    )
+
+
+def _make_voice_event(*, text: str = "", media_path: str = "/tmp/sample.ogg") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.VOICE,
+        source=_make_source(),
+        media_urls=[media_path],
+        media_types=["audio/ogg"],
+        message_id="m1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_event_for_control_flow_promotes_voice_transcript_when_no_text(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr(
+        "tools.transcription_tools.transcribe_audio",
+        lambda path, model=None: {"success": True, "transcript": "buy oat milk", "provider": "local"},
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    event = _make_voice_event()
+
+    prepared = await runner._prepare_event_for_control_flow(event)
+
+    assert prepared.text == "buy oat milk"
+    assert prepared.transcription_text == "buy oat milk"
+    assert prepared.transcription_backend == "local"
+    assert prepared.transcription_origin == "voice"
+
+
+@pytest.mark.asyncio
+async def test_handle_message_interrupt_uses_transcribed_voice_text(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr(
+        "tools.transcription_tools.transcribe_audio",
+        lambda path, model=None: {"success": True, "transcript": "stop now", "provider": "local"},
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._is_user_authorized = MagicMock(return_value=True)
+    running_agent = MagicMock()
+    event = _make_voice_event()
+    session_key = build_session_key(event.source)
+    runner._running_agents = {session_key: running_agent}
+    runner._pending_messages = {}
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    running_agent.interrupt.assert_called_once_with("stop now")
+    assert runner._pending_messages[session_key] == "stop now"
+    assert event.text == "stop now"
+
+
+@pytest.mark.asyncio
+async def test_handle_message_routes_transcribed_voice_into_command_parsing(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr(
+        "tools.transcription_tools.transcribe_audio",
+        lambda path, model=None: {"success": True, "transcript": "/status", "provider": "local"},
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._is_user_authorized = MagicMock(return_value=True)
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock())
+    runner._handle_status_command = AsyncMock(return_value="status ok")
+
+    event = _make_voice_event()
+
+    result = await runner._handle_message(event)
+
+    assert result == "status ok"
+    runner._handle_status_command.assert_awaited_once_with(event)
+    assert event.text == "/status"
+
+
+def test_build_agent_message_text_keeps_transcript_natural_but_marks_stt_uncertainty():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    event = _make_voice_event(text="buy oat milk")
+    event.transcription_text = "buy oat milk"
+    event.transcription_backend = "local"
+    event.transcription_origin = "voice"
+
+    message_text = runner._build_agent_message_text(event)
+
+    assert message_text.startswith("buy oat milk")
+    assert "transcribed from a voice message" in message_text
+    assert "minor transcription errors" in message_text
+    assert "Here's what they said" not in message_text
+    assert "The user sent a voice message" not in message_text


### PR DESCRIPTION
## Summary
- normalize voice/audio transcripts before interrupt and slash-command handling
- preserve transcription metadata on `MessageEvent` so downstream code can keep voice provenance
- keep agent-facing transcript text more natural by replacing the narrated wrapper with a compact source note
- add regression tests for interrupt parity, slash-command parity, and agent message formatting

## Why
Right now gateway STT happens late, after command/interrupt control flow. That means a transcribed voice message cannot behave like normal text for things like `/status` or interrupting a running agent. This change moves transcript promotion earlier while still preserving the fact that the content came from STT.

## Notes
I'm not a technical person, so this PR is being opened on the suggestion of my Hermes agent after comparing my local speech-to-text tweaks against upstream. I tried to keep only the parts that seemed broadly useful upstream.

## Test Plan
- [x] `venv/bin/pytest -q tests/gateway/test_voice_transcription_parity.py tests/gateway/test_stt_config.py tests/gateway/test_platform_base.py`
