### PR TITLE
feat(optional-skills): add universal video URL transcriber skill

### DIFF
--- a/optional-skills/research/video-url-transcriber/SKILL.md
+++ b/optional-skills/research/video-url-transcriber/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: video-url-transcriber
+description: Universal media URL transcriber using yt-dlp + ffmpeg + faster-whisper. Converts public video/audio URLs (not just YouTube) into timestamped JSON transcript segments.
+version: 1.0.0
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [media, transcription, asr, yt-dlp, whisper]
+    category: research
+---
+
+# Video URL Transcriber
+
+Universal URL-to-transcript skill for Hermes.
+
+This skill transcribes **public media URLs** from any platform currently supported by `yt-dlp`.
+It is **not limited to YouTube**.
+
+Pipeline:
+`URL -> yt-dlp fetch -> ffmpeg normalize (mono 16k) -> faster-whisper ASR -> timestamped JSON`
+
+## Requirements
+
+System dependencies:
+
+```bash
+# macOS
+brew install ffmpeg yt-dlp
+
+# Ubuntu/Debian
+sudo apt-get update && sudo apt-get install -y ffmpeg yt-dlp
+```
+
+Python dependencies:
+
+```bash
+pip install yt-dlp faster-whisper
+```
+
+## Quick Usage
+
+Dependency check:
+
+```bash
+python3 SKILL_DIR/scripts/transcribe_url.py --doctor
+```
+
+Transcribe a URL:
+
+```bash
+python3 SKILL_DIR/scripts/transcribe_url.py "https://youtu.be/VIDEO_ID"
+```
+
+Higher quality model:
+
+```bash
+python3 SKILL_DIR/scripts/transcribe_url.py "<url>" --model-size medium
+```
+
+Language hint:
+
+```bash
+python3 SKILL_DIR/scripts/transcribe_url.py "<url>" --language en
+```
+
+## Output Contract
+
+The script returns JSON with:
+
+- `source_url`
+- `platform`
+- `title`
+- `duration_sec`
+- `language`
+- `transcript`
+- `segments[]` with timestamps and optional word-level timing
+- `status`
+
+## Privacy + Keychain Policy
+
+Default behavior never reads browser cookies or keychain data.
+
+If and only if the user explicitly asks to use personal browser session data for an auth-gated URL, run:
+
+```bash
+python3 SKILL_DIR/scripts/transcribe_url.py "<url>" --cookies-from-browser chrome --allow-personal-cookies
+```
+
+Without `--allow-personal-cookies`, cookie usage is rejected.
+
+## When to use this skill vs youtube-content
+
+Use `video-url-transcriber` when:
+- URL is not YouTube
+- YouTube captions are missing/disabled
+- You need audio-derived transcript quality independent of platform caption APIs
+
+Use `youtube-content` when:
+- It is YouTube-only and you want fast caption retrieval from existing subtitles
+
+## Failure handling
+
+If transcription fails, report exact stage:
+- media fetch (`yt-dlp`)
+- audio normalize (`ffmpeg`)
+- ASR (`faster-whisper`)

--- a/optional-skills/research/video-url-transcriber/scripts/transcribe_url.py
+++ b/optional-skills/research/video-url-transcriber/scripts/transcribe_url.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def check_cmd(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+def run_doctor() -> int:
+    checks = [
+        ("python3", check_cmd("python3")),
+        ("ffmpeg", check_cmd("ffmpeg")),
+        ("yt-dlp", check_cmd("yt-dlp")),
+    ]
+
+    for name, ok in checks:
+        print(f"{'OK ' if ok else 'MISS'} {name}")
+
+    try:
+        import yt_dlp  # noqa: F401
+    except Exception as exc:
+        print(f"MISS yt_dlp python package ({exc})", file=sys.stderr)
+        return 1
+
+    try:
+        import faster_whisper  # noqa: F401
+    except Exception as exc:
+        print(f"MISS faster-whisper ({exc})", file=sys.stderr)
+        return 1
+
+    print("OK  yt_dlp python package")
+    print("OK  faster-whisper")
+
+    missing = [name for name, ok in checks if not ok]
+    if missing:
+        print(f"Missing system dependencies: {', '.join(missing)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def extract_info(url: str, cookies_from_browser: str | None = None) -> dict[str, Any]:
+    import yt_dlp
+
+    opts: dict[str, Any] = {
+        "quiet": True,
+        "no_warnings": True,
+        "skip_download": True,
+        "noplaylist": True,
+    }
+    if cookies_from_browser:
+        opts["cookiesfrombrowser"] = (cookies_from_browser,)
+
+    with yt_dlp.YoutubeDL(opts) as ydl:
+        info = ydl.extract_info(url, download=False)
+
+    return {
+        "id": info.get("id"),
+        "title": info.get("title") or "untitled",
+        "duration": info.get("duration"),
+        "extractor_key": info.get("extractor_key") or info.get("extractor") or "unknown",
+        "webpage_url": info.get("webpage_url") or url,
+    }
+
+
+def download_audio_source(url: str, cookies_from_browser: str | None = None) -> Path:
+    import yt_dlp
+
+    out_dir = Path(tempfile.mkdtemp(prefix="hermes_vts_"))
+    outtmpl = str(out_dir / "source.%(ext)s")
+
+    opts: dict[str, Any] = {
+        "quiet": True,
+        "no_warnings": True,
+        "noplaylist": True,
+        "format": "bestaudio/best",
+        "outtmpl": outtmpl,
+        "restrictfilenames": True,
+    }
+    if cookies_from_browser:
+        opts["cookiesfrombrowser"] = (cookies_from_browser,)
+
+    with yt_dlp.YoutubeDL(opts) as ydl:
+        info = ydl.extract_info(url, download=True)
+        filename = ydl.prepare_filename(info)
+
+    return Path(filename)
+
+
+def normalize_to_wav16k(input_path: Path) -> Path:
+    out_dir = Path(tempfile.mkdtemp(prefix="hermes_vts_audio_"))
+    out_path = out_dir / "audio_16k_mono.wav"
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(input_path),
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "-f",
+        "wav",
+        str(out_path),
+    ]
+    subprocess.run(cmd, check=True)
+    return out_path
+
+
+def transcribe_audio(audio_path: Path, model_size: str, language: str | None, word_timestamps: bool) -> dict[str, Any]:
+    from faster_whisper import WhisperModel
+
+    model = WhisperModel(model_size, compute_type="int8")
+    segments_iter, info = model.transcribe(
+        str(audio_path),
+        language=language,
+        vad_filter=True,
+        word_timestamps=word_timestamps,
+        beam_size=5,
+    )
+
+    segments: list[dict[str, Any]] = []
+    transcript_parts: list[str] = []
+
+    for idx, seg in enumerate(segments_iter):
+        text = seg.text.strip()
+        if text:
+            transcript_parts.append(text)
+
+        words = []
+        if word_timestamps and seg.words:
+            for w in seg.words:
+                words.append(
+                    {
+                        "word": w.word,
+                        "start": float(w.start) if w.start is not None else None,
+                        "end": float(w.end) if w.end is not None else None,
+                    }
+                )
+
+        segments.append(
+            {
+                "id": idx,
+                "start": float(seg.start),
+                "end": float(seg.end),
+                "text": text,
+                "speaker": None,
+                "words": words,
+            }
+        )
+
+    return {
+        "language": getattr(info, "language", None),
+        "segments": segments,
+        "transcript": " ".join(transcript_parts).strip(),
+    }
+
+
+def platform_name(extractor_key: str) -> str:
+    key = (extractor_key or "unknown").lower()
+    if "youtube" in key:
+        return "youtube"
+    if "twitter" in key or key == "x":
+        return "x"
+    return key
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Transcribe a media URL into timestamped JSON")
+    parser.add_argument("url", nargs="?", default="")
+    parser.add_argument("--language", default=None)
+    parser.add_argument("--model-size", default="small")
+    parser.add_argument("--no-word-timestamps", action="store_true")
+    parser.add_argument("--persist-media", action="store_true")
+    parser.add_argument("--cookies-from-browser", default=None)
+    parser.add_argument(
+        "--allow-personal-cookies",
+        action="store_true",
+        help="Explicit opt-in for browser cookies (may prompt keychain access).",
+    )
+    parser.add_argument("--doctor", action="store_true")
+
+    args = parser.parse_args()
+
+    if args.doctor:
+        return run_doctor()
+
+    if not args.url:
+        parser.error("url is required unless --doctor is used")
+
+    if args.cookies_from_browser and not args.allow_personal_cookies:
+        parser.error(
+            "--cookies-from-browser requires --allow-personal-cookies; default mode avoids personal browser/keychain data"
+        )
+
+    source_path: Path | None = None
+    audio_path: Path | None = None
+    try:
+        info = extract_info(args.url, cookies_from_browser=args.cookies_from_browser)
+        source_path = download_audio_source(args.url, cookies_from_browser=args.cookies_from_browser)
+        audio_path = normalize_to_wav16k(source_path)
+        asr = transcribe_audio(
+            audio_path,
+            model_size=args.model_size,
+            language=args.language,
+            word_timestamps=not args.no_word_timestamps,
+        )
+
+        payload = {
+            "source_url": info.get("webpage_url") or args.url,
+            "platform": platform_name(info.get("extractor_key") or "unknown"),
+            "title": info.get("title") or "untitled",
+            "duration_sec": info.get("duration"),
+            "language": asr.get("language"),
+            "transcript": asr.get("transcript", ""),
+            "segments": asr.get("segments", []),
+            "metadata": {
+                "extractor_key": info.get("extractor_key"),
+                "video_id": info.get("id"),
+                "model_size": args.model_size,
+            },
+            "status": "completed",
+        }
+        print(json.dumps(payload, ensure_ascii=True, indent=2))
+        return 0
+    except subprocess.CalledProcessError as exc:
+        print(f"transcription failed at ffmpeg stage: {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(f"transcription failed: {exc}", file=sys.stderr)
+        return 3
+    finally:
+        if not args.persist_media:
+            if source_path and source_path.exists():
+                shutil.rmtree(source_path.parent, ignore_errors=True)
+            if audio_path and audio_path.exists():
+                shutil.rmtree(audio_path.parent, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a new **official optional skill**: `video-url-transcriber`.

Location:
- `optional-skills/research/video-url-transcriber/SKILL.md`
- `optional-skills/research/video-url-transcriber/scripts/transcribe_url.py`

This skill is designed as a **platform-agnostic URL transcriber**:

`URL -> yt-dlp fetch -> ffmpeg normalize -> faster-whisper ASR -> timestamped JSON`

## Why

Current `youtube-content` skill is great for YouTube caption retrieval, but it is caption/API dependent and YouTube-scoped.

`video-url-transcriber` is complementary and intended for:
- non-YouTube sources
- cases where captions are unavailable/disabled
- audio-derived transcripts across any site currently supported by `yt-dlp`

## Behavior

- Transcribes public media URLs from compatible platforms (not limited to YouTube)
- Returns structured JSON with transcript + timestamped segments
- Includes `--doctor` dependency check
- Explicit privacy guard:
  - browser cookie usage is blocked unless user passes `--allow-personal-cookies`
  - default flow avoids browser keychain/session access

## Dependencies

Documented in skill:
- system: `ffmpeg`, `yt-dlp`
- python: `yt-dlp`, `faster-whisper`

Kept under `optional-skills/` due heavier runtime dependencies and model footprint.

## Validation

- Script help and argument handling validated
- `--doctor` validated in local environment (reports missing/present deps correctly)
