### PR TITLE
fix: allow agent-created skills with caution-level findings + context_compressor logger cleanup

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -275,7 +275,11 @@ Write only the summary body. Do not include any preamble or prefix; the system w
         n_messages = len(messages)
         if n_messages <= self.protect_first_n + self.protect_last_n + 1:
             if not self.quiet_mode:
-                print(f"⚠️  Cannot compress: only {n_messages} messages (need > {self.protect_first_n + self.protect_last_n + 1})")
+                logger.warning(
+                    "Cannot compress: only %d messages (need > %d)",
+                    n_messages,
+                    self.protect_first_n + self.protect_last_n + 1,
+                )
             return messages
 
         compress_start = self.protect_first_n
@@ -293,11 +297,23 @@ Write only the summary body. Do not include any preamble or prefix; the system w
         display_tokens = current_tokens if current_tokens else self.last_prompt_tokens or estimate_messages_tokens_rough(messages)
 
         if not self.quiet_mode:
-            print(f"\n📦 Context compression triggered ({display_tokens:,} tokens ≥ {self.threshold_tokens:,} threshold)")
-            print(f"   📊 Model context limit: {self.context_length:,} tokens ({self.threshold_percent*100:.0f}% = {self.threshold_tokens:,})")
-
-        if not self.quiet_mode:
-            print(f"   🗜️  Summarizing turns {compress_start+1}-{compress_end} ({len(turns_to_summarize)} turns)")
+            logger.info(
+                "Context compression triggered (%d tokens >= %d threshold)",
+                display_tokens,
+                self.threshold_tokens,
+            )
+            logger.info(
+                "Model context limit: %d tokens (%.0f%% = %d)",
+                self.context_length,
+                self.threshold_percent * 100,
+                self.threshold_tokens,
+            )
+            logger.info(
+                "Summarizing turns %d-%d (%d turns)",
+                compress_start + 1,
+                compress_end,
+                len(turns_to_summarize),
+            )
 
         summary = self._generate_summary(turns_to_summarize)
 
@@ -337,7 +353,7 @@ Write only the summary body. Do not include any preamble or prefix; the system w
                 compressed.append({"role": summary_role, "content": summary})
         else:
             if not self.quiet_mode:
-                print("   ⚠️  No summary model available — middle turns dropped without summary")
+                logger.warning("No summary model available — middle turns dropped without summary")
 
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()
@@ -354,7 +370,12 @@ Write only the summary body. Do not include any preamble or prefix; the system w
         if not self.quiet_mode:
             new_estimate = estimate_messages_tokens_rough(compressed)
             saved_estimate = display_tokens - new_estimate
-            print(f"   ✅ Compressed: {n_messages} → {len(compressed)} messages (~{saved_estimate:,} tokens saved)")
-            print(f"   💡 Compression #{self.compression_count} complete")
+            logger.info(
+                "Compressed: %d -> %d messages (~%d tokens saved)",
+                n_messages,
+                len(compressed),
+                saved_estimate,
+            )
+            logger.info("Compression #%d complete", self.compression_count)
 
         return compressed


### PR DESCRIPTION
Two small fixes cherry-picked onto current main:

1. **Agent-created skill policy** (from PR #1801): Changes agent-created install policy from `(allow, block, block)` to `(allow, allow, block)` so caution-level findings (Docker refs, pip install, git clone) don't block agent-created skills. Critical findings still blocked. Adds 4 tests.

2. **Context compressor logger** (from PR #1822 / #1838): Replaces remaining `print()` calls in `compress()` with `logger.info()`/`logger.warning()`.