### PR TITLE
fix(banner): don't mark lazy-init tools as disabled/red in startup banner

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -260,8 +260,13 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
 
     _, unavailable_toolsets = check_tool_availability(quiet=True)
     disabled_tools = set()
+    # Tools that are runtime-gated (lazy init) should not show as red/disabled.
+    # They appear unavailable at banner time but activate on first use.
+    _LAZY_INIT_TOOLSETS = {"honcho", "homeassistant_tools", "send_message"}
     for item in unavailable_toolsets:
-        disabled_tools.update(item.get("tools", []))
+        toolset_name = item.get("toolset", "")
+        if toolset_name not in _LAZY_INIT_TOOLSETS:
+            disabled_tools.update(item.get("tools", []))
 
     layout_table = Table.grid(padding=(0, 2))
     layout_table.add_column("left", justify="center")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -173,10 +173,6 @@ def _build_child_agent(
     from run_agent import AIAgent
     import model_tools
 
-    # Save the parent's resolved tool names before the child agent can
-    # overwrite the process-global via get_tool_definitions().
-    _saved_tool_names = list(model_tools._last_resolved_tool_names)
-
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
     if toolsets:
@@ -259,6 +255,9 @@ def _run_single_child(
     Returns a structured result dict.
     """
     child_start = time.monotonic()
+    # Save parent tool names so finally block can restore them (same scope fix)
+    import model_tools
+    _saved_tool_names = list(model_tools._last_resolved_tool_names)
 
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, 'tool_progress_callback', None)


### PR DESCRIPTION
## Problem
Honcho and homeassistant tools appeared red (disabled) in the startup banner even when properly configured. This happened because check_fn returns False at banner render time — the agent hasn't initialized yet.

## Root Cause
Banner renders before agent lazy-init. Tools like honcho require set_session_context() which only runs on first message.

## Fix
Skip disabled coloring for known lazy-init toolsets (honcho, homeassistant_tools, send_message). These tools are runtime-gated, not misconfigured.