### PR TITLE
fix(honcho): default session strategy to per-directory

### DIFF
--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -162,10 +162,10 @@ def cmd_setup(args) -> None:
         hermes_host["recallMode"] = new_recall
 
     # Session strategy
-    current_strat = hermes_host.get("sessionStrategy") or cfg.get("sessionStrategy", "per-session")
+    current_strat = hermes_host.get("sessionStrategy") or cfg.get("sessionStrategy", "per-directory")
     print(f"\n  Session strategy options:")
-    print("    per-session   — new Honcho session each run, named by Hermes session ID (default)")
-    print("    per-directory — one session per working directory")
+    print("    per-directory — one session per working directory (default)")
+    print("    per-session   — new Honcho session each run, named by Hermes session ID")
     print("    per-repo      — one session per git repository (uses repo root name)")
     print("    global        — single session across all directories")
     new_strat = _prompt("Session strategy", default=current_strat)

--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -107,7 +107,7 @@ class HonchoClientConfig:
     # "tools"   — Honcho tools only, no auto-injected context
     recall_mode: str = "hybrid"
     # Session resolution
-    session_strategy: str = "per-session"
+    session_strategy: str = "per-directory"
     session_peer_prefix: bool = False
     sessions: dict[str, str] = field(default_factory=dict)
     # Raw global config for anything else consumers need
@@ -201,7 +201,7 @@ class HonchoClientConfig:
         # sessionStrategy / sessionPeerPrefix: host first, root fallback
         session_strategy = (
             host_block.get("sessionStrategy")
-            or raw.get("sessionStrategy", "per-session")
+            or raw.get("sessionStrategy", "per-directory")
         )
         host_prefix = host_block.get("sessionPeerPrefix")
         session_peer_prefix = (
@@ -309,7 +309,7 @@ class HonchoClientConfig:
                 return f"{self.peer_name}-{base}"
             return base
 
-        # per-directory: one Honcho session per working directory
+        # per-directory: one Honcho session per working directory (default)
         if self.session_strategy in ("per-directory", "per-session"):
             base = Path(cwd).name
             if self.session_peer_prefix and self.peer_name:


### PR DESCRIPTION
## Summary

- Default `sessionStrategy` changed from `per-session` to `per-directory`
- Setup wizard updated to show `per-directory` as default

## Problem

With `per-session` (the previous default), every new Hermes session created a new Honcho session keyed by the unique session ID. Cross-session context (peer card, conclusions, dialectic) was never reused -- each run started fresh with no memory of previous conversations.

Users reported that "a session restarts and my agent has absolutely no idea what it was working on" despite having Honcho enabled.

## Fix

`per-directory` maps the working directory name to a stable Honcho session. All Hermes sessions launched from the same directory share the same Honcho session, so peer card, conclusions, and dialectic persist across restarts.

Users who want isolated sessions can still set `sessionStrategy: per-session` in `.honcho/config.json`.

## Test plan

- [ ] Start hermes in a directory, chat, quit. Start again -- Honcho context should carry over
- [ ] `hermes honcho status` should show `per-directory` as session strategy
- [ ] `hermes honcho setup` should show `per-directory` as the default option