### PR TITLE
fix(matrix): correct reply_to parameter name to reply_to_message_id in MessageEvent

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -635,7 +635,7 @@ class MatrixAdapter(BasePlatformAdapter):
             source=source,
             raw_message=getattr(event, "source", {}),
             message_id=event.event_id,
-            reply_to=reply_to,
+            reply_to_message_id=reply_to,
         )
 
         await self.handle_message(msg_event)


### PR DESCRIPTION
Fixes #1842

MessageEvent dataclass expects `reply_to_message_id` but the Matrix connector was passing `reply_to`, causing:
MessageEvent.__init__() got an unexpected keyword argument 'reply_to'

One-line fix: rename the parameter at line 638.