### PR TITLE
fix(gateway): apply home channel env overrides consistently

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -531,14 +531,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.SLACK] = PlatformConfig()
         config.platforms[Platform.SLACK].enabled = True
         config.platforms[Platform.SLACK].token = slack_token
-        # Home channel
-        slack_home = os.getenv("SLACK_HOME_CHANNEL")
-        if slack_home:
-            config.platforms[Platform.SLACK].home_channel = HomeChannel(
-                platform=Platform.SLACK,
-                chat_id=slack_home,
-                name=os.getenv("SLACK_HOME_CHANNEL_NAME", ""),
-            )
+    slack_home = os.getenv("SLACK_HOME_CHANNEL")
+    if slack_home and Platform.SLACK in config.platforms:
+        config.platforms[Platform.SLACK].home_channel = HomeChannel(
+            platform=Platform.SLACK,
+            chat_id=slack_home,
+            name=os.getenv("SLACK_HOME_CHANNEL_NAME", ""),
+        )
     
     # Signal
     signal_url = os.getenv("SIGNAL_HTTP_URL")
@@ -552,13 +551,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "account": signal_account,
             "ignore_stories": os.getenv("SIGNAL_IGNORE_STORIES", "true").lower() in ("true", "1", "yes"),
         })
-        signal_home = os.getenv("SIGNAL_HOME_CHANNEL")
-        if signal_home:
-            config.platforms[Platform.SIGNAL].home_channel = HomeChannel(
-                platform=Platform.SIGNAL,
-                chat_id=signal_home,
-                name=os.getenv("SIGNAL_HOME_CHANNEL_NAME", "Home"),
-            )
+    signal_home = os.getenv("SIGNAL_HOME_CHANNEL")
+    if signal_home and Platform.SIGNAL in config.platforms:
+        config.platforms[Platform.SIGNAL].home_channel = HomeChannel(
+            platform=Platform.SIGNAL,
+            chat_id=signal_home,
+            name=os.getenv("SIGNAL_HOME_CHANNEL_NAME", "Home"),
+        )
 
     # Mattermost
     mattermost_token = os.getenv("MATTERMOST_TOKEN")
@@ -571,13 +570,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         config.platforms[Platform.MATTERMOST].enabled = True
         config.platforms[Platform.MATTERMOST].token = mattermost_token
         config.platforms[Platform.MATTERMOST].extra["url"] = mattermost_url
-        mattermost_home = os.getenv("MATTERMOST_HOME_CHANNEL")
-        if mattermost_home:
-            config.platforms[Platform.MATTERMOST].home_channel = HomeChannel(
-                platform=Platform.MATTERMOST,
-                chat_id=mattermost_home,
-                name=os.getenv("MATTERMOST_HOME_CHANNEL_NAME", "Home"),
-            )
+    mattermost_home = os.getenv("MATTERMOST_HOME_CHANNEL")
+    if mattermost_home and Platform.MATTERMOST in config.platforms:
+        config.platforms[Platform.MATTERMOST].home_channel = HomeChannel(
+            platform=Platform.MATTERMOST,
+            chat_id=mattermost_home,
+            name=os.getenv("MATTERMOST_HOME_CHANNEL_NAME", "Home"),
+        )
 
     # Matrix
     matrix_token = os.getenv("MATRIX_ACCESS_TOKEN")
@@ -599,13 +598,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.MATRIX].extra["password"] = matrix_password
         matrix_e2ee = os.getenv("MATRIX_ENCRYPTION", "").lower() in ("true", "1", "yes")
         config.platforms[Platform.MATRIX].extra["encryption"] = matrix_e2ee
-        matrix_home = os.getenv("MATRIX_HOME_ROOM")
-        if matrix_home:
-            config.platforms[Platform.MATRIX].home_channel = HomeChannel(
-                platform=Platform.MATRIX,
-                chat_id=matrix_home,
-                name=os.getenv("MATRIX_HOME_ROOM_NAME", "Home"),
-            )
+    matrix_home = os.getenv("MATRIX_HOME_ROOM")
+    if matrix_home and Platform.MATRIX in config.platforms:
+        config.platforms[Platform.MATRIX].home_channel = HomeChannel(
+            platform=Platform.MATRIX,
+            chat_id=matrix_home,
+            name=os.getenv("MATRIX_HOME_ROOM_NAME", "Home"),
+        )
 
     # Home Assistant
     hass_token = os.getenv("HASS_TOKEN")
@@ -632,13 +631,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "imap_host": email_imap,
             "smtp_host": email_smtp,
         })
-        email_home = os.getenv("EMAIL_HOME_ADDRESS")
-        if email_home:
-            config.platforms[Platform.EMAIL].home_channel = HomeChannel(
-                platform=Platform.EMAIL,
-                chat_id=email_home,
-                name=os.getenv("EMAIL_HOME_ADDRESS_NAME", "Home"),
-            )
+    email_home = os.getenv("EMAIL_HOME_ADDRESS")
+    if email_home and Platform.EMAIL in config.platforms:
+        config.platforms[Platform.EMAIL].home_channel = HomeChannel(
+            platform=Platform.EMAIL,
+            chat_id=email_home,
+            name=os.getenv("EMAIL_HOME_ADDRESS_NAME", "Home"),
+        )
 
     # SMS (Twilio)
     twilio_sid = os.getenv("TWILIO_ACCOUNT_SID")
@@ -647,13 +646,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.SMS] = PlatformConfig()
         config.platforms[Platform.SMS].enabled = True
         config.platforms[Platform.SMS].api_key = os.getenv("TWILIO_AUTH_TOKEN", "")
-        sms_home = os.getenv("SMS_HOME_CHANNEL")
-        if sms_home:
-            config.platforms[Platform.SMS].home_channel = HomeChannel(
-                platform=Platform.SMS,
-                chat_id=sms_home,
-                name=os.getenv("SMS_HOME_CHANNEL_NAME", "Home"),
-            )
+    sms_home = os.getenv("SMS_HOME_CHANNEL")
+    if sms_home and Platform.SMS in config.platforms:
+        config.platforms[Platform.SMS].home_channel = HomeChannel(
+            platform=Platform.SMS,
+            chat_id=sms_home,
+            name=os.getenv("SMS_HOME_CHANNEL_NAME", "Home"),
+        )
 
     # API Server
     api_server_enabled = os.getenv("API_SERVER_ENABLED", "").lower() in ("true", "1", "yes")
@@ -688,6 +687,5 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.default_reset_policy.at_hour = int(reset_hour)
         except ValueError:
             pass
-
 
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1,11 +1,15 @@
 """Tests for gateway configuration management."""
 
+import os
+from unittest.mock import patch
+
 from gateway.config import (
     GatewayConfig,
     HomeChannel,
     Platform,
     PlatformConfig,
     SessionResetPolicy,
+    _apply_env_overrides,
     load_gateway_config,
 )
 
@@ -158,3 +162,64 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.quick_commands == {}
+
+
+class TestHomeChannelEnvOverrides:
+    def test_existing_platform_configs_accept_home_channel_env_overrides(self):
+        cases = [
+            (
+                Platform.SLACK,
+                PlatformConfig(enabled=True, token="xoxb-from-config"),
+                {"SLACK_HOME_CHANNEL": "C123", "SLACK_HOME_CHANNEL_NAME": "Ops"},
+                ("C123", "Ops"),
+            ),
+            (
+                Platform.SIGNAL,
+                PlatformConfig(
+                    enabled=True,
+                    extra={"http_url": "http://localhost:9090", "account": "+15551234567"},
+                ),
+                {"SIGNAL_HOME_CHANNEL": "+1555000", "SIGNAL_HOME_CHANNEL_NAME": "Phone"},
+                ("+1555000", "Phone"),
+            ),
+            (
+                Platform.MATTERMOST,
+                PlatformConfig(enabled=True, token="mm-token", extra={"url": "https://mm.example.com"}),
+                {"MATTERMOST_HOME_CHANNEL": "ch_abc123", "MATTERMOST_HOME_CHANNEL_NAME": "General"},
+                ("ch_abc123", "General"),
+            ),
+            (
+                Platform.MATRIX,
+                PlatformConfig(enabled=True, token="syt_abc123", extra={"homeserver": "https://matrix.example.org"}),
+                {"MATRIX_HOME_ROOM": "!room123:example.org", "MATRIX_HOME_ROOM_NAME": "Bot Room"},
+                ("!room123:example.org", "Bot Room"),
+            ),
+            (
+                Platform.EMAIL,
+                PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "address": "hermes@test.com",
+                        "imap_host": "imap.test.com",
+                        "smtp_host": "smtp.test.com",
+                    },
+                ),
+                {"EMAIL_HOME_ADDRESS": "user@test.com", "EMAIL_HOME_ADDRESS_NAME": "Inbox"},
+                ("user@test.com", "Inbox"),
+            ),
+            (
+                Platform.SMS,
+                PlatformConfig(enabled=True, api_key="token_abc"),
+                {"SMS_HOME_CHANNEL": "+15559876543", "SMS_HOME_CHANNEL_NAME": "My Phone"},
+                ("+15559876543", "My Phone"),
+            ),
+        ]
+
+        for platform, platform_config, env, expected in cases:
+            config = GatewayConfig(platforms={platform: platform_config})
+            with patch.dict(os.environ, env, clear=True):
+                _apply_env_overrides(config)
+
+            home = config.platforms[platform].home_channel
+            assert home is not None, platform.value
+            assert (home.chat_id, home.name) == expected


### PR DESCRIPTION
## Summary

`*_HOME_CHANNEL` env overrides for Slack, Signal, Mattermost, Matrix, Email, and SMS were only applied inside the branches that also process credential env vars.

As a result, if one of those platforms was already configured via `config.yaml`, setting only the home-channel env vars would not update `home_channel`, even though the same override pattern already works for Telegram and Discord.

```python
# Existing platform config present
SLACK_HOME_CHANNEL = "C123"      # ignored before
TELEGRAM_HOME_CHANNEL = "-1001"  # applied
```

## Fix

Moved the home-channel env override handling for Slack, Signal, Mattermost, Matrix, Email, and SMS out of the credential-env branches in `gateway/config.py`, so existing platform configs can accept home-channel overrides consistently.

This preserves the current behavior of not creating new platform configs from home-channel env vars alone.

## Tests

Added `TestHomeChannelEnvOverrides::test_existing_platform_configs_accept_home_channel_env_overrides` to `tests/gateway/test_config.py`.

Verified under Python 3.11:

```bash
/tmp/hermes311/bin/python -m pytest -o addopts='' tests/gateway/test_config.py -q
# 15 passed
```