### PR TITLE
fix: correct reply_to param name in Matrix MessageEvent construction

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -635,7 +635,7 @@ class MatrixAdapter(BasePlatformAdapter):
             source=source,
             raw_message=getattr(event, "source", {}),
             message_id=event.event_id,
-            reply_to=reply_to,
+            reply_to_message_id=reply_to,
         )
 
         await self.handle_message(msg_event)


### PR DESCRIPTION
The MessageEvent dataclass expects `reply_to_message_id`, not `reply_to`. This was causing Matrix replies to fail with:

```
MessageEvent.__init__() got an unexpected keyword argument reply_to
```

Fixes #1842