### PR TITLE
feat: auto-detect extended context for premium API tiers

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, List, Optional
 from agent.auxiliary_client import call_llm
 from agent.model_metadata import (
     get_model_context_length,
+    get_cached_context_length,
+    get_upgrade_context_tier,
     estimate_messages_tokens_rough,
 )
 
@@ -59,6 +61,17 @@ class ContextCompressor:
         self.compression_count = 0
         self._context_probed = False  # True after a step-down from context error
 
+        # Upgrade probe: some models support higher context on premium plans.
+        # When the default threshold is reached, we upgrade speculatively and
+        # let the next API call confirm whether the user has the higher tier.
+        # Skip probing if the context was loaded from the persistent cache —
+        # that means we already know the user's actual limit from a prior
+        # session and should not re-probe.
+        cached = get_cached_context_length(model, base_url) if base_url else None
+        self._upgrade_tier = None if cached is not None else get_upgrade_context_tier(model)
+        self._upgrade_probe_active = False
+        self._pre_upgrade_context_length = None
+
         self.last_prompt_tokens = 0
         self.last_completion_tokens = 0
         self.last_total_tokens = 0
@@ -71,15 +84,54 @@ class ContextCompressor:
         self.last_completion_tokens = usage.get("completion_tokens", 0)
         self.last_total_tokens = usage.get("total_tokens", 0)
 
+    def _try_activate_upgrade_probe(self, tokens: int) -> bool:
+        """Activate upgrade probe if an upgrade tier is available.
+
+        When the session reaches the default compression threshold and the
+        model has a potential upgrade tier (e.g., 1M on Max plan), we
+        speculatively raise the context limit instead of compressing.  The
+        next API call will either succeed (confirming the upgrade) or fail
+        with a context error (handled by the existing step-down logic).
+
+        Returns True if the probe was activated (caller should skip compression).
+        """
+        if (
+            self._upgrade_tier
+            and not self._context_probed
+            and not self._upgrade_probe_active
+            and self._upgrade_tier > self.context_length
+        ):
+            self._upgrade_probe_active = True
+            self._pre_upgrade_context_length = self.context_length
+            old_ctx = self.context_length
+            self.context_length = self._upgrade_tier
+            self.threshold_tokens = int(self._upgrade_tier * self.threshold_percent)
+            logger.info(
+                "Upgrade probe activated: %s → %s tokens (threshold %s → %s)",
+                f"{old_ctx:,}", f"{self._upgrade_tier:,}",
+                f"{int(old_ctx * self.threshold_percent):,}",
+                f"{self.threshold_tokens:,}",
+            )
+            return True
+        return False
+
     def should_compress(self, prompt_tokens: int = None) -> bool:
         """Check if context exceeds the compression threshold."""
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
-        return tokens >= self.threshold_tokens
+        if tokens >= self.threshold_tokens:
+            if self._try_activate_upgrade_probe(tokens):
+                return False
+            return True
+        return False
 
     def should_compress_preflight(self, messages: List[Dict[str, Any]]) -> bool:
         """Quick pre-flight check using rough estimate (before API call)."""
         rough_estimate = estimate_messages_tokens_rough(messages)
-        return rough_estimate >= self.threshold_tokens
+        if rough_estimate >= self.threshold_tokens:
+            if self._try_activate_upgrade_probe(rough_estimate):
+                return False
+            return True
+        return False
 
     def get_status(self) -> Dict[str, Any]:
         """Get current compression status for display/logging."""

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -34,6 +34,16 @@ CONTEXT_PROBE_TIERS = [
     32_000,
 ]
 
+# Models that may support higher context on premium API tiers (e.g., Max plan).
+# Default context is used initially; if the session grows past it without a
+# context-length error, the upgrade tier is confirmed and cached for future
+# sessions.  This avoids penalising Max-plan users with early compression
+# while keeping the default safe for standard-plan users.
+UPGRADE_CONTEXT_TIERS = {
+    "anthropic/claude-opus-4.6": 1_000_000,
+    "claude-opus-4-6": 1_000_000,
+}
+
 DEFAULT_CONTEXT_LENGTHS = {
     "anthropic/claude-opus-4": 200000,
     "anthropic/claude-opus-4.5": 200000,
@@ -203,6 +213,27 @@ def get_cached_context_length(model: str, base_url: str) -> Optional[int]:
     key = f"{model}@{base_url}"
     cache = _load_context_cache()
     return cache.get(key)
+
+
+def get_upgrade_context_tier(model: str) -> Optional[int]:
+    """Return the potential upgrade context tier for a model, or None.
+
+    Some models support higher context windows on premium API plans (e.g.,
+    Anthropic Max plan gives 1M for Opus 4.6).  This returns the higher
+    limit so the compressor can probe for it instead of compressing early.
+    """
+    if model in UPGRADE_CONTEXT_TIERS:
+        return UPGRADE_CONTEXT_TIERS[model]
+    # Fuzzy match: only check if a known key appears IN the model string
+    # (e.g., "claude-opus-4-6" in "claude-opus-4-6:beta").  The reverse
+    # direction (model in key) is intentionally omitted to prevent
+    # "claude-opus-4" from matching "claude-opus-4-6".
+    for key, tier in sorted(
+        UPGRADE_CONTEXT_TIERS.items(), key=lambda x: len(x[0]), reverse=True
+    ):
+        if key in model:
+            return tier
+    return None
 
 
 def get_next_probe_tier(current_length: int) -> Optional[int]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4971,7 +4971,7 @@ class AIAgent:
             _msg_tok_est = estimate_messages_tokens_rough(messages)
             _preflight_tokens = _sys_tok_est + _msg_tok_est
 
-            if _preflight_tokens >= self.context_compressor.threshold_tokens:
+            if self.context_compressor.should_compress(_preflight_tokens):
                 logger.info(
                     "Preflight compression: ~%s tokens >= %s threshold (model %s, ctx %s)",
                     f"{_preflight_tokens:,}",
@@ -5442,6 +5442,27 @@ class AIAgent:
                             self._safe_print(f"{self.log_prefix}💾 Cached context length: {ctx:,} tokens for {self.model}")
                             self.context_compressor._context_probed = False
 
+                        # Confirm upgrade probe: if we're in upgrade-probe mode
+                        # and the API call succeeded past the old default
+                        # threshold, the user has the premium tier.  We confirm
+                        # just above the old compression threshold (not the full
+                        # context limit) so sessions that stabilise between
+                        # threshold and limit still get cached.
+                        compressor = self.context_compressor
+                        if (
+                            compressor._upgrade_probe_active
+                            and compressor._pre_upgrade_context_length
+                            and prompt_tokens > compressor._pre_upgrade_context_length * compressor.threshold_percent
+                        ):
+                            save_context_length(
+                                self.model, self.base_url, compressor._upgrade_tier
+                            )
+                            self._safe_print(
+                                f"{self.log_prefix}🎉 Extended context confirmed: "
+                                f"{compressor._upgrade_tier:,} tokens for {self.model}"
+                            )
+                            compressor._upgrade_probe_active = False
+
                         self.session_prompt_tokens += prompt_tokens
                         self.session_completion_tokens += completion_tokens
                         self.session_total_tokens += total_tokens
@@ -5715,22 +5736,39 @@ class AIAgent:
                         compressor = self.context_compressor
                         old_ctx = compressor.context_length
 
-                        # Try to parse the actual limit from the error message
-                        parsed_limit = parse_context_limit_from_error(error_msg)
-                        if parsed_limit and parsed_limit < old_ctx:
-                            new_ctx = parsed_limit
-                            self._vprint(f"{self.log_prefix}⚠️  Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})", force=True)
-                        else:
-                            # Step down to the next probe tier
-                            new_ctx = get_next_probe_tier(old_ctx)
-
-                        if new_ctx and new_ctx < old_ctx:
+                        if compressor._upgrade_probe_active:
+                            # Upgrade probe failed — user doesn't have the
+                            # premium tier.  Revert to the pre-upgrade default
+                            # and cache it.  Skip normal step-down logic since
+                            # we already know the correct limit.
+                            new_ctx = compressor._pre_upgrade_context_length
                             compressor.context_length = new_ctx
                             compressor.threshold_tokens = int(new_ctx * compressor.threshold_percent)
+                            compressor._upgrade_probe_active = False
+                            compressor._upgrade_tier = None  # don't probe again
                             compressor._context_probed = True
-                            self._vprint(f"{self.log_prefix}⚠️  Context length exceeded — stepping down: {old_ctx:,} → {new_ctx:,} tokens", force=True)
+                            save_context_length(self.model, self.base_url, new_ctx)
+                            self._vprint(
+                                f"{self.log_prefix}⚠️  Upgrade probe failed — "
+                                f"reverting to {new_ctx:,} tokens (cached for future sessions)",
+                                force=True,
+                            )
                         else:
-                            self._vprint(f"{self.log_prefix}⚠️  Context length exceeded at minimum tier — attempting compression...", force=True)
+                            # Normal step-down: parse limit from error or probe
+                            parsed_limit = parse_context_limit_from_error(error_msg)
+                            if parsed_limit and parsed_limit < old_ctx:
+                                new_ctx = parsed_limit
+                                self._vprint(f"{self.log_prefix}⚠️  Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})", force=True)
+                            else:
+                                new_ctx = get_next_probe_tier(old_ctx)
+
+                            if new_ctx and new_ctx < old_ctx:
+                                compressor.context_length = new_ctx
+                                compressor.threshold_tokens = int(new_ctx * compressor.threshold_percent)
+                                compressor._context_probed = True
+                                self._vprint(f"{self.log_prefix}⚠️  Context length exceeded — stepping down: {old_ctx:,} → {new_ctx:,} tokens", force=True)
+                            else:
+                                self._vprint(f"{self.log_prefix}⚠️  Context length exceeded at minimum tier — attempting compression...", force=True)
 
                         compression_attempts += 1
                         if compression_attempts > max_compression_attempts:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -9,7 +9,8 @@ from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
 @pytest.fixture()
 def compressor():
     """Create a ContextCompressor with mocked dependencies."""
-    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000), \
+         patch("agent.context_compressor.get_upgrade_context_tier", return_value=None):
         c = ContextCompressor(
             model="test/model",
             threshold_percent=0.85,
@@ -513,3 +514,104 @@ class TestCompressWithClient:
         for msg in result:
             if msg.get("role") == "tool" and msg.get("tool_call_id"):
                 assert msg["tool_call_id"] in called_ids
+
+
+# =========================================================================
+# Upgrade probe (auto-detect premium context tiers)
+# =========================================================================
+
+class TestUpgradeProbe:
+    def _make_compressor(self, upgrade_tier):
+        """Create a compressor with a specific upgrade tier (no base_url → cache skipped)."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200000), \
+             patch("agent.context_compressor.get_upgrade_context_tier", return_value=upgrade_tier):
+            return ContextCompressor(
+                model="claude-opus-4-6",
+                threshold_percent=0.50,
+                quiet_mode=True,
+            )
+
+    def test_upgrade_probe_activates_at_threshold(self):
+        """When tokens hit the threshold and an upgrade tier exists, probe
+        activates and should_compress returns False."""
+        c = self._make_compressor(1_000_000)
+        assert c.context_length == 200_000
+        assert c.threshold_tokens == 100_000
+
+        # Tokens exceed threshold → should activate probe, not compress
+        result = c.should_compress(prompt_tokens=110_000)
+        assert result is False
+        assert c._upgrade_probe_active is True
+        assert c.context_length == 1_000_000
+        assert c.threshold_tokens == 500_000
+
+    def test_no_upgrade_tier_compresses_normally(self):
+        """Without an upgrade tier, compression triggers as usual."""
+        c = self._make_compressor(None)
+        result = c.should_compress(prompt_tokens=110_000)
+        assert result is True
+        assert c._upgrade_probe_active is False
+
+    def test_probe_only_activates_once(self):
+        """Upgrade probe should not re-activate after being used."""
+        c = self._make_compressor(1_000_000)
+
+        # First time: activates probe
+        c.should_compress(prompt_tokens=110_000)
+        assert c._upgrade_probe_active is True
+
+        # Simulate error handler deactivating probe and reverting context
+        c._upgrade_probe_active = False
+        c._context_probed = True
+        c.context_length = 200_000
+        c.threshold_tokens = 100_000
+
+        # Second time: should compress normally (probed=True blocks re-probe)
+        result = c.should_compress(prompt_tokens=110_000)
+        assert result is True
+
+    def test_preflight_also_activates_probe(self):
+        """should_compress_preflight should also activate the upgrade probe."""
+        c = self._make_compressor(1_000_000)
+        # Create messages that exceed the threshold (~400K chars ÷ 4 = 100K tokens)
+        msgs = [{"role": "user", "content": "x" * 500_000}]
+        result = c.should_compress_preflight(msgs)
+        assert result is False
+        assert c._upgrade_probe_active is True
+        assert c.context_length == 1_000_000
+
+    def test_pre_upgrade_context_preserved(self):
+        """The original context length is preserved for revert on failure."""
+        c = self._make_compressor(1_000_000)
+        c.should_compress(prompt_tokens=110_000)
+        assert c._pre_upgrade_context_length == 200_000
+
+    def test_cached_context_suppresses_upgrade_probe(self):
+        """When context length was loaded from cache, upgrade probe is disabled."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200000), \
+             patch("agent.context_compressor.get_cached_context_length", return_value=200000), \
+             patch("agent.context_compressor.get_upgrade_context_tier", return_value=1_000_000):
+            c = ContextCompressor(
+                model="claude-opus-4-6",
+                threshold_percent=0.50,
+                quiet_mode=True,
+                base_url="https://api.anthropic.com",
+            )
+        assert c._upgrade_tier is None
+        # Should compress normally, no probe
+        result = c.should_compress(prompt_tokens=110_000)
+        assert result is True
+        assert c._upgrade_probe_active is False
+
+    def test_no_cache_allows_upgrade_probe(self):
+        """Without a cached context length, upgrade probe is enabled."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200000), \
+             patch("agent.context_compressor.get_cached_context_length", return_value=None), \
+             patch("agent.context_compressor.get_upgrade_context_tier", return_value=1_000_000):
+            c = ContextCompressor(
+                model="claude-opus-4-6",
+                threshold_percent=0.50,
+                quiet_mode=True,
+                base_url="https://api.anthropic.com",
+            )
+        assert c._upgrade_tier == 1_000_000

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -22,11 +22,13 @@ from unittest.mock import patch, MagicMock
 from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
+    UPGRADE_CONTEXT_TIERS,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
     get_model_context_length,
     get_next_probe_tier,
     get_cached_context_length,
+    get_upgrade_context_tier,
     parse_context_limit_from_error,
     save_context_length,
     fetch_model_metadata,
@@ -462,3 +464,36 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+# =========================================================================
+# Upgrade context tiers
+# =========================================================================
+
+class TestUpgradeContextTiers:
+    def test_opus_46_has_upgrade_tier(self):
+        assert get_upgrade_context_tier("anthropic/claude-opus-4.6") == 1_000_000
+        assert get_upgrade_context_tier("claude-opus-4-6") == 1_000_000
+
+    def test_sonnet_has_no_upgrade_tier(self):
+        assert get_upgrade_context_tier("anthropic/claude-sonnet-4.6") is None
+        assert get_upgrade_context_tier("claude-sonnet-4-6") is None
+
+    def test_unknown_model_has_no_upgrade_tier(self):
+        assert get_upgrade_context_tier("openai/gpt-5") is None
+
+    def test_fuzzy_match(self):
+        """Upgrade tier should match model IDs that contain the key."""
+        assert get_upgrade_context_tier("anthropic/claude-opus-4.6:beta") == 1_000_000
+
+    def test_no_false_positive_on_shorter_model(self):
+        """claude-opus-4 must NOT match claude-opus-4-6's upgrade tier."""
+        assert get_upgrade_context_tier("claude-opus-4") is None
+        assert get_upgrade_context_tier("anthropic/claude-opus-4") is None
+
+    def test_defaults_remain_200k(self):
+        """Models with upgrade tiers must still default to 200K."""
+        for model in UPGRADE_CONTEXT_TIERS:
+            assert DEFAULT_CONTEXT_LENGTHS.get(model) == 200000, (
+                f"{model} has upgrade tier but default is not 200K"
+            )


### PR DESCRIPTION
## Summary

- Adds speculative upgrade probing for models that support higher context on premium plans (e.g., Claude Opus 4.6: 200K default → 1M on Anthropic Max)
- Default context remains 200K — Max/Team/Enterprise users are automatically detected and upgraded to 1M without any configuration
- Standard-plan users experience no disruption — the probe is transparent and the result is cached for future sessions

## Why not just hardcode 1M?

The 1M context window for Claude 4.6 is **not universal** — it depends on the API plan:

| Tier | Context | Hardcode 1M | This PR (auto-detect) |
|------|---------|-------------|----------------------|
| Max / Team / Enterprise | 1M auto | ✅ Works | ✅ Works |
| Pro (opted in via `/extra-usage`) | 1M | ✅ Works | ✅ Works |
| Pro (not opted in) | 200K | ❌ Breaks — hits wall at 200K | ✅ Works |
| Free / standard API | 200K | ❌ Breaks | ✅ Works |

See also #1820 which proposes hardcoding 1M.

## How it works

1. When the compression threshold (50% of 200K = 100K) is first reached, the compressor speculatively raises the context limit to the upgrade tier (1M) instead of compressing
2. If the next API call **succeeds** past the old threshold → premium tier confirmed, 1M cached
3. If the API call **fails** with a context error → standard tier confirmed, reverts to 200K, compresses normally, 200K cached
4. Future sessions load from cache — no re-probing

## Files changed

| File | Change |
|------|--------|
| `agent/model_metadata.py` | `UPGRADE_CONTEXT_TIERS` dict + `get_upgrade_context_tier()` |
| `agent/context_compressor.py` | Upgrade probe activation in `should_compress()` / `should_compress_preflight()`, cache-aware init |
| `run_agent.py` | Probe confirmation on success path, probe revert on context error (separate branch from normal step-down) |
| `tests/agent/test_model_metadata.py` | 7 new tests for upgrade tiers |
| `tests/agent/test_context_compressor.py` | 7 new tests for probe lifecycle |

## Design decisions

- **Probe at compression threshold, not session start**: avoids wasted API calls for short sessions
- **Cache suppresses re-probing**: `get_cached_context_length` check prevents standard-plan users from re-probing every session
- **Fuzzy match only checks `key in model`** (not reverse): prevents `claude-opus-4` from falsely matching `claude-opus-4-6`'s upgrade tier
- **Error handler uses separate branch for probe revert**: avoids incorrect step-down (200K → 128K) that would occur if the parsed limit equals the pre-upgrade default

## Adding new models

One line in `UPGRADE_CONTEXT_TIERS`:
```python
UPGRADE_CONTEXT_TIERS = {
    "anthropic/claude-opus-4.6": 1_000_000,
    "claude-opus-4-6": 1_000_000,
    # Add new models here
}
```

## Related

- Supersedes #1820 (hardcoding 1M breaks non-Max users)
- Works well with #1852 (cache invalidation when defaults change) — independent but complementary

## Test plan

- [x] 118 tests passing (model_metadata + context_compressor + context overflow)
- [x] Manual test: verify Max-plan user sees 1M context cached after first long session
- [ ] Manual test: verify standard-plan user gets transparent compression at ~200K