### PR TITLE
fix: auto-invalidate stale context length cache when defaults change

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -4,6 +4,8 @@ Pure utility functions with no AIAgent dependency. Used by ContextCompressor
 and run_agent.py for pre-flight context checks.
 """
 
+import hashlib
+import json
 import logging
 import os
 import re
@@ -163,14 +165,45 @@ def _get_context_cache_path() -> Path:
     return hermes_home / "context_length_cache.yaml"
 
 
+def _compute_defaults_hash() -> str:
+    """Compute a stable hash of the hardcoded context length defaults.
+
+    This is stored alongside cached entries so that stale values are
+    automatically discarded when a new hermes-agent version changes the
+    default model context lengths.
+    """
+    # Sort keys for deterministic serialization across Python versions.
+    payload = json.dumps(
+        sorted(DEFAULT_CONTEXT_LENGTHS.items()), sort_keys=True
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
 def _load_context_cache() -> Dict[str, int]:
-    """Load the model+provider → context_length cache from disk."""
+    """Load the model+provider → context_length cache from disk.
+
+    Returns an empty dict (forcing re-probe) when:
+    - the cache file does not exist or is corrupted
+    - the ``defaults_hash`` in the file does not match the current
+      hardcoded defaults, indicating that model context lengths have
+      changed since the cache was written (e.g., new hermes-agent version)
+    """
     path = _get_context_cache_path()
     if not path.exists():
         return {}
     try:
         with open(path) as f:
             data = yaml.safe_load(f) or {}
+        current_hash = _compute_defaults_hash()
+        stored_hash = data.get("defaults_hash", "")
+        if stored_hash != current_hash:
+            logger.info(
+                "Context length cache invalidated: defaults have changed "
+                "(stored=%s, current=%s)",
+                stored_hash or "<none>",
+                current_hash,
+            )
+            return {}
         return data.get("context_lengths", {})
     except Exception as e:
         logger.debug("Failed to load context length cache: %s", e)
@@ -181,7 +214,9 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
     """Persist a discovered context length for a model+provider combo.
 
     Cache key is ``model@base_url`` so the same model name served from
-    different providers can have different limits.
+    different providers can have different limits.  The current defaults
+    hash is stored alongside entries so that stale caches are
+    automatically invalidated when model defaults change.
     """
     key = f"{model}@{base_url}"
     cache = _load_context_cache()
@@ -192,7 +227,14 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w") as f:
-            yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
+            yaml.dump(
+                {
+                    "defaults_hash": _compute_defaults_hash(),
+                    "context_lengths": cache,
+                },
+                f,
+                default_flow_style=False,
+            )
         logger.info("Cached context length %s → %s tokens", key, f"{length:,}")
     except Exception as e:
         logger.debug("Failed to save context length cache: %s", e)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -31,6 +31,7 @@ from agent.model_metadata import (
     save_context_length,
     fetch_model_metadata,
     _MODEL_CACHE_TTL,
+    _compute_defaults_hash,
 )
 
 
@@ -462,3 +463,88 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+    def test_cache_stores_defaults_hash(self, tmp_path):
+        """Cache file should include a defaults_hash field."""
+        cache_file = tmp_path / "cache.yaml"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            save_context_length("model", "http://x", 32768)
+            with open(cache_file) as f:
+                data = yaml.safe_load(f)
+            assert "defaults_hash" in data
+            assert data["defaults_hash"] == _compute_defaults_hash()
+
+
+# =========================================================================
+# Cache invalidation on defaults change
+# =========================================================================
+
+class TestCacheInvalidation:
+    def test_stale_hash_invalidates_cache(self, tmp_path):
+        """Cache entries are discarded when defaults_hash doesn't match."""
+        cache_file = tmp_path / "cache.yaml"
+        # Write a cache with a stale hash
+        with open(cache_file, "w") as f:
+            yaml.dump({
+                "defaults_hash": "stale_hash_from_old_version",
+                "context_lengths": {"model@http://x": 32768},
+            }, f)
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            assert get_cached_context_length("model", "http://x") is None
+
+    def test_matching_hash_preserves_cache(self, tmp_path):
+        """Cache entries are preserved when defaults_hash matches."""
+        cache_file = tmp_path / "cache.yaml"
+        with open(cache_file, "w") as f:
+            yaml.dump({
+                "defaults_hash": _compute_defaults_hash(),
+                "context_lengths": {"model@http://x": 32768},
+            }, f)
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            assert get_cached_context_length("model", "http://x") == 32768
+
+    def test_missing_hash_invalidates_cache(self, tmp_path):
+        """Legacy cache files without defaults_hash are treated as stale."""
+        cache_file = tmp_path / "cache.yaml"
+        # Legacy format: no defaults_hash field
+        with open(cache_file, "w") as f:
+            yaml.dump({
+                "context_lengths": {"model@http://x": 32768},
+            }, f)
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            assert get_cached_context_length("model", "http://x") is None
+
+    def test_save_after_invalidation_writes_new_hash(self, tmp_path):
+        """Saving after invalidation creates a fresh cache with current hash."""
+        cache_file = tmp_path / "cache.yaml"
+        # Start with stale cache
+        with open(cache_file, "w") as f:
+            yaml.dump({
+                "defaults_hash": "old_hash",
+                "context_lengths": {"old_model@http://x": 99999},
+            }, f)
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            # Old entry should be gone
+            assert get_cached_context_length("old_model", "http://x") is None
+            # Save a new entry
+            save_context_length("new_model", "http://y", 64000)
+            # New entry should work
+            assert get_cached_context_length("new_model", "http://y") == 64000
+            # Old entry should still be gone (not carried over)
+            assert get_cached_context_length("old_model", "http://x") is None
+
+    def test_defaults_hash_is_deterministic(self):
+        """Hash should be stable across calls."""
+        h1 = _compute_defaults_hash()
+        h2 = _compute_defaults_hash()
+        assert h1 == h2
+        assert len(h1) == 16  # truncated sha256
+
+    def test_defaults_hash_changes_with_defaults(self):
+        """Hash should change when DEFAULT_CONTEXT_LENGTHS changes."""
+        original_hash = _compute_defaults_hash()
+        modified_defaults = dict(DEFAULT_CONTEXT_LENGTHS)
+        modified_defaults["new/model"] = 999999
+        with patch("agent.model_metadata.DEFAULT_CONTEXT_LENGTHS", modified_defaults):
+            new_hash = _compute_defaults_hash()
+        assert original_hash != new_hash


### PR DESCRIPTION
## Summary

- Adds hash-based invalidation to the persistent context length cache (`~/.hermes/context_length_cache.yaml`)
- When a new hermes-agent version changes `DEFAULT_CONTEXT_LENGTHS`, stale cached values are automatically discarded
- Legacy cache files (without the hash field) are treated as stale and invalidated on first read

## Problem

The context length cache stores discovered model limits across sessions with no expiration or versioning. If a hermes-agent update changes a model's default context length (e.g., a provider upgrades from 128K to 256K, or a new model is added with different defaults), existing cache entries silently override the new default. Users would be stuck on the old limit until they manually delete `~/.hermes/context_length_cache.yaml`.

This affects all models and providers that go through the probing system — not just Anthropic models.

## Solution

A `defaults_hash` field (truncated SHA-256 of `DEFAULT_CONTEXT_LENGTHS`) is stored alongside cached entries. On every cache read, the stored hash is compared against the current hash:

- **Match** → cache is valid, entries preserved
- **Mismatch** → cache is stale, all entries discarded (forces re-probe)
- **Missing** → legacy file, treated as stale

The hash is recomputed from the sorted dict, so it's deterministic and changes only when actual model defaults change.

## Files changed

| File | Change |
|------|--------|
| `agent/model_metadata.py` | `_compute_defaults_hash()`, updated `_load_context_cache()` and `save_context_length()` |
| `tests/agent/test_model_metadata.py` | 7 new tests for hash storage, invalidation, legacy migration, determinism |

## Tradeoff

Changing ANY model's default invalidates ALL cached entries, including correctly-probed local models (e.g., Ollama at 32K). This is acceptable because re-probing is automatic, transparent (one API call per model), and only happens once per hermes-agent update that modifies defaults.

## Related

- Independent of #1849 (auto-detect extended context for premium tiers) — this PR fixes a pre-existing issue with the cache that affects all models
- Works well with #1849, which writes to this cache

## Test plan

- [x] 112 tests passing (69 model_metadata + 29 context_compressor + 14 context overflow — no regressions)
- [ ] Manual: verify legacy cache file (no `defaults_hash`) is invalidated on first session
- [ ] Manual: verify cache survives across sessions when defaults haven't changed