### PR TITLE
fix(openai): route api.openai.com traffic to Responses API to resolve `BadRequestError` with gpt5.4 tool calling.

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -23,6 +23,25 @@ def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
 
+def _resolve_api_mode(*, provider: str, base_url: Optional[str]) -> str:
+    """Select the Hermes transport mode for the resolved provider/base URL.
+
+    Direct ``api.openai.com`` traffic uses the Responses API path. Hermes is a
+    tool-using agent, and GPT-5 tool calls with reasoning are rejected on
+    ``/v1/chat/completions`` by OpenAI.
+    """
+    normalized_provider = (provider or "").strip().lower()
+    normalized_base_url = (base_url or "").strip().lower().rstrip("/")
+
+    if normalized_provider == "openai-codex":
+        return "codex_responses"
+    if normalized_provider == "anthropic":
+        return "anthropic_messages"
+    if "api.openai.com" in normalized_base_url and "openrouter" not in normalized_base_url:
+        return "codex_responses"
+    return "chat_completions"
+
+
 def _get_model_config() -> Dict[str, Any]:
     config = load_config()
     model_cfg = config.get("model")
@@ -137,7 +156,8 @@ def _resolve_named_custom_runtime(
 
     return {
         "provider": "openrouter",
-        "api_mode": custom_provider.get("api_mode", "chat_completions"),
+        "api_mode": custom_provider.get("api_mode")
+        or _resolve_api_mode(provider="openrouter", base_url=base_url),
         "base_url": base_url,
         "api_key": api_key,
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
@@ -209,7 +229,8 @@ def _resolve_openrouter_runtime(
 
     return {
         "provider": "openrouter",
-        "api_mode": _parse_api_mode(model_cfg.get("api_mode")) or "chat_completions",
+        "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
+        or _resolve_api_mode(provider="openrouter", base_url=base_url),
         "base_url": base_url,
         "api_key": api_key,
         "source": source,
@@ -259,7 +280,10 @@ def resolve_runtime_provider(
         creds = resolve_codex_runtime_credentials()
         return {
             "provider": "openai-codex",
-            "api_mode": "codex_responses",
+            "api_mode": _resolve_api_mode(
+                provider="openai-codex",
+                base_url=creds.get("base_url", "").rstrip("/"),
+            ),
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "hermes-auth-store"),
@@ -278,7 +302,10 @@ def resolve_runtime_provider(
             )
         return {
             "provider": "anthropic",
-            "api_mode": "anthropic_messages",
+            "api_mode": _resolve_api_mode(
+                provider="anthropic",
+                base_url="https://api.anthropic.com",
+            ),
             "base_url": "https://api.anthropic.com",
             "api_key": token,
             "source": "env",
@@ -304,7 +331,10 @@ def resolve_runtime_provider(
         creds = resolve_api_key_provider_credentials(provider)
         return {
             "provider": provider,
-            "api_mode": "chat_completions",
+            "api_mode": _resolve_api_mode(
+                provider=provider,
+                base_url=creds.get("base_url", "").rstrip("/"),
+            ),
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "env"),

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -23,20 +23,9 @@ def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
 
-def _resolve_api_mode(*, provider: str, base_url: Optional[str]) -> str:
-    """Select the Hermes transport mode for the resolved provider/base URL.
-
-    Direct ``api.openai.com`` traffic uses the Responses API path. Hermes is a
-    tool-using agent, and GPT-5 tool calls with reasoning are rejected on
-    ``/v1/chat/completions`` by OpenAI.
-    """
-    normalized_provider = (provider or "").strip().lower()
+def _resolve_api_mode(*, base_url: Optional[str]) -> str:
+    """Select the transport mode for custom OpenAI-compatible endpoints."""
     normalized_base_url = (base_url or "").strip().lower().rstrip("/")
-
-    if normalized_provider == "openai-codex":
-        return "codex_responses"
-    if normalized_provider == "anthropic":
-        return "anthropic_messages"
     if "api.openai.com" in normalized_base_url and "openrouter" not in normalized_base_url:
         return "codex_responses"
     return "chat_completions"
@@ -157,7 +146,7 @@ def _resolve_named_custom_runtime(
     return {
         "provider": "openrouter",
         "api_mode": custom_provider.get("api_mode")
-        or _resolve_api_mode(provider="openrouter", base_url=base_url),
+        or _resolve_api_mode(base_url=base_url),
         "base_url": base_url,
         "api_key": api_key,
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
@@ -230,7 +219,7 @@ def _resolve_openrouter_runtime(
     return {
         "provider": "openrouter",
         "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
-        or _resolve_api_mode(provider="openrouter", base_url=base_url),
+        or _resolve_api_mode(base_url=base_url),
         "base_url": base_url,
         "api_key": api_key,
         "source": source,
@@ -280,10 +269,7 @@ def resolve_runtime_provider(
         creds = resolve_codex_runtime_credentials()
         return {
             "provider": "openai-codex",
-            "api_mode": _resolve_api_mode(
-                provider="openai-codex",
-                base_url=creds.get("base_url", "").rstrip("/"),
-            ),
+            "api_mode": "codex_responses",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "hermes-auth-store"),
@@ -302,10 +288,7 @@ def resolve_runtime_provider(
             )
         return {
             "provider": "anthropic",
-            "api_mode": _resolve_api_mode(
-                provider="anthropic",
-                base_url="https://api.anthropic.com",
-            ),
+            "api_mode": "anthropic_messages",
             "base_url": "https://api.anthropic.com",
             "api_key": token,
             "source": "env",
@@ -331,10 +314,7 @@ def resolve_runtime_provider(
         creds = resolve_api_key_provider_credentials(provider)
         return {
             "provider": provider,
-            "api_mode": _resolve_api_mode(
-                provider=provider,
-                base_url=creds.get("base_url", "").rstrip("/"),
-            ),
+            "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "env"),

--- a/run_agent.py
+++ b/run_agent.py
@@ -928,36 +928,6 @@ class AIAgent:
         base_url = (self.base_url or "").lower()
         return "api.openai.com" in base_url and "openrouter" not in base_url
 
-    def _direct_openai_reasoning_effort(self) -> Optional[str]:
-        """Return the OpenAI chat-completions reasoning effort, if applicable.
-
-        Direct ``api.openai.com`` chat-completions calls use the top-level
-        ``reasoning_effort`` parameter rather than OpenRouter's extra-body
-        ``reasoning`` object. Hermes supports broader internal effort labels
-        than OpenAI does, so coerce them conservatively here.
-        """
-        if self.api_mode == "codex_responses":
-            return None
-
-        if not self._uses_direct_openai_responses_api():
-            return None
-
-        if self.reasoning_config and isinstance(self.reasoning_config, dict):
-            if self.reasoning_config.get("enabled") is False:
-                return None
-            effort = str(self.reasoning_config.get("effort", "medium") or "medium").lower()
-        else:
-            effort = "medium"
-
-        effort_map = {
-            "minimal": "low",
-            "low": "low",
-            "medium": "medium",
-            "high": "high",
-            "xhigh": "high",
-        }
-        return effort_map.get(effort, "medium")
-
     def _has_content_after_think_block(self, content: str) -> bool:
         """
         Check if content has actual text after any <think></think> blocks.
@@ -3672,10 +3642,6 @@ class AIAgent:
 
         if self.max_tokens is not None:
             api_kwargs.update(self._max_tokens_param(self.max_tokens))
-
-        openai_reasoning_effort = self._direct_openai_reasoning_effort()
-        if openai_reasoning_effort:
-            api_kwargs["reasoning_effort"] = openai_reasoning_effort
 
         extra_body = {}
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -923,10 +923,15 @@ class AIAgent:
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 
+    @staticmethod
+    def _base_url_uses_direct_openai_responses_api(base_url: Optional[str]) -> bool:
+        """Return True when a base URL targets OpenAI's native Responses API."""
+        normalized_base_url = (base_url or "").lower()
+        return "api.openai.com" in normalized_base_url and "openrouter" not in normalized_base_url
+
     def _uses_direct_openai_responses_api(self) -> bool:
         """Return True when this session targets OpenAI's native Responses API."""
-        base_url = (self.base_url or "").lower()
-        return "api.openai.com" in base_url and "openrouter" not in base_url
+        return self._base_url_uses_direct_openai_responses_api(self.base_url)
 
     def _has_content_after_think_block(self, content: str) -> bool:
         """
@@ -3333,13 +3338,18 @@ class AIAgent:
                     fb_provider)
                 return False
 
-            # Determine api_mode from provider
+            # Determine api_mode from provider/base URL.
             fb_api_mode = "chat_completions"
             if fb_provider == "openai-codex":
                 fb_api_mode = "codex_responses"
             elif fb_provider == "anthropic":
                 fb_api_mode = "anthropic_messages"
             fb_base_url = str(fb_client.base_url)
+            if (
+                fb_api_mode == "chat_completions"
+                and self._base_url_uses_direct_openai_responses_api(fb_base_url)
+            ):
+                fb_api_mode = "codex_responses"
 
             old_model = self.model
             self.model = fb_model

--- a/run_agent.py
+++ b/run_agent.py
@@ -920,6 +920,37 @@ class AIAgent:
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 
+    def _direct_openai_reasoning_effort(self) -> Optional[str]:
+        """Return the OpenAI chat-completions reasoning effort, if applicable.
+
+        Direct ``api.openai.com`` chat-completions calls use the top-level
+        ``reasoning_effort`` parameter rather than OpenRouter's extra-body
+        ``reasoning`` object. Hermes supports broader internal effort labels
+        than OpenAI does, so coerce them conservatively here.
+        """
+        if self.api_mode == "codex_responses":
+            return None
+
+        base_url = (self.base_url or "").lower()
+        if "api.openai.com" not in base_url or "openrouter" in base_url:
+            return None
+
+        if self.reasoning_config and isinstance(self.reasoning_config, dict):
+            if self.reasoning_config.get("enabled") is False:
+                return None
+            effort = str(self.reasoning_config.get("effort", "medium") or "medium").lower()
+        else:
+            effort = "medium"
+
+        effort_map = {
+            "minimal": "low",
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "xhigh": "high",
+        }
+        return effort_map.get(effort, "medium")
+
     def _has_content_after_think_block(self, content: str) -> bool:
         """
         Check if content has actual text after any <think></think> blocks.
@@ -3634,6 +3665,10 @@ class AIAgent:
 
         if self.max_tokens is not None:
             api_kwargs.update(self._max_tokens_param(self.max_tokens))
+
+        openai_reasoning_effort = self._direct_openai_reasoning_effort()
+        if openai_reasoning_effort:
+            api_kwargs["reasoning_effort"] = openai_reasoning_effort
 
         extra_body = {}
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -392,6 +392,12 @@ class AIAgent:
         else:
             self.api_mode = "chat_completions"
 
+        # Direct OpenAI sessions use the Responses API path. GPT-5 tool calls
+        # with reasoning are rejected on /v1/chat/completions, and Hermes is a
+        # tool-using client by default.
+        if self.api_mode == "chat_completions" and self._uses_direct_openai_responses_api():
+            self.api_mode = "codex_responses"
+
         # Pre-warm OpenRouter model metadata cache in a background thread.
         # fetch_model_metadata() is cached for 1 hour; this avoids a blocking
         # HTTP request on the first API response when pricing is estimated.
@@ -912,13 +918,15 @@ class AIAgent:
         'max_completion_tokens'. OpenRouter, local models, and older
         OpenAI models use 'max_tokens'.
         """
-        _is_direct_openai = (
-            "api.openai.com" in self.base_url.lower()
-            and "openrouter" not in self.base_url.lower()
-        )
+        _is_direct_openai = self._uses_direct_openai_responses_api()
         if _is_direct_openai:
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
+
+    def _uses_direct_openai_responses_api(self) -> bool:
+        """Return True when this session targets OpenAI's native Responses API."""
+        base_url = (self.base_url or "").lower()
+        return "api.openai.com" in base_url and "openrouter" not in base_url
 
     def _direct_openai_reasoning_effort(self) -> Optional[str]:
         """Return the OpenAI chat-completions reasoning effort, if applicable.
@@ -931,8 +939,7 @@ class AIAgent:
         if self.api_mode == "codex_responses":
             return None
 
-        base_url = (self.base_url or "").lower()
-        if "api.openai.com" not in base_url or "openrouter" in base_url:
+        if not self._uses_direct_openai_responses_api():
             return None
 
         if self.reasoning_config and isinstance(self.reasoning_config, dict):

--- a/tests/test_fallback_model.py
+++ b/tests/test_fallback_model.py
@@ -277,6 +277,25 @@ class TestTryActivateFallback:
             assert agent.api_mode == "codex_responses"
             assert agent.client is mock_client
 
+    def test_activates_direct_openai_responses_fallback(self):
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "gpt-5.4"},
+        )
+        mock_client = _mock_resolve(
+            api_key="sk-openai-key",
+            base_url="https://api.openai.com/v1",
+        )
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "gpt-5.4"),
+        ):
+            result = agent._try_activate_fallback()
+            assert result is True
+            assert agent.model == "gpt-5.4"
+            assert agent.provider == "openrouter"
+            assert agent.api_mode == "codex_responses"
+            assert agent.client is mock_client
+
     def test_codex_fallback_fails_gracefully_without_credentials(self):
         """Codex fallback should return False if no OAuth credentials available."""
         agent = _make_agent(

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -759,8 +759,13 @@ class TestReasoningEffortDefaults:
             base_url="https://api.openai.com/v1",
         )
         kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
-        assert kwargs["reasoning_effort"] == "medium"
-        assert "extra_body" not in kwargs or "reasoning" not in kwargs.get("extra_body", {})
+        assert agent.api_mode == "codex_responses"
+        assert kwargs["reasoning"]["effort"] == "medium"
+        assert "reasoning_effort" not in kwargs
+        assert "messages" not in kwargs
+        assert kwargs["input"][0]["role"] == "user"
+        assert kwargs["tools"][0]["name"] == "web_search"
+        assert "function" not in kwargs["tools"][0]
 
     def test_direct_openai_reasoning_disabled(self, monkeypatch):
         agent = _make_agent(
@@ -770,7 +775,9 @@ class TestReasoningEffortDefaults:
         )
         agent.reasoning_config = {"enabled": False}
         kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
-        assert "reasoning_effort" not in kwargs
+        assert agent.api_mode == "codex_responses"
+        assert "reasoning" not in kwargs
+        assert kwargs["include"] == []
 
     def test_direct_openai_reasoning_coerces_extended_levels(self, monkeypatch):
         agent = _make_agent(
@@ -780,4 +787,5 @@ class TestReasoningEffortDefaults:
         )
         agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
         kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
-        assert kwargs["reasoning_effort"] == "high"
+        assert agent.api_mode == "codex_responses"
+        assert kwargs["reasoning"]["effort"] == "xhigh"

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -751,3 +751,33 @@ class TestReasoningEffortDefaults:
         agent.reasoning_config = {"enabled": True, "effort": "medium"}
         kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
         assert kwargs["extra_body"]["reasoning"]["effort"] == "medium"
+
+    def test_direct_openai_default_medium(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "openrouter",
+            base_url="https://api.openai.com/v1",
+        )
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert kwargs["reasoning_effort"] == "medium"
+        assert "extra_body" not in kwargs or "reasoning" not in kwargs.get("extra_body", {})
+
+    def test_direct_openai_reasoning_disabled(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "openrouter",
+            base_url="https://api.openai.com/v1",
+        )
+        agent.reasoning_config = {"enabled": False}
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "reasoning_effort" not in kwargs
+
+    def test_direct_openai_reasoning_coerces_extended_levels(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "openrouter",
+            base_url="https://api.openai.com/v1",
+        )
+        agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert kwargs["reasoning_effort"] == "high"

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -154,6 +154,38 @@ def test_custom_endpoint_prefers_openai_key(monkeypatch):
     assert resolved["api_key"] == "zai-key"
 
 
+def test_direct_openai_custom_endpoint_uses_responses_mode(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-key")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["base_url"] == "https://api.openai.com/v1"
+    assert resolved["api_key"] == "sk-openai-key"
+    assert resolved["api_mode"] == "codex_responses"
+
+
+def test_explicit_direct_openai_base_url_uses_responses_mode(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="custom",
+        explicit_api_key="sk-explicit",
+        explicit_base_url="https://api.openai.com/v1/",
+    )
+
+    assert resolved["base_url"] == "https://api.openai.com/v1"
+    assert resolved["api_key"] == "sk-explicit"
+    assert resolved["api_mode"] == "codex_responses"
+
+
 def test_custom_endpoint_uses_saved_config_base_url_when_env_missing(monkeypatch):
     """Persisted custom endpoints in config.yaml must still resolve when
     OPENAI_BASE_URL is absent from the current environment."""


### PR DESCRIPTION
## Summary
Direct `api.openai.com` `gpt-5.4` requests with tool calls and reasoning, fail on `/v1/chat/completions`. This PR changes hermes-agent to route direct OpenAI sessions, including fallback sessions that resolve to the native OpenAI endpoint, through Hermes' existing Responses transport instead.

## Changes
- detect direct `api.openai.com` custom/runtime resolution and select `codex_responses`
- switch direct `api.openai.com` primary agent sessions from chat completions to the Responses API
- apply the same direct `api.openai.com` routing when fallback activation resolves to the native OpenAI endpoint
- keep the change narrowly scoped to the direct OpenAI path instead of changing other provider mode selection
- remove the now-redundant direct-OpenAI chat-completions `reasoning_effort` handling
- add focused fallback coverage for a direct OpenAI backup model

## Issue Reproduction
Local repro used a real `OPENAI_API_KEY` against direct `https://api.openai.com/v1` with `model=gpt-5.4`, `reasoning_config={"enabled": true, "effort": "xhigh"}`, and a dynamically registered tool exposed to Hermes through a runtime custom toolset.

The same runner was executed against both `b3cdc1df` and `e5d24649`:

```python
import json
import os

from run_agent import AIAgent
from tools.registry import registry
from toolsets import create_custom_toolset

registry.register(
    name="ping",
    toolset="repro",
    schema={
        "name": "ping",
        "description": "Return a short ping string.",
        "parameters": {"type": "object", "properties": {}},
    },
    handler=lambda args, **kw: json.dumps({"ok": True}),
)
create_custom_toolset(
    name="repro",
    description="Repro-only toolset",
    tools=["ping"],
)

agent = AIAgent(
    api_key=os.environ["OPENAI_API_KEY"],
    base_url="https://api.openai.com/v1",
    provider="openrouter",
    model="gpt-5.4",
    quiet_mode=True,
    skip_context_files=True,
    skip_memory=True,
    max_tokens=64,
    enabled_toolsets=["repro"],
    reasoning_config={"enabled": True, "effort": "xhigh"},
)
kwargs = agent._build_api_kwargs([
    {"role": "user", "content": "Reply with exactly OK."}
])
print(json.dumps({
    "api_mode": agent.api_mode,
    "request_keys": sorted(kwargs),
    "reasoning": kwargs.get("reasoning"),
    "reasoning_effort": kwargs.get("reasoning_effort"),
}, sort_keys=True))

client = agent._create_request_openai_client(reason="repro")
try:
    if agent.api_mode == "codex_responses":
        response = client.responses.create(**kwargs)
        print(json.dumps({
            "status": getattr(response, "status", None),
            "output_text": getattr(response, "output_text", None),
        }, default=str))
    else:
        client.chat.completions.create(**kwargs)
except Exception as exc:
    print(json.dumps({
        "error_type": type(exc).__name__,
        "error": str(exc),
        "response_text": getattr(getattr(exc, "response", None), "text", None),
    }, default=str))
finally:
    agent._close_request_openai_client(client, reason="repro_done")
```

Before (`b3cdc1df`):

```json
{"api_mode": "chat_completions", "reasoning": null, "reasoning_effort": "high", "request_keys": ["max_completion_tokens", "messages", "model", "reasoning_effort", "timeout", "tools"]}
{"error_type": "BadRequestError", "error": "Error code: 400 - {'error': {'message': 'Function tools with reasoning_effort are not supported for gpt-5.4 in /v1/chat/completions. Please use /v1/responses instead.', 'type': 'invalid_request_error', 'param': 'reasoning_effort', 'code': None}}", "response_text": "{\n  \"error\": {\n    \"message\": \"Function tools with reasoning_effort are not supported for gpt-5.4 in /v1/chat/completions. Please use /v1/responses instead.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"reasoning_effort\",\n    \"code\": null\n  }\n}"}
```

After (`e5d24649`):

```json
{"api_mode": "codex_responses", "reasoning": {"effort": "xhigh", "summary": "auto"}, "reasoning_effort": null, "request_keys": ["include", "input", "instructions", "max_output_tokens", "model", "parallel_tool_calls", "prompt_cache_key", "reasoning", "store", "tool_choice", "tools"]}
{"status": "completed", "output_text": "OK"}
```

## Testing
- `/workspace/.venvs/hermes/bin/python -m pytest tests/test_fallback_model.py tests/test_provider_parity.py tests/test_runtime_provider_resolution.py tests/test_cli_provider_resolution.py -q`
  - `119 passed`
