### PR TITLE
fix(tools): resolve NameError for _saved_tool_names in delegate_tool.py

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -429,16 +429,21 @@ def load_gateway_config() -> GatewayConfig:
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
 
-            # Bridge whatsapp settings from config.yaml into platform config
-            whatsapp_cfg = yaml_cfg.get("whatsapp", {})
-            if isinstance(whatsapp_cfg, dict) and "reply_prefix" in whatsapp_cfg:
-                if Platform.WHATSAPP not in config.platforms:
-                    config.platforms[Platform.WHATSAPP] = PlatformConfig()
-                config.platforms[Platform.WHATSAPP].extra["reply_prefix"] = whatsapp_cfg["reply_prefix"]
     except Exception:
         pass
 
     config = GatewayConfig.from_dict(gw_data)
+
+    # Bridge whatsapp settings from config.yaml into platform config
+    # (must happen after config is created from gw_data)
+    try:
+        whatsapp_cfg = yaml_cfg.get("whatsapp", {})
+        if isinstance(whatsapp_cfg, dict) and "reply_prefix" in whatsapp_cfg:
+            if Platform.WHATSAPP not in config.platforms:
+                config.platforms[Platform.WHATSAPP] = PlatformConfig()
+            config.platforms[Platform.WHATSAPP].extra["reply_prefix"] = whatsapp_cfg["reply_prefix"]
+    except Exception:
+        pass
 
     # Override with environment variables
     _apply_env_overrides(config)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -236,6 +236,10 @@ def _build_child_agent(
     # Set delegation depth so children can't spawn grandchildren
     child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
 
+    # Stash the parent's resolved tool names on the child so _run_single_child()
+    # can restore the process-global after the child finishes.
+    child._saved_tool_names = _saved_tool_names
+
     # Register child for interrupt propagation
     if hasattr(parent_agent, '_active_children'):
         lock = getattr(parent_agent, '_active_children_lock', None)
@@ -372,7 +376,10 @@ def _run_single_child(
     finally:
         # Restore the parent's tool names so the process-global is correct
         # for any subsequent execute_code calls or other consumers.
-        model_tools._last_resolved_tool_names = _saved_tool_names
+        import model_tools
+        _saved = getattr(child, '_saved_tool_names', None)
+        if _saved is not None:
+            model_tools._last_resolved_tool_names = _saved
 
         # Unregister child from interrupt propagation
         if hasattr(parent_agent, '_active_children'):


### PR DESCRIPTION
## Summary
- Fixes a `NameError` crash in subagent delegation. `_saved_tool_names` was defined as a local variable in `_build_child_agent()` but referenced in the separate function `_run_single_child()`, causing every child agent completion to crash in the `finally` block.
- Fix: Stash the saved tool names on the child agent object during construction, then retrieve them via `getattr(child, '_saved_tool_names', None)` in the cleanup block.
- Adds a safe `None` guard so the restore is skipped if the attribute is missing for any reason.
## Test plan
- [x] Run a single-task delegation (`delegate_task` with one goal) and verify it completes without`NameError`
- [x] Run a multi-task parallel delegation and verify all children complete and parent tool names are restored
- [x] Verify that after delegation, the parent agent's `model_tools._last_resolved_tool_names` matches its pre-delegation state