### PR TITLE
fix: move WhatsApp reply_prefix bridging after config initialization

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -429,16 +429,21 @@ def load_gateway_config() -> GatewayConfig:
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
 
-            # Bridge whatsapp settings from config.yaml into platform config
-            whatsapp_cfg = yaml_cfg.get("whatsapp", {})
-            if isinstance(whatsapp_cfg, dict) and "reply_prefix" in whatsapp_cfg:
-                if Platform.WHATSAPP not in config.platforms:
-                    config.platforms[Platform.WHATSAPP] = PlatformConfig()
-                config.platforms[Platform.WHATSAPP].extra["reply_prefix"] = whatsapp_cfg["reply_prefix"]
     except Exception:
         pass
 
     config = GatewayConfig.from_dict(gw_data)
+
+    # Bridge whatsapp settings from config.yaml into platform config
+    # (must happen after config is created from gw_data)
+    try:
+        whatsapp_cfg = yaml_cfg.get("whatsapp", {})
+        if isinstance(whatsapp_cfg, dict) and "reply_prefix" in whatsapp_cfg:
+            if Platform.WHATSAPP not in config.platforms:
+                config.platforms[Platform.WHATSAPP] = PlatformConfig()
+            config.platforms[Platform.WHATSAPP].extra["reply_prefix"] = whatsapp_cfg["reply_prefix"]
+    except Exception:
+        pass
 
     # Override with environment variables
     _apply_env_overrides(config)


### PR DESCRIPTION
## Summary

- **Fixes a silent `NameError`** in `gateway/config.py` where the WhatsApp `reply_prefix` bridging code referenced `config` before it was created by `GatewayConfig.from_dict()`.
- The `except Exception: pass` block swallowed the error, so the `reply_prefix` setting from `config.yaml` was silently ignored.
- **Fix:** Move the bridging block to after `config` is initialized.

## Test plan

- [x] Existing tests `test_reply_prefix_bridged_from_yaml` and `test_empty_reply_prefix_bridged` should now pass
- [x] Verify gateway startup with `whatsapp.reply_prefix` set in config.yaml applies the prefix correctly