### PR TITLE
fix: restore parent tool-name state after delegated runs

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -291,6 +291,69 @@ class TestToolNamePreservation(unittest.TestCase):
 
         self.assertEqual(model_tools._last_resolved_tool_names, original_tools)
 
+    def test_parent_tools_survive_child_construction_mutation(self):
+        """Regression for #1802: child construction overwrites the process-global
+        _last_resolved_tool_names.  The restore in _run_single_child must use
+        the snapshot captured BEFORE construction, not the post-mutation value.
+
+        Without the fix, the parent's tool names are silently replaced by the
+        child's tool names after delegation completes."""
+        import model_tools
+
+        parent = _make_mock_parent(depth=0)
+        parent_tools = ["terminal", "read_file", "web_search", "execute_code", "delegate_task"]
+        child_tools = ["terminal", "read_file"]  # child has a smaller toolset
+        model_tools._last_resolved_tool_names = list(parent_tools)
+
+        def _mutating_constructor(**kwargs):
+            """Simulate AIAgent.__init__ overwriting the global via
+            get_tool_definitions() during child construction."""
+            model_tools._last_resolved_tool_names = list(child_tools)
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1,
+            }
+            return mock_child
+
+        with patch("run_agent.AIAgent", side_effect=_mutating_constructor):
+            delegate_task(goal="Test parent survives mutation", parent_agent=parent)
+
+        # The global must hold the PARENT's tools, not the child's
+        self.assertEqual(model_tools._last_resolved_tool_names, parent_tools)
+
+    def test_batch_parent_tools_survive_multiple_child_mutations(self):
+        """Regression for #1802 (batch mode): when multiple children are built
+        sequentially on the main thread then run on worker threads, each child
+        construction mutates the global.  The final restore must still produce
+        the parent's original tool names, not any child's."""
+        import model_tools
+
+        parent = _make_mock_parent(depth=0)
+        parent_tools = ["terminal", "read_file", "web_search", "execute_code", "delegate_task"]
+        model_tools._last_resolved_tool_names = list(parent_tools)
+
+        call_count = [0]
+
+        def _mutating_constructor(**kwargs):
+            """Each child overwrites the global with a different toolset."""
+            call_count[0] += 1
+            model_tools._last_resolved_tool_names = [f"child{call_count[0]}_tool_a", f"child{call_count[0]}_tool_b"]
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": f"done {call_count[0]}", "completed": True, "api_calls": 1,
+            }
+            return mock_child
+
+        with patch("run_agent.AIAgent", side_effect=_mutating_constructor):
+            tasks = [
+                {"goal": "Task A"},
+                {"goal": "Task B"},
+            ]
+            delegate_task(tasks=tasks, parent_agent=parent)
+
+        # After both children complete, the global must be the PARENT's tools
+        self.assertEqual(model_tools._last_resolved_tool_names, parent_tools)
+
 
 class TestDelegateObservability(unittest.TestCase):
     """Tests for enriched metadata returned by _run_single_child."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -233,6 +233,11 @@ def _build_child_agent(
         iteration_budget=shared_budget,
     )
 
+    # Preserve the parent's resolved tool names on the child so the worker
+    # thread can restore them safely in _run_single_child().
+    child._parent_saved_tool_names = list(_saved_tool_names)
+    child._model_tools_module = model_tools
+
     # Set delegation depth so children can't spawn grandchildren
     child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
 
@@ -372,7 +377,10 @@ def _run_single_child(
     finally:
         # Restore the parent's tool names so the process-global is correct
         # for any subsequent execute_code calls or other consumers.
-        model_tools._last_resolved_tool_names = _saved_tool_names
+        model_tools_module = getattr(child, '_model_tools_module', None) if child is not None else None
+        saved_tool_names = getattr(child, '_parent_saved_tool_names', None) if child is not None else None
+        if model_tools_module is not None and saved_tool_names is not None:
+            model_tools_module._last_resolved_tool_names = list(saved_tool_names)
 
         # Unregister child from interrupt propagation
         if hasattr(parent_agent, '_active_children'):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -462,6 +462,13 @@ def delegate_task(
     # Track goal labels for progress display (truncated for readability)
     task_labels = [t["goal"][:40] for t in task_list]
 
+    # Snapshot parent's tool names on the main thread BEFORE any child
+    # construction can mutate the process-global.  This is the authoritative
+    # value restored after all children finish (especially important for
+    # batch mode where per-child restores race on worker threads).
+    import model_tools as _mt
+    _parent_tool_names_snapshot = list(_mt._last_resolved_tool_names)
+
     # Build all child agents on the main thread (thread-safe construction)
     children = []
     for i, t in enumerate(task_list):
@@ -538,6 +545,12 @@ def delegate_task(
 
         # Sort by task_index so results match input order
         results.sort(key=lambda r: r["task_index"])
+
+    # Authoritative restore of the parent's tool names on the main thread.
+    # Per-child restores in _run_single_child are best-effort (race in batch).
+    # This guarantees the parent gets its original tool names back regardless
+    # of child count, ordering, or worker-thread race conditions.
+    _mt._last_resolved_tool_names = list(_parent_tool_names_snapshot)
 
     total_duration = round(time.monotonic() - overall_start, 2)
 


### PR DESCRIPTION
## Summary
- Preserve the parent agent's resolved tool-name state before child agent construction mutates the process-global cache
- Stash that saved state on the child agent object during `_build_child_agent()`
- Restore the saved parent state from `_run_single_child()` cleanup instead of referencing an out-of-scope local
- Add authoritative main-thread restore in `delegate_task()` after all children finish (critical for batch mode)
- Add regression tests that simulate child construction mutating the global

## Root cause
`delegate_task` splits child lifecycle across `_build_child_agent()` and `_run_single_child()`. The parent tool-name snapshot was captured as `_saved_tool_names` in `_build_child_agent()`, but cleanup in `_run_single_child()` needed to restore that same state after the child finished.

Because the snapshot lived in `_build_child_agent()` local scope, delegated runs could reach cleanup with no in-scope `_saved_tool_names`, raising:

```text
name '_saved_tool_names' is not defined
```

## Why timing matters (vs #1804)

`_build_child_agent()` runs on the **main thread**. During child construction, `get_tool_definitions()` resolves the child's toolset and **overwrites** the process-global `_last_resolved_tool_names` with the child's tool names.

#1804 moves the save into `_run_single_child()` — by that point the global already holds the **child's** tool names, not the parent's. The "restored" state is actually the child's toolset.

This PR saves **before** child construction mutates the global.

## Batch mode

`delegate_task` supports up to 3 parallel tasks. The main thread builds all children sequentially, then worker threads run them concurrently.

With a save inside `_run_single_child()`:
- Each worker saves whatever `_last_resolved_tool_names` happens to be when it starts
- That value could be from any child's construction — race condition between threads

This PR adds an authoritative restore on the main thread after all futures complete, so the parent's tool names are guaranteed regardless of worker-thread ordering.

## Regression tests

Two new tests in `TestToolNamePreservation`:

1. **`test_parent_tools_survive_child_construction_mutation`** — single task. The mock `AIAgent` constructor overwrites `_last_resolved_tool_names` during construction (simulating real behavior). Asserts the parent's original tools are restored after delegation.

2. **`test_batch_parent_tools_survive_multiple_child_mutations`** — batch (2 tasks). Each child's construction overwrites the global with a different toolset. Asserts the parent's original tools are restored after both children complete.

These tests **fail without the fix** and catch the exact regression that caused #1802.

## Comparison

|                        | #1804              | #1864 (this PR)          |
|------------------------|--------------------|--------------------------|
| Fixes NameError?       | Yes                | Yes                      |
| Captures parent state? | No (post-mutation) | Yes (pre-mutation)       |
| Batch/thread-safe?     | No (racy global)   | Yes (per-child + main)   |
| Regression tests?      | No                 | Yes (2 tests)            |
| Complexity             | 2-line             | +76 lines (fix + tests)  |

## Validation
- `./venv/bin/python -m pytest -q tests/tools/test_delegate.py` → 49 passed
- Reproduced the failure from a live delegated run before the fix

Fixes #1802

Co-authored in debugging with Angello Picasso; patch prepared by Yuqi, a Hermes Agent.