### PR TITLE
Fix banner toolset labels for custom skins

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -233,6 +233,17 @@ def _format_context_length(tokens: int) -> str:
     return str(tokens)
 
 
+def _display_toolset_name(toolset_name: str) -> str:
+    """Normalize internal/legacy toolset identifiers for banner display."""
+    if not toolset_name:
+        return "unknown"
+    return (
+        toolset_name[:-6]
+        if toolset_name.endswith("_tools")
+        else toolset_name
+    )
+
+
 def build_welcome_banner(console: Console, model: str, cwd: str,
                          tools: List[dict] = None,
                          enabled_toolsets: List[str] = None,
@@ -297,12 +308,12 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
 
     for tool in tools:
         tool_name = tool["function"]["name"]
-        toolset = get_toolset_for_tool(tool_name) or "other"
+        toolset = _display_toolset_name(get_toolset_for_tool(tool_name) or "other")
         toolsets_dict.setdefault(toolset, []).append(tool_name)
 
     for item in unavailable_toolsets:
         toolset_id = item.get("id", item.get("name", "unknown"))
-        display_name = f"{toolset_id}_tools" if not toolset_id.endswith("_tools") else toolset_id
+        display_name = _display_toolset_name(toolset_id)
         if display_name not in toolsets_dict:
             toolsets_dict[display_name] = []
         for tool_name in item.get("tools", []):
@@ -342,10 +353,10 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
                     colored_names.append(f"[{text}]{name}[/]")
             tools_str = ", ".join(colored_names)
 
-        right_lines.append(f"[dim #B8860B]{toolset}:[/] {tools_str}")
+        right_lines.append(f"[dim {dim}]{toolset}:[/] {tools_str}")
 
     if remaining_toolsets > 0:
-        right_lines.append(f"[dim #B8860B](and {remaining_toolsets} more toolsets...)[/]")
+        right_lines.append(f"[dim {dim}](and {remaining_toolsets} more toolsets...)[/]")
 
     # MCP Servers section (only if configured)
     try:
@@ -356,12 +367,12 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
 
     if mcp_status:
         right_lines.append("")
-        right_lines.append("[bold #FFBF00]MCP Servers[/]")
+        right_lines.append(f"[bold {accent}]MCP Servers[/]")
         for srv in mcp_status:
             if srv["connected"]:
                 right_lines.append(
-                    f"[dim #B8860B]{srv['name']}[/] [#FFF8DC]({srv['transport']})[/] "
-                    f"[dim #B8860B]—[/] [#FFF8DC]{srv['tools']} tool(s)[/]"
+                    f"[dim {dim}]{srv['name']}[/] [{text}]({srv['transport']})[/] "
+                    f"[dim {dim}]—[/] [{text}]{srv['tools']} tool(s)[/]"
                 )
             else:
                 right_lines.append(

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -1,0 +1,50 @@
+from rich.console import Console
+
+import hermes_cli.banner as banner
+import model_tools
+import tools.mcp_tool
+
+
+def test_display_toolset_name_strips_legacy_suffix():
+    assert banner._display_toolset_name("homeassistant_tools") == "homeassistant"
+    assert banner._display_toolset_name("honcho_tools") == "honcho"
+    assert banner._display_toolset_name("browser") == "browser"
+
+
+def test_build_welcome_banner_uses_normalized_toolset_names(monkeypatch):
+    monkeypatch.setattr(
+        model_tools,
+        "check_tool_availability",
+        lambda quiet=False: (
+            ["web"],
+            [
+                {"name": "homeassistant", "tools": ["ha_call_service"]},
+                {"name": "honcho", "tools": ["honcho_conclude"]},
+            ],
+        ),
+    )
+    monkeypatch.setattr(banner, "get_available_skills", lambda: {})
+    monkeypatch.setattr(banner, "get_update_result", lambda timeout=0.5: None)
+    monkeypatch.setattr(tools.mcp_tool, "get_mcp_status", lambda: [])
+
+    console = Console(record=True, force_terminal=False, color_system=None, width=160)
+    banner.build_welcome_banner(
+        console=console,
+        model="anthropic/test-model",
+        cwd="/tmp/project",
+        tools=[
+            {"function": {"name": "web_search"}},
+            {"function": {"name": "read_file"}},
+        ],
+        get_toolset_for_tool=lambda name: {
+            "web_search": "web_tools",
+            "read_file": "file",
+        }.get(name),
+    )
+
+    output = console.export_text()
+    assert "homeassistant:" in output
+    assert "honcho:" in output
+    assert "web:" in output
+    assert "homeassistant_tools:" not in output
+    assert "honcho_tools:" not in output


### PR DESCRIPTION
## Summary
- normalize internal and legacy toolset identifiers before rendering them in the CLI welcome banner
- stop appending `_tools` for unavailable toolsets so Home Assistant and Honcho render with their canonical names
- use active skin colors for toolset rows, the overflow line, and MCP server rows
- add banner regression tests for normalized toolset labels

## Testing
- PYTEST_ADDOPTS='' python -m pytest tests/hermes_cli/test_banner.py -q -o addopts=''
- PYTEST_ADDOPTS='' python -m pytest tests/test_cli_skin_integration.py -q -o addopts=''