### PR TITLE
fix(agent): detect Zhipu GLM context-length errors and include tool tokens in preflight estimate

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,42 +3,27 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |
@@ -20,31 +24,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -60,6 +60,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "qwen/qwen-2.5-72b-instruct": 32768,
     "glm-4.7": 202752,
     "glm-5": 202752,
+    "glm-5-turbo": 202752,  # Zhipu: same 202K context as glm-5
     "glm-4.5": 131072,
     "glm-4.5-flash": 131072,
     "kimi-for-coding": 262144,

--- a/run_agent.py
+++ b/run_agent.py
@@ -4809,12 +4809,17 @@ class AIAgent:
         ):
             _sys_tok_est = estimate_tokens_rough(active_system_prompt or "")
             _msg_tok_est = estimate_messages_tokens_rough(messages)
-            _preflight_tokens = _sys_tok_est + _msg_tok_est
+            # Include tool schema tokens — with many tools these can add 20-30K+ tokens
+            _tool_tok_est = estimate_tokens_rough(json.dumps(self.tools)) if self.tools else 0
+            _preflight_tokens=*** + _msg_tok_est + _tool_tok_est
 
             if _preflight_tokens >= self.context_compressor.threshold_tokens:
                 logger.info(
-                    "Preflight compression: ~%s tokens >= %s threshold (model %s, ctx %s)",
+                    "Preflight compression: ~%s tokens (sys=%s, msg=%s, tools=%s) >= %s threshold (model %s, ctx %s)",
                     f"{_preflight_tokens:,}",
+                    f"{_sys_tok_est:,}",
+                    f"{_msg_tok_est:,}",
+                    f"{_tool_tok_est:,}",
                     f"{self.context_compressor.threshold_tokens:,}",
                     self.model,
                     f"{self.context_compressor.context_length:,}",
@@ -4822,6 +4827,7 @@ class AIAgent:
                 if not self.quiet_mode:
                     print(
                         f"📦 Preflight compression: ~{_preflight_tokens:,} tokens "
+                        f"(sys={_sys_tok_est:,}, msg={_msg_tok_est:,}, tools={_tool_tok_est:,}) "
                         f">= {self.context_compressor.threshold_tokens:,} threshold"
                     )
                 # May need multiple passes for very large sessions with small
@@ -5477,9 +5483,11 @@ class AIAgent:
                     is_context_length_error = any(phrase in error_msg for phrase in [
                         'context length', 'context size', 'maximum context',
                         'token limit', 'too many tokens', 'reduce the length',
-                        'exceeds the limit', 'context window',
+                        'exceeds the limit', 'exceeds max length',  # Zhipu GLM: "Prompt exceeds max length" (error 1261)
+                        'context window',
                         'request entity too large',  # OpenRouter/Nous 413 safety net
                         'prompt is too long',  # Anthropic: "prompt is too long: N tokens > M maximum"
+                        'prompt exceeds',  # Broad catch for prompt-too-long variants
                     ])
                     
                     if is_context_length_error:


### PR DESCRIPTION
## Problem

Zhipu GLM models (glm-5, glm-5-turbo) return **error code 1261** with message `"Prompt exceeds max length"` when the context is too large. This phrase was not in the context-length error detection list in `run_agent.py`, so the retry handler treated it as a non-retryable 400 and crashed after 3 attempts with the same payload instead of compressing and recovering.

Additionally, the preflight compression check only counted system prompt + message tokens, ignoring tool schema tokens. With 50+ tools enabled, schemas can add 20-30K+ tokens — a significant blind spot that delays compression until the API itself rejects the request.

## Changes

### `run_agent.py`

1. **Context-length error phrase list** — Added `'exceeds max length'` and `'prompt exceeds'` to catch Zhipu error 1261 and similar prompt-too-long variants from other providers.

2. **Preflight compression estimate** — Now includes tool schema tokens (`json.dumps(self.tools)`) alongside system prompt and message tokens. This triggers compression earlier when many tools are loaded.

### `agent/model_metadata.py`

- Added explicit `glm-5-turbo` entry (202,752 tokens) to `DEFAULT_CONTEXT_LENGTHS` so it resolves directly without fuzzy matching.

## How to test

1. Start a long session with `glm-5-turbo` and 50+ tools enabled
2. Let the conversation grow past ~100K tokens
3. Previously: crashes with `BadRequestError: Error code: 400 - Prompt exceeds max length` after 3 retries
4. After fix: context compressor triggers, compresses middle turns, retries successfully

## Platforms tested

- macOS (aarch64, Python 3.11)
