### PR TITLE
fix: enforce context_tokens budget on Honcho peer representation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1780,7 +1780,29 @@ class AIAgent:
                 "and what you were working on together. Do not call tools to "
                 "look up information that is already present here.\n"
             )
-            return header + "\n\n".join(parts)
+            assembled = header + "\n\n".join(parts)
+
+            # Enforce context_tokens budget on the assembled block.
+            # The Honcho API's tokens param only limits message history, not
+            # peer_representation/peer_card which can grow unbounded. We must
+            # truncate client-side to respect the user's configured budget.
+            token_budget = (
+                self._honcho._context_tokens
+                if self._honcho and hasattr(self._honcho, "_context_tokens")
+                else None
+            )
+            if token_budget and token_budget > 0:
+                # Rough estimate: 1 token ≈ 4 chars (conservative for English text)
+                char_budget = token_budget * 4
+                if len(assembled) > char_budget:
+                    logger.debug(
+                        "Honcho context exceeds budget (%d chars > %d char limit "
+                        "from %d tokens), truncating",
+                        len(assembled), char_budget, token_budget,
+                    )
+                    assembled = assembled[:char_budget] + "\n\n[… truncated to fit token budget]"
+
+            return assembled
         except Exception as e:
             logger.debug("Honcho prefetch failed (non-fatal): %s", e)
             return ""

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1774,6 +1774,58 @@ class TestHonchoPrefetchScheduling:
         assert "Continuity synthesis" in context
         assert "migration checklist" in context
 
+    def test_honcho_prefetch_truncates_to_token_budget(self, agent):
+        """context_tokens budget should truncate the assembled Honcho block."""
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "session-key"
+        agent._honcho._context_tokens = 50  # 50 tokens ≈ 200 chars
+        # Return a large representation that exceeds the budget
+        large_rep = "x" * 5000
+        agent._honcho.pop_context_result.return_value = {
+            "representation": large_rep,
+            "card": "",
+        }
+        agent._honcho.pop_dialectic_result.return_value = ""
+
+        context = agent._honcho_prefetch("hello")
+
+        # Should be truncated: 50 tokens * 4 chars = 200 chars
+        assert len(context) < 300  # 200 chars + truncation marker
+        assert "truncated to fit token budget" in context
+
+    def test_honcho_prefetch_no_truncation_within_budget(self, agent):
+        """Honcho block within token budget should not be truncated."""
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "session-key"
+        agent._honcho._context_tokens = 5000  # generous budget
+        agent._honcho.pop_context_result.return_value = {
+            "representation": "User likes Python.",
+            "card": "",
+        }
+        agent._honcho.pop_dialectic_result.return_value = ""
+
+        context = agent._honcho_prefetch("hello")
+
+        assert "truncated" not in context
+        assert "User likes Python" in context
+
+    def test_honcho_prefetch_no_truncation_when_no_budget(self, agent):
+        """No context_tokens set means no truncation."""
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "session-key"
+        agent._honcho._context_tokens = None  # no budget
+        large_rep = "x" * 5000
+        agent._honcho.pop_context_result.return_value = {
+            "representation": large_rep,
+            "card": "",
+        }
+        agent._honcho.pop_dialectic_result.return_value = ""
+
+        context = agent._honcho_prefetch("hello")
+
+        assert "truncated" not in context
+        assert len(context) > 5000
+
     def test_queue_honcho_prefetch_skips_tools_mode(self, agent):
         agent._honcho = MagicMock()
         agent._honcho_session_key = "session-key"


### PR DESCRIPTION
## What does this PR do?

Enforces the user's configured `contextTokens` budget on Honcho's `peer_representation` and `peer_card` fields, which were previously injected into the system prompt at full size regardless of the token limit.

The Honcho SDK's `session.context(tokens=N)` parameter only limits **message history** retrieval. The `peer_representation` and `peer_card` fields — containing Explicit Observations, Deductive Observations, Inductive Observations, and the structured peer card — are returned in full by the Honcho server regardless of the `tokens` value. This meant setting `contextTokens: 50` in `~/.honcho/config.json` had zero effect, and users would see 4000-5000+ tokens of Honcho context injected every turn.

The fix adds client-side truncation in `_honcho_prefetch()` after assembling the full context block, capping it to `context_tokens * 4` characters. Ideally the Honcho API itself should respect the `tokens` param for all returned fields, but until that's addressed server-side this prevents runaway token usage.

## Related Issue

<!-- No existing issue — discovered during real usage where contextTokens: 50 was completely ignored -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: After assembling the Honcho context block in `_honcho_prefetch()`, read `self._honcho._context_tokens` and truncate the assembled string to `token_budget * 4` characters if it exceeds the budget. Adds a `[… truncated to fit token budget]` marker when truncation occurs.
- `tests/test_run_agent.py`: Three new unit tests:
  - `test_honcho_prefetch_truncates_to_token_budget` — verifies large context is truncated at budget
  - `test_honcho_prefetch_no_truncation_within_budget` — verifies small context passes through intact
  - `test_honcho_prefetch_no_truncation_when_no_budget` — verifies `None` budget means no truncation

## How to Test

1. Set `contextTokens: 500` in `~/.honcho/config.json` (under `hosts.hermes`)
2. Start a conversation with Honcho enabled (`"enabled": true`)
3. **Before fix**: Honcho context block is 4000-5000+ tokens regardless of the setting
4. **After fix**: Honcho context block is truncated to ~2000 chars (500 tokens × 4 chars/token)
5. Run the new tests: `pytest tests/test_run_agent.py::TestHonchoPrefetchScheduling::test_honcho_prefetch_truncates_to_token_budget tests/test_run_agent.py::TestHonchoPrefetchScheduling::test_honcho_prefetch_no_truncation_within_budget tests/test_run_agent.py::TestHonchoPrefetchScheduling::test_honcho_prefetch_no_truncation_when_no_budget -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent): enforce context_tokens budget on Honcho peer representation`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before fix** (contextTokens: 50, completely ignored):
```
# Honcho Memory (persistent cross-session context)
## User representation
## Explicit Observations
[2026-03-18 05:52:52] azoth is a senior software architect...
[2026-03-18 05:52:52] azoth wants to change the 'enabled' setting...
... (17 Explicit Observations)

## Deductive Observations
... (8 Deductive Observations)

## Inductive Observations
... (17 Inductive Observations, ~500 words each)

Name: Hermes
Role: Autonomous AI agent...
... (full peer card)

Total: ~5000 tokens injected every turn
```

**After fix** (contextTokens: 500, properly enforced):
```
# Honcho Memory (persistent cross-session context)
## User representation
## Explicit Observations
[2026-03-18 05:52:52] azoth is a senior software architect...
[2026-03-18 05:52:52] azoth prefers dark mode in all IDEs...
... (truncated to ~500 tokens)

[… truncated to fit token budget]
```
