### PR TITLE
fix(gateway): wait for launchd process exit before restarting

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -849,6 +849,32 @@ def launchd_stop():
     subprocess.run(["launchctl", "stop", "ai.hermes.gateway"], check=True)
     print("✓ Service stopped")
 
+
+def _wait_for_launchd_job_exit(label: str, timeout: float = 10.0):
+    """Block until the launchd job has no running PID, or timeout."""
+    import time
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            # Job is no longer loaded — definitely not running.
+            return
+        # launchctl list output includes a "PID" line when the process is
+        # alive.  Once the process exits the PID field becomes '-' or 0, or
+        # the entire key disappears.
+        for line in result.stdout.splitlines():
+            if '"PID"' in line or line.strip().startswith('"PID"'):
+                # PID key still present — process is still alive.
+                break
+        else:
+            # No PID key found — process has exited.
+            return
+        time.sleep(0.3)
+
+
 def launchd_restart():
     try:
         launchd_stop()
@@ -856,6 +882,7 @@ def launchd_restart():
         if e.returncode != 3:
             raise
         print("↻ launchd job was unloaded; skipping stop")
+    _wait_for_launchd_job_exit("ai.hermes.gateway")
     launchd_start()
 
 def launchd_status(deep: bool = False):


### PR DESCRIPTION
## What does this PR do?

`hermes gateway restart` stops the gateway but never starts it back up on macOS.

The root cause is a race condition in `launchd_restart()`: `launchctl stop` is asynchronous — it returns immediately while the process is still shutting down. `launchd_start()` then fires `launchctl start` while the old process is still dying, and launchd silently ignores the start request because it considers the job still active.

This PR adds a polling wait between stop and start that blocks until the launchd job's PID clears (up to 10 s timeout), ensuring the old process has fully exited before attempting to start a new one.

The manual restart path (line 1757) already had a `time.sleep(2)` for the same reason — the launchd service path just lacked an equivalent wait.

## Related Issue

<!-- No existing issue found — consider creating one before opening the PR. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: Added `_wait_for_launchd_job_exit()` helper that polls `launchctl list <label>` until the PID key disappears or the job is unloaded (300 ms interval, 10 s timeout).
- `hermes_cli/gateway.py`: `launchd_restart()` now calls `_wait_for_launchd_job_exit("ai.hermes.gateway")` between `launchd_stop()` and `launchd_start()`.

## How to Test

1. Install the gateway as a launchd service: `hermes gateway install`
2. Start the gateway: `hermes gateway start`
3. Confirm it's running: `hermes gateway status`
4. Restart: `hermes gateway restart`
5. Confirm it came back up: `hermes gateway status` — should show running with a new PID

Previously step 4 would stop the gateway and never start it again.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.3.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ hermes gateway restart
✓ Service stopped
✓ Service started
```

Watch the gateway logs to confirm the service stops and starts cleanly:
```
tail -f ~/.hermes/logs/gateway.log ~/.hermes/logs/gateway.error.log
```
