### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -46,8 +46,8 @@ logger = logging.getLogger(__name__)
 _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "zai": "glm-4.5-flash",
     "kimi-coding": "kimi-k2-turbo-preview",
-    "minimax": "MiniMax-M2.5-highspeed",
-    "minimax-cn": "MiniMax-M2.5-highspeed",
+    "minimax": "MiniMax-M2.7-highspeed",
+    "minimax-cn": "MiniMax-M2.7-highspeed",
 }
 
 # OpenRouter app attribution headers

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -66,6 +66,8 @@ MODEL_PRICING = {
     "kimi-k2-turbo-preview": {"input": 0.0, "output": 0.0},
     "kimi-k2-0905-preview": {"input": 0.0, "output": 0.0},
     # MiniMax (direct provider — pricing not published externally, treat as local)
+    "MiniMax-M2.7": {"input": 0.0, "output": 0.0},
+    "MiniMax-M2.7-highspeed": {"input": 0.0, "output": 0.0},
     "MiniMax-M2.5": {"input": 0.0, "output": 0.0},
     "MiniMax-M2.5-highspeed": {"input": 0.0, "output": 0.0},
     "MiniMax-M2.1": {"input": 0.0, "output": 0.0},

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -57,6 +57,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     "kimi-k2-thinking": 262144,
     "kimi-k2-turbo-preview": 262144,
     "kimi-k2-0905-preview": 131072,
+    "MiniMax-M2.7": 204800,
+    "MiniMax-M2.7-highspeed": 204800,
     "MiniMax-M2.5": 204800,
     "MiniMax-M2.5-highspeed": 204800,
     "MiniMax-M2.1": 204800,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -27,7 +27,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("stepfun/step-3.5-flash",          ""),
     ("z-ai/glm-5",                      ""),
     ("moonshotai/kimi-k2.5",            ""),
-    ("minimax/minimax-m2.5",            ""),
+    ("minimax/minimax-m2.7",            ""),
 ]
 
 _PROVIDER_MODELS: dict[str, list[str]] = {
@@ -44,11 +44,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "minimax": [
+        "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
     ],
     "minimax-cn": [
+        "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1198,7 +1198,7 @@ def setup_model_provider(config: dict):
                     save_env_value("LLM_MODEL", custom)
             # else: keep current
         elif selected_provider in ("minimax", "minimax-cn"):
-            minimax_models = ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]
+            minimax_models = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]
             model_choices = list(minimax_models)
             model_choices.append("Custom model")
             model_choices.append(f"Keep current ({current_model})")

--- a/tests/test_fallback_model.py
+++ b/tests/test_fallback_model.py
@@ -118,14 +118,14 @@ class TestTryActivateFallback:
 
     def test_activates_minimax_fallback(self):
         agent = _make_agent(
-            fallback_model={"provider": "minimax", "model": "MiniMax-M2.5"},
+            fallback_model={"provider": "minimax", "model": "MiniMax-M2.7"},
         )
         with (
             patch.dict("os.environ", {"MINIMAX_API_KEY": "sk-mm-key"}),
             patch("run_agent.OpenAI") as mock_openai,
         ):
             assert agent._try_activate_fallback() is True
-            assert agent.model == "MiniMax-M2.5"
+            assert agent.model == "MiniMax-M2.7"
             assert agent.provider == "minimax"
             call_kwargs = mock_openai.call_args[1]
             assert "minimax.io" in call_kwargs["base_url"]
@@ -145,7 +145,7 @@ class TestTryActivateFallback:
     def test_returns_false_when_no_api_key(self):
         """Fallback should fail gracefully when the API key env var is unset."""
         agent = _make_agent(
-            fallback_model={"provider": "minimax", "model": "MiniMax-M2.5"},
+            fallback_model={"provider": "minimax", "model": "MiniMax-M2.7"},
         )
         # Ensure MINIMAX_API_KEY is not in the environment
         env = {k: v for k, v in os.environ.items() if k != "MINIMAX_API_KEY"}

--- a/tools/rl_training_tool.py
+++ b/tools/rl_training_tool.py
@@ -1006,7 +1006,7 @@ async def rl_list_runs() -> str:
 TEST_MODELS = [
     {"id": "qwen/qwen3-8b", "name": "Qwen3 8B", "scale": "small"},
     {"id": "z-ai/glm-4.7-flash", "name": "GLM-4.7 Flash", "scale": "medium"},
-    {"id": "minimax/minimax-m2.5", "name": "MiniMax M2.5", "scale": "large"},
+    {"id": "minimax/minimax-m2.7", "name": "MiniMax M2.7", "scale": "large"},
 ]
 
 # Default test parameters - quick but representative
@@ -1034,7 +1034,7 @@ async def rl_test_inference(
     Test models (varying intelligence levels for robustness):
     - qwen/qwen3-8b (small)
     - zhipu-ai/glm-4-flash (medium)
-    - minimax/minimax-m1 (large)
+    - minimax/minimax-m2.7 (large)
     
     Args:
         num_steps: Steps to run (default: 3, max recommended for testing)
@@ -1366,7 +1366,7 @@ RL_CHECK_STATUS_SCHEMA = {"name": "rl_check_status", "description": "Get status 
 RL_STOP_TRAINING_SCHEMA = {"name": "rl_stop_training", "description": "Stop a running training job. Use if metrics look bad, training is stagnant, or you want to try different settings.", "parameters": {"type": "object", "properties": {"run_id": {"type": "string", "description": "The run ID to stop"}}, "required": ["run_id"]}}
 RL_GET_RESULTS_SCHEMA = {"name": "rl_get_results", "description": "Get final results and metrics for a completed training run. Returns final metrics and path to trained weights.", "parameters": {"type": "object", "properties": {"run_id": {"type": "string", "description": "The run ID to get results for"}}, "required": ["run_id"]}}
 RL_LIST_RUNS_SCHEMA = {"name": "rl_list_runs", "description": "List all training runs (active and completed) with their status.", "parameters": {"type": "object", "properties": {}, "required": []}}
-RL_TEST_INFERENCE_SCHEMA = {"name": "rl_test_inference", "description": "Quick inference test for any environment. Runs a few steps of inference + scoring using OpenRouter. Default: 3 steps x 16 completions = 48 rollouts per model, testing 3 models = 144 total. Tests environment loading, prompt construction, inference parsing, and verifier logic. Use BEFORE training to catch issues.", "parameters": {"type": "object", "properties": {"num_steps": {"type": "integer", "description": "Number of steps to run (default: 3, recommended max for testing)", "default": 3}, "group_size": {"type": "integer", "description": "Completions per step (default: 16, like training)", "default": 16}, "models": {"type": "array", "items": {"type": "string"}, "description": "Optional list of OpenRouter model IDs. Default: qwen/qwen3-8b, z-ai/glm-4.7-flash, minimax/minimax-m2.5"}}, "required": []}}
+RL_TEST_INFERENCE_SCHEMA = {"name": "rl_test_inference", "description": "Quick inference test for any environment. Runs a few steps of inference + scoring using OpenRouter. Default: 3 steps x 16 completions = 48 rollouts per model, testing 3 models = 144 total. Tests environment loading, prompt construction, inference parsing, and verifier logic. Use BEFORE training to catch issues.", "parameters": {"type": "object", "properties": {"num_steps": {"type": "integer", "description": "Number of steps to run (default: 3, recommended max for testing)", "default": 3}, "group_size": {"type": "integer", "description": "Completions per step (default: 16, like training)", "default": 16}, "models": {"type": "array", "items": {"type": "string"}, "description": "Optional list of OpenRouter model IDs. Default: qwen/qwen3-8b, z-ai/glm-4.7-flash, minimax/minimax-m2.7"}}, "required": []}}
 
 _rl_env = ["TINKER_API_KEY", "WANDB_API_KEY"]
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -92,11 +92,11 @@ hermes chat --provider kimi-coding --model moonshot-v1-auto
 # Requires: KIMI_API_KEY in ~/.hermes/.env
 
 # MiniMax (global endpoint)
-hermes chat --provider minimax --model MiniMax-Text-01
+hermes chat --provider minimax --model MiniMax-M2.7
 # Requires: MINIMAX_API_KEY in ~/.hermes/.env
 
 # MiniMax (China endpoint)
-hermes chat --provider minimax-cn --model MiniMax-Text-01
+hermes chat --provider minimax-cn --model MiniMax-M2.7
 # Requires: MINIMAX_CN_API_KEY in ~/.hermes/.env
 ```
 

--- a/website/docs/user-guide/features/rl-training.md
+++ b/website/docs/user-guide/features/rl-training.md
@@ -147,7 +147,7 @@ Default configuration:
 - Tests 3 models at different scales for robustness:
   - `qwen/qwen3-8b` (small)
   - `z-ai/glm-4.7-flash` (medium)
-  - `minimax/minimax-m2.5` (large)
+  - `minimax/minimax-m2.7` (large)
 - Total: ~144 rollouts
 
 This validates:


### PR DESCRIPTION
## Summary
- Add MiniMax-M2.7 and MiniMax-M2.7-highspeed to the model selection list
- Set MiniMax-M2.7 as the new default model
- Retain all previous models (M2.5, M2.5-highspeed, M2.1) as available alternatives
- Update related unit tests and documentation

## Changes
- **agent/model_metadata.py**: Add M2.7 context length entries
- **agent/auxiliary_client.py**: Update default auxiliary model to M2.7-highspeed
- **agent/insights.py**: Add M2.7 pricing entries
- **hermes_cli/models.py**: Add M2.7 to provider model lists, update OpenRouter entry
- **hermes_cli/setup.py**: Add M2.7 to setup wizard model selection
- **tools/rl_training_tool.py**: Update test inference model to M2.7
- **tests/test_fallback_model.py**: Update fallback test to use M2.7
- **docs**: Update configuration examples and RL training docs

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities.

## Testing
- All changes follow existing patterns exactly (model list additions + default updates)
- Unit tests updated to reflect M2.7 as the recommended model
