### PR TITLE
fix(delegate): move _saved_tool_names save/restore to _run_single_child scope

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -173,10 +173,6 @@ def _build_child_agent(
     from run_agent import AIAgent
     import model_tools
 
-    # Save the parent's resolved tool names before the child agent can
-    # overwrite the process-global via get_tool_definitions().
-    _saved_tool_names = list(model_tools._last_resolved_tool_names)
-
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
     if toolsets:
@@ -262,6 +258,13 @@ def _run_single_child(
 
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, 'tool_progress_callback', None)
+
+    # Save the parent's resolved tool names before the child agent can
+    # overwrite the process-global via get_tool_definitions().
+    # This must be in _run_single_child (not _build_child_agent) so the
+    # save/restore happens in the same scope as the try/finally.
+    import model_tools
+    _saved_tool_names = list(model_tools._last_resolved_tool_names)
 
     try:
         result = child.run_conversation(user_message=goal)


### PR DESCRIPTION
## Summary
Fixes #1802

The v0.3.0 refactor split child agent construction (`_build_child_agent`) and execution (`_run_single_child`) into separate functions. This created a scope bug where `_saved_tool_names` was defined in `_build_child_agent` but referenced in `_run_single_child`'s `finally` block, causing a `NameError` on every `delegate_task` call:

```
Error executing tool: Error during OpenAI-compatible API call #2: name '_saved_tool_names' is not defined
```

## Solution
Move the save/restore logic entirely into `_run_single_child`, keeping the save and restore in the same scope as the try/finally block. This is cleaner than passing the variable through and removes the dead save from `_build_child_agent`.

## Impact
- **Before:** All `delegate_task` calls fail with NameError
- **After:** Delegation works correctly

## Testing
- Verified syntax correctness
- The fix is straightforward scope correction that the issue author already validated
