### PR TITLE
fix(matrix): use correct reply_to_message_id parameter name

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -635,7 +635,7 @@ class MatrixAdapter(BasePlatformAdapter):
             source=source,
             raw_message=getattr(event, "source", {}),
             message_id=event.event_id,
-            reply_to=reply_to,
+            reply_to_message_id=reply_to,
         )
 
         await self.handle_message(msg_event)


### PR DESCRIPTION
## Summary
Fixes #1842

The Matrix connector was passing `reply_to` to `MessageEvent`, but the dataclass expects `reply_to_message_id`. This caused replies to fail with:

```
MessageEvent.__init__() got an unexpected keyword argument 'reply_to'
```

## Solution
Changed `reply_to=reply_to` to `reply_to_message_id=reply_to` at line 638 in `gateway/platforms/matrix.py`.

## Impact
- **Before:** Matrix messages fail to be processed; bot doesn't reply
- **After:** Matrix replies work correctly and are properly threaded

## Testing
- Verified syntax correctness
- One-line fix matching the dataclass definition
