### PR TITLE
feat: add AutoResearch toolset for bounded research cycles

### DIFF
--- a/autoresearch/__init__.py
+++ b/autoresearch/__init__.py
@@ -1,0 +1,23 @@
+"""Generic bounded AutoResearch runtime for Hermes."""
+
+from autoresearch.runtime import (
+    inspect_project,
+    inspect_run,
+    list_projects,
+    list_runs,
+    publish_summary,
+    research_cycle,
+    status,
+    validate_project,
+)
+
+__all__ = [
+    "inspect_project",
+    "inspect_run",
+    "list_projects",
+    "list_runs",
+    "publish_summary",
+    "research_cycle",
+    "status",
+    "validate_project",
+]

--- a/autoresearch/manifests.py
+++ b/autoresearch/manifests.py
@@ -1,0 +1,329 @@
+"""Manifest loading and validation for workspace AutoResearch configs."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from autoresearch.models import (
+    AnchorConfig,
+    CommandConfig,
+    EditableMarker,
+    FamilyConfig,
+    InterestingConfig,
+    InterestingRule,
+    MutationConfig,
+    ProjectConfig,
+    SecondaryMetricRule,
+    SelectionConfig,
+)
+
+PROJECT_CONFIG_RELPATH = Path(".hermes") / "autoresearch" / "project.yaml"
+FAMILIES_RELPATH = Path(".hermes") / "autoresearch" / "families"
+
+_ALLOWED_OPS = {"==", "!=", ">", ">=", "<", "<="}
+
+
+class ManifestError(ValueError):
+    """Raised when an AutoResearch manifest is invalid."""
+
+
+def discover_project_root(start: Optional[str | os.PathLike[str]] = None) -> Optional[Path]:
+    """Find the nearest workspace that declares an AutoResearch project."""
+    current = Path(start or os.getcwd()).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / PROJECT_CONFIG_RELPATH).exists():
+            return candidate
+    return None
+
+
+def list_project_roots(start: Optional[str | os.PathLike[str]] = None) -> list[Path]:
+    """Discover nearby workspaces that declare AutoResearch configs."""
+    roots: list[Path] = []
+    start_path = Path(start or os.getcwd()).resolve()
+    nearest = discover_project_root(start_path)
+    if nearest is not None:
+        roots.append(nearest)
+
+    try:
+        for child in start_path.iterdir():
+            if child.is_dir() and (child / PROJECT_CONFIG_RELPATH).exists():
+                resolved = child.resolve()
+                if resolved not in roots:
+                    roots.append(resolved)
+    except OSError:
+        pass
+
+    return roots
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise ManifestError(f"Manifest not found: {path}")
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"Failed to parse YAML at {path}: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise ManifestError(f"Manifest must be a mapping: {path}")
+    return loaded
+
+
+def _load_command_config(raw: dict[str, Any], fallback: Optional[CommandConfig]) -> Optional[CommandConfig]:
+    evaluation = raw.get("evaluation") or raw.get("evaluation_command")
+    validation = raw.get("validation") or raw.get("validation_command")
+    result_json = raw.get("result_json")
+
+    if evaluation is None and fallback is not None:
+        evaluation = fallback.evaluation
+    if validation is None and fallback is not None:
+        validation = fallback.validation
+    if result_json is None and fallback is not None:
+        result_json = fallback.result_json
+
+    if not evaluation or not result_json:
+        return None
+    return CommandConfig(
+        evaluation=str(evaluation),
+        validation=str(validation) if validation else None,
+        result_json=str(result_json),
+    )
+
+
+def load_project_config(project_root: str | os.PathLike[str]) -> ProjectConfig:
+    """Load and normalize the workspace project manifest."""
+    root = Path(project_root).resolve()
+    raw = _load_yaml(root / PROJECT_CONFIG_RELPATH)
+    evaluator = _load_command_config(raw.get("evaluator", {}), None)
+    report = raw.get("report", {}) if isinstance(raw.get("report", {}), dict) else {}
+    publish = raw.get("publish", {}) if isinstance(raw.get("publish", {}), dict) else {}
+    project_id = str(raw.get("project_id") or raw.get("id") or "").strip()
+    description = str(raw.get("description") or "").strip()
+
+    if not project_id:
+        raise ManifestError("project.yaml requires 'project_id'")
+    if not description:
+        raise ManifestError("project.yaml requires 'description'")
+
+    return ProjectConfig(
+        project_id=project_id,
+        description=description,
+        root=root,
+        default_cwd=str(raw.get("default_cwd") or raw.get("cwd") or "."),
+        datasets=list(raw.get("datasets") or []),
+        benchmarks=[str(item) for item in (raw.get("benchmarks") or [])],
+        evaluator=evaluator,
+        report_output_dir=str(report.get("output_dir") or raw.get("report_output_dir") or "research"),
+        publish_target=str(publish.get("default_target") or raw.get("publish_target") or "").strip() or None,
+    )
+
+
+def list_family_files(project_root: str | os.PathLike[str]) -> list[Path]:
+    """Return all family manifest files for the workspace."""
+    family_dir = Path(project_root).resolve() / FAMILIES_RELPATH
+    if not family_dir.exists():
+        return []
+    return sorted(
+        path for path in family_dir.iterdir()
+        if path.suffix.lower() in {".yaml", ".yml"} and path.is_file()
+    )
+
+
+def load_family_config(
+    project_root: str | os.PathLike[str],
+    family_id: str,
+    project: Optional[ProjectConfig] = None,
+) -> FamilyConfig:
+    """Load one family manifest by id."""
+    root = Path(project_root).resolve()
+    project_cfg = project or load_project_config(root)
+    target_file: Optional[Path] = None
+    for path in list_family_files(root):
+        if path.stem == family_id:
+            target_file = path
+            break
+        raw = _load_yaml(path)
+        if str(raw.get("family_id") or raw.get("id") or "").strip() == family_id:
+            target_file = path
+            break
+    if target_file is None:
+        raise ManifestError(f"Unknown family_id '{family_id}' in {root}")
+
+    raw = _load_yaml(target_file)
+    commands = _load_command_config(raw.get("commands", {}), project_cfg.evaluator)
+    if commands is None:
+        raise ManifestError(f"Family '{family_id}' must define evaluation command and result_json")
+
+    selection_raw = raw.get("selection", {}) if isinstance(raw.get("selection", {}), dict) else {}
+    primary_metric = str(selection_raw.get("primary_metric") or "").strip()
+    if not primary_metric:
+        raise ManifestError(f"Family '{family_id}' must define selection.primary_metric")
+
+    secondaries = [
+        SecondaryMetricRule(
+            metric=str(item.get("metric") or "").strip(),
+            min_delta=float(item.get("min_delta", 0.0)),
+        )
+        for item in (selection_raw.get("secondary_metrics") or [])
+        if isinstance(item, dict) and str(item.get("metric") or "").strip()
+    ]
+
+    interesting_raw = raw.get("interesting_if", {}) if isinstance(raw.get("interesting_if", {}), dict) else {}
+    interesting_rules = [
+        InterestingRule(
+            metric=str(item.get("metric") or "").strip(),
+            op=str(item.get("op") or "").strip(),
+            value=item.get("value"),
+        )
+        for item in (interesting_raw.get("rules") or [])
+        if isinstance(item, dict) and str(item.get("metric") or "").strip()
+    ]
+
+    mutation_raw = raw.get("mutation", {}) if isinstance(raw.get("mutation", {}), dict) else {}
+    mutation_mode = str(
+        mutation_raw.get("mode")
+        or raw.get("mutation_mode")
+        or ""
+    ).strip()
+    if not mutation_mode:
+        raise ManifestError(f"Family '{family_id}' must define mutation.mode or mutation_mode")
+
+    anchors_raw = raw.get("anchors") or []
+    anchors = [
+        AnchorConfig(
+            candidate_id=str(item.get("candidate_id") or item.get("id") or "").strip(),
+            label=str(item.get("label") or item.get("candidate_id") or item.get("id") or "").strip(),
+            description=str(item.get("description") or "").strip(),
+            parameters=dict(item.get("parameters") or {}),
+        )
+        for item in anchors_raw
+        if isinstance(item, dict) and str(item.get("candidate_id") or item.get("id") or "").strip()
+    ]
+
+    markers = [
+        EditableMarker(
+            file=str(item.get("file") or "").strip(),
+            start=str(item.get("start") or "").strip(),
+            end=str(item.get("end") or "").strip(),
+        )
+        for item in (raw.get("editable_markers") or [])
+        if isinstance(item, dict) and str(item.get("file") or "").strip()
+    ]
+
+    family = FamilyConfig(
+        family_id=str(raw.get("family_id") or raw.get("id") or family_id).strip(),
+        thesis=str(raw.get("thesis") or raw.get("description") or "").strip(),
+        project_root=root,
+        commands=commands,
+        mutation=MutationConfig(
+            mode=mutation_mode,
+            population=int(mutation_raw.get("population", raw.get("population", 8))),
+            survivors=int(mutation_raw.get("survivors", raw.get("survivors", 3))),
+            parameter_space={
+                str(key): list(value or [])
+                for key, value in dict(mutation_raw.get("parameter_space") or raw.get("parameter_space") or {}).items()
+            },
+            max_mutations_per_candidate=int(mutation_raw.get("max_mutations_per_candidate", 2)),
+            prompt=str(mutation_raw.get("prompt") or raw.get("mutation_prompt") or "").strip(),
+        ),
+        selection=SelectionConfig(
+            primary_metric=primary_metric,
+            goal=str(selection_raw.get("goal") or "maximize").strip() or "maximize",
+            secondary_metrics=secondaries,
+        ),
+        interesting=InterestingConfig(
+            mode=str(interesting_raw.get("mode") or "all").strip() or "all",
+            rules=interesting_rules,
+        ),
+        anchors=anchors,
+        editable_files=[str(item) for item in (raw.get("editable_files") or [])],
+        editable_markers=markers,
+    )
+
+    errors = validate_project_family(project_cfg, family)
+    if errors:
+        raise ManifestError("; ".join(errors))
+    return family
+
+
+def validate_project_family(project: ProjectConfig, family: FamilyConfig) -> list[str]:
+    """Return manifest validation errors for a project/family pair."""
+    errors: list[str] = []
+
+    if family.selection.goal not in {"maximize", "minimize"}:
+        errors.append(f"Family '{family.family_id}' has invalid selection.goal '{family.selection.goal}'")
+
+    if family.interesting.mode not in {"all", "any"}:
+        errors.append(f"Family '{family.family_id}' has invalid interesting_if.mode '{family.interesting.mode}'")
+
+    if family.mutation.mode not in {"param_mutation", "agent_patch"}:
+        errors.append(f"Family '{family.family_id}' has invalid mutation mode '{family.mutation.mode}'")
+
+    if not family.anchors:
+        errors.append(f"Family '{family.family_id}' must define at least one anchor")
+
+    anchor_ids = [anchor.candidate_id for anchor in family.anchors]
+    if len(anchor_ids) != len(set(anchor_ids)):
+        errors.append(f"Family '{family.family_id}' has duplicate anchor candidate_ids")
+
+    if family.mutation.population < 1:
+        errors.append(f"Family '{family.family_id}' population must be >= 1")
+    if family.mutation.survivors < 1:
+        errors.append(f"Family '{family.family_id}' survivors must be >= 1")
+
+    if family.mutation.mode == "param_mutation" and not family.mutation.parameter_space:
+        errors.append(f"Family '{family.family_id}' requires parameter_space for param_mutation")
+
+    if family.mutation.mode == "agent_patch" and not family.editable_files:
+        errors.append(f"Family '{family.family_id}' requires editable_files for agent_patch")
+
+    editable_set = set(family.editable_files)
+    for marker in family.editable_markers:
+        if marker.file not in editable_set:
+            errors.append(
+                f"Family '{family.family_id}' marker for '{marker.file}' must also appear in editable_files"
+            )
+        if not marker.start or not marker.end:
+            errors.append(f"Family '{family.family_id}' marker for '{marker.file}' needs start and end tokens")
+
+    for rule in family.interesting.rules:
+        if rule.op not in _ALLOWED_OPS:
+            errors.append(f"Family '{family.family_id}' has invalid interesting_if op '{rule.op}'")
+
+    for secondary in family.selection.secondary_metrics:
+        if not secondary.metric:
+            errors.append(f"Family '{family.family_id}' has empty secondary metric rule")
+
+    if not family.commands.evaluation.strip():
+        errors.append(f"Family '{family.family_id}' must define commands.evaluation")
+    if not family.commands.result_json.strip():
+        errors.append(f"Family '{family.family_id}' must define commands.result_json")
+
+    if not project.report_output_dir.strip():
+        errors.append("project.yaml report output directory must not be empty")
+
+    return errors
+
+
+def validate_project_manifest(project_root: str | os.PathLike[str]) -> dict[str, Any]:
+    """Validate the project manifest and all family manifests."""
+    root = Path(project_root).resolve()
+    project = load_project_config(root)
+    families: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for family_file in list_family_files(root):
+        try:
+            family = load_family_config(root, family_file.stem, project=project)
+            families.append(family.to_dict())
+        except ManifestError as exc:
+            errors.append(f"{family_file.name}: {exc}")
+
+    return {
+        "valid": not errors,
+        "project": project.to_dict(),
+        "families": families,
+        "errors": errors,
+    }

--- a/autoresearch/models.py
+++ b/autoresearch/models.py
@@ -1,0 +1,192 @@
+"""Normalized AutoResearch configuration models."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class CommandConfig:
+    """Commands and result paths for candidate validation/evaluation."""
+
+    evaluation: str
+    result_json: str
+    validation: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SecondaryMetricRule:
+    """Selector guardrail for metrics that must not regress too far."""
+
+    metric: str
+    min_delta: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SelectionConfig:
+    """Selector behavior for ranking and keeping candidates."""
+
+    primary_metric: str
+    goal: str = "maximize"
+    secondary_metrics: list[SecondaryMetricRule] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "primary_metric": self.primary_metric,
+            "goal": self.goal,
+            "secondary_metrics": [rule.to_dict() for rule in self.secondary_metrics],
+        }
+
+
+@dataclass(frozen=True)
+class InterestingRule:
+    """One boolean rule used to decide whether a report is worth writing."""
+
+    metric: str
+    op: str
+    value: Any
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class InterestingConfig:
+    """Report/publication interestingness policy."""
+
+    mode: str = "all"
+    rules: list[InterestingRule] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "rules": [rule.to_dict() for rule in self.rules],
+        }
+
+
+@dataclass(frozen=True)
+class EditableMarker:
+    """Marker-bounded editable region inside a file."""
+
+    file: str
+    start: str
+    end: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AnchorConfig:
+    """Seed/benchmark candidate declared in a family config."""
+
+    candidate_id: str
+    label: str
+    description: str = ""
+    parameters: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MutationConfig:
+    """Candidate generation policy."""
+
+    mode: str
+    population: int = 8
+    survivors: int = 3
+    parameter_space: dict[str, list[Any]] = field(default_factory=dict)
+    max_mutations_per_candidate: int = 2
+    prompt: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ProjectConfig:
+    """Top-level workspace AutoResearch config."""
+
+    project_id: str
+    description: str
+    root: Path
+    default_cwd: str = "."
+    datasets: list[Any] = field(default_factory=list)
+    benchmarks: list[str] = field(default_factory=list)
+    evaluator: Optional[CommandConfig] = None
+    report_output_dir: str = "research"
+    publish_target: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "project_id": self.project_id,
+            "description": self.description,
+            "root": str(self.root),
+            "default_cwd": self.default_cwd,
+            "datasets": list(self.datasets),
+            "benchmarks": list(self.benchmarks),
+            "evaluator": self.evaluator.to_dict() if self.evaluator else None,
+            "report_output_dir": self.report_output_dir,
+            "publish_target": self.publish_target,
+        }
+
+
+@dataclass(frozen=True)
+class FamilyConfig:
+    """One bounded search family inside a project."""
+
+    family_id: str
+    thesis: str
+    project_root: Path
+    commands: CommandConfig
+    mutation: MutationConfig
+    selection: SelectionConfig
+    interesting: InterestingConfig
+    anchors: list[AnchorConfig]
+    editable_files: list[str] = field(default_factory=list)
+    editable_markers: list[EditableMarker] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "family_id": self.family_id,
+            "thesis": self.thesis,
+            "project_root": str(self.project_root),
+            "commands": self.commands.to_dict(),
+            "mutation": self.mutation.to_dict(),
+            "selection": self.selection.to_dict(),
+            "interesting": self.interesting.to_dict(),
+            "anchors": [anchor.to_dict() for anchor in self.anchors],
+            "editable_files": list(self.editable_files),
+            "editable_markers": [marker.to_dict() for marker in self.editable_markers],
+        }
+
+
+@dataclass
+class WorkspaceInfo:
+    """Runtime metadata for one candidate workspace."""
+
+    path: Path
+    method: str
+    source_root: Path
+    repo_root: Optional[Path] = None
+    branch: Optional[str] = None
+    editable_base_contents: dict[str, Optional[str]] = field(default_factory=dict)
+    snapshot: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "method": self.method,
+            "source_root": str(self.source_root),
+            "repo_root": str(self.repo_root) if self.repo_root else None,
+            "branch": self.branch,
+        }

--- a/autoresearch/reports.py
+++ b/autoresearch/reports.py
@@ -1,0 +1,116 @@
+"""Markdown report rendering and publish-summary helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def write_run_report(
+    *,
+    project: dict[str, Any],
+    family: dict[str, Any],
+    run: dict[str, Any],
+    output_path: Path,
+) -> str:
+    """Render and write one interesting-run report."""
+    champion = run.get("selector", {}).get("champion") or {}
+    kept = run.get("selector", {}).get("kept_candidates") or []
+    anchors = run.get("anchors") or []
+    lines = [
+        f"# AutoResearch Run: {project['project_id']} / {family['family_id']}",
+        "",
+        f"- Run ID: `{run['run_id']}`",
+        f"- Created: `{run['created_at']}`",
+        f"- Project root: `{run['project_root']}`",
+        f"- Thesis: {family.get('thesis') or 'n/a'}",
+        "",
+        "## Summary",
+        "",
+    ]
+
+    if champion:
+        lines.extend(
+            [
+                f"- Champion: `{champion.get('candidate_id')}`",
+                f"- Parent: `{champion.get('parent_candidate_id') or 'n/a'}`",
+                f"- Primary metric (`{run['selection']['primary_metric']}`): `{champion.get('primary_metric')}`",
+                f"- Improvement vs parent: `{champion.get('primary_delta')}`",
+            ]
+        )
+    else:
+        lines.append("- No champion selected.")
+
+    lines.extend(
+        [
+            "",
+            "## Anchors",
+            "",
+        ]
+    )
+    for anchor in anchors:
+        lines.append(
+            f"- `{anchor['candidate_id']}`: primary metric `{anchor.get('primary_metric')}`"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Shortlisted Candidates",
+            "",
+        ]
+    )
+    if kept:
+        for candidate in kept:
+            lines.append(
+                f"- `{candidate['candidate_id']}`: parent `{candidate.get('parent_candidate_id') or 'n/a'}`, primary `{candidate.get('primary_metric')}`, delta `{candidate.get('primary_delta')}`"
+            )
+    else:
+        lines.append("- No shortlisted candidates survived selector checks.")
+
+    lines.extend(
+        [
+            "",
+            "## Artifacts",
+            "",
+            f"- Run metadata: `{Path(run['run_path']) / 'run.json'}`",
+        ]
+    )
+    if champion and champion.get("result_json"):
+        lines.append(f"- Champion result JSON: `{champion['result_json']}`")
+    if champion and champion.get("workspace_path"):
+        lines.append(f"- Champion workspace: `{champion['workspace_path']}`")
+
+    lines.extend(
+        [
+            "",
+            "## Interestingness",
+            "",
+            f"- Verdict: `{run.get('interesting', {}).get('verdict')}`",
+            f"- Reason: {run.get('interesting', {}).get('reason') or 'n/a'}",
+        ]
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    text = "\n".join(lines).rstrip() + "\n"
+    output_path.write_text(text, encoding="utf-8")
+    return text
+
+
+def build_publish_summary(run: dict[str, Any]) -> str:
+    """Build a short messaging-friendly summary for a completed run."""
+    selector = run.get("selector", {})
+    champion = selector.get("champion")
+    base = f"AutoResearch {run.get('project_id')}/{run.get('family_id')} run `{run.get('run_id')}`"
+    if not champion:
+        return f"{base}: no champion selected."
+
+    report_path = run.get("report_path")
+    message = (
+        f"{base}: champion `{champion['candidate_id']}` "
+        f"hit `{champion.get('primary_metric')}` on `{run['selection']['primary_metric']}` "
+        f"(delta `{champion.get('primary_delta')}` vs parent `{champion.get('parent_candidate_id') or 'n/a'}`)."
+    )
+    if report_path:
+        message += f" Report: `{report_path}`."
+    return message

--- a/autoresearch/runtime.py
+++ b/autoresearch/runtime.py
@@ -1,0 +1,893 @@
+"""Runtime orchestration for generic bounded AutoResearch cycles."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import random
+import uuid
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from autoresearch.manifests import (
+    ManifestError,
+    discover_project_root,
+    list_family_files,
+    list_project_roots,
+    load_family_config,
+    load_project_config,
+    validate_project_manifest,
+)
+from autoresearch.models import FamilyConfig, ProjectConfig, WorkspaceInfo
+from autoresearch.reports import build_publish_summary, write_run_report
+from autoresearch.workspaces import create_candidate_workspace, list_changed_files
+
+
+class AutoResearchRuntimeError(RuntimeError):
+    """Raised when a research-cycle step fails in a user-visible way."""
+
+
+def _iso_now() -> str:
+    return datetime.now().astimezone().isoformat()
+
+
+def _slug(value: str) -> str:
+    text = "".join(ch.lower() if ch.isalnum() else "-" for ch in value.strip())
+    parts = [part for part in text.split("-") if part]
+    return "-".join(parts) or "item"
+
+
+def _resolve_project_root(project_root: Optional[str] = None) -> Path:
+    root = Path(project_root).resolve() if project_root else discover_project_root()
+    if root is None:
+        raise AutoResearchRuntimeError(
+            "No AutoResearch workspace found. Create .hermes/autoresearch/project.yaml in your project."
+        )
+    return Path(root).resolve()
+
+
+def _run_dir(project: ProjectConfig, run_id: str) -> Path:
+    return project.root / ".hermes" / "autoresearch" / "runs" / run_id
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@contextmanager
+def _temporary_env(updates: dict[str, Optional[str]], chdir: Optional[Path] = None):
+    previous_env: dict[str, Optional[str]] = {}
+    previous_cwd = Path.cwd()
+    try:
+        for key, value in updates.items():
+            previous_env[key] = os.environ.get(key)
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        if chdir is not None:
+            os.chdir(chdir)
+        yield
+    finally:
+        if chdir is not None:
+            os.chdir(previous_cwd)
+        for key, old_value in previous_env.items():
+            if old_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
+
+
+def _json_command_result(raw: str) -> dict[str, Any]:
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AutoResearchRuntimeError(f"Expected JSON tool result, got: {raw[:400]}") from exc
+
+
+def _run_command(command: str, workdir: Path, task_id: Optional[str]) -> dict[str, Any]:
+    from tools.terminal_tool import terminal_tool
+
+    return _json_command_result(
+        terminal_tool(
+            command=command,
+            workdir=str(workdir),
+            task_id=task_id,
+        )
+    )
+
+
+def _safe_format(template: str, context: dict[str, Any]) -> str:
+    try:
+        return template.format_map(context)
+    except KeyError as exc:
+        missing = exc.args[0]
+        raise AutoResearchRuntimeError(
+            f"Command template references missing placeholder '{missing}': {template}"
+        ) from exc
+
+
+def _metric_value(payload: Any, dotted_path: str) -> Any:
+    current = payload
+    for segment in dotted_path.split("."):
+        if isinstance(current, dict):
+            if segment not in current:
+                raise KeyError(dotted_path)
+            current = current[segment]
+            continue
+        if isinstance(current, list):
+            index = int(segment)
+            current = current[index]
+            continue
+        raise KeyError(dotted_path)
+    return current
+
+
+def _metric_delta(goal: str, candidate_value: float, parent_value: float) -> float:
+    if goal == "minimize":
+        return parent_value - candidate_value
+    return candidate_value - parent_value
+
+
+def _sort_key(goal: str, value: Any) -> float:
+    numeric = float(value)
+    return -numeric if goal == "minimize" else numeric
+
+
+def _compare(op: str, left: Any, right: Any) -> bool:
+    if op == "==":
+        return left == right
+    if op == "!=":
+        return left != right
+    if op == ">":
+        return left > right
+    if op == ">=":
+        return left >= right
+    if op == "<":
+        return left < right
+    if op == "<=":
+        return left <= right
+    raise AutoResearchRuntimeError(f"Unsupported comparison op: {op}")
+
+
+def _parse_marker_ranges(content: str, start_token: str, end_token: str) -> tuple[int, int]:
+    lines = content.splitlines()
+    start_index = next((index for index, line in enumerate(lines, start=1) if start_token in line), None)
+    end_index = next((index for index, line in enumerate(lines, start=1) if end_token in line), None)
+    if start_index is None or end_index is None or end_index <= start_index:
+        raise AutoResearchRuntimeError(
+            f"Could not resolve editable marker range between '{start_token}' and '{end_token}'"
+        )
+    return start_index, end_index
+
+
+def _changed_line_ranges(base_content: Optional[str], new_content: Optional[str]) -> list[tuple[int, int]]:
+    import difflib
+
+    before = (base_content or "").splitlines()
+    after = (new_content or "").splitlines()
+    ranges: list[tuple[int, int]] = []
+    matcher = difflib.SequenceMatcher(a=before, b=after)
+    for tag, i1, i2, _j1, _j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        start = i1 + 1
+        end = max(i2, i1 + 1)
+        ranges.append((start, end))
+    return ranges
+
+
+def _review_agent_patch_candidate(
+    family: FamilyConfig,
+    workspace: WorkspaceInfo,
+) -> dict[str, Any]:
+    changed_files = list_changed_files(workspace)
+    allowed_files = set(family.editable_files)
+    forbidden = [path for path in changed_files if path not in allowed_files]
+    if forbidden:
+        return {
+            "accepted": False,
+            "reasons": [f"Edited forbidden files: {', '.join(sorted(forbidden))}"],
+            "changed_files": changed_files,
+        }
+
+    marker_errors: list[str] = []
+    markers_by_file = {marker.file: marker for marker in family.editable_markers}
+    for relpath in changed_files:
+        marker = markers_by_file.get(relpath)
+        if marker is None:
+            continue
+        base_content = workspace.editable_base_contents.get(relpath)
+        target_path = workspace.path / relpath
+        new_content = target_path.read_text(encoding="utf-8") if target_path.exists() else None
+        try:
+            marker_start, marker_end = _parse_marker_ranges(base_content or new_content or "", marker.start, marker.end)
+        except AutoResearchRuntimeError as exc:
+            marker_errors.append(str(exc))
+            continue
+        for start, end in _changed_line_ranges(base_content, new_content):
+            if start <= marker_start or end >= marker_end:
+                marker_errors.append(
+                    f"Changes in '{relpath}' exceeded editable marker bounds {marker.start}..{marker.end}"
+                )
+                break
+
+    return {
+        "accepted": not marker_errors,
+        "reasons": marker_errors,
+        "changed_files": changed_files,
+    }
+
+
+def _load_result_payload(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise AutoResearchRuntimeError(f"Evaluation command did not create result_json: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise AutoResearchRuntimeError(f"Malformed result_json at {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise AutoResearchRuntimeError(f"result_json must contain a JSON object: {path}")
+    return payload
+
+
+def _evaluate_candidate(
+    *,
+    project: ProjectConfig,
+    family: FamilyConfig,
+    run_id: str,
+    candidate: dict[str, Any],
+    workspace: WorkspaceInfo,
+    task_id: Optional[str],
+) -> dict[str, Any]:
+    candidate_dir = _run_dir(project, run_id) / "candidates"
+    candidate_dir.mkdir(parents=True, exist_ok=True)
+    candidate_json = candidate_dir / f"{candidate['candidate_id']}.json"
+    result_json = candidate_dir / f"{candidate['candidate_id']}--result.json"
+
+    candidate_payload = {
+        "candidate_id": candidate["candidate_id"],
+        "label": candidate.get("label", candidate["candidate_id"]),
+        "description": candidate.get("description", ""),
+        "parent_candidate_id": candidate.get("parent_candidate_id"),
+        "parameters": copy.deepcopy(candidate.get("parameters") or {}),
+        "mutation_mode": family.mutation.mode,
+        "mutated_fields": list(candidate.get("mutated_fields") or []),
+    }
+    _write_json(candidate_json, candidate_payload)
+
+    command_ctx = {
+        "project_root": str(project.root),
+        "workspace": str(workspace.path),
+        "workspace_path": str(workspace.path),
+        "cwd": str((workspace.path / project.default_cwd).resolve()),
+        "candidate_id": candidate["candidate_id"],
+        "family_id": family.family_id,
+        "project_id": project.project_id,
+        "candidate_json": str(candidate_json),
+        "result_json": str(result_json),
+    }
+
+    validation_result = None
+    if family.commands.validation:
+        validation_cmd = _safe_format(family.commands.validation, command_ctx)
+        validation_result = _run_command(validation_cmd, workspace.path / project.default_cwd, task_id)
+        if validation_result.get("exit_code") != 0:
+            raise AutoResearchRuntimeError(
+                f"Validation command failed for {candidate['candidate_id']}: {validation_result.get('output') or validation_result.get('error')}"
+            )
+
+    evaluation_cmd = _safe_format(family.commands.evaluation, command_ctx)
+    evaluation_result = _run_command(evaluation_cmd, workspace.path / project.default_cwd, task_id)
+    if evaluation_result.get("exit_code") != 0:
+        raise AutoResearchRuntimeError(
+            f"Evaluation command failed for {candidate['candidate_id']}: {evaluation_result.get('output') or evaluation_result.get('error')}"
+        )
+
+    payload = _load_result_payload(result_json)
+    primary_metric = float(_metric_value(payload, family.selection.primary_metric))
+    return {
+        **candidate,
+        "workspace": workspace.to_dict(),
+        "workspace_path": str(workspace.path),
+        "result_json": str(result_json),
+        "candidate_json": str(candidate_json),
+        "validation_result": validation_result,
+        "evaluation_result": evaluation_result,
+        "metrics": payload,
+        "primary_metric": primary_metric,
+    }
+
+
+def _generate_param_candidates(
+    family: FamilyConfig,
+    *,
+    seed: int,
+    population: int,
+) -> list[dict[str, Any]]:
+    rng = random.Random(seed)
+    seen: set[str] = set()
+    parents = family.anchors
+    for anchor in parents:
+        seen.add(json.dumps(anchor.parameters, sort_keys=True))
+
+    dimensions = list(family.mutation.parameter_space.items())
+    candidates: list[dict[str, Any]] = []
+    attempts = 0
+    max_attempts = max(50, population * 20)
+
+    while len(candidates) < population and attempts < max_attempts:
+        attempts += 1
+        parent = rng.choice(parents)
+        params = copy.deepcopy(parent.parameters)
+        mutate_count = min(
+            max(1, family.mutation.max_mutations_per_candidate),
+            len(dimensions),
+        )
+        chosen = rng.sample(dimensions, k=max(1, min(len(dimensions), rng.randint(1, mutate_count))))
+        mutated_fields: list[str] = []
+        for field_name, values in chosen:
+            options = [value for value in values if value != params.get(field_name)]
+            if not options:
+                continue
+            params[field_name] = rng.choice(options)
+            mutated_fields.append(field_name)
+        if not mutated_fields:
+            continue
+        signature = json.dumps(params, sort_keys=True)
+        if signature in seen:
+            continue
+        seen.add(signature)
+        candidate_index = len(candidates) + 1
+        candidates.append(
+            {
+                "candidate_id": f"{family.family_id}_gen_{candidate_index:03d}",
+                "label": f"{family.family_id} Candidate {candidate_index:03d}",
+                "description": f"Generated from {parent.candidate_id} by mutating {', '.join(mutated_fields)}.",
+                "parent_candidate_id": parent.candidate_id,
+                "parameters": params,
+                "mutated_fields": mutated_fields,
+            }
+        )
+    return candidates
+
+
+def _run_agent_patch(
+    *,
+    project: ProjectConfig,
+    family: FamilyConfig,
+    workspace: WorkspaceInfo,
+    candidate: dict[str, Any],
+    model: Optional[str],
+) -> dict[str, Any]:
+    from run_agent import AIAgent
+
+    editable_lines = [f"- {path}" for path in family.editable_files]
+    if family.editable_markers:
+        editable_lines.extend(
+            f"- {marker.file}: only between `{marker.start}` and `{marker.end}`"
+            for marker in family.editable_markers
+        )
+
+    prompt = "\n".join(
+        [
+            f"You are generating an AutoResearch candidate inside {workspace.path}.",
+            f"Project: {project.project_id}",
+            f"Family: {family.family_id}",
+            f"Thesis: {family.thesis}",
+            f"Parent candidate: {candidate.get('parent_candidate_id') or 'anchor'}",
+            "Only edit the allowed files below. Do not touch any other files.",
+            *editable_lines,
+            "",
+            "Make one plausible improvement aligned with the thesis and save the files.",
+            "Do not explain the plan first. Make the changes directly, then summarize them briefly.",
+        ]
+    )
+    if family.mutation.prompt:
+        prompt = f"{prompt}\n\nAdditional family guidance:\n{family.mutation.prompt}"
+
+    env_updates = {
+        "TERMINAL_CWD": str(workspace.path),
+        "HERMES_WRITE_SAFE_ROOT": str(workspace.path),
+    }
+    with _temporary_env(env_updates, chdir=workspace.path):
+        agent = AIAgent(
+            model=model or os.getenv("HERMES_MODEL") or "anthropic/claude-opus-4.6",
+            max_iterations=20,
+            enabled_toolsets=["file", "terminal", "todo"],
+            quiet_mode=True,
+            save_trajectories=False,
+            skip_memory=True,
+            platform="cli",
+        )
+        response = agent.chat(prompt)
+
+    return {
+        "model": model or os.getenv("HERMES_MODEL") or "anthropic/claude-opus-4.6",
+        "response": response,
+    }
+
+
+def _generate_agent_patch_candidates(
+    *,
+    project: ProjectConfig,
+    family: FamilyConfig,
+    run_id: str,
+    population: int,
+    model: Optional[str],
+) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    parents = family.anchors
+    for candidate_index in range(1, population + 1):
+        parent = parents[(candidate_index - 1) % len(parents)]
+        candidate = {
+            "candidate_id": f"{family.family_id}_gen_{candidate_index:03d}",
+            "label": f"{family.family_id} Candidate {candidate_index:03d}",
+            "description": f"Agent patch candidate generated from {parent.candidate_id}.",
+            "parent_candidate_id": parent.candidate_id,
+            "parameters": copy.deepcopy(parent.parameters),
+            "mutated_fields": [],
+        }
+        workspace = create_candidate_workspace(project.root, run_id, candidate["candidate_id"], family.editable_files)
+        candidate["workspace"] = workspace
+        candidate["agent_patch"] = _run_agent_patch(
+            project=project,
+            family=family,
+            workspace=workspace,
+            candidate=candidate,
+            model=model,
+        )
+        candidates.append(candidate)
+    return candidates
+
+
+def _selector_payload(
+    *,
+    family: FamilyConfig,
+    anchors: list[dict[str, Any]],
+    candidates: list[dict[str, Any]],
+    survivors: int,
+) -> dict[str, Any]:
+    ranked = sorted(
+        candidates,
+        key=lambda item: _sort_key(family.selection.goal, item["primary_metric"]),
+        reverse=True,
+    )
+    shortlisted = ranked[:survivors]
+    anchor_map = {anchor["candidate_id"]: anchor for anchor in anchors}
+    kept: list[dict[str, Any]] = []
+
+    for candidate in shortlisted:
+        parent = anchor_map.get(candidate.get("parent_candidate_id"))
+        if parent is None:
+            continue
+        primary_delta = _metric_delta(
+            family.selection.goal,
+            float(candidate["primary_metric"]),
+            float(parent["primary_metric"]),
+        )
+        if primary_delta <= 0:
+            candidate["selector_reasons"] = ["Primary metric did not beat parent."]
+            candidate["primary_delta"] = primary_delta
+            continue
+
+        selector_errors: list[str] = []
+        for rule in family.selection.secondary_metrics:
+            candidate_metric = float(_metric_value(candidate["metrics"], rule.metric))
+            parent_metric = float(_metric_value(parent["metrics"], rule.metric))
+            delta = _metric_delta(family.selection.goal, candidate_metric, parent_metric)
+            if delta < rule.min_delta:
+                selector_errors.append(
+                    f"Secondary metric '{rule.metric}' regressed by {delta}, below min_delta {rule.min_delta}"
+                )
+        candidate["primary_delta"] = primary_delta
+        candidate["selector_reasons"] = selector_errors
+        if not selector_errors:
+            kept.append(candidate)
+
+    champion = None
+    if kept:
+        champion = sorted(
+            kept,
+            key=lambda item: _sort_key(family.selection.goal, item["primary_metric"]),
+            reverse=True,
+        )[0]
+
+    return {
+        "ranked_candidates": [
+            {
+                "candidate_id": item["candidate_id"],
+                "parent_candidate_id": item.get("parent_candidate_id"),
+                "primary_metric": item["primary_metric"],
+                "result_json": item.get("result_json"),
+                "workspace_path": item.get("workspace_path"),
+            }
+            for item in ranked
+        ],
+        "kept_candidates": [
+            {
+                "candidate_id": item["candidate_id"],
+                "parent_candidate_id": item.get("parent_candidate_id"),
+                "primary_metric": item["primary_metric"],
+                "primary_delta": item.get("primary_delta"),
+                "result_json": item.get("result_json"),
+                "workspace_path": item.get("workspace_path"),
+            }
+            for item in kept
+        ],
+        "champion": (
+            {
+                "candidate_id": champion["candidate_id"],
+                "parent_candidate_id": champion.get("parent_candidate_id"),
+                "primary_metric": champion["primary_metric"],
+                "primary_delta": champion.get("primary_delta"),
+                "result_json": champion.get("result_json"),
+                "workspace_path": champion.get("workspace_path"),
+                "metrics": champion.get("metrics"),
+            }
+            if champion
+            else None
+        ),
+    }
+
+
+def _interesting_payload(
+    *,
+    project: ProjectConfig,
+    family: FamilyConfig,
+    run_id: str,
+    selector: dict[str, Any],
+) -> dict[str, Any]:
+    champion = selector.get("champion")
+    if champion is None:
+        return {"verdict": False, "reason": "No champion selected."}
+    if not family.interesting.rules:
+        return {"verdict": True, "reason": "Champion selected and no explicit interestingness rules were configured."}
+
+    context = {
+        "project": project.to_dict(),
+        "family": family.to_dict(),
+        "run": {"run_id": run_id},
+        "selector": selector,
+        "champion": champion,
+    }
+    verdicts: list[bool] = []
+    failed_descriptions: list[str] = []
+    for rule in family.interesting.rules:
+        try:
+            left = _metric_value(context, rule.metric)
+        except (KeyError, IndexError, ValueError):
+            verdicts.append(False)
+            failed_descriptions.append(f"Missing metric '{rule.metric}'")
+            continue
+        passed = _compare(rule.op, left, rule.value)
+        verdicts.append(passed)
+        if not passed:
+            failed_descriptions.append(f"{rule.metric} {rule.op} {rule.value} was false (left={left})")
+
+    verdict = all(verdicts) if family.interesting.mode == "all" else any(verdicts)
+    return {
+        "verdict": verdict,
+        "reason": "All interestingness rules passed." if verdict else "; ".join(failed_descriptions),
+    }
+
+
+def list_projects(project_root: Optional[str] = None) -> dict[str, Any]:
+    roots = list_project_roots(project_root)
+    projects = []
+    for root in roots:
+        try:
+            project = load_project_config(root)
+        except ManifestError as exc:
+            projects.append({"path": str(root), "error": str(exc)})
+            continue
+        projects.append(
+            {
+                "project_id": project.project_id,
+                "description": project.description,
+                "path": str(root),
+                "families": [path.stem for path in list_family_files(root)],
+            }
+        )
+    return {"count": len(projects), "projects": projects}
+
+
+def inspect_project(project_root: Optional[str] = None) -> dict[str, Any]:
+    root = _resolve_project_root(project_root)
+    project = load_project_config(root)
+    families = [load_family_config(root, path.stem, project=project).to_dict() for path in list_family_files(root)]
+    return {"project": project.to_dict(), "families": families}
+
+
+def validate_project(project_root: Optional[str] = None) -> dict[str, Any]:
+    root = _resolve_project_root(project_root)
+    return validate_project_manifest(root)
+
+
+def research_cycle(
+    *,
+    project_root: Optional[str] = None,
+    family_id: str,
+    population: Optional[int] = None,
+    survivors: Optional[int] = None,
+    seed: int = 7,
+    model: Optional[str] = None,
+    task_id: Optional[str] = None,
+) -> dict[str, Any]:
+    root = _resolve_project_root(project_root)
+    project = load_project_config(root)
+    family = load_family_config(root, family_id, project=project)
+    run_id = f"ar-{datetime.now().strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:6]}"
+    run_path = _run_dir(project, run_id)
+    run_path.mkdir(parents=True, exist_ok=True)
+
+    actual_population = int(population or family.mutation.population)
+    actual_survivors = int(survivors or family.mutation.survivors)
+
+    run_record: dict[str, Any] = {
+        "run_id": run_id,
+        "created_at": _iso_now(),
+        "project_id": project.project_id,
+        "family_id": family.family_id,
+        "project_root": str(project.root),
+        "run_path": str(run_path),
+        "status": "running",
+        "phase": "anchors",
+        "selection": {
+            "primary_metric": family.selection.primary_metric,
+            "goal": family.selection.goal,
+            "survivors": actual_survivors,
+        },
+        "project": project.to_dict(),
+        "family": family.to_dict(),
+        "anchors": [],
+        "candidates": [],
+        "selector": {},
+        "interesting": {"verdict": False, "reason": "Run has not completed yet."},
+        "report_path": None,
+        "summary": None,
+    }
+    _write_json(run_path / "run.json", run_record)
+
+    try:
+        anchors: list[dict[str, Any]] = []
+        for anchor in family.anchors:
+            workspace = create_candidate_workspace(project.root, run_id, anchor.candidate_id, family.editable_files)
+            anchor_candidate = {
+                "candidate_id": anchor.candidate_id,
+                "label": anchor.label,
+                "description": anchor.description,
+                "parent_candidate_id": None,
+                "parameters": copy.deepcopy(anchor.parameters),
+                "mutated_fields": [],
+            }
+            evaluated = _evaluate_candidate(
+                project=project,
+                family=family,
+                run_id=run_id,
+                candidate=anchor_candidate,
+                workspace=workspace,
+                task_id=task_id,
+            )
+            anchors.append(evaluated)
+        run_record["anchors"] = [
+            {
+                "candidate_id": item["candidate_id"],
+                "primary_metric": item["primary_metric"],
+                "result_json": item["result_json"],
+                "workspace_path": item["workspace_path"],
+                "metrics": item["metrics"],
+            }
+            for item in anchors
+        ]
+        run_record["phase"] = "generate"
+        _write_json(run_path / "run.json", run_record)
+
+        if family.mutation.mode == "param_mutation":
+            generated = _generate_param_candidates(family, seed=seed, population=actual_population)
+            generated_wrapped = []
+            for candidate in generated:
+                workspace = create_candidate_workspace(project.root, run_id, candidate["candidate_id"], family.editable_files)
+                candidate["workspace"] = workspace
+                generated_wrapped.append(candidate)
+        else:
+            generated_wrapped = _generate_agent_patch_candidates(
+                project=project,
+                family=family,
+                run_id=run_id,
+                population=actual_population,
+                model=model,
+            )
+
+        accepted: list[dict[str, Any]] = []
+        rejected: list[dict[str, Any]] = []
+
+        run_record["phase"] = "review"
+        _write_json(run_path / "run.json", run_record)
+
+        for candidate in generated_wrapped:
+            workspace = candidate.pop("workspace")
+            if family.mutation.mode == "agent_patch":
+                review = _review_agent_patch_candidate(family, workspace)
+            else:
+                review = {"accepted": True, "reasons": [], "changed_files": []}
+            candidate["review"] = review
+            if not review["accepted"]:
+                rejected.append(
+                    {
+                        **candidate,
+                        "workspace": workspace.to_dict(),
+                        "workspace_path": str(workspace.path),
+                    }
+                )
+                continue
+
+            evaluated = _evaluate_candidate(
+                project=project,
+                family=family,
+                run_id=run_id,
+                candidate=candidate,
+                workspace=workspace,
+                task_id=task_id,
+            )
+            evaluated["review"] = review
+            accepted.append(evaluated)
+
+        run_record["candidates"] = [
+            {
+                "candidate_id": item["candidate_id"],
+                "parent_candidate_id": item.get("parent_candidate_id"),
+                "primary_metric": item.get("primary_metric"),
+                "result_json": item.get("result_json"),
+                "workspace_path": item.get("workspace_path"),
+                "review": item.get("review"),
+                "agent_patch": item.get("agent_patch"),
+            }
+            for item in accepted + rejected
+        ]
+        run_record["phase"] = "select"
+        _write_json(run_path / "run.json", run_record)
+
+        selector = _selector_payload(
+            family=family,
+            anchors=anchors,
+            candidates=accepted,
+            survivors=actual_survivors,
+        )
+        run_record["selector"] = selector
+        interesting = _interesting_payload(project=project, family=family, run_id=run_id, selector=selector)
+        run_record["interesting"] = interesting
+
+        if selector.get("champion") and interesting.get("verdict"):
+            report_rel = Path(project.report_output_dir) / datetime.now().strftime("%Y-%m-%d") / f"{_slug(project.project_id)}--{run_id}.md"
+            report_path = project.root / report_rel
+            write_run_report(
+                project=project.to_dict(),
+                family=family.to_dict(),
+                run={
+                    **run_record,
+                    "selector": selector,
+                },
+                output_path=report_path,
+            )
+            run_record["report_path"] = str(report_path)
+
+        run_record["summary"] = build_publish_summary(run_record)
+        run_record["status"] = "completed"
+        run_record["phase"] = "completed"
+        run_record["completed_at"] = _iso_now()
+        _write_json(run_path / "run.json", run_record)
+        return run_record
+
+    except Exception as exc:
+        run_record["status"] = "failed"
+        run_record["phase"] = "failed"
+        run_record["error"] = str(exc)
+        run_record["completed_at"] = _iso_now()
+        _write_json(run_path / "run.json", run_record)
+        raise
+
+
+def _load_run(project_root: Path, run_id: str) -> dict[str, Any]:
+    path = _run_dir(load_project_config(project_root), run_id) / "run.json"
+    if not path.exists():
+        raise AutoResearchRuntimeError(f"Unknown AutoResearch run '{run_id}'")
+    return _read_json(path)
+
+
+def status(*, run_id: str, project_root: Optional[str] = None) -> dict[str, Any]:
+    root = _resolve_project_root(project_root)
+    run = _load_run(root, run_id)
+    return {
+        "run_id": run["run_id"],
+        "status": run["status"],
+        "phase": run["phase"],
+        "error": run.get("error"),
+        "report_path": run.get("report_path"),
+        "summary": run.get("summary"),
+    }
+
+
+def list_runs(project_root: Optional[str] = None, limit: int = 20) -> dict[str, Any]:
+    root = _resolve_project_root(project_root)
+    runs_root = root / ".hermes" / "autoresearch" / "runs"
+    rows = []
+    if runs_root.exists():
+        for entry in sorted(runs_root.iterdir(), reverse=True):
+            run_json = entry / "run.json"
+            if not run_json.exists():
+                continue
+            payload = _read_json(run_json)
+            rows.append(
+                {
+                    "run_id": payload["run_id"],
+                    "created_at": payload["created_at"],
+                    "project_id": payload["project_id"],
+                    "family_id": payload["family_id"],
+                    "status": payload["status"],
+                    "report_path": payload.get("report_path"),
+                }
+            )
+    return {"count": len(rows[:limit]), "runs": rows[:limit]}
+
+
+def inspect_run(*, run_id: str, project_root: Optional[str] = None) -> dict[str, Any]:
+    root = _resolve_project_root(project_root)
+    run = _load_run(root, run_id)
+    report_preview = None
+    if run.get("report_path"):
+        report_path = Path(run["report_path"])
+        if report_path.exists():
+            report_preview = report_path.read_text(encoding="utf-8")[:4000]
+    return {"run": run, "report_preview": report_preview}
+
+
+def publish_summary(
+    *,
+    run_id: str,
+    project_root: Optional[str] = None,
+    target: Optional[str] = None,
+    send: bool = False,
+) -> dict[str, Any]:
+    root = _resolve_project_root(project_root)
+    run = _load_run(root, run_id)
+    summary = run.get("summary") or build_publish_summary(run)
+    resolved_target = target or run.get("project", {}).get("publish_target")
+
+    payload = {
+        "run_id": run_id,
+        "summary": summary,
+        "target": resolved_target,
+        "sent": False,
+    }
+
+    if send:
+        from tools.send_message_tool import send_message_tool
+
+        if not resolved_target:
+            raise AutoResearchRuntimeError(
+                "publish_summary(send=True) requires an explicit target or project.publish.default_target"
+            )
+        send_result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": resolved_target,
+                    "message": summary,
+                }
+            )
+        )
+        payload["sent"] = bool(send_result.get("success"))
+        payload["send_result"] = send_result
+
+    return payload
+
+

--- a/autoresearch/workspaces.py
+++ b/autoresearch/workspaces.py
@@ -1,0 +1,193 @@
+"""Workspace isolation helpers for AutoResearch candidate evaluation."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from autoresearch.models import WorkspaceInfo
+
+
+def _path_is_within_root(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def git_repo_root(start: Path) -> Optional[Path]:
+    """Return the enclosing git repo root, if any."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(start),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip()).resolve()
+
+
+def _ensure_gitignore_entry(repo_root: Path, entry: str) -> None:
+    gitignore = repo_root / ".gitignore"
+    existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    lines = existing.splitlines()
+    if entry in lines:
+        return
+    with open(gitignore, "a", encoding="utf-8") as handle:
+        if existing and not existing.endswith("\n"):
+            handle.write("\n")
+        handle.write(f"{entry}\n")
+
+
+def _copy_worktreeinclude_entries(repo_root: Path, workspace_path: Path) -> None:
+    include_file = repo_root / ".worktreeinclude"
+    if not include_file.exists():
+        return
+
+    repo_root_resolved = repo_root.resolve()
+    workspace_resolved = workspace_path.resolve()
+    for raw_line in include_file.read_text(encoding="utf-8").splitlines():
+        entry = raw_line.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        src = repo_root / entry
+        dst = workspace_path / entry
+        try:
+            src_resolved = src.resolve(strict=False)
+            dst_resolved = dst.resolve(strict=False)
+        except (OSError, ValueError):
+            continue
+        if not _path_is_within_root(src_resolved, repo_root_resolved):
+            continue
+        if not _path_is_within_root(dst_resolved, workspace_resolved):
+            continue
+        if src.is_file():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(src), str(dst))
+        elif src.is_dir() and not dst.exists():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            os.symlink(str(src_resolved), str(dst))
+
+
+def _snapshot_tree(root: Path) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).as_posix()
+        if rel.startswith(".git/"):
+            continue
+        snapshot[rel] = str(path.stat().st_mtime_ns)
+    return snapshot
+
+
+def create_candidate_workspace(
+    project_root: Path,
+    run_id: str,
+    candidate_id: str,
+    editable_files: list[str],
+) -> WorkspaceInfo:
+    """Create an isolated workspace for one candidate."""
+    workspace_path = (
+        project_root
+        / ".hermes"
+        / "autoresearch"
+        / "workspaces"
+        / run_id
+        / candidate_id
+    )
+    workspace_path.parent.mkdir(parents=True, exist_ok=True)
+
+    repo_root = git_repo_root(project_root)
+    method = "copy"
+    branch = None
+    snapshot: dict[str, str] = {}
+
+    if repo_root is not None:
+        _ensure_gitignore_entry(repo_root, ".hermes/autoresearch/")
+        branch = f"hermes/autoresearch-{uuid.uuid4().hex[:10]}"
+        result = subprocess.run(
+            ["git", "worktree", "add", str(workspace_path), "-b", branch, "HEAD"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            method = "git_worktree"
+            _copy_worktreeinclude_entries(repo_root, workspace_path)
+
+    if method != "git_worktree":
+        if workspace_path.exists():
+            shutil.rmtree(workspace_path)
+        shutil.copytree(
+            project_root,
+            workspace_path,
+            ignore=shutil.ignore_patterns(
+                ".git",
+                ".hermes",
+                ".worktrees",
+                "__pycache__",
+                ".pytest_cache",
+                "node_modules",
+            ),
+        )
+        snapshot = _snapshot_tree(workspace_path)
+
+    base_contents = {}
+    for relpath in editable_files:
+        target = workspace_path / relpath
+        if target.exists():
+            base_contents[relpath] = target.read_text(encoding="utf-8")
+        else:
+            base_contents[relpath] = None
+
+    return WorkspaceInfo(
+        path=workspace_path,
+        method=method,
+        source_root=project_root,
+        repo_root=repo_root,
+        branch=branch,
+        editable_base_contents=base_contents,
+        snapshot=snapshot,
+    )
+
+
+def list_changed_files(workspace: WorkspaceInfo) -> list[str]:
+    """Return changed relative paths inside a candidate workspace."""
+    if workspace.method == "git_worktree":
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=str(workspace.path),
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        changed: list[str] = []
+        for line in result.stdout.splitlines():
+            if len(line) < 4:
+                continue
+            path = line[3:].strip()
+            if " -> " in path:
+                path = path.split(" -> ", 1)[1].strip()
+            if path:
+                changed.append(path.replace("\\", "/"))
+        return sorted(set(changed))
+
+    current = _snapshot_tree(workspace.path)
+    changed = set(workspace.snapshot).symmetric_difference(current)
+    for relpath, stamp in workspace.snapshot.items():
+        if relpath in current and current[relpath] != stamp:
+            changed.add(relpath)
+    return sorted(changed)
+

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -91,6 +91,7 @@ CONFIGURABLE_TOOLSETS = [
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
+    ("autoresearch",    "AutoResearch",               "bounded research-cycle automation"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
@@ -99,7 +100,7 @@ CONFIGURABLE_TOOLSETS = [
 # Toolsets that are OFF by default for new installs.
 # They're still in _HERMES_CORE_TOOLS (available at runtime if enabled),
 # but the setup checklist won't pre-select them for first-time users.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl"}
+_DEFAULT_OFF_TOOLSETS = {"autoresearch", "moa", "homeassistant", "rl"}
 
 # Platform display config
 PLATFORMS = {
@@ -1375,3 +1376,5 @@ def tools_disable_enable_command(args):
     if successful:
         verb = "Disabled" if action == "disable" else "Enabled"
         _print_success(f"{verb}: {', '.join(successful)}")
+
+

--- a/model_tools.py
+++ b/model_tools.py
@@ -83,6 +83,7 @@ def _discover_tools():
         "tools.skill_manager_tool",
         "tools.browser_tool",
         "tools.cronjob_tools",
+        "tools.autoresearch_tool",
         "tools.rl_training_tool",
         "tools.tts_tool",
         "tools.todo_tool",
@@ -384,3 +385,4 @@ def check_toolset_requirements() -> Dict[str, bool]:
 def check_tool_availability(quiet: bool = False) -> Tuple[List[str], List[dict]]:
     """Return (available_toolsets, unavailable_info)."""
     return registry.check_tool_availability(quiet=quiet)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ hermes-acp = "acp_adapter.entry:main"
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_state", "hermes_time", "mini_swe_runner", "rl_cli", "utils"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "cron", "honcho_integration", "acp_adapter"]
+include = ["agent", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "cron", "honcho_integration", "acp_adapter", "autoresearch", "autoresearch.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -103,3 +103,4 @@ markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
 ]
 addopts = "-m 'not integration' -n auto"
+

--- a/skills/research/autoresearch/SKILL.md
+++ b/skills/research/autoresearch/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: autoresearch
+description: Run bounded AutoResearch cycles on a workspace-defined project. Inspect manifests, validate before running, respect editable bounds, and only publish interesting runs.
+version: 1.0.0
+author: Hermes Agent + Teknium
+tags: [autoresearch, research, experimentation, evaluation]
+---
+
+# AutoResearch
+
+Use this skill when a workspace defines AutoResearch manifests under `.hermes/autoresearch/` and the user wants Hermes to explore, evaluate, and summarize bounded research candidates.
+
+## Workflow
+
+1. Start with `autoresearch(action="list_projects")` or `autoresearch(action="inspect_project")`.
+2. Run `autoresearch(action="validate_project")` before any research cycle.
+3. Use `autoresearch(action="research_cycle", family_id="...")` to execute one bounded family.
+4. Inspect results with `status`, `list_runs`, or `inspect_run`.
+5. Only use `publish_summary` when the run is interesting or the user explicitly wants a summary anyway.
+
+## Guardrails
+
+- Respect the project's declared editable files and editable marker ranges.
+- Do not mutate files outside the bounded mutable surface.
+- Prefer the built-in `research_cycle` flow over ad hoc manual mutation.
+- Treat evaluator commands and result JSON as the source of truth for selection.
+- Reports are per interesting run, not per candidate.
+- Use Hermes messaging tools for delivery. Do not invent a parallel Telegram workflow.
+
+## Project Contract
+
+AutoResearch workspaces use:
+- `.hermes/autoresearch/project.yaml`
+- `.hermes/autoresearch/families/*.yaml`
+- `.hermes/autoresearch/runs/<run_id>/`
+- `.hermes/autoresearch/workspaces/<run_id>/<candidate_id>/`
+- `research/YYYY-MM-DD/<project-id>--<run-id>.md`
+
+## Good Habits
+
+- Summarize the project thesis and family thesis before running.
+- Mention the primary metric and selector constraints in plain language.
+- When a run fails validation or evaluation, explain that failure instead of guessing.
+- If a report exists, cite the report path in your response.
+- If the user wants recurring summaries, combine AutoResearch with `cronjob` and `send_message` rather than reimplementing scheduling.

--- a/tests/test_autoresearch_integration.py
+++ b/tests/test_autoresearch_integration.py
@@ -1,0 +1,35 @@
+"""Integration tests for AutoResearch tool registration and config wiring."""
+
+import sys
+import types
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parent.parent / 'tools'
+if 'tools' not in sys.modules:
+    tools_pkg = types.ModuleType('tools')
+    tools_pkg.__path__ = [str(TOOLS_DIR)]
+    sys.modules['tools'] = tools_pkg
+
+from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS, _get_platform_tools
+from model_tools import get_tool_definitions, get_toolset_for_tool
+from toolsets import resolve_toolset
+
+
+def test_autoresearch_toolset_resolves_to_single_tool():
+    assert resolve_toolset('autoresearch') == ['autoresearch']
+
+
+def test_autoresearch_tool_is_registered_in_model_tools():
+    definitions = get_tool_definitions(enabled_toolsets=['autoresearch'], quiet_mode=True)
+    names = [item['function']['name'] for item in definitions]
+
+    assert names == ['autoresearch']
+    assert get_toolset_for_tool('autoresearch') == 'autoresearch'
+
+
+def test_autoresearch_is_default_off_but_explicitly_enabled_when_configured():
+    assert 'autoresearch' in _DEFAULT_OFF_TOOLSETS
+
+    enabled = _get_platform_tools({'platform_toolsets': {'cli': ['autoresearch']}}, 'cli')
+
+    assert 'autoresearch' in enabled

--- a/tests/test_autoresearch_runtime.py
+++ b/tests/test_autoresearch_runtime.py
@@ -1,0 +1,286 @@
+"""Runtime tests for Hermes AutoResearch."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from autoresearch import runtime, workspaces
+
+
+def _write_param_project(root: Path) -> None:
+    families_dir = root / '.hermes' / 'autoresearch' / 'families'
+    families_dir.mkdir(parents=True)
+    (families_dir.parent / 'project.yaml').write_text(
+        dedent(
+            '''
+            project_id: demo-project
+            description: Demo AutoResearch project
+            default_cwd: .
+            datasets:
+              - demo.csv
+            benchmarks:
+              - baseline
+            report_output_dir: research
+            publish_target: telegram
+            evaluator:
+              evaluation: "eval-param|{candidate_json}|{result_json}"
+              result_json: "{result_json}"
+            '''
+        ).strip()
+        + '\n',
+        encoding='utf-8',
+    )
+    (families_dir / 'params.yaml').write_text(
+        dedent(
+            '''
+            family_id: params
+            thesis: Search alpha values.
+            commands:
+              validation: "validate|{candidate_id}"
+              evaluation: "eval-param|{candidate_json}|{result_json}"
+              result_json: "{result_json}"
+            mutation:
+              mode: param_mutation
+              population: 2
+              survivors: 1
+              parameter_space:
+                alpha: [0.2, 0.8, 0.9]
+            selection:
+              primary_metric: metrics.holdout.score
+              goal: maximize
+              secondary_metrics:
+                - metric: metrics.validation.score
+                  min_delta: 0.0
+            interesting_if:
+              mode: all
+              rules:
+                - metric: champion.primary_delta
+                  op: ">"
+                  value: 0.1
+            anchors:
+              - candidate_id: baseline
+                label: Baseline
+                description: Baseline anchor
+                parameters:
+                  alpha: 0.2
+            '''
+        ).strip()
+        + '\n',
+        encoding='utf-8',
+    )
+    (root / 'demo.csv').write_text('alpha,score\n0.2,0.2\n', encoding='utf-8')
+
+
+def _write_agent_patch_project(root: Path) -> None:
+    families_dir = root / '.hermes' / 'autoresearch' / 'families'
+    families_dir.mkdir(parents=True)
+    (families_dir.parent / 'project.yaml').write_text(
+        dedent(
+            '''
+            project_id: patch-project
+            description: Agent patch AutoResearch project
+            default_cwd: .
+            report_output_dir: research
+            evaluator:
+              evaluation: "eval-patch|{workspace}|{result_json}"
+              result_json: "{result_json}"
+            '''
+        ).strip()
+        + '\n',
+        encoding='utf-8',
+    )
+    (families_dir / 'patches.yaml').write_text(
+        dedent(
+            '''
+            family_id: patches
+            thesis: Improve the strategy file.
+            commands:
+              validation: "validate|{candidate_id}"
+              evaluation: "eval-patch|{workspace}|{result_json}"
+              result_json: "{result_json}"
+            mutation:
+              mode: agent_patch
+              population: 1
+              survivors: 1
+              prompt: Raise the score without touching forbidden files.
+            selection:
+              primary_metric: metrics.holdout.score
+              goal: maximize
+            interesting_if:
+              mode: all
+              rules:
+                - metric: champion.primary_delta
+                  op: ">"
+                  value: 0
+            anchors:
+              - candidate_id: baseline
+                label: Baseline
+                parameters: {}
+            editable_files:
+              - strategy.txt
+            editable_markers:
+              - file: strategy.txt
+                start: "# START"
+                end: "# END"
+            '''
+        ).strip()
+        + '\n',
+        encoding='utf-8',
+    )
+    (root / 'strategy.txt').write_text('# START\nalpha=1\n# END\n', encoding='utf-8')
+
+
+def _fake_terminal_tool(command: str, **kwargs) -> str:
+    del kwargs
+    action, *parts = command.split('|')
+    if action == 'validate':
+        return json.dumps({'exit_code': 0, 'output': 'validated'})
+    if action == 'eval-param':
+        candidate_path = Path(parts[0])
+        result_path = Path(parts[1])
+        candidate = json.loads(candidate_path.read_text(encoding='utf-8'))
+        alpha = float(candidate['parameters'].get('alpha', 0.0))
+        payload = {
+            'metrics': {
+                'holdout': {'score': alpha},
+                'validation': {'score': alpha},
+            }
+        }
+        result_path.write_text(json.dumps(payload), encoding='utf-8')
+        return json.dumps({'exit_code': 0, 'output': 'ok'})
+    if action == 'eval-patch':
+        workspace = Path(parts[0])
+        result_path = Path(parts[1])
+        score = 0.0
+        for line in (workspace / 'strategy.txt').read_text(encoding='utf-8').splitlines():
+            if line.startswith('alpha='):
+                score = float(line.split('=', 1)[1].strip())
+                break
+        payload = {
+            'metrics': {
+                'holdout': {'score': score},
+                'validation': {'score': score},
+            }
+        }
+        result_path.write_text(json.dumps(payload), encoding='utf-8')
+        return json.dumps({'exit_code': 0, 'output': 'ok'})
+    raise AssertionError(f'Unexpected command: {command}')
+
+
+
+def _fake_run_command(command: str, workdir: Path, task_id: str | None) -> dict:
+    del workdir, task_id
+    return json.loads(_fake_terminal_tool(command))
+def test_param_mutation_cycle_writes_report_and_summary(tmp_path, monkeypatch):
+    root = tmp_path / 'project'
+    root.mkdir()
+    _write_param_project(root)
+    monkeypatch.setattr(runtime, '_run_command', _fake_run_command)
+
+    listed = runtime.list_projects(str(root))
+    assert listed['count'] == 1
+    assert listed['projects'][0]['project_id'] == 'demo-project'
+
+    inspected = runtime.inspect_project(str(root))
+    assert inspected['project']['project_id'] == 'demo-project'
+    assert inspected['families'][0]['family_id'] == 'params'
+
+    validation = runtime.validate_project(str(root))
+    assert validation['valid'] is True
+
+    result = runtime.research_cycle(
+        project_root=str(root),
+        family_id='params',
+        population=2,
+        survivors=1,
+        seed=1,
+    )
+
+    assert result['status'] == 'completed'
+    assert result['interesting']['verdict'] is True
+    assert result['report_path']
+    assert Path(result['report_path']).exists()
+    assert result['selector']['champion']['primary_delta'] > 0
+    assert 'champion' in result['summary']
+
+    status_payload = runtime.status(run_id=result['run_id'], project_root=str(root))
+    assert status_payload['status'] == 'completed'
+    assert status_payload['report_path'] == result['report_path']
+
+    runs = runtime.list_runs(project_root=str(root))
+    assert runs['count'] == 1
+    assert runs['runs'][0]['run_id'] == result['run_id']
+
+    inspected_run = runtime.inspect_run(run_id=result['run_id'], project_root=str(root))
+    assert 'AutoResearch Run' in inspected_run['report_preview']
+
+    publish = runtime.publish_summary(run_id=result['run_id'], project_root=str(root))
+    assert publish['summary'] == result['summary']
+    assert publish['sent'] is False
+
+
+def test_agent_patch_cycle_rejects_forbidden_files(tmp_path, monkeypatch):
+    root = tmp_path / 'project'
+    root.mkdir()
+    _write_agent_patch_project(root)
+    monkeypatch.setattr(runtime, '_run_command', _fake_run_command)
+
+    def fake_run_agent_patch(*, workspace, **kwargs):
+        del kwargs
+        (workspace.path / 'forbidden.txt').write_text('nope\n', encoding='utf-8')
+        return {'model': 'test-model', 'response': 'wrote forbidden file'}
+
+    monkeypatch.setattr(runtime, '_run_agent_patch', fake_run_agent_patch)
+
+    result = runtime.research_cycle(
+        project_root=str(root),
+        family_id='patches',
+        population=1,
+        survivors=1,
+        seed=1,
+        model='test-model',
+    )
+
+    assert result['status'] == 'completed'
+    assert result['selector']['champion'] is None
+    assert result['interesting']['verdict'] is False
+    assert result['report_path'] is None
+    assert len(result['candidates']) == 1
+    assert result['candidates'][0]['review']['accepted'] is False
+    assert 'forbidden files' in result['candidates'][0]['review']['reasons'][0].lower()
+
+
+def test_create_candidate_workspace_uses_git_worktree_when_repo_exists(tmp_path):
+    if shutil.which('git') is None:
+        pytest.skip('git is not installed')
+
+    root = tmp_path / 'repo'
+    root.mkdir()
+    (root / 'app.py').write_text('print("hello")\n', encoding='utf-8')
+
+    subprocess.run(['git', 'init'], cwd=root, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'config', 'user.email', 'test@example.com'], cwd=root, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'config', 'user.name', 'Test User'], cwd=root, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'add', 'app.py'], cwd=root, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'commit', '-m', 'init'], cwd=root, check=True, capture_output=True, text=True)
+
+    workspace = workspaces.create_candidate_workspace(root, 'run-1', 'candidate-1', ['app.py'])
+    try:
+        assert workspace.method == 'git_worktree'
+        assert (workspace.path / 'app.py').exists()
+        assert '.hermes/autoresearch/' in (root / '.gitignore').read_text(encoding='utf-8')
+
+        (workspace.path / 'app.py').write_text('print("updated")\n', encoding='utf-8')
+        assert workspaces.list_changed_files(workspace) == ['app.py']
+    finally:
+        subprocess.run(['git', 'worktree', 'remove', str(workspace.path), '--force'], cwd=root, check=True, capture_output=True, text=True)
+
+
+
+

--- a/tests/tools/test_autoresearch_tool.py
+++ b/tests/tools/test_autoresearch_tool.py
@@ -1,0 +1,58 @@
+"""Tests for the action-oriented AutoResearch tool."""
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / 'tools'
+if 'tools' not in sys.modules:
+    tools_pkg = types.ModuleType('tools')
+    tools_pkg.__path__ = [str(TOOLS_DIR)]
+    sys.modules['tools'] = tools_pkg
+
+from tools.autoresearch_tool import autoresearch_tool
+
+
+def test_autoresearch_tool_dispatches_research_cycle():
+    with patch('tools.autoresearch_tool.research_cycle', return_value={'run_id': 'run-1', 'status': 'completed'}) as mock_run:
+        payload = json.loads(
+            autoresearch_tool(
+                {
+                    'action': 'research_cycle',
+                    'family_id': 'params',
+                    'population': 3,
+                    'survivors': 2,
+                    'seed': 11,
+                    'model': 'test-model',
+                },
+                task_id='task-123',
+            )
+        )
+
+    assert payload['success'] is True
+    assert payload['run_id'] == 'run-1'
+    mock_run.assert_called_once_with(
+        project_root=None,
+        family_id='params',
+        population=3,
+        survivors=2,
+        seed=11,
+        model='test-model',
+        task_id='task-123',
+    )
+
+
+def test_autoresearch_tool_requires_family_id_for_research_cycle():
+    payload = json.loads(autoresearch_tool({'action': 'research_cycle'}))
+
+    assert payload['success'] is False
+    assert 'family_id' in payload['error']
+
+
+def test_autoresearch_tool_requires_run_id_for_publish_summary():
+    payload = json.loads(autoresearch_tool({'action': 'publish_summary'}))
+
+    assert payload['success'] is False
+    assert 'run_id' in payload['error']

--- a/tools/autoresearch_tool.py
+++ b/tools/autoresearch_tool.py
@@ -1,0 +1,153 @@
+"""Action-oriented AutoResearch tool for Hermes."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from autoresearch.runtime import (
+    inspect_project,
+    inspect_run,
+    list_projects,
+    list_runs,
+    publish_summary,
+    research_cycle,
+    status,
+    validate_project,
+)
+from tools.registry import registry
+
+
+AUTORESEARCH_SCHEMA = {
+    "name": "autoresearch",
+    "description": (
+        "Run bounded AutoResearch workflows for a workspace-defined project. "
+        "Use list_projects and inspect_project first, validate_project before running, "
+        "research_cycle to execute a family, status/list_runs/inspect_run to inspect results, "
+        "and publish_summary to prepare or send a short messaging summary."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "list_projects",
+                    "inspect_project",
+                    "validate_project",
+                    "research_cycle",
+                    "status",
+                    "list_runs",
+                    "inspect_run",
+                    "publish_summary",
+                ],
+                "description": "AutoResearch action to perform.",
+            },
+            "project_root": {
+                "type": "string",
+                "description": "Optional workspace root containing .hermes/autoresearch/project.yaml. Defaults to the nearest discovered project.",
+            },
+            "family_id": {
+                "type": "string",
+                "description": "Family ID to run for action='research_cycle'.",
+            },
+            "run_id": {
+                "type": "string",
+                "description": "Run ID for status, inspect_run, or publish_summary.",
+            },
+            "population": {
+                "type": "integer",
+                "description": "Optional override for generated candidate count.",
+            },
+            "survivors": {
+                "type": "integer",
+                "description": "Optional override for how many candidates survive ranking before selector checks.",
+            },
+            "seed": {
+                "type": "integer",
+                "description": "Random seed used for param_mutation families.",
+            },
+            "model": {
+                "type": "string",
+                "description": "Optional model override for agent_patch generation.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of runs to return for action='list_runs'.",
+            },
+            "target": {
+                "type": "string",
+                "description": "Optional messaging target for publish_summary, for example 'telegram' or 'discord:#research'.",
+            },
+            "send": {
+                "type": "boolean",
+                "description": "When true, publish_summary also sends the summary through Hermes messaging.",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+def autoresearch_tool(args: dict[str, Any], **kwargs) -> str:
+    """Dispatch AutoResearch tool actions."""
+    action = (args.get("action") or "").strip().lower()
+    project_root = args.get("project_root")
+
+    try:
+        if action == "list_projects":
+            payload = list_projects(project_root)
+        elif action == "inspect_project":
+            payload = inspect_project(project_root)
+        elif action == "validate_project":
+            payload = validate_project(project_root)
+        elif action == "research_cycle":
+            family_id = args.get("family_id")
+            if not family_id:
+                return json.dumps({"success": False, "error": "family_id is required for action='research_cycle'"}, indent=2)
+            payload = research_cycle(
+                project_root=project_root,
+                family_id=family_id,
+                population=args.get("population"),
+                survivors=args.get("survivors"),
+                seed=args.get("seed", 7),
+                model=args.get("model"),
+                task_id=kwargs.get("task_id"),
+            )
+        elif action == "status":
+            run_id = args.get("run_id")
+            if not run_id:
+                return json.dumps({"success": False, "error": "run_id is required for action='status'"}, indent=2)
+            payload = status(run_id=run_id, project_root=project_root)
+        elif action == "list_runs":
+            payload = list_runs(project_root=project_root, limit=int(args.get("limit", 20)))
+        elif action == "inspect_run":
+            run_id = args.get("run_id")
+            if not run_id:
+                return json.dumps({"success": False, "error": "run_id is required for action='inspect_run'"}, indent=2)
+            payload = inspect_run(run_id=run_id, project_root=project_root)
+        elif action == "publish_summary":
+            run_id = args.get("run_id")
+            if not run_id:
+                return json.dumps({"success": False, "error": "run_id is required for action='publish_summary'"}, indent=2)
+            payload = publish_summary(
+                run_id=run_id,
+                project_root=project_root,
+                target=args.get("target"),
+                send=bool(args.get("send", False)),
+            )
+        else:
+            return json.dumps({"success": False, "error": f"Unknown autoresearch action '{action}'"}, indent=2)
+        return json.dumps({"success": True, **payload}, indent=2)
+    except Exception as exc:
+        return json.dumps({"success": False, "error": str(exc)}, indent=2)
+
+
+registry.register(
+    name="autoresearch",
+    toolset="autoresearch",
+    schema=AUTORESEARCH_SCHEMA,
+    handler=autoresearch_tool,
+    check_fn=lambda: True,
+    emoji="AR",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -136,6 +136,12 @@ TOOLSETS = {
         "includes": []
     },
     
+    "autoresearch": {
+        "description": "Workspace-defined bounded AutoResearch cycles for optional research automation",
+        "tools": ["autoresearch"],
+        "includes": []
+    },
+    
     "rl": {
         "description": "RL training tools for running reinforcement learning on Tinker-Atropos",
         "tools": [
@@ -552,3 +558,4 @@ if __name__ == "__main__":
     print(f"  Created 'my_custom' toolset:")
     print(f"    Description: {custom_info['description']}")
     print(f"    Resolved tools: {', '.join(custom_info['resolved_tools'])}")
+

--- a/website/docs/user-guide/features/autoresearch.md
+++ b/website/docs/user-guide/features/autoresearch.md
@@ -1,0 +1,419 @@
+---
+sidebar_position: 6
+title: "AutoResearch"
+description: "Run bounded, manifest-driven research cycles inside Hermes and generate reports only for interesting runs"
+---
+
+# AutoResearch
+
+AutoResearch is an optional Hermes feature for running structured research loops against a workspace-defined project.
+
+It is designed for cases where you want Hermes to:
+
+- evaluate anchor strategies or baseline candidates
+- generate bounded variants
+- review them against explicit edit rules
+- score them with your own evaluator command
+- select a champion using holdout-aware rules
+- write a Markdown report only when the run is interesting
+- optionally prepare or send a short summary for Telegram or other Hermes messaging targets
+
+AutoResearch is built into Hermes as an optional toolset, so nothing happens unless you enable it and define a project manifest in your workspace.
+
+## What AutoResearch does
+
+The built-in research loop is:
+
+`anchor -> generate -> review -> evaluate -> select -> report -> publish summary`
+
+In practice:
+
+1. Hermes loads your AutoResearch project and family manifests.
+2. It evaluates the declared anchor candidates first.
+3. It generates new candidates with either:
+   - `param_mutation`
+   - `agent_patch`
+4. It reviews generated candidates against your editable-file rules.
+5. It runs your evaluator command, which must write structured JSON.
+6. It ranks and filters candidates with your selector rules.
+7. It writes one report for the run if the final result is interesting.
+8. It can prepare or send a short publishable summary.
+
+## What to expect
+
+AutoResearch is not a free-form autonomous coding mode. It is intentionally bounded.
+
+What it expects from you:
+
+- a workspace with `.hermes/autoresearch/project.yaml`
+- one or more family manifests under `.hermes/autoresearch/families/`
+- evaluator commands that Hermes can run from the workspace
+- evaluator output written to a declared JSON file
+- explicit selection and interestingness rules
+
+What it gives you back:
+
+- isolated candidate workspaces
+- run metadata under `.hermes/autoresearch/runs/<run_id>/`
+- candidate artifacts under the run folder
+- optional Markdown reports under `research/YYYY-MM-DD/`
+- a short summary string suitable for `send_message`
+
+## Enabling the tool
+
+AutoResearch is an optional toolset and is off by default for new installs.
+
+You can enable it with the normal Hermes tools flow:
+
+```bash
+hermes tools
+```
+
+Or with the CLI tool toggles:
+
+```bash
+hermes tools enable autoresearch --platform cli
+```
+
+Once enabled, Hermes can use the `autoresearch` tool.
+
+## Workspace contract
+
+AutoResearch looks for these paths inside your project:
+
+```text
+.hermes/autoresearch/project.yaml
+.hermes/autoresearch/families/*.yaml
+.hermes/autoresearch/runs/<run_id>/
+.hermes/autoresearch/workspaces/<run_id>/<candidate_id>/
+research/YYYY-MM-DD/<project-id>--<run-id>.md
+```
+
+## Project manifest
+
+`project.yaml` defines the shared project-level contract:
+
+- `project_id`
+- `description`
+- `default_cwd`
+- `datasets`
+- `benchmarks`
+- `evaluator`
+- `report_output_dir`
+- `publish_target`
+
+Example:
+
+```yaml
+project_id: mean-reversion-demo
+description: Research bounded variants of a mean-reversion strategy
+default_cwd: .
+datasets:
+  - data/btc_1h.csv
+benchmarks:
+  - baseline
+report_output_dir: research
+publish_target: telegram
+evaluator:
+  evaluation: "python evaluate.py --candidate {candidate_json} --out {result_json}"
+  result_json: "{result_json}"
+```
+
+## Family manifest
+
+Each family defines one bounded search space.
+
+Important fields:
+
+- `family_id`
+- `thesis`
+- `commands.validation`
+- `commands.evaluation`
+- `commands.result_json`
+- `mutation`
+- `selection`
+- `interesting_if`
+- `anchors`
+- `editable_files`
+- `editable_markers`
+
+Example:
+
+```yaml
+family_id: threshold-sweep
+thesis: Search threshold combinations without changing the whole strategy
+commands:
+  validation: "python validate.py --candidate {candidate_json}"
+  evaluation: "python evaluate.py --candidate {candidate_json} --out {result_json}"
+  result_json: "{result_json}"
+mutation:
+  mode: param_mutation
+  population: 8
+  survivors: 3
+  parameter_space:
+    entry_threshold: [0.5, 0.75, 1.0]
+    exit_threshold: [0.1, 0.2, 0.3]
+selection:
+  primary_metric: metrics.holdout.sharpe
+  goal: maximize
+  secondary_metrics:
+    - metric: metrics.validation.sharpe
+      min_delta: 0.0
+interesting_if:
+  mode: all
+  rules:
+    - metric: champion.primary_delta
+      op: ">"
+      value: 0.1
+anchors:
+  - candidate_id: baseline
+    label: Baseline
+    parameters:
+      entry_threshold: 0.5
+      exit_threshold: 0.1
+```
+
+## Mutation modes
+
+### `param_mutation`
+
+Use this when your research space is a bounded parameter search.
+
+Hermes mutates only the declared parameter space and evaluates each candidate with your command contract.
+
+Use this when:
+
+- your strategies are mostly configuration-driven
+- you want deterministic and easy-to-audit variation
+- you do not want the model editing source files
+
+### `agent_patch`
+
+Use this when Hermes should propose file edits, but only within a declared mutable surface.
+
+For `agent_patch`, define:
+
+- `editable_files`
+- optional `editable_markers`
+
+Hermes will reject candidates that:
+
+- touch forbidden files
+- exceed editable marker bounds
+- fail validation
+- fail evaluation
+
+This is the safer path for code mutation because AutoResearch evaluates candidates in isolated workspaces and never mutates the live workspace directly during the research run.
+
+## Evaluator contract
+
+Your evaluator command is the source of truth.
+
+It must:
+
+- accept the placeholders you define in the manifest
+- run from the workspace
+- write a JSON object to the declared `result_json` path
+
+AutoResearch expects metrics to be addressable by dotted paths such as:
+
+```text
+metrics.holdout.score
+metrics.validation.sharpe
+metrics.stress.max_drawdown
+```
+
+Those paths are used by:
+
+- `selection.primary_metric`
+- `selection.secondary_metrics`
+- `interesting_if.rules`
+
+## Tool actions
+
+Hermes exposes AutoResearch through one action-style tool:
+
+```python
+autoresearch(action="list_projects")
+autoresearch(action="inspect_project")
+autoresearch(action="validate_project")
+autoresearch(action="research_cycle", family_id="threshold-sweep")
+autoresearch(action="status", run_id="ar-...")
+autoresearch(action="list_runs")
+autoresearch(action="inspect_run", run_id="ar-...")
+autoresearch(action="publish_summary", run_id="ar-...")
+```
+
+### `list_projects`
+
+Finds discoverable AutoResearch projects and their family IDs.
+
+Use this first when you are not sure which workspace Hermes should target.
+
+### `inspect_project`
+
+Returns the parsed project manifest and family definitions.
+
+Use this to confirm:
+
+- the project root
+- available families
+- mutation mode
+- metrics used for selection
+
+### `validate_project`
+
+Validates the manifests before you run anything.
+
+Use this before every first run in a new workspace or after editing manifests.
+
+### `research_cycle`
+
+Runs the full bounded loop for one family.
+
+Useful parameters:
+
+- `family_id`
+- `population`
+- `survivors`
+- `seed`
+- `model` for `agent_patch`
+
+### `status`
+
+Returns a compact run status:
+
+- `status`
+- `phase`
+- `error`
+- `report_path`
+- `summary`
+
+### `list_runs`
+
+Shows recent runs for the current AutoResearch workspace.
+
+### `inspect_run`
+
+Returns the full run record and a preview of the generated report if one exists.
+
+### `publish_summary`
+
+Builds a short messaging-ready summary for a completed run.
+
+It can also send the summary if you provide `send=true` and a valid messaging target is configured.
+
+## Reports
+
+AutoResearch writes one report per interesting run, not one report per candidate.
+
+The report includes:
+
+- project and family information
+- anchor summary
+- shortlisted candidates
+- selected champion
+- key metric deltas
+- artifact paths
+- interestingness verdict and reason
+
+If a run is not interesting, AutoResearch still stores the run metadata but does not write a report file.
+
+## Candidate isolation
+
+Each candidate is evaluated in its own isolated workspace under:
+
+```text
+.hermes/autoresearch/workspaces/<run_id>/<candidate_id>/
+```
+
+Behavior:
+
+- uses `git worktree` when the project is in a git repo and worktree creation succeeds
+- falls back to a filesystem copy when worktrees are unavailable
+- ignores `.hermes` during copy fallback to avoid recursive workspace nesting
+
+This keeps candidate evaluation away from the live working tree.
+
+## Selection and interestingness
+
+Selection is not just “best score wins”.
+
+By default, AutoResearch requires:
+
+- a candidate to beat its parent on the primary metric
+- secondary metrics to stay within configured tolerances
+
+Interestingness is a separate gate. Even a valid champion does not produce a report unless the run passes `interesting_if`.
+
+This separation is useful when you want:
+
+- quiet storage of mediocre runs
+- reports only for genuinely notable improvements
+- publishable summaries only for high-signal results
+
+## Messaging and scheduling
+
+AutoResearch does not implement its own scheduler.
+
+Use existing Hermes features for that:
+
+- `publish_summary` for one-off summaries
+- `send_message` for delivery
+- `cronjob` for recurring research runs or recurring digests
+
+Recommended pattern:
+
+1. run `autoresearch(action="research_cycle", ...)`
+2. call `autoresearch(action="publish_summary", ...)`
+3. optionally deliver through Hermes messaging
+4. if you want automation, schedule that workflow with `cronjob`
+
+## Good usage pattern
+
+A reliable workflow looks like this:
+
+1. `list_projects`
+2. `inspect_project`
+3. `validate_project`
+4. `research_cycle`
+5. `inspect_run`
+6. `publish_summary`
+
+That keeps the feature predictable and easier to debug.
+
+## Limitations in v1
+
+AutoResearch is intentionally conservative.
+
+Current limitations:
+
+- projects integrate through command contracts, not Python plugin hooks
+- `param_mutation` is bounded by explicit parameter spaces
+- `agent_patch` is bounded by explicit editable files and markers
+- no free-form whole-repo mutation
+- no built-in scheduling layer
+- no RL training loop inside AutoResearch itself
+
+These constraints are deliberate. They make the feature safer to run, easier to understand, and easier to upstream.
+
+## When AutoResearch is a good fit
+
+AutoResearch works best when:
+
+- you already have an evaluator script or benchmark command
+- you can express success with structured metrics
+- you want many bounded experiments, not one giant autonomous rewrite
+- you want Markdown reports for high-signal outcomes
+- you want Hermes to help orchestrate research, not replace your evaluator
+
+## When it is not a good fit
+
+It is not the best tool when:
+
+- your task has no evaluator command
+- success is entirely subjective
+- the model needs unrestricted code mutation
+- the search space is undefined or open-ended
+
+In those cases, regular Hermes coding workflows or a custom skill may be a better fit.


### PR DESCRIPTION
- Introduced workspace isolation helpers in `autoresearch/workspaces.py` for managing candidate evaluations.
- Added AutoResearch tool configuration in `hermes_cli/tools_config.py` and integrated it into `toolsets.py` and `model_tools.py`.
- Implemented the AutoResearch action-oriented tool in `tools/autoresearch_tool.py` with project inspection, validation, run, status, reporting, and summary actions.
- Created integration and runtime tests for AutoResearch functionality in `tests/test_autoresearch_runtime.py`, `tests/test_autoresearch_integration.py`, and `tests/tools/test_autoresearch_tool.py`.
- Documented AutoResearch features and usage in `website/docs/user-guide/features/autoresearch.md`.
- Added workspace-local project and family manifest examples through the new demo/sample flow and manifest documentation.
- Ensured candidate isolation during evaluations to prevent interference with live workspaces, including a copy-fallback fix to ignore `.hermes` and avoid recursive workspace nesting.

## What does this PR do?

This PR adds `autoresearch` as an optional built-in Hermes feature for bounded, manifest-driven research workflows.

It lets a workspace define a research project in `.hermes/autoresearch/project.yaml` plus one or more research families in `.hermes/autoresearch/families/*.yaml`, then run a structured loop:

`anchor -> generate -> review -> evaluate -> select -> report -> publish summary`

The implementation is intentionally generic and opt-in. It does not change core agent loop semantics, does not require a plugin API, and keeps evaluation bounded by explicit manifests and evaluator commands. In v1 it supports both `param_mutation` and `agent_patch`, evaluates candidates in isolated workspaces, persists run artifacts under `.hermes/autoresearch/`, and only writes Markdown reports for interesting runs.

This approach fits Hermes well because it reuses existing toolset/config patterns, keeps the feature off by default for new users, and gives projects a clear command-based contract instead of baking in domain-specific assumptions.

## Related Issue

Fixes #

## Type of Change

- [ ] ?? Bug fix (non-breaking change that fixes an issue)
- [x] ? New feature (non-breaking change that adds functionality)
- [ ] ?? Security fix
- [x] ?? Documentation update
- [x] ? Tests (adding or improving test coverage)
- [ ] ?? Refactor (no behavior change)
- [x] ?? New skill (bundled or hub)

## Changes Made

- Added new AutoResearch runtime package in `autoresearch/`:
  - `autoresearch/models.py`
  - `autoresearch/manifests.py`
  - `autoresearch/workspaces.py`
  - `autoresearch/reports.py`
  - `autoresearch/runtime.py`
  - `autoresearch/__init__.py`
- Added the action-style Hermes tool in `tools/autoresearch_tool.py`
- Registered the tool in `model_tools.py`
- Added the optional `autoresearch` toolset in `toolsets.py`
- Added `autoresearch` to the interactive tool configurator and kept it default-off in `hermes_cli/tools_config.py`
- Included the new package in `pyproject.toml`
- Added bundled skill guidance in `skills/research/autoresearch/SKILL.md`
- Added feature documentation in `website/docs/user-guide/features/autoresearch.md`
- Added tests:
  - `tests/test_autoresearch_runtime.py`
  - `tests/test_autoresearch_integration.py`
  - `tests/tools/test_autoresearch_tool.py`
- Fixed copy-fallback workspace isolation to ignore `.hermes` and prevent recursive nesting

## How to Test

1. Enable the toolset in a repo that includes this PR:
   ```bash
   hermes tools enable autoresearch --platform cli
   ```
2. Create or use a workspace with:
   - `.hermes/autoresearch/project.yaml`
   - `.hermes/autoresearch/families/*.yaml`
   - an evaluator command that writes structured JSON to `result_json`
3. Run either:
   ```bash
   pytest -o addopts= tests/test_autoresearch_runtime.py tests/test_autoresearch_integration.py tests/tools/test_autoresearch_tool.py
   ```
   or start Hermes in that workspace and ask it to inspect, validate, run a family, and show the report path/summary.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux and Windows-oriented code paths

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) � or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys � or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows � or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) � or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior � or N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) � see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

Focused validation commands that passed locally:

```bash
py -3 -m pytest -o addopts= tests/test_autoresearch_runtime.py tests/tools/test_autoresearch_tool.py tests/test_autoresearch_integration.py
py -3 -m pytest -o addopts= tests/test_toolsets.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_tools_disable_enable.py
```

Example successful demo run summary:

```text
AutoResearch demo-threshold-search/threshold-sweep run `ar-...`: champion `threshold-sweep_gen_003` hit `0.6875` on `metrics.holdout.score` (delta `0.25` vs parent `baseline`).
```


