### PR TITLE
fix: respect model.default from config.yaml when using openai-codex provider

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1048,7 +1048,7 @@ class HermesCLI:
         # Track whether model was explicitly chosen by the user or fell back
         # to the global default.  Provider-specific normalisation may override
         # the default silently but should warn when overriding an explicit choice.
-        self._model_is_default = not model
+        self._model_is_default = not model and not _config_model
 
         self._explicit_api_key = api_key
         self._explicit_base_url = base_url


### PR DESCRIPTION
## Problem

When using the `openai-codex` provider, the model selection from `config.yaml` is ignored and always resets to `gpt-5.4`.

**Example:**
```yaml
# ~/.hermes/config.yaml
model:
  default: gpt-5.3-codex
  provider: openai-codex
```

Even with the above config, Hermes would use `gpt-5.4` instead of `gpt-5.3-codex`.

## Root Cause

In `cli.py` line 1051, the `_model_is_default` flag only checked CLI arguments:

```python
self._model_is_default = not model  # Only checks CLI arg
```

When no `--model` CLI argument was provided, this was `True` even though the user had set `model.default` in `config.yaml`. The normalization logic in `_normalize_model_for_provider()` then replaced the user's configured model with the Codex default (`gpt-5.4`).

## Fix

Check both CLI arguments AND config.yaml when determining if the model is the default:

```python
self._model_is_default = not model and not _config_model
```

Now `_model_is_default` is only `True` when **neither** CLI argument **nor** config.yaml specified a model.

## Behavior After Fix

| Scenario | Before | After |
|----------|--------|-------|
| No CLI arg, no config model | → gpt-5.4 ✓ | → gpt-5.4 ✓ |
| No CLI arg, config: gpt-5.3-codex | → gpt-5.4 ✗ | → gpt-5.3-codex ✓ |
| CLI: gpt-5.2-codex | → gpt-5.2-codex ✓ | → gpt-5.2-codex ✓ |

## Testing

Tested with:
- `model.default: gpt-5.3-codex` in config.yaml
- Provider set to `openai-codex`
- No CLI model argument

Result: Model correctly stays as `gpt-5.3-codex` instead of being replaced with `gpt-5.4`.