### PR TITLE
fix: search all sources by default in session_search

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -758,7 +758,7 @@ class SessionDB:
             return []
 
         if source_filter is None:
-            source_filter = ["cli", "telegram", "discord", "whatsapp", "slack"]
+            source_filter = ["cli", "telegram", "discord", "whatsapp", "slack", "acp"]
 
         # Build WHERE clauses dynamically
         where_clauses = ["messages_fts MATCH ?"]

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -757,16 +757,14 @@ class SessionDB:
         if not query:
             return []
 
-        if source_filter is None:
-            source_filter = ["cli", "telegram", "discord", "whatsapp", "slack", "acp"]
-
         # Build WHERE clauses dynamically
         where_clauses = ["messages_fts MATCH ?"]
         params: list = [query]
 
-        source_placeholders = ",".join("?" for _ in source_filter)
-        where_clauses.append(f"s.source IN ({source_placeholders})")
-        params.extend(source_filter)
+        if source_filter is not None:
+            source_placeholders = ",".join("?" for _ in source_filter)
+            where_clauses.append(f"s.source IN ({source_placeholders})")
+            params.extend(source_filter)
 
         if role_filter:
             role_placeholders = ",".join("?" for _ in role_filter)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -218,6 +218,17 @@ class TestFTS5Search:
         sources = [r["source"] for r in results]
         assert "acp" in sources
 
+    def test_search_default_includes_all_platforms(self, db):
+        """Default search (no source_filter) should find sessions from any platform."""
+        for src in ("cli", "telegram", "signal", "homeassistant", "acp", "matrix"):
+            sid = f"s-{src}"
+            db.create_session(session_id=sid, source=src)
+            db.append_message(sid, role="user", content=f"universal search test from {src}")
+
+        results = db.search_messages("universal search test")
+        found_sources = {r["source"] for r in results}
+        assert found_sources == {"cli", "telegram", "signal", "homeassistant", "acp", "matrix"}
+
     def test_search_with_role_filter(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="What is FastAPI?")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -210,6 +210,14 @@ class TestFTS5Search:
         sources = [r["source"] for r in results]
         assert all(s == "telegram" for s in sources)
 
+    def test_search_default_sources_include_acp(self, db):
+        db.create_session(session_id="s1", source="acp")
+        db.append_message("s1", role="user", content="ACP question about Python")
+
+        results = db.search_messages("Python")
+        sources = [r["source"] for r in results]
+        assert "acp" in sources
+
     def test_search_with_role_filter(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="What is FastAPI?")


### PR DESCRIPTION
## Summary

Salvage of PR #1817 by @someoneexistsontheinternet (cherry-picked with authorship preserved), plus a follow-up fix.

**Original PR #1817:** Added `acp` to the hardcoded default `source_filter` in `search_messages()`, fixing ACP sessions being invisible to `session_search`.

**Follow-up fix:** Removed the hardcoded allowlist entirely. The old default list (`cli, telegram, discord, whatsapp, slack`) silently excluded sessions from signal, mattermost, matrix, homeassistant, email, sms, dingtalk, api_server, and acp. Instead of maintaining an ever-growing allowlist, `source_filter=None` now means "search all sources." Callers can still pass an explicit `source_filter` to narrow results.

## Changes
- `hermes_state.py`: Remove hardcoded default `source_filter`; make source filtering conditional (only applied when explicitly provided)
- `tests/test_hermes_state.py`: Keep contributor's ACP regression test + add new test verifying all platforms are searched by default

## Test plan
- `python -m pytest tests/test_hermes_state.py -n0 -q` — 115 passed
- Full suite — 5316 passed (24 pre-existing failures in test_delegate.py)