### PR TITLE
fix(delegate): move _saved_tool_names save/restore to _run_single_child scope

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -173,10 +173,6 @@ def _build_child_agent(
     from run_agent import AIAgent
     import model_tools
 
-    # Save the parent's resolved tool names before the child agent can
-    # overwrite the process-global via get_tool_definitions().
-    _saved_tool_names = list(model_tools._last_resolved_tool_names)
-
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
     if toolsets:
@@ -262,6 +258,13 @@ def _run_single_child(
 
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, 'tool_progress_callback', None)
+
+    # Save the parent's resolved tool names before the child agent can
+    # overwrite the process-global via get_tool_definitions().
+    # This must be in _run_single_child (not _build_child_agent) so the
+    # save/restore happens in the same scope as the try/finally.
+    import model_tools
+    _saved_tool_names = list(model_tools._last_resolved_tool_names)
 
     try:
         result = child.run_conversation(user_message=goal)


### PR DESCRIPTION
Cherry-picked from PR #1884 by @Bartok9 (authorship preserved). Fixes #1802.

The v0.3.0 refactor split child agent construction and execution into separate functions (`_build_child_agent` and `_run_single_child`). This left `_saved_tool_names` defined in `_build_child_agent` but referenced in `_run_single_child`'s `finally` block, causing a `NameError` on every `delegate_task` call.

Moves the save/restore into `_run_single_child` so it's in the same scope as the try/finally. All 47 delegate tests pass.