### PR TITLE
fix(matrix): use correct reply_to_message_id parameter name

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -635,7 +635,7 @@ class MatrixAdapter(BasePlatformAdapter):
             source=source,
             raw_message=getattr(event, "source", {}),
             message_id=event.event_id,
-            reply_to=reply_to,
+            reply_to_message_id=reply_to,
         )
 
         await self.handle_message(msg_event)


### PR DESCRIPTION
Cherry-picks PR #1885 by @Bartok9. Fixes #1842.

Matrix adapter was passing `reply_to=reply_to` to `MessageEvent`, but the dataclass field is `reply_to_message_id`. Every other adapter uses the correct name. This caused Matrix replies to crash.

Supersedes #1885.