### PR TITLE
fix: improve delegation status detection for subagents

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -285,7 +285,27 @@ def _run_single_child(
         elif completed and summary:
             status = "completed"
         else:
-            status = "failed"
+            # Check if work was actually done even if max_iterations was hit
+            # by looking at tool calls in the conversation
+            messages = result.get("messages") or []
+            successful_tool_calls = 0
+            failed_tool_calls = 0
+            if isinstance(messages, list):
+                for msg in messages:
+                    if isinstance(msg, dict) and msg.get("role") == "tool":
+                        content = msg.get("content", "")
+                        if content and "error" in content[:80].lower():
+                            failed_tool_calls += 1
+                        else:
+                            successful_tool_calls += 1
+            
+            # If we have successful tool calls, consider it completed
+            if successful_tool_calls > 0 and failed_tool_calls == 0:
+                status = "completed"  # Work was done successfully
+            elif successful_tool_calls > failed_tool_calls:
+                status = "completed"  # More success than failure
+            else:
+                status = "failed"
 
         # Build tool trace from conversation messages (already in memory).
         # Uses tool_call_id to correctly pair parallel tool calls with results.


### PR DESCRIPTION
## Problem

When using `delegate_task` to spawn subagents, tasks that successfully complete their work (create files, run commands, etc.) but hit the `max_iterations` limit before cleanly finishing are incorrectly reported as `status: failed`.

## Example

A subagent that:
1. Successfully creates a file with `write_file`
2. Verifies it with `read_file`
3. Hits `max_iterations` before generating a final summary

Would show `status: failed` even though the work was completed successfully.

## Root Cause

The completion check in `delegate_tool.py` only looked at the `completed` flag:
```python
if interrupted:
    status = interrupted
elif completed and summary:
    status = completed
else:
    status = failed  # Too strict!
```

The `completed` flag is set to `False` when `max_iterations` is hit, regardless of whether work was actually done.

## Fix

Check if successful tool calls were made. If the subagent successfully used tools without errors, consider the task completed:

```python
# Count successful vs failed tool calls
successful_tool_calls = 0
failed_tool_calls = 0
for msg in messages:
    if msg.get(role) == tool:
        content = msg.get(content, )
        if error in content[:80].lower():
            failed_tool_calls += 1
        else:
            successful_tool_calls += 1

# If successful tool calls, mark as completed
if successful_tool_calls > 0 and failed_tool_calls == 0:
    status = completed
elif successful_tool_calls > failed_tool_calls:
    status = completed
```

## Testing

Tested with multiple parallel delegation tasks:
- All tasks successfully created files and ran commands
- Status now correctly shows `completed` instead of `failed`
- Tool traces accurately reflect what was executed