### PR TITLE
fix(gateway): detect script-style gateway processes for --replace

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -87,6 +87,7 @@ def _looks_like_gateway_process(pid: int) -> bool:
 
     patterns = (
         "hermes_cli.main gateway",
+        "hermes_cli/main.py gateway",
         "hermes gateway",
         "gateway/run.py",
     )
@@ -105,6 +106,7 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
     cmdline = " ".join(str(part) for part in argv)
     patterns = (
         "hermes_cli.main gateway",
+        "hermes_cli/main.py gateway",
         "hermes gateway",
         "gateway/run.py",
     )

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -31,6 +31,7 @@ def find_gateway_pids() -> list:
     pids = []
     patterns = [
         "hermes_cli.main gateway",
+        "hermes_cli/main.py gateway",
         "hermes gateway",
         "gateway/run.py",
     ]

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -42,6 +42,26 @@ class TestGatewayPidState:
 
         assert status.get_running_pid() == os.getpid()
 
+    def test_get_running_pid_accepts_script_style_gateway_cmdline(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "argv": ["/venv/bin/python", "/repo/hermes_cli/main.py", "gateway", "run", "--replace"],
+            "start_time": 123,
+        }))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda pid: "/venv/bin/python /repo/hermes_cli/main.py gateway run --replace",
+        )
+
+        assert status.get_running_pid() == os.getpid()
+
 
 class TestGatewayRuntimeStatus:
     def test_write_runtime_status_overwrites_stale_pid_on_restart(self, tmp_path, monkeypatch):


### PR DESCRIPTION
Cherry-picked from PR #1831 by @TheSameCat2 (authorship preserved). Fixes #1830.

Adds `hermes_cli/main.py gateway` to the recognized process-detection patterns in `_looks_like_gateway_process()`, `_record_looks_like_gateway()`, and `find_gateway_pids()`. Without this, `--replace` fails to detect gateway instances started via script-style invocations, allowing duplicate instances that produce duplicate Discord replies.

Includes regression test. All 9 status tests pass.