### PR TITLE
docs: fix MCP install commands — use uv, not bare pip

### DIFF
--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -37,8 +37,13 @@ That last part matters. Good MCP usage is not just “connect everything.” It 
 
 ## Step 1: install MCP support
 
+If you installed Hermes with the standard install script, MCP support is already included (the installer runs `uv pip install -e ".[all]"`).
+
+If you installed without extras and need to add MCP separately:
+
 ```bash
-pip install hermes-agent[mcp]
+cd ~/.hermes/hermes-agent
+uv pip install -e ".[mcp]"
 ```
 
 For npm-based servers, make sure Node.js and `npx` are available.

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -372,8 +372,8 @@ hermes chat --continue
 
 **Solution:**
 ```bash
-# Ensure MCP dependencies are installed
-pip install hermes-agent[mcp]
+# Ensure MCP dependencies are installed (already included in standard install)
+cd ~/.hermes/hermes-agent && uv pip install -e ".[mcp]"
 
 # For npm-based servers, ensure Node.js is available
 node --version

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -20,10 +20,11 @@ If you have ever wanted Hermes to use a tool that already exists somewhere else,
 
 ## Quick start
 
-1. Install MCP support:
+1. Install MCP support (already included if you used the standard install script):
 
 ```bash
-pip install hermes-agent[mcp]
+cd ~/.hermes/hermes-agent
+uv pip install -e ".[mcp]"
 ```
 
 2. Add an MCP server to `~/.hermes/config.yaml`:
@@ -374,7 +375,9 @@ Inspect the project root and explain the directory layout.
 Check:
 
 ```bash
-pip install hermes-agent[mcp]
+# Verify MCP deps are installed (already included in standard install)
+cd ~/.hermes/hermes-agent && uv pip install -e ".[mcp]"
+
 node --version
 npx --version
 ```


### PR DESCRIPTION
Fixes confusion reported by a Discord user (nbot) who tried `pip install hermes-agent[mcp]` inside the Hermes venv and found pip wasn't available.

**The problem:**
- 3 docs pages told users to run `pip install hermes-agent[mcp]`
- The Hermes venv is created by `uv`, so bare `pip` isn't installed
- The standard install already includes MCP via `.[all]`, so most users don't need this step at all

**The fix:**
- All 4 occurrences across 3 pages now use `uv pip install -e ".[mcp]"` with the correct `cd` path
- Added note that standard install already includes MCP support
- Affected pages: `guides/use-mcp-with-hermes.md`, `user-guide/features/mcp.md`, `reference/faq.md`