### PR TITLE
feat(cli): add /statusbar command to toggle context bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1215,6 +1215,9 @@ class HermesCLI:
         self._voice_tts_done = threading.Event()
         self._voice_tts_done.set()
 
+        # Status bar visibility (toggled via /statusbar)
+        self._status_bar_visible = True
+
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
@@ -1322,6 +1325,8 @@ class HermesCLI:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
 
     def _get_status_bar_fragments(self):
+        if not self._status_bar_visible:
+            return []
         try:
             snapshot = self._get_status_bar_snapshot()
             width = shutil.get_terminal_size((80, 24)).columns
@@ -3551,6 +3556,10 @@ class HermesCLI:
                 self._handle_skills_command(cmd_original)
         elif canonical == "platforms":
             self._show_gateway_status()
+        elif canonical == "statusbar":
+            self._status_bar_visible = not self._status_bar_visible
+            state = "visible" if self._status_bar_visible else "hidden"
+            self.console.print(f"  Status bar {state}")
         elif canonical == "verbose":
             self._toggle_verbose()
         elif canonical == "reasoning":
@@ -6587,9 +6596,12 @@ class HermesCLI:
             filter=Condition(lambda: cli_ref._voice_mode),
         )
 
-        status_bar = Window(
-            content=FormattedTextControl(lambda: cli_ref._get_status_bar_fragments()),
-            height=1,
+        status_bar = ConditionalContainer(
+            Window(
+                content=FormattedTextControl(lambda: cli_ref._get_status_bar_fragments()),
+                height=1,
+            ),
+            filter=Condition(lambda: cli_ref._status_bar_visible),
         )
 
         # Layout: interactive prompt widgets + ruled input at bottom.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -81,6 +81,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, args_hint="[text]", subcommands=("clear",)),
     CommandDef("personality", "Set a predefined personality", "Configuration",
                args_hint="[name]"),
+    CommandDef("statusbar", "Toggle the context/model status bar", "Configuration",
+               cli_only=True, aliases=("sb",)),
     CommandDef("verbose", "Cycle tool progress display: off -> new -> all -> verbose",
                "Configuration", cli_only=True),
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",


### PR DESCRIPTION
Adds `/statusbar` (alias `/sb`) slash command to toggle the bottom status bar on/off.

The status bar shows model name, context usage percentage, token counts, and session duration. Some users find it distracting or want the extra terminal line back.

- Toggle: `/statusbar` or `/sb`
- Uses `ConditionalContainer` so the bar takes zero vertical space when hidden (no blank line)
- Visible by default (existing behavior unchanged)