### PR TITLE
chore: add search to huggingface-hub skill description

### DIFF
--- a/skills/mlops/huggingface-hub/SKILL.md
+++ b/skills/mlops/huggingface-hub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huggingface-hub
-description: Hugging Face Hub CLI (hf) — download/upload models and datasets, manage repos, query datasets with SQL, deploy inference endpoints, manage Spaces and buckets. Use when uploading to, downloading from, or managing anything on HuggingFace Hub.
+description: Hugging Face Hub CLI (hf) — search, download, and upload models and datasets, manage repos, query datasets with SQL, deploy inference endpoints, manage Spaces and buckets. Use when searching, uploading to, downloading from, or managing anything on HuggingFace Hub.
 version: 1.0.0
 author: Hugging Face
 license: MIT


### PR DESCRIPTION
Adds 'search' to the description so the agent picks this skill when users ask to find models or datasets on HuggingFace.