### PR TITLE
feat: inject model and provider into system prompt

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2061,6 +2061,10 @@ class AIAgent:
         timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
         if self.pass_session_id and self.session_id:
             timestamp_line += f"\nSession ID: {self.session_id}"
+        if self.model:
+            timestamp_line += f"\nModel: {self.model}"
+        if self.provider:
+            timestamp_line += f"\nProvider: {self.provider}"
         prompt_parts.append(timestamp_line)
 
         platform_key = (self.platform or "").lower().strip()


### PR DESCRIPTION
Adds model name and provider to the system prompt metadata block, right after the session ID and timestamp:

```
Conversation started: Tuesday, March 18, 2026 02:30 AM
Session ID: abc123
Model: anthropic/claude-opus-4.6
Provider: anthropic
```

These are frozen at session build time and don't change mid-conversation, so prompt caching is unaffected. 278 tests pass.