### PR TITLE
feat(session): configurable write-through SQLite flush per tool-call turn

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -355,6 +355,13 @@ session_reset:
   idle_minutes: 1440   # Inactivity timeout in minutes (default: 1440 = 24 hours)
   at_hour: 4           # Daily reset hour, 0-23 local time (default: 4 AM)
 
+# Session persistence — controls SQLite flush strategy during conversations.
+session:
+  write_through_flush: true   # Flush messages to SQLite after every tool-call
+                               # turn, not just at session end. Improves crash
+                               # resilience at negligible cost. Disable only if
+                               # per-turn DB writes are a bottleneck.
+
 # When true, group/channel chats use one session per participant when the platform
 # provides a user ID. This is the secure default and prevents users in the same
 # room from sharing context, interrupts, and token costs. Set false only if you

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -321,6 +321,15 @@ DEFAULT_CONFIG = {
     # (apiKey, workspace, peerName, sessions, enabled) comes from the global config.
     "honcho": {},
 
+    # Session persistence — controls how aggressively messages are flushed
+    # to the SQLite session DB during a conversation.
+    "session": {
+        # When true, flush messages to SQLite after every tool-call turn
+        # (not just at session end). Improves crash resilience at negligible
+        # performance cost.
+        "write_through_flush": True,
+    },
+
     # IANA timezone (e.g. "Asia/Kolkata", "America/New_York").
     # Empty string means use server-local time.
     "timezone": "",

--- a/run_agent.py
+++ b/run_agent.py
@@ -852,6 +852,10 @@ class AIAgent:
         except Exception:
             _agent_cfg = {}
 
+        # Session persistence — per-turn SQLite flush for crash resilience
+        session_cfg = _agent_cfg.get("session", {})
+        self._write_through_flush = session_cfg.get("write_through_flush", True)
+
         # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
         self._memory_store = None
         self._memory_enabled = False
@@ -6413,7 +6417,11 @@ class AIAgent:
                     # Save session log incrementally (so progress is visible even if interrupted)
                     self._session_messages = messages
                     self._save_session_log(messages)
-                    
+                    # Write-through: flush to SQLite after every tool-call turn so
+                    # messages survive crashes between turns (not just at session end).
+                    if self._write_through_flush:
+                        self._flush_messages_to_session_db(messages, conversation_history)
+
                     # Continue loop for next response
                     continue
                 

--- a/tests/agent/test_write_through_persistence.py
+++ b/tests/agent/test_write_through_persistence.py
@@ -1,0 +1,212 @@
+"""Tests for configurable write-through session DB persistence.
+
+Verifies that:
+1. The session.write_through_flush config key defaults to True
+2. When enabled, _flush_messages_to_session_db is called after each tool-call turn
+3. When disabled, per-turn flush is skipped (only happens at session end)
+4. Per-turn flushes are idempotent via _last_flushed_db_idx
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test: config default
+# ---------------------------------------------------------------------------
+
+class TestWriteThroughConfig:
+    """Verify the session.write_through_flush config key."""
+
+    def test_default_config_has_write_through_enabled(self):
+        """DEFAULT_CONFIG includes session.write_through_flush = True."""
+        from hermes_cli.config import DEFAULT_CONFIG
+        assert DEFAULT_CONFIG["session"]["write_through_flush"] is True
+
+    def test_load_config_returns_write_through_default(self):
+        """load_config() returns write_through_flush = True when no user override."""
+        from hermes_cli.config import load_config
+        config = load_config()
+        assert config["session"]["write_through_flush"] is True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_agent(session_db=None, write_through_override=None):
+    """Create a minimal AIAgent suitable for unit tests.
+
+    If write_through_override is provided, it is set after construction
+    to test the disabled path without needing a config file override.
+    """
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+        agent = AIAgent(
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id="test-write-through",
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    if write_through_override is not None:
+        agent._write_through_flush = write_through_override
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# Test: constructor sets _write_through_flush from config
+# ---------------------------------------------------------------------------
+
+class TestWriteThroughInit:
+    """Verify _write_through_flush is set during construction."""
+
+    def test_default_is_true(self):
+        """Agent defaults to _write_through_flush = True."""
+        agent = _make_agent()
+        assert agent._write_through_flush is True
+
+
+# ---------------------------------------------------------------------------
+# Test: per-turn flush behaviour
+# ---------------------------------------------------------------------------
+
+class TestWriteThroughPerTurnFlush:
+    """Verify that the tool-call continue path respects _write_through_flush."""
+
+    def test_enabled_flushes_per_turn(self):
+        """With write_through enabled, per-turn flush writes to session DB."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test_wt.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = _make_agent(session_db=db, write_through_override=True)
+            agent._save_session_log = MagicMock()
+
+            messages = [
+                {"role": "user", "content": "what time is it?"},
+                {"role": "assistant", "content": "", "tool_calls": [
+                    {"name": "terminal", "arguments": '{"command": "date"}'},
+                ]},
+                {"role": "tool", "content": "Wed Mar 19 12:00:00 UTC 2026",
+                 "tool_call_id": "call_1", "tool_name": "terminal"},
+            ]
+            conversation_history = []
+
+            # Simulate the per-turn flush that runs in the tool-call continue path
+            if agent._write_through_flush:
+                agent._flush_messages_to_session_db(messages, conversation_history)
+
+            rows = db.get_messages(agent.session_id)
+            assert len(rows) == 3, f"Expected 3 messages flushed per-turn, got {len(rows)}"
+
+    def test_disabled_skips_per_turn_flush(self):
+        """With write_through disabled, per-turn path does not flush to DB."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test_wt_off.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = _make_agent(session_db=db, write_through_override=False)
+            agent._save_session_log = MagicMock()
+
+            messages = [
+                {"role": "user", "content": "what time is it?"},
+                {"role": "assistant", "content": "", "tool_calls": [
+                    {"name": "terminal", "arguments": '{"command": "date"}'},
+                ]},
+                {"role": "tool", "content": "Wed Mar 19 12:00:00 UTC 2026",
+                 "tool_call_id": "call_1", "tool_name": "terminal"},
+            ]
+            conversation_history = []
+
+            # Simulate the per-turn check — should NOT flush
+            if agent._write_through_flush:
+                agent._flush_messages_to_session_db(messages, conversation_history)
+
+            rows = db.get_messages(agent.session_id)
+            assert len(rows) == 0, f"Expected 0 messages with write_through disabled, got {len(rows)}"
+
+    def test_session_end_flushes_regardless(self):
+        """_persist_session always flushes, even with write_through disabled."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test_persist.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = _make_agent(session_db=db, write_through_override=False)
+            agent._save_session_log = MagicMock()
+
+            messages = [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi there"},
+            ]
+
+            # _persist_session is the end-of-session path — always flushes
+            agent._persist_session(messages, [])
+
+            rows = db.get_messages(agent.session_id)
+            assert len(rows) == 2, f"Expected 2 messages at session end, got {len(rows)}"
+
+    def test_per_turn_flush_is_idempotent(self):
+        """Multiple per-turn flushes don't duplicate messages."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test_idemp.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = _make_agent(session_db=db, write_through_override=True)
+
+            messages = [
+                {"role": "user", "content": "q1"},
+                {"role": "assistant", "content": "a1"},
+            ]
+            conversation_history = []
+
+            # Simulate 3 consecutive per-turn flushes with same messages
+            agent._flush_messages_to_session_db(messages, conversation_history)
+            agent._flush_messages_to_session_db(messages, conversation_history)
+            agent._flush_messages_to_session_db(messages, conversation_history)
+
+            rows = db.get_messages(agent.session_id)
+            assert len(rows) == 2, f"Expected 2 messages (no dupes), got {len(rows)}"
+
+    def test_incremental_per_turn_flush(self):
+        """Each turn adds only new messages to the DB."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test_incr.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = _make_agent(session_db=db, write_through_override=True)
+            conversation_history = []
+
+            # Turn 1: user asks, assistant uses tool
+            messages = [
+                {"role": "user", "content": "turn 1"},
+                {"role": "assistant", "content": "tool result 1"},
+            ]
+            agent._flush_messages_to_session_db(messages, conversation_history)
+            assert len(db.get_messages(agent.session_id)) == 2
+
+            # Turn 2: new messages appended
+            messages.append({"role": "user", "content": "turn 2"})
+            messages.append({"role": "assistant", "content": "tool result 2"})
+            agent._flush_messages_to_session_db(messages, conversation_history)
+            assert len(db.get_messages(agent.session_id)) == 4
+
+            # Turn 3: one more
+            messages.append({"role": "user", "content": "turn 3"})
+            agent._flush_messages_to_session_db(messages, conversation_history)
+            assert len(db.get_messages(agent.session_id)) == 5


### PR DESCRIPTION
## What does this PR do?

Adds a configurable per-turn SQLite flush in the tool-call continue path, so session messages survive agent crashes between turns — not just at session end.

Currently, `_save_session_log` (JSON) runs after every tool-call turn, but `_flush_messages_to_session_db` (SQLite) only runs inside `_persist_session` at the end of a conversation. If the agent crashes mid-conversation, the JSON log has the messages but the SQLite DB does not. This matters for any external system querying the session DB for live conversation state (monitoring, analytics, gateway session search).

The fix is a single conditional call gated by a new `session.write_through_flush` config key (default: `true`). It reuses the existing `_flush_messages_to_session_db` method and its `_last_flushed_db_idx` cursor, so repeated calls are idempotent and duplicate-free (#860).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config.py` — Add `session.write_through_flush` (default `True`) to `DEFAULT_CONFIG`
- `run_agent.py` — Load config in constructor, conditionally flush to SQLite after `_save_session_log` in the tool-call continue loop
- `cli-config.yaml.example` — Document the new config section
- `tests/agent/test_write_through_persistence.py` — 8 tests covering config defaults, enabled/disabled flush behaviour, session-end flush independence, idempotency, and incremental writes

## How to Test

1. `pytest tests/agent/test_write_through_persistence.py -v` — all 8 new tests pass
2. `pytest tests/test_860_dedup.py -v` — existing dedup tests unaffected (9 pass)
3. Manual: run a multi-turn conversation, kill the agent mid-tool-call, query the session DB — messages up to the last completed turn are present
4. Manual: set `session.write_through_flush: false` in `~/.hermes/config.yaml`, repeat — DB only has messages from the final `_persist_session` call

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(session):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora 43 (Bazzite), Python 3.14.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — config read + conditional method call, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A