### PR TITLE
feat: upgrade MiniMax default model from M2.5 to M2.7

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -110,6 +110,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     "gemini-3.1-pro": 1048576,
     "gemini-3-pro": 1048576,
     "gemini-3-flash": 1048576,
+    "minimax-m2.7": 204800,
+    "minimax-m2.7-highspeed": 204800,
     "minimax-m2.5": 204800,
     "minimax-m2.5-free": 204800,
     "minimax-m2.1": 204800,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1466,11 +1466,15 @@ _PROVIDER_MODELS = {
         "kimi-k2-0905-preview",
     ],
     "minimax": [
+        "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
     ],
     "minimax-cn": [
+        "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -39,7 +39,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("qwen/qwen3.5-plus-02-15",         ""),
     ("qwen/qwen3.5-35b-a3b",            ""),
     ("stepfun/step-3.5-flash",          ""),
-    ("minimax/minimax-m2.5",            ""),
+    ("minimax/minimax-m2.7",            ""),
     ("z-ai/glm-5",                      ""),
     ("z-ai/glm-5-turbo",                ""),
     ("moonshotai/kimi-k2.5",            ""),

--- a/tests/test_setup_model_selection.py
+++ b/tests/test_setup_model_selection.py
@@ -32,8 +32,8 @@ class TestSetupProviderModelSelection:
     @pytest.mark.parametrize("provider_id,expected_defaults", [
         ("zai", ["glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"]),
         ("kimi-coding", ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"]),
-        ("minimax", ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
-        ("minimax-cn", ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
+        ("minimax", ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
+        ("minimax-cn", ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
     ])
     @patch("hermes_cli.models.fetch_api_models", return_value=[])
     @patch("hermes_cli.config.get_env_value", return_value="fake-key")


### PR DESCRIPTION
## Summary

Upgrades the MiniMax model references from M2.5 to M2.7 across the codebase:

- **hermes_cli/main.py**: Add `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` to `_PROVIDER_MODELS` for both `minimax` and `minimax-cn` providers
- **agent/model_metadata.py**: Add `minimax-m2.7` and `minimax-m2.7-highspeed` bare model IDs to `DEFAULT_CONTEXT_LENGTHS` for proper context window lookups
- **hermes_cli/models.py**: Upgrade router model reference from `minimax/minimax-m2.5` to `minimax/minimax-m2.7`
- **tests/test_setup_model_selection.py**: Update test expectations to include M2.7 models in provider model lists

## Context

MiniMax M2.7 is the latest model release from MiniMax, succeeding M2.5. The M2.7 model offers improved performance while maintaining the same 204K context window. This PR ensures M2.7 is available as the top model option for users selecting MiniMax providers.

## Test plan

- [x] All changed files pass Python syntax validation
- [x] Test expectations updated to match new model lists
