### PR TITLE
fix(security): catch sensitive path writes in approval checks

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -328,6 +328,16 @@ class TestTeePattern:
         assert dangerous is True
         assert key is not None
 
+    def test_tee_custom_hermes_home_env(self):
+        dangerous, key, desc = detect_dangerous_command("echo x | tee $HERMES_HOME/.env")
+        assert dangerous is True
+        assert key is not None
+
+    def test_tee_quoted_custom_hermes_home_env(self):
+        dangerous, key, desc = detect_dangerous_command('echo x | tee "$HERMES_HOME/.env"')
+        assert dangerous is True
+        assert key is not None
+
     def test_tee_tmp_safe(self):
         dangerous, key, desc = detect_dangerous_command("echo hello | tee /tmp/output.txt")
         assert dangerous is False
@@ -359,6 +369,30 @@ class TestFindExecFullPathRm:
 
     def test_find_print_safe(self):
         dangerous, key, desc = detect_dangerous_command("find . -name '*.py' -print")
+        assert dangerous is False
+        assert key is None
+
+
+class TestSensitiveRedirectPattern:
+    """Detect shell redirection writes to sensitive user-managed paths."""
+
+    def test_redirect_to_custom_hermes_home_env(self):
+        dangerous, key, desc = detect_dangerous_command("echo x > $HERMES_HOME/.env")
+        assert dangerous is True
+        assert key is not None
+
+    def test_append_to_home_ssh_authorized_keys(self):
+        dangerous, key, desc = detect_dangerous_command("cat key >> $HOME/.ssh/authorized_keys")
+        assert dangerous is True
+        assert key is not None
+
+    def test_append_to_tilde_ssh_authorized_keys(self):
+        dangerous, key, desc = detect_dangerous_command("cat key >> ~/.ssh/authorized_keys")
+        assert dangerous is True
+        assert key is not None
+
+    def test_redirect_to_safe_tmp_file(self):
+        dangerous, key, desc = detect_dangerous_command("echo hello > /tmp/output.txt")
         assert dangerous is False
         assert key is None
 
@@ -463,4 +497,3 @@ class TestForkBombDetection:
     def test_colon_in_safe_command_not_flagged(self):
         dangerous, key, desc = detect_dangerous_command("echo hello:world")
         assert dangerous is False
-

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -17,6 +17,21 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# Sensitive write targets that should trigger approval even when referenced
+# via shell expansions like $HOME or $HERMES_HOME.
+_SSH_SENSITIVE_PATH = r'(?:~|\$home|\$\{home\})/\.ssh(?:/|$)'
+_HERMES_ENV_PATH = (
+    r'(?:~\/\.hermes/|'
+    r'(?:\$home|\$\{home\})/\.hermes/|'
+    r'(?:\$hermes_home|\$\{hermes_home\})/)'
+    r'\.env\b'
+)
+_SENSITIVE_WRITE_TARGET = (
+    r'(?:/etc/|/dev/sd|'
+    rf'{_SSH_SENSITIVE_PATH}|'
+    rf'{_HERMES_ENV_PATH})'
+)
+
 # =========================================================================
 # Dangerous command patterns
 # =========================================================================
@@ -45,7 +60,8 @@ DANGEROUS_PATTERNS = [
     (r'\b(python[23]?|perl|ruby|node)\s+-[ec]\s+', "script execution via -e/-c flag"),
     (r'\b(curl|wget)\b.*\|\s*(ba)?sh\b', "pipe remote content to shell"),
     (r'\b(bash|sh|zsh|ksh)\s+<\s*<?\s*\(\s*(curl|wget)\b', "execute remote script via process substitution"),
-    (r'\btee\b.*(/etc/|/dev/sd|\.ssh/|\.hermes/\.env)', "overwrite system file via tee"),
+    (rf'\btee\b.*["\']?{_SENSITIVE_WRITE_TARGET}', "overwrite system file via tee"),
+    (rf'>>?\s*["\']?{_SENSITIVE_WRITE_TARGET}', "overwrite system file via redirection"),
     (r'\bxargs\s+.*\brm\b', "xargs with rm"),
     (r'\bfind\b.*-exec\s+(/\S*/)?rm\b', "find -exec rm"),
     (r'\bfind\b.*-delete\b', "find -delete"),


### PR DESCRIPTION
## What does this PR do?
Fixes dangerous-command approval checks that missed sensitive path writes when the target path was expressed via shell expansions or redirection.

Previously, commands like these could bypass approval detection:
- `echo x | tee $HERMES_HOME/.env`
- `echo x > $HERMES_HOME/.env`
- `cat key >> $HOME/.ssh/authorized_keys`
- `cat key >> ~/.ssh/authorized_keys`

This change expands the approval patterns to catch those cases and adds regression tests.

## Type of Change
- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made
- Added sensitive path matching for `$HERMES_HOME/.env`
- Added approval coverage for `>` / `>>` writes to sensitive paths
- Added regression tests for env-expanded and redirection-based writes

## How to Test
1. Run `source .venv/bin/activate`
2. Run `pytest -o addopts='' tests/tools/test_approval.py -q`
3. Run `pytest -o addopts='' tests/tools/test_yolo_mode.py -q`
4. Confirm commands targeting `$HERMES_HOME/.env` and `authorized_keys` are flagged, while safe writes like `/tmp/output.txt` are not
