### PR TITLE
fix(skills): block path traversal during quarantine install

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -308,7 +308,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     """Fetch, quarantine, scan, confirm, and install a skill."""
     from tools.skills_hub import (
         GitHubAuth, create_source_router, ensure_hub_dirs,
-        quarantine_bundle, install_from_quarantine, HubLockFile,
+        quarantine_bundle, install_from_quarantine, HubLockFile, append_audit_log,
     )
     from tools.skills_guard import scan_skill, should_allow_install, format_scan_report
 
@@ -352,7 +352,13 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     extra_metadata.update(getattr(bundle, "metadata", {}) or {})
 
     # Quarantine the bundle
-    q_path = quarantine_bundle(bundle)
+    try:
+        q_path = quarantine_bundle(bundle)
+    except ValueError as exc:
+        c.print(f"[bold red]Installation blocked:[/] {exc}\n")
+        append_audit_log("BLOCKED", bundle.name, bundle.source,
+                         bundle.trust_level, "invalid_bundle_path", str(exc))
+        return
     c.print(f"[dim]Quarantined to {q_path.relative_to(q_path.parent.parent.parent)}[/]")
 
     # Scan
@@ -411,7 +417,14 @@ def do_install(identifier: str, category: str = "", force: bool = False,
             return
 
     # Install
-    install_dir = install_from_quarantine(q_path, bundle.name, category, bundle, result)
+    try:
+        install_dir = install_from_quarantine(q_path, bundle.name, category, bundle, result)
+    except ValueError as exc:
+        shutil.rmtree(q_path, ignore_errors=True)
+        c.print(f"[bold red]Installation blocked:[/] {exc}\n")
+        append_audit_log("BLOCKED", bundle.name, bundle.source,
+                         bundle.trust_level, "invalid_install_path", str(exc))
+        return
     from tools.skills_hub import SKILLS_DIR
     c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from tools.skills_hub import (
     GitHubAuth,
     GitHubSource,
@@ -22,6 +24,7 @@ from tools.skills_hub import (
     append_audit_log,
     _skill_meta_to_dict,
     quarantine_bundle,
+    install_from_quarantine,
 )
 
 
@@ -891,3 +894,77 @@ class TestQuarantineBundleBinaryAssets:
 
         assert (q_path / "SKILL.md").read_text(encoding="utf-8").startswith("---")
         assert (q_path / "assets" / "neutts-cli" / "samples" / "jo.wav").read_bytes() == b"RIFF\x00\x01fakewav"
+
+    def test_quarantine_bundle_rejects_absolute_and_traversal_paths(self, tmp_path):
+        import tools.skills_hub as hub
+
+        hub_dir = tmp_path / "skills" / ".hub"
+        abs_target = tmp_path / "abs-write.txt"
+        escaped_target = tmp_path / "skills" / "escaped.txt"
+
+        with patch.object(hub, "SKILLS_DIR", tmp_path / "skills"), \
+             patch.object(hub, "HUB_DIR", hub_dir), \
+             patch.object(hub, "LOCK_FILE", hub_dir / "lock.json"), \
+             patch.object(hub, "QUARANTINE_DIR", hub_dir / "quarantine"), \
+             patch.object(hub, "AUDIT_LOG", hub_dir / "audit.log"), \
+             patch.object(hub, "TAPS_FILE", hub_dir / "taps.json"), \
+             patch.object(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache"):
+            bundle = SkillBundle(
+                name="evil-skill",
+                files={
+                    str(abs_target): "ABS",
+                    "../../../escaped.txt": "TRAVERSAL",
+                    "SKILL.md": "---\nname: evil-skill\n---\n",
+                },
+                source="community",
+                identifier="evil/skill",
+                trust_level="community",
+            )
+
+            with pytest.raises(ValueError, match="relative|escapes"):
+                quarantine_bundle(bundle)
+
+        assert not abs_target.exists()
+        assert not escaped_target.exists()
+
+
+class TestInstallFromQuarantinePathValidation:
+    def test_rejects_traversal_in_install_target(self, tmp_path):
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        hub_dir = tmp_path / "skills" / ".hub"
+        quarantine_path = hub_dir / "quarantine" / "demo"
+        quarantine_path.mkdir(parents=True)
+        (quarantine_path / "SKILL.md").write_text("---\nname: demo\n---\n", encoding="utf-8")
+
+        with patch.object(hub, "SKILLS_DIR", tmp_path / "skills"), \
+             patch.object(hub, "HUB_DIR", hub_dir), \
+             patch.object(hub, "LOCK_FILE", hub_dir / "lock.json"), \
+             patch.object(hub, "QUARANTINE_DIR", hub_dir / "quarantine"), \
+             patch.object(hub, "AUDIT_LOG", hub_dir / "audit.log"), \
+             patch.object(hub, "TAPS_FILE", hub_dir / "taps.json"), \
+             patch.object(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache"):
+            bundle = SkillBundle(
+                name="demo",
+                files={"SKILL.md": "---\nname: demo\n---\n"},
+                source="community",
+                identifier="evil/skill",
+                trust_level="community",
+            )
+            scan_result = ScanResult(
+                skill_name="demo",
+                source="community",
+                trust_level="community",
+                verdict="safe",
+                findings=[],
+            )
+
+            with pytest.raises(ValueError, match="escapes|single path segment"):
+                install_from_quarantine(
+                    quarantine_path,
+                    "../escaped",
+                    "",
+                    bundle,
+                    scan_result,
+                )

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -24,7 +24,7 @@ import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse, urlunparse
 
@@ -53,6 +53,29 @@ INDEX_CACHE_DIR = HUB_DIR / "index-cache"
 
 # Cache duration for remote index fetches
 INDEX_CACHE_TTL = 3600  # 1 hour
+
+
+# ---------------------------------------------------------------------------
+# Path validation
+# ---------------------------------------------------------------------------
+
+def _sanitize_bundle_subpath(path: str, *, allow_nested: bool) -> str:
+    """Normalize a bundle-controlled path and reject traversal/absolute writes."""
+    raw = str(path or "").strip()
+    if not raw:
+        raise ValueError("Skill bundle contains an empty path")
+
+    normalized = raw.replace("\\", "/")
+    if normalized.startswith("/") or re.match(r"^[A-Za-z]:/", normalized):
+        raise ValueError(f"Skill bundle path must be relative: {path!r}")
+
+    parts = [part for part in PurePosixPath(normalized).parts if part not in ("", ".")]
+    if not parts or any(part == ".." for part in parts):
+        raise ValueError(f"Skill bundle path escapes the install directory: {path!r}")
+    if not allow_nested and len(parts) != 1:
+        raise ValueError(f"Skill bundle name must be a single path segment: {path!r}")
+
+    return str(PurePosixPath(*parts))
 
 
 # ---------------------------------------------------------------------------
@@ -2254,12 +2277,18 @@ def ensure_hub_dirs() -> None:
 def quarantine_bundle(bundle: SkillBundle) -> Path:
     """Write a skill bundle to the quarantine directory for scanning."""
     ensure_hub_dirs()
-    dest = QUARANTINE_DIR / bundle.name
+    safe_name = _sanitize_bundle_subpath(bundle.name, allow_nested=False)
+    sanitized_files: dict[str, Union[str, bytes]] = {}
+    for rel_path, file_content in bundle.files.items():
+        safe_rel_path = _sanitize_bundle_subpath(rel_path, allow_nested=True)
+        sanitized_files[safe_rel_path] = file_content
+
+    dest = QUARANTINE_DIR / safe_name
     if dest.exists():
         shutil.rmtree(dest)
     dest.mkdir(parents=True)
 
-    for rel_path, file_content in bundle.files.items():
+    for rel_path, file_content in sanitized_files.items():
         file_dest = dest / rel_path
         file_dest.parent.mkdir(parents=True, exist_ok=True)
         if isinstance(file_content, bytes):
@@ -2278,10 +2307,13 @@ def install_from_quarantine(
     scan_result: ScanResult,
 ) -> Path:
     """Move a scanned skill from quarantine into the skills directory."""
-    if category:
-        install_dir = SKILLS_DIR / category / skill_name
+    safe_skill_name = _sanitize_bundle_subpath(skill_name, allow_nested=False)
+    safe_category = _sanitize_bundle_subpath(category, allow_nested=True) if category else ""
+
+    if safe_category:
+        install_dir = SKILLS_DIR / safe_category / safe_skill_name
     else:
-        install_dir = SKILLS_DIR / skill_name
+        install_dir = SKILLS_DIR / safe_skill_name
 
     if install_dir.exists():
         shutil.rmtree(install_dir)


### PR DESCRIPTION
## What does this PR do?
Fixes a path traversal issue in Skills Hub quarantine/install handling.

Previously, `quarantine_bundle()` trusted bundle-controlled file paths and wrote them to disk before scanning. That meant a malicious bundle could use absolute paths or `..` segments to write outside the quarantine directory before the security scan ran.

This change validates bundle names, bundle file paths, and install targets before writing or moving anything on disk.

## Type of Change
- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made
- Reject absolute paths and traversal segments in skill bundle file paths
- Reject invalid bundle names and install target paths
- Block invalid bundle installs cleanly in the CLI with audit logging
- Added regression tests covering quarantine and install path validation

## How to Test
1. Run `source .venv/bin/activate`
2. Run `pytest -o addopts='' tests/tools/test_skills_hub.py -q`
3. Confirm bundles with paths like `/tmp/file.txt` or `../../../outside.txt` are rejected
4. Confirm normal nested skill files like `assets/...` still install correctly
