### PR TITLE
fix(skills): block category path traversal in skill manager

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from tools.skill_manager_tool import (
     _validate_name,
+    _validate_category,
     _validate_frontmatter,
     _validate_file_path,
     _find_skill,
@@ -80,6 +81,22 @@ class TestValidateName:
         assert "Invalid skill name 'skill name'" in err
         err = _validate_name("skill@name")
         assert "Invalid skill name 'skill@name'" in err
+
+
+class TestValidateCategory:
+    def test_valid_categories(self):
+        assert _validate_category(None) is None
+        assert _validate_category("") is None
+        assert _validate_category("devops") is None
+        assert _validate_category("mlops-v2") is None
+
+    def test_path_traversal_rejected(self):
+        err = _validate_category("../escape")
+        assert "Invalid category '../escape'" in err
+
+    def test_absolute_path_rejected(self):
+        err = _validate_category("/tmp/escape")
+        assert "Invalid category '/tmp/escape'" in err
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +207,29 @@ class TestCreateSkill:
         with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path):
             result = _create_skill("my-skill", "no frontmatter here")
         assert result["success"] is False
+
+    def test_create_rejects_category_traversal(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir):
+            result = _create_skill("my-skill", VALID_SKILL_CONTENT, category="../escape")
+
+        assert result["success"] is False
+        assert "Invalid category '../escape'" in result["error"]
+        assert not (tmp_path / "escape").exists()
+
+    def test_create_rejects_absolute_category(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        outside = tmp_path / "outside"
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir):
+            result = _create_skill("my-skill", VALID_SKILL_CONTENT, category=str(outside))
+
+        assert result["success"] is False
+        assert f"Invalid category '{outside}'" in result["error"]
+        assert not (outside / "my-skill" / "SKILL.md").exists()
 
 
 class TestEditSkill:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -106,6 +106,31 @@ def _validate_name(name: str) -> Optional[str]:
     return None
 
 
+def _validate_category(category: Optional[str]) -> Optional[str]:
+    """Validate an optional category name used as a single directory segment."""
+    if category is None:
+        return None
+    if not isinstance(category, str):
+        return "Category must be a string."
+
+    category = category.strip()
+    if not category:
+        return None
+    if "/" in category or "\\" in category:
+        return (
+            f"Invalid category '{category}'. Use lowercase letters, numbers, "
+            "hyphens, dots, and underscores. Categories must be a single directory name."
+        )
+    if len(category) > MAX_NAME_LENGTH:
+        return f"Category exceeds {MAX_NAME_LENGTH} characters."
+    if not VALID_NAME_RE.match(category):
+        return (
+            f"Invalid category '{category}'. Use lowercase letters, numbers, "
+            "hyphens, dots, and underscores. Categories must be a single directory name."
+        )
+    return None
+
+
 def _validate_frontmatter(content: str) -> Optional[str]:
     """
     Validate that SKILL.md content has proper frontmatter with required fields.
@@ -231,6 +256,10 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     """Create a new user skill with SKILL.md content."""
     # Validate name
     err = _validate_name(name)
+    if err:
+        return {"success": False, "error": err}
+
+    err = _validate_category(category)
     if err:
         return {"success": False, "error": err}
 


### PR DESCRIPTION
## What does this PR do?
Fixes a path traversal issue in `skill_manage(create, ...)` when `category` is provided.

Previously, `category` was used directly as a filesystem path segment without validation. That meant values like `../escape` could write a new skill outside `~/.hermes/skills`.

This change validates category names as single safe directory names before creating the skill.

## Type of Change
- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made
- Added category validation for skill creation
- Reject traversal and absolute-path style category values
- Added regression tests covering invalid category inputs

## How to Test
1. Run `source .venv/bin/activate`
2. Run `pytest tests/tools/test_skill_manager_tool.py -q`
3. Verify normal categories like `devops` still work
4. Verify categories like `../escape` and absolute paths are rejected
