### PR TITLE
fix(agent): normalize parallel file operation paths

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -308,8 +308,11 @@ def _extract_parallel_scope_path(tool_name: str, function_args: dict) -> Path | 
     if not isinstance(raw_path, str) or not raw_path.strip():
         return None
 
-    # Avoid resolve(); the file may not exist yet.
-    return Path(raw_path).expanduser()
+    # Avoid resolve(); the file may not exist yet. But do collapse lexical
+    # aliases like "./" and "../" so same-target writes do not get
+    # misclassified as independent and run concurrently.
+    normalized = os.path.normpath(os.path.expanduser(raw_path.strip()))
+    return Path(normalized)
 
 
 def _paths_overlap(left: Path, right: Path) -> bool:

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1086,6 +1086,27 @@ class TestPathsOverlap:
         assert not _paths_overlap(Path("src/a.py"), Path(""))
 
 
+class TestParallelScopeNormalization:
+    def test_extract_parallel_scope_path_normalizes_dotdot_segments(self):
+        from run_agent import _extract_parallel_scope_path
+
+        assert _extract_parallel_scope_path("write_file", {"path": "subdir/../notes.txt"}) == Path("notes.txt")
+
+    def test_same_effective_path_disables_parallel_batch(self):
+        from run_agent import _should_parallelize_tool_batch
+
+        tool_calls = [
+            _mock_tool_call("write_file", json.dumps({"path": "notes.txt", "content": "a"})),
+            _mock_tool_call("patch", json.dumps({
+                "path": "subdir/../notes.txt",
+                "old_string": "a",
+                "new_string": "b",
+            })),
+        ]
+
+        assert _should_parallelize_tool_batch(tool_calls) is False
+
+
 class TestHandleMaxIterations:
     def test_returns_summary(self, agent):
         resp = _mock_response(content="Here is a summary of what I did.")


### PR DESCRIPTION
## What does this PR do?
Fixes a parallel tool execution safety bug in the agent run loop.

Previously, path-scoped file operations were compared using raw lexical paths. That meant two tool calls targeting the same file through different path spellings (for example `notes.txt` and `subdir/../notes.txt`) could be misclassified as independent and executed in parallel.

This change normalizes path-scoped tool targets before overlap checks so same-target file operations fall back to sequential execution.

## Type of Change
- [x] Bug fix
- [x] Safety fix
- [x] Tests

## Changes Made
- Normalize path-scoped file operation targets before overlap detection
- Prevent same-file alias paths from being treated as independent
- Added regression tests for normalized overlap detection

## How to Test
1. Run `source .venv/bin/activate`
2. Run `pytest tests/test_run_agent.py -q -k 'ParallelScopeNormalization or TestPathsOverlap'`
3. Confirm `notes.txt` and `subdir/../notes.txt` are treated as overlapping
4. Confirm the batch falls back to sequential execution
