### PR TITLE
fix: respect config.yaml model.base_url for Anthropic provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -654,10 +654,23 @@ def _try_anthropic() -> Tuple[Optional[Any], Optional[str]]:
     if not token:
         return None, None
 
+    # Allow base URL override from config.yaml model.base_url
+    base_url = _ANTHROPIC_DEFAULT_BASE_URL
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        model_cfg = cfg.get("model")
+        if isinstance(model_cfg, dict):
+            cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
+            if cfg_base_url:
+                base_url = cfg_base_url
+    except Exception:
+        pass
+
     model = _API_KEY_PROVIDER_AUX_MODELS.get("anthropic", "claude-haiku-4-5-20251001")
-    logger.debug("Auxiliary client: Anthropic native (%s)", model)
-    real_client = build_anthropic_client(token, _ANTHROPIC_DEFAULT_BASE_URL)
-    return AnthropicAuxiliaryClient(real_client, model, token, _ANTHROPIC_DEFAULT_BASE_URL), model
+    logger.debug("Auxiliary client: Anthropic native (%s) at %s", model, base_url)
+    real_client = build_anthropic_client(token, base_url)
+    return AnthropicAuxiliaryClient(real_client, model, token, base_url), model
 
 
 def _resolve_forced_provider(forced: str) -> Tuple[Optional[OpenAI], Optional[str]]:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -307,10 +307,14 @@ def resolve_runtime_provider(
                 "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
                 "run 'claude setup-token', or authenticate with 'claude /login'."
             )
+        # Allow base URL override from config.yaml model.base_url
+        model_cfg = _get_model_config()
+        cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
+        base_url = cfg_base_url or "https://api.anthropic.com"
         return {
             "provider": "anthropic",
             "api_mode": "anthropic_messages",
-            "base_url": "https://api.anthropic.com",
+            "base_url": base_url,
             "api_key": token,
             "source": "env",
             "requested_provider": requested_provider,


### PR DESCRIPTION
## Summary

Fixes #1948 — Anthropic provider base URL is hardcoded after #1675 removed `ANTHROPIC_BASE_URL` env var.

## Problem

After #1675, the Anthropic provider always uses `https://api.anthropic.com` regardless of `config.yaml` settings. Users who need Anthropic-compatible proxies (Sub2API, LiteLLM, etc.) have no configuration path.

## Changes

**`hermes_cli/runtime_provider.py`**
- Read `model.base_url` from config.yaml when resolving the Anthropic provider
- Fall back to `https://api.anthropic.com` when not set (zero behavior change for default users)

**`agent/auxiliary_client.py`**
- Same change in `_try_anthropic()` for auxiliary client (vision, compression, etc.)
- Wrapped in try/except to avoid breaking if config loading fails

## Usage

```yaml
# config.yaml
model:
  default: anthropic/claude-opus-4.6
  provider: anthropic
  base_url: http://localhost:8080  # now respected
```

## Testing

- 106 auxiliary-related tests pass
- No behavior change when `model.base_url` is not set
- Consistent with how alibaba and other providers already handle base URL overrides