### PR TITLE
feat(honcho): support instance-local config via HERMES_HOME

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2795,6 +2795,17 @@ class HermesCLI:
             if hasattr(self.agent, "_invalidate_system_prompt"):
                 self.agent._invalidate_system_prompt()
 
+            # Tools-mode startup prewarm: fire in background so first turn
+            # gets lightweight personalization without blocking.
+            _hcfg = getattr(self.agent, "_honcho_config", None)
+            if (
+                _hcfg is not None
+                and getattr(_hcfg, "recall_mode", None) == "tools"
+                and getattr(_hcfg, "tools_startup_context", False)
+                and getattr(_hcfg, "peer_name", None)
+            ):
+                self.agent._schedule_honcho_startup_prewarm(_hcfg.peer_name)
+
             if self._session_db:
                 try:
                     self._session_db.create_session(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -494,6 +494,32 @@ class GatewayRunner:
         except Exception as exc:
             logger.debug("Gateway Honcho startup prewarm setup failed: %s", exc)
 
+    def _pop_gateway_honcho_startup_snapshot(self, honcho_config) -> dict | None:
+        """Return and clear a cached startup snapshot for the configured Honcho peer.
+
+        Gateway keeps startup snapshots process-wide because each incoming message
+        creates a fresh AIAgent instance. This helper hands the cached snapshot to
+        the next agent exactly once when tools-mode startup context is enabled.
+        """
+        if not honcho_config:
+            return None
+        if getattr(honcho_config, "recall_mode", None) != "tools":
+            return None
+        if not getattr(honcho_config, "tools_startup_context", False):
+            return None
+        peer_id = getattr(honcho_config, "peer_name", None)
+        if not peer_id:
+            return None
+
+        cache = getattr(self, "_honcho_startup_cache", None)
+        if not cache:
+            return None
+
+        snapshot = cache.pop(peer_id, None)
+        if not snapshot:
+            return None
+        return {peer_id: snapshot}
+
     # -- Setup skill availability ----------------------------------------
 
     def _has_setup_skill(self) -> bool:
@@ -4850,6 +4876,7 @@ class GatewayRunner:
 
             pr = self._provider_routing
             honcho_manager, honcho_config = self._get_or_create_gateway_honcho(session_key)
+            startup_snapshot = self._pop_gateway_honcho_startup_snapshot(honcho_config)
             reasoning_config = self._load_reasoning_config()
             self._reasoning_config = reasoning_config
             # Set up streaming consumer if enabled
@@ -4910,6 +4937,8 @@ class GatewayRunner:
                 session_db=self._session_db,
                 fallback_model=self._fallback_model,
             )
+            if startup_snapshot:
+                agent._honcho_startup_snapshot = startup_snapshot
             
             # Store agent reference for interrupt support
             agent_holder[0] = agent

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -441,6 +441,59 @@ class GatewayRunner:
         for session_key in list(managers.keys()):
             self._shutdown_gateway_honcho(session_key)
     
+    def _schedule_gateway_honcho_startup_prewarm(self, session_key: str) -> None:
+        """Fire background Honcho startup prewarm for tools mode after session reset.
+
+        Non-blocking. Snapshot stored in self._honcho_startup_cache keyed by
+        peer_name (stable Honcho identity, not ephemeral session key).
+        Consumed on the first real turn of the new session via the RunAgent
+        instance created for that turn.
+        """
+        try:
+            from honcho_integration.client import HonchoClientConfig, get_honcho_client
+            from honcho_integration.session import HonchoSessionManager
+            import threading as _threading
+
+            hcfg = HonchoClientConfig.from_global_config()
+            if (
+                not hcfg.enabled
+                or not hcfg.api_key
+                or hcfg.recall_mode != "tools"
+                or not hcfg.tools_startup_context
+                or not hcfg.peer_name
+            ):
+                return
+
+            peer_id = hcfg.peer_name
+            if not hasattr(self, "_honcho_startup_cache"):
+                self._honcho_startup_cache: dict = {}
+
+            def _run():
+                try:
+                    client = get_honcho_client(hcfg)
+                    manager = HonchoSessionManager(
+                        honcho=client,
+                        config=hcfg,
+                        context_tokens=hcfg.context_tokens,
+                    )
+                    snapshot = manager.fetch_startup_snapshot(peer_id)
+                    if snapshot:
+                        self._honcho_startup_cache[peer_id] = snapshot
+                        logger.debug(
+                            "Gateway Honcho startup snapshot ready for peer %s", peer_id
+                        )
+                except Exception as exc:
+                    logger.debug(
+                        "Gateway Honcho startup prewarm failed (non-fatal): %s", exc
+                    )
+
+            t = _threading.Thread(
+                target=_run, name="honcho-gw-startup-prewarm", daemon=True
+            )
+            t.start()
+        except Exception as exc:
+            logger.debug("Gateway Honcho startup prewarm setup failed: %s", exc)
+
     # -- Setup skill availability ----------------------------------------
 
     def _has_setup_skill(self) -> bool:
@@ -2363,6 +2416,9 @@ class GatewayRunner:
 
         self._shutdown_gateway_honcho(session_key)
         
+        # Tools-mode startup prewarm for next session
+        self._schedule_gateway_honcho_startup_prewarm(session_key)
+
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -717,13 +717,14 @@ def run_doctor(args):
     print(color("◆ Honcho Memory", Colors.CYAN, Colors.BOLD))
 
     try:
-        from honcho_integration.client import HonchoClientConfig, GLOBAL_CONFIG_PATH
+        from honcho_integration.client import HonchoClientConfig, resolve_config_path
         hcfg = HonchoClientConfig.from_global_config()
+        _honcho_cfg_path = resolve_config_path()
 
-        if not GLOBAL_CONFIG_PATH.exists():
+        if not _honcho_cfg_path.exists():
             check_warn("Honcho config not found", f"run: hermes honcho setup")
         elif not hcfg.enabled:
-            check_info("Honcho disabled (set enabled: true in ~/.honcho/config.json to activate)")
+            check_info(f"Honcho disabled (set enabled: true in {_honcho_cfg_path} to activate)")
         elif not hcfg.api_key:
             check_fail("Honcho API key not set", "run: hermes honcho setup")
             issues.append("No Honcho API key — run 'hermes honcho setup'")

--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -162,10 +162,10 @@ def cmd_setup(args) -> None:
         hermes_host["recallMode"] = new_recall
 
     # Session strategy
-    current_strat = hermes_host.get("sessionStrategy") or cfg.get("sessionStrategy", "per-session")
+    current_strat = hermes_host.get("sessionStrategy") or cfg.get("sessionStrategy", "per-directory")
     print(f"\n  Session strategy options:")
-    print("    per-session   — new Honcho session each run, named by Hermes session ID (default)")
-    print("    per-directory — one session per working directory")
+    print("    per-directory — one session per working directory (default)")
+    print("    per-session   — new Honcho session each run, named by Hermes session ID")
     print("    per-repo      — one session per git repository (uses repo root name)")
     print("    global        — single session across all directories")
     new_strat = _prompt("Session strategy", default=current_strat)

--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -39,6 +39,22 @@ def _write_config(cfg: dict, path: Path | None = None) -> None:
     )
 
 
+def _host_block(cfg: dict) -> dict:
+    return ((cfg.get("hosts") or {}).get(HOST) or {})
+
+
+def _ensure_host_block(cfg: dict) -> dict:
+    return cfg.setdefault("hosts", {}).setdefault(HOST, {})
+
+
+def _effective_value(cfg: dict, key: str, default=None):
+    """Resolve host-scoped config with root fallback, preserving explicit False."""
+    host_val = _host_block(cfg).get(key)
+    if host_val is not None:
+        return host_val
+    return cfg.get(key, default)
+
+
 def _resolve_api_key(cfg: dict) -> str:
     """Resolve API key with host -> root -> env fallback."""
     host_key = ((cfg.get("hosts") or {}).get(HOST) or {}).get("apiKey")
@@ -59,6 +75,19 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
     else:
         val = sys.stdin.readline().strip()
     return val or (default or "")
+
+
+def _parse_bool(value: str, default: bool = False) -> bool:
+    if value is None:
+        return default
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return default
+    if normalized in {"y", "yes", "true", "1", "on"}:
+        return True
+    if normalized in {"n", "no", "false", "0", "off"}:
+        return False
+    return default
 
 
 def _ensure_sdk_installed() -> bool:
@@ -109,8 +138,7 @@ def cmd_setup(args) -> None:
 
     # All writes go to hosts.hermes — root keys are managed by the user
     # or the honcho CLI only.
-    hosts = cfg.setdefault("hosts", {})
-    hermes_host = hosts.setdefault(HOST, {})
+    hermes_host = _ensure_host_block(cfg)
 
     # API key — shared credential, lives at root so all hosts can read it
     current_key = cfg.get("apiKey", "")
@@ -127,12 +155,12 @@ def cmd_setup(args) -> None:
         return
 
     # Peer name
-    current_peer = hermes_host.get("peerName") or cfg.get("peerName", "")
+    current_peer = _effective_value(cfg, "peerName", "")
     new_peer = _prompt("Your name (user peer)", default=current_peer or os.getenv("USER", "user"))
     if new_peer:
         hermes_host["peerName"] = new_peer
 
-    current_workspace = hermes_host.get("workspace") or cfg.get("workspace", "hermes")
+    current_workspace = _effective_value(cfg, "workspace", "hermes")
     new_workspace = _prompt("Workspace ID", default=current_workspace)
     if new_workspace:
         hermes_host["workspace"] = new_workspace
@@ -140,7 +168,7 @@ def cmd_setup(args) -> None:
     hermes_host.setdefault("aiPeer", HOST)
 
     # Memory mode
-    current_mode = hermes_host.get("memoryMode") or cfg.get("memoryMode", "hybrid")
+    current_mode = _effective_value(cfg, "memoryMode", "hybrid")
     print(f"\n  Memory mode options:")
     print("    hybrid  — write to both Honcho and local MEMORY.md (default)")
     print("    honcho  — Honcho only, skip MEMORY.md writes")
@@ -151,7 +179,7 @@ def cmd_setup(args) -> None:
         hermes_host["memoryMode"] = "hybrid"
 
     # Write frequency
-    current_wf = str(hermes_host.get("writeFrequency") or cfg.get("writeFrequency", "async"))
+    current_wf = str(_effective_value(cfg, "writeFrequency", "async"))
     print(f"\n  Write frequency options:")
     print("    async   — background thread, no token cost (recommended)")
     print("    turn    — sync write after every turn")
@@ -164,7 +192,7 @@ def cmd_setup(args) -> None:
         hermes_host["writeFrequency"] = new_wf if new_wf in ("async", "turn", "session") else "async"
 
     # Recall mode
-    _raw_recall = hermes_host.get("recallMode") or cfg.get("recallMode", "hybrid")
+    _raw_recall = _effective_value(cfg, "recallMode", "hybrid")
     current_recall = "hybrid" if _raw_recall not in ("hybrid", "context", "tools") else _raw_recall
     print(f"\n  Recall mode options:")
     print("    hybrid  — auto-injected context + Honcho tools available (default)")
@@ -174,8 +202,22 @@ def cmd_setup(args) -> None:
     if new_recall in ("hybrid", "context", "tools"):
         hermes_host["recallMode"] = new_recall
 
+    current_startup_ctx = bool(_effective_value(cfg, "toolsStartupContext", False))
+    startup_default = "y" if current_startup_ctx else "n"
+    print(f"\n  Tools startup context:")
+    print("    y — in recallMode=tools, inject lightweight startup memory on first turn")
+    print("    n — keep tools mode cold-start behavior")
+    startup_answer = _prompt(
+        "Enable lightweight startup context in tools mode? (y/n)",
+        default=startup_default,
+    )
+    hermes_host["toolsStartupContext"] = _parse_bool(
+        startup_answer,
+        default=current_startup_ctx,
+    )
+
     # Session strategy
-    current_strat = hermes_host.get("sessionStrategy") or cfg.get("sessionStrategy", "per-directory")
+    current_strat = _effective_value(cfg, "sessionStrategy", "per-directory")
     print(f"\n  Session strategy options:")
     print("    per-directory — one session per working directory (default)")
     print("    per-session   — new Honcho session each run, named by Hermes session ID")
@@ -213,6 +255,8 @@ def cmd_setup(args) -> None:
         _mode_str = f"{hcfg.memory_mode}  (peers: {overrides})"
     print(f"  Mode:      {_mode_str}")
     print(f"  Frequency: {hcfg.write_frequency}")
+    print(f"  Recall:    {hcfg.recall_mode}")
+    print(f"  Startup:   {getattr(hcfg, 'tools_startup_context', False)}")
     print(f"\n  Honcho tools available in chat:")
     print(f"    honcho_context  — ask Honcho a question about you (LLM-synthesized)")
     print(f"    honcho_search       — semantic search over your history (no LLM)")
@@ -263,6 +307,7 @@ def cmd_status(args) -> None:
     print(f"  User peer:      {hcfg.peer_name or 'not set'}")
     print(f"  Session key:    {hcfg.resolve_session_name()}")
     print(f"  Recall mode:    {hcfg.recall_mode}")
+    print(f"  Startup ctx:    {hcfg.tools_startup_context}")
     print(f"  Memory mode:    {hcfg.memory_mode}")
     if hcfg.peer_memory_modes:
         print(f"  Per-peer modes:")
@@ -339,12 +384,10 @@ def cmd_peer(args) -> None:
 
     if user_name is None and ai_name is None and reasoning is None:
         # Show current values
-        hosts = cfg.get("hosts", {})
-        hermes = hosts.get(HOST, {})
-        user = hermes.get('peerName') or cfg.get('peerName') or '(not set)'
-        ai = hermes.get('aiPeer') or cfg.get('aiPeer') or HOST
-        lvl = hermes.get("dialecticReasoningLevel") or cfg.get("dialecticReasoningLevel") or "low"
-        max_chars = hermes.get("dialecticMaxChars") or cfg.get("dialecticMaxChars") or 600
+        user = _effective_value(cfg, 'peerName', '(not set)') or '(not set)'
+        ai = _effective_value(cfg, 'aiPeer', HOST)
+        lvl = _effective_value(cfg, "dialecticReasoningLevel", "low")
+        max_chars = _effective_value(cfg, "dialecticMaxChars", 600)
         print(f"\nHoncho peers\n" + "─" * 40)
         print(f"  User peer:   {user}")
         print(f"    Your identity in Honcho. Messages you send build this peer's card.")
@@ -389,11 +432,7 @@ def cmd_mode(args) -> None:
     mode_arg = getattr(args, "mode", None)
 
     if mode_arg is None:
-        current = (
-            (cfg.get("hosts") or {}).get(HOST, {}).get("memoryMode")
-            or cfg.get("memoryMode")
-            or "hybrid"
-        )
+        current = _effective_value(cfg, "memoryMode", "hybrid")
         print(f"\nHoncho memory mode\n" + "─" * 40)
         for m, desc in MODES.items():
             marker = " ←" if m == current else ""
@@ -413,16 +452,14 @@ def cmd_mode(args) -> None:
 def cmd_tokens(args) -> None:
     """Show or set token budget settings."""
     cfg = _read_config()
-    hosts = cfg.get("hosts", {})
-    hermes = hosts.get(HOST, {})
 
     context = getattr(args, "context", None)
     dialectic = getattr(args, "dialectic", None)
 
     if context is None and dialectic is None:
-        ctx_tokens = hermes.get("contextTokens") or cfg.get("contextTokens") or "(Honcho default)"
-        d_chars = hermes.get("dialecticMaxChars") or cfg.get("dialecticMaxChars") or 600
-        d_level = hermes.get("dialecticReasoningLevel") or cfg.get("dialecticReasoningLevel") or "low"
+        ctx_tokens = _effective_value(cfg, "contextTokens", "(Honcho default)")
+        d_chars = _effective_value(cfg, "dialecticMaxChars", 600)
+        d_level = _effective_value(cfg, "dialecticReasoningLevel", "low")
         print(f"\nHoncho budgets\n" + "─" * 40)
         print()
         print(f"  Context     {ctx_tokens} tokens")

--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -10,22 +10,30 @@ import os
 import sys
 from pathlib import Path
 
-GLOBAL_CONFIG_PATH = Path.home() / ".honcho" / "config.json"
+from honcho_integration.client import resolve_config_path, GLOBAL_CONFIG_PATH
+
 HOST = "hermes"
 
 
+def _config_path() -> Path:
+    """Return the active Honcho config path (instance-local or global)."""
+    return resolve_config_path()
+
+
 def _read_config() -> dict:
-    if GLOBAL_CONFIG_PATH.exists():
+    path = _config_path()
+    if path.exists():
         try:
-            return json.loads(GLOBAL_CONFIG_PATH.read_text(encoding="utf-8"))
+            return json.loads(path.read_text(encoding="utf-8"))
         except Exception:
             pass
     return {}
 
 
-def _write_config(cfg: dict) -> None:
-    GLOBAL_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    GLOBAL_CONFIG_PATH.write_text(
+def _write_config(cfg: dict, path: Path | None = None) -> None:
+    path = path or _config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
         json.dumps(cfg, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
@@ -87,9 +95,14 @@ def cmd_setup(args) -> None:
     """Interactive Honcho setup wizard."""
     cfg = _read_config()
 
+    active_path = _config_path()
     print("\nHoncho memory setup\n" + "─" * 40)
     print("  Honcho gives Hermes persistent cross-session memory.")
-    print("  Config is shared with other hosts at ~/.honcho/config.json\n")
+    if active_path != GLOBAL_CONFIG_PATH:
+        print(f"  Instance config: {active_path}")
+    else:
+        print("  Config is shared with other hosts at ~/.honcho/config.json")
+    print()
 
     if not _ensure_sdk_installed():
         return
@@ -176,7 +189,7 @@ def cmd_setup(args) -> None:
     hermes_host.setdefault("saveMessages", True)
 
     _write_config(cfg)
-    print(f"\n  Config written to {GLOBAL_CONFIG_PATH}")
+    print(f"\n  Config written to {active_path}")
 
     # Test connection
     print("  Testing connection... ", end="", flush=True)
@@ -223,8 +236,10 @@ def cmd_status(args) -> None:
 
     cfg = _read_config()
 
+    active_path = _config_path()
+
     if not cfg:
-        print("  No Honcho config found at ~/.honcho/config.json")
+        print(f"  No Honcho config found at {active_path}")
         print("  Run 'hermes honcho setup' to configure.\n")
         return
 
@@ -243,7 +258,7 @@ def cmd_status(args) -> None:
     print(f"  API key:        {masked}")
     print(f"  Workspace:      {hcfg.workspace_id}")
     print(f"  Host:           {hcfg.host}")
-    print(f"  Config path:    {GLOBAL_CONFIG_PATH}")
+    print(f"  Config path:    {active_path}")
     print(f"  AI peer:        {hcfg.ai_peer}")
     print(f"  User peer:      {hcfg.peer_name or 'not set'}")
     print(f"  Session key:    {hcfg.resolve_session_name()}")
@@ -275,7 +290,7 @@ def cmd_sessions(args) -> None:
     if not sessions:
         print("  No session mappings configured.\n")
         print("  Add one with: hermes honcho map <session-name>")
-        print("  Or edit ~/.honcho/config.json directly.\n")
+        print(f"  Or edit {_config_path()} directly.\n")
         return
 
     cwd = os.getcwd()
@@ -361,7 +376,7 @@ def cmd_peer(args) -> None:
 
     if changed:
         _write_config(cfg)
-        print(f"  Saved to {GLOBAL_CONFIG_PATH}\n")
+        print(f"  Saved to {_config_path()}\n")
 
 
 def cmd_mode(args) -> None:
@@ -434,7 +449,7 @@ def cmd_tokens(args) -> None:
 
     if changed:
         _write_config(cfg)
-        print(f"  Saved to {GLOBAL_CONFIG_PATH}\n")
+        print(f"  Saved to {_config_path()}\n")
 
 
 def cmd_identity(args) -> None:

--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -1,7 +1,9 @@
 """Honcho client initialization and configuration.
 
-Reads the global ~/.honcho/config.json when available, falling back
-to environment variables.
+Resolution order for config file:
+  1. $HERMES_HOME/honcho.json  (instance-local, enables isolated Hermes instances)
+  2. ~/.honcho/config.json     (global, shared across all Honcho-enabled apps)
+  3. Environment variables     (HONCHO_API_KEY, HONCHO_ENVIRONMENT)
 
 Resolution order for host-specific settings:
   1. Explicit host block fields (always win)
@@ -25,6 +27,24 @@ logger = logging.getLogger(__name__)
 
 GLOBAL_CONFIG_PATH = Path.home() / ".honcho" / "config.json"
 HOST = "hermes"
+
+
+def _get_hermes_home() -> Path:
+    """Get HERMES_HOME without importing hermes_cli (avoids circular deps)."""
+    return Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+
+
+def resolve_config_path() -> Path:
+    """Return the active Honcho config path.
+
+    Checks $HERMES_HOME/honcho.json first (instance-local), then falls back
+    to ~/.honcho/config.json (global).  Returns the global path if neither
+    exists (for first-time setup writes).
+    """
+    local_path = _get_hermes_home() / "honcho.json"
+    if local_path.exists():
+        return local_path
+    return GLOBAL_CONFIG_PATH
 
 
 _RECALL_MODE_ALIASES = {"auto": "hybrid"}
@@ -132,11 +152,11 @@ class HonchoClientConfig:
         host: str = HOST,
         config_path: Path | None = None,
     ) -> HonchoClientConfig:
-        """Create config from ~/.honcho/config.json.
+        """Create config from the resolved Honcho config path.
 
-        Falls back to environment variables if the file doesn't exist.
+        Resolution: $HERMES_HOME/honcho.json -> ~/.honcho/config.json -> env vars.
         """
-        path = config_path or GLOBAL_CONFIG_PATH
+        path = config_path or resolve_config_path()
         if not path.exists():
             logger.debug("No global Honcho config at %s, falling back to env", path)
             return cls.from_env()

--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -126,6 +126,10 @@ class HonchoClientConfig:
     # "context" — auto-injected context only, Honcho tools removed
     # "tools"   — Honcho tools only, no auto-injected context
     recall_mode: str = "hybrid"
+    # Optional lightweight cached startup context for recallMode=tools.
+    # When True, Hermes pre-fetches user representation + peer card in the
+    # background on /new or session reset and injects it on the first real turn.
+    tools_startup_context: bool = False
     # Session resolution
     session_strategy: str = "per-directory"
     session_peer_prefix: bool = False
@@ -268,6 +272,11 @@ class HonchoClientConfig:
                 host_block.get("recallMode")
                 or raw.get("recallMode")
                 or "hybrid"
+            ),
+            tools_startup_context=bool(
+                host_block.get("toolsStartupContext")
+                if host_block.get("toolsStartupContext") is not None
+                else raw.get("toolsStartupContext", False)
             ),
             session_strategy=session_strategy,
             session_peer_prefix=session_peer_prefix,

--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -107,7 +107,7 @@ class HonchoClientConfig:
     # "tools"   — Honcho tools only, no auto-injected context
     recall_mode: str = "hybrid"
     # Session resolution
-    session_strategy: str = "per-session"
+    session_strategy: str = "per-directory"
     session_peer_prefix: bool = False
     sessions: dict[str, str] = field(default_factory=dict)
     # Raw global config for anything else consumers need
@@ -209,7 +209,7 @@ class HonchoClientConfig:
         # sessionStrategy / sessionPeerPrefix: host first, root fallback
         session_strategy = (
             host_block.get("sessionStrategy")
-            or raw.get("sessionStrategy", "per-session")
+            or raw.get("sessionStrategy", "per-directory")
         )
         host_prefix = host_block.get("sessionPeerPrefix")
         session_peer_prefix = (
@@ -318,7 +318,7 @@ class HonchoClientConfig:
                 return f"{self.peer_name}-{base}"
             return base
 
-        # per-directory: one Honcho session per working directory
+        # per-directory: one Honcho session per working directory (default)
         if self.session_strategy in ("per-directory", "per-session"):
             base = Path(cwd).name
             if self.session_peer_prefix and self.peer_name:

--- a/honcho_integration/session.py
+++ b/honcho_integration/session.py
@@ -823,6 +823,62 @@ class HonchoSessionManager:
             logger.debug("Failed to fetch peer card from Honcho: %s", e)
             return []
 
+    def fetch_startup_snapshot(self, peer_id: str) -> dict[str, str]:
+        """
+        Fetch a lightweight user snapshot for tools-mode startup context.
+
+        Unlike get_prefetch_context, this does NOT require an active session
+        in the local cache. It bootstraps a minimal peer object from peer_id
+        alone, so it can be called right after /new before any session exists.
+
+        Returns a dict with 'representation' and 'card' keys (empty strings
+        on failure). Intentionally excludes AI peer context and dialectic —
+        those are V2 concerns.
+        """
+        try:
+            user_peer = self._get_or_create_peer(peer_id)
+            # Use a minimal temporary session to call context().
+            # We need a session object for context(); pick the first cached
+            # session if available, otherwise create a throw-away one keyed
+            # by peer_id so we don't pollute the real session namespace.
+            session_key = next(iter(self._sessions_cache), None)
+            if session_key:
+                honcho_session = self._sessions_cache[session_key]
+                # Resolve assistant peer from the cached session
+                local_sess = next(
+                    (s for s in self._cache.values() if s.honcho_session_id == session_key),
+                    None,
+                )
+                assistant_peer_id = (
+                    local_sess.assistant_peer_id
+                    if local_sess
+                    else (self._config.ai_peer if self._config else "hermes-assistant")
+                )
+            else:
+                # No session cached yet — create a bootstrap session object.
+                # This does NOT add peers or load messages; it just gives us
+                # a handle to call context() against.
+                assistant_peer_id = self._config.ai_peer if self._config else "hermes-assistant"
+                session_key = self._sanitize_id(f"startup-{peer_id}")
+                honcho_session = self.honcho.session(session_key)
+
+            result: dict[str, str] = {}
+            ctx = honcho_session.context(
+                summary=False,
+                tokens=self._context_tokens,
+                peer_target=peer_id,
+                peer_perspective=assistant_peer_id,
+            )
+            card = ctx.peer_card or []
+            result["representation"] = ctx.peer_representation or ""
+            result["card"] = (
+                "\n".join(card) if isinstance(card, list) else str(card)
+            )
+            return result
+        except Exception as e:
+            logger.debug("fetch_startup_snapshot failed for peer %s: %s", peer_id, e)
+            return {}
+
     def search_context(self, session_key: str, query: str, max_tokens: int = 800) -> str:
         """
         Semantic search over Honcho session context.

--- a/run_agent.py
+++ b/run_agent.py
@@ -904,7 +904,7 @@ class AIAgent:
                 pass  # Memory is optional -- don't break agent init
         
         # Honcho AI-native memory (cross-session user modeling)
-        # Reads ~/.honcho/config.json as the single source of truth.
+        # Reads $HERMES_HOME/honcho.json (instance) or ~/.honcho/config.json (global).
         self._honcho = None  # HonchoSessionManager | None
         self._honcho_session_key = honcho_session_key
         self._honcho_config = None  # HonchoClientConfig | None

--- a/run_agent.py
+++ b/run_agent.py
@@ -2069,8 +2069,73 @@ class AIAgent:
                     logger.debug("Honcho context pre-warmed for first turn")
             except Exception as exc:
                 logger.debug("Honcho context prefetch failed (non-fatal): %s", exc)
+        elif hcfg.tools_startup_context and hcfg.peer_name:
+            self._schedule_honcho_startup_prewarm(hcfg.peer_name)
 
         self._register_honcho_exit_hook()
+
+    def _schedule_honcho_startup_prewarm(self, peer_id: str) -> None:
+        """Fire a background fetch of user snapshot for tools-mode startup context.
+
+        Non-blocking. Result stored in self._honcho_startup_snapshot keyed by
+        peer_id. Consumed once on the first real user turn via _pop_startup_snapshot().
+        """
+        import threading as _threading
+
+        if not self._honcho:
+            return
+
+        def _run():
+            try:
+                snapshot = self._honcho.fetch_startup_snapshot(peer_id)
+                if snapshot:
+                    if not hasattr(self, "_honcho_startup_snapshot"):
+                        self._honcho_startup_snapshot = {}
+                    self._honcho_startup_snapshot[peer_id] = snapshot
+                    logger.debug(
+                        "Honcho tools startup snapshot ready for peer %s", peer_id
+                    )
+            except Exception as exc:
+                logger.debug(
+                    "Honcho tools startup prewarm failed (non-fatal): %s", exc
+                )
+
+        t = _threading.Thread(
+            target=_run, name="honcho-startup-prewarm", daemon=True
+        )
+        t.start()
+
+    def _pop_startup_snapshot(self) -> str:
+        """Return and clear the startup snapshot for the current session's peer.
+
+        Returns empty string if no snapshot is ready or feature is disabled.
+        Only consumes once — subsequent calls return "".
+        """
+        if not self._honcho_config or not self._honcho_config.tools_startup_context:
+            return ""
+        peer_id = getattr(self._honcho_config, "peer_name", None)
+        if not peer_id:
+            return ""
+        cache = getattr(self, "_honcho_startup_snapshot", {})
+        snapshot = cache.pop(peer_id, None)
+        if not snapshot:
+            return ""
+        parts = []
+        rep = snapshot.get("representation", "")
+        card = snapshot.get("card", "")
+        if rep:
+            parts.append("## User representation\n" + rep)
+        if card:
+            parts.append(card)
+        if not parts:
+            return ""
+        return (
+            "# Honcho Memory (startup context)\n"
+            "Lightweight cross-session personalization fetched at session start. "
+            "Use this for personalization on the first turn. "
+            "Call honcho_context or honcho_search for deeper recall.\n\n"
+            + "\n\n".join(parts)
+        )
 
     def _register_honcho_exit_hook(self) -> None:
         """Register a process-exit flush hook without clobbering signal handlers."""
@@ -5415,6 +5480,14 @@ class AIAgent:
                         self._honcho_turn_context = prefetched_context
             except Exception as e:
                 logger.debug("Honcho prefetch failed (non-fatal): %s", e)
+        elif _recall_mode == "tools" and not conversation_history:
+            try:
+                startup_ctx = self._pop_startup_snapshot()
+                if startup_ctx:
+                    self._honcho_turn_context = startup_ctx
+                    logger.debug("Honcho tools startup snapshot injected on first turn")
+            except Exception as e:
+                logger.debug("Honcho startup snapshot inject failed (non-fatal): %s", e)
 
         # Add user message
         user_msg = {"role": "user", "content": user_message}

--- a/tests/gateway/test_honcho_lifecycle.py
+++ b/tests/gateway/test_honcho_lifecycle.py
@@ -90,6 +90,7 @@ class TestGatewayHonchoLifecycle:
         runner = _make_runner()
         event = _make_event()
         runner._shutdown_gateway_honcho = MagicMock()
+        runner._schedule_gateway_honcho_startup_prewarm = MagicMock()
         runner._async_flush_memories = AsyncMock()
         runner.session_store = MagicMock()
         runner.session_store._generate_session_key.return_value = "gateway-key"
@@ -101,8 +102,43 @@ class TestGatewayHonchoLifecycle:
         result = await runner._handle_reset_command(event)
 
         runner._shutdown_gateway_honcho.assert_called_once_with("gateway-key")
+        runner._schedule_gateway_honcho_startup_prewarm.assert_called_once_with("gateway-key")
         runner._async_flush_memories.assert_called_once_with("old-session", "gateway-key")
         assert "Session reset" in result
+
+    def test_pop_gateway_honcho_startup_snapshot_consumes_cached_peer_snapshot(self):
+        runner = _make_runner()
+        runner._honcho_startup_cache = {
+            "alice": {"representation": "rep", "card": "card"},
+        }
+        hcfg = SimpleNamespace(
+            recall_mode="tools",
+            tools_startup_context=True,
+            peer_name="alice",
+        )
+
+        snapshot = runner._pop_gateway_honcho_startup_snapshot(hcfg)
+
+        assert snapshot == {"alice": {"representation": "rep", "card": "card"}}
+        assert runner._honcho_startup_cache == {}
+
+    def test_pop_gateway_honcho_startup_snapshot_skips_non_tools_mode(self):
+        runner = _make_runner()
+        runner._honcho_startup_cache = {
+            "alice": {"representation": "rep", "card": "card"},
+        }
+        hcfg = SimpleNamespace(
+            recall_mode="hybrid",
+            tools_startup_context=True,
+            peer_name="alice",
+        )
+
+        snapshot = runner._pop_gateway_honcho_startup_snapshot(hcfg)
+
+        assert snapshot is None
+        assert runner._honcho_startup_cache == {
+            "alice": {"representation": "rep", "card": "card"},
+        }
 
     def test_flush_memories_reuses_gateway_session_key_and_skips_honcho_sync(self):
         runner = _make_runner()

--- a/tests/honcho_integration/test_cli.py
+++ b/tests/honcho_integration/test_cli.py
@@ -1,6 +1,11 @@
 """Tests for Honcho CLI helpers."""
 
-from honcho_integration.cli import _resolve_api_key
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from honcho_integration import cli as honcho_cli
+from honcho_integration.cli import _effective_value, _resolve_api_key
 
 
 class TestResolveApiKey:
@@ -26,4 +31,118 @@ class TestResolveApiKey:
         monkeypatch.setenv("HONCHO_API_KEY", "env-key")
         assert _resolve_api_key({}) == "env-key"
         monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+
+
+class TestEffectiveValue:
+    def test_prefers_explicit_false_in_host_block(self):
+        cfg = {
+            "toolsStartupContext": True,
+            "hosts": {
+                "hermes": {
+                    "toolsStartupContext": False,
+                }
+            },
+        }
+
+        assert _effective_value(cfg, "toolsStartupContext", default=None) is False
+
+
+class TestHonchoCliWrites:
+    def test_cmd_setup_writes_host_scoped_values_and_keeps_root_defaults(self, tmp_path, monkeypatch):
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({
+            "apiKey": "root-key",
+            "memoryMode": "honcho",
+            "recallMode": "context",
+            "toolsStartupContext": False,
+            "sessionStrategy": "global",
+            "hosts": {
+                "hermes": {
+                    "peerName": "old-user",
+                }
+            },
+        }))
+        monkeypatch.setattr(honcho_cli, "GLOBAL_CONFIG_PATH", cfg_path)
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_ensure_sdk_installed", lambda: True)
+
+        prompts = iter([
+            "",          # keep root api key
+            "eri",       # peer name
+            "hermes-ws", # workspace
+            "hybrid",    # memory mode
+            "turn",      # write frequency
+            "tools",     # recall mode
+            "y",         # startup context
+            "per-repo",  # session strategy
+        ])
+        monkeypatch.setattr(honcho_cli, "_prompt", lambda *a, **k: next(prompts))
+        monkeypatch.setattr(honcho_cli, "_write_config", lambda cfg: cfg_path.write_text(json.dumps(cfg, indent=2)))
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: json.loads(cfg_path.read_text()))
+
+        fake_hcfg = SimpleNamespace(
+            workspace_id="hermes-ws",
+            peer_name="eri",
+            memory_mode="hybrid",
+            peer_memory_modes={},
+            write_frequency="turn",
+            recall_mode="tools",
+            tools_startup_context=True,
+            resolve_session_name=lambda: "session-name",
+        )
+        monkeypatch.setattr("honcho_integration.client.reset_honcho_client", lambda: None)
+        monkeypatch.setattr("honcho_integration.client.HonchoClientConfig.from_global_config", lambda: fake_hcfg)
+        monkeypatch.setattr("honcho_integration.client.get_honcho_client", lambda cfg: MagicMock())
+
+        honcho_cli.cmd_setup(SimpleNamespace())
+
+        saved = json.loads(cfg_path.read_text())
+        assert saved["apiKey"] == "root-key"
+        assert saved["memoryMode"] == "honcho"
+        assert saved["recallMode"] == "context"
+        assert saved["toolsStartupContext"] is False
+        assert saved["sessionStrategy"] == "global"
+
+        hermes = saved["hosts"]["hermes"]
+        assert hermes["peerName"] == "eri"
+        assert hermes["workspace"] == "hermes-ws"
+        assert hermes["memoryMode"] == "hybrid"
+        assert hermes["writeFrequency"] == "turn"
+        assert hermes["recallMode"] == "tools"
+        assert hermes["toolsStartupContext"] is True
+        assert hermes["sessionStrategy"] == "per-repo"
+        assert hermes["aiPeer"] == "hermes"
+
+    def test_cmd_mode_writes_host_override_without_touching_root_default(self, tmp_path, monkeypatch):
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({
+            "memoryMode": "honcho",
+            "hosts": {"hermes": {}},
+        }))
+        monkeypatch.setattr(honcho_cli, "GLOBAL_CONFIG_PATH", cfg_path)
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+
+        honcho_cli.cmd_mode(SimpleNamespace(mode="hybrid"))
+
+        saved = json.loads(cfg_path.read_text())
+        assert saved["memoryMode"] == "honcho"
+        assert saved["hosts"]["hermes"]["memoryMode"] == "hybrid"
+
+    def test_cmd_tokens_writes_host_override_without_touching_root_default(self, tmp_path, monkeypatch):
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({
+            "contextTokens": 321,
+            "dialecticMaxChars": 456,
+            "hosts": {"hermes": {}},
+        }))
+        monkeypatch.setattr(honcho_cli, "GLOBAL_CONFIG_PATH", cfg_path)
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+
+        honcho_cli.cmd_tokens(SimpleNamespace(context=800, dialectic=600))
+
+        saved = json.loads(cfg_path.read_text())
+        assert saved["contextTokens"] == 321
+        assert saved["dialecticMaxChars"] == 456
+        assert saved["hosts"]["hermes"]["contextTokens"] == 800
+        assert saved["hosts"]["hermes"]["dialecticMaxChars"] == 600
 

--- a/tests/honcho_integration/test_client.py
+++ b/tests/honcho_integration/test_client.py
@@ -11,6 +11,7 @@ from honcho_integration.client import (
     HonchoClientConfig,
     get_honcho_client,
     reset_honcho_client,
+    resolve_config_path,
     GLOBAL_CONFIG_PATH,
     HOST,
 )
@@ -25,7 +26,7 @@ class TestHonchoClientConfigDefaults:
         assert config.environment == "production"
         assert config.enabled is False
         assert config.save_messages is True
-        assert config.session_strategy == "per-session"
+        assert config.session_strategy == "per-directory"
         assert config.recall_mode == "hybrid"
         assert config.session_peer_prefix is False
         assert config.linked_hosts == []
@@ -157,7 +158,7 @@ class TestFromGlobalConfig:
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps({"apiKey": "key"}))
         config = HonchoClientConfig.from_global_config(config_path=config_file)
-        assert config.session_strategy == "per-session"
+        assert config.session_strategy == "per-directory"
 
     def test_context_tokens_host_block_wins(self, tmp_path):
         """Host block contextTokens should override root."""
@@ -328,6 +329,47 @@ class TestGetLinkedWorkspaces:
         )
         workspaces = config.get_linked_workspaces()
         assert "cursor" in workspaces
+
+
+class TestResolveConfigPath:
+    def test_prefers_hermes_home_when_exists(self, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        local_cfg = hermes_home / "honcho.json"
+        local_cfg.write_text('{"apiKey": "local"}')
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            result = resolve_config_path()
+        assert result == local_cfg
+
+    def test_falls_back_to_global_when_no_local(self, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        # No honcho.json in HERMES_HOME
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            result = resolve_config_path()
+        assert result == GLOBAL_CONFIG_PATH
+
+    def test_falls_back_to_global_without_hermes_home_env(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_HOME", None)
+            result = resolve_config_path()
+        assert result == GLOBAL_CONFIG_PATH
+
+    def test_from_global_config_uses_local_path(self, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        local_cfg = hermes_home / "honcho.json"
+        local_cfg.write_text(json.dumps({
+            "apiKey": "local-key",
+            "workspace": "local-ws",
+        }))
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            config = HonchoClientConfig.from_global_config()
+        assert config.api_key == "local-key"
+        assert config.workspace_id == "local-ws"
 
 
 class TestResetHonchoClient:

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -103,3 +103,52 @@ class TestHonchoClientConfigAutoEnable:
 
         assert cfg.api_key == "fallback-key"
         assert cfg.enabled is True  # from_env() sets enabled=True
+
+
+class TestHonchoClientConfigToolsStartupContext:
+    def test_tools_startup_context_uses_root_default_when_host_missing(self, tmp_path):
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "toolsStartupContext": True,
+            "hosts": {
+                "hermes": {
+                    "enabled": True,
+                }
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.tools_startup_context is True
+
+    def test_tools_startup_context_host_true_overrides_root_false(self, tmp_path):
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "toolsStartupContext": False,
+            "hosts": {
+                "hermes": {
+                    "toolsStartupContext": True,
+                    "enabled": True,
+                }
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.tools_startup_context is True
+
+    def test_tools_startup_context_host_false_overrides_root_true(self, tmp_path):
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "toolsStartupContext": True,
+            "hosts": {
+                "hermes": {
+                    "toolsStartupContext": False,
+                    "enabled": True,
+                }
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.tools_startup_context is False

--- a/tests/test_honcho_startup_context.py
+++ b/tests/test_honcho_startup_context.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+
+from run_agent import AIAgent
+
+
+class TestHonchoStartupContext:
+    def test_pop_startup_snapshot_formats_and_consumes_once(self):
+        agent = object.__new__(AIAgent)
+        agent._honcho_config = SimpleNamespace(
+            tools_startup_context=True,
+            peer_name="alice",
+        )
+        agent._honcho_startup_snapshot = {
+            "alice": {
+                "representation": "Knows the user well.",
+                "card": "- prefers directness",
+            }
+        }
+
+        first = agent._pop_startup_snapshot()
+        second = agent._pop_startup_snapshot()
+
+        assert "# Honcho Memory (startup context)" in first
+        assert "## User representation\nKnows the user well." in first
+        assert "- prefers directness" in first
+        assert second == ""
+
+    def test_pop_startup_snapshot_returns_empty_when_feature_disabled(self):
+        agent = object.__new__(AIAgent)
+        agent._honcho_config = SimpleNamespace(
+            tools_startup_context=False,
+            peer_name="alice",
+        )
+        agent._honcho_startup_snapshot = {
+            "alice": {"representation": "Knows the user well.", "card": "- prefers directness"}
+        }
+
+        assert agent._pop_startup_snapshot() == ""
+        assert agent._honcho_startup_snapshot == {
+            "alice": {"representation": "Knows the user well.", "card": "- prefers directness"}
+        }


### PR DESCRIPTION
## Summary
- Honcho config resolution now checks `$HERMES_HOME/honcho.json` first, falling back to `~/.honcho/config.json`
- Enables isolated Hermes instances with independent Honcho credentials, workspaces, and settings
- Adds optional lightweight startup context for `recallMode=tools` via `toolsStartupContext`
- Wires gateway startup prewarm all the way through to the fresh `AIAgent` instance created for the next turn
- Updates `hermes honcho setup` and related CLI commands to respect host-scoped Honcho config with root fallback, while continuing to write Hermes-owned workflow settings under `hosts.hermes`
- Surfaces the active config path plus startup-context status in Honcho CLI output

## Notes
- This PR now includes the stacked tools-startup-context work on top of the original `HERMES_HOME` instance-local config change
- No separate PR was opened for the startup-context work; it is intentionally built into this branch/PR
- `.claude/` remains untracked and is not part of this PR

## Test plan
- [x] Targeted Honcho startup-context and CLI write-path tests pass
- [x] `python -m pytest tests/honcho_integration/test_cli.py tests/test_honcho_client_config.py tests/test_honcho_startup_context.py tests/gateway/test_honcho_lifecycle.py -q`
- [x] Broader relevant suite passes:
      `python -m pytest tests/honcho_integration/ tests/gateway/ tests/tools/test_honcho_tools.py tests/test_honcho_client_config.py tests/test_honcho_startup_context.py -q`
- [x] Verified `$HERMES_HOME/honcho.json` is still resolved when present
- [x] Verified fallback to `~/.honcho/config.json` when no instance-local config exists
- [x] Verified host-scoped writes preserve shared root defaults where intended
- [x] Verified tools-mode startup snapshot is injected exactly once and gateway reset prewarm is consumed on the next turn

Related meta issue: #2210
