### PR TITLE
fix: send error details to user in gateway outer exception handler

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1099,6 +1099,22 @@ class BasePlatformAdapter(ABC):
             print(f"[{self.name}] Error handling message: {e}")
             import traceback
             traceback.print_exc()
+            # Send the error to the user so they aren't left with radio silence
+            try:
+                error_type = type(e).__name__
+                error_detail = str(e)[:300] if str(e) else "no details available"
+                _thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+                await self.send(
+                    chat_id=event.source.chat_id,
+                    content=(
+                        f"Sorry, I encountered an error ({error_type}).\n"
+                        f"{error_detail}\n"
+                        "Try again or use /reset to start a fresh session."
+                    ),
+                    metadata=_thread_metadata,
+                )
+            except Exception:
+                pass  # Last resort — don't let error reporting crash the handler
         finally:
             # Stop typing indicator
             typing_task.cancel()


### PR DESCRIPTION
## Summary

When an error occurs during response processing in `_process_message_background` (the outer try/except in `gateway/platforms/base.py`), the error was only logged to server console via `print()` + `traceback.print_exc()`. The user saw the typing indicator stop but received no message — radio silence.

This was reported by a Telegram user who kept getting silent failures with no way to diagnose what was wrong.

## What changed

The outer `except` block in `_process_message_background()` now attempts to send the error type and detail (truncated to 300 chars) to the user's chat, matching the error format already used by the inner handler in `gateway/run.py`.

The send attempt is wrapped in its own try/except so if even error reporting fails, it won't crash the handler.

## Why two layers?

- **Inner handler** (`gateway/run.py:2119`): Catches agent/API errors during `_handle_message()` — already returns error details to user. Works well.
- **Outer handler** (`base.py:1098`): Catches errors during response *delivery* (extract_media, send, image routing, etc.) or anything that escapes the inner handler. Previously silent. **Now fixed.**

## Test plan

- Gateway tests pass (1194 passed, 2 pre-existing failures in unrelated WhatsApp reply prefix tests)
- No new dependencies or config changes