### PR TITLE
fix(agent): add Claude Code identity headers for Anthropic OAuth tokens

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -695,6 +695,16 @@ class AIAgent:
                     client_kwargs["default_headers"] = {
                         "User-Agent": "KimiCLI/1.3",
                     }
+                # Anthropic OAuth tokens (sk-ant-oat) require Claude Code identity headers
+                # to unlock Sonnet/Opus access. Without these, only Haiku works.
+                if api_key and api_key.startswith("sk-ant-oat"):
+                    existing = client_kwargs.get("default_headers", {})
+                    existing.update({
+                        "anthropic-beta": "claude-code-20250219,oauth-2025-04-20",
+                        "user-agent": "claude-cli/2.1.75",
+                        "x-app": "cli",
+                    })
+                    client_kwargs["default_headers"] = existing
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client


### PR DESCRIPTION
Fixes #1961

## Problem
Anthropic OAuth tokens (sk-ant-oat) only worked with Haiku. Sonnet and Opus returned 403/permission errors.

## Root Cause
Anthropic requires Claude Code identity headers when using OAuth tokens with premium models. Without these headers, only Haiku tier is accessible.

## Fix
When an Anthropic OAuth token is detected (sk-ant-oat prefix), automatically inject the required headers:
- `anthropic-beta: claude-code-20250219,oauth-2025-04-20`
- `user-agent: claude-cli/2.1.75`
- `x-app: cli`

## Reference
Pi-mono's Anthropic provider (badlogic/pi-mono packages/ai/src/providers/anthropic.ts) uses the same headers for OAuth token support.
