### PR TITLE
fix(honcho): sync aiPeer with SOUL.md identity at runtime

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2331,6 +2331,28 @@ class AIAgent:
             tool["function"]["name"] for tool in self.tools
         } if self.tools else set()
 
+    @staticmethod
+    def _extract_agent_name_from_soul(soul_content: str) -> str | None:
+        """Extract agent name from SOUL.md content.
+
+        Looks for 'You are <Name>' at the start of the identity text.
+        Returns the name (sanitized for Honcho peer ID), or None.
+        """
+        import re
+        # Match "You are <Name>" — capture up to the first comma, period,
+        # newline, or sentence connector (and/who/that/an/a).
+        match = re.search(
+            r"(?i)you are\s+(.+?)(?:\s*[,.\n;]|\s+(?:and|who|that|which)\s|\s+an?\s)",
+            soul_content,
+        )
+        if not match:
+            return None
+        raw_name = match.group(1).strip()
+        if not raw_name or raw_name.lower() in ("a", "an", "the"):
+            return None
+        # Sanitize for Honcho peer ID: lowercase, replace spaces with hyphens
+        return re.sub(r"[^a-zA-Z0-9_-]", "-", raw_name).strip("-").lower() or None
+
     def _activate_honcho(
         self,
         hcfg,
@@ -2342,6 +2364,22 @@ class AIAgent:
         """Finish Honcho setup once a session manager is available."""
         if not self._honcho:
             return
+
+        # Sync aiPeer with SOUL.md identity at runtime so renamed agents
+        # don't create duplicate Honcho entities.
+        if not self.skip_context_files:
+            try:
+                soul_content = load_soul_md()
+                if soul_content:
+                    soul_name = self._extract_agent_name_from_soul(soul_content)
+                    if soul_name and soul_name != hcfg.ai_peer:
+                        logger.info(
+                            "Honcho aiPeer overridden from SOUL.md: %s → %s",
+                            hcfg.ai_peer, soul_name,
+                        )
+                        hcfg.ai_peer = soul_name
+            except Exception:
+                pass
 
         if not self._honcho_session_key:
             session_title = None

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2005,6 +2005,38 @@ class TestSystemPromptStability:
         mock_prefetch.assert_not_called()
 
 
+class TestExtractAgentNameFromSoul:
+    """Tests for AIAgent._extract_agent_name_from_soul()."""
+
+    def test_standard_identity(self):
+        assert AIAgent._extract_agent_name_from_soul(
+            "You are Atlas Agent, an intelligent AI assistant."
+        ) == "atlas-agent"
+
+    def test_single_word_name(self):
+        assert AIAgent._extract_agent_name_from_soul(
+            "You are Sentinel, a protective agent."
+        ) == "sentinel"
+
+    def test_case_insensitive(self):
+        assert AIAgent._extract_agent_name_from_soul(
+            "you are My Custom Bot and you help people"
+        ) == "my-custom-bot"
+
+    def test_no_match(self):
+        assert AIAgent._extract_agent_name_from_soul(
+            "This is an AI assistant that helps with tasks."
+        ) is None
+
+    def test_hermes_default(self):
+        assert AIAgent._extract_agent_name_from_soul(
+            "You are Hermes Agent, an intelligent AI assistant created by Nous Research."
+        ) == "hermes-agent"
+
+    def test_empty_string(self):
+        assert AIAgent._extract_agent_name_from_soul("") is None
+
+
 class TestHonchoActivation:
     def test_disabled_config_skips_honcho_init(self):
         hcfg = HonchoClientConfig(


### PR DESCRIPTION
## Summary
- When a user renames the agent via SOUL.md (e.g. "You are Atlas"), the Honcho `aiPeer` stayed as `"hermes"`, causing the old name to leak back into context via Honcho's peer representation and creating duplicate entities
- Now `_activate_honcho` parses SOUL.md for "You are <Name>" and overrides `hcfg.ai_peer` at runtime (not persisted to config)
- Keeps Honcho peer identity in sync with agent identity without mutating config files

## Test plan
- [x] Unit tests for name extraction (standard, single word, case insensitive, no match, empty)
- [x] Renamed SOUL.md overrides aiPeer at runtime
- [x] Default "hermes" peer unchanged when SOUL.md absent or empty
- [x] Multi-word names sanitized correctly (e.g. "Cosmania Sentinel" -> "cosmania-sentinel")

Related meta issue: #2210
