### PR TITLE
docs: add WZRD as a real plugin example

### DIFF
--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -41,6 +41,18 @@ Start Hermes — your tools appear alongside built-in tools. The model can call 
 | Project | `.hermes/plugins/` | Project-specific plugins |
 | pip | `hermes_agent.plugins` entry_points | Distributed packages |
 
+## Real-world example: WZRD
+
+WZRD is a packaged Hermes plugin that treats model momentum as an attention prior rather than a router. It follows the same `plugin.yaml` + `__init__.py` + handler structure described above and exposes three tools:
+
+- `wzrd_trending`
+- `wzrd_candidates`
+- `wzrd_compare`
+
+The plugin keeps routing separate from execution: it surfaces momentum-informed candidates, but leaves the final provider and endpoint choice to the execution router.
+
+Source: [twzrd-sol/wzrd-final](https://github.com/twzrd-sol/wzrd-final/tree/main/agents/hermes-plugin/wzrd-plugin)
+
 ## Available hooks
 
 | Hook | Fires when |

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -51,7 +51,7 @@ WZRD is a packaged Hermes plugin that treats model momentum as an attention prio
 
 The plugin keeps routing separate from execution: it surfaces momentum-informed candidates, but leaves the final provider and endpoint choice to the execution router.
 
-Source: [twzrd-sol/wzrd-final](https://github.com/twzrd-sol/wzrd-final/tree/main/agents/hermes-plugin/wzrd-plugin)
+Source: [twzrd-sol/wzrd-final](https://github.com/twzrd-sol/wzrd-final/tree/main/agents/hermes/wzrd_plugin)
 
 ## Available hooks
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -51,7 +51,7 @@ WZRD is a packaged Hermes plugin that treats model momentum as an attention prio
 
 The plugin keeps routing separate from execution: it surfaces momentum-informed candidates, but leaves the final provider and endpoint choice to the execution router.
 
-Source: [twzrd-sol/wzrd-final](https://github.com/twzrd-sol/wzrd-final/tree/main/agents/hermes/wzrd_plugin)
+Source: [twzrd-sol/wzrd-velocity](https://github.com/twzrd-sol/wzrd-velocity)
 
 ## Available hooks
 


### PR DESCRIPTION
Adds a short real-world example to the Hermes plugin docs for WZRD, a packaged plugin that acts as an attention prior rather than a router.

What this PR does:
- Documents WZRD as a pip-distributed Hermes plugin example
- Lists the real tools: wzrd_trending, wzrd_candidates, wzrd_compare
- Clarifies the routing/execution split for plugin authors

Scope:
- Docs only
- No runtime changes
- No impact on core plugin loading