### PR TITLE
fix: discard pending approvals on new agent activity (#1888)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23,7 +23,6 @@ import sys
 import signal
 import tempfile
 import threading
-import time
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from datetime import datetime
@@ -217,7 +216,7 @@ from gateway.session import (
     build_session_context_prompt,
     build_session_key,
 )
-from gateway.delivery import DeliveryRouter, DeliveryTarget
+from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
 
 logger = logging.getLogger(__name__)
@@ -1543,7 +1542,9 @@ class GatewayRunner:
                 # Show full command without consuming the approval
                 cmd = self._pending_approvals[session_key_preview]["command"]
                 return f"Full command:\n\n```\n{cmd}\n```\n\nReply yes/no to approve or deny."
-            # If it's not clearly an approval/denial, fall through to normal processing
+            else:
+                self._pending_approvals.pop(session_key_preview, None)
+                logger.info("Unrelated message cleared pending approval for session %s", session_key_preview)
         
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
@@ -2061,7 +2062,26 @@ class GatewayRunner:
                 from tools.approval import pop_pending
                 pending = pop_pending(session_key)
                 if pending:
-                    self._pending_approvals[session_key] = pending
+                    # NEW: Improved Option D - Sequential ordering / Shadowing protection
+                    # If the agent sent a new message or called another tool in this turn, 
+                    # the old approval is considered "shadowed" and discarded to prevent accidents.
+                    is_shadowed = False
+                    messages = agent_result.get("messages", [])
+                
+                    for msg in reversed(messages):
+                        if msg.get("role") == "assistant":
+                            # If assistant sent text or any tool call (not just 'clarify')
+                            if msg.get("content") or msg.get("tool_calls"):
+                                is_shadowed = True
+                                break
+                        if msg.get("role") == "user":
+                            # We only check the current interaction turn
+                            break
+
+                    if not is_shadowed:
+                        self._pending_approvals[session_key] = pending
+                    else:
+                        logger.info("✨ [Issue 1888] Shadowed approval discarded for session %s due to new agent activity", session_key)
             except Exception as e:
                 logger.debug("Failed to check pending approvals: %s", e)
             
@@ -2569,7 +2589,7 @@ class GatewayRunner:
                 else:
                     preview = prompt[:50] + "..." if len(prompt) > 50 else prompt
                 lines.append(f"• `{name}` — {preview}")
-            lines.append(f"\nUsage: `/personality <name>`")
+            lines.append("\nUsage: `/personality <name>`")
             return "\n".join(lines)
 
         def _resolve_prompt(value):


### PR DESCRIPTION
## What does this PR do?
This PR prevents the gateway from incorrectly interpreting user "yes/no" responses as approvals for stale, out-of-context commands. If the assistant moves on to a new turn (sends text or calls a tool), any previous pending approval is now discarded.

## Related Issue
Fixes #1888

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made
- Modified `_handle_message` in `gateway/run.py`.
- Added logic to clear `self._pending_approvals` if new assistant activity (content or tool calls) is detected.
- Added a "Shadowed approval" log message for better observability.

## How to Test
## Proof of Testing (Screenshots)

### 1. Context Switch Logic in Telegram
As seen below, when the agent answers an unrelated question ("favorite color"), the previous `sudo rm` approval is correctly shadowed. Saying "yes" afterwards does not trigger the dangerous command.

<img width="1002" height="505" alt="18881" src="https://github.com/user-attachments/assets/20eafbf5-833c-4614-8f4a-cf5b6ec633bd" />

### 2. Gateway Logs
The logs clearly show the shadowing logic triggering exactly when expected:
`✨ [Issue 1888] Shadowed approval discarded...`

<img width="1002" height="48" alt="18882" src="https://github.com/user-attachments/assets/bcde40ec-e2bf-4c01-84fb-bc505df73f3d" />