### PR TITLE
feat(mcp): add hermes-council adversarial deliberation server config

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -615,6 +615,12 @@ toolsets:
 #     args: ["-y", "@modelcontextprotocol/server-github"]
 #     env:
 #       GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
+#   council:
+#     command: hermes-council-server
+#     env:
+#       COUNCIL_API_KEY: ""
+#       COUNCIL_MODEL: "nousresearch/hermes-3-llama-3.1-70b"
+#     timeout: 180
 #
 # Sampling (server-initiated LLM requests) — enabled by default.
 # Per-server config under the 'sampling' key:

--- a/optional-skills/council/adversarial-council/SKILL.md
+++ b/optional-skills/council/adversarial-council/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: adversarial-council
+description: Run multi-perspective adversarial deliberation using the hermes-council MCP server. Five personas (Advocate, Skeptic, Oracle, Contrarian, Arbiter) debate questions through structured rounds, producing calibrated verdicts with confidence scores and evidence links. Use when the user needs rigorous analysis, safety gating, or quality evaluation.
+version: 1.0.0
+requires: hermes-council MCP server (pip install git+https://github.com/Ridwannurudeen/hermes-council.git)
+author: Ridwannurudeen
+tags: [council, adversarial, deliberation, safety, evaluation, mcp]
+---
+
+# Adversarial Council
+
+Run structured adversarial deliberation through five personas from distinct intellectual traditions.
+
+## Setup (one-time)
+
+### 1. Install the server
+
+    pip install git+https://github.com/Ridwannurudeen/hermes-council.git
+
+### 2. Add to hermes config
+
+In `cli-config.yaml`:
+
+```yaml
+mcp_servers:
+  council:
+    command: hermes-council-server
+    env:
+      COUNCIL_API_KEY: ""  # Your OpenRouter/OpenAI API key
+      COUNCIL_MODEL: "nousresearch/hermes-3-llama-3.1-70b"
+    timeout: 180
+```
+
+### 3. Set API key
+
+    export OPENROUTER_API_KEY=your-key-here
+
+## Available Tools
+
+| Tool | Use When | Personas Used |
+|------|----------|---------------|
+| `council_query` | Complex questions needing multi-perspective analysis | All 5 (Advocate, Skeptic, Oracle, Contrarian, Arbiter) |
+| `council_evaluate` | Evaluating content quality with configurable criteria | All 5 |
+| `council_gate` | Quick safety check before high-stakes actions | Skeptic + Oracle + Arbiter |
+
+## The Five Personas
+
+| Persona | Tradition | What They Do |
+|---------|-----------|-------------|
+| **Advocate** | Steel-manning | Builds strongest case FOR the position |
+| **Skeptic** | Popperian falsification | Finds the observation that kills the claim |
+| **Oracle** | Empirical base-rate reasoning | Grounds debate in historical data and statistics |
+| **Contrarian** | Kuhnian paradigm critique | Rejects the framing, proposes alternative paradigms |
+| **Arbiter** | Bayesian synthesis | Synthesizes all views with explicit prior/posterior updates |
+
+## Usage Patterns
+
+### Deep analysis of a complex question
+
+Use `council_query` with a focused question. The council returns:
+- Individual persona arguments with confidence scores
+- Evidence links and references
+- Arbiter synthesis with Bayesian prior/posterior updates
+- Final verdict with calibrated confidence
+
+### Quality evaluation
+
+Use `council_evaluate` with the content to evaluate and optional criteria:
+- `accuracy` — factual correctness
+- `depth` — analytical thoroughness
+- `evidence` — citation and data support
+- `falsifiability` — testable predictions
+
+### Safety gating before actions
+
+Use `council_gate` before high-stakes actions. Returns allow/deny with:
+- Skeptic's risk assessment
+- Oracle's base-rate analysis
+- Arbiter's synthesized recommendation
+
+## Response Format
+
+All tools return structured JSON with:
+- `verdict` — the synthesized conclusion
+- `confidence` — calibrated 0.0-1.0 score
+- `persona_results` — individual persona analyses
+- `_meta` — token usage and cost estimates
+
+## Tips
+
+- Council makes 3-5 LLM calls per invocation — use `council_gate` for quick checks
+- Set timeout to 180s in config (deliberation takes longer than single calls)
+- Custom personas can be added via `~/.hermes-council/config.yaml`
+- DPO preference pairs are included for RL training use cases


### PR DESCRIPTION
## Summary

Adds [hermes-council](https://github.com/Ridwannurudeen/hermes-council) integration — a standalone **adversarial preflight + deliberation** MCP server where five personas from distinct intellectual traditions debate questions through structured rounds, producing calibrated verdicts with confidence scores, evidence-grounded sources, and DPO preference pairs for RL training.

**Context**: PR #848 proposed adding an adversarial council directly into hermes-agent core. @teknium1 closed it (not merged) noting the concept was solid but belonged as an **external MCP server** — citing concerns about core tool injection, provider bypass, hidden LLM costs, and brittle regex parsing. hermes-council was rebuilt from scratch as a standalone FastMCP stdio server that addresses all four concerns.

## Files Changed

| File | Change | Description |
|------|--------|-------------|
| `cli-config.yaml.example` | Modified | Added commented `council` MCP server entry (+6 lines) |
| `optional-skills/council/adversarial-council/SKILL.md` | Added | Discoverable skill definition for `hermes skills browse` |

## Prerequisites

1. Install the hermes-council server (v0.1.1+ recommended for the hardened SSRF guard):
   ```bash
   pip install "hermes-council>=0.1.1"
   ```

2. Set an API key (OpenRouter, Nous, or OpenAI):
   ```bash
   export OPENROUTER_API_KEY=your-key-here
   ```

3. Uncomment the `council` section in `cli-config.yaml`:
   ```yaml
   mcp_servers:
     council:
       command: hermes-council-server
       env:
         COUNCIL_API_KEY: ""  # Your OpenRouter API key
         COUNCIL_MODEL: "nousresearch/hermes-3-llama-3.1-70b"
       timeout: 180  # Council makes 3-5 LLM calls per invocation
   ```

## Tools Exposed

| Tool | Description | Personas |
|------|-------------|----------|
| `council_query` | Full 5-persona adversarial deliberation | Advocate, Skeptic, Oracle, Contrarian, Arbiter |
| `council_evaluate` | Evaluate content quality through adversarial critique | All 5 |
| `council_gate` | Structured allow / allow_with_conditions / deny verdict with `blocking_risks`, `required_checks`, `safe_alternative` | Skeptic + Oracle + Arbiter |
| `council_preflight` | Wraps `council_gate` with pre-considered checks for risky actions | Skeptic + Oracle + Arbiter |
| `council_review_plan` | Flags blocking risks, missing steps, weak assumptions in plans before execution | All 5 |
| `council_review_diff` | Code-review pass for bugs, security risks, regressions, missing tests | All 5 |
| `council_review_claim` | Fact-check / stress-test claims with evidence grounding | All 5 |
| `council_decision` | Compare options, recommend one with risks and next actions | All 5 |

## Optional Capabilities

**Evidence grounding** — `council_query` and `council_review_claim` can pull URLs from the question/context and fall back to DuckDuckGo search. SSRF-hardened (v0.1.1):

- Resolves DNS and rejects hostnames whose returned addresses are private / loopback / link-local / multicast / reserved (defeats DNS rebinding).
- Connects to a validated public IP with the original hostname preserved for SNI / cert validation.
- Follows redirects manually with per-hop revalidation, cap 5 (a 30x to a private IP cannot bypass the guard).
- Rejects obfuscated host forms: `0x`-prefixed hex, decimal-encoded IPv4 (`http://2130706433/`), all-numeric-with-dots, `*.local` hostnames.

Verified vs unverified-search-result distinction surfaced to the council prompt and final verdict.

**Audit logging** — opt-in local audit trail of every verdict written to `~/.hermes-council/audit/` as JSON. Each record contains the timestamp, tool name, sha256 request hash, and the full request + response payloads (so you can replay or diff verdicts). Off by default; never sends data anywhere.

| Env Var | Default | Purpose |
|---------|---------|---------|
| `COUNCIL_AUDIT_LOG` | `0` | `1` to enable audit logging |
| `COUNCIL_AUDIT_DIR` | `~/.hermes-council/audit` | Override audit directory |
| `COUNCIL_EVIDENCE_TIMEOUT` | `8` | Per-fetch seconds |
| `COUNCIL_EVIDENCE_SEARCH` | `1` | `0` to disable DuckDuckGo fallback |

## Architecture

```
hermes-agent ──stdio──▶ hermes-council-server
                              │
                              ├─ Advocate (steel-mans the position)
                              ├─ Skeptic (Popperian falsification)
                              ├─ Oracle (empirical base rates)
                              ├─ Contrarian (challenges the framing)
                              └─ Arbiter (Bayesian synthesis + verdict)
                              │
                              ▼
                         OpenRouter API
                    (own key, own model)
```

## Example Output

<details>
<summary>council_query response (truncated)</summary>

```json
{
  "verdict": "The claim holds under specific conditions but fails to account for...",
  "confidence": 0.72,
  "persona_results": {
    "advocate": {
      "argument": "Strong evidence supports this position because...",
      "confidence": 0.85,
      "evidence": ["Source A (2024)", "Dataset B"]
    },
    "skeptic": {
      "argument": "The critical flaw is the absence of falsifiable predictions...",
      "confidence": 0.45,
      "evidence": ["Counter-study C"]
    },
    "oracle": {
      "argument": "Historical base rate for similar claims: 34% accuracy...",
      "confidence": 0.62,
      "evidence": ["Base rate analysis"]
    },
    "contrarian": {
      "argument": "The entire framing assumes X, but paradigm Y suggests...",
      "confidence": 0.58,
      "evidence": ["Alternative framework"]
    },
    "arbiter": {
      "prior": 0.5,
      "posterior": 0.72,
      "synthesis": "Updating from prior 0.5 → 0.72 after weighing all perspectives..."
    }
  },
  "_meta": {
    "total_tokens": 4250,
    "cost_estimate_usd": 0.0034,
    "model": "nousresearch/hermes-3-llama-3.1-70b",
    "personas_succeeded": 5,
    "personas_failed": 0
  }
}
```

</details>

## Why External MCP Server

- **No core modifications** — zero changes to `model_tools.py` or `toolsets.py`
- **Own provider config** — uses `COUNCIL_API_KEY` / `COUNCIL_MODEL` env vars, never touches the agent's provider
- **Cost transparency** — returns token usage and cost estimates in `_meta` on every response
- **Structured output** — uses JSON mode with regex fallback, no brittle parsing

## Test Plan

- [x] Config example follows existing `mcp_servers` pattern (commented, with env vars)
- [x] No core code changes — config example + optional skill only
- [x] hermes-council server has [122 tests](https://github.com/Ridwannurudeen/hermes-council/actions) with CI (Python 3.11-3.13 + ruff linting)
- [x] Skill follows established `optional-skills/` pattern (same structure as blender-mcp)
- [x] Verified `hermes-council-server` launches and registers all 8 tools
