### PR TITLE
Fix/misc bug fixes

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -158,7 +158,9 @@ def _deliver_result(job: dict, content: str) -> None:
     # Run the async send in a fresh event loop (safe from any thread)
     try:
         result = asyncio.run(_send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id))
-    except RuntimeError:
+    except RuntimeError as e:
+        if "event loop" not in str(e).lower():
+            raise
         # asyncio.run() fails if there's already a running loop in this thread;
         # spin up a new thread to avoid that.
         import concurrent.futures
@@ -524,14 +526,15 @@ def tick(verbose: bool = True) -> int:
 
         return executed
     finally:
-        if fcntl:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+        if lock_fd is not None:
+            if fcntl:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            elif msvcrt:
+                try:
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
+            lock_fd.close()
 
 
 if __name__ == "__main__":

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -890,9 +890,12 @@ class SessionStore:
                 logger.debug("Session DB operation failed: %s", e)
         
         # Also write legacy JSONL (keeps existing tooling working during transition)
-        transcript_path = self.get_transcript_path(session_id)
-        with open(transcript_path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(message, ensure_ascii=False) + "\n")
+        try:
+            transcript_path = self.get_transcript_path(session_id)
+            with open(transcript_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(message, ensure_ascii=False) + "\n")
+        except OSError as e:
+            logger.debug("Failed to write JSONL transcript for session %s: %s", session_id, e)
     
     def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Replace the entire transcript for a session with new messages.

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -159,7 +159,10 @@ def _read_pid_record() -> Optional[dict]:
     if not pid_path.exists():
         return None
 
-    raw = pid_path.read_text().strip()
+    try:
+        raw = pid_path.read_text().strip()
+    except OSError:
+        return None
     if not raw:
         return None
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -148,6 +148,7 @@ class SessionDB:
                 except sqlite3.OperationalError:
                     pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 2")
+                self._conn.commit()
             if current_version < 3:
                 # v3: add title column to sessions
                 try:
@@ -155,6 +156,7 @@ class SessionDB:
                 except sqlite3.OperationalError:
                     pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 3")
+                self._conn.commit()
             if current_version < 4:
                 # v4: add unique index on title (NULLs allowed, only non-NULL must be unique)
                 try:
@@ -165,6 +167,7 @@ class SessionDB:
                 except sqlite3.OperationalError:
                     pass  # Index already exists
                 cursor.execute("UPDATE schema_version SET version = 4")
+                self._conn.commit()
             if current_version < 5:
                 new_columns = [
                     ("cache_read_tokens", "INTEGER DEFAULT 0"),
@@ -185,6 +188,7 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass
                 cursor.execute("UPDATE schema_version SET version = 5")
+                self._conn.commit()
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -851,23 +855,25 @@ class SessionDB:
 
     def session_count(self, source: str = None) -> int:
         """Count sessions, optionally filtered by source."""
-        if source:
-            cursor = self._conn.execute(
-                "SELECT COUNT(*) FROM sessions WHERE source = ?", (source,)
-            )
-        else:
-            cursor = self._conn.execute("SELECT COUNT(*) FROM sessions")
-        return cursor.fetchone()[0]
+        with self._lock:
+            if source:
+                cursor = self._conn.execute(
+                    "SELECT COUNT(*) FROM sessions WHERE source = ?", (source,)
+                )
+            else:
+                cursor = self._conn.execute("SELECT COUNT(*) FROM sessions")
+            return cursor.fetchone()[0]
 
     def message_count(self, session_id: str = None) -> int:
         """Count messages, optionally for a specific session."""
-        if session_id:
-            cursor = self._conn.execute(
-                "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
-            )
-        else:
-            cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
-        return cursor.fetchone()[0]
+        with self._lock:
+            if session_id:
+                cursor = self._conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
+                )
+            else:
+                cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
+            return cursor.fetchone()[0]
 
     # =========================================================================
     # Export and cleanup

--- a/run_agent.py
+++ b/run_agent.py
@@ -287,7 +287,10 @@ def _should_parallelize_tool_batch(tool_calls) -> bool:
         if tool_name in _PATH_SCOPED_TOOLS:
             scoped_path = _extract_parallel_scope_path(tool_name, function_args)
             if scoped_path is None:
-                return False
+                # Path couldn't be extracted; fall back to parallel-safe check
+                if tool_name not in _PARALLEL_SAFE_TOOLS:
+                    return False
+                continue
             if any(_paths_overlap(scoped_path, existing) for existing in reserved_paths):
                 return False
             reserved_paths.append(scoped_path)
@@ -1718,7 +1721,6 @@ class AIAgent:
             self._todo_store.write(last_todo_response, merge=False)
             if not self.quiet_mode:
                 self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
-        _set_interrupt(False)
     
     @property
     def is_interrupted(self) -> bool:
@@ -3555,8 +3557,16 @@ class AIAgent:
             "image/jpg": ".jpg",
         }.get(mime, ".jpg")
         tmp = tempfile.NamedTemporaryFile(prefix="anthropic_image_", suffix=suffix, delete=False)
-        with tmp:
-            tmp.write(base64.b64decode(data))
+        try:
+            with tmp:
+                tmp.write(base64.b64decode(data))
+        except Exception:
+            # Clean up the temp file on decode/write failure
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
+            raise
         path = Path(tmp.name)
         return str(path), path
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -308,8 +308,11 @@ def _extract_parallel_scope_path(tool_name: str, function_args: dict) -> Path | 
     if not isinstance(raw_path, str) or not raw_path.strip():
         return None
 
-    # Avoid resolve(); the file may not exist yet.
-    return Path(raw_path).expanduser()
+    # Avoid resolve(); the file may not exist yet. But do collapse lexical
+    # aliases like "./" and "../" so same-target writes do not get
+    # misclassified as independent and run concurrently.
+    normalized = os.path.normpath(os.path.expanduser(raw_path.strip()))
+    return Path(normalized)
 
 
 def _paths_overlap(left: Path, right: Path) -> bool:

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1086,6 +1086,27 @@ class TestPathsOverlap:
         assert not _paths_overlap(Path("src/a.py"), Path(""))
 
 
+class TestParallelScopeNormalization:
+    def test_extract_parallel_scope_path_normalizes_dotdot_segments(self):
+        from run_agent import _extract_parallel_scope_path
+
+        assert _extract_parallel_scope_path("write_file", {"path": "subdir/../notes.txt"}) == Path("notes.txt")
+
+    def test_same_effective_path_disables_parallel_batch(self):
+        from run_agent import _should_parallelize_tool_batch
+
+        tool_calls = [
+            _mock_tool_call("write_file", json.dumps({"path": "notes.txt", "content": "a"})),
+            _mock_tool_call("patch", json.dumps({
+                "path": "subdir/../notes.txt",
+                "old_string": "a",
+                "new_string": "b",
+            })),
+        ]
+
+        assert _should_parallelize_tool_batch(tool_calls) is False
+
+
 class TestHandleMaxIterations:
     def test_returns_summary(self, agent):
         resp = _mock_response(content="Here is a summary of what I did.")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,7 +23,10 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
-import fcntl
+try:
+    import fcntl
+except ImportError:
+    fcntl = None  # Not available on Windows
 import json
 import logging
 import os
@@ -130,6 +133,10 @@ class MemoryStore:
         Uses a separate .lock file so the memory file itself can still be
         atomically replaced via os.replace().
         """
+        if fcntl is None:
+            # No file locking on Windows — yield without lock
+            yield
+            return
         lock_path = path.with_suffix(path.suffix + ".lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         fd = open(lock_path, "w")

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -47,7 +47,6 @@ import re
 import asyncio
 from typing import List, Dict, Any, Optional
 import httpx
-from firecrawl import Firecrawl
 from agent.auxiliary_client import async_call_llm
 from tools.debug_helpers import DebugSession
 from tools.website_policy import check_website_access
@@ -115,6 +114,7 @@ def _get_firecrawl_client():
             kwargs["api_key"] = api_key
         if api_url:
             kwargs["api_url"] = api_url
+        from firecrawl import Firecrawl
         _firecrawl_client = Firecrawl(**kwargs)
     return _firecrawl_client
 


### PR DESCRIPTION
## Summary
Fix 11 independently discovered bugs across the agent core, gateway, cron scheduler, and tools — none tracked in existing issues.

## Bugs Fixed

| # | Scope | Bug | Severity |
|---|-------|-----|----------|
| 1 | `run_agent.py` | `_hydrate_todo_store()` unconditionally called `_set_interrupt(False)`, silently clearing pending interrupts on every `run_conversation` call | High |
| 2 | `run_agent.py` | `read_file` listed in both `_PATH_SCOPED_TOOLS` and `_PARALLEL_SAFE_TOOLS` — when called without a path arg, the path-scoped check returned `False` first, unnecessarily serializing the entire batch | Medium |
| 3 | `run_agent.py` | `_materialize_data_url_for_vision()` created a `NamedTemporaryFile(delete=False)` but never cleaned it up if `base64.b64decode()` raised | Medium |
| 4 | `hermes_state.py` | `session_count()` and `message_count()` were the only `SessionDB` methods that didn't acquire `self._lock` — race condition under concurrent gateway requests | High |
| 5 | `hermes_state.py` | Schema migrations ran all steps under a single commit — a mid-migration crash left the DB with a mismatched version and no way to resume | Medium |
| 6 | `web_tools.py` | Top-level `from firecrawl import Firecrawl` crashed the entire web tools module for users on Tavily or Parallel backends | High |
| 7 | `memory_tool.py` | Unconditional `import fcntl` — immediate `ImportError` on Windows, violating CONTRIBUTING.md cross-platform rules | High |
| 8 | `gateway/session.py` | `append_to_transcript()` JSONL write had no error handling — disk full or permission errors crashed the gateway message handler | Medium |
| 9 | `gateway/status.py` | `_read_pid_record()` called `read_text()` without `try/except` — concurrent PID file writes caused unhandled `OSError` | Medium |
| 10 | `cron/scheduler.py` | `finally` block called `lock_fd.close()` unconditionally, but `lock_fd` could still be `None` if `open()` never completed → `AttributeError` | Medium |
| 11 | `cron/scheduler.py` | `except RuntimeError` in `_deliver_result()` was too broad — any `RuntimeError` from `_send_to_platform` (not just event-loop errors) triggered a spurious retry in a new thread, risking double delivery | High |

## Test Plan
- [ ] `pytest tests/ -v` passes
- [ ] Import `web_tools` without firecrawl package installed (Tavily/Parallel backend)
- [ ] Import `memory_tool` on Windows (fcntl guard)
- [ ] Concurrent gateway sessions don't trigger SQLite threading errors on count methods
- [ ] Cron `tick()` handles `KeyboardInterrupt` during lock acquisition without `AttributeError`
