### PR TITLE
fix(setup): auto-install matrix-nio during hermes setup

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2763,10 +2763,45 @@ def setup_gateway(config: dict):
         if token or get_env_value("MATRIX_PASSWORD"):
             # E2EE
             print()
-            if prompt_yes_no("Enable end-to-end encryption (E2EE)?", False):
+            want_e2ee = prompt_yes_no("Enable end-to-end encryption (E2EE)?", False)
+            if want_e2ee:
                 save_env_value("MATRIX_ENCRYPTION", "true")
                 print_success("E2EE enabled")
-                print_info("   Requires: pip install 'matrix-nio[e2e]'")
+
+            # Auto-install matrix-nio
+            matrix_pkg = "matrix-nio[e2e]" if want_e2ee else "matrix-nio"
+            try:
+                import nio  # noqa: F401
+            except ImportError:
+                print_info(f"Installing {matrix_pkg}...")
+                import subprocess
+
+                uv_bin = shutil.which("uv")
+                if uv_bin:
+                    result = subprocess.run(
+                        [
+                            uv_bin,
+                            "pip",
+                            "install",
+                            "--python",
+                            sys.executable,
+                            matrix_pkg,
+                        ],
+                        capture_output=True,
+                        text=True,
+                    )
+                else:
+                    result = subprocess.run(
+                        [sys.executable, "-m", "pip", "install", matrix_pkg],
+                        capture_output=True,
+                        text=True,
+                    )
+                if result.returncode == 0:
+                    print_success(f"{matrix_pkg} installed")
+                else:
+                    print_warning(
+                        f"Install failed — run manually: pip install '{matrix_pkg}'"
+                    )
 
             # Allowed users
             print()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ all = [
   "hermes-agent[modal]",
   "hermes-agent[daytona]",
   "hermes-agent[messaging]",
+  "hermes-agent[matrix]",
   "hermes-agent[cron]",
   "hermes-agent[cli]",
   "hermes-agent[dev]",


### PR DESCRIPTION
## Summary

Auto-install `matrix-nio` during `hermes setup` when the user configures Matrix. Previously, setup only saved credentials to `.env` but never installed the required Python package, causing the gateway to fail with "matrix-nio not installed".

## The Bug

1. User runs `hermes setup` and configures Matrix
2. Setup saves `MATRIX_HOMESERVER`, `MATRIX_ACCESS_TOKEN`, etc. to `.env`
3. Setup never installs `matrix-nio` — just prints a manual hint
4. User starts gateway → crash: "matrix-nio not installed"
5. Additionally, `matrix-nio` was not included in the `[all]` extra in `pyproject.toml`, so even `pip install hermes-agent[all]` didn't install it

## The Fix

- Added auto-install logic to the Matrix setup block in `hermes_cli/setup.py`, following the same pattern already used by Modal (`swe-rex[modal]`) and Daytona backends: `try: import nio / except ImportError: subprocess.run(uv pip install ...)`
- Installs `matrix-nio[e2e]` when E2EE is enabled, plain `matrix-nio` otherwise
- Falls back to `pip install` if `uv` is not available
- Added `hermes-agent[matrix]` to the `[all]` extra in `pyproject.toml`

## Test Plan

- [ ] Run `hermes setup`, configure Matrix, verify `matrix-nio` is installed automatically
- [ ] Verify gateway starts successfully after setup
- [ ] Verify `pip install hermes-agent[all]` now includes `matrix-nio`

Closes #1973
