### PR TITLE
fix(install): include Matrix support in the default full install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ all = [
   "hermes-agent[modal]",
   "hermes-agent[daytona]",
   "hermes-agent[messaging]",
+  "hermes-agent[matrix]",
   "hermes-agent[cron]",
   "hermes-agent[cli]",
   "hermes-agent[dev]",

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,0 +1,18 @@
+"""Regression tests for packaging metadata in pyproject.toml."""
+
+from pathlib import Path
+import tomllib
+
+
+def _load_optional_dependencies():
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        project = tomllib.load(handle)["project"]
+    return project["optional-dependencies"]
+
+
+def test_all_extra_includes_matrix_dependency():
+    optional_dependencies = _load_optional_dependencies()
+
+    assert "matrix" in optional_dependencies
+    assert "hermes-agent[matrix]" in optional_dependencies["all"]


### PR DESCRIPTION
Fixes #1973

## Summary

Fresh installs that use `uv pip install -e ".[all]"` or `uv pip install -e ".[all,dev]"` do not install Matrix support, even though Matrix can be configured in `hermes gateway setup`.

The `matrix` extra is defined in `pyproject.toml`, but it was not included in the `all` extra. As a result, a fresh install can collect Matrix credentials successfully, but gateway startup still fails with:

```text
Matrix: matrix-nio not installed. Run: pip install 'matrix-nio[e2e]'
```

## Fix

Added `hermes-agent[matrix]` to the `all` extra in `pyproject.toml`.

This keeps Matrix as an optional extra for targeted installs, while making the default full install match the behavior implied by the setup flow and install docs.

## Tests

Added `tests/test_project_metadata.py::test_all_extra_includes_matrix_dependency` to prevent the `matrix` extra from being dropped from `all` again.

Verified under Python 3.11:

```bash
/tmp/hermes311/bin/python -m pytest -o addopts='' tests/test_project_metadata.py -q
# 1 passed
```

Also re-checked the existing `.[all]` update/install path tests:

```bash
/tmp/hermes311/bin/python -m pytest -o addopts='' tests/hermes_cli/test_update_autostash.py -q
# 13 passed
```