### PR TITLE
fix(auth): correct OpenCode Go API key provider metadata

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -199,9 +199,9 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     "opencode-go": ProviderConfig(
         id="opencode-go",
         name="OpenCode Go",
-        auth_type="***",
+        auth_type="api_key",
         inference_base_url="https://opencode.ai/zen/go/v1",
-        api_key_env_vars=("OPEN...",),
+        api_key_env_vars=("OPENCODE_GO_API_KEY",),
         base_url_env_var="OPENCODE_GO_BASE_URL",
     ),
     "kilocode": ProviderConfig(

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -44,6 +44,7 @@ class TestProviderRegistry:
         ("minimax-cn", "MiniMax (China)", "api_key"),
         ("ai-gateway", "AI Gateway", "api_key"),
         ("kilocode", "Kilo Code", "api_key"),
+        ("opencode-go", "OpenCode Go", "api_key"),
     ])
     def test_provider_registered(self, provider_id, name, auth_type):
         assert provider_id in PROVIDER_REGISTRY
@@ -86,6 +87,11 @@ class TestProviderRegistry:
         pconfig = PROVIDER_REGISTRY["kilocode"]
         assert pconfig.api_key_env_vars == ("KILOCODE_API_KEY",)
         assert pconfig.base_url_env_var == "KILOCODE_BASE_URL"
+
+    def test_opencode_go_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["opencode-go"]
+        assert pconfig.api_key_env_vars == ("OPENCODE_GO_API_KEY",)
+        assert pconfig.base_url_env_var == "OPENCODE_GO_BASE_URL"
 
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"

--- a/tests/test_model_provider_persistence.py
+++ b/tests/test_model_provider_persistence.py
@@ -100,6 +100,27 @@ class TestProviderPersistsAfterModelSave:
         )
         assert model.get("default") == "kimi-k2.5"
 
+    def test_opencode_go_prompts_with_valid_env_key(self, config_home):
+        """OpenCode Go should use the real API key env var during setup."""
+        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.config import load_config
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=[]), \
+             patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
+             patch("hermes_cli.auth.deactivate_provider"), \
+             patch("builtins.input", side_effect=["sk-go-test-key", "", "glm-5"]):
+            _model_flow_api_key_provider(load_config(), "opencode-go", "old-model")
+
+        env_text = (config_home / ".env").read_text()
+        assert "OPENCODE_GO_API_KEY=sk-go-test-key" in env_text
+
+        import yaml
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict), f"model should be dict, got {type(model)}"
+        assert model.get("provider") == "opencode-go"
+        assert model.get("default") == "glm-5"
+
     def test_copilot_provider_saved_when_selected(self, config_home):
         """_model_flow_copilot should persist provider/base_url/model together."""
         from hermes_cli.main import _model_flow_copilot


### PR DESCRIPTION
Fixes #1983

## Summary

Configuring the OpenCode Go provider via the API-key flow could crash with:

```text
ValueError: Invalid environment variable name: 'OPEN...'
```

The root cause was a broken `opencode-go` entry in `hermes_cli/auth.py`:

- `auth_type` was set to `***`
- `api_key_env_vars` was set to `("OPEN...",)`

This caused the generic API-key provider flow to pass an invalid env var name to `save_env_value(...)` when prompting for the OpenCode Go API key.

## Fix

Corrected the `opencode-go` provider metadata in `hermes_cli/auth.py` to use:

- `auth_type="api_key"`
- `api_key_env_vars=("OPENCODE_GO_API_KEY",)`

This aligns the provider registry with the existing OpenCode Go config/setup flow and allows the generic API-key provider path to save the key correctly.

## Tests

Added regression coverage for both the registry metadata and the interactive provider flow:

- `tests/test_api_key_providers.py`
- `tests/test_model_provider_persistence.py`

Verified under Python 3.11:

```bash
/tmp/hermes311/bin/python -m pytest -o addopts='' tests/test_api_key_providers.py -q
# 103 passed
```

```bash
/tmp/hermes311/bin/python -m pytest -o addopts='' tests/test_model_provider_persistence.py -q
# 6 passed
```
