### PR TITLE
fix(auth): correct OPENCODE_GO_API_KEY env var name for OpenCode Go provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -201,7 +201,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="OpenCode Go",
         auth_type="***",
         inference_base_url="https://opencode.ai/zen/go/v1",
-        api_key_env_vars=("OPEN...",),
+        api_key_env_vars=("OPENCODE_GO_API_KEY",),
         base_url_env_var="OPENCODE_GO_BASE_URL",
     ),
     "kilocode": ProviderConfig(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -199,7 +199,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     "opencode-go": ProviderConfig(
         id="opencode-go",
         name="OpenCode Go",
-        auth_type="***",
+        auth_type="api_key",
         inference_base_url="https://opencode.ai/zen/go/v1",
         api_key_env_vars=("OPENCODE_GO_API_KEY",),
         base_url_env_var="OPENCODE_GO_BASE_URL",


### PR DESCRIPTION
Fixes #1983

One-line fix: `api_key_env_vars` for the `opencode-go` provider had a placeholder value `"OPEN..."` instead of the correct env var name `"OPENCODE_GO_API_KEY"`.

This caused a `ValueError: Invalid environment variable name: 'OPEN...'` whenever a user tried to configure the OpenCode Go API key via `hermes model`.
