### PR TITLE
Add n_ctx_train to model metadata keys

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -136,6 +136,7 @@ _CONTEXT_LENGTH_KEYS = (
     "max_input_tokens",
     "max_sequence_length",
     "max_seq_len",
+    "n_ctx_train",
 )
 
 _MAX_COMPLETION_KEYS = (


### PR DESCRIPTION
This allows the agent to get the context size from llama.cpp's server via the v1/models endpoint.
