### PR TITLE
fix(agent): support full context length resolution for direct Gemini API endpoints

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -172,6 +172,7 @@ def _is_known_provider_base_url(base_url: str) -> bool:
         "api.moonshot.ai",
         "api.kimi.com",
         "api.minimax",
+        "generativelanguage.googleapis.com",
     )
     return any(known_host in host for known_host in known_hosts)
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -218,6 +218,23 @@ class TestGetModelContextLength:
 
         assert result == CONTEXT_PROBE_TIERS[0]
 
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_gemini_endpoint_recognized_as_known_provider(self, mock_endpoint_fetch, mock_fetch):
+        mock_fetch.return_value = {}
+        # The endpoint fetch might fail or return empty for Gemini
+        mock_endpoint_fetch.return_value = {}
+
+        result = get_model_context_length(
+            "google/gemini-2.5-pro",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+            api_key="test-key",
+        )
+
+        # Because generativelanguage.googleapis.com is a known provider, it falls through to
+        # DEFAULT_CONTEXT_LENGTHS which gives 1048576, instead of CONTEXT_PROBE_TIERS[0].
+        assert result == 1048576
+
 
 # =========================================================================
 # fetch_model_metadata — caching, TTL, slugs, failures

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -400,6 +400,7 @@ Any service with an OpenAI-compatible API works. Some popular options:
 | [Cerebras](https://cerebras.ai) | `https://api.cerebras.ai/v1` | Wafer-scale chip inference |
 | [Mistral AI](https://mistral.ai) | `https://api.mistral.ai/v1` | Mistral models |
 | [OpenAI](https://openai.com) | `https://api.openai.com/v1` | Direct OpenAI access |
+| [Google Gemini](https://ai.google.dev) | `https://generativelanguage.googleapis.com/v1beta` | Direct Gemini API access |
 | [Azure OpenAI](https://azure.microsoft.com) | `https://YOUR.openai.azure.com/` | Enterprise OpenAI |
 | [LocalAI](https://localai.io) | `http://localhost:8080/v1` | Self-hosted, multi-model |
 | [Jan](https://jan.ai) | `http://localhost:1337/v1` | Desktop app with local models |


### PR DESCRIPTION
## Summary

* Add `generativelanguage.googleapis.com` to `known_hosts` to correctly recognize Google Gemini API endpoints.
* Enable full context length (e.g. 1M+ tokens) resolution instead of falling back to restricted unknown proxy limits.
* Add test coverage for custom Gemini endpoint context length resolution.

## Test plan

* [x] `pytest tests/agent/test_model_metadata.py` passes successfully.

💘 Generated with Crush