### PR TITLE
fix: add homebrew browser path on apple silicon

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -69,7 +69,12 @@ from agent.auxiliary_client import call_llm
 logger = logging.getLogger(__name__)
 
 # Standard PATH entries for environments with minimal PATH (e.g. systemd services)
-_SANE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+# Add Apple Silicon Homebrew paths only on macOS arm64, where launchd commonly
+# omits /opt/homebrew/bin and browser tooling depends on Homebrew-installed Node.
+if sys.platform == "darwin" and platform.machine() == "arm64":
+    _SANE_PATH = "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+else:
+    _SANE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # Throttle screenshot cleanup to avoid repeated full directory scans.
 _last_screenshot_cleanup_by_dir: dict[str, float] = {}


### PR DESCRIPTION

## Summary

On Apple Silicon macOS, Hermes browser automation can fail when launched from launchd, because the inherited PATH is often minimal:

    /usr/bin:/bin:/usr/sbin:/sbin

On this machine, the browser automation stack depends on Homebrew-installed binaries located in:

    /opt/homebrew/bin

That means Hermes may work fine from an interactive shell, but fail in a background service context where Homebrew paths are missing.

This surfaced while debugging StreamYard automation, where browser-related subprocess/runtime discovery was failing under the gateway service.

## What this PR changes

This PR adds a narrowly scoped PATH fallback for Apple Silicon macOS only.

Specifically, it:
- detects darwin
- detects arm64
- prepends /opt/homebrew/bin when appropriate

## Why this is intentionally narrow

I did not want to change global PATH behavior for every platform.

This patch is specifically targeted at the common:
- macOS
- Apple Silicon
- Homebrew
- launchd service

setup.

It avoids changing behavior for:
- Intel Macs
- Linux
- other environments that do not match this profile

## Why it matters

Without this adjustment, Hermes can behave inconsistently depending on how it is launched:

- works from an interactive terminal
- fails from a launchd-managed background service

That kind of environment-sensitive behavior makes browser automation brittle and much harder to debug.

## Validation

Validated manually against the environment that exposed the issue:

- macOS on Apple Silicon
- launchd service environment with restricted PATH
- Homebrew-installed node tooling in /opt/homebrew/bin

## Notes

I did not run the full pytest suite in the isolated worktree used to prepare this patch, because that worktree did not have the project virtualenv bootstrapped.
