### PR TITLE
fix: inherit fallback_model in subagents, batch runner, and cron jobs

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -308,6 +308,22 @@ def _process_single_prompt(
         
         # Initialize agent with sampled toolsets and log prefix for identification
         log_prefix = f"[B{batch_num}:P{prompt_index}]"
+
+        # Load fallback_model from config for batch agents
+        _fallback_model = None
+        try:
+            import yaml as _yaml
+            from pathlib import Path as _Path
+            _cfg_path = _Path(os.getenv('HERMES_HOME', _Path.home() / '.hermes')) / 'config.yaml'
+            if _cfg_path.exists():
+                with open(_cfg_path) as _f:
+                    _cfg = _yaml.safe_load(_f) or {}
+                _fb = _cfg.get('fallback_model', {}) or {}
+                if _fb.get('provider') and _fb.get('model'):
+                    _fallback_model = _fb
+        except Exception:
+            pass
+
         agent = AIAgent(
             base_url=config.get("base_url"),
             api_key=config.get("api_key"),
@@ -328,6 +344,7 @@ def _process_single_prompt(
             prefill_messages=config.get("prefill_messages"),
             skip_context_files=True,  # Don't pollute trajectories with SOUL.md/AGENTS.md
             skip_memory=True,  # Don't use persistent memory in batch runs
+            fallback_model=_fallback_model,
         )
 
         # Run the agent with task_id to ensure each task gets its own isolated VM

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -364,6 +364,20 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             },
         )
 
+        # Load fallback_model from config for cron agents
+        _fallback_model = None
+        try:
+            import yaml as _yaml
+            _cfg_path = Path(os.getenv('HERMES_HOME', Path.home() / '.hermes')) / 'config.yaml'
+            if _cfg_path.exists():
+                with open(_cfg_path) as _f:
+                    _cfg = _yaml.safe_load(_f) or {}
+                _fb = _cfg.get('fallback_model', {}) or {}
+                if _fb.get('provider') and _fb.get('model'):
+                    _fallback_model = _fb
+        except Exception:
+            pass
+
         agent = AIAgent(
             model=turn_route["model"],
             api_key=turn_route["runtime"].get("api_key"),
@@ -384,6 +398,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             platform="cron",
             session_id=f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}",
             session_db=_session_db,
+            fallback_model=_fallback_model,
         )
         
         result = agent.run_conversation(prompt)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -204,6 +204,22 @@ def _build_child_agent(
     effective_acp_command = getattr(parent_agent, "acp_command", None)
     effective_acp_args = list(getattr(parent_agent, "acp_args", []) or [])
 
+    # Inherit fallback_model from parent agent, or load from config
+    _fallback_model = getattr(parent_agent, "fallback_model", None)
+    if not _fallback_model:
+        try:
+            import yaml as _yaml
+            from pathlib import Path as _Path
+            _cfg_path = _Path(os.getenv('HERMES_HOME', _Path.home() / '.hermes')) / 'config.yaml'
+            if _cfg_path.exists():
+                with open(_cfg_path) as _f:
+                    _cfg = _yaml.safe_load(_f) or {}
+                _fb = _cfg.get('fallback_model', {}) or {}
+                if _fb.get('provider') and _fb.get('model'):
+                    _fallback_model = _fb
+        except Exception:
+            pass
+
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,
@@ -231,6 +247,7 @@ def _build_child_agent(
         provider_sort=parent_agent.provider_sort,
         tool_progress_callback=child_progress_cb,
         iteration_budget=shared_budget,
+        fallback_model=_fallback_model,
     )
     child._delegate_saved_tool_names = list(_saved_tool_names)
 


### PR DESCRIPTION
## Problem

When fallback_model is configured in config.yaml, it was only being passed to the parent AIAgent. Child agents spawned via delegate_task, batch_runner, and cron/scheduler were not inheriting this setting, leaving them without fallback protection during provider outages or rate limits.

## Scenario

1. Parent agent starts on Anthropic
2. Anthropic has an outage or rate limits
3. Parent falls back to configured fallback model (e.g., OpenRouter GLM-5)
4. Parent spawns a subagent via delegate_task
5. Bug: Subagent tries to use Anthropic (inherited model) but has fallback_model=None
6. Subagent crashes instead of falling back

## Fix

This PR adds fallback_model inheritance in three locations:

- tools/delegate_tool.py: Inherits from parent agent's fallback_model attribute, or loads from config if not set
- batch_runner.py: Loads from config
- cron/scheduler.py: Loads from config

Each location now passes fallback_model to the AIAgent constructor.

## Files Changed

- tools/delegate_tool.py - Added fallback_model resolution and parameter
- batch_runner.py - Added fallback_model loading from config
- cron/scheduler.py - Added fallback_model loading from config

## Testing

The fix was verified by:
1. Corrupting OAuth credentials to force primary provider failure
2. Confirming parent agent falls back successfully
3. Code inspection showing child agents now receive fallback_model parameter

The change is minimal and non-breaking - agents without fallback_model configured continue to work as before (no fallback protection).