### PR TITLE
fix(telegram): prevent sending empty message chunks

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -349,6 +349,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 _NetErr = OSError  # type: ignore[misc,assignment]
 
             for i, chunk in enumerate(chunks):
+                if chunk is None or not str(chunk).strip():
+                    continue
                 msg = None
                 for _send_attempt in range(3):
                     try:
@@ -366,6 +368,8 @@ class TelegramAdapter(BasePlatformAdapter):
                             if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
                                 logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
                                 plain_chunk = _strip_mdv2(chunk)
+                                if plain_chunk is None or not str(plain_chunk).strip():
+                                          continue
                                 msg = await self._bot.send_message(
                                     chat_id=int(chat_id),
                                     text=plain_chunk,


### PR DESCRIPTION
## What does this PR do?

Prevents empty or whitespace-only message chunks from being sent via Telegram.

## Why is this needed?

In some edge cases, message chunking can produce empty strings, which may result in blank messages or API issues.

## Changes Made

- Added checks to skip empty chunks before sending messages
- Applied validation for both markdown and plain text fallback paths

## How to Test

1. Trigger a response that results in empty chunks
2. Verify no empty messages are sent