### PR TITLE
fix: use argparse entrypoint in top-level launcher

### DIFF
--- a/hermes
+++ b/hermes
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 """
-Hermes Agent CLI Launcher
+Hermes Agent CLI launcher.
 
-This is a convenience wrapper to launch the Hermes CLI.
-Usage: ./hermes [options]
+This wrapper should behave like the installed `hermes` command, including
+subcommands such as `gateway`, `cron`, and `doctor`.
 """
 
 if __name__ == "__main__":
-    from cli import main
-    import fire
-    fire.Fire(main)
+    from hermes_cli.main import main
+    main()

--- a/tests/hermes_cli/test_launcher.py
+++ b/tests/hermes_cli/test_launcher.py
@@ -1,0 +1,42 @@
+"""Tests for the top-level `./hermes` launcher script."""
+
+import runpy
+import sys
+import types
+from pathlib import Path
+
+
+def test_launcher_delegates_to_argparse_entrypoint(monkeypatch):
+    """`./hermes gateway` should use `hermes_cli.main`, not the legacy Fire wrapper."""
+    launcher_path = Path(__file__).resolve().parents[2] / "hermes"
+    called = []
+
+    fake_main_module = types.ModuleType("hermes_cli.main")
+
+    def fake_main():
+        called.append("hermes_cli.main")
+
+    fake_main_module.main = fake_main
+    monkeypatch.setitem(sys.modules, "hermes_cli.main", fake_main_module)
+
+    fake_cli_module = types.ModuleType("cli")
+
+    def legacy_cli_main(*args, **kwargs):  # pragma: no cover - defensive only
+        raise AssertionError("launcher should not import cli.main")
+
+    fake_cli_module.main = legacy_cli_main
+    monkeypatch.setitem(sys.modules, "cli", fake_cli_module)
+
+    fake_fire_module = types.ModuleType("fire")
+
+    def legacy_fire(*args, **kwargs):  # pragma: no cover - defensive only
+        raise AssertionError("launcher should not invoke fire.Fire")
+
+    fake_fire_module.Fire = legacy_fire
+    monkeypatch.setitem(sys.modules, "fire", fake_fire_module)
+
+    monkeypatch.setattr(sys, "argv", [str(launcher_path), "gateway", "status"])
+
+    runpy.run_path(str(launcher_path), run_name="__main__")
+
+    assert called == ["hermes_cli.main"]


### PR DESCRIPTION
## Summary
- make the top-level `./hermes` launcher call `hermes_cli.main.main()`
- remove the legacy Fire-based wrapper path
- add a regression test covering `./hermes gateway ...` dispatch

## Why
The wrapper should behave like the installed `hermes` command and support subcommands like `gateway`, `cron`, and `doctor`.

## Test Plan
- [x] `./venv/bin/python -m pytest tests/hermes_cli/test_launcher.py -q`

## Notes
- source fork branch: `gito369:fix/top-level-launcher-entrypoint-upstream`
- commit: `f6b44554`