### PR TITLE
feat(terminal): add Morph compute provider

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -167,6 +167,7 @@ def load_cli_config() -> Dict[str, Any]:
             "singularity_image": "docker://nikolaik/python-nodejs:python3.11-nodejs20",
             "modal_image": "nikolaik/python-nodejs:python3.11-nodejs20",
             "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
+            "morph_image_id": "morphvm-minimal",
             "docker_volumes": [],  # host:container volume mounts for Docker backend
             "docker_mount_cwd_to_workspace": False,  # explicit opt-in only; default off for sandbox isolation
         },
@@ -336,6 +337,7 @@ def load_cli_config() -> Dict[str, Any]:
         "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
         "modal_image": "TERMINAL_MODAL_IMAGE",
         "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+        "morph_image_id": "TERMINAL_MORPH_IMAGE_ID",
         # SSH config
         "ssh_host": "TERMINAL_SSH_HOST",
         "ssh_user": "TERMINAL_SSH_USER",
@@ -7345,6 +7347,7 @@ def main(
                     result = cli.agent.run_conversation(
                         user_message=query,
                         conversation_history=cli.conversation_history,
+                        task_id=cli.session_id,
                     )
                     response = result.get("final_response", "") if isinstance(result, dict) else str(result)
                     if response:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -114,6 +114,7 @@ if _config_path.exists():
                 "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
                 "modal_image": "TERMINAL_MODAL_IMAGE",
                 "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+                "morph_image_id": "TERMINAL_MORPH_IMAGE_ID",
                 "ssh_host": "TERMINAL_SSH_HOST",
                 "ssh_user": "TERMINAL_SSH_USER",
                 "ssh_port": "TERMINAL_SSH_PORT",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -35,6 +35,7 @@ _EXTRA_ENV_KEYS = frozenset({
     "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
     "DINGTALK_CLIENT_ID", "DINGTALK_CLIENT_SECRET",
     "TERMINAL_ENV", "TERMINAL_SSH_KEY", "TERMINAL_SSH_PORT",
+    "TERMINAL_MORPH_IMAGE_ID",
     "WHATSAPP_MODE", "WHATSAPP_ENABLED",
     "MATTERMOST_HOME_CHANNEL", "MATTERMOST_REPLY_MODE",
     "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_HOME_ROOM",
@@ -128,7 +129,8 @@ DEFAULT_CONFIG = {
         "singularity_image": "docker://nikolaik/python-nodejs:python3.11-nodejs20",
         "modal_image": "nikolaik/python-nodejs:python3.11-nodejs20",
         "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
-        # Container resource limits (docker, singularity, modal, daytona — ignored for local/ssh)
+        "morph_image_id": "morphvm-minimal",
+        # Container resource limits (docker, singularity, modal, daytona, morph — ignored for local/ssh)
         "container_cpu": 1,
         "container_memory": 5120,       # MB (default 5GB)
         "container_disk": 51200,        # MB (default 50GB)
@@ -392,6 +394,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
     4: ["VOICE_TOOLS_OPENAI_KEY", "ELEVENLABS_API_KEY"],
     5: ["WHATSAPP_ENABLED", "WHATSAPP_MODE", "WHATSAPP_ALLOWED_USERS",
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
+    8: ["MORPH_API_KEY"],
     10: ["TAVILY_API_KEY"],
 }
 
@@ -1219,9 +1222,9 @@ def load_config() -> Dict[str, Any]:
     import copy
     ensure_hermes_home()
     config_path = get_config_path()
-    
+
     config = copy.deepcopy(DEFAULT_CONFIG)
-    
+
     if config_path.exists():
         try:
             with open(config_path, encoding="utf-8") as f:
@@ -1237,7 +1240,7 @@ def load_config() -> Dict[str, Any]:
             config = _deep_merge(config, user_config)
         except Exception as e:
             print(f"Warning: Failed to load config: {e}")
-    
+
     return _expand_env_vars(_normalize_max_turns_config(config))
 
 
@@ -1614,6 +1617,7 @@ def show_config():
     keys = [
         ("OPENROUTER_API_KEY", "OpenRouter"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
+        ("MORPH_API_KEY", "Morph"),
         ("PARALLEL_API_KEY", "Parallel"),
         ("FIRECRAWL_API_KEY", "Firecrawl"),
         ("TAVILY_API_KEY", "Tavily"),
@@ -1662,6 +1666,10 @@ def show_config():
         print(f"  Daytona image: {terminal.get('daytona_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
         daytona_key = get_env_value('DAYTONA_API_KEY')
         print(f"  API key:      {'configured' if daytona_key else '(not set)'}")
+    elif terminal.get('backend') == 'morph':
+        print(f"  Morph image:    {terminal.get('morph_image_id', '') or '(not set)'}")
+        morph_key = get_env_value('MORPH_API_KEY')
+        print(f"  API key:        {'configured' if morph_key else '(not set)'}")
     elif terminal.get('backend') == 'ssh':
         ssh_host = get_env_value('TERMINAL_SSH_HOST')
         ssh_user = get_env_value('TERMINAL_SSH_USER')
@@ -1772,6 +1780,7 @@ def set_config_value(key: str, value: str):
         'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
         'GITHUB_TOKEN', 'HONCHO_API_KEY', 'WANDB_API_KEY',
         'TINKER_API_KEY',
+        'TERMINAL_MORPH_IMAGE_ID',
     ]
     
     if key.upper() in api_keys or key.upper().endswith('_API_KEY') or key.upper().endswith('_TOKEN') or key.upper().startswith('TERMINAL_SSH'):
@@ -1826,6 +1835,7 @@ def set_config_value(key: str, value: str):
         "terminal.modal_image": "TERMINAL_MODAL_IMAGE",
         "terminal.daytona_image": "TERMINAL_DAYTONA_IMAGE",
         "terminal.docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+        "terminal.morph_image_id": "TERMINAL_MORPH_IMAGE_ID",
         "terminal.cwd": "TERMINAL_CWD",
         "terminal.timeout": "TERMINAL_TIMEOUT",
         "terminal.sandbox_dir": "TERMINAL_SANDBOX_DIR",

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -10,7 +10,13 @@ import subprocess
 import shutil
 from pathlib import Path
 
-from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
+from hermes_cli.config import (
+    get_project_root,
+    get_hermes_home,
+    get_env_path,
+    get_env_value,
+    load_config,
+)
 
 PROJECT_ROOT = get_project_root()
 HERMES_HOME = get_hermes_home()
@@ -454,6 +460,37 @@ def run_doctor(args):
             check_fail("daytona SDK not installed", "(pip install daytona)")
             issues.append("Install daytona SDK: pip install daytona")
 
+    if terminal_env == "morph":
+        morph_key = get_env_value("MORPH_API_KEY")
+        morph_image = (
+            get_env_value("TERMINAL_MORPH_IMAGE_ID")
+            or load_config().get("terminal", {}).get("morph_image_id", "")
+        )
+        if morph_key:
+            check_ok("Morph API key", "(configured)")
+        else:
+            check_fail("MORPH_API_KEY not set", "(required for TERMINAL_ENV=morph)")
+            issues.append("Set MORPH_API_KEY environment variable")
+
+        if morph_image:
+            check_ok("Morph base image", f"({morph_image})")
+        else:
+            check_fail(
+                "TERMINAL_MORPH_IMAGE_ID not set",
+                "(required for TERMINAL_ENV=morph)",
+            )
+            issues.append(
+                "Set TERMINAL_MORPH_IMAGE_ID in .env or terminal.morph_image_id in config"
+            )
+
+        try:
+            import morphcloud  # noqa: F401
+
+            check_ok("morphcloud SDK", "(installed)")
+        except ImportError:
+            check_fail("morphcloud SDK not installed", "(pip install morphcloud)")
+            issues.append("Install morphcloud SDK: pip install 'morphcloud>=0.1.106'")
+
     # Node.js + agent-browser (for browser automation tools)
     if shutil.which("node"):
         check_ok("Node.js")
@@ -687,7 +724,6 @@ def run_doctor(args):
     else:
         check_warn("Skills Hub directory not initialized", "(run: hermes skills list)")
 
-    from hermes_cli.config import get_env_value
     github_token = get_env_value("GITHUB_TOKEN") or get_env_value("GH_TOKEN")
     if github_token:
         check_ok("GitHub token configured (authenticated API access)")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1964,11 +1964,26 @@ def setup_terminal_backend(config: dict):
         "Modal - serverless cloud sandbox",
         "SSH - run on a remote machine",
         "Daytona - persistent cloud development environment",
+        "Morph - computers from the future",
     ]
-    idx_to_backend = {0: "local", 1: "docker", 2: "modal", 3: "ssh", 4: "daytona"}
-    backend_to_idx = {"local": 0, "docker": 1, "modal": 2, "ssh": 3, "daytona": 4}
+    idx_to_backend = {
+        0: "local",
+        1: "docker",
+        2: "modal",
+        3: "ssh",
+        4: "daytona",
+        5: "morph",
+    }
+    backend_to_idx = {
+        "local": 0,
+        "docker": 1,
+        "modal": 2,
+        "ssh": 3,
+        "daytona": 4,
+        "morph": 5,
+    }
 
-    next_idx = 5
+    next_idx = 6
     if is_linux:
         terminal_choices.append("Singularity/Apptainer - HPC-friendly container")
         idx_to_backend[next_idx] = "singularity"
@@ -2186,6 +2201,70 @@ def setup_terminal_backend(config: dict):
         image = prompt("  Sandbox image", current_image)
         config["terminal"]["daytona_image"] = image
         save_env_value("TERMINAL_DAYTONA_IMAGE", image)
+
+        _prompt_container_resources(config)
+
+    elif selected_backend == "morph":
+        print_success("Terminal backend: Morph")
+        print_info("Persistent Morph Cloud instances started from a cached base snapshot.")
+        print_info("Hermes reattaches by task_id, refreshes TTL, and pauses idle workspaces.")
+        print_info("This backend targets Morph Instances; Devboxes remain a separate future option.")
+
+        try:
+            __import__("morphcloud")
+        except ImportError:
+            print_info("Installing morphcloud SDK...")
+            import subprocess
+
+            uv_bin = shutil.which("uv")
+            if uv_bin:
+                result = subprocess.run(
+                    [uv_bin, "pip", "install", "--python", sys.executable, "morphcloud>=0.1.106"],
+                    capture_output=True,
+                    text=True,
+                )
+            else:
+                result = subprocess.run(
+                    [sys.executable, "-m", "pip", "install", "morphcloud>=0.1.106"],
+                    capture_output=True,
+                    text=True,
+                )
+            if result.returncode == 0:
+                print_success("morphcloud SDK installed")
+            else:
+                print_warning("Install failed — run manually: pip install 'morphcloud>=0.1.106'")
+                if result.stderr:
+                    print_info(f"  Error: {result.stderr.strip().splitlines()[-1]}")
+
+        print()
+        existing_key = get_env_value("MORPH_API_KEY")
+        if existing_key:
+            print_info("  Morph API key: already configured")
+            if prompt_yes_no("  Update API key?", False):
+                api_key = prompt("    Morph API key", password=True)
+                if api_key:
+                    save_env_value("MORPH_API_KEY", api_key)
+                    print_success("    Updated")
+        else:
+            api_key = prompt("    Morph API key", password=True)
+            if api_key:
+                save_env_value("MORPH_API_KEY", api_key)
+                print_success("    Configured")
+
+        print()
+        print_info("Base image:")
+        print_info("  Use a Morph base image ID such as morphvm-minimal.")
+        print_info("  Hermes creates or reuses a cached base snapshot using image + CPU + memory + disk.")
+        current_image = config.get("terminal", {}).get(
+            "morph_image_id",
+            get_env_value("TERMINAL_MORPH_IMAGE_ID") or "",
+        )
+        image_id = prompt("  Morph base image ID", current_image)
+        config["terminal"]["morph_image_id"] = image_id
+        if image_id:
+            save_env_value("TERMINAL_MORPH_IMAGE_ID", image_id)
+        else:
+            print_warning("Morph requires a base image ID before commands will work.")
 
         _prompt_container_resources(config)
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -115,6 +115,7 @@ def show_status(args):
     keys = {
         "OpenRouter": "OPENROUTER_API_KEY",
         "OpenAI": "OPENAI_API_KEY",
+        "Morph": "MORPH_API_KEY",
         "Z.AI/GLM": "GLM_API_KEY",
         "Kimi": "KIMI_API_KEY",
         "MiniMax": "MINIMAX_API_KEY",
@@ -234,10 +235,24 @@ def show_status(args):
         docker_image = os.getenv("TERMINAL_DOCKER_IMAGE", "python:3.11-slim")
         print(f"  Docker Image: {docker_image}")
     elif terminal_env == "daytona":
-        daytona_image = os.getenv("TERMINAL_DAYTONA_IMAGE", "nikolaik/python-nodejs:python3.11-nodejs20")
+        daytona_image = os.getenv(
+            "TERMINAL_DAYTONA_IMAGE",
+            "nikolaik/python-nodejs:python3.11-nodejs20",
+        )
         print(f"  Daytona Image: {daytona_image}")
-    
-    sudo_password = os.getenv("SUDO_PASSWORD", "")
+    elif terminal_env == "morph":
+        morph_image = (
+            get_env_value("TERMINAL_MORPH_IMAGE_ID")
+            or load_config().get("terminal", {}).get("morph_image_id", "")
+        )
+        morph_key = get_env_value("MORPH_API_KEY") or ""
+        print(f"  Morph Image: {morph_image or '(not set)'}")
+        print(
+            f"  Morph API Key: {check_mark(bool(morph_key))} "
+            f"{'configured' if morph_key else 'not set'}"
+        )
+
+    sudo_password = get_env_value("SUDO_PASSWORD") or ""
     print(f"  Sudo:         {check_mark(bool(sudo_password))} {'enabled' if sudo_password else 'disabled'}")
     
     # =========================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 [project.optional-dependencies]
 modal = ["swe-rex[modal]>=1.4.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
+morph = ["morphcloud>=0.1.106"]
 dev = ["pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2"]
 messaging = ["python-telegram-bot>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 cron = ["croniter>=6.0.0,<7"]
@@ -68,6 +69,7 @@ yc-bench = ["yc-bench @ git+https://github.com/collinear-ai/yc-bench.git ; pytho
 all = [
   "hermes-agent[modal]",
   "hermes-agent[daytona]",
+  "hermes-agent[morph]",
   "hermes-agent[messaging]",
   "hermes-agent[cron]",
   "hermes-agent[cli]",

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -67,6 +67,7 @@ class TestLoadConfigDefaults:
             assert "max_turns" not in config
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
+            assert config["terminal"]["morph_image_id"] == "morphvm-minimal"
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):

--- a/tests/hermes_cli/test_morph_terminal_backend.py
+++ b/tests/hermes_cli/test_morph_terminal_backend.py
@@ -1,0 +1,140 @@
+"""Tests for Morph terminal backend CLI/config surfaces."""
+
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from hermes_cli.config import get_env_path, load_config
+from hermes_cli.setup import setup_terminal_backend
+from hermes_cli.status import show_status
+
+
+@pytest.fixture()
+def isolated_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    return tmp_path
+
+
+def test_setup_terminal_backend_morph_updates_config_and_env(
+    isolated_hermes_home, monkeypatch
+):
+    monkeypatch.setitem(sys.modules, "morphcloud", ModuleType("morphcloud"))
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.delenv("MORPH_API_KEY", raising=False)
+    monkeypatch.delenv("TERMINAL_MORPH_IMAGE_ID", raising=False)
+
+    config = load_config()
+
+    def _pick_morph(_question, choices, _default):
+        return next(
+            index for index, choice in enumerate(choices) if choice.startswith("Morph -")
+        )
+
+    prompt_values = iter(
+        [
+            "morph-api-key",
+            "morphvm-minimal",
+            "yes",
+            "2",
+            "6144",
+            "20480",
+        ]
+    )
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", _pick_morph)
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_values))
+
+    setup_terminal_backend(config)
+
+    env_text = get_env_path().read_text(encoding="utf-8")
+    assert config["terminal"]["backend"] == "morph"
+    assert config["terminal"]["morph_image_id"] == "morphvm-minimal"
+    assert config["terminal"]["container_cpu"] == 2.0
+    assert config["terminal"]["container_memory"] == 6144
+    assert config["terminal"]["container_disk"] == 20480
+    assert "MORPH_API_KEY=morph-api-key" in env_text
+    assert "TERMINAL_MORPH_IMAGE_ID=morphvm-minimal" in env_text
+    assert "TERMINAL_ENV=morph" in env_text
+
+
+def test_show_status_includes_morph_backend_details(monkeypatch, capsys):
+    monkeypatch.setenv("TERMINAL_ENV", "morph")
+    monkeypatch.setenv("MORPH_API_KEY", "morph-key")
+    monkeypatch.setenv("TERMINAL_MORPH_IMAGE_ID", "morphvm-minimal")
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+
+    show_status(SimpleNamespace(all=False, deep=False))
+    output = capsys.readouterr().out
+
+    assert "Backend:      morph" in output
+    assert "Morph Image: morphvm-minimal" in output
+    assert "Morph API Key:" in output
+
+
+def test_show_status_uses_default_morph_image_when_env_missing(
+    isolated_hermes_home, monkeypatch, capsys
+):
+    monkeypatch.setenv("TERMINAL_ENV", "morph")
+    monkeypatch.setenv("MORPH_API_KEY", "morph-key")
+    monkeypatch.delenv("TERMINAL_MORPH_IMAGE_ID", raising=False)
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+
+    show_status(SimpleNamespace(all=False, deep=False))
+    output = capsys.readouterr().out
+
+    assert "Morph Image: morphvm-minimal" in output
+
+
+def test_doctor_reports_morph_configuration(monkeypatch, isolated_hermes_home, capsys):
+    monkeypatch.setenv("TERMINAL_ENV", "morph")
+    monkeypatch.setenv("MORPH_API_KEY", "morph-key")
+    monkeypatch.setenv("TERMINAL_MORPH_IMAGE_ID", "morphvm-minimal")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setitem(sys.modules, "morphcloud", ModuleType("morphcloud"))
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+
+    import hermes_cli.doctor as doctor_module
+
+    doctor_module = importlib.reload(doctor_module)
+    doctor_module.run_doctor(SimpleNamespace(fix=False))
+    output = capsys.readouterr().out
+
+    assert "Morph API key" in output
+    assert "Morph base image" in output
+    assert "morphcloud SDK" in output
+
+
+def test_doctor_uses_default_morph_image_when_env_missing(
+    monkeypatch, isolated_hermes_home, capsys
+):
+    monkeypatch.setenv("TERMINAL_ENV", "morph")
+    monkeypatch.setenv("MORPH_API_KEY", "morph-key")
+    monkeypatch.delenv("TERMINAL_MORPH_IMAGE_ID", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setitem(sys.modules, "morphcloud", ModuleType("morphcloud"))
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+
+    import hermes_cli.doctor as doctor_module
+
+    doctor_module = importlib.reload(doctor_module)
+    doctor_module.run_doctor(SimpleNamespace(fix=False))
+    output = capsys.readouterr().out
+
+    assert "Morph base image" in output
+    assert "morphvm-minimal" in output

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -125,3 +125,10 @@ class TestConfigYamlRouting:
             "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=true" in env_content
             or "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=True" in env_content
         )
+
+    def test_terminal_morph_image_syncs_to_env(self, _isolated_hermes_home):
+        set_config_value("terminal.morph_image_id", "morphvm-minimal")
+        config = _read_config(_isolated_hermes_home)
+        env = _read_env(_isolated_hermes_home)
+        assert "morph_image_id: morphvm-minimal" in config
+        assert "TERMINAL_MORPH_IMAGE_ID=morphvm-minimal" in env

--- a/tests/integration/test_morph_terminal.py
+++ b/tests/integration/test_morph_terminal.py
@@ -1,0 +1,142 @@
+"""Integration tests for the Morph terminal backend.
+
+Requires:
+    TERMINAL_ENV=morph
+    MORPH_API_KEY=...
+    TERMINAL_MORPH_IMAGE_ID=<Morph base image ID>  # optional, defaults to morphvm-minimal
+
+Run with:
+    TERMINAL_ENV=morph pytest tests/integration/test_morph_terminal.py -v
+"""
+
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+if not os.getenv("MORPH_API_KEY"):
+    pytest.skip("MORPH_API_KEY not set", allow_module_level=True)
+
+try:
+    import morphcloud  # noqa: F401
+except ImportError:
+    pytest.skip("morphcloud not installed", allow_module_level=True)
+
+import importlib.util
+import signal
+
+parent_dir = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(parent_dir))
+tools_pkg = ModuleType("tools")
+tools_pkg.__path__ = [str(parent_dir / "tools")]
+sys.modules["tools"] = tools_pkg
+
+spec = importlib.util.spec_from_file_location(
+    "terminal_tool", parent_dir / "tools" / "terminal_tool.py"
+)
+terminal_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(terminal_module)
+
+terminal_tool = terminal_module.terminal_tool
+cleanup_vm = terminal_module.cleanup_vm
+RUN_TOKEN = uuid.uuid4().hex[:8]
+
+
+def _integration_timeout_handler(signum, frame):
+    raise TimeoutError("Test exceeded 240 second timeout")
+
+
+@pytest.fixture(autouse=True)
+def _force_morph(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "morph")
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
+
+
+@pytest.fixture(autouse=True)
+def _enforce_test_timeout():
+    old = signal.signal(signal.SIGALRM, _integration_timeout_handler)
+    signal.alarm(240)
+    yield
+    signal.alarm(0)
+    signal.signal(signal.SIGALRM, old)
+
+
+def _run(command, task_id, **kwargs):
+    kwargs.setdefault("timeout", 180)
+    kwargs.setdefault("workdir", "/root")
+    return json.loads(terminal_tool(command, task_id=task_id, **kwargs))
+
+
+def _task_id(name: str) -> str:
+    return f"{name}_{RUN_TOKEN}"
+
+
+def test_echo_roundtrip():
+    task_id = _task_id("morph_test_echo")
+    try:
+        result = _run("echo 'Hello from Morph!'", task_id)
+        assert result["exit_code"] == 0, result
+        assert "Hello from Morph!" in result["output"]
+    finally:
+        cleanup_vm(task_id)
+
+
+def test_nonzero_exit_propagates():
+    task_id = _task_id("morph_test_nonzero")
+    try:
+        result = _run("exit 42", task_id)
+        assert result["exit_code"] == 42, result
+    finally:
+        cleanup_vm(task_id)
+
+
+def test_persistent_workspace_reattaches_after_cleanup(monkeypatch):
+    task_id = _task_id("morph_test_persist")
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "true")
+    try:
+        first = _run("echo 'survive' > /tmp/morph_persist.txt", task_id)
+        assert first["exit_code"] == 0, first
+
+        cleanup_vm(task_id)
+
+        second = _run("cat /tmp/morph_persist.txt", task_id)
+        assert second["exit_code"] == 0, second
+        assert "survive" in second["output"]
+    finally:
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
+        cleanup_vm(task_id)
+
+
+def test_task_ids_are_isolated():
+    task_a = _task_id("morph_test_iso_a")
+    task_b = _task_id("morph_test_iso_b")
+    try:
+        first = _run("echo 'secret' > /tmp/morph_isolated.txt", task_a)
+        assert first["exit_code"] == 0, first
+
+        second = _run(
+            "cat /tmp/morph_isolated.txt 2>/dev/null || echo NOT_FOUND",
+            task_b,
+        )
+        assert second["exit_code"] == 0, second
+        assert "NOT_FOUND" in second["output"]
+        assert "secret" not in second["output"]
+    finally:
+        cleanup_vm(task_a)
+        cleanup_vm(task_b)
+
+
+def test_timeout_returns_timeout_result():
+    task_id = _task_id("morph_test_timeout")
+    try:
+        result = _run("sleep 30", task_id, timeout=3)
+        assert result["exit_code"] == 124, result
+        assert result["error"] is None, result
+    finally:
+        cleanup_vm(task_id)

--- a/tests/test_cli_single_query_task_id.py
+++ b/tests/test_cli_single_query_task_id.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+
+class _DummyAgent:
+    def __init__(self):
+        self.calls = []
+        self.quiet_mode = False
+
+    def run_conversation(self, user_message, conversation_history=None, task_id=None):
+        self.calls.append((user_message, conversation_history, task_id))
+        return {"final_response": "ok"}
+
+
+class _DummyCLI:
+    def __init__(self, **kwargs):
+        del kwargs
+        self.session_id = "session-123"
+        self.system_prompt = ""
+        self.preloaded_skills = []
+        self.tool_progress_mode = "all"
+        self._active_agent_route_signature = "sig"
+        self.agent = _DummyAgent()
+        self.conversation_history = []
+
+    def _ensure_runtime_credentials(self):
+        return True
+
+    def _resolve_turn_agent_config(self, query):
+        del query
+        return {
+            "signature": "sig",
+            "model": "gpt-5.4",
+            "runtime": {},
+            "label": "default",
+        }
+
+    def _init_agent(self, **kwargs):
+        del kwargs
+        return True
+
+    def show_banner(self):
+        return None
+
+    def show_tools(self):
+        return None
+
+    def show_toolsets(self):
+        return None
+
+    def run(self):
+        return None
+
+
+def test_main_single_query_uses_cli_session_id_as_task_id(monkeypatch, capsys):
+    import cli as cli_mod
+
+    created = {}
+
+    def fake_cli(**kwargs):
+        del kwargs
+        created["cli"] = _DummyCLI()
+        return created["cli"]
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", fake_cli)
+
+    cli_mod.main(query="hello", quiet=True)
+
+    cli_obj = created["cli"]
+    assert cli_obj.agent.calls == [("hello", [], "session-123")]
+
+    out = capsys.readouterr().out
+    assert "ok" in out
+    assert "session_id: session-123" in out

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -71,6 +71,10 @@ class TestContainerSkip:
         result = check_all_command_guards("rm -rf /", "daytona")
         assert result["approved"] is True
 
+    def test_morph_skips_both(self):
+        result = check_all_command_guards("rm -rf /", "morph")
+        assert result["approved"] is True
+
 
 # ---------------------------------------------------------------------------
 # tirith allow + safe command

--- a/tests/tools/test_morph_environment.py
+++ b/tests/tools/test_morph_environment.py
@@ -1,0 +1,530 @@
+"""Unit tests for the Morph Cloud execution environment backend."""
+
+import importlib
+import logging
+import sys
+import threading
+from types import ModuleType, SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parent.parent.parent
+tools_pkg = ModuleType("tools")
+tools_pkg.__path__ = [str(_repo_root / "tools")]
+sys.modules["tools"] = tools_pkg
+environments_pkg = ModuleType("tools.environments")
+environments_pkg.__path__ = [str(_repo_root / "tools" / "environments")]
+sys.modules["tools.environments"] = environments_pkg
+tools_pkg.environments = environments_pkg
+
+
+def _exec_response(stdout="", stderr="", exit_code=0):
+    return SimpleNamespace(stdout=stdout, stderr=stderr, exit_code=exit_code)
+
+
+def _resource_spec(vcpus=1, memory=5120, disk_size=51200):
+    return SimpleNamespace(vcpus=vcpus, memory=memory, disk_size=disk_size)
+
+
+class FakeMorphApiError(Exception):
+    def __init__(self, status_code, message="Morph API error"):
+        self.status_code = status_code
+        super().__init__(message)
+
+
+class FakeSnapshot:
+    def __init__(
+        self,
+        snapshot_id,
+        *,
+        image_id="morphvm-minimal",
+        vcpus=1,
+        memory=5120,
+        disk_size=51200,
+        metadata=None,
+        digest=None,
+        status="ready",
+    ):
+        self.id = snapshot_id
+        self.refs = SimpleNamespace(image_id=image_id)
+        self.spec = _resource_spec(vcpus=vcpus, memory=memory, disk_size=disk_size)
+        self.metadata = dict(metadata or {})
+        self.digest = digest
+        self.status = status
+        self.wait_calls = []
+        self.set_metadata_calls = []
+
+    def wait_until_ready(self, timeout=None):
+        self.wait_calls.append(timeout)
+        self.status = "ready"
+
+    def set_metadata(self, metadata):
+        self.set_metadata_calls.append(metadata)
+        self.metadata = dict(metadata)
+
+
+class FakeInstance:
+    def __init__(
+        self,
+        instance_id,
+        *,
+        status="ready",
+        created=1,
+        metadata=None,
+        vcpus=1,
+        memory=5120,
+        disk_size=51200,
+    ):
+        self.id = instance_id
+        self.status = status
+        self.created = created
+        self.metadata = dict(metadata or {})
+        self.spec = _resource_spec(vcpus=vcpus, memory=memory, disk_size=disk_size)
+        self.wake_on = SimpleNamespace(wake_on_ssh=False)
+        self.ttl = SimpleNamespace(ttl_seconds=None, ttl_action=None)
+        self.resume_calls = 0
+        self.stop_calls = 0
+        self.wait_calls = []
+        self.set_metadata_calls = []
+        self.set_ttl_calls = []
+        self.set_wake_on_calls = []
+        self.exec_calls = []
+        self.exec_responses = []
+        self.exec_side_effect = None
+
+    def resume(self):
+        self.resume_calls += 1
+        self.status = "ready"
+
+    def wait_until_ready(self, timeout=None):
+        self.wait_calls.append(timeout)
+        if self.status in ("pending", "paused", "saving"):
+            self.status = "ready"
+        if self.status == "error":
+            raise RuntimeError("instance error")
+
+    def set_metadata(self, metadata):
+        self.set_metadata_calls.append(metadata)
+        self.metadata = dict(metadata)
+
+    def set_ttl(self, ttl_seconds, ttl_action=None):
+        self.set_ttl_calls.append((ttl_seconds, ttl_action))
+        self.ttl.ttl_seconds = ttl_seconds
+        self.ttl.ttl_action = ttl_action
+
+    def set_wake_on(self, wake_on_ssh=None, wake_on_http=None):
+        self.set_wake_on_calls.append((wake_on_ssh, wake_on_http))
+        if wake_on_ssh is not None:
+            self.wake_on.wake_on_ssh = wake_on_ssh
+
+    def stop(self):
+        self.stop_calls += 1
+
+    def exec(self, command, timeout=None, on_stdout=None, on_stderr=None):
+        self.exec_calls.append({"command": command, "timeout": timeout})
+        if callable(self.exec_side_effect):
+            return self.exec_side_effect(
+                command, timeout=timeout, on_stdout=on_stdout, on_stderr=on_stderr
+            )
+        if self.exec_responses:
+            return self.exec_responses.pop(0)
+        return _exec_response()
+
+
+class FakeInstancesAPI:
+    def __init__(self, *, listed_instances=None, start_instance=None):
+        self.listed_instances = list(listed_instances or [])
+        self.start_instance = start_instance or FakeInstance("inst-start", created=999)
+        self.by_id = {instance.id: instance for instance in self.listed_instances}
+        self.by_id[self.start_instance.id] = self.start_instance
+        self.list_calls = []
+        self.get_calls = []
+        self.get_side_effect = None
+        self.start_calls = []
+
+    def list(self, metadata=None):
+        self.list_calls.append(metadata)
+        return list(self.listed_instances)
+
+    def get(self, instance_id):
+        self.get_calls.append(instance_id)
+        if self.get_side_effect is not None:
+            raise self.get_side_effect
+        if instance_id not in self.by_id:
+            raise RuntimeError("not found")
+        return self.by_id[instance_id]
+
+    def start(
+        self,
+        snapshot_id,
+        metadata=None,
+        ttl_seconds=None,
+        ttl_action=None,
+        timeout=None,
+    ):
+        self.start_calls.append(
+            {
+                "snapshot_id": snapshot_id,
+                "metadata": metadata,
+                "ttl_seconds": ttl_seconds,
+                "ttl_action": ttl_action,
+                "timeout": timeout,
+            }
+        )
+        self.by_id[self.start_instance.id] = self.start_instance
+        self.start_instance.wait_until_ready(timeout=timeout)
+        return self.start_instance
+
+
+class FakeSnapshotsAPI:
+    def __init__(self, *, create_snapshot=None):
+        self.create_snapshot = create_snapshot or FakeSnapshot("snapshot-created")
+        self.create_calls = []
+
+    def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        snapshot = self.create_snapshot
+        snapshot.refs.image_id = kwargs.get("image_id") or snapshot.refs.image_id
+        snapshot.spec = _resource_spec(
+            vcpus=kwargs.get("vcpus") or snapshot.spec.vcpus,
+            memory=kwargs.get("memory") or snapshot.spec.memory,
+            disk_size=kwargs.get("disk_size") or snapshot.spec.disk_size,
+        )
+        snapshot.digest = kwargs.get("digest")
+        snapshot.metadata = dict(kwargs.get("metadata") or {})
+        return snapshot
+
+
+class FakeMorphClient:
+    def __init__(self, instances_api, snapshots_api):
+        self.instances = instances_api
+        self.snapshots = snapshots_api
+
+
+@pytest.fixture()
+def morph_factory(monkeypatch):
+    holder = {"client": None}
+    module = ModuleType("morphcloud")
+    module.MorphCloudClient = lambda *args, **kwargs: holder["client"]
+    monkeypatch.setitem(sys.modules, "morphcloud", module)
+    monkeypatch.delenv("TERMINAL_MORPH_GENERATION", raising=False)
+    morph_module = importlib.import_module("tools.environments.morph")
+
+    monkeypatch.setattr(morph_module, "is_interrupted", lambda: False)
+
+    def _make_env(
+        *,
+        listed_instances=None,
+        start_instance=None,
+        create_snapshot=None,
+        **kwargs,
+    ):
+        image_id = kwargs.pop("image_id", "morphvm-minimal")
+        api = FakeInstancesAPI(
+            listed_instances=listed_instances,
+            start_instance=start_instance,
+        )
+        snapshots_api = FakeSnapshotsAPI(
+            create_snapshot=create_snapshot,
+        )
+        holder["client"] = FakeMorphClient(api, snapshots_api)
+        env = morph_module.MorphEnvironment(
+            image_id=image_id,
+            task_id="task-123",
+            **kwargs,
+        )
+        env._morph_module = morph_module
+        env._fake_api = api
+        env._fake_snapshots_api = snapshots_api
+        return env, api
+
+    return _make_env
+
+
+def test_starts_new_instance_when_workspace_is_missing(morph_factory):
+    start_instance = FakeInstance("inst-start", status="pending", created=50)
+    env, api = morph_factory(
+        listed_instances=[],
+        start_instance=start_instance,
+        cpu=2,
+        memory=6144,
+        disk=20480,
+        lifetime_seconds=900,
+    )
+
+    assert env._instance is start_instance
+    assert env._fake_snapshots_api.create_calls[0]["image_id"] == "morphvm-minimal"
+    assert api.start_calls == [
+        {
+            "snapshot_id": "snapshot-created",
+            "metadata": {
+                "kind": "hermes-agent",
+                "hermes-agent:task_id": "task-123",
+                "hermes-agent:resource": "workspace",
+                "hermes-agent:backend": "morph",
+                "hermes-agent:generation": "hermes-morph-v1",
+                "hermes-agent:image_id": "morphvm-minimal",
+                "hermes-agent:base_snapshot_digest": env._base_snapshot_digest,
+                "webUIName": "Hermes Agent task-123",
+            },
+            "ttl_seconds": 900,
+            "ttl_action": "pause",
+            "timeout": 180,
+        }
+    ]
+    assert start_instance.wait_calls
+    assert start_instance.set_ttl_calls[-1] == (900, "pause")
+    assert start_instance.set_wake_on_calls[-1] == (True, None)
+
+
+def test_materializes_image_base_snapshot_with_digest(morph_factory):
+    start_instance = FakeInstance("inst-start", created=50)
+    create_snapshot = FakeSnapshot("snapshot-created")
+    env, api = morph_factory(
+        listed_instances=[],
+        start_instance=start_instance,
+        create_snapshot=create_snapshot,
+        image_id="morphvm-minimal",
+        cpu=2,
+        memory=6144,
+        disk=20480,
+        lifetime_seconds=900,
+    )
+
+    assert env._instance is start_instance
+    assert len(env._fake_snapshots_api.create_calls) == 1
+    create_call = env._fake_snapshots_api.create_calls[0]
+    assert create_call["image_id"] == "morphvm-minimal"
+    assert create_call["vcpus"] == 2
+    assert create_call["memory"] == 6144
+    assert create_call["disk_size"] == 20480
+    assert create_call["digest"].startswith("hermes-morph-base:")
+    assert create_call["metadata"]["kind"] == "hermes-agent"
+    assert create_call["metadata"]["hermes-agent:resource"] == "base-snapshot"
+    assert create_call["metadata"]["hermes-agent:backend"] == "morph"
+    assert create_call["metadata"]["hermes-agent:image_id"] == "morphvm-minimal"
+    assert create_call["metadata"]["webUIName"] == (
+        "Hermes Agent Base morphvm-minimal (2 CPU, 6144 MB, 20480 MB)"
+    )
+    assert api.start_calls[0]["snapshot_id"] == "snapshot-created"
+    assert api.start_calls[0]["metadata"]["webUIName"] == "Hermes Agent task-123"
+
+
+def test_reuses_ready_instance_without_boot(morph_factory):
+    ready = FakeInstance("inst-ready", status="ready", created=10)
+    env, api = morph_factory(listed_instances=[ready])
+
+    assert env._instance is ready
+    assert api.start_calls == []
+    assert api.list_calls[0]["hermes-agent:task_id"] == "task-123"
+    assert ready.set_ttl_calls[-1] == (300, "pause")
+    assert ready.set_wake_on_calls[-1] == (True, None)
+
+
+def test_resumes_paused_instance(morph_factory):
+    paused = FakeInstance("inst-paused", status="paused", created=11)
+    env, api = morph_factory(listed_instances=[paused])
+
+    assert env._instance is paused
+    assert paused.resume_calls == 1
+    assert paused.wait_calls
+    assert api.start_calls == []
+
+
+def test_attached_instance_backfills_metadata_without_overwriting_name(morph_factory):
+    ready = FakeInstance(
+        "inst-ready",
+        status="ready",
+        created=12,
+        metadata={
+            "kind": "hermes-agent",
+            "hermes-agent:task_id": "task-123",
+            "hermes-agent:resource": "workspace",
+            "hermes-agent:backend": "morph",
+            "hermes-agent:generation": "hermes-morph-v1",
+            "webUIName": "Custom Workspace",
+        },
+    )
+
+    env, api = morph_factory(
+        listed_instances=[ready],
+        image_id="morphvm-minimal",
+        cpu=2,
+        memory=6144,
+        disk=20480,
+    )
+
+    assert env._instance is ready
+    assert api.start_calls == []
+    assert ready.set_metadata_calls[-1]["webUIName"] == "Custom Workspace"
+    assert ready.set_metadata_calls[-1]["kind"] == "hermes-agent"
+    assert ready.set_metadata_calls[-1]["hermes-agent:image_id"] == "morphvm-minimal"
+    assert (
+        ready.set_metadata_calls[-1]["hermes-agent:base_snapshot_digest"]
+        == env._base_snapshot_digest
+    )
+
+
+def test_missing_instance_refresh_recreates_workspace(morph_factory):
+    ready = FakeInstance("inst-ready", status="ready", created=10)
+    replacement = FakeInstance("inst-fresh", status="ready", created=11)
+    env, api = morph_factory(listed_instances=[ready], start_instance=replacement)
+    api.listed_instances = []
+    api.by_id.pop("inst-ready", None)
+    api.get_side_effect = FakeMorphApiError(404, "missing")
+
+    env._ensure_instance_ready()
+
+    assert api.get_calls[-1] == "inst-ready"
+    assert len(api.start_calls) == 1
+    assert env._instance is replacement
+
+
+def test_transient_refresh_error_is_raised_without_recreating_workspace(
+    morph_factory, caplog
+):
+    ready = FakeInstance("inst-ready", status="ready", created=10)
+    env, api = morph_factory(listed_instances=[ready])
+    api.get_side_effect = FakeMorphApiError(503, "temporary failure")
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(FakeMorphApiError, match="temporary failure"):
+            env._ensure_instance_ready()
+
+    assert api.get_calls[-1] == "inst-ready"
+    assert api.start_calls == []
+    assert env._instance is ready
+    assert "failed to refresh instance inst-ready for task task-123" in caplog.text
+
+
+def test_exec_script_uses_runtime_state_dir_not_literal_shell_vars(morph_factory):
+    env, _ = morph_factory()
+
+    script = env._build_exec_script("echo hi", "/root", 30, "abc123")
+
+    assert "state_dir=/tmp/hermes-morph" in script
+    assert "mkdir -p \"$state_dir\"" in script
+    assert "pid_file=\"$state_dir/abc123.pid\"" in script
+    assert "pgid_file=\"$state_dir/abc123.pgid\"" in script
+    assert "\\$state_dir" not in script
+    assert "\\$pid_file" not in script
+    assert "\\$pgid_file" not in script
+
+
+def test_duplicate_matches_quarantine_extras_deterministically(morph_factory):
+    older = FakeInstance("inst-old", status="ready", created=10)
+    newer = FakeInstance("inst-new", status="ready", created=20)
+
+    env, api = morph_factory(listed_instances=[older, newer])
+
+    assert env._instance is newer
+    assert api.start_calls == []
+    assert older.set_metadata_calls
+    quarantined = older.set_metadata_calls[-1]
+    assert quarantined["kind"] == "hermes-agent"
+    assert quarantined["hermes-agent:resource"] == "workspace-quarantine"
+    assert quarantined["hermes-agent:quarantine_reason"] == "duplicate_task_id"
+    assert quarantined["hermes-agent:quarantine_winner"] == "inst-new"
+    assert quarantined["hermes-agent:task_id"].startswith("quarantined:task-123:")
+
+
+def test_all_error_matches_are_quarantined_and_replaced(morph_factory):
+    err_a = FakeInstance("inst-a", status="error", created=1)
+    err_b = FakeInstance("inst-b", status="error", created=2)
+    start_instance = FakeInstance("inst-fresh", status="ready", created=3)
+
+    env, api = morph_factory(listed_instances=[err_a, err_b], start_instance=start_instance)
+
+    assert env._instance is start_instance
+    assert len(api.start_calls) == 1
+    assert err_a.set_metadata_calls
+    assert err_b.set_metadata_calls
+    assert (
+        err_a.set_metadata_calls[-1]["hermes-agent:quarantine_reason"]
+        == "all_matches_error"
+    )
+
+
+def test_execute_wraps_timeout_cwd_and_stdin(morph_factory):
+    ready = FakeInstance("inst-ready", status="ready", created=10)
+    ready.exec_responses = [_exec_response(stdout="ok", exit_code=0)]
+    env, api = morph_factory(listed_instances=[ready])
+
+    result = env.execute("python3", cwd="/workspace", timeout=7, stdin_data="print('hi')")
+
+    assert result == {"output": "ok", "returncode": 0}
+    call = ready.exec_calls[-1]
+    assert call["command"][:2] == ["bash", "-lc"]
+    script = call["command"][2]
+    assert "cd /workspace" in script
+    assert "timeout 7 bash -lc" in script
+    assert "HERMES_EOF_" in script
+    assert "print" in script
+    assert call["timeout"] == 27
+    assert api.get_calls[-1] == "inst-ready"
+
+
+def test_execute_wraps_sudo_password_pipe(morph_factory, monkeypatch):
+    ready = FakeInstance("inst-ready", status="ready", created=10)
+    ready.exec_responses = [_exec_response(stdout="done", exit_code=0)]
+    env, _ = morph_factory(listed_instances=[ready])
+    monkeypatch.setattr(
+        env,
+        "_prepare_command",
+        lambda command: ("sudo -S echo hi", "topsecret\n"),
+    )
+
+    env.execute("echo hi")
+
+    script = ready.exec_calls[-1]["command"][2]
+    assert "printf" in script
+    assert "topsecret" in script
+    assert "sudo -S echo hi" in script
+
+
+def test_persistent_cleanup_detaches_without_stopping_instance(morph_factory):
+    ready = FakeInstance("inst-ready", status="ready", created=10)
+    env, api = morph_factory(listed_instances=[ready], lifetime_seconds=1200)
+    previous_ttl_count = len(ready.set_ttl_calls)
+
+    env.cleanup()
+
+    assert ready.stop_calls == 0
+    assert env._instance is ready
+    assert len(ready.set_ttl_calls) >= previous_ttl_count
+    assert api.get_calls[-1] == "inst-ready"
+
+
+def test_nonpersistent_cleanup_stops_instance(morph_factory):
+    ready = FakeInstance("inst-ready", status="ready", created=10)
+    env, _ = morph_factory(listed_instances=[ready], persistent_filesystem=False)
+
+    env.cleanup()
+
+    assert ready.stop_calls == 1
+    assert env._instance is None
+
+
+def test_interrupt_returns_130_and_issues_remote_kill(morph_factory, monkeypatch):
+    ready = FakeInstance("inst-ready", status="ready", created=10)
+    gate = threading.Event()
+    calls = {"count": 0}
+
+    def _exec_side_effect(command, timeout=None, on_stdout=None, on_stderr=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            gate.wait(timeout=2)
+            return _exec_response(stdout="late", exit_code=0)
+        return _exec_response(stdout="", exit_code=0)
+
+    ready.exec_side_effect = _exec_side_effect
+    env, _ = morph_factory(listed_instances=[ready])
+    monkeypatch.setattr(env._morph_module, "is_interrupted", lambda: True)
+
+    try:
+        result = env.execute("sleep 10")
+        assert result["returncode"] == 130
+        assert calls["count"] >= 2
+    finally:
+        gate.set()

--- a/tests/tools/test_morph_terminal_integration.py
+++ b/tests/tools/test_morph_terminal_integration.py
@@ -1,0 +1,139 @@
+"""Tests for Morph terminal backend integration."""
+
+import importlib
+import os
+import sys
+import threading
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+tools_pkg = ModuleType("tools")
+tools_pkg.__path__ = [str(_repo_root / "tools")]
+sys.modules["tools"] = tools_pkg
+
+terminal_module = importlib.import_module("tools.terminal_tool")
+file_tools_module = importlib.import_module("tools.file_tools")
+
+
+def test_get_env_config_sanitizes_host_cwd_for_morph():
+    with patch.dict(
+        os.environ,
+        {
+            "TERMINAL_ENV": "morph",
+            "TERMINAL_CWD": "/home/tester/project",
+        },
+        clear=True,
+    ):
+        config = terminal_module._get_env_config()
+        assert config["cwd"] == "/root"
+        assert config["morph_image_id"] == "morphvm-minimal"
+
+
+def test_get_env_config_defaults_cwd_to_root_for_morph():
+    with patch.dict(
+        os.environ,
+        {
+            "TERMINAL_ENV": "morph",
+        },
+        clear=True,
+    ):
+        config = terminal_module._get_env_config()
+        assert config["cwd"] == "/root"
+        assert config["morph_image_id"] == "morphvm-minimal"
+
+
+def test_create_environment_constructs_morph_backend():
+    with patch("tools.environments.morph.MorphEnvironment") as mock_env:
+        terminal_module._create_environment(
+            env_type="morph",
+            image="morphvm-minimal",
+            cwd="/root",
+            timeout=45,
+            container_config={
+                "container_cpu": 2.5,
+                "container_memory": 6144,
+                "container_disk": 20480,
+                "container_persistent": True,
+                "lifetime_seconds": 900,
+            },
+            task_id="task-morph",
+        )
+
+    mock_env.assert_called_once_with(
+        image_id="morphvm-minimal",
+        cwd="/root",
+        timeout=45,
+        cpu=2.5,
+        memory=6144,
+        disk=20480,
+        persistent_filesystem=True,
+        task_id="task-morph",
+        lifetime_seconds=900,
+    )
+
+
+def test_file_tools_use_morph_image_override(monkeypatch):
+    fake_env = object()
+    fake_file_ops = object()
+    create_calls = []
+
+    monkeypatch.setattr(terminal_module, "_active_environments", {}, raising=False)
+    monkeypatch.setattr(terminal_module, "_last_activity", {}, raising=False)
+    monkeypatch.setattr(terminal_module, "_creation_locks", {}, raising=False)
+    monkeypatch.setattr(terminal_module, "_env_lock", threading.Lock(), raising=False)
+    monkeypatch.setattr(
+        terminal_module, "_creation_locks_lock", threading.Lock(), raising=False
+    )
+    monkeypatch.setattr(
+        terminal_module,
+        "_task_env_overrides",
+        {"task-morph": {"morph_image_id": "morphvm-override"}},
+        raising=False,
+    )
+    monkeypatch.setattr(terminal_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_module,
+        "_get_env_config",
+        lambda: {
+            "env_type": "morph",
+            "morph_image_id": "morphvm-default",
+            "cwd": "/root",
+            "timeout": 60,
+            "lifetime_seconds": 444,
+            "container_cpu": 1,
+            "container_memory": 5120,
+            "container_disk": 51200,
+            "container_persistent": True,
+            "docker_volumes": [],
+        },
+    )
+
+    def _fake_create_environment(**kwargs):
+        create_calls.append(kwargs)
+        return fake_env
+
+    monkeypatch.setattr(terminal_module, "_create_environment", _fake_create_environment)
+    monkeypatch.setattr(file_tools_module, "_file_ops_cache", {}, raising=False)
+    monkeypatch.setattr(file_tools_module, "ShellFileOperations", lambda env: fake_file_ops)
+
+    result = file_tools_module._get_file_ops("task-morph")
+
+    assert result is fake_file_ops
+    assert create_calls[0]["image"] == "morphvm-override"
+    assert create_calls[0]["container_config"]["lifetime_seconds"] == 444
+
+
+def test_check_terminal_requirements_for_morph(monkeypatch):
+    monkeypatch.setitem(sys.modules, "morphcloud", ModuleType("morphcloud"))
+    monkeypatch.setenv("TERMINAL_ENV", "morph")
+    monkeypatch.setenv("MORPH_API_KEY", "morph-key")
+    monkeypatch.setenv("TERMINAL_MORPH_IMAGE_ID", "morphvm-minimal")
+
+    assert terminal_module.check_terminal_requirements() is True

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -885,6 +885,7 @@ class TestSkillViewPrerequisites:
             ("docker", "docker-backed skills"),
             ("singularity", "singularity-backed skills"),
             ("modal", "modal-backed skills"),
+            ("morph", "morph-backed skills"),
         ],
     )
     def test_remote_backend_keeps_setup_needed_after_local_secret_capture(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -373,7 +373,7 @@ def check_dangerous_command(command: str, env_type: str,
     Returns:
         {"approved": True/False, "message": str or None, ...}
     """
-    if env_type in ("docker", "singularity", "modal", "daytona"):
+    if env_type in ("docker", "singularity", "modal", "daytona", "morph"):
         return {"approved": True, "message": None}
 
     # --yolo: bypass all approval prompts
@@ -447,7 +447,7 @@ def check_all_command_guards(command: str, env_type: str,
     other was shown to the user.
     """
     # Skip containers for both checks
-    if env_type in ("docker", "singularity", "modal", "daytona"):
+    if env_type in ("docker", "singularity", "modal", "daytona", "morph"):
         return {"approved": True, "message": None}
 
     # --yolo or approvals.mode=off: bypass all approval prompts

--- a/tools/environments/morph.py
+++ b/tools/environments/morph.py
@@ -1,0 +1,521 @@
+"""Morph Cloud execution environment with metadata-based workspace reuse."""
+
+import hashlib
+import json
+import logging
+import math
+import os
+import shlex
+import threading
+import time
+import uuid
+from typing import Optional
+
+from tools.environments.base import BaseEnvironment
+from tools.interrupt import is_interrupted
+
+logger = logging.getLogger(__name__)
+
+
+class MorphEnvironment(BaseEnvironment):
+    """Morph Cloud instance execution backend.
+
+    Workspace identity is keyed by Hermes' task_id via Morph metadata. In
+    persistent mode, cleanup detaches locally and relies on Morph TTL pause +
+    wake-on-SSH for warm reattachment on later turns.
+    """
+
+    _STATUS_PRIORITY = {
+        "ready": 0,
+        "paused": 1,
+        "pending": 2,
+        "saving": 3,
+        "error": 4,
+    }
+    _KIND = "hermes-agent"
+    _METADATA_PREFIX = "hermes-agent:"
+
+    def __init__(
+        self,
+        image_id: str,
+        cwd: str = "/root",
+        timeout: int = 60,
+        cpu: float = 1,
+        memory: int = 5120,
+        disk: int = 51200,
+        persistent_filesystem: bool = True,
+        task_id: str = "default",
+        lifetime_seconds: int = 300,
+    ):
+        if not image_id:
+            raise ValueError(
+                "Morph environment requires a Morph base image identifier "
+                "(set TERMINAL_MORPH_IMAGE_ID or terminal.morph_image_id)."
+            )
+
+        if cwd == "~":
+            cwd = "/root"
+        super().__init__(cwd=cwd or "/root", timeout=timeout)
+
+        from morphcloud import MorphCloudClient
+
+        self._persistent = persistent_filesystem
+        self._task_id = task_id
+        self._image_id = image_id.strip()
+        self._cpu = max(1, math.ceil(cpu))
+        self._memory = max(256, int(memory))
+        self._disk = max(1024, int(disk))
+        self._lifetime_seconds = max(0, int(lifetime_seconds))
+        self._lock = threading.RLock()
+        self._ready_timeout = max(180, int(timeout))
+        self._generation = os.getenv("TERMINAL_MORPH_GENERATION", "hermes-morph-v1")
+        self._client = MorphCloudClient(
+            api_key=os.getenv("MORPH_API_KEY") or None,
+            base_url=os.getenv("MORPH_BASE_URL") or None,
+            profile=os.getenv("MORPH_PROFILE") or None,
+        )
+        self._base_snapshot_digest = self._compute_base_snapshot_digest(self._image_id)
+        self._workspace_metadata = {
+            "kind": self._KIND,
+            **self._metadata_fields(
+                task_id=task_id,
+                resource="workspace",
+                backend="morph",
+                generation=self._generation,
+            ),
+        }
+        self._instance_metadata = {
+            **self._workspace_metadata,
+            **self._metadata_fields(
+                image_id=self._image_id,
+                base_snapshot_digest=self._base_snapshot_digest,
+            ),
+            "webUIName": self._instance_name(),
+        }
+        self._base_snapshot_metadata = {
+            "kind": self._KIND,
+            **self._metadata_fields(
+                resource="base-snapshot",
+                backend="morph",
+                generation=self._generation,
+                image_id=self._image_id,
+            ),
+            "webUIName": self._base_snapshot_name(),
+        }
+        self._instance = None
+        self._base_snapshot = None
+
+        with self._lock:
+            self._instance = self._attach_or_create_instance()
+            self._apply_runtime_policy()
+
+    def _ttl_action(self) -> str:
+        return "pause" if self._persistent else "stop"
+
+    def _ttl_seconds(self) -> Optional[int]:
+        return self._lifetime_seconds if self._lifetime_seconds > 0 else None
+
+    def _compute_base_snapshot_digest(self, image_id: str) -> str:
+        payload = json.dumps(
+            {
+                "generation": self._generation,
+                "image_id": image_id,
+                "vcpus": self._cpu,
+                "memory": self._memory,
+                "disk_size": self._disk,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return f"hermes-morph-base:{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"
+
+    def _base_snapshot_name(self) -> str:
+        return (
+            f"Hermes Agent Base {self._image_id} "
+            f"({self._cpu} CPU, {self._memory} MB, {self._disk} MB)"
+        )
+
+    def _instance_name(self) -> str:
+        return f"Hermes Agent {self._task_id}"
+
+    def _metadata_fields(self, **values: str) -> dict[str, str]:
+        return {
+            f"{self._METADATA_PREFIX}{key}": value
+            for key, value in values.items()
+        }
+
+    def _materialize_base_snapshot(self):
+        if self._base_snapshot is not None:
+            return self._base_snapshot
+
+        snapshot = self._client.snapshots.create(
+            image_id=self._image_id,
+            vcpus=self._cpu,
+            memory=self._memory,
+            disk_size=self._disk,
+            digest=self._base_snapshot_digest,
+            metadata=self._base_snapshot_metadata,
+        )
+        self._ensure_metadata(snapshot, self._base_snapshot_metadata)
+
+        self._base_snapshot = snapshot
+        return snapshot
+
+    @staticmethod
+    def _ensure_metadata(resource, defaults: dict[str, str]) -> None:
+        current = dict(getattr(resource, "metadata", {}) or {})
+        merged = dict(current)
+        changed = False
+        for key, value in defaults.items():
+            if merged.get(key) in (None, ""):
+                merged[key] = value
+                changed = True
+        if changed:
+            resource.set_metadata(merged)
+
+    @staticmethod
+    def _status_name(instance) -> str:
+        status = getattr(instance, "status", "")
+        return str(getattr(status, "value", status)).lower()
+
+    def _status_sort_key(self, instance) -> tuple[int, int, str]:
+        created = int(getattr(instance, "created", 0) or 0)
+        status_name = self._status_name(instance)
+        return (
+            self._STATUS_PRIORITY.get(status_name, len(self._STATUS_PRIORITY)),
+            -created,
+            str(getattr(instance, "id", "")),
+        )
+
+    def _combine_output(self, response) -> str:
+        stdout = getattr(response, "stdout", "") or ""
+        stderr = getattr(response, "stderr", "") or ""
+        if stdout and stderr and not stdout.endswith("\n"):
+            return f"{stdout}\n{stderr}"
+        return f"{stdout}{stderr}"
+
+    def _lookup_instances(self):
+        return list(self._client.instances.list(metadata=self._workspace_metadata))
+
+    def _quarantine_instances(
+        self,
+        instances: list,
+        *,
+        reason: str,
+        winner_id: str = "",
+    ) -> None:
+        for instance in instances:
+            try:
+                metadata = dict(getattr(instance, "metadata", {}) or {})
+                metadata.update(
+                    {
+                        "kind": self._KIND,
+                        **self._metadata_fields(
+                            resource="workspace-quarantine",
+                            backend="morph",
+                            task_id=f"quarantined:{self._task_id}:{instance.id}",
+                            quarantine_reason=reason,
+                            quarantined_task_id=self._task_id,
+                            quarantined_at=str(int(time.time())),
+                        ),
+                    }
+                )
+                if winner_id:
+                    metadata[f"{self._METADATA_PREFIX}quarantine_winner"] = winner_id
+                instance.set_metadata(metadata)
+                logger.warning(
+                    "Morph: quarantined duplicate workspace %s for task %s (%s)",
+                    getattr(instance, "id", "<unknown>"),
+                    self._task_id,
+                    reason,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Morph: failed to quarantine instance %s for task %s: %s",
+                    getattr(instance, "id", "<unknown>"),
+                    self._task_id,
+                    e,
+                )
+
+    def _select_existing_instance(self, instances: list):
+        if not instances:
+            return None
+
+        usable = [instance for instance in instances if self._status_name(instance) != "error"]
+        if not usable:
+            self._quarantine_instances(instances, reason="all_matches_error")
+            return None
+
+        ordered = sorted(usable, key=self._status_sort_key)
+        winner = ordered[0]
+        duplicates = [
+            instance
+            for instance in instances
+            if getattr(instance, "id", None) != winner.id
+        ]
+        if duplicates:
+            self._quarantine_instances(
+                duplicates,
+                reason="duplicate_task_id",
+                winner_id=winner.id,
+            )
+        return winner
+
+    def _wait_for_ready(self, instance) -> None:
+        status = self._status_name(instance)
+        if status == "ready":
+            return
+        if status == "paused":
+            instance.resume()
+            logger.info("Morph: resumed paused instance %s", instance.id)
+        elif status in ("pending", "saving"):
+            logger.info("Morph: waiting for instance %s to become ready", instance.id)
+        instance.wait_until_ready(timeout=self._ready_timeout)
+
+    def _start_instance(self):
+        snapshot = self._materialize_base_snapshot()
+        ttl_seconds = self._ttl_seconds()
+        instance = self._client.instances.start(
+            snapshot_id=snapshot.id,
+            metadata=self._instance_metadata,
+            ttl_seconds=ttl_seconds,
+            ttl_action=self._ttl_action() if ttl_seconds is not None else None,
+            timeout=self._ready_timeout,
+        )
+        self._ensure_metadata(instance, self._instance_metadata)
+        logger.info("Morph: started instance %s for task %s", instance.id, self._task_id)
+        return instance
+
+    def _attach_or_create_instance(self):
+        candidate = self._select_existing_instance(self._lookup_instances())
+        if candidate is None:
+            return self._start_instance()
+        self._wait_for_ready(candidate)
+        self._ensure_metadata(candidate, self._instance_metadata)
+        logger.info(
+            "Morph: attached to existing instance %s for task %s",
+            candidate.id,
+            self._task_id,
+        )
+        return candidate
+
+    @staticmethod
+    def _is_missing_instance_error(exc: Exception) -> bool:
+        return getattr(exc, "status_code", None) == 404
+
+    def _refresh_instance(self):
+        if self._instance is None:
+            return None
+
+        instance_id = self._instance.id
+        try:
+            self._instance = self._client.instances.get(instance_id)
+        except Exception as exc:
+            if self._is_missing_instance_error(exc):
+                logger.info(
+                    "Morph: instance %s for task %s no longer exists",
+                    instance_id,
+                    self._task_id,
+                )
+                self._instance = None
+                return None
+
+            logger.warning(
+                "Morph: failed to refresh instance %s for task %s: %s",
+                instance_id,
+                self._task_id,
+                exc,
+            )
+            raise
+
+        return self._instance
+
+    def _ensure_instance_ready(self) -> None:
+        instance = self._refresh_instance()
+        if instance is None:
+            self._instance = self._attach_or_create_instance()
+            return
+
+        status = self._status_name(instance)
+        if status == "error":
+            self._quarantine_instances([instance], reason="selected_instance_error")
+            self._instance = self._start_instance()
+            return
+
+        self._wait_for_ready(instance)
+
+    def _apply_runtime_policy(self) -> None:
+        if self._instance is None:
+            return
+
+        ttl_seconds = self._ttl_seconds()
+        if ttl_seconds is not None:
+            self._instance.set_ttl(ttl_seconds=ttl_seconds, ttl_action=self._ttl_action())
+
+        if self._persistent:
+            wake_on = getattr(
+                getattr(self._instance, "wake_on", None),
+                "wake_on_ssh",
+                False,
+            )
+            if not wake_on:
+                self._instance.set_wake_on(wake_on_ssh=True)
+
+    def _build_exec_script(
+        self,
+        exec_command: str,
+        cwd: str,
+        timeout: int,
+        token: str,
+    ) -> str:
+        quoted_cwd = shlex.quote(cwd or self.cwd or "/root")
+        quoted_command = shlex.quote(exec_command)
+        safe_timeout = max(1, int(timeout))
+        return (
+            "state_dir=/tmp/hermes-morph; "
+            "mkdir -p \"$state_dir\"; "
+            f"pid_file=\"$state_dir/{token}.pid\"; "
+            f"pgid_file=\"$state_dir/{token}.pgid\"; "
+            "cleanup() { rm -f \"$pid_file\" \"$pgid_file\"; }; "
+            "trap cleanup EXIT; "
+            "echo $$ > \"$pid_file\"; "
+            "ps -o pgid= -p $$ | tr -d ' ' > \"$pgid_file\"; "
+            f"cd {quoted_cwd} || exit 1; "
+            f"timeout {safe_timeout} bash -lc {quoted_command}"
+        )
+
+    def _interrupt_remote_command(self, token: str) -> None:
+        if self._instance is None:
+            return
+
+        script = (
+            "state_dir=/tmp/hermes-morph; "
+            f"pid_file=\"$state_dir/{token}.pid\"; "
+            f"pgid_file=\"$state_dir/{token}.pgid\"; "
+            "if [ -s \"$pgid_file\" ]; then "
+            "kill -- -$(cat \"$pgid_file\") 2>/dev/null || true; "
+            "fi; "
+            "if [ -s \"$pid_file\" ]; then "
+            "kill $(cat \"$pid_file\") 2>/dev/null || true; "
+            "fi; "
+            "rm -f \"$pid_file\" \"$pgid_file\""
+        )
+        try:
+            self._instance.exec(["bash", "-lc", script], timeout=10)
+        except Exception as e:
+            logger.debug(
+                "Morph: remote interrupt helper failed for task %s: %s",
+                self._task_id,
+                e,
+            )
+
+    def execute(
+        self,
+        command: str,
+        cwd: str = "",
+        *,
+        timeout: Optional[int] = None,
+        stdin_data: Optional[str] = None,
+    ) -> dict:
+        if stdin_data is not None:
+            marker = f"HERMES_EOF_{uuid.uuid4().hex[:8]}"
+            while marker in stdin_data:
+                marker = f"HERMES_EOF_{uuid.uuid4().hex[:8]}"
+            command = f"{command} << '{marker}'\n{stdin_data}\n{marker}"
+
+        exec_command, sudo_stdin = self._prepare_command(command)
+        if sudo_stdin is not None:
+            exec_command = (
+                f"printf '%s\\n' {shlex.quote(sudo_stdin.rstrip())} | {exec_command}"
+            )
+
+        effective_cwd = cwd or self.cwd or "/root"
+        effective_timeout = max(1, int(timeout or self.timeout))
+        command_token = uuid.uuid4().hex[:12]
+        remote_script = self._build_exec_script(
+            exec_command,
+            effective_cwd,
+            effective_timeout,
+            command_token,
+        )
+
+        result_holder = {"response": None, "error": None}
+
+        def _run() -> None:
+            try:
+                with self._lock:
+                    self._ensure_instance_ready()
+                    instance = self._instance
+                result_holder["response"] = instance.exec(
+                    ["bash", "-lc", remote_script],
+                    timeout=effective_timeout + 20,
+                )
+            except Exception as e:
+                result_holder["error"] = e
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+
+        deadline = time.monotonic() + effective_timeout + 25
+        while thread.is_alive():
+            thread.join(timeout=0.2)
+            if is_interrupted():
+                self._interrupt_remote_command(command_token)
+                thread.join(timeout=2)
+                return {
+                    "output": "[Command interrupted - Morph workspace left available for reuse]",
+                    "returncode": 130,
+                }
+            if time.monotonic() > deadline:
+                self._interrupt_remote_command(command_token)
+                thread.join(timeout=2)
+                return self._timeout_result(effective_timeout)
+
+        if result_holder["error"] is not None:
+            err = result_holder["error"]
+            if isinstance(err, TimeoutError):
+                return self._timeout_result(effective_timeout)
+            return {"output": f"Morph execution error: {err}", "returncode": 1}
+
+        response = result_holder["response"]
+        try:
+            with self._lock:
+                self._refresh_instance()
+                self._apply_runtime_policy()
+        except Exception as e:
+            logger.warning(
+                "Morph: failed to refresh TTL/wake settings for task %s: %s",
+                self._task_id,
+                e,
+            )
+
+        return {
+            "output": self._combine_output(response),
+            "returncode": getattr(response, "exit_code", 1),
+        }
+
+    def cleanup(self):
+        with self._lock:
+            if self._instance is None:
+                return
+
+            try:
+                if self._persistent:
+                    self._refresh_instance()
+                    if self._instance is not None:
+                        self._apply_runtime_policy()
+                        logger.info(
+                            "Morph: detached from persistent instance %s for task %s",
+                            self._instance.id,
+                            self._task_id,
+                        )
+                else:
+                    self._instance.stop()
+                    logger.info(
+                        "Morph: stopped instance %s for task %s",
+                        self._instance.id,
+                        self._task_id,
+                    )
+                    self._instance = None
+            except Exception as e:
+                logger.warning("Morph: cleanup failed for task %s: %s", self._task_id, e)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -100,6 +100,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 image = overrides.get("modal_image") or config["modal_image"]
             elif env_type == "daytona":
                 image = overrides.get("daytona_image") or config["daytona_image"]
+            elif env_type == "morph":
+                image = overrides.get("morph_image_id") or config["morph_image_id"]
             else:
                 image = ""
 
@@ -107,13 +109,14 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
 
             container_config = None
-            if env_type in ("docker", "singularity", "modal", "daytona"):
+            if env_type in ("docker", "singularity", "modal", "daytona", "morph"):
                 container_config = {
                     "container_cpu": config.get("container_cpu", 1),
                     "container_memory": config.get("container_memory", 5120),
                     "container_disk": config.get("container_disk", 51200),
                     "container_persistent": config.get("container_persistent", True),
                     "docker_volumes": config.get("docker_volumes", []),
+                    "lifetime_seconds": config.get("lifetime_seconds", 300),
                 }
 
             ssh_config = None

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -100,7 +100,7 @@ _PLATFORM_MAP = {
     "windows": "win32",
 }
 _EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub"))
-_REMOTE_ENV_BACKENDS = frozenset({"docker", "singularity", "modal", "ssh", "daytona"})
+_REMOTE_ENV_BACKENDS = frozenset({"docker", "singularity", "modal", "ssh", "daytona", "morph"})
 _secret_capture_callback = None
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -482,7 +482,7 @@ def _get_env_config() -> Dict[str, Any]:
         ):
             host_cwd = candidate
             cwd = "/workspace"
-    elif env_type in ("modal", "docker", "singularity", "daytona") and cwd:
+    elif env_type in ("modal", "docker", "singularity", "daytona", "morph") and cwd:
         # Host paths and relative paths that won't work inside containers
         is_host_path = any(cwd.startswith(p) for p in host_prefixes)
         is_relative = not os.path.isabs(cwd)  # e.g. "." or "src/"
@@ -499,6 +499,7 @@ def _get_env_config() -> Dict[str, Any]:
         "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
         "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
         "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
+        "morph_image_id": os.getenv("TERMINAL_MORPH_IMAGE_ID", "morphvm-minimal"),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
@@ -554,6 +555,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     persistent = cc.get("container_persistent", True)
     volumes = cc.get("docker_volumes", [])
     docker_forward_env = cc.get("docker_forward_env", [])
+    lifetime_seconds = cc.get("lifetime_seconds", 300)
 
     if env_type == "local":
         lc = local_config or {}
@@ -607,6 +609,20 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             persistent_filesystem=persistent, task_id=task_id,
         )
 
+    elif env_type == "morph":
+        from tools.environments.morph import MorphEnvironment as _MorphEnvironment
+        return _MorphEnvironment(
+            image_id=image,
+            cwd=cwd,
+            timeout=timeout,
+            cpu=cpu,
+            memory=memory,
+            disk=disk,
+            persistent_filesystem=persistent,
+            task_id=task_id,
+            lifetime_seconds=lifetime_seconds,
+        )
+
     elif env_type == "ssh":
         if not ssh_config or not ssh_config.get("host") or not ssh_config.get("user"):
             raise ValueError("SSH environment requires ssh_host and ssh_user to be configured")
@@ -621,7 +637,10 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
         )
 
     else:
-        raise ValueError(f"Unknown environment type: {env_type}. Use 'local', 'docker', 'singularity', 'modal', 'daytona', or 'ssh'")
+        raise ValueError(
+            f"Unknown environment type: {env_type}. "
+            "Use 'local', 'docker', 'singularity', 'modal', 'daytona', 'morph', or 'ssh'"
+        )
 
 
 def _cleanup_inactive_envs(lifetime_seconds: int = 300):
@@ -898,6 +917,8 @@ def terminal_tool(
             image = overrides.get("modal_image") or config["modal_image"]
         elif env_type == "daytona":
             image = overrides.get("daytona_image") or config["daytona_image"]
+        elif env_type == "morph":
+            image = overrides.get("morph_image_id") or config["morph_image_id"]
         else:
             image = ""
 
@@ -951,7 +972,7 @@ def terminal_tool(
                             }
 
                         container_config = None
-                        if env_type in ("docker", "singularity", "modal", "daytona"):
+                        if env_type in ("docker", "singularity", "modal", "daytona", "morph"):
                             container_config = {
                                 "container_cpu": config.get("container_cpu", 1),
                                 "container_memory": config.get("container_memory", 5120),
@@ -959,6 +980,7 @@ def terminal_tool(
                                 "container_persistent": config.get("container_persistent", True),
                                 "docker_volumes": config.get("docker_volumes", []),
                                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                                "lifetime_seconds": config.get("lifetime_seconds", 300),
                             }
 
                         local_config = None
@@ -1234,11 +1256,13 @@ def check_terminal_requirements() -> bool:
         elif env_type == "daytona":
             from daytona import Daytona
             return os.getenv("DAYTONA_API_KEY") is not None
-
+        elif env_type == "morph":
+            import morphcloud  # noqa: F401
+            return bool(config.get("morph_image_id")) and bool(os.getenv("MORPH_API_KEY"))
         else:
             logger.error(
                 "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
-                "modal, daytona, ssh.",
+                "modal, daytona, morph, ssh.",
                 env_type,
             )
             return False


### PR DESCRIPTION
## What does this PR do?

Adds [Morph](https://cloud.morph.so) as a new execution backend for Hermes terminal and file tools.

Commands run in Morph instances through the official `morphcloud` SDK. Hermes creates or reuses a cached base snapshot for the selected Morph environment and requested machine shape, starts workspaces from that snapshot, and reattaches persistent workspaces by `task_id`.

Persistent Morph workspaces use instance TTL pause/resume with wake-on-SSH enabled, so Hermes can detach locally while keeping the remote filesystem available for later reuse.

**Usage:**
```yaml
terminal:
  backend: "morph"
  container_cpu: 1
  container_memory: 5120
  container_disk: 51200
```
```bash
pip install "hermes-agent[morph]"
export MORPH_API_KEY=...
```

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

| Area | Files | What |
|------|-------|------|
| Backend | `tools/environments/morph.py` | New `MorphEnvironment` with image-backed cached base snapshots, `task_id` workspace reuse, TTL pause/resume policy, wake-on-SSH, interrupt handling, and Hermes metadata / `webUIName` tagging |
| Pipeline | `tools/terminal_tool.py`, `tools/file_tools.py`, `tools/approval.py` | Backend selection, Morph config plumbing, file-tool reuse, and command-guard bypass for Morph sandboxes |
| CLI | `cli.py`, `hermes_cli/setup.py`, `hermes_cli/config.py` | Setup wizard support, Morph defaults, and single-query CLI `task_id` propagation |
| Status & Doctor | `hermes_cli/status.py`, `hermes_cli/doctor.py` | Morph visibility in status and doctor output |
| Gateway | `gateway/run.py` | Morph terminal config env bridge |
| Packaging | `pyproject.toml` | Optional `morph` extra |
| Tests | `tests/tools/test_morph_environment.py`, `tests/tools/test_morph_terminal_integration.py`, `tests/hermes_cli/test_morph_terminal_backend.py`, `tests/integration/test_morph_terminal.py`, `tests/test_cli_single_query_task_id.py` | Focused unit, control-plane, CLI, and live integration coverage |

## Usage Examples

These were run locally from the Hermes checkout with real `MORPH_API_KEY` and `OPENAI_API_KEY` values loaded from devbox secrets.

One-time setup for the CLI session:

```bash
python -m hermes_cli.main config set terminal.backend morph
python -m hermes_cli.main config set model.default gpt-5.4
```

### Basic chat

```bash
PYTHONPATH=. \
OPENAI_BASE_URL=https://api.openai.com/v1 \
python -m hermes_cli.main chat -Q --provider auto -m gpt-5.4 \
  -q "Reply with exactly: hello"
```

Final output:

```text
hello
```

### Terminal tool on Morph

```bash
PYTHONPATH=. \
OPENAI_BASE_URL=https://api.openai.com/v1 \
python -m hermes_cli.main chat -Q --provider auto -m gpt-5.4 -t terminal \
  -q "Use the terminal tool to run: echo hello-from-morph. Reply with exactly that output and nothing else."
```

Final output:

```text
hello-from-morph
```

## How to Test

1. Install `hermes-agent[morph]` and set `MORPH_API_KEY`
2. Configure `terminal.backend=morph`
3. Run a terminal-backed prompt, for example:
   ```bash
   python -m hermes_cli.main chat -Q -t terminal -q "Run echo hello in the terminal and return only the output."
   ```

## Testing Done

- Focused Morph slice:
  - `/workspace/.venvs/hermes/bin/python -m pytest -o addopts='' -n 0 tests/tools/test_morph_environment.py tests/tools/test_morph_terminal_integration.py tests/hermes_cli/test_morph_terminal_backend.py tests/hermes_cli/test_doctor.py tests/hermes_cli/test_status.py tests/hermes_cli/test_status_model_provider.py tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_config.py tests/test_cli_single_query_task_id.py tests/tools/test_command_guards.py tests/tools/test_modal_sandbox_fixes.py -q`
  - `138 passed, 2 skipped`
- Live Morph integration against the real API:
  - `env -u TERMINAL_MORPH_IMAGE_ID TERMINAL_ENV=morph /workspace/.venvs/hermes/bin/python -m pytest -o addopts='' -m integration -n 0 tests/integration/test_morph_terminal.py -q`
  - `5 passed in 10.79s`

The live integration run used a real `MORPH_API_KEY` from devbox secrets and exercised the default Morph-backed execution path against the real Morph API, including nonzero exit handling, task isolation, persistent reattach, and timeout behavior.


