### PR TITLE
fix: resolve glm-5 context defaults on custom endpoints

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 from agent.auxiliary_client import call_llm
 from agent.model_metadata import (
     get_model_context_length,
+    resolve_model_context_length,
     estimate_messages_tokens_rough,
 )
 
@@ -56,7 +57,16 @@ class ContextCompressor:
         self.summary_target_tokens = summary_target_tokens
         self.quiet_mode = quiet_mode
 
+        context_info = resolve_model_context_length(model, base_url=base_url, api_key=api_key)
         self.context_length = get_model_context_length(model, base_url=base_url, api_key=api_key)
+        if context_info["context_length"] == self.context_length:
+            self.context_length_source = context_info["source"]
+            self.context_length_known = bool(context_info.get("known", True))
+        else:
+            # Preserve compatibility for tests and callers that patch
+            # get_model_context_length directly.
+            self.context_length_source = "legacy"
+            self.context_length_known = True
         self.threshold_tokens = int(self.context_length * threshold_percent)
         self.compression_count = 0
         self._context_probed = False  # True after a step-down from context error

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -71,8 +71,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     "meta-llama/llama-3.3-70b-instruct": 131072,
     "deepseek/deepseek-chat-v3": 65536,
     "qwen/qwen-2.5-72b-instruct": 32768,
-    "glm-4.7": 202752,
-    "glm-5": 202752,
+    "glm-4.7": 200000,
+    "glm-5": 200000,
     "glm-4.5": 131072,
     "glm-4.5-flash": 131072,
     "kimi-for-coding": 262144,
@@ -113,7 +113,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "minimax-m2.5": 204800,
     "minimax-m2.5-free": 204800,
     "minimax-m2.1": 204800,
-    "glm-4.6": 202752,
+    "glm-4.6": 200000,
     "kimi-k2": 262144,
     "qwen3-coder": 32768,
     "big-pickle": 128000,
@@ -143,6 +143,76 @@ _MAX_COMPLETION_KEYS = (
     "max_output_tokens",
     "max_tokens",
 )
+
+
+def _get_exact_default_context_length(model: str) -> Optional[int]:
+    """Return an exact hardcoded default for the model, if one exists."""
+    model_lower = (model or "").strip().lower()
+    if not model_lower:
+        return None
+    for default_model, length in DEFAULT_CONTEXT_LENGTHS.items():
+        if default_model.lower() == model_lower:
+            return length
+    return None
+
+
+def resolve_model_context_length(model: str, base_url: str = "", api_key: str = "") -> Dict[str, Any]:
+    """Resolve context length and indicate whether it is authoritative.
+
+    Sources:
+      - cache: persisted from a previously discovered exact limit
+      - endpoint: explicit `/models` metadata from the active endpoint
+      - openrouter: OpenRouter models API metadata
+      - default_exact: exact match in hardcoded defaults
+      - default_fuzzy: fallback substring match in hardcoded defaults
+      - probe: provisional internal tier for unknown models
+    """
+    # 1. Check persistent cache (model+provider)
+    if base_url:
+        cached = get_cached_context_length(model, base_url)
+        if cached is not None:
+            return {"context_length": cached, "source": "cache", "known": True}
+
+    # 2. Active endpoint metadata for explicit custom routes
+    if _is_custom_endpoint(base_url):
+        endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
+        if model in endpoint_metadata:
+            context_length = endpoint_metadata[model].get("context_length")
+            if isinstance(context_length, int):
+                return {"context_length": context_length, "source": "endpoint", "known": True}
+
+        exact_default = _get_exact_default_context_length(model)
+        if exact_default is not None:
+            return {"context_length": exact_default, "source": "default_exact", "known": True}
+
+        if not _is_known_provider_base_url(base_url):
+            # Explicit third-party endpoints should not borrow fuzzy global
+            # defaults from unrelated providers with similarly named models.
+            return {"context_length": CONTEXT_PROBE_TIERS[0], "source": "probe", "known": False}
+
+    # 3. OpenRouter API metadata
+    metadata = fetch_model_metadata()
+    if model in metadata:
+        return {
+            "context_length": metadata[model].get("context_length", 128000),
+            "source": "openrouter",
+            "known": True,
+        }
+
+    # 4. Exact hardcoded defaults
+    exact_default = _get_exact_default_context_length(model)
+    if exact_default is not None:
+        return {"context_length": exact_default, "source": "default_exact", "known": True}
+
+    # 5. Hardcoded defaults (fuzzy match — longest key first for specificity)
+    for default_model, length in sorted(
+        DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
+    ):
+        if default_model in model or model in default_model:
+            return {"context_length": length, "source": "default_fuzzy", "known": True}
+
+    # 6. Unknown model — start at highest probe tier
+    return {"context_length": CONTEXT_PROBE_TIERS[0], "source": "probe", "known": False}
 
 
 def _normalize_base_url(base_url: str) -> str:
@@ -449,38 +519,7 @@ def get_model_context_length(model: str, base_url: str = "", api_key: str = "") 
     4. Hardcoded DEFAULT_CONTEXT_LENGTHS (fuzzy match for hosted routes only)
     5. First probe tier (2M) — will be narrowed on first context error
     """
-    # 1. Check persistent cache (model+provider)
-    if base_url:
-        cached = get_cached_context_length(model, base_url)
-        if cached is not None:
-            return cached
-
-    # 2. Active endpoint metadata for explicit custom routes
-    if _is_custom_endpoint(base_url):
-        endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
-        if model in endpoint_metadata:
-            context_length = endpoint_metadata[model].get("context_length")
-            if isinstance(context_length, int):
-                return context_length
-        if not _is_known_provider_base_url(base_url):
-            # Explicit third-party endpoints should not borrow fuzzy global
-            # defaults from unrelated providers with similarly named models.
-            return CONTEXT_PROBE_TIERS[0]
-
-    # 3. OpenRouter API metadata
-    metadata = fetch_model_metadata()
-    if model in metadata:
-        return metadata[model].get("context_length", 128000)
-
-    # 4. Hardcoded defaults (fuzzy match — longest key first for specificity)
-    for default_model, length in sorted(
-        DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
-    ):
-        if default_model in model or model in default_model:
-            return length
-
-    # 5. Unknown model — start at highest probe tier
-    return CONTEXT_PROBE_TIERS[0]
+    return int(resolve_model_context_length(model, base_url=base_url, api_key=api_key)["context_length"])
 
 
 def estimate_tokens_rough(text: str) -> int:

--- a/cli.py
+++ b/cli.py
@@ -1290,10 +1290,11 @@ class HermesCLI:
         if compressor:
             context_tokens = getattr(compressor, "last_prompt_tokens", 0) or 0
             context_length = getattr(compressor, "context_length", 0) or 0
+            context_length_known = getattr(compressor, "context_length_known", True)
             snapshot["context_tokens"] = context_tokens
-            snapshot["context_length"] = context_length or None
+            snapshot["context_length"] = context_length if (context_length and context_length_known) else None
             snapshot["compressions"] = getattr(compressor, "compression_count", 0) or 0
-            if context_length:
+            if context_length and context_length_known:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
 
         return snapshot
@@ -1904,7 +1905,8 @@ class HermesCLI:
             # Get context length for display
             ctx_len = None
             if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
-                ctx_len = self.agent.context_compressor.context_length
+                if getattr(self.agent.context_compressor, "context_length_known", True):
+                    ctx_len = self.agent.context_compressor.context_length
             
             # Build and display the banner
             build_welcome_banner(
@@ -3377,7 +3379,8 @@ class HermesCLI:
                     cwd = os.getenv("TERMINAL_CWD", os.getcwd())
                     ctx_len = None
                     if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
-                        ctx_len = self.agent.context_compressor.context_length
+                        if getattr(self.agent.context_compressor, "context_length_known", True):
+                            ctx_len = self.agent.context_compressor.context_length
                     build_welcome_banner(
                         console=cc,
                         model=self.model,
@@ -4275,7 +4278,8 @@ class HermesCLI:
         compressor = agent.context_compressor
         last_prompt = compressor.last_prompt_tokens
         ctx_len = compressor.context_length
-        pct = (last_prompt / ctx_len * 100) if ctx_len else 0
+        ctx_known = getattr(compressor, "context_length_known", True)
+        pct = (last_prompt / ctx_len * 100) if (ctx_len and ctx_known) else 0
         compressions = compressor.compression_count
 
         msg_count = len(self.conversation_history)
@@ -4314,7 +4318,10 @@ class HermesCLI:
         else:
             print(f"  Total cost:              {'n/a':>10}")
         print(f"  {'─' * 40}")
-        print(f"  Current context:  {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")
+        if ctx_len and ctx_known:
+            print(f"  Current context:  {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")
+        else:
+            print(f"  Current context:  {last_prompt:,} / unknown")
         print(f"  Messages:         {msg_count}")
         print(f"  Compressions:     {compressions}")
         if cost_result.status == "unknown":

--- a/run_agent.py
+++ b/run_agent.py
@@ -1000,9 +1000,15 @@ class AIAgent:
         
         if not self.quiet_mode:
             if compression_enabled:
-                print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {self.context_compressor.threshold_tokens:,})")
+                if getattr(self.context_compressor, "context_length_known", True):
+                    print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {self.context_compressor.threshold_tokens:,})")
+                else:
+                    print(f"📊 Context limit: unknown (compress threshold provisional at {self.context_compressor.threshold_tokens:,} tokens)")
             else:
-                print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)")
+                if getattr(self.context_compressor, "context_length_known", True):
+                    print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)")
+                else:
+                    print("📊 Context limit: unknown (auto-compression disabled)")
     
     @staticmethod
     def _safe_print(*args, **kwargs):
@@ -5933,15 +5939,20 @@ class AIAgent:
                         parsed_limit = parse_context_limit_from_error(error_msg)
                         if parsed_limit and parsed_limit < old_ctx:
                             new_ctx = parsed_limit
+                            compressor.context_length_known = True
+                            compressor.context_length_source = "error_limit"
+                            compressor._context_probed = True
                             self._vprint(f"{self.log_prefix}⚠️  Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})", force=True)
                         else:
                             # Step down to the next probe tier
                             new_ctx = get_next_probe_tier(old_ctx)
+                            compressor.context_length_known = False
+                            compressor.context_length_source = "probe"
+                            compressor._context_probed = False
 
                         if new_ctx and new_ctx < old_ctx:
                             compressor.context_length = new_ctx
                             compressor.threshold_tokens = int(new_ctx * compressor.threshold_percent)
-                            compressor._context_probed = True
                             self._vprint(f"{self.log_prefix}⚠️  Context length exceeded — stepping down: {old_ctx:,} → {new_ctx:,} tokens", force=True)
                         else:
                             self._vprint(f"{self.log_prefix}⚠️  Context length exceeded at minimum tier — attempting compression...", force=True)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5944,11 +5944,13 @@ class AIAgent:
                             compressor._context_probed = True
                             self._vprint(f"{self.log_prefix}⚠️  Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})", force=True)
                         else:
-                            # Step down to the next probe tier
+                            # Step down to the next probe tier. This remains a
+                            # probe-derived discovery, so keep it eligible for
+                            # persistence after the next successful response.
                             new_ctx = get_next_probe_tier(old_ctx)
                             compressor.context_length_known = False
                             compressor.context_length_source = "probe"
-                            compressor._context_probed = False
+                            compressor._context_probed = True
 
                         if new_ctx and new_ctx < old_ctx:
                             compressor.context_length = new_ctx

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -126,6 +126,10 @@ class TestDefaultContextLengths:
             if "gemini" in key:
                 assert value == 1048576, f"{key} should be 1048576"
 
+    def test_glm_200k_class_models_use_200k_defaults(self):
+        for model_name in ("glm-4.6", "glm-4.7", "glm-5"):
+            assert DEFAULT_CONTEXT_LENGTHS[model_name] == 200000
+
     def test_all_values_positive(self):
         for key, value in DEFAULT_CONTEXT_LENGTHS.items():
             assert value > 0, f"{key} has non-positive context length"
@@ -217,6 +221,34 @@ class TestGetModelContextLength:
         )
 
         assert result == CONTEXT_PROBE_TIERS[0]
+
+    @pytest.mark.parametrize(
+        ("model_name", "expected"),
+        [
+            ("glm-5", 200000),
+            ("anthropic/claude-sonnet-4", 200000),
+            ("openai/gpt-4o", 128000),
+        ],
+    )
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_custom_endpoint_without_metadata_keeps_exact_known_default(
+        self,
+        mock_endpoint_fetch,
+        mock_fetch,
+        model_name,
+        expected,
+    ):
+        mock_fetch.return_value = {}
+        mock_endpoint_fetch.return_value = {}
+
+        result = get_model_context_length(
+            model_name,
+            base_url="https://example-proxy.invalid/v1",
+            api_key="test-key",
+        )
+
+        assert result == expected
 
 
 # =========================================================================

--- a/tests/test_cli_status_bar.py
+++ b/tests/test_cli_status_bar.py
@@ -27,6 +27,7 @@ def _attach_agent(
     context_tokens: int,
     context_length: int,
     compressions: int = 0,
+    context_length_known: bool = True,
 ):
     cli_obj.agent = SimpleNamespace(
         model=cli_obj.model,
@@ -43,6 +44,7 @@ def _attach_agent(
         context_compressor=SimpleNamespace(
             last_prompt_tokens=context_tokens,
             context_length=context_length,
+            context_length_known=context_length_known,
             compression_count=compressions,
         ),
     )
@@ -109,6 +111,23 @@ class TestCLIStatusBar:
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
         assert "200K" not in text
+
+    def test_build_status_bar_hides_probe_only_context_limit(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="unknown/model"),
+            prompt_tokens=45_700,
+            completion_tokens=2_400,
+            total_tokens=48_100,
+            api_calls=7,
+            context_tokens=45_700,
+            context_length=2_000_000,
+            context_length_known=False,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "45.7K/2M" not in text
+        assert "ctx --" in text
 
     def test_build_status_bar_text_handles_missing_agent(self):
         cli_obj = _make_cli()

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -19,6 +19,7 @@ import pytest
 import run_agent
 from honcho_integration.client import HonchoClientConfig
 from run_agent import AIAgent, _inject_honcho_turn_context
+from agent.model_metadata import get_next_probe_tier
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 
 
@@ -258,6 +259,52 @@ class TestExtractReasoning:
         result = agent._extract_reasoning(msg)
         assert "part1" in result
         assert "part2" in result
+
+
+class TestContextProbeCaching:
+    def test_probe_step_down_is_cached_after_successful_retry(self, agent):
+        old_ctx = agent.context_compressor.context_length
+        expected_ctx = get_next_probe_tier(old_ctx)
+        assert expected_ctx is not None
+
+        agent.base_url = "https://example-proxy.invalid/v1"
+        agent.model = "unknown/model"
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.save_trajectories = False
+
+        err_400 = Exception("Error code: 400 - Please reduce the length of the messages")
+        err_400.status_code = 400
+        ok_resp = _mock_response(
+            content="Recovered after probe step-down",
+            finish_reason="stop",
+            usage={"prompt_tokens": 1234, "completion_tokens": 56, "total_tokens": 1290},
+        )
+        agent.client.chat.completions.create.side_effect = [err_400, ok_resp]
+
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.save_context_length") as mock_save_context_length,
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "hello"}],
+                "compressed prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        assert result["completed"] is True
+        assert agent.context_compressor.context_length == expected_ctx
+        assert agent.context_compressor.context_length_known is False
+        mock_save_context_length.assert_called_once_with(agent.model, agent.base_url, expected_ctx)
 
     def test_deduplication(self, agent):
         msg = _mock_assistant_msg(


### PR DESCRIPTION
## Summary
- keep exact known context defaults for models like `glm-5` even on custom OpenAI-compatible endpoints
- stop showing provisional probe-only limits like `2M` in CLI status/usage/banner output
- normalize GLM 200K-class defaults to `200000` and add regressions for exact-known vs fuzzy-unknown endpoint behavior

## Verification
- `python -m pytest -o addopts= tests/agent/test_context_compressor.py tests/agent/test_model_metadata.py tests/test_cli_status_bar.py -q`
  - 107 passed

