### PR TITLE
fix: respect DashScope v1 runtime mode for alibaba

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -326,19 +326,6 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
-    # Alibaba Cloud / DashScope (Anthropic-compatible endpoint)
-    if provider == "alibaba":
-        creds = resolve_api_key_provider_credentials(provider)
-        base_url = creds.get("base_url", "").rstrip("/") or "https://dashscope-intl.aliyuncs.com/apps/anthropic"
-        return {
-            "provider": "alibaba",
-            "api_mode": "anthropic_messages",
-            "base_url": base_url,
-            "api_key": creds.get("api_key", ""),
-            "source": creds.get("source", "env"),
-            "requested_provider": requested_provider,
-        }
-
     # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -493,6 +493,32 @@ def test_api_key_provider_default_url_stays_chat_completions(monkeypatch):
     assert resolved["base_url"] == "https://api.minimax.io/v1"
 
 
+def test_alibaba_default_anthropic_endpoint_uses_anthropic_messages(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+    monkeypatch.delenv("DASHSCOPE_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://dashscope-intl.aliyuncs.com/apps/anthropic"
+
+
+def test_alibaba_openai_compatible_v1_endpoint_stays_chat_completions(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+    monkeypatch.setenv("DASHSCOPE_BASE_URL", "https://coding-intl.dashscope.aliyuncs.com/v1")
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://coding-intl.dashscope.aliyuncs.com/v1"
+
+
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     """Custom providers should accept api_mode: anthropic_messages."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-anthropic-proxy")


### PR DESCRIPTION
## Problem
A user configured Hermes through the Alibaba Cloud / DashScope setup flow, entered the OpenAI-compatible DashScope coding endpoint:

- `https://coding-intl.dashscope.aliyuncs.com/v1`
- model: `glm-5`

Setup persisted that base URL correctly, but runtime still had a special-case `alibaba` branch that always forced `api_mode="anthropic_messages"`.

That meant the provider setup and the runtime transport logic disagreed:
- setup allowed and saved a `/v1` OpenAI-compatible endpoint
- runtime treated all Alibaba routes as Anthropic-compatible

In practice this caused the Alibaba setup to fail after configuration, because Hermes would not respect the protocol implied by the saved base URL.

## Root Cause
`resolve_runtime_provider()` hardcoded `provider == "alibaba"` to `anthropic_messages` instead of letting Alibaba go through the normal API-key provider resolution path. Other API-key providers already derive mode from:
- explicit `model.api_mode` config
- URL shape, such as `.../anthropic`
- otherwise defaulting to `chat_completions`

Alibaba was bypassing that logic entirely.

## Fix
- remove the Alibaba-specific runtime override
- route Alibaba through the standard API-key provider path
- preserve Anthropic-mode behavior for the default DashScope Anthropic endpoint (`/apps/anthropic`)
- keep OpenAI-compatible DashScope `/v1` endpoints on `chat_completions`

## Verification
- `python -m pytest -o addopts= tests/test_runtime_provider_resolution.py -q`\n  - 28 passed\n\n## Regression Coverage\nAdded explicit tests for both supported Alibaba/DashScope modes:\n- default `/apps/anthropic` endpoint -> `anthropic_messages`\n- `https://coding-intl.dashscope.aliyuncs.com/v1` -> `chat_completions`\n