### PR TITLE
feat: add Cerebras as a first-class provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,15 @@
 # GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai
 
 # =============================================================================
+# LLM PROVIDER (Cerebras)
+# =============================================================================
+# Ultra-fast wafer-scale inference. OpenAI-compatible endpoint.
+# Get your key at: https://cloud.cerebras.ai/
+# CEREBRAS_API_KEY=your_cerebras_key_here
+# Optional base URL override (default: https://api.cerebras.ai/v1)
+# CEREBRAS_BASE_URL=https://api.cerebras.ai/v1
+
+# =============================================================================
 # LLM PROVIDER (z.ai / GLM)
 # =============================================================================
 # z.ai provides access to ZhipuAI GLM models (GLM-4-Plus, etc.)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -106,6 +106,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
+    "cerebras": "llama3.1-8b",
 }
 
 # OpenRouter app attribution headers

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -24,13 +24,14 @@ logger = logging.getLogger(__name__)
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
-    "gemini", "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic", "deepseek",
+    "gemini", "cerebras", "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba",
     "custom", "local",
     # Common aliases
     "google", "google-gemini", "google-ai-studio",
     "glm", "z-ai", "z.ai", "zhipu", "github", "github-copilot",
     "github-models", "kimi", "moonshot", "claude", "deep-seek",
+    "cs",
     "opencode", "zen", "go", "vercel", "kilo", "dashscope", "aliyun", "qwen",
 })
 
@@ -187,6 +188,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
     "api.fireworks.ai": "fireworks",
+    "api.cerebras.ai": "cerebras",
 }
 
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -169,6 +169,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "togetherai": "togetherai",
     "perplexity": "perplexity",
     "cohere": "cohere",
+    "cerebras": "cerebras",
 }
 
 # Reverse mapping: models.dev → Hermes (built lazily)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -24,6 +24,7 @@ model:
   #   "minimax"      - MiniMax global (requires: MINIMAX_API_KEY)
   #   "minimax-cn"   - MiniMax China (requires: MINIMAX_CN_API_KEY)
   #   "huggingface"  - Hugging Face Inference (requires: HF_TOKEN)
+  #   "cerebras"     - Cerebras (requires: CEREBRAS_API_KEY — https://cloud.cerebras.ai/)
   #   "kilocode"     - KiloCode gateway (requires: KILOCODE_API_KEY)
   #   "ai-gateway"   - Vercel AI Gateway (requires: AI_GATEWAY_API_KEY)
   #
@@ -317,6 +318,7 @@ compression:
 #   "openrouter" - Force OpenRouter (requires OPENROUTER_API_KEY)
 #   "nous"       - Force Nous Portal (requires: hermes login)
 #   "gemini"      - Force Google AI Studio direct (requires: GOOGLE_API_KEY or GEMINI_API_KEY)
+#   "cerebras"    - Cerebras (requires: CEREBRAS_API_KEY)
 #   "codex"       - Force Codex OAuth (requires: hermes model → Codex).
 #                  Uses gpt-5.3-codex which supports vision.
 #   "main"       - Use your custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY).

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -70,6 +70,7 @@ DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
 DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+DEFAULT_CEREBRAS_BASE_URL = "https://api.cerebras.ai/v1"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
@@ -232,6 +233,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://router.huggingface.co/v1",
         api_key_env_vars=("HF_TOKEN",),
         base_url_env_var="HF_BASE_URL",
+    ),
+    "cerebras": ProviderConfig(
+        id="cerebras",
+        name="Cerebras",
+        auth_type="api_key",
+        inference_base_url=DEFAULT_CEREBRAS_BASE_URL,
+        api_key_env_vars=("CEREBRAS_API_KEY",),
+        base_url_env_var="CEREBRAS_BASE_URL",
     ),
 }
 
@@ -820,6 +829,7 @@ def resolve_provider(
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
+        "cerebras-cloud": "cerebras", "cs": "cerebras",
         # Local server aliases — route through the generic custom provider
         "lmstudio": "custom", "lm-studio": "custom", "lm_studio": "custom",
         "ollama": "custom", "vllm": "custom", "llamacpp": "custom",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -771,6 +771,22 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "CEREBRAS_API_KEY": {
+        "description": "Cerebras Cloud API key (ultra-fast wafer-scale inference)",
+        "prompt": "Cerebras API key",
+        "url": "https://cloud.cerebras.ai/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "CEREBRAS_BASE_URL": {
+        "description": "Cerebras API base URL override (default: https://api.cerebras.ai/v1)",
+        "prompt": "Cerebras base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
 
     # ── Tool API keys ──
     "EXA_API_KEY": {

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -932,6 +932,7 @@ def select_provider_and_model(args=None):
         "kilocode": "Kilo Code",
         "alibaba": "Alibaba Cloud (DashScope)",
         "huggingface": "Hugging Face",
+        "cerebras": "Cerebras",
         "custom": "Custom endpoint",
     }
     active_label = provider_labels.get(active, active) if active else "none"
@@ -963,6 +964,7 @@ def select_provider_and_model(args=None):
         ("opencode-go", "OpenCode Go (open models, $10/month subscription)"),
         ("ai-gateway", "AI Gateway (Vercel — 200+ models, pay-per-use)"),
         ("alibaba", "Alibaba Cloud / DashScope Coding (Qwen + multi-provider)"),
+        ("cerebras", "Cerebras (ultra-fast wafer-scale inference)"),
     ]
 
     # Add user-defined custom providers from config.yaml
@@ -1057,7 +1059,7 @@ def select_provider_and_model(args=None):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("gemini", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface"):
+    elif selected_provider in ("gemini", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "cerebras"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
 
@@ -4240,7 +4242,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "cerebras", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -85,6 +85,7 @@ _PASSTHROUGH_PROVIDERS: frozenset[str] = frozenset({
     "minimax-cn",
     "alibaba",
     "huggingface",
+    "cerebras",
     "openai-codex",
     "custom",
 })

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -480,6 +480,7 @@ _PROVIDER_LABELS = {
     "kilocode": "Kilo Code",
     "alibaba": "Alibaba Cloud (DashScope)",
     "huggingface": "Hugging Face",
+    "cerebras": "Cerebras",
     "custom": "Custom endpoint",
 }
 
@@ -521,6 +522,8 @@ _PROVIDER_ALIASES = {
     "hf": "huggingface",
     "hugging-face": "huggingface",
     "huggingface-hub": "huggingface",
+    "cerebras-cloud": "cerebras",
+    "cs": "cerebras",
 }
 
 
@@ -761,7 +764,7 @@ def list_available_providers() -> list[dict[str, str]]:
     # Canonical providers in display order
     _PROVIDER_ORDER = [
         "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
-        "gemini", "huggingface",
+        "gemini", "cerebras", "huggingface",
         "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
         "opencode-zen", "opencode-go",
         "ai-gateway", "deepseek", "custom",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -121,6 +121,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="HF_BASE_URL",
     ),
+    "cerebras": HermesOverlay(
+        transport="openai_chat",
+        base_url_env_var="CEREBRAS_BASE_URL",
+    ),
 }
 
 
@@ -200,6 +204,10 @@ ALIASES: Dict[str, str] = {
     # deepseek
     "deep-seek": "deepseek",
 
+    # cerebras
+    "cerebras-cloud": "cerebras",
+    "cs": "cerebras",
+
     # alibaba
     "dashscope": "alibaba",
     "aliyun": "alibaba",
@@ -232,6 +240,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
     "local": "Local endpoint",
+    "cerebras": "Cerebras",
 }
 
 
@@ -367,6 +376,7 @@ LABELS: Dict[str, str] = {
     "huggingface": "Hugging Face",
     "local": "Local endpoint",
     "custom": "Custom endpoint",
+    "cerebras": "Cerebras",
     # Legacy Hermes IDs (point to same providers)
     "ai-gateway": "Vercel AI Gateway",
     "kilocode": "Kilo Gateway",

--- a/tests/hermes_cli/test_cerebras_provider.py
+++ b/tests/hermes_cli/test_cerebras_provider.py
@@ -1,0 +1,227 @@
+"""Tests for Cerebras provider integration."""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider, resolve_api_key_provider_credentials
+from hermes_cli.models import _PROVIDER_MODELS, _PROVIDER_LABELS, _PROVIDER_ALIASES, normalize_provider
+from hermes_cli.model_normalize import normalize_model_for_provider
+from agent.model_metadata import _URL_TO_PROVIDER, _PROVIDER_PREFIXES
+from agent.models_dev import PROVIDER_TO_MODELS_DEV, list_agentic_models
+
+
+# ── Provider Registry ──
+
+class TestCerebrasProviderRegistry:
+    def test_cerebras_in_registry(self):
+        assert "cerebras" in PROVIDER_REGISTRY
+
+    def test_cerebras_config(self):
+        pconfig = PROVIDER_REGISTRY["cerebras"]
+        assert pconfig.id == "cerebras"
+        assert pconfig.name == "Cerebras"
+        assert pconfig.auth_type == "api_key"
+        assert pconfig.inference_base_url == "https://api.cerebras.ai/v1"
+
+    def test_cerebras_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["cerebras"]
+        assert pconfig.api_key_env_vars == ("CEREBRAS_API_KEY",)
+        assert pconfig.base_url_env_var == "CEREBRAS_BASE_URL"
+
+    def test_cerebras_base_url(self):
+        assert "api.cerebras.ai" in PROVIDER_REGISTRY["cerebras"].inference_base_url
+
+
+# ── Provider Aliases ──
+
+PROVIDER_ENV_VARS = (
+    "OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY", "GEMINI_API_KEY", "CEREBRAS_API_KEY",
+    "GLM_API_KEY", "ZAI_API_KEY", "KIMI_API_KEY",
+    "MINIMAX_API_KEY", "DEEPSEEK_API_KEY",
+)
+
+@pytest.fixture(autouse=True)
+def _clean_provider_env(monkeypatch):
+    for var in PROVIDER_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestCerebrasAliases:
+    def test_explicit_cerebras(self):
+        assert resolve_provider("cerebras") == "cerebras"
+
+    def test_alias_cerebras_cloud(self):
+        assert resolve_provider("cerebras-cloud") == "cerebras"
+
+    def test_alias_cs(self):
+        assert resolve_provider("cs") == "cerebras"
+
+    def test_models_py_aliases(self):
+        assert _PROVIDER_ALIASES.get("cerebras-cloud") == "cerebras"
+        assert _PROVIDER_ALIASES.get("cs") == "cerebras"
+
+    def test_normalize_provider(self):
+        assert normalize_provider("cerebras") == "cerebras"
+        assert normalize_provider("cs") == "cerebras"
+
+
+# ── Auto-detection ──
+
+class TestCerebrasAutoDetection:
+    def test_auto_detects_cerebras_api_key(self, monkeypatch):
+        monkeypatch.setenv("CEREBRAS_API_KEY", "test-cerebras-key")
+        assert resolve_provider("auto") == "cerebras"
+
+
+# ── Credential Resolution ──
+
+class TestCerebrasCredentials:
+    def test_resolve_with_cerebras_api_key(self, monkeypatch):
+        monkeypatch.setenv("CEREBRAS_API_KEY", "cerebras-secret")
+        creds = resolve_api_key_provider_credentials("cerebras")
+        assert creds["provider"] == "cerebras"
+        assert creds["api_key"] == "cerebras-secret"
+        assert creds["base_url"] == "https://api.cerebras.ai/v1"
+
+    def test_resolve_with_custom_base_url(self, monkeypatch):
+        monkeypatch.setenv("CEREBRAS_API_KEY", "key")
+        monkeypatch.setenv("CEREBRAS_BASE_URL", "https://custom.cerebras/v1")
+        creds = resolve_api_key_provider_credentials("cerebras")
+        assert creds["base_url"] == "https://custom.cerebras/v1"
+
+    def test_runtime_cerebras(self, monkeypatch):
+        monkeypatch.setenv("CEREBRAS_API_KEY", "cerebras-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="cerebras")
+        assert result["provider"] == "cerebras"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "cerebras-key"
+        assert result["base_url"] == "https://api.cerebras.ai/v1"
+
+
+# ── Model Catalog (dynamic — no static list) ──
+
+class TestCerebrasModelCatalog:
+    def test_no_static_model_list(self):
+        """Cerebras models are discovered dynamically via models.dev + live API."""
+        assert "cerebras" not in _PROVIDER_MODELS
+
+    def test_provider_label(self):
+        assert "cerebras" in _PROVIDER_LABELS
+        assert _PROVIDER_LABELS["cerebras"] == "Cerebras"
+
+
+# ── Model Normalization ──
+
+class TestCerebrasModelNormalization:
+    def test_passthrough_bare_name(self):
+        """Cerebras is a passthrough provider — model names used as-is."""
+        assert normalize_model_for_provider("gpt-oss-120b", "cerebras") == "gpt-oss-120b"
+
+    def test_passthrough_llama(self):
+        assert normalize_model_for_provider("llama3.1-8b", "cerebras") == "llama3.1-8b"
+
+
+# ── URL-to-Provider Mapping ──
+
+class TestCerebrasUrlMapping:
+    def test_url_to_provider(self):
+        assert _URL_TO_PROVIDER.get("api.cerebras.ai") == "cerebras"
+
+    def test_provider_prefix_canonical(self):
+        assert "cerebras" in _PROVIDER_PREFIXES
+
+    def test_provider_prefix_alias(self):
+        assert "cs" in _PROVIDER_PREFIXES
+
+
+# ── models.dev Integration ──
+
+class TestCerebrasModelsDev:
+    def test_cerebras_mapped(self):
+        assert PROVIDER_TO_MODELS_DEV.get("cerebras") == "cerebras"
+
+    def test_list_agentic_models_with_mock_data(self):
+        """list_agentic_models filters correctly from mock models.dev data."""
+        mock_data = {
+            "cerebras": {
+                "models": {
+                    "gpt-oss-120b": {"tool_call": True},
+                    "llama3.1-8b": {"tool_call": True},
+                    "some-embedding": {"tool_call": False},
+                }
+            }
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=mock_data):
+            result = list_agentic_models("cerebras")
+        assert "gpt-oss-120b" in result
+        assert "llama3.1-8b" in result
+        assert "some-embedding" not in result
+
+
+# ── Agent Init (no SyntaxError) ──
+
+class TestCerebrasAgentInit:
+    def test_agent_imports_without_error(self):
+        """Verify run_agent.py has no SyntaxError."""
+        import importlib
+        import run_agent
+        importlib.reload(run_agent)
+
+    def test_cerebras_agent_uses_chat_completions(self, monkeypatch):
+        """Cerebras falls through to chat_completions — no special elif needed."""
+        monkeypatch.setenv("CEREBRAS_API_KEY", "test-key")
+        with patch("run_agent.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from run_agent import AIAgent
+            agent = AIAgent(
+                model="gpt-oss-120b",
+                provider="cerebras",
+                api_key="test-key",
+                base_url="https://api.cerebras.ai/v1",
+            )
+            assert agent.api_mode == "chat_completions"
+            assert agent.provider == "cerebras"
+
+
+# ── providers.py New System ──
+
+class TestCerebrasProvidersNew:
+    def test_overlay_exists(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+        assert "cerebras" in HERMES_OVERLAYS
+        overlay = HERMES_OVERLAYS["cerebras"]
+        assert overlay.transport == "openai_chat"
+        assert overlay.base_url_env_var == "CEREBRAS_BASE_URL"
+
+    def test_alias_resolves(self):
+        from hermes_cli.providers import normalize_provider as np
+        assert np("cerebras") == "cerebras"
+        assert np("cs") == "cerebras"
+        assert np("cerebras-cloud") == "cerebras"
+
+    def test_label_override(self):
+        from hermes_cli.providers import _LABEL_OVERRIDES
+        assert _LABEL_OVERRIDES.get("cerebras") == "Cerebras"
+
+    def test_get_label(self):
+        from hermes_cli.providers import get_label
+        assert get_label("cerebras") == "Cerebras"
+
+    def test_get_provider(self):
+        from hermes_cli.providers import get_provider
+        pdef = get_provider("cerebras")
+        assert pdef is not None
+        assert pdef.id == "cerebras"
+        assert pdef.transport == "openai_chat"
+
+
+# ── Auxiliary Model ──
+
+class TestCerebrasAuxiliary:
+    def test_aux_model_defined(self):
+        from agent.auxiliary_client import _API_KEY_PROVIDER_AUX_MODELS
+        assert "cerebras" in _API_KEY_PROVIDER_AUX_MODELS
+        assert _API_KEY_PROVIDER_AUX_MODELS["cerebras"] == "llama3.1-8b"


### PR DESCRIPTION
## Summary

Add **Cerebras** (`api.cerebras.ai`) as a first-class built-in provider. Cerebras offers ultra-fast wafer-scale inference with an OpenAI-compatible endpoint.

**Rebuilt from scratch** on current upstream/main to follow the standard 12-file provider checklist (matching the Gemini, Ollama Cloud, and other recent provider PRs). The original PR was 3 weeks behind and missing several files from the new providers.py system.

## Changes

| File | What |
|------|------|
| `hermes_cli/auth.py` | `PROVIDER_REGISTRY` entry + aliases (`cerebras-cloud`, `cs`) |
| `hermes_cli/config.py` | `CEREBRAS_API_KEY` + `CEREBRAS_BASE_URL` in `OPTIONAL_ENV_VARS` |
| `hermes_cli/models.py` | Label, aliases, provider order (no static model list) |
| `hermes_cli/model_normalize.py` | Added to `_PASSTHROUGH_PROVIDERS` |
| `hermes_cli/providers.py` | `HermesOverlay` + label + alias entries |
| `hermes_cli/main.py` | Setup flow, `--provider` choices, provider dispatch |
| `agent/model_metadata.py` | `_PROVIDER_PREFIXES` + `_URL_TO_PROVIDER` mapping |
| `agent/models_dev.py` | `PROVIDER_TO_MODELS_DEV` mapping |
| `agent/auxiliary_client.py` | Default aux model (`llama3.1-8b`) |
| `.env.example` | Documented env vars |
| `cli-config.yaml.example` | Provider list + auxiliary comments |

### Dynamic model discovery

No static model list — models discovered dynamically via models.dev registry (primary) and live `/v1/models` endpoint (secondary). Current models.dev catalog includes: `gpt-oss-120b`, `llama3.1-8b`, `zai-glm-4.7`, `qwen-3-235b-a22b-instruct-2507`.

### Key design decisions

- **Passthrough normalization** — Cerebras uses its own model names as-is, no vendor-prefixed format
- **Not an aggregator** — direct provider with its own model set
- **`llama3.1-8b` as aux model** — fast/cheap for vision, compression, and web extract tasks
- **`cs` short alias** — quick access via `--provider cs`

## Test plan

- [x] `python -m pytest tests/hermes_cli/test_cerebras_provider.py -v` — 30 passed
- [x] `python -m pytest tests/hermes_cli/ tests/agent/ -q` — 2390 passed, 9 failed (all pre-existing on upstream/main)
- [ ] `hermes setup model` → select cerebras → dynamic model list shown
- [ ] `hermes chat --provider cerebras` with `CEREBRAS_API_KEY` set
