### PR TITLE
fix(delegate): fix _saved_tool_names used before assignment in _build_child_agent

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -232,7 +232,6 @@ def _build_child_agent(
         tool_progress_callback=child_progress_cb,
         iteration_budget=shared_budget,
     )
-    child._delegate_saved_tool_names = list(_saved_tool_names)
 
     # Set delegation depth so children can't spawn grandchildren
     child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
@@ -380,11 +379,7 @@ def _run_single_child(
     finally:
         # Restore the parent's tool names so the process-global is correct
         # for any subsequent execute_code calls or other consumers.
-        import model_tools
-
-        saved_tool_names = getattr(child, "_delegate_saved_tool_names", None)
-        if isinstance(saved_tool_names, list):
-            model_tools._last_resolved_tool_names = list(saved_tool_names)
+        model_tools._last_resolved_tool_names = _saved_tool_names
 
         # Unregister child from interrupt propagation
         if hasattr(parent_agent, '_active_children'):


### PR DESCRIPTION
Fixes #2027

## Problem
The variable `_saved_tool_names` was being used at line 235 in `_build_child_agent` but only defined at line 272 in `_run_single_child`. This caused a NameError in all delegate-related tests.

## Solution
- Removed the line that stores `_saved_tool_names` on child object (was using undefined var)
- Use the local `_saved_tool_names` directly in the finally block since save/restore now happens entirely within `_run_single_child` scope

This is a minimal, focused fix that addresses the scoping issue without changing other functionality.