### PR TITLE
feat(transcription): add .aac audio format support

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1145,7 +1145,7 @@ class BasePlatformAdapter(ABC):
                         logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
 
                 # Send extracted media files — route by file type
-                _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
+                _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a', '.aac'}
                 _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
                 _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
-_AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a"}
+_AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".aac"}
 _VOICE_EXTS = {".ogg", ".opus"}
 
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -60,7 +60,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 
-SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg"}
+SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 


### PR DESCRIPTION
Fixes #1963

## Problem
Rocketchat on Android sends voice notes as .aac files, which are currently rejected by the transcription tool filter.

## Solution
Add `.aac` to supported audio formats across the codebase:
- `transcription_tools.py`: Add to `SUPPORTED_FORMATS` set
- `send_message_tool.py`: Add to `_AUDIO_EXTS` for consistent handling
- `gateway/platforms/base.py`: Add to `_AUDIO_EXTS` for routing

OpenAI's Whisper API already supports AAC format natively, so no backend changes needed.