### PR TITLE
fix(cron): support Telegram topic delivery via platform:chat_id:thread_id format

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -80,11 +80,16 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
         }
 
     if ":" in deliver:
-        platform_name, chat_id = deliver.split(":", 1)
+        platform_name, rest = deliver.split(":", 1)
+        # Check for thread_id suffix (e.g. "telegram:-1003724596514:17")
+        if ":" in rest:
+            chat_id, thread_id = rest.split(":", 1)
+        else:
+            chat_id, thread_id = rest, None
         return {
             "platform": platform_name,
             "chat_id": chat_id,
-            "thread_id": None,
+            "thread_id": thread_id,
         }
 
     platform_name = deliver

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -62,6 +62,28 @@ class TestResolveDeliveryTarget:
             "thread_id": "17585",
         }
 
+    def test_explicit_telegram_topic_target_with_thread_id(self):
+        """deliver: 'telegram:chat_id:thread_id' parses correctly."""
+        job = {
+            "deliver": "telegram:-1003724596514:17",
+        }
+        assert _resolve_delivery_target(job) == {
+            "platform": "telegram",
+            "chat_id": "-1003724596514",
+            "thread_id": "17",
+        }
+
+    def test_explicit_telegram_chat_id_without_thread_id(self):
+        """deliver: 'telegram:chat_id' sets thread_id to None."""
+        job = {
+            "deliver": "telegram:-1003724596514",
+        }
+        assert _resolve_delivery_target(job) == {
+            "platform": "telegram",
+            "chat_id": "-1003724596514",
+            "thread_id": None,
+        }
+
     def test_bare_platform_uses_matching_origin_chat(self):
         job = {
             "deliver": "telegram",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -370,7 +370,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "deliver": {
                 "type": "string",
-                "description": "Delivery target: origin, local, telegram, discord, slack, whatsapp, signal, matrix, mattermost, homeassistant, dingtalk, email, sms, or platform:chat_id"
+                "description": "Delivery target: origin, local, telegram, discord, slack, whatsapp, signal, matrix, mattermost, homeassistant, dingtalk, email, sms, or platform:chat_id or platform:chat_id:thread_id for Telegram topics. Examples: 'origin', 'local', 'telegram', 'telegram:-1001234567890:17585', 'discord:#engineering'"
             },
             "model": {
                 "type": "string",


### PR DESCRIPTION
## Summary

### Problem

The current implementation prevents cron job to send Telegram messages to Topics inside Telegram groups.

### Solution

Parse `thread_id` from explicit `deliver` target (e.g. `telegram:-1003724596514:17`) in `_resolve_delivery_target()` and forward it to `_send_to_platform` and `mirror_to_session`.

Previously `_resolve_delivery_target()` always set `thread_id=None` when parsing the `platform:chat_id` format, breaking cron job delivery to specific Telegram topics.

## Changes

- **cron/scheduler.py**: Parse `:thread_id` suffix when present in deliver target
- **tests/cron/test_scheduler.py**: Added two tests for the new parsing behavior
- **tools/cronjob_tools.py**: Updated `CRONJOB_SCHEMA` `deliver` description to document the `platform:chat_id:thread_id` format

## Testing

```
tests/cron/test_scheduler.py: 27 passed
tests/tools/test_send_message_tool.py: 19 passed
```