### PR TITLE
fix: auto-detect local model name and context length for local servers

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -136,6 +136,8 @@ _CONTEXT_LENGTH_KEYS = (
     "max_input_tokens",
     "max_sequence_length",
     "max_seq_len",
+    "n_ctx_train",
+    "n_ctx",
 )
 
 _MAX_COMPLETION_KEYS = (
@@ -342,6 +344,25 @@ def fetch_endpoint_model_metadata(
                     entry["pricing"] = pricing
                 _add_model_aliases(cache, model_id, entry)
 
+            # If this is a llama.cpp server, query /props for actual allocated context
+            is_llamacpp = any(
+                m.get("owned_by") == "llamacpp"
+                for m in payload.get("data", []) if isinstance(m, dict)
+            )
+            if is_llamacpp:
+                try:
+                    props_url = candidate.rstrip("/").replace("/v1", "") + "/props"
+                    props_resp = requests.get(props_url, headers=headers, timeout=5)
+                    if props_resp.ok:
+                        props = props_resp.json()
+                        gen_settings = props.get("default_generation_settings", {})
+                        n_ctx = gen_settings.get("n_ctx")
+                        model_alias = props.get("model_alias", "")
+                        if n_ctx and model_alias and model_alias in cache:
+                            cache[model_alias]["context_length"] = n_ctx
+                except Exception:
+                    pass
+
             _endpoint_model_metadata_cache[normalized] = cache
             _endpoint_model_metadata_cache_time[normalized] = time.time()
             return cache
@@ -458,8 +479,16 @@ def get_model_context_length(model: str, base_url: str = "", api_key: str = "") 
     # 2. Active endpoint metadata for explicit custom routes
     if _is_custom_endpoint(base_url):
         endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
-        if model in endpoint_metadata:
-            context_length = endpoint_metadata[model].get("context_length")
+        matched = endpoint_metadata.get(model)
+        if not matched and len(endpoint_metadata) == 1:
+            matched = next(iter(endpoint_metadata.values()))
+        elif not matched:
+            for key in endpoint_metadata:
+                if model in key or key in model:
+                    matched = endpoint_metadata[key]
+                    break
+        if matched:
+            context_length = matched.get("context_length")
             if isinstance(context_length, int):
                 return context_length
         if not _is_known_provider_base_url(base_url):

--- a/cli.py
+++ b/cli.py
@@ -1046,6 +1046,14 @@ class HermesCLI:
         _config_model = _model_config.get("default", "") if isinstance(_model_config, dict) else (_model_config or "")
         _FALLBACK_MODEL = "anthropic/claude-opus-4.6"
         self.model = model or _config_model or _FALLBACK_MODEL
+        # Auto-detect model from local server if still on fallback
+        if self.model == _FALLBACK_MODEL:
+            _base_url = _model_config.get("base_url", "") if isinstance(_model_config, dict) else ""
+            if "localhost" in _base_url or "127.0.0.1" in _base_url:
+                from hermes_cli.runtime_provider import _auto_detect_local_model
+                _detected = _auto_detect_local_model(_base_url)
+                if _detected:
+                    self.model = _detected
         # Track whether model was explicitly chosen by the user or fell back
         # to the global default.  Provider-specific normalisation may override
         # the default silently but should warn when overriding an explicit choice.
@@ -1251,6 +1259,8 @@ class HermesCLI:
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         model_name = self.model or "unknown"
         model_short = model_name.split("/")[-1] if "/" in model_name else model_name
+        if model_short.endswith(".gguf"):
+            model_short = model_short[:-5]
         if len(model_short) > 26:
             model_short = f"{model_short[:23]}..."
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -289,6 +289,8 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         _hero = HERMES_CADUCEUS
     left_lines = ["", _hero, ""]
     model_short = model.split("/")[-1] if "/" in model else model
+    if model_short.endswith(".gguf"):
+        model_short = model_short[:-5]
     if len(model_short) > 28:
         model_short = model_short[:25] + "..."
     ctx_str = f" [dim {dim}]·[/] [dim {dim}]{_format_context_length(context_length)} context[/]" if context_length else ""

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -24,11 +24,41 @@ def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
 
+def _auto_detect_local_model(base_url: str) -> str:
+    """Query a local server for its model name when only one model is loaded."""
+    if not base_url:
+        return ""
+    try:
+        import requests
+        url = base_url.rstrip("/")
+        if not url.endswith("/v1"):
+            url += "/v1"
+        resp = requests.get(url + "/models", timeout=5)
+        if resp.ok:
+            models = resp.json().get("data", [])
+            if len(models) == 1:
+                model_id = models[0].get("id", "")
+                if model_id:
+                    return model_id
+    except Exception:
+        pass
+    return ""
+
+
 def _get_model_config() -> Dict[str, Any]:
     config = load_config()
     model_cfg = config.get("model")
     if isinstance(model_cfg, dict):
-        return dict(model_cfg)
+        cfg = dict(model_cfg)
+        default = cfg.get("default", "").strip()
+        base_url = cfg.get("base_url", "").strip()
+        is_local = "localhost" in base_url or "127.0.0.1" in base_url
+        is_fallback = not default or default == "anthropic/claude-opus-4.6"
+        if is_local and is_fallback and base_url:
+            detected = _auto_detect_local_model(base_url)
+            if detected:
+                cfg["default"] = detected
+        return cfg
     if isinstance(model_cfg, str) and model_cfg.strip():
         return {"default": model_cfg.strip()}
     return {}


### PR DESCRIPTION
local users running hermes with llama.cpp, vLLM, or other local servers see "claude-opus-4.6" as the model name and "2M" as the context length in the status bar. both are wrong. the model name comes from a hardcoded default in config.py and the context falls back to the highest probe tier because the model name doesn't match what the server reports.

this PR fixes it by teaching hermes to read what the local server already exposes.

on startup if the configured model is still the default fallback and the base_url points to localhost, hermes queries /v1/models. if exactly one model is loaded it uses that name automatically. no manual model name config needed.

for context length, added n_ctx_train and n_ctx to the detection keys so hermes recognizes llama.cpp responses. for llama.cpp servers specifically it also queries /props to get the actual allocated context instead of the training context from GGUF metadata. a server launched with -c 131072 now correctly shows 131K not 262K or 2M.

when the config says Qwen3.5-9B-Q4_K_M but the server reports Qwen3.5-9B-Q4_K_M.gguf, hermes now matches them. also handles single-model servers where the name doesn't match at all by using the only available model.

.gguf suffix is stripped from both the welcome banner and the bottom status bar for cleaner local display.

all changes are guarded by localhost detection and silent fallbacks. if the endpoint is unreachable or returns unexpected data hermes falls back to existing behavior. API and cloud users are completely unaffected.

tested on qwen 3.5 9B Q4 running on llama.cpp via RTX 3060. before showed claude-opus-4.6 with 2M context. after shows Qwen3.5-9B-Q4_K_M with 131.072K context.

planning to also remove the placeholder API key requirement for local endpoints and work toward auto-discovering local servers without manual config in follow-up PRs.