### PR TITLE
fix(tools): fix NameError crashing delegate_task on every invocation

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -232,7 +232,6 @@ def _build_child_agent(
         tool_progress_callback=child_progress_cb,
         iteration_budget=shared_budget,
     )
-    child._delegate_saved_tool_names = list(_saved_tool_names)
 
     # Set delegation depth so children can't spawn grandchildren
     child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
@@ -270,6 +269,7 @@ def _run_single_child(
     # save/restore happens in the same scope as the try/finally.
     import model_tools
     _saved_tool_names = list(model_tools._last_resolved_tool_names)
+    child._delegate_saved_tool_names = _saved_tool_names
 
     try:
         result = child.run_conversation(user_message=goal)


### PR DESCRIPTION
## What

`_build_child_agent()` referenced `_saved_tool_names` at line 235, but that variable is only defined inside `_run_single_child()` at line 272. This caused a `NameError` on **every** `delegate_task` call, completely breaking subagent delegation.

The developer's own comment at lines 267-270 even says:
> "This must be in _run_single_child (not _build_child_agent) so the save/restore happens in the same scope as the try/finally."

The line was placed in the wrong function during a refactor.

## Fix

- Remove `child._delegate_saved_tool_names = list(_saved_tool_names)` from `_build_child_agent()`
- Add `child._delegate_saved_tool_names = _saved_tool_names` in `_run_single_child()` right after `_saved_tool_names` is defined

This puts the assignment in the correct scope where `_saved_tool_names` exists, and ensures the `finally` block's restore logic (which reads `child._delegate_saved_tool_names`) works correctly.

## How to test

Before: calling `delegate_task` raises `NameError: name '_saved_tool_names' is not defined`

After: delegation works, parent tool names are saved/restored correctly across child agent runs.

## Platforms tested

- macOS