### PR TITLE
fix: normalize live Chrome CDP endpoints for browser tools

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3926,7 +3926,7 @@ class HermesCLI:
         parts = cmd.strip().split(None, 1)
         sub = parts[1].lower().strip() if len(parts) > 1 else "status"
 
-        _DEFAULT_CDP = "ws://localhost:9222"
+        _DEFAULT_CDP = "http://localhost:9222"
         current = os.environ.get("BROWSER_CDP_URL", "").strip()
 
         if sub.startswith("connect"):

--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -1,0 +1,47 @@
+from unittest.mock import Mock, patch
+
+
+HOST = "example-host"
+PORT = 9223
+WS_URL = f"ws://{HOST}:{PORT}/devtools/browser/abc123"
+HTTP_URL = f"http://{HOST}:{PORT}"
+VERSION_URL = f"{HTTP_URL}/json/version"
+
+
+class TestResolveCdpOverride:
+    def test_keeps_full_devtools_websocket_url(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        assert _resolve_cdp_override(WS_URL) == WS_URL
+
+    def test_resolves_http_discovery_endpoint_to_websocket(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
+
+        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+            resolved = _resolve_cdp_override(HTTP_URL)
+
+        assert resolved == WS_URL
+        mock_get.assert_called_once_with(VERSION_URL, timeout=10)
+
+    def test_resolves_bare_ws_hostport_to_discovery_websocket(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
+
+        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+            resolved = _resolve_cdp_override(f"ws://{HOST}:{PORT}")
+
+        assert resolved == WS_URL
+        mock_get.assert_called_once_with(VERSION_URL, timeout=10)
+
+    def test_falls_back_to_raw_url_when_discovery_fails(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        with patch("tools.browser_tool.requests.get", side_effect=RuntimeError("boom")):
+            assert _resolve_cdp_override(HTTP_URL) == HTTP_URL

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -106,14 +106,63 @@ def _get_extraction_model() -> Optional[str]:
     return os.getenv("AUXILIARY_WEB_EXTRACT_MODEL", "").strip() or None
 
 
+def _resolve_cdp_override(cdp_url: str) -> str:
+    """Normalize a user-supplied CDP endpoint into a concrete connectable URL.
+
+    Accepts:
+    - full websocket endpoints: ws://host:port/devtools/browser/...
+    - HTTP discovery endpoints: http://host:port or http://host:port/json/version
+    - bare websocket host:port values like ws://host:port
+
+    For discovery-style endpoints we fetch /json/version and return the
+    webSocketDebuggerUrl so downstream tools always receive a concrete browser
+    websocket instead of an ambiguous host:port URL.
+    """
+    raw = (cdp_url or "").strip()
+    if not raw:
+        return ""
+
+    lowered = raw.lower()
+    if "/devtools/browser/" in lowered:
+        return raw
+
+    discovery_url = raw
+    if lowered.startswith("ws://") or lowered.startswith("wss://"):
+        if raw.count(":") == 2 and raw.rstrip("/").rsplit(":", 1)[-1].isdigit() and "/" not in raw.split(":", 2)[-1]:
+            discovery_url = ("http://" if lowered.startswith("ws://") else "https://") + raw.split("://", 1)[1]
+        else:
+            return raw
+
+    if discovery_url.lower().endswith("/json/version"):
+        version_url = discovery_url
+    else:
+        version_url = discovery_url.rstrip("/") + "/json/version"
+
+    try:
+        response = requests.get(version_url, timeout=10)
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:
+        logger.warning("Failed to resolve CDP endpoint %s via %s: %s", raw, version_url, exc)
+        return raw
+
+    ws_url = str(payload.get("webSocketDebuggerUrl") or "").strip()
+    if ws_url:
+        logger.info("Resolved CDP endpoint %s -> %s", raw, ws_url)
+        return ws_url
+
+    logger.warning("CDP discovery at %s did not return webSocketDebuggerUrl; using raw endpoint", version_url)
+    return raw
+
+
 def _get_cdp_override() -> str:
-    """Return a user-supplied CDP URL override, or empty string.
+    """Return a normalized user-supplied CDP URL override, or empty string.
 
     When ``BROWSER_CDP_URL`` is set (e.g. via ``/browser connect``), we skip
     both Browserbase and the local headless launcher and connect directly to
     the supplied Chrome DevTools Protocol endpoint.
     """
-    return os.environ.get("BROWSER_CDP_URL", "").strip()
+    return _resolve_cdp_override(os.environ.get("BROWSER_CDP_URL", ""))
 
 
 # ============================================================================


### PR DESCRIPTION
Summary
This fixes #1937 by normalizing BROWSER_CDP_URL before passing it to agent-browser / Playwright.

What changed:
- resolve HTTP discovery endpoints like http://host:port and http://host:port/json/version to webSocketDebuggerUrl
- resolve bare websocket root endpoints like ws://host:port through /json/version so Hermes uses the real /devtools/browser/... websocket
- keep full ws://.../devtools/browser/... endpoints unchanged
- change /browser connect default from ws://localhost:9222 to http://localhost:9222
- add regression tests for CDP URL normalization

Problem
Hermes previously forwarded BROWSER_CDP_URL too literally.

If the user supplied a root CDP endpoint like:
- ws://localhost:9222
- ws://host:port
- http://host:port

Hermes could pass that directly to agent-browser, but Chrome's actual attach target is the browser websocket returned by:
- http://host:port/json/version
- webSocketDebuggerUrl = ws://host:port/devtools/browser/...

As a result, browser_navigate could fail even though the local CDP endpoint was valid and reachable.

Why this matters
This makes live Chrome connections much more robust and lets users store a stable discovery endpoint in .env, for example:

BROWSER_CDP_URL=http://localhost:9222

instead of needing to manually copy a changing /devtools/browser/... websocket URL.

Implementation
1. tools/browser_tool.py
- add _resolve_cdp_override()
- normalize discovery-style CDP endpoints into the concrete webSocketDebuggerUrl
- return the resolved websocket URL from _get_cdp_override()

2. cli.py
- change /browser connect default endpoint from:
  ws://localhost:9222
  to:
  http://localhost:9222

3. tests/tools/test_browser_cdp_override.py
- add regression coverage for:
  - full /devtools/browser/... websocket passthrough
  - http://host:port resolution
  - ws://host:port resolution
  - fallback when discovery fails

Verification
- targeted tests pass
- verified live against a working Chrome CDP endpoint
- confirmed that a bare value like:
  BROWSER_CDP_URL=ws://host:port
  is now resolved to the real /devtools/browser/... websocket URL
- confirmed browser_navigate succeeds after resolution

Fixes
- Fixes #1937