### PR TITLE
fix(cron): warn and skip missing skills instead of crashing job

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -194,7 +194,8 @@ def _build_job_prompt(job: dict) -> str:
         loaded = json.loads(skill_view(skill_name))
         if not loaded.get("success"):
             error = loaded.get("error") or f"Failed to load skill '{skill_name}'"
-            raise RuntimeError(error)
+            logger.warning("Cron job '%s': skill not found, skipping — %s", job.get("name", job.get("id")), error)
+            continue
 
         content = str(loaded.get("content") or "").strip()
         if parts:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -190,11 +190,13 @@ def _build_job_prompt(job: dict) -> str:
     from tools.skills_tool import skill_view
 
     parts = []
+    skipped: list[str] = []
     for skill_name in skill_names:
         loaded = json.loads(skill_view(skill_name))
         if not loaded.get("success"):
             error = loaded.get("error") or f"Failed to load skill '{skill_name}'"
             logger.warning("Cron job '%s': skill not found, skipping — %s", job.get("name", job.get("id")), error)
+            skipped.append(skill_name)
             continue
 
         content = str(loaded.get("content") or "").strip()
@@ -207,6 +209,15 @@ def _build_job_prompt(job: dict) -> str:
                 content,
             ]
         )
+
+    if skipped:
+        notice = (
+            f"[SYSTEM: The following skill(s) were listed for this job but could not be found "
+            f"and were skipped: {', '.join(skipped)}. "
+            f"Start your response with a brief notice so the user is aware, e.g.: "
+            f"'⚠️ Skill(s) not found and skipped: {', '.join(skipped)}']"
+        )
+        parts.insert(0, notice)
 
     if prompt:
         parts.extend(["", f"The user has provided the following instruction alongside the skill invocation: {prompt}"])

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -452,7 +452,7 @@ class TestRunJobSkillBacked:
 
 
 class TestBuildJobPromptMissingSkill:
-    """Verify that a missing skill logs a warning and does not crash the job."""
+    """Verify that a missing skill logs a warning, notifies the user, and does not crash the job."""
 
     def _missing_skill_view(self, name: str) -> str:
         return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
@@ -471,6 +471,13 @@ class TestBuildJobPromptMissingSkill:
                 _build_job_prompt({"name": "My Job", "skills": ["ghost-skill"], "prompt": "do something"})
         assert any("ghost-skill" in record.message for record in caplog.records)
 
+    def test_missing_skill_injects_user_notice_into_prompt(self):
+        """A system notice about the missing skill is injected into the prompt so the agent notifies the user."""
+        with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
+            result = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+        assert "ghost-skill" in result
+        assert "not found" in result.lower() or "skipped" in result.lower()
+
     def test_valid_skill_loaded_alongside_missing(self):
         """A valid skill is still loaded when another skill in the list is missing."""
 
@@ -483,3 +490,5 @@ class TestBuildJobPromptMissingSkill:
             result = _build_job_prompt({"skills": ["ghost-skill", "real-skill"], "prompt": "go"})
         assert "Real skill content." in result
         assert "go" in result
+        # missing skill notice is also present
+        assert "ghost-skill" in result

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, run_job
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, run_job, _build_job_prompt
 
 
 class TestResolveOrigin:
@@ -449,3 +449,37 @@ class TestRunJobSkillBacked:
         assert "Instructions for blogwatcher." in prompt_arg
         assert "Instructions for find-nearby." in prompt_arg
         assert "Combine the results." in prompt_arg
+
+
+class TestBuildJobPromptMissingSkill:
+    """Verify that a missing skill logs a warning and does not crash the job."""
+
+    def _missing_skill_view(self, name: str) -> str:
+        return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
+
+    def test_missing_skill_does_not_raise(self):
+        """Job should run even when a referenced skill is not installed."""
+        with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
+            result = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+        # prompt is preserved even though skill was skipped
+        assert "do something" in result
+
+    def test_missing_skill_logs_warning(self, caplog):
+        """A warning is logged when a skill cannot be found."""
+        with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+            with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
+                _build_job_prompt({"name": "My Job", "skills": ["ghost-skill"], "prompt": "do something"})
+        assert any("ghost-skill" in record.message for record in caplog.records)
+
+    def test_valid_skill_loaded_alongside_missing(self):
+        """A valid skill is still loaded when another skill in the list is missing."""
+
+        def _mixed_skill_view(name: str) -> str:
+            if name == "real-skill":
+                return json.dumps({"success": True, "content": "Real skill content."})
+            return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
+
+        with patch("tools.skills_tool.skill_view", side_effect=_mixed_skill_view):
+            result = _build_job_prompt({"skills": ["ghost-skill", "real-skill"], "prompt": "go"})
+        assert "Real skill content." in result
+        assert "go" in result


### PR DESCRIPTION
## Problem

When a cron job references a skill that is no longer installed, `_build_job_prompt()` raised a `RuntimeError` immediately. This crashed the job before the prompt could run and before any output was delivered to the user — resulting in silent failures with no Telegram/Discord notification.

## Fix

Two-layer approach in `cron/scheduler.py:_build_job_prompt()`:

**1. Server-side log** — `logger.warning` records the missing skill in the gateway logs.

**2. User-visible notice** — a `[SYSTEM: ...]` notice is injected into the job prompt so the agent starts its response with something like:
> ⚠️ Skill(s) not found and skipped: screenshot-website

That text becomes part of `final_response`, which is what actually gets delivered to the user's chat.

```python
# Before — hard crash, no delivery
if not loaded.get("success"):
    raise RuntimeError(error)

# After — warn + skip, user gets notified via delivered response
if not loaded.get("success"):
    logger.warning("Cron job '%s': skill not found, skipping — %s", ...)
    skipped.append(skill_name)
    continue

# After the loop, inject a notice into the prompt:
if skipped:
    notice = "[SYSTEM: skill(s) not found and skipped: ..., start response with a brief notice]"
    parts.insert(0, notice)
```

The job continues with any remaining valid skills and the user prompt rather than failing entirely.

## Tests

Added `TestBuildJobPromptMissingSkill` in `tests/cron/test_scheduler.py`:

- `test_missing_skill_does_not_raise` — missing skill does not raise; prompt is preserved
- `test_missing_skill_logs_warning` — a `WARNING` is logged with the skill name
- `test_missing_skill_injects_user_notice_into_prompt` — the skipped skill name appears in the returned prompt string (user will see it in delivery)
- `test_valid_skill_loaded_alongside_missing` — valid skills in the same list are still loaded, and the notice is present alongside them