### PR TITLE
feat(tools): add base_url support to OpenAI TTS provider

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -239,6 +239,7 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     oai_config = tts_config.get("openai", {})
     model = oai_config.get("model", DEFAULT_OPENAI_MODEL)
     voice = oai_config.get("voice", DEFAULT_OPENAI_VOICE)
+    base_url = oai_config.get("base_url", "https://api.openai.com/v1")
 
     # Determine response format from extension
     if output_path.endswith(".ogg"):
@@ -247,7 +248,7 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         response_format = "mp3"
 
     OpenAIClient = _import_openai_client()
-    client = OpenAIClient(api_key=api_key, base_url="https://api.openai.com/v1")
+    client = OpenAIClient(api_key=api_key, base_url=base_url)
     response = client.audio.speech.create(
         model=model,
         voice=voice,

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -404,6 +404,7 @@ tts:
   openai:
     model: "gpt-4o-mini-tts"
     voice: "alloy"                 # alloy, echo, fable, onyx, nova, shimmer
+    base_url: "https://api.openai.com/v1"  # optional: override for self-hosted or OpenAI-compatible endpoints
   neutts:
     ref_audio: ''
     ref_text: ''


### PR DESCRIPTION
## What and Why

The OpenAI TTS provider previously had `base_url` hardcoded to `https://api.openai.com/v1`, making it impossible to use self-hosted or OpenAI-compatible TTS services.

This PR reads `base_url` from `~/.hermes/config.yaml` under `tts.openai.base_url`, falling back to the official endpoint when not set. No behavior change for existing users.

## Usage

```yaml
tts:
  provider: openai
  openai:
    base_url: http://localhost:8000/v1  # e.g. LocalAI, or any OpenAI-compatible TTS endpoint
    voice: alloy
```

## Changes

- `tools/tts_tool.py`: read `base_url` from `oai_config` in `_generate_openai_tts()`
- `website/docs/user-guide/features/voice-mode.md`: document the new `base_url` field under `tts.openai`

## How to Test

1. Set `tts.provider: openai` and `tts.openai.base_url: http://localhost:8000/v1` in `~/.hermes/config.yaml`
2. Run `hermes chat -q "Say hello"` with TTS enabled — requests should go to the custom endpoint
3. Without `base_url` set, behavior is identical to before

## Platform

Tested on macOS.
