### PR TITLE
fix(deps): add dingtalk-stream and httpx to messaging extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 modal = ["swe-rex[modal]>=1.4.0"]
 daytona = ["daytona>=0.148.0"]
 dev = ["pytest", "pytest-asyncio", "pytest-xdist", "mcp>=1.2.0"]
-messaging = ["python-telegram-bot>=20.0", "discord.py[voice]>=2.0", "aiohttp>=3.9.0", "slack-bolt>=1.18.0", "slack-sdk>=3.27.0", "dingtalk-stream>=1.0.0", "httpx>=0.24.0"]
+messaging = ["python-telegram-bot>=20.0", "discord.py[voice]>=2.0", "aiohttp>=3.9.0", "slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]
 cron = ["croniter"]
 slack = ["slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]
 matrix = ["matrix-nio[e2e]>=0.24.0"]
@@ -60,6 +60,7 @@ mcp = ["mcp>=1.2.0"]
 homeassistant = ["aiohttp>=3.9.0"]
 sms = ["aiohttp>=3.9.0"]
 acp = ["agent-client-protocol>=0.8.1,<1.0"]
+dingtalk = ["dingtalk-stream>=1.0.0"]
 rl = [
   "atroposlib @ git+https://github.com/NousResearch/atropos.git",
   "tinker @ git+https://github.com/thinking-machines-lab/tinker.git",
@@ -84,6 +85,7 @@ all = [
   "hermes-agent[sms]",
   "hermes-agent[acp]",
   "hermes-agent[voice]",
+  "hermes-agent[dingtalk]",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 modal = ["swe-rex[modal]>=1.4.0"]
 daytona = ["daytona>=0.148.0"]
 dev = ["pytest", "pytest-asyncio", "pytest-xdist", "mcp>=1.2.0"]
-messaging = ["python-telegram-bot>=20.0", "discord.py[voice]>=2.0", "aiohttp>=3.9.0", "slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]
+messaging = ["python-telegram-bot>=20.0", "discord.py[voice]>=2.0", "aiohttp>=3.9.0", "slack-bolt>=1.18.0", "slack-sdk>=3.27.0", "dingtalk-stream>=1.0.0", "httpx>=0.24.0"]
 cron = ["croniter"]
 slack = ["slack-bolt>=1.18.0", "slack-sdk>=3.27.0"]
 matrix = ["matrix-nio[e2e]>=0.24.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ mcp = ["mcp>=1.2.0"]
 homeassistant = ["aiohttp>=3.9.0"]
 sms = ["aiohttp>=3.9.0"]
 acp = ["agent-client-protocol>=0.8.1,<1.0"]
-dingtalk = ["dingtalk-stream>=1.0.0"]
+dingtalk = ["dingtalk-stream>=0.1.0"]
 rl = [
   "atroposlib @ git+https://github.com/NousResearch/atropos.git",
   "tinker @ git+https://github.com/thinking-machines-lab/tinker.git",


### PR DESCRIPTION
Fixes #2062

## Problem
`gateway/platforms/dingtalk.py` requires `dingtalk-stream` but the package was not listed anywhere in `pyproject.toml`, causing an `ImportError` for users who installed with `.[all]` or `.[messaging]`.

## Fix
- Added a dedicated `dingtalk = ["dingtalk-stream>=1.0.0"]` optional-dependency group
- Added `hermes-agent[dingtalk]` to the `[all]` extras group

This follows the same pattern as other platform-specific extras (`slack`, `sms`, `homeassistant`, etc.) and allows users to install only DingTalk deps with `pip install hermes-agent[dingtalk]`.

## How to Test
pip install -e ".[all]"
pip show dingtalk-stream  # should be installed
