### PR TITLE
fix(reasoning): prevent duplicate display and [thinking] spam for local models

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4173,7 +4173,10 @@ class HermesCLI:
             self.agent.quiet_mode = not self.verbose
             # Auto-enable reasoning display in verbose mode
             if self.verbose:
-                self.agent.reasoning_callback = self._on_reasoning
+                self.agent.reasoning_callback = (
+                    self._stream_reasoning_delta if self.streaming_enabled
+                    else self._on_reasoning
+                )
             elif not self.show_reasoning:
                 self.agent.reasoning_callback = None
 
@@ -4217,7 +4220,10 @@ class HermesCLI:
         if arg in ("show", "on"):
             self.show_reasoning = True
             if self.agent:
-                self.agent.reasoning_callback = self._on_reasoning
+                self.agent.reasoning_callback = (
+                    self._stream_reasoning_delta if self.streaming_enabled
+                    else self._on_reasoning
+                )
             save_config_value("display.show_reasoning", True)
             _cprint(f"  {_GOLD}✓ Reasoning display: ON (saved){_RST}")
             _cprint(f"  {_DIM}  Model thinking will be shown during and after each response.{_RST}")

--- a/run_agent.py
+++ b/run_agent.py
@@ -4036,6 +4036,7 @@ class AIAgent:
         so both the tool-call path and the final-response path share one builder.
         """
         reasoning_text = self._extract_reasoning(assistant_message)
+        _from_structured = bool(reasoning_text)
 
         # Fallback: extract inline <think> blocks from content when no structured
         # reasoning fields are present (some models/providers embed thinking
@@ -4051,10 +4052,14 @@ class AIAgent:
             logging.debug(f"Captured reasoning ({len(reasoning_text)} chars): {reasoning_text}")
 
         if reasoning_text and self.reasoning_callback:
-            try:
-                self.reasoning_callback(reasoning_text)
-            except Exception:
-                pass
+            # Skip callback for <think>-extracted reasoning when streaming handled display.
+            # When streaming is active, _stream_delta() in cli.py already displays <think>
+            # blocks during streaming. Firing the callback again would cause duplicate display.
+            if _from_structured or not self.stream_delta_callback:
+                try:
+                    self.reasoning_callback(reasoning_text)
+                except Exception:
+                    pass
 
         msg = {
             "role": "assistant",

--- a/tests/agent/test_reasoning_display.py
+++ b/tests/agent/test_reasoning_display.py
@@ -1,0 +1,186 @@
+"""Tests for reasoning display fix.
+
+FIX A (run_agent.py _build_assistant_message):
+    <think>-extracted reasoning callback is skipped when stream_delta_callback is
+    set, because streaming already displayed it. Structured reasoning always fires
+    the callback regardless.
+
+FIX B (cli.py /verbose and /reasoning show toggles):
+    When streaming is enabled, reasoning_callback should be set to
+    _stream_reasoning_delta, not _on_reasoning.
+"""
+
+import re
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Helpers: minimal stand-ins for the logic under test
+# ---------------------------------------------------------------------------
+
+
+def _extract_reasoning_stub(assistant_message):
+    """Mirror the structured-reasoning extraction from _extract_reasoning()."""
+    parts = []
+    if getattr(assistant_message, "reasoning", None):
+        parts.append(assistant_message.reasoning)
+    if getattr(assistant_message, "reasoning_content", None):
+        val = assistant_message.reasoning_content
+        if val not in parts:
+            parts.append(val)
+    return "\n\n".join(parts) if parts else None
+
+
+def _run_build_assistant_message(
+    assistant_message,
+    *,
+    stream_delta_callback,
+    reasoning_callback,
+):
+    """
+    Replicate only the reasoning-callback portion of _build_assistant_message()
+    after FIX A is applied.
+
+    Returns whether reasoning_callback was called.
+    """
+    reasoning_text = _extract_reasoning_stub(assistant_message)
+    _from_structured = reasoning_text is not None
+
+    if not reasoning_text:
+        content = assistant_message.content or ""
+        think_blocks = re.findall(r"<think>(.*?)</think>", content, flags=re.DOTALL)
+        if think_blocks:
+            combined = "\n\n".join(b.strip() for b in think_blocks if b.strip())
+            reasoning_text = combined or None
+
+    if reasoning_text and reasoning_callback:
+        # FIX A: skip callback for <think>-extracted reasoning when streaming,
+        # because _stream_delta() already displayed it during token delivery.
+        if _from_structured or not stream_delta_callback:
+            try:
+                reasoning_callback(reasoning_text)
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Tests for FIX A
+# ---------------------------------------------------------------------------
+
+
+def test_think_tag_callback_skipped_when_streaming():
+    """
+    When stream_delta_callback is set (streaming mode) and reasoning came from a
+    <think> block (not structured fields), reasoning_callback must NOT be called.
+    The streaming path already displayed the thinking tokens in real-time.
+    """
+    msg = SimpleNamespace(
+        content="<think>reasoning here</think>answer",
+        reasoning=None,
+        reasoning_content=None,
+    )
+    callback = MagicMock()
+
+    _run_build_assistant_message(
+        msg,
+        stream_delta_callback=MagicMock(),  # streaming ON
+        reasoning_callback=callback,
+    )
+
+    callback.assert_not_called()
+
+
+def test_think_tag_callback_fires_when_not_streaming():
+    """
+    When stream_delta_callback is None (non-streaming), <think>-extracted
+    reasoning MUST trigger reasoning_callback so the user sees the thinking.
+    """
+    msg = SimpleNamespace(
+        content="<think>reasoning here</think>answer",
+        reasoning=None,
+        reasoning_content=None,
+    )
+    callback = MagicMock()
+
+    _run_build_assistant_message(
+        msg,
+        stream_delta_callback=None,  # streaming OFF
+        reasoning_callback=callback,
+    )
+
+    callback.assert_called_once()
+    args, _ = callback.call_args
+    assert "reasoning here" in args[0]
+
+
+def test_structured_reasoning_callback_fires_when_streaming():
+    """
+    Structured reasoning (via message.reasoning or message.reasoning_content)
+    must ALWAYS trigger reasoning_callback, even in streaming mode.
+    The streaming path only surfaces <think> blocks during delivery; structured
+    reasoning arrives as a separate API field and needs the callback to display.
+    """
+    msg = SimpleNamespace(
+        content="answer",
+        reasoning="structured thinking",
+        reasoning_content=None,
+    )
+    callback = MagicMock()
+
+    _run_build_assistant_message(
+        msg,
+        stream_delta_callback=MagicMock(),  # streaming ON
+        reasoning_callback=callback,
+    )
+
+    callback.assert_called_once()
+    args, _ = callback.call_args
+    assert "structured thinking" in args[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests for FIX B
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_toggle_uses_stream_callback_when_streaming():
+    """
+    When streaming is enabled and the user toggles reasoning on (/reasoning show
+    or /verbose), agent.reasoning_callback should be set to _stream_reasoning_delta,
+    not _on_reasoning.
+
+    This mirrors the FIX B logic:
+        agent.reasoning_callback = (
+            _stream_reasoning_delta if streaming_enabled else _on_reasoning
+        )
+    """
+
+    # Minimal stand-in for the CLI instance
+    class FakeCLI:
+        streaming_enabled = True
+
+        def _stream_reasoning_delta(self, text: str) -> None:
+            pass
+
+        def _on_reasoning(self, text: str) -> None:
+            pass
+
+        def _apply_reasoning_toggle_on(self):
+            """Replicate the FIX B assignment from /reasoning show."""
+            if self.agent:
+                self.agent.reasoning_callback = (
+                    self._stream_reasoning_delta
+                    if self.streaming_enabled
+                    else self._on_reasoning
+                )
+
+    cli = FakeCLI()
+    cli.agent = SimpleNamespace(reasoning_callback=None)
+
+    cli._apply_reasoning_toggle_on()
+
+    assert cli.agent.reasoning_callback == cli._stream_reasoning_delta, (
+        "When streaming is enabled, reasoning_callback should be _stream_reasoning_delta"
+    )
+    assert cli.agent.reasoning_callback != cli._on_reasoning

--- a/tests/test_reasoning_command.py
+++ b/tests/test_reasoning_command.py
@@ -369,6 +369,8 @@ class TestInlineThinkBlockExtraction(unittest.TestCase):
         agent._extract_reasoning = AIAgent._extract_reasoning.__get__(agent)
         agent.verbose_logging = False
         agent.reasoning_callback = None
+        # No streaming active by default; callback should fire for <think> blocks.
+        agent.stream_delta_callback = None
         return agent
 
     def test_single_think_block_extracted(self):
@@ -424,6 +426,41 @@ class TestInlineThinkBlockExtraction(unittest.TestCase):
         agent._build_assistant_message(api_msg, "stop")
         self.assertEqual(len(captured), 1)
         self.assertIn("Deep analysis", captured[0])
+
+    def test_callback_skipped_for_inline_think_when_streaming(self):
+        """When streaming is active, <think>-extracted reasoning must NOT fire the callback.
+
+        _stream_delta() in cli.py already displayed the <think> block during
+        streaming, so firing reasoning_callback again would duplicate the output.
+        """
+        agent = self._make_agent()
+        # Simulate an active streaming consumer.
+        agent.stream_delta_callback = lambda text: None
+        captured = []
+        agent.reasoning_callback = lambda t: captured.append(t)
+        api_msg = self._build_msg("<think>Deep analysis here.</think>Answer.")
+        agent._build_assistant_message(api_msg, "stop")
+        self.assertEqual(len(captured), 0, "callback must be suppressed when streaming is active")
+
+    def test_callback_fires_for_structured_reasoning_even_when_streaming(self):
+        """Structured API reasoning (not from <think> blocks) must always fire the callback.
+
+        Structured reasoning arrives via dedicated API fields (e.g. `reasoning`),
+        not via the streamed content, so _stream_delta() never displayed it.
+        The callback must still fire so the UI can render it.
+        """
+        agent = self._make_agent()
+        # Simulate an active streaming consumer.
+        agent.stream_delta_callback = lambda text: None
+        captured = []
+        agent.reasoning_callback = lambda t: captured.append(t)
+        api_msg = self._build_msg(
+            "Response text.",
+            reasoning="Structured reasoning from API.",
+        )
+        agent._build_assistant_message(api_msg, "stop")
+        self.assertEqual(len(captured), 1)
+        self.assertIn("Structured reasoning", captured[0])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fix A**: Skip duplicate reasoning callback in `_build_assistant_message()` when streaming already displayed `<think>` blocks
- **Fix B**: `/verbose` and `/reasoning show` toggles now use `_stream_reasoning_delta` when streaming is enabled, preventing `[thinking]` one-word-per-line spam

## Root Cause

Local models (Ollama, LM Studio) embed reasoning in `<think>` tags in `delta.content`. Two bugs:

1. `_stream_delta()` displayed reasoning during streaming, then `_build_assistant_message()` fired `reasoning_callback` again with the same content → duplicate blocks
2. Mid-session reasoning toggles always set callback to `_on_reasoning` (block-mode), ignoring streaming state → each per-token call produced a separate `[thinking]` line

## Test plan

- [x] `test_think_tag_callback_skipped_when_streaming` — no duplicate callback when streaming active
- [x] `test_think_tag_callback_fires_when_not_streaming` — callback fires when not streaming
- [x] `test_structured_reasoning_callback_fires_when_streaming` — structured reasoning always fires
- [x] `test_reasoning_toggle_uses_stream_callback_when_streaming` — toggle uses correct callback
- [x] E2E: Ollama with streaming + show_reasoning → single reasoning block, no duplicates

Closes #2069