### PR TITLE
fix(packaging): add minisweagent_path to py-modules in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_state", "hermes_time", "mini_swe_runner", "rl_cli", "utils"]
+py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_state", "hermes_time", "mini_swe_runner", "minisweagent_path", "rl_cli", "utils"]
 
 [tool.setuptools.packages.find]
 include = ["agent", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "cron", "honcho_integration", "acp_adapter"]


### PR DESCRIPTION
## Summary

Closes #2075

`minisweagent_path.py` is a top-level module imported by `mini_swe_runner.py` and code execution tests, but was missing from the `py-modules` list in `pyproject.toml`. This caused it to be excluded from built wheels, breaking non-editable installs (nix, pipx, `pip install`).

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Add `"minisweagent_path"` to `py-modules` list |

**1 file changed, 1 insertion, 1 deletion.**

## How to test

```bash
# Verify module is included in wheel
pipx run build
unzip -l dist/*.whl | grep minisweagent_path
# Should show: minisweagent_path.py

# Existing tests pass
python3 -m pytest tests/test_minisweagent_path.py -v
```

## Platform

Tested on Linux (WSL2, Python 3.11). Packaging change only — no platform-specific impact.