### PR TITLE
Add document_parse tool with LiteParse fallback

### DIFF
--- a/agent/document_parsing.py
+++ b/agent/document_parsing.py
@@ -1,0 +1,641 @@
+"""Document parsing foundation for local ingestion workflows.
+
+This module provides a normalized parsing interface that Hermes can build on
+for future workspace and RAG features. LiteParse is treated as an optional
+backend for richer local extraction from PDFs, Office files, and images.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+TEXT_FILE_SUFFIXES = {
+    ".md",
+    ".txt",
+    ".rst",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".csv",
+    ".tsv",
+    ".py",
+    ".js",
+    ".ts",
+    ".tsx",
+    ".jsx",
+    ".html",
+    ".css",
+    ".xml",
+    ".ini",
+    ".cfg",
+    ".conf",
+    ".toml",
+    ".sql",
+    ".sh",
+}
+
+LITEPARSE_FILE_SUFFIXES = {
+    ".pdf",
+    ".docx",
+    ".xlsx",
+    ".pptx",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".bmp",
+    ".tiff",
+    ".webp",
+    ".svg",
+}
+
+
+class DocumentParsingError(RuntimeError):
+    """Raised when a document cannot be parsed with the requested backend."""
+
+
+class DocumentParserUnavailable(DocumentParsingError):
+    """Raised when an optional parser backend is requested but unavailable."""
+
+
+@dataclass
+class ParsedTextItem:
+    text: str
+    bbox: Optional[Dict[str, float]] = None
+    confidence: Optional[float] = None
+
+
+@dataclass
+class ParsedPage:
+    page_number: int
+    text: str = ""
+    items: list[ParsedTextItem] = field(default_factory=list)
+    width: Optional[float] = None
+    height: Optional[float] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ParsedDocument:
+    source_path: str
+    parser_backend: str
+    text: str
+    pages: list[ParsedPage] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class DocumentScreenshot:
+    page_number: int
+    image_path: str
+    image_format: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def load_document_parser_config() -> dict:
+    """Load the documents section from Hermes config."""
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config().get("documents", {}) or {}
+    except Exception:
+        return {}
+
+
+def is_text_file(path: str | Path) -> bool:
+    return Path(path).suffix.lower() in TEXT_FILE_SUFFIXES
+
+
+def supports_liteparse(path: str | Path) -> bool:
+    return Path(path).suffix.lower() in LITEPARSE_FILE_SUFFIXES
+
+
+def liteparse_python_available() -> bool:
+    try:
+        from liteparse import LiteParse  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def liteparse_cli_available() -> bool:
+    return _find_liteparse_cli() is not None
+
+
+def liteparse_available() -> bool:
+    return liteparse_python_available() or liteparse_cli_available()
+
+
+def resolve_document_parser_backend(
+    path: str | Path,
+    backend: Optional[str] = None,
+    config: Optional[dict] = None,
+) -> str:
+    """Resolve the parser backend for the given file."""
+    cfg = config if config is not None else load_document_parser_config()
+    preferred = (backend or cfg.get("parser_backend") or "auto").strip().lower()
+
+    if preferred not in {"auto", "basic", "liteparse"}:
+        raise DocumentParsingError(f"Unknown document parser backend: {preferred}")
+
+    if preferred == "basic":
+        return "basic"
+
+    if preferred == "liteparse":
+        if not supports_liteparse(path):
+            raise DocumentParsingError(
+                f"LiteParse backend does not support {Path(path).suffix or 'this file type'}."
+            )
+        if not liteparse_available():
+            raise DocumentParserUnavailable(
+                "LiteParse backend requested but neither the Python package nor the `lit` CLI is available."
+            )
+        return "liteparse"
+
+    if supports_liteparse(path) and liteparse_available():
+        return "liteparse"
+    return "basic"
+
+
+def parse_document(
+    path: str | Path,
+    backend: Optional[str] = None,
+    config: Optional[dict] = None,
+    parse_options: Optional[dict] = None,
+) -> ParsedDocument:
+    """Parse *path* into a normalized document structure."""
+    source = Path(path).expanduser().resolve()
+    if not source.is_file():
+        raise DocumentParsingError(f"Document not found: {source}")
+
+    resolved_backend = resolve_document_parser_backend(source, backend=backend, config=config)
+    if resolved_backend == "basic":
+        return _parse_with_basic_backend(source)
+    return _parse_with_liteparse(source, config=config, parse_options=parse_options)
+
+
+def create_document_screenshots(
+    path: str | Path,
+    backend: Optional[str] = None,
+    config: Optional[dict] = None,
+    screenshot_options: Optional[dict] = None,
+) -> list[DocumentScreenshot]:
+    """Create page screenshots for a local document using LiteParse."""
+    source = Path(path).expanduser().resolve()
+    if not source.is_file():
+        raise DocumentParsingError(f"Document not found: {source}")
+
+    resolved_backend = resolve_document_parser_backend(source, backend=backend, config=config)
+    if resolved_backend != "liteparse":
+        raise DocumentParsingError("Screenshot generation requires the LiteParse backend.")
+
+    return _create_liteparse_screenshots(source, config=config, screenshot_options=screenshot_options)
+
+
+def _parse_with_basic_backend(path: Path) -> ParsedDocument:
+    if not is_text_file(path):
+        raise DocumentParsingError(
+            f"Basic parser only supports text-like files; got {path.suffix or 'unknown type'}."
+        )
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        text = path.read_text(encoding="utf-8", errors="replace")
+
+    return ParsedDocument(
+        source_path=str(path),
+        parser_backend="basic",
+        text=text,
+        pages=[ParsedPage(page_number=1, text=text)] if text else [],
+        metadata={"page_count": 1 if text else 0},
+    )
+
+
+def _parse_with_liteparse(
+    path: Path,
+    config: Optional[dict] = None,
+    parse_options: Optional[dict] = None,
+) -> ParsedDocument:
+    cfg = _liteparse_config(config, overrides=parse_options)
+    cli_command = _find_liteparse_cli()
+    python_error: Optional[Exception] = None
+
+    if liteparse_python_available():
+        try:
+            return _parse_with_liteparse_python(path, cfg, cli_command=cli_command)
+        except Exception as exc:
+            python_error = exc
+
+    if cli_command:
+        try:
+            return _parse_with_liteparse_cli(path, cfg, cli_command=cli_command)
+        except Exception as exc:
+            if python_error is not None:
+                raise DocumentParsingError(
+                    f"LiteParse Python backend failed ({python_error}); CLI fallback also failed ({exc})."
+                ) from exc
+            raise
+
+    if python_error is not None:
+        raise DocumentParsingError(f"LiteParse Python backend failed: {python_error}") from python_error
+
+    raise DocumentParserUnavailable(
+        "LiteParse parsing requested but no backend is available. Install `liteparse` or the `lit` CLI."
+    )
+
+
+def _liteparse_config(config: Optional[dict], overrides: Optional[dict] = None) -> dict:
+    cfg = config if config is not None else load_document_parser_config()
+    liteparse_cfg = cfg.get("liteparse", {}) or {}
+    merged = {
+        "ocr_enabled": liteparse_cfg.get("ocr_enabled", True),
+        "ocr_server_url": liteparse_cfg.get("ocr_server_url") or "",
+        "ocr_language": liteparse_cfg.get("ocr_language") or "en",
+        "dpi": liteparse_cfg.get("dpi", 150),
+        "target_pages": liteparse_cfg.get("target_pages") or "",
+        "max_pages": liteparse_cfg.get("max_pages", 10000),
+        "no_precise_bbox": bool(liteparse_cfg.get("no_precise_bbox", False)),
+        "preserve_small_text": bool(liteparse_cfg.get("preserve_small_text", False)),
+        "image_format": liteparse_cfg.get("image_format", "png"),
+        "screenshot_output_dir": liteparse_cfg.get("screenshot_output_dir") or "",
+    }
+    if overrides:
+        for key, value in overrides.items():
+            if value is not None:
+                merged[key] = value
+    return merged
+
+
+def _find_liteparse_cli() -> Optional[str]:
+    """Find the LiteParse CLI command using Hermes' normal external-tool pattern."""
+    which_result = shutil.which("liteparse")
+    if which_result:
+        return which_result
+
+    repo_root = Path(__file__).resolve().parents[1]
+    local_candidates = [
+        repo_root / "node_modules" / ".bin" / "liteparse",
+        repo_root.parent / "node_modules" / ".bin" / "liteparse",
+    ]
+    for candidate in local_candidates:
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return str(candidate)
+
+    npx_path = shutil.which("npx")
+    if npx_path:
+        return "npx liteparse"
+
+    return None
+
+
+def _create_liteparse_screenshots(
+    path: Path,
+    config: Optional[dict] = None,
+    screenshot_options: Optional[dict] = None,
+) -> list[DocumentScreenshot]:
+    cfg = _liteparse_config(config, overrides=screenshot_options)
+    cli_command = _find_liteparse_cli()
+    python_error: Optional[Exception] = None
+
+    if liteparse_python_available():
+        try:
+            return _create_liteparse_screenshots_python(path, cfg, cli_command=cli_command)
+        except Exception as exc:
+            python_error = exc
+
+    if cli_command:
+        try:
+            return _create_liteparse_screenshots_cli(path, cfg, cli_command=cli_command)
+        except Exception as exc:
+            if python_error is not None:
+                raise DocumentParsingError(
+                    f"LiteParse Python screenshot backend failed ({python_error}); CLI fallback also failed ({exc})."
+                ) from exc
+            raise
+
+    if python_error is not None:
+        raise DocumentParsingError(f"LiteParse Python screenshot backend failed: {python_error}") from python_error
+
+    raise DocumentParserUnavailable(
+        "LiteParse screenshot support requested but no backend is available."
+    )
+
+
+def _parse_with_liteparse_python(path: Path, config: dict, cli_command: Optional[str] = None) -> ParsedDocument:
+    from liteparse import LiteParse
+
+    parser = LiteParse(
+        cli_path=cli_command,
+    )
+    result = parser.parse(
+        str(path),
+        ocr_enabled=config["ocr_enabled"],
+        ocr_server_url=config["ocr_server_url"] or None,
+        ocr_language=config["ocr_language"],
+        max_pages=config["max_pages"],
+        target_pages=config["target_pages"] or None,
+        dpi=config["dpi"],
+        precise_bounding_box=not config["no_precise_bbox"],
+        preserve_very_small_text=config["preserve_small_text"],
+    )
+    return _normalize_liteparse_python_result(path, result)
+
+
+def _create_liteparse_screenshots_python(
+    path: Path,
+    config: dict,
+    cli_command: Optional[str] = None,
+) -> list[DocumentScreenshot]:
+    from liteparse import LiteParse
+
+    parser = LiteParse(cli_path=cli_command)
+    output_dir = config["screenshot_output_dir"] or tempfile.mkdtemp(prefix="hermes_liteparse_")
+    shots = parser.screenshot(
+        str(path),
+        output_dir=output_dir,
+        target_pages=config["target_pages"] or None,
+        dpi=config["dpi"],
+        image_format=config["image_format"],
+    )
+    screenshots = []
+    for shot in shots:
+        page_number = getattr(shot, "page_num", None) or getattr(shot, "pageNum", None)
+        image_path = getattr(shot, "image_path", None) or getattr(shot, "path", None)
+        screenshots.append(
+            DocumentScreenshot(
+                page_number=int(page_number),
+                image_path=str(image_path),
+                image_format=config["image_format"],
+            )
+        )
+    return screenshots
+
+
+def _parse_with_liteparse_cli(path: Path, config: dict, cli_command: Optional[str] = None) -> ParsedDocument:
+    resolved_command = cli_command or _find_liteparse_cli()
+    if not resolved_command:
+        raise DocumentParserUnavailable("LiteParse CLI not found.")
+
+    cmd = shlex.split(resolved_command) + [
+        "parse",
+        str(path),
+        "--format",
+        "json",
+        "-q",
+        "--ocr-language",
+        str(config["ocr_language"]),
+        "--dpi",
+        str(config["dpi"]),
+        "--max-pages",
+        str(config["max_pages"]),
+    ]
+    if not config["ocr_enabled"]:
+        cmd.append("--no-ocr")
+    if config["ocr_server_url"]:
+        cmd.extend(["--ocr-server-url", str(config["ocr_server_url"])])
+    if config["target_pages"]:
+        cmd.extend(["--target-pages", str(config["target_pages"])])
+    if config["no_precise_bbox"]:
+        cmd.append("--no-precise-bbox")
+    if config["preserve_small_text"]:
+        cmd.append("--preserve-small-text")
+
+    completed = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
+        raise DocumentParsingError(f"`lit parse` failed: {stderr}")
+
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise DocumentParsingError(f"LiteParse CLI returned invalid JSON: {exc}") from exc
+
+    return _normalize_liteparse_cli_result(path, payload)
+
+
+def _create_liteparse_screenshots_cli(
+    path: Path,
+    config: dict,
+    cli_command: Optional[str] = None,
+) -> list[DocumentScreenshot]:
+    resolved_command = cli_command or _find_liteparse_cli()
+    if not resolved_command:
+        raise DocumentParserUnavailable("LiteParse CLI not found.")
+
+    output_dir = Path(config["screenshot_output_dir"] or tempfile.mkdtemp(prefix="hermes_liteparse_"))
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cmd = shlex.split(resolved_command) + [
+        "screenshot",
+        str(path),
+        "-o",
+        str(output_dir),
+        "--format",
+        str(config["image_format"]),
+        "--dpi",
+        str(config["dpi"]),
+        "-q",
+    ]
+    if config["target_pages"]:
+        cmd.extend(["--target-pages", str(config["target_pages"])])
+
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
+        raise DocumentParsingError(f"`liteparse screenshot` failed: {stderr}")
+
+    suffix = f".{config['image_format']}"
+    screenshots = []
+    for image_file in sorted(output_dir.glob(f"*{suffix}")):
+        page_num = _extract_page_number(image_file.stem)
+        if page_num is None:
+            continue
+        screenshots.append(
+            DocumentScreenshot(
+                page_number=page_num,
+                image_path=str(image_file),
+                image_format=config["image_format"],
+            )
+        )
+    return screenshots
+
+
+def _normalize_liteparse_python_result(path: Path, result: Any) -> ParsedDocument:
+    pages: list[ParsedPage] = []
+    raw_pages = getattr(result, "pages", None) or []
+    for index, raw_page in enumerate(raw_pages, start=1):
+        page = _normalize_python_page(raw_page, fallback_page_number=index)
+        pages.append(page)
+
+    text = getattr(result, "text", None)
+    if not isinstance(text, str):
+        text = "\n\n".join(page.text for page in pages if page.text).strip()
+
+    return ParsedDocument(
+        source_path=str(path),
+        parser_backend="liteparse-python",
+        text=text or "",
+        pages=pages,
+        metadata={"page_count": len(pages)},
+    )
+
+
+def _normalize_python_page(raw_page: Any, fallback_page_number: int) -> ParsedPage:
+    page_number = (
+        getattr(raw_page, "pageNum", None)
+        or getattr(raw_page, "page_number", None)
+        or getattr(raw_page, "page", None)
+        or fallback_page_number
+    )
+    items = []
+    raw_items = getattr(raw_page, "textItems", None) or getattr(raw_page, "text_items", None) or []
+    for raw_item in raw_items:
+        item_text = str(getattr(raw_item, "text", None) or getattr(raw_item, "str", "") or "")
+        bbox = _coerce_bbox(getattr(raw_item, "bbox", None)) or _coerce_item_box(raw_item)
+        confidence = getattr(raw_item, "confidence", None)
+        items.append(ParsedTextItem(text=item_text, bbox=bbox, confidence=confidence))
+
+    page_text = getattr(raw_page, "text", None)
+    if not isinstance(page_text, str):
+        page_text = "\n".join(item.text for item in items if item.text)
+
+    raw_bboxes = getattr(raw_page, "boundingBoxes", None) or getattr(raw_page, "bounding_boxes", None) or []
+    bounding_boxes = [bbox for bbox in (_coerce_bbox(raw_bbox) for raw_bbox in raw_bboxes) if bbox]
+
+    return ParsedPage(
+        page_number=int(page_number),
+        text=page_text or "",
+        items=items,
+        width=_coerce_float(getattr(raw_page, "width", None)),
+        height=_coerce_float(getattr(raw_page, "height", None)),
+        metadata={"bounding_boxes": bounding_boxes},
+    )
+
+
+def _normalize_liteparse_cli_result(path: Path, payload: Dict[str, Any]) -> ParsedDocument:
+    raw_pages = payload.get("pages", []) or payload.get("json", {}).get("pages", []) or []
+    pages = [
+        _normalize_cli_page(raw_page, fallback_page_number=index)
+        for index, raw_page in enumerate(raw_pages, start=1)
+    ]
+    text = payload.get("text")
+    if not isinstance(text, str):
+        text = "\n\n".join(page.text for page in pages if page.text).strip()
+
+    return ParsedDocument(
+        source_path=str(path),
+        parser_backend="liteparse-cli",
+        text=text or "",
+        pages=pages,
+        metadata={"page_count": len(pages)},
+    )
+
+
+def _normalize_cli_page(raw_page: Dict[str, Any], fallback_page_number: int) -> ParsedPage:
+    raw_items = raw_page.get("textItems") or raw_page.get("text_items") or []
+    items = []
+    for raw_item in raw_items:
+        items.append(
+            ParsedTextItem(
+                text=str(raw_item.get("text", raw_item.get("str", "")) or ""),
+                bbox=_coerce_bbox(raw_item.get("bbox")) or _coerce_item_box(raw_item),
+                confidence=_coerce_float(raw_item.get("confidence")),
+            )
+        )
+
+    page_text = raw_page.get("text")
+    if not isinstance(page_text, str):
+        page_text = "\n".join(item.text for item in items if item.text)
+    raw_bboxes = raw_page.get("boundingBoxes") or raw_page.get("bounding_boxes") or []
+    bounding_boxes = [bbox for bbox in (_coerce_bbox(raw_bbox) for raw_bbox in raw_bboxes) if bbox]
+
+    return ParsedPage(
+        page_number=int(
+            raw_page.get("pageNum")
+            or raw_page.get("page_number")
+            or raw_page.get("page")
+            or fallback_page_number
+        ),
+        text=page_text or "",
+        items=items,
+        width=_coerce_float(raw_page.get("width")),
+        height=_coerce_float(raw_page.get("height")),
+        metadata={"bounding_boxes": bounding_boxes},
+    )
+
+
+def _coerce_bbox(value: Any) -> Optional[Dict[str, float]]:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        keys = ("x1", "y1", "x2", "y2")
+        if all(key in value for key in keys):
+            return {key: float(value[key]) for key in keys}
+    if isinstance(value, (list, tuple)) and len(value) == 4:
+        x1, y1, x2, y2 = value
+        return {"x1": float(x1), "y1": float(y1), "x2": float(x2), "y2": float(y2)}
+    return None
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_page_number(stem: str) -> Optional[int]:
+    if stem.startswith("page_"):
+        try:
+            return int(stem.replace("page_", ""))
+        except ValueError:
+            return None
+    return None
+
+
+def _coerce_item_box(value: Any) -> Optional[Dict[str, float]]:
+    if isinstance(value, dict):
+        x = value.get("x")
+        y = value.get("y")
+        width = value.get("width", value.get("w"))
+        height = value.get("height", value.get("h"))
+    else:
+        x = getattr(value, "x", None)
+        y = getattr(value, "y", None)
+        width = getattr(value, "width", None)
+        if width is None:
+            width = getattr(value, "w", None)
+        height = getattr(value, "height", None)
+        if height is None:
+            height = getattr(value, "h", None)
+
+    if None in (x, y, width, height):
+        return None
+    return {
+        "x1": float(x),
+        "y1": float(y),
+        "x2": float(x) + float(width),
+        "y2": float(y) + float(height),
+    }

--- a/cli.py
+++ b/cli.py
@@ -177,6 +177,21 @@ def load_cli_config() -> Dict[str, Any]:
             "inactivity_timeout": 120,  # Auto-cleanup inactive browser sessions after 2 min
             "record_sessions": False,  # Auto-record browser sessions as WebM videos
         },
+        "documents": {
+            "parser_backend": "auto",
+            "liteparse": {
+                "ocr_enabled": True,
+                "ocr_server_url": "",
+                "ocr_language": "en",
+                "dpi": 150,
+                "target_pages": "",
+                "max_pages": 10000,
+                "no_precise_bbox": False,
+                "preserve_small_text": False,
+                "image_format": "png",
+                "screenshot_output_dir": "",
+            },
+        },
         "compression": {
             "enabled": True,      # Auto-compress when approaching context limit
             "threshold": 0.50,    # Compress at 50% of model's context limit

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -148,6 +148,22 @@ DEFAULT_CONFIG = {
         "record_sessions": False,  # Auto-record browser sessions as WebM videos
     },
 
+    "documents": {
+        "parser_backend": "auto",  # auto | liteparse | basic
+        "liteparse": {
+            "ocr_enabled": True,
+            "ocr_server_url": "",
+            "ocr_language": "en",
+            "dpi": 150,
+            "target_pages": "",
+            "max_pages": 10000,
+            "no_precise_bbox": False,
+            "preserve_small_text": False,
+            "image_format": "png",
+            "screenshot_output_dir": "",
+        },
+    },
+
     # Filesystem checkpoints — automatic snapshots before destructive file ops.
     # When enabled, the agent takes a snapshot of the working directory once per
     # conversation turn (on first write_file/patch call).  Use /rollback to restore.
@@ -372,7 +388,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 10,
+    "_config_version": 11,
 }
 
 # =============================================================================

--- a/model_tools.py
+++ b/model_tools.py
@@ -95,6 +95,7 @@ def _discover_tools():
         "tools.send_message_tool",
         "tools.honcho_tools",
         "tools.homeassistant_tool",
+        "tools.document_parse_tool",
     ]
     import importlib
     for mod_name in _modules:

--- a/optional-skills/research/document-parse/SKILL.md
+++ b/optional-skills/research/document-parse/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: document-parse
+description: This skill should be used when the user asks to "parse a PDF", "extract text from a document", "read a DOCX", "read a PPTX", "extract an XLSX", "OCR an image", "get page screenshots from a PDF", or needs help deciding when to use document_parse instead of read_file or web_extract.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [Documents, PDF, OCR, LiteParse, Ingestion, Parsing]
+---
+
+# Document Parse
+
+Use `document_parse` as the primary tool for local documents that are not well-served by `read_file`.
+
+## When to Use
+
+- Use `read_file` for plain text source files when line-oriented reading matters.
+- Use `web_extract` for remote URLs and website content.
+- Use `document_parse` for local PDFs, Office documents, images, and mixed-layout files.
+- Use `document_parse` when OCR, page filtering, bounding boxes, or screenshots are needed.
+
+## Recommended Workflow
+
+1. Start with `document_parse(path=..., backend="auto")`.
+2. Add `target_pages` when only a subset of pages matter.
+3. Set `include_pages=true` when page-local output is needed.
+4. Add `include_text_items=true` or `include_bounding_boxes=true` only together with `include_pages=true`, and only when layout-aware output is needed.
+5. Enable `generate_screenshots=true` when page images are needed for downstream vision workflows.
+
+## Important Options
+
+- `backend`: use `auto` by default; force `liteparse` only when local LiteParse behavior is specifically required.
+- `ocr_enabled`: disable for clean text PDFs to reduce work; enable for scans and image-heavy documents.
+- `ocr_language`: set the correct language code for non-English documents.
+- `target_pages`: use values like `1-5,10` to reduce noise and runtime.
+- `dpi`: raise for difficult OCR cases; keep default for normal text documents.
+- `precise_bounding_box`: enable when exact spatial structure matters.
+- `preserve_small_text`: enable for slides, spreadsheets, or dense PDFs with tiny labels.
+
+## Fallback Guidance
+
+- If LiteParse is unavailable, `document_parse` still handles text-like local files with the basic parser.
+- If a non-text document fails with the basic parser, install LiteParse and retry.
+- If screenshot generation is requested without LiteParse, expect an error and switch to a LiteParse-capable environment.
+
+## Troubleshooting
+
+- For scanned PDFs or photographed pages: keep OCR enabled and raise `dpi`.
+- For huge documents: limit with `target_pages` before asking for summaries.
+- For layout-sensitive extraction: request pages plus bounding boxes instead of only top-level text.
+- For downstream ingestion: prefer `include_pages=true` so later chunking can stay page-aware.
+
+## Reference
+
+LiteParse library usage docs:
+- `https://developers.llamaindex.ai/liteparse/guides/library-usage/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ mcp = ["mcp>=1.2.0"]
 homeassistant = ["aiohttp>=3.9.0"]
 sms = ["aiohttp>=3.9.0"]
 acp = ["agent-client-protocol>=0.8.1,<1.0"]
+liteparse = ["liteparse"]
 rl = [
   "atroposlib @ git+https://github.com/NousResearch/atropos.git",
   "tinker @ git+https://github.com/thinking-machines-lab/tinker.git",
@@ -83,6 +84,7 @@ all = [
   "hermes-agent[homeassistant]",
   "hermes-agent[sms]",
   "hermes-agent[acp]",
+  "hermes-agent[liteparse]",
   "hermes-agent[voice]",
 ]
 

--- a/tests/agent/test_document_parsing.py
+++ b/tests/agent/test_document_parsing.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from types import SimpleNamespace
+
+from agent import document_parsing as dp
+
+
+def test_parse_document_with_basic_backend_for_text_file(tmp_path):
+    doc = tmp_path / "notes.md"
+    doc.write_text("# Notes\nhello world\n", encoding="utf-8")
+
+    parsed = dp.parse_document(doc, backend="basic")
+
+    assert parsed.parser_backend == "basic"
+    assert parsed.text == "# Notes\nhello world\n"
+    assert parsed.metadata["page_count"] == 1
+    assert parsed.pages[0].page_number == 1
+
+
+def test_resolve_document_parser_backend_prefers_liteparse_for_supported_files(monkeypatch, tmp_path):
+    doc = tmp_path / "report.pdf"
+    doc.write_bytes(b"%PDF-1.4")
+    monkeypatch.setattr(dp, "liteparse_available", lambda: True)
+
+    backend = dp.resolve_document_parser_backend(doc)
+
+    assert backend == "liteparse"
+
+
+def test_parse_document_uses_liteparse_python_backend(monkeypatch, tmp_path):
+    doc = tmp_path / "report.pdf"
+    doc.write_bytes(b"%PDF-1.4")
+
+    expected = dp.ParsedDocument(
+        source_path=str(doc.resolve()),
+        parser_backend="liteparse-python",
+        text="parsed text",
+        pages=[dp.ParsedPage(page_number=1, text="parsed text")],
+        metadata={"page_count": 1},
+    )
+
+    monkeypatch.setattr(dp, "liteparse_python_available", lambda: True)
+    monkeypatch.setattr(dp, "_find_liteparse_cli", lambda: None)
+    monkeypatch.setattr(dp, "_parse_with_liteparse_python", lambda path, config, cli_command=None: expected)
+
+    parsed = dp.parse_document(doc, backend="liteparse")
+
+    assert parsed == expected
+
+
+def test_parse_with_liteparse_python_passes_cli_path_and_parse_options(monkeypatch, tmp_path):
+    doc = tmp_path / "report.pdf"
+    doc.write_bytes(b"%PDF-1.4")
+    captured = {}
+
+    class FakeLiteParse:
+        def __init__(self, cli_path=None):
+            captured["cli_path"] = cli_path
+
+        def parse(self, file_path, **kwargs):
+            captured["file_path"] = file_path
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(
+                text="python parsed text",
+                pages=[
+                    SimpleNamespace(
+                        pageNum=1,
+                        text="python parsed text",
+                        textItems=[],
+                    )
+                ],
+            )
+
+    monkeypatch.setitem(sys.modules, "liteparse", SimpleNamespace(LiteParse=FakeLiteParse))
+
+    parsed = dp._parse_with_liteparse_python(
+        doc.resolve(),
+        {
+            "ocr_enabled": False,
+            "ocr_server_url": "",
+            "ocr_language": "fra",
+            "dpi": 300,
+            "target_pages": "1-3",
+            "max_pages": 12,
+            "no_precise_bbox": True,
+            "preserve_small_text": True,
+        },
+        cli_command="npx liteparse",
+    )
+
+    assert parsed.parser_backend == "liteparse-python"
+    assert captured["cli_path"] == "npx liteparse"
+    assert captured["file_path"] == str(doc.resolve())
+    assert captured["kwargs"]["ocr_enabled"] is False
+    assert captured["kwargs"]["ocr_language"] == "fra"
+    assert captured["kwargs"]["max_pages"] == 12
+    assert captured["kwargs"]["target_pages"] == "1-3"
+    assert captured["kwargs"]["dpi"] == 300
+    assert captured["kwargs"]["precise_bounding_box"] is False
+    assert captured["kwargs"]["preserve_very_small_text"] is True
+
+
+def test_parse_document_falls_back_to_liteparse_cli(monkeypatch, tmp_path):
+    doc = tmp_path / "report.pdf"
+    doc.write_bytes(b"%PDF-1.4")
+    captured = {}
+
+    def fake_python_backend(path, config):
+        raise RuntimeError("python backend unavailable")
+
+    def fake_run(cmd, capture_output, text, check):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps(
+                {
+                    "text": "cli parsed text",
+                    "pages": [
+                        {
+                            "pageNum": 1,
+                            "textItems": [
+                                {
+                                    "text": "cli parsed text",
+                                    "bbox": [1, 2, 3, 4],
+                                    "confidence": 0.9,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(dp, "liteparse_python_available", lambda: True)
+    monkeypatch.setattr(dp, "_parse_with_liteparse_python", fake_python_backend)
+    monkeypatch.setattr(dp, "_find_liteparse_cli", lambda: "npx liteparse")
+    monkeypatch.setattr(dp.subprocess, "run", fake_run)
+
+    parsed = dp.parse_document(
+        doc,
+        backend="liteparse",
+        config={
+            "parser_backend": "liteparse",
+            "liteparse": {
+                "ocr_enabled": False,
+                "ocr_language": "fra",
+                "dpi": 300,
+                "target_pages": "1-2",
+                "max_pages": 25,
+                "no_precise_bbox": True,
+                "preserve_small_text": True,
+            },
+        },
+    )
+
+    assert parsed.parser_backend == "liteparse-cli"
+    assert parsed.text == "cli parsed text"
+    assert parsed.pages[0].items[0].bbox == {"x1": 1.0, "y1": 2.0, "x2": 3.0, "y2": 4.0}
+    assert captured["cmd"][:3] == ["npx", "liteparse", "parse"]
+    assert "--no-ocr" in captured["cmd"]
+    assert "--ocr-language" in captured["cmd"]
+    assert "--target-pages" in captured["cmd"]
+    assert "--no-precise-bbox" in captured["cmd"]
+    assert "--preserve-small-text" in captured["cmd"]
+
+
+def test_find_liteparse_cli_checks_path_local_and_npx(monkeypatch, tmp_path):
+    repo_root = tmp_path / "repo"
+    agent_dir = repo_root / "agent"
+    node_bin = repo_root / "node_modules" / ".bin"
+    node_bin.mkdir(parents=True)
+    local_cli = node_bin / "liteparse"
+    local_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+    local_cli.chmod(0o755)
+
+    monkeypatch.setattr(dp, "__file__", str(agent_dir / "document_parsing.py"))
+    monkeypatch.setattr(dp.shutil, "which", lambda cmd: None if cmd != "npx" else "/usr/bin/npx")
+
+    assert dp._find_liteparse_cli() == str(local_cli)
+
+    monkeypatch.setattr(dp.shutil, "which", lambda cmd: "/usr/local/bin/liteparse" if cmd == "liteparse" else None)
+    assert dp._find_liteparse_cli() == "/usr/local/bin/liteparse"
+
+
+def test_normalize_liteparse_python_result_maps_pages_and_items(tmp_path):
+    doc = tmp_path / "report.pdf"
+    doc.write_bytes(b"%PDF-1.4")
+    result = SimpleNamespace(
+        text="overall text",
+        pages=[
+            SimpleNamespace(
+                pageNum=2,
+                boundingBoxes=[{"x1": 20, "y1": 21, "x2": 22, "y2": 23}],
+                textItems=[
+                    SimpleNamespace(
+                        str="line one",
+                        x=10,
+                        y=11,
+                        width=2,
+                        height=2,
+                        confidence=0.75,
+                    )
+                ],
+            )
+        ],
+    )
+
+    parsed = dp._normalize_liteparse_python_result(doc.resolve(), result)
+
+    assert parsed.parser_backend == "liteparse-python"
+    assert parsed.pages[0].page_number == 2
+    assert parsed.pages[0].items[0].confidence == 0.75
+    assert parsed.pages[0].items[0].bbox == {"x1": 10.0, "y1": 11.0, "x2": 12.0, "y2": 13.0}
+    assert parsed.pages[0].metadata["bounding_boxes"][0]["x1"] == 20.0
+
+
+def test_create_document_screenshots_uses_python_backend(monkeypatch, tmp_path):
+    doc = tmp_path / "report.pdf"
+    doc.write_bytes(b"%PDF-1.4")
+
+    class FakeShot:
+        page_num = 1
+        image_path = "/tmp/page_1.png"
+
+    monkeypatch.setattr(dp, "liteparse_python_available", lambda: True)
+    monkeypatch.setattr(dp, "_find_liteparse_cli", lambda: "npx liteparse")
+    monkeypatch.setattr(
+        dp,
+        "_create_liteparse_screenshots_python",
+        lambda path, config, cli_command=None: [
+            dp.DocumentScreenshot(page_number=1, image_path="/tmp/page_1.png", image_format="png")
+        ],
+    )
+
+    screenshots = dp.create_document_screenshots(doc, backend="liteparse")
+
+    assert screenshots[0].page_number == 1
+    assert screenshots[0].image_path == "/tmp/page_1.png"
+
+
+def test_default_config_includes_documents_parser_settings():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["documents"]["parser_backend"] == "auto"
+    assert DEFAULT_CONFIG["documents"]["liteparse"]["ocr_language"] == "en"
+    assert DEFAULT_CONFIG["documents"]["liteparse"]["image_format"] == "png"

--- a/tests/test_cli_documents_config.py
+++ b/tests/test_cli_documents_config.py
@@ -1,0 +1,9 @@
+from cli import load_cli_config
+
+
+def test_load_cli_config_defaults_include_documents_settings():
+    config = load_cli_config()
+
+    assert config["documents"]["parser_backend"] == "auto"
+    assert config["documents"]["liteparse"]["ocr_language"] == "en"
+    assert config["documents"]["liteparse"]["image_format"] == "png"

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -7,6 +7,7 @@ from model_tools import (
     handle_function_call,
     get_all_tool_names,
     get_toolset_for_tool,
+    get_tool_definitions,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
     TOOL_TO_TOOLSET_MAP,
@@ -101,3 +102,7 @@ class TestBackwardCompat:
     def test_tool_to_toolset_map(self):
         assert isinstance(TOOL_TO_TOOLSET_MAP, dict)
         assert len(TOOL_TO_TOOLSET_MAP) > 0
+
+    def test_hermes_acp_includes_document_parse(self):
+        names = [entry["function"]["name"] for entry in get_tool_definitions(["hermes-acp"], quiet_mode=True)]
+        assert "document_parse" in names

--- a/tests/tools/test_document_parse_skill.py
+++ b/tests/tools/test_document_parse_skill.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from tools.skill_manager_tool import _validate_frontmatter
+
+
+def test_document_parse_skill_has_valid_frontmatter_and_body():
+    skill_path = Path("optional-skills/research/document-parse/SKILL.md")
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert _validate_frontmatter(content) is None
+    assert "document_parse" in content
+    assert "https://developers.llamaindex.ai/liteparse/guides/library-usage/" in content

--- a/tests/tools/test_document_parse_tool.py
+++ b/tests/tools/test_document_parse_tool.py
@@ -1,0 +1,200 @@
+"""Tests for tools/document_parse_tool.py."""
+
+from __future__ import annotations
+
+import json
+
+from model_tools import get_tool_definitions
+from tools import document_parse_tool as tool
+
+
+def test_document_parse_tool_requires_path():
+    result = json.loads(tool.document_parse_tool(path=""))
+
+    assert result["success"] is False
+    assert "Path is required" in result["error"]
+
+
+def test_document_parse_tool_returns_truncated_text(monkeypatch):
+    class FakeParsed:
+        source_path = "/tmp/report.pdf"
+        parser_backend = "liteparse-cli"
+        text = "abcdefghij"
+        metadata = {"page_count": 1}
+        pages = []
+
+    monkeypatch.setattr(tool, "parse_document", lambda path, backend="auto", parse_options=None: FakeParsed())
+
+    result = json.loads(tool.document_parse_tool(path="/tmp/report.pdf", max_chars=5))
+
+    assert result["success"] is True
+    assert result["parser_backend"] == "liteparse-cli"
+    assert result["truncated"] is True
+    assert "...[truncated]..." in result["text"]
+
+
+def test_document_parse_tool_honors_zero_max_chars(monkeypatch):
+    class FakeParsed:
+        source_path = "/tmp/report.pdf"
+        parser_backend = "liteparse-cli"
+        text = "abcdefghij"
+        metadata = {"page_count": 1}
+        pages = []
+
+    monkeypatch.setattr(tool, "parse_document", lambda path, backend="auto", parse_options=None: FakeParsed())
+
+    result = json.loads(tool.document_parse_tool(path="/tmp/report.pdf", max_chars=0))
+
+    assert result["success"] is True
+    assert result["text"] == ""
+    assert result["truncated"] is True
+
+
+def test_document_parse_tool_includes_pages(monkeypatch):
+    class FakePage:
+        page_number = 1
+        text = "page text"
+        items = [object(), object()]
+        metadata = {"bounding_boxes": [{"x1": 1, "y1": 2, "x2": 3, "y2": 4}]}
+        width = 100
+        height = 200
+
+    class FakeParsed:
+        source_path = "/tmp/report.pdf"
+        parser_backend = "liteparse-python"
+        text = "all text"
+        metadata = {"page_count": 1}
+        pages = [FakePage()]
+
+    monkeypatch.setattr(tool, "parse_document", lambda path, backend="auto", parse_options=None: FakeParsed())
+
+    result = json.loads(tool.document_parse_tool(path="/tmp/report.pdf", include_pages=True))
+
+    assert result["success"] is True
+    assert result["page_count"] == 1
+    assert result["pages"][0]["page_number"] == 1
+    assert result["pages"][0]["item_count"] == 2
+    assert result["pages"][0]["bounding_box_count"] == 1
+
+
+def test_document_parse_tool_passes_parse_options(monkeypatch):
+    captured = {}
+
+    class FakeParsed:
+        source_path = "/tmp/report.pdf"
+        parser_backend = "liteparse-python"
+        text = "all text"
+        metadata = {"page_count": 0}
+        pages = []
+
+    def fake_parse_document(path, backend="auto", parse_options=None):
+        captured["path"] = path
+        captured["backend"] = backend
+        captured["parse_options"] = parse_options
+        return FakeParsed()
+
+    monkeypatch.setattr(tool, "parse_document", fake_parse_document)
+
+    result = json.loads(
+        tool.document_parse_tool(
+            path="/tmp/report.pdf",
+            backend="liteparse",
+            ocr_enabled=False,
+            ocr_language="fra",
+            target_pages="1-3",
+            dpi=300,
+            precise_bounding_box=False,
+            preserve_small_text=True,
+        )
+    )
+
+    assert result["success"] is True
+    assert captured["backend"] == "liteparse"
+    assert captured["parse_options"]["ocr_enabled"] is False
+    assert captured["parse_options"]["ocr_language"] == "fra"
+    assert captured["parse_options"]["target_pages"] == "1-3"
+    assert captured["parse_options"]["dpi"] == 300
+    assert captured["parse_options"]["no_precise_bbox"] is True
+    assert captured["parse_options"]["preserve_small_text"] is True
+
+
+def test_document_parse_tool_includes_text_items_and_bounding_boxes(monkeypatch):
+    class FakeItem:
+        text = "hello"
+        bbox = {"x1": 1, "y1": 2, "x2": 3, "y2": 4}
+        confidence = 0.9
+
+    class FakePage:
+        page_number = 1
+        text = "page text"
+        items = [FakeItem()]
+        metadata = {"bounding_boxes": [{"x1": 5, "y1": 6, "x2": 7, "y2": 8}]}
+        width = 100
+        height = 200
+
+    class FakeParsed:
+        source_path = "/tmp/report.pdf"
+        parser_backend = "liteparse-python"
+        text = "all text"
+        metadata = {"page_count": 1}
+        pages = [FakePage()]
+
+    monkeypatch.setattr(tool, "parse_document", lambda path, backend="auto", parse_options=None: FakeParsed())
+
+    result = json.loads(
+        tool.document_parse_tool(
+            path="/tmp/report.pdf",
+            include_pages=True,
+            include_text_items=True,
+            include_bounding_boxes=True,
+        )
+    )
+
+    assert result["pages"][0]["text_items"][0]["text"] == "hello"
+    assert result["pages"][0]["bounding_boxes"][0]["x1"] == 5
+
+
+def test_document_parse_tool_generates_screenshots(monkeypatch):
+    class FakeParsed:
+        source_path = "/tmp/report.pdf"
+        parser_backend = "liteparse-python"
+        text = "all text"
+        metadata = {"page_count": 0}
+        pages = []
+
+    class FakeShot:
+        def to_dict(self):
+            return {"page_number": 1, "image_path": "/tmp/page_1.png", "image_format": "png"}
+
+    monkeypatch.setattr(tool, "parse_document", lambda path, backend="auto", parse_options=None: FakeParsed())
+    monkeypatch.setattr(tool, "create_document_screenshots", lambda **kwargs: [FakeShot()])
+
+    result = json.loads(
+        tool.document_parse_tool(
+            path="/tmp/report.pdf",
+            generate_screenshots=True,
+            screenshot_image_format="png",
+        )
+    )
+
+    assert result["screenshots"][0]["page_number"] == 1
+    assert result["screenshots"][0]["image_format"] == "png"
+
+
+def test_document_parse_tool_surfaces_parser_errors(monkeypatch):
+    monkeypatch.setattr(
+        tool,
+        "parse_document",
+        lambda path, backend="auto", parse_options=None: (_ for _ in ()).throw(tool.DocumentParsingError("bad parse")),
+    )
+
+    result = json.loads(tool.document_parse_tool(path="/tmp/report.pdf"))
+
+    assert result["success"] is False
+    assert result["error"] == "bad parse"
+
+
+def test_document_parse_tool_is_exposed_in_tool_definitions():
+    tool_names = [entry["function"]["name"] for entry in get_tool_definitions(["documents"], quiet_mode=True)]
+
+    assert "document_parse" in tool_names

--- a/tools/document_parse_tool.py
+++ b/tools/document_parse_tool.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Document parsing tool backed by Hermes' parser abstraction."""
+
+import json
+from typing import Any, Dict
+
+from agent.document_parsing import (
+    create_document_screenshots,
+    DocumentParserUnavailable,
+    DocumentParsingError,
+    parse_document,
+)
+from tools.registry import registry
+
+
+DEFAULT_MAX_CHARS = 20_000
+
+
+def _truncate_text(text: str, max_chars: int) -> tuple[str, bool]:
+    if max_chars < 0 or len(text) <= max_chars:
+        return text, False
+    if max_chars == 0:
+        return "", bool(text)
+    return text[:max_chars] + "\n...[truncated]...", True
+
+
+def document_parse_tool(
+    path: str,
+    backend: str = "auto",
+    max_chars: int = DEFAULT_MAX_CHARS,
+    include_pages: bool = False,
+    include_text_items: bool = False,
+    include_bounding_boxes: bool = False,
+    ocr_enabled: bool | None = None,
+    ocr_server_url: str | None = None,
+    ocr_language: str | None = None,
+    target_pages: str | None = None,
+    dpi: int | None = None,
+    precise_bounding_box: bool | None = None,
+    preserve_small_text: bool | None = None,
+    generate_screenshots: bool = False,
+    screenshot_output_dir: str | None = None,
+    screenshot_image_format: str | None = None,
+) -> str:
+    """Parse a local document and return normalized extracted text."""
+    if not path or not str(path).strip():
+        return json.dumps({"success": False, "error": "Path is required."}, ensure_ascii=False)
+
+    max_chars = max(0, min(int(max_chars), 200_000))
+    parse_options = {
+        "ocr_enabled": ocr_enabled,
+        "ocr_server_url": ocr_server_url,
+        "ocr_language": ocr_language,
+        "target_pages": target_pages,
+        "dpi": dpi,
+        "no_precise_bbox": None if precise_bounding_box is None else not bool(precise_bounding_box),
+        "preserve_small_text": preserve_small_text,
+    }
+    screenshot_options = {
+        "target_pages": target_pages,
+        "dpi": dpi,
+        "image_format": screenshot_image_format,
+        "screenshot_output_dir": screenshot_output_dir,
+    }
+
+    try:
+        parsed = parse_document(path=path, backend=backend, parse_options=parse_options)
+    except (DocumentParsingError, DocumentParserUnavailable) as exc:
+        return json.dumps(
+            {
+                "success": False,
+                "error": str(exc),
+                "path": path,
+                "backend": backend,
+            },
+            ensure_ascii=False,
+        )
+
+    text, truncated = _truncate_text(parsed.text, max_chars)
+    result: Dict[str, Any] = {
+        "success": True,
+        "path": parsed.source_path,
+        "parser_backend": parsed.parser_backend,
+        "text": text,
+        "truncated": truncated,
+        "metadata": parsed.metadata,
+        "page_count": len(parsed.pages),
+    }
+
+    if include_pages:
+        pages = []
+        for page in parsed.pages:
+            page_text, page_truncated = _truncate_text(page.text, max_chars)
+            pages.append(
+                {
+                    "page_number": page.page_number,
+                    "text": page_text,
+                    "truncated": page_truncated,
+                    "item_count": len(page.items),
+                    "bounding_box_count": len(page.metadata.get("bounding_boxes", [])),
+                    "width": page.width,
+                    "height": page.height,
+                }
+            )
+            if include_text_items:
+                pages[-1]["text_items"] = [
+                    {
+                        "text": item.text,
+                        "bbox": item.bbox,
+                        "confidence": item.confidence,
+                    }
+                    for item in page.items
+                ]
+            if include_bounding_boxes:
+                pages[-1]["bounding_boxes"] = page.metadata.get("bounding_boxes", [])
+        result["pages"] = pages
+
+    if generate_screenshots:
+        try:
+            screenshots = create_document_screenshots(
+                path=path,
+                backend=backend,
+                screenshot_options=screenshot_options,
+            )
+            result["screenshots"] = [shot.to_dict() for shot in screenshots]
+        except (DocumentParsingError, DocumentParserUnavailable) as exc:
+            result["screenshot_error"] = str(exc)
+
+    return json.dumps(result, ensure_ascii=False)
+
+
+def check_document_parse_requirements() -> bool:
+    """The tool is always available; unsupported files fail at runtime with a clear error."""
+    return True
+
+
+DOCUMENT_PARSE_SCHEMA = {
+    "name": "document_parse",
+    "description": (
+        "Extract text from a local document path. Supports plain text-like files directly and "
+        "can use LiteParse for PDFs, Office files, and images when installed. Use this when "
+        "you need the contents of a local document that read_file cannot handle well, such as "
+        "PDF, DOCX, PPTX, XLSX, or image-based documents. Returns normalized extracted text "
+        "with optional per-page output."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Path to the local document file to parse.",
+            },
+            "backend": {
+                "type": "string",
+                "enum": ["auto", "liteparse", "basic"],
+                "description": "Parsing backend. Use auto unless you need to force LiteParse or basic text parsing.",
+            },
+            "max_chars": {
+                "type": "integer",
+                "description": "Maximum characters of extracted text to return. Default 20000.",
+                "minimum": 0,
+            },
+            "include_pages": {
+                "type": "boolean",
+                "description": "When true, include per-page extracted text and metadata.",
+            },
+            "include_text_items": {
+                "type": "boolean",
+                "description": "When true and include_pages is enabled, include per-page text items with bbox/confidence metadata.",
+            },
+            "include_bounding_boxes": {
+                "type": "boolean",
+                "description": "When true and include_pages is enabled, include per-page bounding box arrays when available from LiteParse.",
+            },
+            "ocr_enabled": {
+                "type": "boolean",
+                "description": "Override OCR on/off for this parse call.",
+            },
+            "ocr_server_url": {
+                "type": "string",
+                "description": "Optional OCR server URL to use instead of the default LiteParse OCR flow.",
+            },
+            "ocr_language": {
+                "type": "string",
+                "description": "OCR language code such as en, fra, or deu.",
+            },
+            "target_pages": {
+                "type": "string",
+                "description": "Specific pages to parse or screenshot, for example '1-5,10'.",
+            },
+            "dpi": {
+                "type": "integer",
+                "description": "Rendering DPI for OCR and screenshots. Higher values can improve OCR quality but are slower.",
+            },
+            "precise_bounding_box": {
+                "type": "boolean",
+                "description": "Enable or disable precise bounding boxes for LiteParse-backed parsing.",
+            },
+            "preserve_small_text": {
+                "type": "boolean",
+                "description": "Preserve very small text when supported by LiteParse.",
+            },
+            "generate_screenshots": {
+                "type": "boolean",
+                "description": "When true, generate page screenshots for the parsed document using LiteParse.",
+            },
+            "screenshot_output_dir": {
+                "type": "string",
+                "description": "Optional directory where screenshots should be written.",
+            },
+            "screenshot_image_format": {
+                "type": "string",
+                "enum": ["png", "jpg"],
+                "description": "Image format for generated screenshots.",
+            },
+        },
+        "required": ["path"],
+    },
+}
+
+
+registry.register(
+    name="document_parse",
+    toolset="documents",
+    schema=DOCUMENT_PARSE_SCHEMA,
+    handler=lambda args, **kw: document_parse_tool(
+        path=args.get("path", ""),
+        backend=args.get("backend", "auto"),
+        max_chars=args.get("max_chars", DEFAULT_MAX_CHARS),
+        include_pages=bool(args.get("include_pages", False)),
+        include_text_items=bool(args.get("include_text_items", False)),
+        include_bounding_boxes=bool(args.get("include_bounding_boxes", False)),
+        ocr_enabled=args.get("ocr_enabled"),
+        ocr_server_url=args.get("ocr_server_url"),
+        ocr_language=args.get("ocr_language"),
+        target_pages=args.get("target_pages"),
+        dpi=args.get("dpi"),
+        precise_bounding_box=args.get("precise_bounding_box"),
+        preserve_small_text=args.get("preserve_small_text"),
+        generate_screenshots=bool(args.get("generate_screenshots", False)),
+        screenshot_output_dir=args.get("screenshot_output_dir"),
+        screenshot_image_format=args.get("screenshot_image_format"),
+    ),
+    check_fn=check_document_parse_requirements,
+    emoji="📄",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -52,6 +52,8 @@ _HERMES_CORE_TOOLS = [
     "todo", "memory",
     # Session history search
     "session_search",
+    # Document parsing
+    "document_parse",
     # Clarifying questions
     "clarify",
     # Code execution + delegation
@@ -177,6 +179,12 @@ TOOLSETS = {
         "tools": ["session_search"],
         "includes": []
     },
+
+    "documents": {
+        "description": "Parse local documents such as PDFs, DOCX, PPTX, XLSX, images, and text files into normalized text",
+        "tools": ["document_parse"],
+        "includes": []
+    },
     
     "clarify": {
         "description": "Ask the user clarifying questions (multiple-choice or open-ended)",
@@ -237,6 +245,7 @@ TOOLSETS = {
             "web_search", "web_extract",
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
+            "document_parse",
             "vision_analyze",
             "skills_list", "skill_view", "skill_manage",
             "browser_navigate", "browser_snapshot", "browser_click",


### PR DESCRIPTION
## Summary
Adds a new `document_parse` Hermes tool powered by an optional LiteParse backend.

[LiteParse](https://developers.llamaindex.ai/liteparse/) is a local document parsing layer that supports PDFs, Office documents, images, OCR, layout metadata, and page screenshots without requiring an API key. This PR integrates that capability into Hermes as a first-class tool while keeping the scope limited to parsing and usage guidance.

## Why LiteParse
LiteParse is a strong fit for Hermes because it provides:
- local parsing with no required cloud service or API key
- support for PDF, DOCX, PPTX, XLSX, images, and text-like files
- OCR controls for scanned or image-heavy documents
- page-aware structured output with text items and bounding boxes
- screenshot generation for PDF pages
- both a Python wrapper and CLI interface, which maps well to Hermes' fallback patterns

That makes it a good parsing primitive for future document ingestion work without forcing Hermes into a hosted parsing dependency.

## What Changed
- added `agent/document_parsing.py` as the normalized parsing foundation
- added `tools/document_parse_tool.py` and registered `document_parse`
- integrated LiteParse as an optional backend with Python-wrapper support and CLI fallback
- wired tool discovery in `model_tools.py`
- added a `documents` toolset and exposed `document_parse` in CLI, gateway, and ACP/editor toolsets
- added `documents:` config defaults in `~/.hermes/config.yaml` and mirrored CLI defaults
- added optional dependency extra `hermes-agent[liteparse]`
- added an optional skill at `optional-skills/research/document-parse/SKILL.md` with guidance for when and how to use the tool effectively
- added focused tests for parser behavior, screenshot generation, config defaults, skill validation, and tool exposure

## Tool Capabilities
`document_parse` now supports:
- local PDFs, Office files, images, and text-like files
- LiteParse-backed OCR controls
- page-limited parsing via `target_pages`
- page-aware output via `include_pages`
- optional text item and bounding box output
- PDF page screenshot generation for downstream vision workflows

## Scope
This PR is intentionally limited to document parsing as a tool and usage guidance as a skill.

It does **not** add:
- embeddings
- vector stores
- retrieval/search over parsed content
- workspace ingestion/indexing
- auto-context injection / full RAG behavior

## Why This Shape
Hermes should treat LiteParse as a parsing primitive, not as the full knowledgebase system.

This PR therefore focuses on:
1. exposing LiteParse-backed parsing as a real Hermes tool
2. normalizing the output into Hermes-owned structures
3. adding a skill so the agent can use the tool correctly

That keeps the integration useful on its own while making it a clean foundation for follow-up ingestion and knowledgebase work.

## Verification
```bash
python -m pytest -o addopts='' tests/tools/test_document_parse_tool.py tests/test_model_tools.py tests/test_cli_documents_config.py -q
python -m pytest -o addopts='' tests/agent/test_document_parsing.py tests/tools/test_document_parse_skill.py -q
```

## Follow-up
A later PR can build on this LiteParse-backed parsing layer for:
- workspace ingestion
- upload processing
- persistent document normalization
- document-oriented knowledgebase/RAG indexing

Closes #844
