### PR TITLE
Add @ context references for files, folders, diffs, git, and URLs

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import mimetypes
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Awaitable, Callable
+
+from agent.model_metadata import estimate_tokens_rough
+
+REFERENCE_PATTERN = re.compile(
+    r"(?<![\w/])@(?:(?P<simple>diff|staged)\b|(?P<kind>file|folder|git|url):(?P<value>\S+))"
+)
+
+
+@dataclass(frozen=True)
+class ContextReference:
+    raw: str
+    kind: str
+    target: str
+    start: int
+    end: int
+    line_start: int | None = None
+    line_end: int | None = None
+
+
+@dataclass
+class ContextReferenceResult:
+    message: str
+    original_message: str
+    references: list[ContextReference] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    injected_tokens: int = 0
+    expanded: bool = False
+    blocked: bool = False
+
+
+def parse_context_references(message: str) -> list[ContextReference]:
+    refs: list[ContextReference] = []
+    if not message:
+        return refs
+
+    for match in REFERENCE_PATTERN.finditer(message):
+        simple = match.group("simple")
+        if simple:
+            refs.append(
+                ContextReference(
+                    raw=match.group(0),
+                    kind=simple,
+                    target="",
+                    start=match.start(),
+                    end=match.end(),
+                )
+            )
+            continue
+
+        kind = match.group("kind")
+        value = match.group("value") or ""
+        line_start = None
+        line_end = None
+        target = value
+
+        if kind == "file":
+            range_match = re.match(r"^(?P<path>.+?):(?P<start>\d+)(?:-(?P<end>\d+))?$", value)
+            if range_match:
+                target = range_match.group("path")
+                line_start = int(range_match.group("start"))
+                line_end = int(range_match.group("end") or range_match.group("start"))
+
+        refs.append(
+            ContextReference(
+                raw=match.group(0),
+                kind=kind,
+                target=target,
+                start=match.start(),
+                end=match.end(),
+                line_start=line_start,
+                line_end=line_end,
+            )
+        )
+
+    return refs
+
+
+def preprocess_context_references(
+    message: str,
+    *,
+    cwd: str | Path,
+    context_length: int,
+    url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
+) -> ContextReferenceResult:
+    return asyncio.run(
+        preprocess_context_references_async(
+            message,
+            cwd=cwd,
+            context_length=context_length,
+            url_fetcher=url_fetcher,
+        )
+    )
+
+
+async def preprocess_context_references_async(
+    message: str,
+    *,
+    cwd: str | Path,
+    context_length: int,
+    url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
+) -> ContextReferenceResult:
+    refs = parse_context_references(message)
+    if not refs:
+        return ContextReferenceResult(message=message, original_message=message)
+
+    cwd_path = Path(cwd).expanduser().resolve()
+    warnings: list[str] = []
+    blocks: list[str] = []
+    injected_tokens = 0
+
+    for ref in refs:
+        warning, block = await _expand_reference(ref, cwd_path, url_fetcher=url_fetcher)
+        if warning:
+            warnings.append(warning)
+        if block:
+            blocks.append(block)
+            injected_tokens += estimate_tokens_rough(block)
+
+    hard_limit = max(1, int(context_length * 0.50))
+    soft_limit = max(1, int(context_length * 0.25))
+    if injected_tokens > hard_limit:
+        warnings.append(
+            f"@ context injection refused: {injected_tokens} tokens exceeds the 50% hard limit ({hard_limit})."
+        )
+        return ContextReferenceResult(
+            message=message,
+            original_message=message,
+            references=refs,
+            warnings=warnings,
+            injected_tokens=injected_tokens,
+            expanded=False,
+            blocked=True,
+        )
+
+    if injected_tokens > soft_limit:
+        warnings.append(
+            f"@ context injection warning: {injected_tokens} tokens exceeds the 25% soft limit ({soft_limit})."
+        )
+
+    stripped = _remove_reference_tokens(message, refs)
+    final = stripped
+    if warnings:
+        final = f"{final}\n\n--- Context Warnings ---\n" + "\n".join(f"- {warning}" for warning in warnings)
+    if blocks:
+        final = f"{final}\n\n--- Attached Context ---\n\n" + "\n\n".join(blocks)
+
+    return ContextReferenceResult(
+        message=final.strip(),
+        original_message=message,
+        references=refs,
+        warnings=warnings,
+        injected_tokens=injected_tokens,
+        expanded=bool(blocks or warnings),
+        blocked=False,
+    )
+
+
+async def _expand_reference(
+    ref: ContextReference,
+    cwd: Path,
+    *,
+    url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
+) -> tuple[str | None, str | None]:
+    try:
+        if ref.kind == "file":
+            return _expand_file_reference(ref, cwd)
+        if ref.kind == "folder":
+            return _expand_folder_reference(ref, cwd)
+        if ref.kind == "diff":
+            return _expand_git_reference(ref, cwd, ["diff"], "git diff")
+        if ref.kind == "staged":
+            return _expand_git_reference(ref, cwd, ["diff", "--staged"], "git diff --staged")
+        if ref.kind == "git":
+            count = max(1, min(int(ref.target or "1"), 10))
+            return _expand_git_reference(ref, cwd, ["log", f"-{count}", "-p"], f"git log -{count} -p")
+        if ref.kind == "url":
+            content = await _fetch_url_content(ref.target, url_fetcher=url_fetcher)
+            if not content:
+                return f"{ref.raw}: no content extracted", None
+            return None, f"🌐 {ref.raw} ({estimate_tokens_rough(content)} tokens)\n{content}"
+    except Exception as exc:
+        return f"{ref.raw}: {exc}", None
+
+    return f"{ref.raw}: unsupported reference type", None
+
+
+def _expand_file_reference(ref: ContextReference, cwd: Path) -> tuple[str | None, str | None]:
+    path = _resolve_path(cwd, ref.target)
+    if not path.exists():
+        return f"{ref.raw}: file not found", None
+    if not path.is_file():
+        return f"{ref.raw}: path is not a file", None
+    if _is_binary_file(path):
+        return f"{ref.raw}: binary files are not supported", None
+
+    text = path.read_text(encoding="utf-8")
+    if ref.line_start is not None:
+        lines = text.splitlines()
+        start_idx = max(ref.line_start - 1, 0)
+        end_idx = min(ref.line_end or ref.line_start, len(lines))
+        text = "\n".join(lines[start_idx:end_idx])
+
+    lang = _code_fence_language(path)
+    label = ref.raw
+    return None, f"📄 {label} ({estimate_tokens_rough(text)} tokens)\n```{lang}\n{text}\n```"
+
+
+def _expand_folder_reference(ref: ContextReference, cwd: Path) -> tuple[str | None, str | None]:
+    path = _resolve_path(cwd, ref.target)
+    if not path.exists():
+        return f"{ref.raw}: folder not found", None
+    if not path.is_dir():
+        return f"{ref.raw}: path is not a folder", None
+
+    listing = _build_folder_listing(path, cwd)
+    return None, f"📁 {ref.raw} ({estimate_tokens_rough(listing)} tokens)\n{listing}"
+
+
+def _expand_git_reference(
+    ref: ContextReference,
+    cwd: Path,
+    args: list[str],
+    label: str,
+) -> tuple[str | None, str | None]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip() or "git command failed"
+        return f"{ref.raw}: {stderr}", None
+    content = result.stdout.strip()
+    if not content:
+        content = "(no output)"
+    return None, f"🧾 {label} ({estimate_tokens_rough(content)} tokens)\n```diff\n{content}\n```"
+
+
+async def _fetch_url_content(
+    url: str,
+    *,
+    url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
+) -> str:
+    fetcher = url_fetcher or _default_url_fetcher
+    content = fetcher(url)
+    if inspect.isawaitable(content):
+        content = await content
+    return str(content or "").strip()
+
+
+async def _default_url_fetcher(url: str) -> str:
+    from tools.web_tools import web_extract_tool
+
+    raw = await web_extract_tool([url], format="markdown", use_llm_processing=True)
+    payload = json.loads(raw)
+    docs = payload.get("data", {}).get("documents", [])
+    if not docs:
+        return ""
+    doc = docs[0]
+    return str(doc.get("content") or doc.get("raw_content") or "").strip()
+
+
+def _resolve_path(cwd: Path, target: str) -> Path:
+    path = Path(os.path.expanduser(target))
+    if not path.is_absolute():
+        path = cwd / path
+    return path.resolve()
+
+
+def _remove_reference_tokens(message: str, refs: list[ContextReference]) -> str:
+    pieces: list[str] = []
+    cursor = 0
+    for ref in refs:
+        pieces.append(message[cursor:ref.start])
+        cursor = ref.end
+    pieces.append(message[cursor:])
+    text = "".join(pieces)
+    text = re.sub(r"\s{2,}", " ", text)
+    text = re.sub(r"\s+([,.;:!?])", r"\1", text)
+    return text.strip()
+
+
+def _is_binary_file(path: Path) -> bool:
+    mime, _ = mimetypes.guess_type(path.name)
+    if mime and not mime.startswith("text/") and not any(
+        path.name.endswith(ext) for ext in (".py", ".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".js", ".ts")
+    ):
+        return True
+    chunk = path.read_bytes()[:4096]
+    return b"\x00" in chunk
+
+
+def _build_folder_listing(path: Path, cwd: Path, limit: int = 200) -> str:
+    lines = [f"{path.relative_to(cwd)}/"]
+    entries = _iter_visible_entries(path, cwd, limit=limit)
+    for entry in entries:
+        rel = entry.relative_to(cwd)
+        indent = "  " * max(len(rel.parts) - len(path.relative_to(cwd).parts) - 1, 0)
+        if entry.is_dir():
+            lines.append(f"{indent}- {entry.name}/")
+        else:
+            meta = _file_metadata(entry)
+            lines.append(f"{indent}- {entry.name} ({meta})")
+    if len(entries) >= limit:
+        lines.append("- ...")
+    return "\n".join(lines)
+
+
+def _iter_visible_entries(path: Path, cwd: Path, limit: int) -> list[Path]:
+    rg_entries = _rg_files(path, cwd, limit=limit)
+    if rg_entries is not None:
+        output: list[Path] = []
+        seen_dirs: set[Path] = set()
+        for rel in rg_entries:
+            full = cwd / rel
+            for parent in full.parents:
+                if parent == cwd or parent in seen_dirs or path not in {parent, *parent.parents}:
+                    continue
+                seen_dirs.add(parent)
+                output.append(parent)
+            output.append(full)
+        return sorted({p for p in output if p.exists()}, key=lambda p: (not p.is_dir(), str(p)))
+
+    output = []
+    for root, dirs, files in os.walk(path):
+        dirs[:] = sorted(d for d in dirs if not d.startswith(".") and d != "__pycache__")
+        files = sorted(f for f in files if not f.startswith("."))
+        root_path = Path(root)
+        for d in dirs:
+            output.append(root_path / d)
+            if len(output) >= limit:
+                return output
+        for f in files:
+            output.append(root_path / f)
+            if len(output) >= limit:
+                return output
+    return output
+
+
+def _rg_files(path: Path, cwd: Path, limit: int) -> list[Path] | None:
+    try:
+        result = subprocess.run(
+            ["rg", "--files", str(path.relative_to(cwd))],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return None
+    if result.returncode != 0:
+        return None
+    files = [Path(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+    return files[:limit]
+
+
+def _file_metadata(path: Path) -> str:
+    if _is_binary_file(path):
+        return f"{path.stat().st_size} bytes"
+    try:
+        line_count = path.read_text(encoding="utf-8").count("\n") + 1
+    except Exception:
+        return f"{path.stat().st_size} bytes"
+    return f"{line_count} lines"
+
+
+def _code_fence_language(path: Path) -> str:
+    mapping = {
+        ".py": "python",
+        ".js": "javascript",
+        ".ts": "typescript",
+        ".tsx": "tsx",
+        ".jsx": "jsx",
+        ".json": "json",
+        ".md": "markdown",
+        ".sh": "bash",
+        ".yml": "yaml",
+        ".yaml": "yaml",
+        ".toml": "toml",
+    }
+    return mapping.get(path.suffix.lower(), "")

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -16,6 +16,7 @@ from agent.model_metadata import estimate_tokens_rough
 REFERENCE_PATTERN = re.compile(
     r"(?<![\w/])@(?:(?P<simple>diff|staged)\b|(?P<kind>file|folder|git|url):(?P<value>\S+))"
 )
+TRAILING_PUNCTUATION = ",.;!?"
 
 
 @dataclass(frozen=True)
@@ -60,7 +61,7 @@ def parse_context_references(message: str) -> list[ContextReference]:
             continue
 
         kind = match.group("kind")
-        value = match.group("value") or ""
+        value = _strip_trailing_punctuation(match.group("value") or "")
         line_start = None
         line_end = None
         target = value
@@ -93,6 +94,7 @@ def preprocess_context_references(
     cwd: str | Path,
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
+    allowed_root: str | Path | None = None,
 ) -> ContextReferenceResult:
     return asyncio.run(
         preprocess_context_references_async(
@@ -100,6 +102,7 @@ def preprocess_context_references(
             cwd=cwd,
             context_length=context_length,
             url_fetcher=url_fetcher,
+            allowed_root=allowed_root,
         )
     )
 
@@ -110,18 +113,25 @@ async def preprocess_context_references_async(
     cwd: str | Path,
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
+    allowed_root: str | Path | None = None,
 ) -> ContextReferenceResult:
     refs = parse_context_references(message)
     if not refs:
         return ContextReferenceResult(message=message, original_message=message)
 
     cwd_path = Path(cwd).expanduser().resolve()
+    allowed_root_path = Path(allowed_root).expanduser().resolve() if allowed_root is not None else None
     warnings: list[str] = []
     blocks: list[str] = []
     injected_tokens = 0
 
     for ref in refs:
-        warning, block = await _expand_reference(ref, cwd_path, url_fetcher=url_fetcher)
+        warning, block = await _expand_reference(
+            ref,
+            cwd_path,
+            url_fetcher=url_fetcher,
+            allowed_root=allowed_root_path,
+        )
         if warning:
             warnings.append(warning)
         if block:
@@ -172,12 +182,13 @@ async def _expand_reference(
     cwd: Path,
     *,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
+    allowed_root: Path | None = None,
 ) -> tuple[str | None, str | None]:
     try:
         if ref.kind == "file":
-            return _expand_file_reference(ref, cwd)
+            return _expand_file_reference(ref, cwd, allowed_root=allowed_root)
         if ref.kind == "folder":
-            return _expand_folder_reference(ref, cwd)
+            return _expand_folder_reference(ref, cwd, allowed_root=allowed_root)
         if ref.kind == "diff":
             return _expand_git_reference(ref, cwd, ["diff"], "git diff")
         if ref.kind == "staged":
@@ -196,8 +207,13 @@ async def _expand_reference(
     return f"{ref.raw}: unsupported reference type", None
 
 
-def _expand_file_reference(ref: ContextReference, cwd: Path) -> tuple[str | None, str | None]:
-    path = _resolve_path(cwd, ref.target)
+def _expand_file_reference(
+    ref: ContextReference,
+    cwd: Path,
+    *,
+    allowed_root: Path | None = None,
+) -> tuple[str | None, str | None]:
+    path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
     if not path.exists():
         return f"{ref.raw}: file not found", None
     if not path.is_file():
@@ -217,8 +233,13 @@ def _expand_file_reference(ref: ContextReference, cwd: Path) -> tuple[str | None
     return None, f"📄 {label} ({estimate_tokens_rough(text)} tokens)\n```{lang}\n{text}\n```"
 
 
-def _expand_folder_reference(ref: ContextReference, cwd: Path) -> tuple[str | None, str | None]:
-    path = _resolve_path(cwd, ref.target)
+def _expand_folder_reference(
+    ref: ContextReference,
+    cwd: Path,
+    *,
+    allowed_root: Path | None = None,
+) -> tuple[str | None, str | None]:
+    path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
     if not path.exists():
         return f"{ref.raw}: folder not found", None
     if not path.is_dir():
@@ -273,11 +294,29 @@ async def _default_url_fetcher(url: str) -> str:
     return str(doc.get("content") or doc.get("raw_content") or "").strip()
 
 
-def _resolve_path(cwd: Path, target: str) -> Path:
+def _resolve_path(cwd: Path, target: str, *, allowed_root: Path | None = None) -> Path:
     path = Path(os.path.expanduser(target))
     if not path.is_absolute():
         path = cwd / path
-    return path.resolve()
+    resolved = path.resolve()
+    if allowed_root is not None:
+        try:
+            resolved.relative_to(allowed_root)
+        except ValueError as exc:
+            raise ValueError("path is outside the allowed workspace") from exc
+    return resolved
+
+
+def _strip_trailing_punctuation(value: str) -> str:
+    stripped = value.rstrip(TRAILING_PUNCTUATION)
+    while stripped.endswith((")", "]", "}")):
+        closer = stripped[-1]
+        opener = {")": "(", "]": "[", "}": "{"}[closer]
+        if stripped.count(closer) > stripped.count(opener):
+            stripped = stripped[:-1]
+            continue
+        break
+    return stripped
 
 
 def _remove_reference_tokens(message: str, refs: list[ContextReference]) -> str:

--- a/cli.py
+++ b/cli.py
@@ -2369,6 +2369,45 @@ class HermesCLI:
             return f"{prefix}\n\n{user_text}" if user_text else prefix
         return user_text or "What do you see in this image?"
 
+    def _expand_context_references_for_turn(
+        self,
+        message: str,
+        *,
+        cwd: str | Path | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+    ):
+        """Expand ``@file``/``@folder``/git/url references before the LLM sees them."""
+        from agent.context_references import preprocess_context_references
+        from agent.model_metadata import get_model_context_length
+
+        effective_cwd = Path(cwd or os.getcwd())
+        effective_model = model or self.model
+        effective_base_url = base_url if base_url is not None else self.base_url
+        effective_api_key = api_key if api_key is not None else self.api_key
+        context_length = get_model_context_length(
+            effective_model,
+            base_url=effective_base_url or "",
+            api_key=effective_api_key or "",
+        )
+
+        result = preprocess_context_references(
+            message,
+            cwd=effective_cwd,
+            context_length=context_length,
+        )
+
+        if result.references:
+            ref_count = len(result.references)
+            _cprint(
+                f"  {_DIM}[@ context: {ref_count} reference{'s' if ref_count != 1 else ''}, "
+                f"{result.injected_tokens} tokens injected]{_RST}"
+            )
+        for warning in result.warnings:
+            _cprint(f"  {_DIM}⚠ {warning}{_RST}")
+        return result
+
     def _show_tool_availability_warnings(self):
         """Show warnings about disabled tools due to missing API keys."""
         try:
@@ -5261,6 +5300,17 @@ class HermesCLI:
             route_label=turn_route["label"],
         ):
             return None
+
+        if isinstance(message, str):
+            expanded_context = self._expand_context_references_for_turn(
+                message,
+                model=turn_route["model"],
+                base_url=turn_route["runtime"].get("base_url"),
+                api_key=turn_route["runtime"].get("api_key"),
+            )
+            if expanded_context.blocked:
+                return "\n".join(expanded_context.warnings) or "Context injection refused."
+            message = expanded_context.message
         
         # Pre-process images through the vision tool (Gemini Flash) so the
         # main model receives text descriptions instead of raw base64 image

--- a/docs/plans/2026-03-20-at-context-references.md
+++ b/docs/plans/2026-03-20-at-context-references.md
@@ -1,0 +1,217 @@
+# @ Context References Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `@file:`, `@folder:`, `@diff`, `@staged`, `@git:N`, and `@url:` message references that expand into scoped context before the LLM sees the message, with token budgeting, CLI completion, gateway support, and tests.
+
+**Architecture:** Implement a reusable preprocessing module that parses and expands `@` references against the current working directory, estimates injected token cost, and returns a rewritten user message plus structured metadata. Wire that module into the CLI input path and gateway message path, and extend the existing prompt_toolkit completer to support `@file:` and `@folder:` path completion without regressing slash-command completion.
+
+**Tech Stack:** Python, prompt_toolkit, pytest, git subprocesses, Hermes auxiliary web extraction, existing model metadata/token estimation helpers.
+
+---
+
+### Task 1: Add failing parser and expander tests
+
+**Files:**
+- Create: `tests/test_context_references.py`
+
+**Step 1: Write the failing test**
+
+Add focused tests for:
+- parsing multiple references in one message
+- ignoring emails and bare `@username`
+- expanding `@file:path` and `@file:path:start-end`
+- expanding `@folder:path/`
+- expanding `@diff`, `@staged`, and `@git:N`
+- rejecting binary or missing files with inline warnings
+- enforcing soft/hard token budgets
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_context_references.py -q`
+
+Expected: FAIL because the module does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create a new reusable module, likely `agent/context_references.py`, with:
+- a parser for typed references only
+- expansion helpers for file, folder, git, and url references
+- rough token accounting using `agent.model_metadata.estimate_tokens_rough`
+- a result object containing rewritten message, token totals, warnings, and a display summary
+
+**Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_context_references.py -q`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_context_references.py agent/context_references.py
+git commit -m "feat: add @ context reference parser and expander"
+```
+
+### Task 2: Add failing CLI completion tests
+
+**Files:**
+- Modify: `tests/hermes_cli/test_commands.py`
+- Modify: `hermes_cli/commands.py`
+
+**Step 1: Write the failing test**
+
+Add tests covering:
+- `@file:` path completion
+- `@folder:` directory-only completion
+- keeping slash-command completion unchanged
+- continuing existing path completion for plain path-like words
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tests/hermes_cli/test_commands.py -q`
+
+Expected: FAIL on the new `@file:` / `@folder:` completion assertions.
+
+**Step 3: Write minimal implementation**
+
+Extend `SlashCommandCompleter` in `hermes_cli/commands.py` to:
+- detect `@file:` and `@folder:` under the cursor
+- reuse a path-completion helper with optional directory-only filtering
+- preserve slash-command behavior and existing non-slash path completion
+- use `rg --files`-style semantics where practical, but avoid depending on shell calls in the completer
+
+**Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && python -m pytest tests/hermes_cli/test_commands.py -q`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/hermes_cli/test_commands.py hermes_cli/commands.py
+git commit -m "feat: add @file and @folder completion"
+```
+
+### Task 3: Add failing CLI preprocessing tests
+
+**Files:**
+- Create: `tests/test_cli_context_references.py`
+- Modify: `cli.py`
+
+**Step 1: Write the failing test**
+
+Add tests that verify the CLI:
+- expands `@` references before `self.conversation_history.append(...)`
+- preserves the user-visible original prompt logging
+- surfaces warnings for over-budget or invalid references
+- passes the expanded text, not the raw marker string, into `run_conversation`
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_cli_context_references.py -q`
+
+Expected: FAIL because CLI preprocessing is not wired yet.
+
+**Step 3: Write minimal implementation**
+
+In `cli.py`:
+- call the shared preprocessor after paste expansion and before `self.chat(...)`
+- or, if cleaner, call it inside `HermesCLI.chat()` before appending to history
+- print concise context-injection status and warnings
+- keep voice-prefix behavior operating on the expanded message
+
+**Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_cli_context_references.py -q`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_cli_context_references.py cli.py
+git commit -m "feat: expand @ references in cli messages"
+```
+
+### Task 4: Add failing gateway preprocessing tests
+
+**Files:**
+- Create: `tests/gateway/test_context_references.py`
+- Modify: `gateway/run.py`
+
+**Step 1: Write the failing test**
+
+Add tests that verify gateway text messages:
+- expand `@file:` and git references before `_run_agent`
+- preserve normal command routing
+- include warnings for invalid references
+- skip expansion safely when not in a git repo or when url extraction fails
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tests/gateway/test_context_references.py -q`
+
+Expected: FAIL because the gateway path is still raw.
+
+**Step 3: Write minimal implementation**
+
+In `gateway/run.py`:
+- preprocess text after existing transcription/document-note enrichment and before `_run_agent`
+- resolve paths from the messaging CWD / terminal CWD
+- thread any warning/status text into the outgoing conversation in a way that informs the model and the user without mutating prior history
+
+**Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && python -m pytest tests/gateway/test_context_references.py -q`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/gateway/test_context_references.py gateway/run.py
+git commit -m "feat: expand @ references in gateway messages"
+```
+
+### Task 5: Add docs and final integration verification
+
+**Files:**
+- Modify: `website/docs/user-guide/cli.md`
+- Modify: `website/docs/user-guide/features/skins.md` (only if command docs need cross-link cleanup; otherwise skip)
+- Create or Modify: `website/docs/user-guide/features/context-references.md`
+- Modify: `website/sidebars.ts`
+
+**Step 1: Write the failing test**
+
+If docs tests exist for sidebar/doc links, add or update them. Otherwise skip the explicit failing-doc-test step and verify with targeted checks.
+
+**Step 2: Run targeted verification**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tests/test_context_references.py tests/test_cli_context_references.py tests/hermes_cli/test_commands.py tests/gateway/test_context_references.py -q`
+- `source .venv/bin/activate && python -m pytest tests/test_cli_init.py tests/gateway/ -q`
+
+Expected: PASS
+
+**Step 3: Write minimal documentation**
+
+Document:
+- supported reference forms
+- budget behavior
+- completion support in the CLI
+- gateway limitations vs CLI
+
+**Step 4: Run broader verification**
+
+Run: `source .venv/bin/activate && python -m pytest tests/ -q`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add website/docs/user-guide/cli.md website/docs/user-guide/features/context-references.md website/sidebars.ts
+git commit -m "docs: document @ context references"
+```

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1295,6 +1295,7 @@ class GatewayRunner:
             message,
             cwd=effective_cwd,
             context_length=context_length,
+            allowed_root=effective_cwd,
         )
     
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
@@ -1983,9 +1984,12 @@ class GatewayRunner:
             if not found_in_history:
                 message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
+        runtime_kwargs = _resolve_runtime_agent_kwargs()
         expanded_context = await self._expand_context_references_for_message(
             message_text,
             model=_resolve_gateway_model(),
+            base_url=runtime_kwargs.get("base_url"),
+            api_key=runtime_kwargs.get("api_key"),
         )
         if expanded_context.references:
             logger.info(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1268,6 +1268,34 @@ class GatewayRunner:
         if config and hasattr(config, "get_unauthorized_dm_behavior"):
             return config.get_unauthorized_dm_behavior(platform)
         return "pair"
+
+    async def _expand_context_references_for_message(
+        self,
+        message: str,
+        *,
+        cwd: str | Path | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+    ):
+        """Expand ``@...`` references for gateway-originated text messages."""
+        from agent.context_references import preprocess_context_references_async
+        from agent.model_metadata import get_model_context_length
+
+        effective_cwd = Path(
+            cwd or os.getenv("MESSAGING_CWD") or os.getenv("TERMINAL_CWD") or str(Path.home())
+        )
+        effective_model = model or _resolve_gateway_model()
+        context_length = get_model_context_length(
+            effective_model,
+            base_url=base_url or "",
+            api_key=api_key or "",
+        )
+        return await preprocess_context_references_async(
+            message,
+            cwd=effective_cwd,
+            context_length=context_length,
+        )
     
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
@@ -1954,6 +1982,21 @@ class GatewayRunner:
             )
             if not found_in_history:
                 message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+
+        expanded_context = await self._expand_context_references_for_message(
+            message_text,
+            model=_resolve_gateway_model(),
+        )
+        if expanded_context.references:
+            logger.info(
+                "Expanded %d @ context reference(s) for session %s (%d tokens)",
+                len(expanded_context.references),
+                session_entry.session_id,
+                expanded_context.injected_tokens,
+            )
+        if expanded_context.blocked:
+            return "\n".join(expanded_context.warnings) or "Context injection refused."
+        message_text = expanded_context.message
 
         try:
             # Emit agent:start hook

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -345,7 +346,63 @@ class SlashCommandCompleter(Completer):
         return None
 
     @staticmethod
-    def _path_completions(word: str, limit: int = 30):
+    def _extract_reference_word(text: str) -> tuple[str, str] | None:
+        """Extract ``@file:...`` / ``@folder:...`` token under the cursor."""
+        if not text:
+            return None
+        i = len(text) - 1
+        while i >= 0 and text[i] != " ":
+            i -= 1
+        word = text[i + 1:]
+        for prefix in ("@file:", "@folder:"):
+            if word.startswith(prefix):
+                return prefix, word[len(prefix):]
+        return None
+
+    @staticmethod
+    def _load_ignore_patterns(root: Path) -> list[str]:
+        patterns: list[str] = []
+        for name in (".gitignore", ".hermesignore"):
+            path = root / name
+            if not path.exists():
+                continue
+            try:
+                for line in path.read_text(encoding="utf-8").splitlines():
+                    stripped = line.strip()
+                    if stripped and not stripped.startswith("#"):
+                        patterns.append(stripped.lstrip("/"))
+            except OSError:
+                continue
+        return patterns
+
+    @staticmethod
+    def _is_ignored(candidate: Path, root: Path, patterns: list[str]) -> bool:
+        rel = os.path.relpath(candidate, root).replace(os.sep, "/")
+        for pattern in patterns:
+            cleaned = pattern.rstrip("/")
+            if not cleaned:
+                continue
+            if rel == cleaned or rel.startswith(f"{cleaned}/"):
+                return True
+            if cleaned.startswith("*.") and rel.endswith(cleaned[1:]):
+                return True
+        git_dir = root / ".git"
+        if git_dir.exists():
+            try:
+                result = subprocess.run(
+                    ["git", "check-ignore", "-q", rel],
+                    cwd=root,
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode == 0:
+                    return True
+            except OSError:
+                pass
+        return False
+
+    @staticmethod
+    def _path_completions(word: str, limit: int = 30, directories_only: bool = False):
         """Yield Completion objects for file paths matching *word*."""
         expanded = os.path.expanduser(word)
         # Split into directory part and prefix to match inside it
@@ -355,6 +412,9 @@ class SlashCommandCompleter(Completer):
         else:
             search_dir = os.path.dirname(expanded) or "."
             prefix = os.path.basename(expanded)
+
+        root = Path.cwd()
+        ignore_patterns = SlashCommandCompleter._load_ignore_patterns(root)
 
         try:
             entries = os.listdir(search_dir)
@@ -371,6 +431,12 @@ class SlashCommandCompleter(Completer):
 
             full_path = os.path.join(search_dir, entry)
             is_dir = os.path.isdir(full_path)
+            path_obj = Path(full_path).resolve()
+
+            if SlashCommandCompleter._is_ignored(path_obj, root, ignore_patterns):
+                continue
+            if directories_only and not is_dir:
+                continue
 
             # Build the completion text (what replaces the typed word)
             if word.startswith("~"):
@@ -398,6 +464,20 @@ class SlashCommandCompleter(Completer):
     def get_completions(self, document, complete_event):
         text = document.text_before_cursor
         if not text.startswith("/"):
+            reference_word = self._extract_reference_word(text)
+            if reference_word is not None:
+                prefix, path_word = reference_word
+                for completion in self._path_completions(
+                    path_word,
+                    directories_only=(prefix == "@folder:"),
+                ):
+                    yield Completion(
+                        f"{prefix}{completion.text}",
+                        start_position=-(len(prefix) + len(path_word)),
+                        display=f"{prefix}{completion.display}",
+                        display_meta=completion.display_meta,
+                    )
+                return
             # Try file path completion for non-slash input
             path_word = self._extract_path_word(text)
             if path_word is not None:

--- a/tests/gateway/test_context_references.py
+++ b/tests/gateway/test_context_references.py
@@ -87,7 +87,11 @@ async def test_gateway_handle_message_expands_context_references(monkeypatch, tm
         }
     )
 
-    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***", "base_url": "http://localhost:1234/v1"},
+    )
     monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda: "anthropic/claude-opus-4.6")
     monkeypatch.setattr(
         "agent.model_metadata.get_model_context_length",
@@ -101,6 +105,57 @@ async def test_gateway_handle_message_expands_context_references(monkeypatch, tm
     sent_message = runner._run_agent.await_args.kwargs["message"]
     assert "hello from gateway" in sent_message
     assert "@file:notes.txt" in sent_message
+
+
+@pytest.mark.asyncio
+async def test_gateway_handle_message_uses_runtime_provider_for_budget(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    (tmp_path / "notes.txt").write_text("hello from gateway\n", encoding="utf-8")
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 10,
+            "input_tokens": 20,
+            "output_tokens": 5,
+            "model": "anthropic/test",
+        }
+    )
+
+    runtime_kwargs = {"api_key": "custom-key", "base_url": "http://localhost:1234/v1"}
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: runtime_kwargs)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda: "custom-model")
+    seen = {}
+
+    def fake_context_length(model, *, base_url="", api_key="", **_kwargs):
+        seen["model"] = model
+        seen["base_url"] = base_url
+        seen["api_key"] = api_key
+        return 100000
+
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", fake_context_length)
+    monkeypatch.setenv("MESSAGING_CWD", str(tmp_path))
+
+    result = await runner._handle_message(_make_event("inspect @file:notes.txt"))
+
+    assert result == "ok"
+    assert seen == {
+        "model": "custom-model",
+        "base_url": "http://localhost:1234/v1",
+        "api_key": "custom-key",
+    }
 
 
 @pytest.mark.asyncio
@@ -125,3 +180,31 @@ async def test_gateway_preprocess_context_references_returns_warning_when_blocke
 
     assert result.blocked
     assert any("50%" in warning for warning in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_gateway_preprocess_restricts_paths_to_messaging_cwd(monkeypatch, tmp_path):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100000,
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "notes.txt").write_text("inside\n", encoding="utf-8")
+    (tmp_path / "secret.txt").write_text("outside\n", encoding="utf-8")
+
+    result = await GatewayRunner._expand_context_references_for_message(
+        runner,
+        "inspect @file:../secret.txt and @file:notes.txt",
+        cwd=workspace,
+        model="anthropic/claude-opus-4.6",
+        base_url="",
+        api_key="",
+    )
+
+    assert "inside" in result.message
+    assert "```\noutside\n```" not in result.message
+    assert any("outside the allowed workspace" in warning for warning in result.warnings)

--- a/tests/gateway/test_context_references.py
+++ b/tests/gateway/test_context_references.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner(session_entry: SessionEntry):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {Platform.TELEGRAM: MagicMock(send=AsyncMock())}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner.session_store.has_any_sessions.return_value = True
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._clear_session_env = lambda: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_gateway_handle_message_expands_context_references(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    (tmp_path / "notes.txt").write_text("hello from gateway\n", encoding="utf-8")
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 10,
+            "input_tokens": 20,
+            "output_tokens": 5,
+            "model": "anthropic/test",
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda: "anthropic/claude-opus-4.6")
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100000,
+    )
+    monkeypatch.setenv("MESSAGING_CWD", str(tmp_path))
+
+    result = await runner._handle_message(_make_event("inspect @file:notes.txt"))
+
+    assert result == "ok"
+    sent_message = runner._run_agent.await_args.kwargs["message"]
+    assert "hello from gateway" in sent_message
+    assert "@file:notes.txt" in sent_message
+
+
+@pytest.mark.asyncio
+async def test_gateway_preprocess_context_references_returns_warning_when_blocked(monkeypatch, tmp_path):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 20,
+    )
+    (tmp_path / "notes.txt").write_text("x" * 400, encoding="utf-8")
+
+    result = await GatewayRunner._expand_context_references_for_message(
+        runner,
+        "inspect @file:notes.txt",
+        cwd=tmp_path,
+        model="anthropic/claude-opus-4.6",
+        base_url="",
+        api_key="",
+    )
+
+    assert result.blocked
+    assert any("50%" in warning for warning in result.warnings)

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -258,6 +258,38 @@ class TestSlashCommandCompleter:
     def test_no_completions_for_empty_input(self):
         assert _completions(SlashCommandCompleter(), "") == []
 
+    def test_file_reference_completion_for_at_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+        (tmp_path / "src" / "other.txt").write_text("x\n", encoding="utf-8")
+
+        completions = _completions(SlashCommandCompleter(), "inspect @file:src/ma")
+
+        assert [item.text for item in completions] == ["@file:src/main.py"]
+
+    def test_folder_reference_completion_only_lists_directories(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "src").mkdir()
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "README.md").write_text("# Demo\n", encoding="utf-8")
+
+        completions = _completions(SlashCommandCompleter(), "inspect @folder:s")
+        texts = {item.text for item in completions}
+
+        assert "@folder:src/" in texts
+        assert "@folder:scripts/" in texts
+        assert all(not text.endswith("README.md") for text in texts)
+
+    def test_plain_path_completion_still_works(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+
+        completions = _completions(SlashCommandCompleter(), "open src/ma")
+
+        assert [item.text for item in completions] == ["src/main.py"]
+
     # -- skill commands via provider ------------------------------------
 
     def test_skill_commands_are_completed_from_provider(self):

--- a/tests/test_cli_context_references.py
+++ b/tests/test_cli_context_references.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import cli as cli_module
+from cli import HermesCLI
+
+
+def _make_cli_stub() -> HermesCLI:
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.model = "anthropic/claude-opus-4.6"
+    cli_obj.base_url = "https://openrouter.ai/api/v1"
+    cli_obj.api_key = "test-key"
+    cli_obj.console = MagicMock()
+    cli_obj.console.width = 80
+    cli_obj.show_reasoning = False
+    cli_obj.bell_on_complete = False
+    cli_obj._streaming_box_opened = False
+    cli_obj._stream_started = False
+    cli_obj._stream_buf = ""
+    cli_obj._stream_box_opened = False
+    cli_obj._secret_capture_callback = lambda *_args, **_kwargs: None
+    cli_obj._ensure_runtime_credentials = lambda: True
+    cli_obj._resolve_turn_agent_config = lambda _message: {
+        "signature": "sig",
+        "model": cli_obj.model,
+        "runtime": {},
+        "label": "default",
+    }
+    cli_obj._active_agent_route_signature = "sig"
+    cli_obj._init_agent = lambda **_kwargs: True
+    cli_obj._preprocess_images_with_vision = lambda message, _images: message
+    cli_obj._reset_stream_state = lambda: None
+    cli_obj._invalidate = lambda *args, **kwargs: None
+    cli_obj._flush_stream = lambda: None
+    cli_obj._clear_session_env = lambda: None
+    cli_obj._interrupt_queue = None
+    cli_obj._clarify_state = False
+    cli_obj._clarify_freetext = False
+    cli_obj._voice_tts = False
+    cli_obj._voice_mode = False
+    cli_obj._voice_continuous = False
+    cli_obj._voice_recording = False
+    cli_obj._voice_tts_done = MagicMock()
+    cli_obj._session_db = None
+    cli_obj.session_id = "sess-1"
+    cli_obj.conversation_history = []
+    cli_obj.agent = SimpleNamespace(
+        run_conversation=lambda **kwargs: {
+            "messages": [{"role": "user", "content": kwargs["user_message"]}],
+            "final_response": "ok",
+        },
+        interrupt=lambda *_args, **_kwargs: None,
+    )
+    return cli_obj
+
+
+def test_cli_expand_context_references_uses_model_context(monkeypatch, tmp_path):
+    cli_obj = _make_cli_stub()
+    (tmp_path / "notes.txt").write_text("hello\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *args, **kwargs: 4096,
+    )
+
+    captured = {}
+
+    def fake_preprocess(message, *, cwd, context_length, url_fetcher=None):
+        captured["message"] = message
+        captured["cwd"] = cwd
+        captured["context_length"] = context_length
+        return SimpleNamespace(
+            message="expanded message",
+            original_message=message,
+            warnings=["warn"],
+            injected_tokens=123,
+            references=[object()],
+            expanded=True,
+            blocked=False,
+        )
+
+    monkeypatch.setattr("agent.context_references.preprocess_context_references", fake_preprocess)
+
+    result = cli_obj._expand_context_references_for_turn("inspect @file:notes.txt", cwd=tmp_path)
+
+    assert result.message == "expanded message"
+    assert captured["message"] == "inspect @file:notes.txt"
+    assert captured["cwd"] == tmp_path
+    assert captured["context_length"] == 4096
+
+
+def test_cli_chat_sends_expanded_message_to_agent(monkeypatch, tmp_path):
+    cli_obj = _make_cli_stub()
+    monkeypatch.setattr(cli_module, "ChatConsole", lambda: MagicMock(print=lambda *_a, **_k: None))
+    monkeypatch.setattr(cli_module, "_accent_hex", lambda: "gold")
+    monkeypatch.setattr(
+        "agent.title_generator.maybe_auto_title",
+        lambda *_args, **_kwargs: None,
+    )
+
+    cli_obj._expand_context_references_for_turn = lambda message, **_kwargs: SimpleNamespace(
+        message="expanded message",
+        original_message=message,
+        warnings=[],
+        injected_tokens=12,
+        references=[object()],
+        expanded=True,
+        blocked=False,
+    )
+
+    response = cli_obj.chat("inspect @file:notes.txt")
+
+    assert response == "ok"
+    assert cli_obj.conversation_history[0]["content"] == "expanded message"

--- a/tests/test_context_references.py
+++ b/tests/test_context_references.py
@@ -71,6 +71,18 @@ def test_parse_typed_references_ignores_emails_and_handles():
     assert refs[2].target == "2"
 
 
+def test_parse_references_strips_trailing_punctuation():
+    from agent.context_references import parse_context_references
+
+    refs = parse_context_references(
+        "review @file:README.md, then see (@url:https://example.com/docs)."
+    )
+
+    assert [ref.kind for ref in refs] == ["file", "url"]
+    assert refs[0].target == "README.md"
+    assert refs[1].target == "https://example.com/docs"
+
+
 def test_expand_file_range_and_folder_listing(sample_repo: Path):
     from agent.context_references import preprocess_context_references
 
@@ -185,3 +197,25 @@ def test_sync_url_expansion_uses_async_fetcher(sample_repo: Path):
 
     assert result.expanded
     assert "Content for https://example.com/spec" in result.message
+
+
+def test_restricts_paths_to_allowed_root(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "notes.txt").write_text("inside\n", encoding="utf-8")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("outside\n", encoding="utf-8")
+
+    result = preprocess_context_references(
+        "read @file:../secret.txt and @file:notes.txt",
+        cwd=workspace,
+        context_length=100_000,
+        allowed_root=workspace,
+    )
+
+    assert result.expanded
+    assert "```\noutside\n```" not in result.message
+    assert "inside" in result.message
+    assert any("outside the allowed workspace" in warning for warning in result.warnings)

--- a/tests/test_context_references.py
+++ b/tests/test_context_references.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def sample_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.name", "Hermes Tests")
+    _git(repo, "config", "user.email", "tests@example.com")
+
+    (repo / "src").mkdir()
+    (repo / "src" / "main.py").write_text(
+        "def alpha():\n"
+        "    return 'a'\n\n"
+        "def beta():\n"
+        "    return 'b'\n",
+        encoding="utf-8",
+    )
+    (repo / "src" / "helper.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (repo / "README.md").write_text("# Demo\n", encoding="utf-8")
+    (repo / "blob.bin").write_bytes(b"\x00\x01\x02binary")
+
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+
+    (repo / "src" / "main.py").write_text(
+        "def alpha():\n"
+        "    return 'changed'\n\n"
+        "def beta():\n"
+        "    return 'b'\n",
+        encoding="utf-8",
+    )
+    (repo / "src" / "helper.py").write_text("VALUE = 2\n", encoding="utf-8")
+    _git(repo, "add", "src/helper.py")
+    return repo
+
+
+def test_parse_typed_references_ignores_emails_and_handles():
+    from agent.context_references import parse_context_references
+
+    message = (
+        "email me at user@example.com and ping @teammate "
+        "but include @file:src/main.py:1-2 plus @diff and @git:2 "
+        "and @url:https://example.com/docs"
+    )
+
+    refs = parse_context_references(message)
+
+    assert [ref.kind for ref in refs] == ["file", "diff", "git", "url"]
+    assert refs[0].target == "src/main.py"
+    assert refs[0].line_start == 1
+    assert refs[0].line_end == 2
+    assert refs[2].target == "2"
+
+
+def test_expand_file_range_and_folder_listing(sample_repo: Path):
+    from agent.context_references import preprocess_context_references
+
+    result = preprocess_context_references(
+        "Review @file:src/main.py:1-2 and @folder:src/",
+        cwd=sample_repo,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert "Review and" in result.message
+    assert "Review @file:src/main.py:1-2" not in result.message
+    assert "--- Attached Context ---" in result.message
+    assert "def alpha():" in result.message
+    assert "return 'changed'" in result.message
+    assert "def beta():" not in result.message
+    assert "src/" in result.message
+    assert "main.py" in result.message
+    assert "helper.py" in result.message
+    assert result.injected_tokens > 0
+    assert not result.warnings
+
+
+def test_expand_git_diff_staged_and_log(sample_repo: Path):
+    from agent.context_references import preprocess_context_references
+
+    result = preprocess_context_references(
+        "Inspect @diff and @staged and @git:1",
+        cwd=sample_repo,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert "git diff" in result.message
+    assert "git diff --staged" in result.message
+    assert "git log -1 -p" in result.message
+    assert "initial" in result.message
+    assert "return 'changed'" in result.message
+    assert "VALUE = 2" in result.message
+
+
+def test_binary_and_missing_files_become_warnings(sample_repo: Path):
+    from agent.context_references import preprocess_context_references
+
+    result = preprocess_context_references(
+        "Check @file:blob.bin and @file:nope.txt",
+        cwd=sample_repo,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert len(result.warnings) == 2
+    assert "binary" in result.message.lower()
+    assert "not found" in result.message.lower()
+
+
+def test_soft_budget_warns_and_hard_budget_refuses(sample_repo: Path):
+    from agent.context_references import preprocess_context_references
+
+    soft = preprocess_context_references(
+        "Check @file:src/main.py",
+        cwd=sample_repo,
+        context_length=100,
+    )
+    assert soft.expanded
+    assert any("25%" in warning for warning in soft.warnings)
+
+    hard = preprocess_context_references(
+        "Check @file:src/main.py and @file:README.md",
+        cwd=sample_repo,
+        context_length=20,
+    )
+    assert not hard.expanded
+    assert hard.blocked
+    assert "@file:src/main.py" in hard.message
+    assert any("50%" in warning for warning in hard.warnings)
+
+
+@pytest.mark.asyncio
+async def test_async_url_expansion_uses_fetcher(sample_repo: Path):
+    from agent.context_references import preprocess_context_references_async
+
+    async def fake_fetch(url: str) -> str:
+        assert url == "https://example.com/spec"
+        return "# Spec\n\nImportant details."
+
+    result = await preprocess_context_references_async(
+        "Use @url:https://example.com/spec",
+        cwd=sample_repo,
+        context_length=100_000,
+        url_fetcher=fake_fetch,
+    )
+
+    assert result.expanded
+    assert "Important details." in result.message
+    assert result.injected_tokens > 0
+
+
+def test_sync_url_expansion_uses_async_fetcher(sample_repo: Path):
+    from agent.context_references import preprocess_context_references
+
+    async def fake_fetch(url: str) -> str:
+        await asyncio.sleep(0)
+        return f"Content for {url}"
+
+    result = preprocess_context_references(
+        "Use @url:https://example.com/spec",
+        cwd=sample_repo,
+        context_length=100_000,
+        url_fetcher=fake_fetch,
+    )
+
+    assert result.expanded
+    assert "Content for https://example.com/spec" in result.message

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -117,6 +117,8 @@ Common examples:
 
 For the full built-in CLI and messaging lists, see [Slash Commands Reference](../reference/slash-commands.md).
 
+Hermes also supports inline `@` context references such as `@file:src/main.py`, `@folder:src/`, `@diff`, and `@url:https://...`. In the CLI, `Tab` completes `@file:` and `@folder:` paths directly in the input box. See [Context References](features/context-references.md).
+
 For setup, providers, silence tuning, and messaging/Discord voice usage, see [Voice Mode](features/voice-mode.md).
 
 :::tip

--- a/website/docs/user-guide/features/context-references.md
+++ b/website/docs/user-guide/features/context-references.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 6
+title: "Context References"
+description: "Use @ references to inject files, folders, diffs, git history, and URLs into a Hermes message"
+---
+
+# Context References
+
+Hermes can expand scoped context references directly inside your message before it reaches the model.
+
+This lets you tell Hermes exactly what to read instead of hoping it searches the right files.
+
+## Supported references
+
+| Reference | Example | What Hermes injects |
+|------|------|------|
+| `@file:` | `@file:src/main.py` | Full text of the file |
+| `@file:` with range | `@file:src/main.py:10-40` | Only the requested line range |
+| `@folder:` | `@folder:src/` | A directory listing with file metadata |
+| `@diff` | `@diff` | Current unstaged git diff |
+| `@staged` | `@staged` | Current staged git diff |
+| `@git:N` | `@git:3` | `git log -3 -p` output |
+| `@url:` | `@url:https://example.com/spec` | Extracted page content |
+
+References can appear anywhere in the message and you can mix multiple references in one turn.
+
+```text
+Review @file:agent/context_references.py and compare it with @diff
+```
+
+## How expansion works
+
+Hermes keeps your plain-language message, removes the raw `@...` tokens from that sentence, and appends an `Attached Context` section containing the expanded content.
+
+That means a prompt like:
+
+```text
+Review @file:src/main.py:1-20 and @diff
+```
+
+becomes something like:
+
+```text
+Review and
+
+--- Attached Context ---
+
+📄 @file:src/main.py:1-20 (...)
+...
+
+🧾 git diff (...)
+...
+```
+
+## Token budget rules
+
+Hermes estimates the number of tokens injected by `@` references before sending the turn to the model.
+
+- Above 25% of the current model context window: Hermes warns that the injected context is large.
+- Above 50% of the current model context window: Hermes refuses the expansion for that turn.
+
+This prevents a few large references from silently blowing up the prompt.
+
+## CLI behavior
+
+The interactive CLI supports autocomplete for:
+
+- `@file:`
+- `@folder:`
+
+`Tab` completes matching paths while keeping slash-command completion intact.
+
+Regular path completion still works for plain path-like text such as `src/main.py`.
+
+## Gateway behavior
+
+Messaging platforms such as Telegram and Discord also expand `@` references in plain text messages.
+
+Differences from the CLI:
+
+- There is no interactive path autocomplete.
+- Paths resolve from the messaging working directory (`MESSAGING_CWD`, or the configured terminal CWD).
+- Git references only work when that directory is inside a git repository.
+
+## Notes and limitations
+
+- Hermes only matches typed reference prefixes. It does not treat email addresses like `user@example.com` or handles like `@teammate` as context references.
+- Binary files are skipped with a warning.
+- Missing files or invalid git commands produce warnings instead of crashing the turn.
+- URL extraction depends on the configured web extraction backend.

--- a/website/docs/user-guide/messaging/open-webui.md
+++ b/website/docs/user-guide/messaging/open-webui.md
@@ -10,13 +10,11 @@ description: "Connect Open WebUI to Hermes Agent via the OpenAI-compatible API s
 
 ## Architecture
 
-```
-┌──────────────────┐    POST /v1/chat/completions    ┌──────────────────────┐
-│   Open WebUI     │ ──────────────────────────────► │  hermes-agent        │
-│   (browser UI)   │    SSE streaming response       │  gateway API server  │
-│   port 3000      │ ◄────────────────────────────── │  port 8642           │
-└──────────────────┘                                  └──────────────────────┘
-```
+Open WebUI and Hermes Agent communicate like this:
+
+- Open WebUI browser UI on port `3000`
+- Sends `POST /v1/chat/completions` to Hermes Agent's gateway API server on port `8642`
+- Hermes streams responses back over SSE
 
 Open WebUI connects to Hermes Agent's API server just like it would connect to OpenAI. Your agent handles the requests with its full toolset — terminal, file operations, web search, memory, skills — and returns the final response.
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -62,6 +62,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/skills',
             'user-guide/features/memory',
             'user-guide/features/context-files',
+            'user-guide/features/context-references',
             'user-guide/features/personality',
             'user-guide/features/skins',
           ],


### PR DESCRIPTION
## Summary
- add a reusable `@` context reference parser/expander for `@file`, ranged `@file`, `@folder`, `@diff`, `@staged`, `@git:N`, and `@url`
- wire reference expansion into both CLI and gateway message preprocessing, with token-budget warnings/refusal behavior
- add CLI autocomplete for `@file:` and `@folder:` and document the new feature in the user guide

Closes #682.

## Testing
- `source .venv/bin/activate && python -m pytest -o addopts='' tests/test_context_references.py tests/hermes_cli/test_commands.py tests/test_cli_context_references.py tests/gateway/test_context_references.py -q`
- `source .venv/bin/activate && python -m pytest -o addopts='' tests/ -q` *(fails in this environment on unrelated existing tests outside this change set: `tests/hermes_cli/test_gateway_service.py::TestEnsureUserSystemdEnv::test_sets_xdg_runtime_dir_when_missing`, `tests/integration/test_ha_integration.py::TestGatewayWebSocket::test_event_received_and_forwarded`, `tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_direct_endpoint_does_not_fall_back_to_openrouter_api_key_env`, `tests/tools/test_transcription.py::TestGetProvider::test_explicit_openai_no_key_returns_none`, `tests/tools/test_transcription.py::TestTranscribeOpenAI::test_no_key`, and three `tests/tools/test_web_tools_config.py::TestParallelClientConfig::*` cases because `parallel` is not installed.)*
