### PR TITLE
feat(context): add observation masking to reduce token usage

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -47,10 +47,14 @@ class ContextCompressor:
         base_url: str = "",
         api_key: str = "",
         config_context_length: int | None = None,
+        observation_masking: bool = True,
+        observation_masking_window: int = 4,
     ):
         self.model = model
         self.base_url = base_url
         self.api_key = api_key
+        self.observation_masking = observation_masking
+        self.observation_masking_window = observation_masking_window
         self.threshold_percent = threshold_percent
         self.protect_first_n = protect_first_n
         self.protect_last_n = protect_last_n
@@ -277,6 +281,48 @@ Write only the summary body. Do not include any preamble or prefix; the system w
             idx = check
         return idx
 
+    def mask_observations(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Replace tool result content in older turns with a short placeholder.
+
+        Keeps the last `observation_masking_window` assistant turns unmasked.
+        Only masks tool/function result messages (role='tool').
+        The agent's own reasoning (assistant messages) is never modified.
+        """
+        if not self.observation_masking:
+            return messages
+
+        # Count assistant turns from the end to find the masking boundary
+        assistant_turns_from_end = 0
+        mask_before_idx = 0
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i].get("role") == "assistant":
+                assistant_turns_from_end += 1
+                if assistant_turns_from_end >= self.observation_masking_window:
+                    mask_before_idx = i
+                    break
+
+        if mask_before_idx == 0:
+            return messages  # Not enough turns to mask anything
+
+        masked = []
+        for i, msg in enumerate(messages):
+            if i >= mask_before_idx:
+                masked.append(msg)
+                continue
+            if msg.get("role") == "tool":
+                original = msg.get("content", "")
+                if isinstance(original, str):
+                    n_chars = len(original)
+                elif isinstance(original, list):
+                    n_chars = sum(len(str(c)) for c in original)
+                else:
+                    n_chars = len(str(original))
+                if n_chars > 0:
+                    msg = msg.copy()
+                    msg["content"] = f"[observation masked — {n_chars} chars, use session_search to recall if needed]"
+            masked.append(msg)
+        return masked
+
     def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None) -> List[Dict[str, Any]]:
         """Compress conversation messages by summarizing middle turns.
 
@@ -284,6 +330,8 @@ Write only the summary body. Do not include any preamble or prefix; the system w
         After compression, orphaned tool_call / tool_result pairs are cleaned
         up so the API never receives mismatched IDs.
         """
+        # First pass: mask old tool observations cheaply (no LLM call)
+        messages = self.mask_observations(messages)
         n_messages = len(messages)
         if n_messages <= self.protect_first_n + self.protect_last_n + 1:
             if not self.quiet_mode:

--- a/cli.py
+++ b/cli.py
@@ -212,6 +212,10 @@ def load_cli_config() -> Dict[str, Any]:
             },
         },
         "toolsets": ["all"],
+        "context": {
+            "observation_masking": True,   # Replace old tool outputs with placeholders before LLM summarization
+            "observation_masking_window": 4,  # Keep last N assistant turns unmasked
+        },
         "display": {
             "compact": False,
             "resume_display": "full",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -357,6 +357,11 @@ DEFAULT_CONFIG = {
     # Or dict format: {"name": {"description": "...", "system_prompt": "...", "tone": "...", "style": "..."}}
     "personalities": {},
 
+    # Observation masking for context compression
+    "context": {
+        "observation_masking": True,
+        "observation_masking_window": 4,
+    },
     # Pre-exec security scanning via tirith
     "security": {
         "redact_secrets": True,

--- a/run_agent.py
+++ b/run_agent.py
@@ -982,6 +982,9 @@ class AIAgent:
             except (TypeError, ValueError):
                 _config_context_length = None
         
+        _context_cfg = _agent_cfg.get("context", {})
+        _obs_masking = _context_cfg.get("observation_masking", True)
+        _obs_window = _context_cfg.get("observation_masking_window", 4)
         self.context_compressor = ContextCompressor(
             model=self.model,
             threshold_percent=compression_threshold,
@@ -993,6 +996,8 @@ class AIAgent:
             base_url=self.base_url,
             api_key=getattr(self, "api_key", ""),
             config_context_length=_config_context_length,
+            observation_masking=_obs_masking,
+            observation_masking_window=_obs_window,
         )
         self.compression_enabled = compression_enabled
         self._user_turn_count = 0

--- a/tests/agent/test_observation_masking.py
+++ b/tests/agent/test_observation_masking.py
@@ -1,0 +1,94 @@
+"""Tests for observation masking in ContextCompressor."""
+import pytest
+from unittest.mock import patch, MagicMock
+from agent.context_compressor import ContextCompressor
+
+
+def make_compressor(**kwargs):
+    with patch("agent.context_compressor.get_model_context_length", return_value=128000):
+        return ContextCompressor(model="test", quiet_mode=True, **kwargs)
+
+
+def make_messages(n_turns):
+    """Create n_turns of assistant+tool pairs."""
+    msgs = []
+    for i in range(n_turns):
+        msgs.append({"role": "assistant", "content": f"Calling tool turn {i}", "tool_calls": [{"id": f"tc{i}"}]})
+        msgs.append({"role": "tool", "tool_call_id": f"tc{i}", "content": f"Tool output for turn {i} — " + "x" * 200})
+    return msgs
+
+
+class TestMaskObservations:
+
+    def test_masks_old_tool_outputs(self):
+        c = make_compressor(observation_masking=True, observation_masking_window=2)
+        msgs = make_messages(4)
+        result = c.mask_observations(msgs)
+        # First 2 turns (4 messages) should be masked
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        masked = [m for m in tool_msgs if "observation masked" in m.get("content", "")]
+        unmasked = [m for m in tool_msgs if "observation masked" not in m.get("content", "")]
+        assert len(masked) == 2
+        assert len(unmasked) == 2
+
+    def test_preserves_recent_tool_outputs(self):
+        c = make_compressor(observation_masking=True, observation_masking_window=2)
+        msgs = make_messages(4)
+        result = c.mask_observations(msgs)
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        # Last 2 tool outputs should be unmasked
+        assert "observation masked" not in tool_msgs[-1]["content"]
+        assert "observation masked" not in tool_msgs[-2]["content"]
+
+    def test_masked_content_shows_char_count(self):
+        c = make_compressor(observation_masking=True, observation_masking_window=1)
+        msgs = make_messages(3)
+        result = c.mask_observations(msgs)
+        masked_msgs = [m for m in result if m.get("role") == "tool" and "observation masked" in m.get("content", "")]
+        for m in masked_msgs:
+            assert "chars" in m["content"]
+
+    def test_assistant_messages_never_masked(self):
+        c = make_compressor(observation_masking=True, observation_masking_window=1)
+        msgs = make_messages(4)
+        result = c.mask_observations(msgs)
+        assistant_msgs = [m for m in result if m.get("role") == "assistant"]
+        for m in assistant_msgs:
+            assert "observation masked" not in str(m.get("content", ""))
+
+    def test_disabled_masking_returns_unchanged(self):
+        c = make_compressor(observation_masking=False, observation_masking_window=2)
+        msgs = make_messages(4)
+        result = c.mask_observations(msgs)
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        for m in tool_msgs:
+            assert "observation masked" not in m.get("content", "")
+
+    def test_too_few_turns_no_masking(self):
+        c = make_compressor(observation_masking=True, observation_masking_window=4)
+        msgs = make_messages(2)
+        result = c.mask_observations(msgs)
+        assert result == msgs
+
+    def test_default_masking_enabled(self):
+        c = make_compressor()
+        assert c.observation_masking is True
+
+    def test_default_window_is_four(self):
+        c = make_compressor()
+        assert c.observation_masking_window == 4
+
+    def test_masking_runs_before_compression(self):
+        """mask_observations is called at the start of compress()."""
+        c = make_compressor(observation_masking=True, observation_masking_window=2)
+        msgs = make_messages(10)
+        # Patch _generate_summary to avoid LLM call
+        with patch.object(c, "_generate_summary", return_value="summary"):
+            with patch.object(c, "should_compress", return_value=True):
+                result = c.compress(msgs, current_tokens=200000)
+        # After compress, old tool outputs in compressed result should be masked
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        if tool_msgs:
+            # At least some masking happened
+            contents = [m.get("content", "") for m in tool_msgs]
+            assert any("observation masked" in c for c in contents) or len(result) < len(msgs)


### PR DESCRIPTION
## Summary

Closes #2046

Adds lightweight observation masking as a first-pass in `context_compressor.py`, before LLM summarization kicks in. Replaces old tool outputs with short placeholders — zero extra API calls, no latency added.

Based on JetBrains Research (NeurIPS 2025 DL4Code, arXiv:2508.21433) showing observation masking achieves the same performance as LLM summarization at 52.7% cost reduction.

## Config

```yaml
# ~/.hermes/config.yaml
context:
  observation_masking: true          # default: true
  observation_masking_window: 4      # keep last N assistant turns unmasked
```

## Behavior

1. For turns older than `observation_masking_window`, tool result content is replaced with: `[observation masked — N chars, use session_search to recall if needed]`
2. Assistant messages (reasoning, actions) are never modified
3. LLM summarization remains as second-pass safety net

## Changes

- `agent/context_compressor.py` — `mask_observations()` method + call at start of `compress()`
- `run_agent.py` — pass config values to `ContextCompressor`
- `cli.py` — `context.observation_masking` defaults
- `tests/agent/test_observation_masking.py` — 9 tests