### PR TITLE
fix(tools): normalise MCP object schemas without properties

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -106,6 +106,18 @@ class TestSchemaConversion:
         assert schema["parameters"]["type"] == "object"
         assert schema["parameters"]["properties"] == {}
 
+    def test_object_schema_without_properties_gets_normalized(self):
+        from tools.mcp_tool import _convert_mcp_schema
+
+        mcp_tool = _make_mcp_tool(
+            name="ask",
+            description="Ask Crawl4AI",
+            input_schema={"type": "object"},
+        )
+        schema = _convert_mcp_schema("crawl4ai", mcp_tool)
+
+        assert schema["parameters"] == {"type": "object", "properties": {}}
+
     def test_tool_name_prefix_format(self):
         from tools.mcp_tool import _convert_mcp_schema
 
@@ -1856,6 +1868,33 @@ class TestSamplingCallbackText:
         call_args = mock_call.call_args
         messages = call_args.kwargs["messages"]
         assert messages[0] == {"role": "system", "content": "Be helpful"}
+
+    def test_server_tools_with_object_schema_are_normalized(self):
+        """Server-provided tools should gain empty properties for object schemas."""
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = _make_llm_response()
+        server_tool = SimpleNamespace(
+            name="ask",
+            description="Ask Crawl4AI",
+            inputSchema={"type": "object"},
+        )
+
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=fake_client.chat.completions.create.return_value,
+        ) as mock_call:
+            params = _make_sampling_params(tools=[server_tool])
+            asyncio.run(self.handler(None, params))
+
+        tools = mock_call.call_args.kwargs["tools"]
+        assert tools == [{
+            "type": "function",
+            "function": {
+                "name": "ask",
+                "description": "Ask Crawl4AI",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }]
 
     def test_length_stop_reason(self):
         """finish_reason='length' maps to stopReason='maxTokens'."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -605,7 +605,9 @@ class SamplingHandler:
                     "function": {
                         "name": getattr(t, "name", ""),
                         "description": getattr(t, "description", "") or "",
-                        "parameters": getattr(t, "inputSchema", {}) or {},
+                        "parameters": _normalize_mcp_input_schema(
+                            getattr(t, "inputSchema", None)
+                        ),
                     },
                 }
                 for t in server_tools
@@ -1213,6 +1215,17 @@ def _make_check_fn(server_name: str):
 # Discovery & registration
 # ---------------------------------------------------------------------------
 
+def _normalize_mcp_input_schema(schema: dict | None) -> dict:
+    """Normalize MCP input schemas for LLM tool-calling compatibility."""
+    if not schema:
+        return {"type": "object", "properties": {}}
+
+    if schema.get("type") == "object" and "properties" not in schema:
+        return {**schema, "properties": {}}
+
+    return schema
+
+
 def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
     """Convert an MCP tool listing to the Hermes registry schema format.
 
@@ -1231,10 +1244,7 @@ def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
     return {
         "name": prefixed_name,
         "description": mcp_tool.description or f"MCP tool {mcp_tool.name} from {server_name}",
-        "parameters": mcp_tool.inputSchema if mcp_tool.inputSchema else {
-            "type": "object",
-            "properties": {},
-        },
+        "parameters": _normalize_mcp_input_schema(mcp_tool.inputSchema),
     }
 
 


### PR DESCRIPTION
## What does this PR do?

Normalises MCP tool input schemas that declare `{"type": "object"}` without a `properties` field before forwarding them to the LLM tool-calling API. This fixes a `400 Bad Request` from OpenAI when an MCP server exposes a bare object schema, such as Crawl4AI's `ask` tool:

```text
Invalid schema for function 'mcp_crawl4ai_ask':
In context=(), object schema missing properties.
```

The normalisation is applied in both MCP tool discovery/registration and the MCP sampling callback when server-provided tools are forwarded to the model, which are the only two places I could find the MCP tool schema reaching the model.

Regression tests covering both paths included.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

 ## Changes Made

- Added `_normalize_mcp_input_schema()` in `tools/mcp_tool.py` [used USian spelling for codebase consistency ;p]
- Updated MCP schema conversion in `tools/mcp_tool.py` to normalise bare object schemas before registration
- Updated the sampling callback in `tools/mcp_tool.py` to normalise server-provided tool schemas before forwarding them to the model
- Added a regression test in `tests/tools/test_mcp_tool.py` for MCP tool schemas with `{"type": "object"}` and no `properties`
- Added a regression test in `tests/tools/test_mcp_tool.py` covering the sampling callback path for server-provided tools with the same schema shape

## How to Test

1. Run:
   ```bash
   pytest tests/tools/test_mcp_tool.py -q tests/tools/test_mcp_tool_issue_948.py -q
   ```
2. Verify the MCP tests pass, including the new regression coverage for object schemas without `properties`.
3. Reproduce against an MCP server exposing a tool with `{"type": "object"}` input schema and confirm the gateway no longer sends an OpenAI-invalid function schema for that tool.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A