### PR TITLE
feat(provider): named provider presets with /provider switching and hermes provider CLI

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2535,9 +2535,65 @@ class GatewayRunner:
             aliases = f"  _(also: {', '.join(p['aliases'])})_" if p["aliases"] else ""
             lines.append(f"{auth} `{p['id']}` — {p['label']}{aliases}{marker}")
 
+        # Show presets if any
+        from hermes_cli.runtime_provider import list_provider_presets, get_default_preset_name
+        presets = list_provider_presets()
+        if presets:
+            lines.append("")
+            lines.append("**Provider presets** (from config.yaml):")
+            default_preset = get_default_preset_name()
+            for pname, pcfg in presets.items():
+                ptype = pcfg.get("type", "openai-compatible")
+                pmodel = pcfg.get("model", "")
+                marker = " <- default" if pname == default_preset else ""
+                lines.append("* `{}` -- {} / {}{}".format(pname, ptype, pmodel, marker))
+            lines.append("")
+            lines.append("Switch preset: `/provider <name>`")
         lines.append("")
-        lines.append("Switch: `/model provider:model-name`")
+        lines.append("Switch model: `/model provider:model-name`")
         lines.append("Setup: `hermes setup`")
+
+        # Handle switching: /provider <name>
+        args = event.get_command_args().strip()
+        if args:
+            from hermes_cli.runtime_provider import get_provider_preset
+            preset = get_provider_preset(args)
+            if preset is None:
+                available = ", ".join(presets.keys()) if presets else "none"
+                return "Unknown provider preset: `{}`\nAvailable: {}".format(args, available)
+            ptype = preset.get("type", "openai-compatible")
+            pmodel = preset.get("model", "")
+            pbase_url = preset.get("base_url", "")
+            papi_key = preset.get("api_key", "")
+            if pmodel:
+                os.environ["HERMES_MODEL"] = pmodel
+            if papi_key:
+                os.environ["OPENAI_API_KEY"] = papi_key
+            if pbase_url:
+                os.environ["OPENAI_BASE_URL"] = pbase_url
+            else:
+                os.environ.pop("OPENAI_BASE_URL", None)
+            os.environ["HERMES_INFERENCE_PROVIDER"] = ptype
+            try:
+                import yaml as _yaml
+                config_path = _hermes_home / "config.yaml"
+                user_config = {}
+                if config_path.exists():
+                    with open(config_path, encoding="utf-8") as f:
+                        user_config = _yaml.safe_load(f) or {}
+                if "model" not in user_config or not isinstance(user_config["model"], dict):
+                    user_config["model"] = {}
+                if pmodel:
+                    user_config["model"]["default"] = pmodel
+                user_config["model"]["provider"] = ptype
+                with open(config_path, "w", encoding="utf-8") as f:
+                    _yaml.dump(user_config, f, default_flow_style=False, sort_keys=False)
+            except Exception as e:
+                return "Switched to preset `{}` (session only -- could not save: {})".format(args, e)
+            self._effective_model = None
+            self._effective_provider = None
+            return "Switched to provider preset `{}` ({} / {})\n_(takes effect on next message)_".format(args, ptype, pmodel)
+
         return "\n".join(lines)
     
     async def _handle_personality_command(self, event: MessageEvent) -> str:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -300,6 +300,13 @@ DEFAULT_CONFIG = {
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
     },
 
+    # Provider presets — named provider configurations for easy switching.
+    # Use /provider <name> in gateway or "hermes provider set <name>" in CLI.
+    # Supports env var interpolation: ${ENV_VAR}
+    "providers": {},
+    # Default provider preset name to use on startup (empty = use model.provider)
+    "default_provider": "",
+
     # Subagent delegation — override the provider:model used by delegate_task
     # so child agents can run on a different (cheaper/faster) provider and model.
     # Uses the same runtime provider resolution as CLI/gateway startup, so all

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3507,6 +3507,22 @@ For more help on a command:
     skills_parser.set_defaults(func=cmd_skills)
 
     # =========================================================================
+    # provider command
+    # =========================================================================
+    provider_parser = subparsers.add_parser("provider", help="Manage provider presets")
+    provider_subparsers = provider_parser.add_subparsers(dest="provider_action")
+    provider_subparsers.add_parser("list", help="List all configured provider presets")
+    provider_set = provider_subparsers.add_parser("set", help="Switch to a provider preset")
+    provider_set.add_argument("name", help="Preset name to switch to")
+    provider_show = provider_subparsers.add_parser("show", help="Show details of a provider preset")
+    provider_show.add_argument("name", help="Preset name to show")
+    def cmd_provider(args):
+        from hermes_cli.provider_cmd import cmd_provider as _cmd
+        _cmd(args)
+    provider_parser.set_defaults(func=cmd_provider)
+
+
+    # =========================================================================
     # honcho command
     # =========================================================================
     honcho_parser = subparsers.add_parser(

--- a/hermes_cli/provider_cmd.py
+++ b/hermes_cli/provider_cmd.py
@@ -1,0 +1,103 @@
+"""hermes provider CLI commands — list and switch provider presets."""
+from __future__ import annotations
+import os
+import sys
+from pathlib import Path
+
+
+def cmd_provider(args):
+    from hermes_cli.runtime_provider import (
+        list_provider_presets,
+        get_provider_preset,
+        get_default_preset_name,
+    )
+    action = getattr(args, "provider_action", None)
+
+    if action == "list" or action is None:
+        presets = list_provider_presets()
+        default_name = get_default_preset_name()
+        if not presets:
+            print("No provider presets configured.")
+            print("Add a 'providers' section to ~/.hermes/config.yaml")
+            print("")
+            print("Example:")
+            print("  providers:")
+            print("    local:")
+            print("      type: openai-compatible")
+            print("      model: meta-llama/Llama-3.3-70B-Instruct")
+            print("      base_url: http://localhost:8000/v1")
+            print("      api_key: dummy")
+            print("  default_provider: local")
+            return
+        print("Provider presets:")
+        for name, cfg in presets.items():
+            ptype = cfg.get("type", "openai-compatible")
+            pmodel = cfg.get("model", "")
+            pbase = cfg.get("base_url", "")
+            marker = " [default]" if name == default_name else ""
+            print("  {}{}".format(name, marker))
+            print("    type:  {}".format(ptype))
+            if pmodel:
+                print("    model: {}".format(pmodel))
+            if pbase:
+                print("    url:   {}".format(pbase))
+
+    elif action == "set":
+        name = args.name
+        from hermes_cli.runtime_provider import get_provider_preset
+        preset = get_provider_preset(name)
+        if preset is None:
+            presets = list_provider_presets()
+            available = ", ".join(presets.keys()) if presets else "none"
+            print("Unknown provider preset: {}".format(name))
+            print("Available: {}".format(available))
+            sys.exit(1)
+        ptype = preset.get("type", "openai-compatible")
+        pmodel = preset.get("model", "")
+        pbase_url = preset.get("base_url", "")
+        papi_key = preset.get("api_key", "")
+        # Apply to env
+        if pmodel:
+            os.environ["HERMES_MODEL"] = pmodel
+        if papi_key:
+            os.environ["OPENAI_API_KEY"] = papi_key
+        if pbase_url:
+            os.environ["OPENAI_BASE_URL"] = pbase_url
+        else:
+            os.environ.pop("OPENAI_BASE_URL", None)
+        os.environ["HERMES_INFERENCE_PROVIDER"] = ptype
+        # Persist to config
+        try:
+            import yaml
+            hermes_home = Path(os.getenv("HERMES_HOME", str(Path.home() / ".hermes")))
+            config_path = hermes_home / "config.yaml"
+            user_config = {}
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+            if "model" not in user_config or not isinstance(user_config["model"], dict):
+                user_config["model"] = {}
+            if pmodel:
+                user_config["model"]["default"] = pmodel
+            user_config["model"]["provider"] = ptype
+            with open(config_path, "w", encoding="utf-8") as f:
+                yaml.dump(user_config, f, default_flow_style=False, sort_keys=False)
+            print("Switched to provider preset: {} ({} / {})".format(name, ptype, pmodel))
+            print("Saved to config.")
+        except Exception as e:
+            print("Switched to preset {} (session only — could not save: {})".format(name, e))
+
+    elif action == "show":
+        name = args.name
+        preset = get_provider_preset(name)
+        if preset is None:
+            print("Unknown provider preset: {}".format(name))
+            sys.exit(1)
+        print("Preset: {}".format(name))
+        for k, v in preset.items():
+            if k == "api_key" and v:
+                print("  {}: {}...".format(k, str(v)[:8]))
+            else:
+                print("  {}: {}".format(k, v))
+    else:
+        print("Usage: hermes provider [list|set <name>|show <name>]")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -43,6 +43,50 @@ def _auto_detect_local_model(base_url: str) -> str:
     except Exception:
         pass
     return ""
+def _expand_env_vars(value: str) -> str:
+    """Expand ${ENV_VAR} patterns in config values."""
+    import re
+    def replacer(m):
+        return os.environ.get(m.group(1), m.group(0))
+    return re.sub(r"\$\{([^}]+)\}", replacer, value)
+
+
+def get_provider_preset(name: str) -> Optional[Dict[str, Any]]:
+    """Return a named provider preset from config, or None if not found."""
+    config = load_config()
+    presets = config.get("providers", {})
+    if not isinstance(presets, dict):
+        return None
+    preset = presets.get(name)
+    if not isinstance(preset, dict):
+        return None
+    result = {}
+    for k, v in preset.items():
+        result[k] = _expand_env_vars(str(v)) if isinstance(v, str) else v
+    return result
+
+
+def list_provider_presets() -> Dict[str, Dict[str, Any]]:
+    """Return all named provider presets from config."""
+    config = load_config()
+    presets = config.get("providers", {})
+    if not isinstance(presets, dict):
+        return {}
+    result = {}
+    for name, preset in presets.items():
+        if isinstance(preset, dict):
+            expanded = {}
+            for k, v in preset.items():
+                expanded[k] = _expand_env_vars(str(v)) if isinstance(v, str) else v
+            result[name] = expanded
+    return result
+
+
+def get_default_preset_name() -> Optional[str]:
+    """Return the configured default_provider preset name, or None."""
+    config = load_config()
+    name = config.get("default_provider", "")
+    return name.strip() if isinstance(name, str) and name.strip() else None
 
 
 def _get_model_config() -> Dict[str, Any]:

--- a/tests/test_provider_presets.py
+++ b/tests/test_provider_presets.py
@@ -1,0 +1,184 @@
+"""Tests for provider presets feature (#1891)."""
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from hermes_cli.runtime_provider import (
+    _expand_env_vars,
+    get_provider_preset,
+    list_provider_presets,
+    get_default_preset_name,
+)
+
+
+SAMPLE_CONFIG = {
+    "providers": {
+        "local": {
+            "type": "openai-compatible",
+            "model": "meta-llama/Llama-3.3-70B-Instruct",
+            "base_url": "http://localhost:8000/v1",
+            "api_key": "dummy",
+        },
+        "openrouter": {
+            "type": "openrouter",
+            "model": "anthropic/claude-3.5-sonnet",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "${OPENROUTER_API_KEY}",
+        },
+        "anthropic": {
+            "type": "anthropic",
+            "model": "claude-sonnet-4-20250514",
+            "api_key": "${ANTHROPIC_API_KEY}",
+        },
+    },
+    "default_provider": "local",
+}
+
+
+# ---------------------------------------------------------------------------
+# _expand_env_vars
+# ---------------------------------------------------------------------------
+
+def test_expand_env_vars_substitutes_known_var(monkeypatch):
+    monkeypatch.setenv("MY_KEY", "secret123")
+    assert _expand_env_vars("${MY_KEY}") == "secret123"
+
+
+def test_expand_env_vars_keeps_unknown_var():
+    result = _expand_env_vars("${UNDEFINED_VAR_XYZ}")
+    assert result == "${UNDEFINED_VAR_XYZ}"
+
+
+def test_expand_env_vars_no_vars():
+    assert _expand_env_vars("plain string") == "plain string"
+
+
+def test_expand_env_vars_multiple(monkeypatch):
+    monkeypatch.setenv("A", "hello")
+    monkeypatch.setenv("B", "world")
+    assert _expand_env_vars("${A}-${B}") == "hello-world"
+
+
+# ---------------------------------------------------------------------------
+# get_provider_preset
+# ---------------------------------------------------------------------------
+
+def test_get_provider_preset_returns_known():
+    with patch("hermes_cli.runtime_provider.load_config", return_value=SAMPLE_CONFIG):
+        preset = get_provider_preset("local")
+    assert preset is not None
+    assert preset["type"] == "openai-compatible"
+    assert preset["model"] == "meta-llama/Llama-3.3-70B-Instruct"
+
+
+def test_get_provider_preset_returns_none_for_unknown():
+    with patch("hermes_cli.runtime_provider.load_config", return_value=SAMPLE_CONFIG):
+        assert get_provider_preset("nonexistent") is None
+
+
+def test_get_provider_preset_expands_env_vars(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key-abc")
+    with patch("hermes_cli.runtime_provider.load_config", return_value=SAMPLE_CONFIG):
+        preset = get_provider_preset("openrouter")
+    assert preset["api_key"] == "or-key-abc"
+
+
+def test_get_provider_preset_no_base_url_for_anthropic():
+    with patch("hermes_cli.runtime_provider.load_config", return_value=SAMPLE_CONFIG):
+        preset = get_provider_preset("anthropic")
+    assert preset is not None
+    assert "base_url" not in preset
+
+
+def test_get_provider_preset_empty_providers():
+    with patch("hermes_cli.runtime_provider.load_config", return_value={}):
+        assert get_provider_preset("local") is None
+
+
+# ---------------------------------------------------------------------------
+# list_provider_presets
+# ---------------------------------------------------------------------------
+
+def test_list_provider_presets_returns_all():
+    with patch("hermes_cli.runtime_provider.load_config", return_value=SAMPLE_CONFIG):
+        presets = list_provider_presets()
+    assert set(presets.keys()) == {"local", "openrouter", "anthropic"}
+
+
+def test_list_provider_presets_empty():
+    with patch("hermes_cli.runtime_provider.load_config", return_value={}):
+        assert list_provider_presets() == {}
+
+
+def test_list_provider_presets_invalid_type():
+    config = {"providers": "not-a-dict"}
+    with patch("hermes_cli.runtime_provider.load_config", return_value=config):
+        assert list_provider_presets() == {}
+
+
+# ---------------------------------------------------------------------------
+# get_default_preset_name
+# ---------------------------------------------------------------------------
+
+def test_get_default_preset_name():
+    with patch("hermes_cli.runtime_provider.load_config", return_value=SAMPLE_CONFIG):
+        assert get_default_preset_name() == "local"
+
+
+def test_get_default_preset_name_empty():
+    with patch("hermes_cli.runtime_provider.load_config", return_value={}):
+        assert get_default_preset_name() is None
+
+
+def test_get_default_preset_name_whitespace():
+    config = {"default_provider": "  "}
+    with patch("hermes_cli.runtime_provider.load_config", return_value=config):
+        assert get_default_preset_name() is None
+
+
+# ---------------------------------------------------------------------------
+# cmd_provider CLI
+# ---------------------------------------------------------------------------
+
+def test_cmd_provider_list_no_presets(capsys):
+    with patch("hermes_cli.runtime_provider.load_config", return_value={}):
+        from hermes_cli.provider_cmd import cmd_provider
+        args = MagicMock()
+        args.provider_action = "list"
+        cmd_provider(args)
+    out = capsys.readouterr().out
+    assert "No provider presets configured" in out
+
+
+def test_cmd_provider_list_with_presets(capsys):
+    with patch("hermes_cli.runtime_provider.load_config", return_value=SAMPLE_CONFIG):
+        from hermes_cli.provider_cmd import cmd_provider
+        args = MagicMock()
+        args.provider_action = "list"
+        cmd_provider(args)
+    out = capsys.readouterr().out
+    assert "local" in out
+    assert "openrouter" in out
+    assert "[default]" in out
+
+
+def test_cmd_provider_show(capsys):
+    with patch("hermes_cli.runtime_provider.load_config", return_value=SAMPLE_CONFIG):
+        from hermes_cli.provider_cmd import cmd_provider
+        args = MagicMock()
+        args.provider_action = "show"
+        args.name = "local"
+        cmd_provider(args)
+    out = capsys.readouterr().out
+    assert "local" in out
+    assert "openai-compatible" in out
+
+
+def test_cmd_provider_show_unknown(capsys):
+    import sys
+    with patch("hermes_cli.runtime_provider.load_config", return_value=SAMPLE_CONFIG):
+        from hermes_cli.provider_cmd import cmd_provider
+        args = MagicMock()
+        args.provider_action = "show"
+        args.name = "nonexistent"
+        with pytest.raises(SystemExit):
+            cmd_provider(args)


### PR DESCRIPTION
Closes #1891

## Summary

Adds named provider presets to `config.yaml` for non-destructive switching between providers.

## Config

```yaml
providers:
  anthropic:
    type: anthropic
    model: claude-sonnet-4-20250514
    api_key: ${ANTHROPIC_API_KEY}

  openrouter:
    type: openrouter
    model: anthropic/claude-3.5-sonnet
    base_url: https://openrouter.ai/api/v1
    api_key: ${OPENROUTER_API_KEY}

  local:
    type: openai-compatible
    model: meta-llama/Llama-3.3-70B-Instruct
    base_url: http://localhost:8000/v1
    api_key: dummy

default_provider: anthropic
```

## Changes

- **`hermes_cli/config.py`** — adds `providers: {}` and `default_provider: ""` to DEFAULT_CONFIG
- **`hermes_cli/runtime_provider.py`** — adds `get_provider_preset()`, `list_provider_presets()`, `get_default_preset_name()`, `_expand_env_vars()`
- **`gateway/run.py`** — extends `/provider` command to list presets and switch via `/provider <name>`
- **`hermes_cli/provider_cmd.py`** — new module for `hermes provider list/set/show` CLI commands
- **`hermes_cli/main.py`** — registers `hermes provider` subcommand

## Features

- `/provider <name>` in gateway — switches provider preset, persists to config
- `hermes provider list` — lists all configured presets with default marker
- `hermes provider set <name>` — switches preset from CLI
- `hermes provider show <name>` — shows preset details
- `${ENV_VAR}` interpolation in preset values
- Persists to `~/.hermes/config.yaml` on switch

## Testing

- 19 new tests covering env var expansion, preset lookup, list, CLI commands
- 44 passed, 0 failed