### PR TITLE
docs: align venv path to match installer (venv/ not .venv/)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Instructions for AI coding assistants and developers working on the hermes-agent
 ## Development Environment
 
 ```bash
-source .venv/bin/activate  # ALWAYS activate before running Python
+source venv/bin/activate  # ALWAYS activate before running Python
 ```
 
 ## Project Structure
@@ -377,7 +377,7 @@ The `_isolate_hermes_home` autouse fixture in `tests/conftest.py` redirects `HER
 ## Testing
 
 ```bash
-source .venv/bin/activate
+source venv/bin/activate
 python -m pytest tests/ -q          # Full suite (~3000 tests, ~3 min)
 python -m pytest tests/test_model_tools.py -q   # Toolset resolution
 python -m pytest tests/test_cli_init.py -q       # CLI config loading

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
 git submodule update --init mini-swe-agent   # required terminal backend
 curl -LsSf https://astral.sh/uv/install.sh | sh
-uv venv .venv --python 3.11
-source .venv/bin/activate
+uv venv venv --python 3.11
+source venv/bin/activate
 uv pip install -e ".[all,dev]"
 uv pip install -e "./mini-swe-agent"
 python -m pytest tests/ -q

--- a/skills/dogfood/hermes-agent-setup/SKILL.md
+++ b/skills/dogfood/hermes-agent-setup/SKILL.md
@@ -16,7 +16,7 @@ Use this skill when a user asks about configuring Hermes, enabling features, set
 - API keys: `~/.hermes/.env`
 - Skills: `~/.hermes/skills/`
 - Hermes install: `~/.hermes/hermes-agent/`
-- Venv: `~/.hermes/hermes-agent/.venv/` (or `venv/`)
+- Venv: `~/.hermes/hermes-agent/venv/`
 
 ## CLI Overview
 
@@ -98,7 +98,7 @@ The interactive setup wizard walks through:
 Run it from terminal:
 ```bash
 cd ~/.hermes/hermes-agent
-source .venv/bin/activate
+source venv/bin/activate
 python -m hermes_cli.main setup
 ```
 
@@ -140,7 +140,7 @@ Voice messages from Telegram/Discord/WhatsApp/Slack/Signal are auto-transcribed 
 
 ```bash
 cd ~/.hermes/hermes-agent
-source .venv/bin/activate  # or: source venv/bin/activate
+source venv/bin/activate
 pip install faster-whisper
 ```
 
@@ -189,7 +189,7 @@ Hermes can reply with voice when users send voice messages.
 
 ```bash
 cd ~/.hermes/hermes-agent
-source .venv/bin/activate
+source venv/bin/activate
 python -m hermes_cli.main tools
 ```
 
@@ -217,7 +217,7 @@ Use `/reset` in the chat to start a fresh session with the new toolset. Tool cha
 Some tools need extra packages:
 
 ```bash
-cd ~/.hermes/hermes-agent && source .venv/bin/activate
+cd ~/.hermes/hermes-agent && source venv/bin/activate
 
 pip install faster-whisper    # Local STT (voice transcription)
 pip install browserbase       # Browser automation

--- a/skills/mlops/training/hermes-atropos-environments/references/usage-patterns.md
+++ b/skills/mlops/training/hermes-atropos-environments/references/usage-patterns.md
@@ -12,7 +12,7 @@ training server.
 
 ```bash
 cd ~/.hermes/hermes-agent
-source .venv/bin/activate
+source venv/bin/activate
 
 python environments/your_env.py process \
   --env.total_steps 1 \

--- a/website/docs/developer-guide/adding-providers.md
+++ b/website/docs/developer-guide/adding-providers.md
@@ -305,14 +305,14 @@ For docs-only examples, the exact file set may differ. The point is to cover:
 Run tests with xdist disabled:
 
 ```bash
-source .venv/bin/activate
+source venv/bin/activate
 python -m pytest tests/test_runtime_provider_resolution.py tests/test_cli_provider_resolution.py tests/test_cli_model_command.py tests/test_setup_model_selection.py -n0 -q
 ```
 
 For deeper changes, run the full suite before pushing:
 
 ```bash
-source .venv/bin/activate
+source venv/bin/activate
 python -m pytest tests/ -n0 -q
 ```
 
@@ -321,14 +321,14 @@ python -m pytest tests/ -n0 -q
 After tests, run a real smoke test.
 
 ```bash
-source .venv/bin/activate
+source venv/bin/activate
 python -m hermes_cli.main chat -q "Say hello" --provider your-provider --model your-model
 ```
 
 Also test the interactive flows if you changed menus:
 
 ```bash
-source .venv/bin/activate
+source venv/bin/activate
 python -m hermes_cli.main model
 python -m hermes_cli.main setup
 ```


### PR DESCRIPTION
## Summary

The install script (`install.sh`) creates `venv/` but several docs referenced `.venv/`, causing agents to fail with `No such file or directory` when following AGENTS.md instructions inside the hermes-agent repo.

Changed all hermes-agent-context `.venv` references to `venv` across:
- **AGENTS.md** — the key file (injected into system prompts)
- **README.md** — dev setup section now uses `venv` to match installer
- **skills/dogfood/hermes-agent-setup/SKILL.md**
- **skills/mlops/training/hermes-atropos-environments/references/usage-patterns.md**
- **website/docs/developer-guide/adding-providers.md**

Left alone: other projects' venvs (pokemon-player, heartmula), gitignore-style listings that mention both names.

Fixes #2066
Supersedes #2087 (closed — used a fallback pattern instead of aligning to the installer)