### PR TITLE
Enforce always-on core toolsets in setup and runtime

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7029,11 +7029,16 @@ def main(
                     toolsets_list.append(str(t))
     else:
         # Check config for CLI toolsets, fallback to hermes-cli
-        config_cli_toolsets = CLI_CONFIG.get("platform_toolsets", {}).get("cli")
-        if config_cli_toolsets and isinstance(config_cli_toolsets, list):
-            toolsets_list = config_cli_toolsets
-        else:
-            toolsets_list = ["hermes-cli"]
+        try:
+            from hermes_cli.tools_config import get_platform_runtime_toolsets
+
+            toolsets_list = get_platform_runtime_toolsets(CLI_CONFIG, "cli")
+        except Exception:
+            config_cli_toolsets = CLI_CONFIG.get("platform_toolsets", {}).get("cli")
+            if config_cli_toolsets and isinstance(config_cli_toolsets, list):
+                toolsets_list = config_cli_toolsets
+            else:
+                toolsets_list = ["hermes-cli"]
     
     parsed_skills = _parse_skills_argument(skills)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3225,12 +3225,20 @@ class GatewayRunner:
                 Platform.DINGTALK: "dingtalk",
             }.get(source.platform, "telegram")
 
-            config_toolsets = platform_toolsets_config.get(platform_config_key)
-            if config_toolsets and isinstance(config_toolsets, list):
-                enabled_toolsets = config_toolsets
-            else:
-                default_toolset = default_toolset_map.get(source.platform, "hermes-telegram")
-                enabled_toolsets = [default_toolset]
+            try:
+                from hermes_cli.tools_config import get_platform_runtime_toolsets
+
+                enabled_toolsets = get_platform_runtime_toolsets(
+                    {"platform_toolsets": platform_toolsets_config},
+                    platform_config_key,
+                )
+            except Exception:
+                config_toolsets = platform_toolsets_config.get(platform_config_key)
+                if config_toolsets and isinstance(config_toolsets, list):
+                    enabled_toolsets = config_toolsets
+                else:
+                    default_toolset = default_toolset_map.get(source.platform, "hermes-telegram")
+                    enabled_toolsets = [default_toolset]
 
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
 
@@ -4336,12 +4344,20 @@ class GatewayRunner:
         }.get(source.platform, "telegram")
         
         # Use config override if present (list of toolsets), otherwise hardcoded default
-        config_toolsets = platform_toolsets_config.get(platform_config_key)
-        if config_toolsets and isinstance(config_toolsets, list):
-            enabled_toolsets = config_toolsets
-        else:
-            default_toolset = default_toolset_map.get(source.platform, "hermes-telegram")
-            enabled_toolsets = [default_toolset]
+        try:
+            from hermes_cli.tools_config import get_platform_runtime_toolsets
+
+            enabled_toolsets = get_platform_runtime_toolsets(
+                {"platform_toolsets": platform_toolsets_config},
+                platform_config_key,
+            )
+        except Exception:
+            config_toolsets = platform_toolsets_config.get(platform_config_key)
+            if config_toolsets and isinstance(config_toolsets, list):
+                enabled_toolsets = config_toolsets
+            else:
+                default_toolset = default_toolset_map.get(source.platform, "hermes-telegram")
+                enabled_toolsets = [default_toolset]
         
         # Tool progress mode from config.yaml: "all", "new", "verbose", "off"
         # Falls back to env vars for backward compatibility

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -163,9 +163,10 @@ def _ensure_user_systemd_env() -> None:
     """
     uid = os.getuid()
     if "XDG_RUNTIME_DIR" not in os.environ:
-        runtime_dir = f"/run/user/{uid}"
-        if Path(runtime_dir).exists():
-            os.environ["XDG_RUNTIME_DIR"] = runtime_dir
+        # Set the canonical per-user runtime dir even when the path is not
+        # mounted yet. systemctl/journalctl expect this conventional location,
+        # and the bus-path existence check below remains the safety gate.
+        os.environ["XDG_RUNTIME_DIR"] = f"/run/user/{uid}"
 
     if "DBUS_SESSION_BUS_ADDRESS" not in os.environ:
         xdg_runtime = os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{uid}")

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -72,29 +72,38 @@ def _prompt_yes_no(question: str, default: bool = True) -> bool:
 
 # ─── Toolset Registry ─────────────────────────────────────────────────────────
 
+# Toolsets that are always enabled and are not user-toggleable.
+CORE_TOOLSETS = [
+    ("terminal",        "💻 Terminal & Processes",      "terminal, process"),
+    ("file",            "📁 File Operations",           "read, write, patch, search"),
+    ("code_execution",  "⚡ Code Execution",            "execute_code"),
+    ("skills",          "📚 Skills",                    "list, view, manage"),
+    ("todo",            "📋 Task Planning",             "todo"),
+    ("memory",          "💾 Memory",                    "persistent memory across sessions"),
+    ("session_search",  "🔎 Session Search",            "search past conversations"),
+    ("delegation",      "👥 Task Delegation",           "delegate_task"),
+]
+
+CORE_TOOLSET_KEYS = {ts_key for ts_key, _, _ in CORE_TOOLSETS}
+
 # Toolsets shown in the configurator, grouped for display.
 # Each entry: (toolset_name, label, description)
 # These map to keys in toolsets.py TOOLSETS dict.
 CONFIGURABLE_TOOLSETS = [
     ("web",             "🔍 Web Search & Scraping",    "web_search, web_extract"),
     ("browser",         "🌐 Browser Automation",       "navigate, click, type, scroll"),
-    ("terminal",        "💻 Terminal & Processes",      "terminal, process"),
-    ("file",            "📁 File Operations",           "read, write, patch, search"),
-    ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
-    ("skills",          "📚 Skills",                    "list, view, manage"),
-    ("todo",            "📋 Task Planning",             "todo"),
-    ("memory",          "💾 Memory",                    "persistent memory across sessions"),
-    ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
-    ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
 ]
+
+_ALL_BUILTIN_TOOLSETS = CORE_TOOLSETS + CONFIGURABLE_TOOLSETS
+_ALL_BUILTIN_TOOLSET_KEYS = {ts_key for ts_key, _, _ in _ALL_BUILTIN_TOOLSETS}
 
 # Toolsets that are OFF by default for new installs.
 # They're still in _HERMES_CORE_TOOLS (available at runtime if enabled),
@@ -356,43 +365,58 @@ def _platform_toolset_summary(config: dict, platforms: Optional[List[str]] = Non
     return summary
 
 
-def _get_platform_tools(config: dict, platform: str) -> Set[str]:
-    """Resolve which individual toolset names are enabled for a platform."""
-    from toolsets import resolve_toolset, TOOLSETS
-
+def _resolve_platform_toolset_names(config: dict, platform: str) -> List[str]:
+    """Return stored toolset entries for a platform, or its legacy default."""
     platform_toolsets = config.get("platform_toolsets", {})
     toolset_names = platform_toolsets.get(platform)
 
     if toolset_names is None or not isinstance(toolset_names, list):
         default_ts = PLATFORMS[platform]["default_toolset"]
-        toolset_names = [default_ts]
+        return [default_ts]
+    return toolset_names
+
+
+def _get_platform_tools(config: dict, platform: str) -> Set[str]:
+    """Resolve runtime toolsets for a platform, including always-on core toolsets."""
+    from toolsets import resolve_toolset
+
+    toolset_names = _resolve_platform_toolset_names(config, platform)
 
     # Resolve to individual tool names, then map back to which
-    # configurable toolsets are covered
+    # built-in toolsets are covered.
     all_tool_names = set()
     for ts_name in toolset_names:
         all_tool_names.update(resolve_toolset(ts_name))
 
-    # Map individual tool names back to configurable toolset keys
+    # Map individual tool names back to built-in toolset keys.
     enabled_toolsets = set()
-    for ts_key, _, _ in CONFIGURABLE_TOOLSETS:
+    for ts_key, _, _ in _ALL_BUILTIN_TOOLSETS:
         ts_tools = set(resolve_toolset(ts_key))
         if ts_tools and ts_tools.issubset(all_tool_names):
             enabled_toolsets.add(ts_key)
 
+    enabled_toolsets.update(CORE_TOOLSET_KEYS)
     return enabled_toolsets
+
+
+def _get_optional_platform_tools(config: dict, platform: str) -> Set[str]:
+    """Resolve user-selectable optional toolsets for a platform."""
+    return _get_platform_tools(config, platform) - CORE_TOOLSET_KEYS
+
+
+def get_platform_runtime_toolsets(config: dict, platform: str) -> List[str]:
+    """Return sorted runtime toolset names for a platform."""
+    return sorted(_get_platform_tools(config, platform))
 
 
 def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[str]):
     """Save the selected toolset keys for a platform to config.
 
     Preserves any non-configurable toolset entries (like MCP server names)
-    that were already in the config for this platform.
+    that were already in the config for this platform. Core toolsets are
+    always re-added even if callers omit them.
     """
     config.setdefault("platform_toolsets", {})
-
-    # Get the set of all configurable toolset keys
-    configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
 
     # Get existing toolsets for this platform
     existing_toolsets = config.get("platform_toolsets", {}).get(platform, [])
@@ -402,11 +426,12 @@ def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[
     # Preserve any entries that are NOT configurable toolsets (i.e. MCP server names)
     preserved_entries = {
         entry for entry in existing_toolsets
-        if entry not in configurable_keys
+        if entry not in _ALL_BUILTIN_TOOLSET_KEYS
     }
 
-    # Merge preserved entries with new enabled toolsets
-    config["platform_toolsets"][platform] = sorted(enabled_toolset_keys | preserved_entries)
+    # Merge preserved entries with core + selected optional toolsets
+    builtin_entries = CORE_TOOLSET_KEYS | set(enabled_toolset_keys)
+    config["platform_toolsets"][platform] = sorted(builtin_entries | preserved_entries)
     save_config(config)
 
 
@@ -521,7 +546,7 @@ def _prompt_choice(question: str, choices: list, default: int = 0) -> int:
 
 
 def _prompt_toolset_checklist(platform_label: str, enabled: Set[str]) -> Set[str]:
-    """Multi-select checklist of toolsets. Returns set of selected toolset keys."""
+    """Multi-select checklist of optional toolsets. Returns selected toolset keys."""
     from hermes_cli.curses_ui import curses_checklist
 
     labels = []
@@ -936,14 +961,20 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
         for pkey in enabled_platforms:
             pinfo = PLATFORMS[pkey]
             enabled = summary.get(pkey, set())
-            count = len(enabled)
+            count = len(enabled - CORE_TOOLSET_KEYS)
             print(color(f"  {pinfo['label']}", Colors.BOLD) + color(f"  ({count}/{total})", Colors.DIM))
+            print(color("    Core:", Colors.DIM))
+            for ts_key, label, _ in CORE_TOOLSETS:
+                print(color(f"      ✓ {label}", Colors.GREEN))
             if enabled:
+                print(color("    Optional:", Colors.DIM))
                 for ts_key in sorted(enabled):
+                    if ts_key in CORE_TOOLSET_KEYS:
+                        continue
                     label = next((l for k, l, _ in CONFIGURABLE_TOOLSETS if k == ts_key), ts_key)
                     print(color(f"    ✓ {label}", Colors.GREEN))
-            else:
-                print(color("    (none enabled)", Colors.DIM))
+                if not (enabled - CORE_TOOLSET_KEYS):
+                    print(color("      (none enabled)", Colors.DIM))
         print()
         return
     print(color("⚕ Hermes Tool Configuration", Colors.CYAN, Colors.BOLD))
@@ -955,7 +986,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
     if first_install:
         for pkey in enabled_platforms:
             pinfo = PLATFORMS[pkey]
-            current_enabled = _get_platform_tools(config, pkey)
+            current_enabled = _get_optional_platform_tools(config, pkey)
 
             # Uncheck toolsets that should be off by default
             checklist_preselected = current_enabled - _DEFAULT_OFF_TOOLSETS
@@ -1054,11 +1085,11 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
             # Use the union of all platforms' current tools as the starting state
             all_current = set()
             for pk in platform_keys:
-                all_current |= _get_platform_tools(config, pk)
+                all_current |= _get_optional_platform_tools(config, pk)
             new_enabled = _prompt_toolset_checklist("All platforms", all_current)
             if new_enabled != all_current:
                 for pk in platform_keys:
-                    prev = _get_platform_tools(config, pk)
+                    prev = _get_optional_platform_tools(config, pk)
                     added = new_enabled - prev
                     removed = prev - new_enabled
                     pinfo_inner = PLATFORMS[pk]
@@ -1080,7 +1111,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                 print(color("  ✓ Saved configuration for all platforms", Colors.GREEN))
                 # Update choice labels
                 for ci, pk in enumerate(platform_keys):
-                    new_count = len(_get_platform_tools(config, pk))
+                    new_count = len(_get_optional_platform_tools(config, pk))
                     total = len(CONFIGURABLE_TOOLSETS)
                     platform_choices[ci] = f"Configure {PLATFORMS[pk]['label']}  ({new_count}/{total} enabled)"
             else:
@@ -1092,7 +1123,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
         pinfo = PLATFORMS[pkey]
 
         # Get current enabled toolsets for this platform
-        current_enabled = _get_platform_tools(config, pkey)
+        current_enabled = _get_optional_platform_tools(config, pkey)
 
         # Show checklist
         new_enabled = _prompt_toolset_checklist(pinfo["label"], current_enabled)
@@ -1125,7 +1156,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
         print()
 
         # Update the choice label with new count
-        new_count = len(_get_platform_tools(config, pkey))
+        new_count = len(_get_optional_platform_tools(config, pkey))
         total = len(CONFIGURABLE_TOOLSETS)
         platform_choices[idx] = f"Configure {pinfo['label']}  ({new_count}/{total} enabled)"
 
@@ -1271,7 +1302,7 @@ def _configure_mcp_tools_interactive(config: dict):
 
 def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str], action: str):
     """Add or remove built-in toolsets for a platform."""
-    enabled = _get_platform_tools(config, platform)
+    enabled = _get_optional_platform_tools(config, platform)
     if action == "disable":
         updated = enabled - set(toolset_names)
     else:
@@ -1307,6 +1338,10 @@ def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]
 def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = "cli"):
     """Print a summary of enabled/disabled toolsets and MCP tool filters."""
     print(f"Built-in toolsets ({platform}):")
+    print("  Core toolsets (always enabled):")
+    for ts_key, label, _ in CORE_TOOLSETS:
+        print(f"  {color('✓ enabled', Colors.GREEN)}  {ts_key}  {color(label, Colors.DIM)}")
+    print("  Optional toolsets:")
     for ts_key, label, _ in CONFIGURABLE_TOOLSETS:
         status = (color("✓ enabled", Colors.GREEN) if ts_key in enabled_toolsets
                   else color("✗ disabled", Colors.RED))
@@ -1350,6 +1385,12 @@ def tools_disable_enable_command(args):
     toolset_targets = [t for t in targets if ":" not in t]
     mcp_targets = [t for t in targets if ":" in t]
 
+    core_targets = [t for t in toolset_targets if t in CORE_TOOLSET_KEYS]
+    if core_targets:
+        for name in core_targets:
+            _print_error(f"Core toolset '{name}' is always enabled and cannot be {action}d")
+        toolset_targets = [t for t in toolset_targets if t not in CORE_TOOLSET_KEYS]
+
     valid_toolsets = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
     unknown_toolsets = [t for t in toolset_targets if t not in valid_toolsets]
     if unknown_toolsets:
@@ -1370,7 +1411,9 @@ def tools_disable_enable_command(args):
 
     successful = [
         t for t in targets
-        if t not in unknown_toolsets and (":" not in t or t.split(":")[0] not in failed_servers)
+        if t not in unknown_toolsets
+        and t not in core_targets
+        and (":" not in t or t.split(":")[0] not in failed_servers)
     ]
     if successful:
         verb = "Disabled" if action == "disable" else "Enabled"

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from hermes_cli.tools_config import (
+    CORE_TOOLSET_KEYS,
     _get_platform_tools,
     _platform_toolset_summary,
     _save_platform_tools,
@@ -23,7 +24,7 @@ def test_get_platform_tools_preserves_explicit_empty_selection():
 
     enabled = _get_platform_tools(config, "cli")
 
-    assert enabled == set()
+    assert enabled == CORE_TOOLSET_KEYS
 
 
 def test_platform_toolset_summary_uses_explicit_platform_list():
@@ -72,7 +73,7 @@ def test_save_platform_tools_preserves_mcp_server_names():
     assert "custom-mcp-server" in saved_toolsets
     assert "web" in saved_toolsets
     assert "browser" in saved_toolsets
-    assert "terminal" not in saved_toolsets
+    assert CORE_TOOLSET_KEYS.issubset(set(saved_toolsets))
 
 
 def test_save_platform_tools_handles_empty_existing_config():
@@ -84,7 +85,7 @@ def test_save_platform_tools_handles_empty_existing_config():
 
     saved_toolsets = config["platform_toolsets"]["telegram"]
     assert "web" in saved_toolsets
-    assert "terminal" in saved_toolsets
+    assert CORE_TOOLSET_KEYS.issubset(set(saved_toolsets))
 
 
 def test_save_platform_tools_handles_invalid_existing_config():
@@ -100,3 +101,4 @@ def test_save_platform_tools_handles_invalid_existing_config():
 
     saved_toolsets = config["platform_toolsets"]["cli"]
     assert "web" in saved_toolsets
+    assert CORE_TOOLSET_KEYS.issubset(set(saved_toolsets))

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -2,7 +2,7 @@
 from argparse import Namespace
 from unittest.mock import patch
 
-from hermes_cli.tools_config import tools_disable_enable_command
+from hermes_cli.tools_config import CORE_TOOLSET_KEYS, tools_disable_enable_command
 
 
 # ── Built-in toolset disable ────────────────────────────────────────────────
@@ -26,7 +26,7 @@ class TestToolsDisableBuiltin:
             tools_disable_enable_command(Namespace(tools_action="disable", names=["web", "memory"], platform="cli"))
         saved = mock_save.call_args[0][0]
         assert "web" not in saved["platform_toolsets"]["cli"]
-        assert "memory" not in saved["platform_toolsets"]["cli"]
+        assert "memory" in saved["platform_toolsets"]["cli"]
         assert "terminal" in saved["platform_toolsets"]["cli"]
 
     def test_disable_already_absent_is_idempotent(self):
@@ -36,6 +36,16 @@ class TestToolsDisableBuiltin:
             tools_disable_enable_command(Namespace(tools_action="disable", names=["web"], platform="cli"))
         saved = mock_save.call_args[0][0]
         assert "web" not in saved["platform_toolsets"]["cli"]
+
+    def test_disable_core_toolset_is_rejected(self, capsys):
+        config = {"platform_toolsets": {"cli": ["web", "memory", "terminal"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="disable", names=["terminal"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert "terminal" in saved["platform_toolsets"]["cli"]
+        out = capsys.readouterr().out
+        assert "always enabled" in out
 
 
 # ── Built-in toolset enable ─────────────────────────────────────────────────
@@ -147,6 +157,9 @@ class TestToolsList:
         out = capsys.readouterr().out
         assert "web" in out
         assert "memory" in out
+        assert "Core toolsets" in out
+        for core_name in CORE_TOOLSET_KEYS:
+            assert core_name in out
 
     def test_list_shows_mcp_excluded_tools(self, capsys):
         config = {


### PR DESCRIPTION
## Summary
- make the issue #322 tool-selection flow treat terminal/file/code-execution/skills/todo/memory/session-search/delegation as always-on core toolsets
- keep `hermes setup` and `hermes tools` editing only the optional toolsets, while persisting platform toolsets with the core set re-added automatically
- make CLI and gateway startup resolve runtime toolsets through the same core-aware logic instead of trusting raw `platform_toolsets` lists
- harden `_ensure_user_systemd_env()` so it always seeds `XDG_RUNTIME_DIR` when missing, fixing the existing gateway service test expectation

## Verification
- `python -m pytest -o addopts='' tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_tools_disable_enable.py tests/test_cli_tools_command.py tests/tools/test_terminal_tool_requirements.py -q`
- `python -m pytest -o addopts='' tests/hermes_cli/test_gateway_service.py::TestEnsureUserSystemdEnv -q`
- `python -m pytest -o addopts='' tests/ -x -q`

## Notes
- A full-suite run still hits an unrelated pre-existing failure in `tests/integration/test_ha_integration.py::TestGatewayWebSocket::test_event_received_and_forwarded`, where the integration expectation conflicts with the adapter's current default filtering behavior and the existing unit-test contract.
- Closes #322
