### PR TITLE
Ensure HONCHO_BASE_URL is read for local Honcho installations

### DIFF
--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -117,11 +117,13 @@ class HonchoClientConfig:
     def from_env(cls, workspace_id: str = "hermes") -> HonchoClientConfig:
         """Create config from environment variables (fallback)."""
         api_key = os.environ.get("HONCHO_API_KEY")
+        base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
         return cls(
             workspace_id=workspace_id,
             api_key=api_key,
             environment=os.environ.get("HONCHO_ENVIRONMENT", "production"),
-            enabled=bool(api_key),
+            base_url=base_url,
+            enabled=bool(api_key or base_url),
         )
 
     @classmethod
@@ -171,8 +173,14 @@ class HonchoClientConfig:
             or raw.get("environment", "production")
         )
 
-        # Auto-enable when API key is present (unless explicitly disabled)
-        # Host-level enabled wins, then root-level, then auto-enable if key exists.
+        base_url = (
+            raw.get("baseUrl")
+            or os.environ.get("HONCHO_BASE_URL", "").strip()
+            or None
+        )
+
+        # Auto-enable when API key or base_url is present (unless explicitly disabled)
+        # Host-level enabled wins, then root-level, then auto-enable if key/url exists.
         host_enabled = host_block.get("enabled")
         root_enabled = raw.get("enabled")
         if host_enabled is not None:
@@ -180,8 +188,8 @@ class HonchoClientConfig:
         elif root_enabled is not None:
             enabled = root_enabled
         else:
-            # Not explicitly set anywhere -> auto-enable if API key exists
-            enabled = bool(api_key)
+            # Not explicitly set anywhere -> auto-enable if API key or base_url exists
+            enabled = bool(api_key or base_url)
 
         # write_frequency: accept int or string
         raw_wf = (
@@ -214,6 +222,7 @@ class HonchoClientConfig:
             workspace_id=workspace,
             api_key=api_key,
             environment=environment,
+            base_url=base_url,
             peer_name=host_block.get("peerName") or raw.get("peerName"),
             ai_peer=ai_peer,
             linked_hosts=linked_hosts,
@@ -348,11 +357,12 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
     if config is None:
         config = HonchoClientConfig.from_global_config()
 
-    if not config.api_key:
+    if not config.api_key and not config.base_url:
         raise ValueError(
             "Honcho API key not found. "
             "Get your API key at https://app.honcho.dev, "
-            "then run 'hermes honcho setup' or set HONCHO_API_KEY."
+            "then run 'hermes honcho setup' or set HONCHO_API_KEY. "
+            "For local instances, set HONCHO_BASE_URL instead."
         )
 
     try:

--- a/tests/honcho_integration/test_client.py
+++ b/tests/honcho_integration/test_client.py
@@ -60,6 +60,21 @@ class TestFromEnv:
         config = HonchoClientConfig.from_env(workspace_id="custom")
         assert config.workspace_id == "custom"
 
+    def test_reads_base_url_from_env(self):
+        with patch.dict(os.environ, {"HONCHO_BASE_URL": "http://localhost:8000"}, clear=False):
+            config = HonchoClientConfig.from_env()
+        assert config.base_url == "http://localhost:8000"
+        assert config.enabled is True
+
+    def test_enabled_without_api_key_when_base_url_set(self):
+        """base_url alone (no API key) is sufficient to enable a local instance."""
+        with patch.dict(os.environ, {"HONCHO_BASE_URL": "http://localhost:8000"}, clear=False):
+            os.environ.pop("HONCHO_API_KEY", None)
+            config = HonchoClientConfig.from_env()
+        assert config.api_key is None
+        assert config.base_url == "http://localhost:8000"
+        assert config.enabled is True
+
 
 class TestFromGlobalConfig:
     def test_missing_config_falls_back_to_env(self, tmp_path):
@@ -187,6 +202,36 @@ class TestFromGlobalConfig:
         with patch.dict(os.environ, {"HONCHO_API_KEY": "env-key"}):
             config = HonchoClientConfig.from_global_config(config_path=config_file)
         assert config.api_key == "env-key"
+
+    def test_base_url_env_fallback(self, tmp_path):
+        """HONCHO_BASE_URL env var is used when no baseUrl in config JSON."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"workspace": "local"}))
+
+        with patch.dict(os.environ, {"HONCHO_BASE_URL": "http://localhost:8000"}, clear=False):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://localhost:8000"
+        assert config.enabled is True
+
+    def test_base_url_from_config_root(self, tmp_path):
+        """baseUrl in config root is read and takes precedence over env var."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"baseUrl": "http://config-host:9000"}))
+
+        with patch.dict(os.environ, {"HONCHO_BASE_URL": "http://localhost:8000"}, clear=False):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://config-host:9000"
+
+    def test_base_url_not_read_from_host_block(self, tmp_path):
+        """baseUrl is a root-level connection setting, not overridable per-host (consistent with apiKey)."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "baseUrl": "http://root:9000",
+            "hosts": {"hermes": {"baseUrl": "http://host-block:9001"}},
+        }))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://root:9000"
 
 
 class TestResolveSessionName:


### PR DESCRIPTION
## What does this PR do?

## Summary

- `HONCHO_BASE_URL` env var was silently ignored — the Honcho client never read it, making local/self-hosted Honcho instances impossible to configure via `.env`
- `from_env()` now reads `HONCHO_BASE_URL` and enables Honcho when `base_url` is set, even without an API key
- `from_global_config()` now reads `baseUrl` from config root (consistent with `apiKey` — not overridable per host block), with `HONCHO_BASE_URL` env var as fallback
- `get_honcho_client()` guard relaxed from `not api_key` to `not api_key and not base_url`, allowing no-auth local instances

**Result:** Setting `HONCHO_BASE_URL=http://localhost:8000` in `~/.hermes/.env` now correctly routes the Honcho client to a local instance with no API key required.

## Test plan

- [ x] Added `test_reads_base_url_from_env` — `HONCHO_BASE_URL` is read and sets `base_url`; `enabled` becomes `True`
- [x ] Added `test_enabled_without_api_key_when_base_url_set` — no API key needed when `base_url` is present
- [ x] Added `test_base_url_env_fallback` — `HONCHO_BASE_URL` env var used when no `baseUrl` in config JSON
- [ x] Added `test_base_url_from_config_root` — `baseUrl` in config root takes precedence over env var
- [ x] Added `test_base_url_not_read_from_host_block` — `baseUrl` is root-only (consistent with `apiKey`)


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

## `honcho_integration/client.py`

### `from_env()` — read `HONCHO_BASE_URL`, enable on `base_url` alone

```python
# Before
api_key = os.environ.get("HONCHO_API_KEY")
return cls(
    workspace_id=workspace_id,
    api_key=api_key,
    environment=os.environ.get("HONCHO_ENVIRONMENT", "production"),
    enabled=bool(api_key),
)

# After
api_key = os.environ.get("HONCHO_API_KEY")
base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
return cls(
    workspace_id=workspace_id,
    api_key=api_key,
    environment=os.environ.get("HONCHO_ENVIRONMENT", "production"),
    base_url=base_url,
    enabled=bool(api_key or base_url),
)
```

### `from_global_config()` — read `baseUrl` from config root with env var fallback, pass to constructor, update auto-enable

```python
# Before (no base_url resolution)
api_key = (
    host_block.get("apiKey")
    or raw.get("apiKey")
    or os.environ.get("HONCHO_API_KEY")
)
# ...
enabled = bool(api_key)
# ...
return cls(
    ...
    environment=environment,
    # no base_url
    ...
)

# After
api_key = (
    host_block.get("apiKey")
    or raw.get("apiKey")
    or os.environ.get("HONCHO_API_KEY")
)
base_url = (
    raw.get("baseUrl")
    or os.environ.get("HONCHO_BASE_URL", "").strip()
    or None
)
# ...
enabled = bool(api_key or base_url)
# ...
return cls(
    ...
    environment=environment,
    base_url=base_url,
    ...
)
```

### `get_honcho_client()` — relax API key guard to allow no-auth local instances

```python
# Before
if not config.api_key:
    raise ValueError(
        "Honcho API key not found. "
        "Get your API key at https://app.honcho.dev, "
        "then run 'hermes honcho setup' or set HONCHO_API_KEY."
    )

# After
if not config.api_key and not config.base_url:
    raise ValueError(
        "Honcho API key not found. "
        "Get your API key at https://app.honcho.dev, "
        "then run 'hermes honcho setup' or set HONCHO_API_KEY. "
        "For local instances, set HONCHO_BASE_URL instead."
    )
```


- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Have a running local Honcho install
2. Add the HONCHO_BASE_URL to .env for Hermes Agent as documented
3. Existing behavior: Receive an API key error and instructions to run hermes honcho setup on first prompt with agent
4. This fix: No error received and the local Honcho instance is written/read from

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ x] I've run `pytest tests/ -q` and all tests pass
- [ x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

