### PR TITLE
fix(agent): strip trailing empty assistant messages before API calls to prevent prefill rejection

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2217,7 +2217,18 @@ class AIAgent:
                 "Pre-call sanitizer: added %d stub tool result(s)",
                 len(missing_results),
             )
-
+        # 3. Strip trailing empty assistant messages to prevent prefill rejection.
+        # These can leak from Responses API reasoning-only turns (Codex/MiniMax)
+        # where an empty assistant message is required by the Responses API but
+        # must NOT be sent to Chat Completions or Anthropic Messages API providers.
+        while (
+            messages
+            and messages[-1].get("role") == "assistant"
+            and not (messages[-1].get("content") or "").strip()
+            and not messages[-1].get("tool_calls")
+        ):
+            logger.debug("Pre-call sanitizer: removed trailing empty assistant message")
+            messages = messages[:-1]
         return messages
 
     @staticmethod


### PR DESCRIPTION
Fixes #2128

## Problem
Commit e84d952d added an empty assistant message after reasoning-only responses for the Responses API (required by `missing_following_item`). This empty message leaks into conversation history and gets sent to Chat Completions / Anthropic Messages API providers that reject trailing assistant messages as unsupported prefill:

`litellm.BadRequestError: This model does not support assistant message prefill. The conversation must end with a user message.`

## Fix
Added step 3 to `_sanitize_api_messages()` that strips trailing empty assistant messages (no content, no tool_calls) before every API call. This runs unconditionally so it protects all providers — Chat Completions, Anthropic Messages API, and any OpenAI-compatible endpoint.

## Why here?
`_sanitize_api_messages()` already runs before every LLM call and handles similar cleanup tasks (orphaned tool calls, stub results). This is the natural place for this fix.