### PR TITLE
fix(state): add missing thread lock to session_count() and message_count()

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -855,23 +855,25 @@ class SessionDB:
 
     def session_count(self, source: str = None) -> int:
         """Count sessions, optionally filtered by source."""
-        if source:
-            cursor = self._conn.execute(
-                "SELECT COUNT(*) FROM sessions WHERE source = ?", (source,)
-            )
-        else:
-            cursor = self._conn.execute("SELECT COUNT(*) FROM sessions")
-        return cursor.fetchone()[0]
+        with self._lock:
+            if source:
+                cursor = self._conn.execute(
+                    "SELECT COUNT(*) FROM sessions WHERE source = ?", (source,)
+                )
+            else:
+                cursor = self._conn.execute("SELECT COUNT(*) FROM sessions")
+            return cursor.fetchone()[0]
 
     def message_count(self, session_id: str = None) -> int:
         """Count messages, optionally for a specific session."""
-        if session_id:
-            cursor = self._conn.execute(
-                "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
-            )
-        else:
-            cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
-        return cursor.fetchone()[0]
+        with self._lock:
+            if session_id:
+                cursor = self._conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
+                )
+            else:
+                cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
+            return cursor.fetchone()[0]
 
     # =========================================================================
     # Export and cleanup


### PR DESCRIPTION
## Summary

- `SessionDB.session_count()` and `SessionDB.message_count()` accessed `self._conn` without `self._lock`, unlike all 22 other database methods in the class
- Wraps both methods with `with self._lock:` to match the existing thread-safety pattern

## Context

The class docstring promises: *"Thread-safe for the common gateway pattern (multiple reader threads, single writer via WAL mode)."* These two utility methods were the only ones missing the lock, creating a race condition risk in the gateway's multi-threaded environment.

## Test plan

- [x] Verify `session_count()` and `message_count()` still return correct results
- [x] Confirm no deadlocks by running gateway with multiple platforms

Fixes #2130

🤖 Generated with [Claude Code](https://claude.com/claude-code)