### PR TITLE
fix(state): add thread lock to session_count() and message_count()

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -855,23 +855,25 @@ class SessionDB:
 
     def session_count(self, source: str = None) -> int:
         """Count sessions, optionally filtered by source."""
-        if source:
-            cursor = self._conn.execute(
-                "SELECT COUNT(*) FROM sessions WHERE source = ?", (source,)
-            )
-        else:
-            cursor = self._conn.execute("SELECT COUNT(*) FROM sessions")
-        return cursor.fetchone()[0]
+        with self._lock:
+            if source:
+                cursor = self._conn.execute(
+                    "SELECT COUNT(*) FROM sessions WHERE source = ?", (source,)
+                )
+            else:
+                cursor = self._conn.execute("SELECT COUNT(*) FROM sessions")
+            return cursor.fetchone()[0]
 
     def message_count(self, session_id: str = None) -> int:
         """Count messages, optionally for a specific session."""
-        if session_id:
-            cursor = self._conn.execute(
-                "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
-            )
-        else:
-            cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
-        return cursor.fetchone()[0]
+        with self._lock:
+            if session_id:
+                cursor = self._conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
+                )
+            else:
+                cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
+            return cursor.fetchone()[0]
 
     # =========================================================================
     # Export and cleanup


### PR DESCRIPTION
## Summary

Adds missing thread lock to `session_count()` and `message_count()` methods in `SessionDB`.

## Problem

`SessionDB` promises thread-safety (line 111):

> Thread-safe for the common gateway pattern (multiple reader threads, single writer via WAL mode). Each method opens its own cursor.

All 22 other database-accessing methods properly wrap operations in `with self._lock:`. However, `session_count()` (line 856) and `message_count()` (line 866) access `self._conn` without any lock.

In the gateway's multi-threaded environment, this can cause:
- `sqlite3.ProgrammingError` from concurrent connection access
- Race conditions during reads (cursor interleaving)
- Inconsistent `fetchone()` results on shared connection

## Solution

Wrap both methods with `with self._lock:`, matching the pattern used by all other methods in the class.

## Testing

- Verified the fix matches the existing locking pattern used throughout the class
- The change is minimal and surgical — only adds the required lock context manager

Fixes #2130