### PR TITLE
fix(toolsets): share visited set across sibling includes in resolve_toolset()

### DIFF
--- a/toolsets.py
+++ b/toolsets.py
@@ -355,9 +355,9 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
             all_tools.update(resolved)
         return list(all_tools)
 
-    # Check for cycles
+    # Already resolved (diamond dependency) or circular — skip either way.
+    # Tools from this toolset are already in the result set.
     if name in visited:
-        print(f"⚠️  Circular dependency detected in toolset '{name}'")
         return []
     
     visited.add(name)
@@ -372,7 +372,7 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
     
     # Recursively resolve included toolsets
     for included_name in toolset.get("includes", []):
-        included_tools = resolve_toolset(included_name, visited.copy())
+        included_tools = resolve_toolset(included_name, visited)
         tools.update(included_tools)
     
     return list(tools)


### PR DESCRIPTION
## Summary

- Remove `visited.copy()` on include recursion (line 375) so sibling branches share the visited set — prevents redundant resolution of diamond dependencies and duplicate cycle warnings
- Keep `visited.copy()` on the `"all"`/`"*"` alias path (line 354) so each top-level toolset is resolved independently
- Remove misleading `print()` cycle warning — with a shared visited set, a revisit can mean diamond dependency (not a bug) or cycle; silently returning `[]` is correct in both cases since tools are collected into a set

## Test plan

- [x] All 20 existing `tests/test_toolsets.py` tests pass (including `test_cycle_detection`)
- [x] Diamond dependencies (A→[B,C], B→D, C→D) resolve correctly with D visited once
- [x] Mutual cycles (A↔B) terminate and return both tools
- [x] Branching cycles (A→[B,C], B↔C) terminate with all tools, no duplicate warnings
- [x] Deep cycles (A→B→C→D→B) terminate with all tools
- [x] Self-cycles (A→A) terminate
- [x] `all`/`*` alias resolves all tools correctly
- [x] Built-in toolsets (web, debugging, safe, hermes-gateway) unaffected

Fixes #2134

🤖 Generated with [Claude Code](https://claude.com/claude-code)