### PR TITLE
fix(tools): resource leak and double socket close in code_execution_tool

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -299,17 +299,19 @@ def _rpc_server_loop(
                 # Suppress stdout/stderr from internal tool handlers so
                 # their status prints don't leak into the CLI spinner.
                 try:
-                    _real_stdout, _real_stderr = sys.stdout, sys.stderr
-                    sys.stdout = open(os.devnull, "w")
-                    sys.stderr = open(os.devnull, "w")
+                    _devnull = open(os.devnull, "w")
                     try:
-                        result = handle_function_call(
-                            tool_name, tool_args, task_id=task_id
-                        )
+                        _real_stdout, _real_stderr = sys.stdout, sys.stderr
+                        sys.stdout = _devnull
+                        sys.stderr = _devnull
+                        try:
+                            result = handle_function_call(
+                                tool_name, tool_args, task_id=task_id
+                            )
+                        finally:
+                            sys.stdout, sys.stderr = _real_stdout, _real_stderr
                     finally:
-                        sys.stdout.close()
-                        sys.stderr.close()
-                        sys.stdout, sys.stderr = _real_stdout, _real_stderr
+                        _devnull.close()
                 except Exception as exc:
                     logger.error("Tool call failed in sandbox: %s", exc, exc_info=True)
                     result = json.dumps({"error": str(exc)})
@@ -574,6 +576,7 @@ def execute_code(
 
         # Wait for RPC thread to finish
         server_sock.close()  # break accept() so thread exits promptly
+        server_sock = None    # prevent double-close in finally
         rpc_thread.join(timeout=3)
 
         # Build response


### PR DESCRIPTION
## Summary

- **Resource leak**: Two separate `open(os.devnull, "w")` calls could leak a file handle if the second one threw. Now uses a single handle with nested try/finally ensuring cleanup.
- **Double close**: `server_sock.close()` was called in the try block and again in finally. Now sets `server_sock = None` after the first close so finally skips it.

## Test plan

- [x] Verified single devnull handle: normal path closes correctly, exception path closes correctly
- [x] Verified only 1 `open()` call instead of 2
- [x] Verified `server_sock = None` prevents double close in finally
- [x] Existing code execution tests pass (61 skipped — require sandbox env, not failures)

Fixes #2136