### PR TITLE
fix(email): guard against empty IMAP search data before indexing

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -230,7 +230,7 @@ class EmailAdapter(BasePlatformAdapter):
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
             status, data = imap.uid("search", None, "ALL")
-            if status == "OK" and data[0]:
+            if status == "OK" and data and data[0]:
                 for uid in data[0].split():
                     self._seen_uids.add(uid)
             imap.logout()
@@ -295,7 +295,7 @@ class EmailAdapter(BasePlatformAdapter):
             imap.select("INBOX")
 
             status, data = imap.uid("search", None, "UNSEEN")
-            if status != "OK" or not data[0]:
+            if status != "OK" or not data or not data[0]:
                 imap.logout()
                 return results
 


### PR DESCRIPTION
## Summary

- Add `data and` check before accessing `data[0]` at both IMAP search call sites (connect and fetch methods)
- Prevents `IndexError` when IMAP returns an empty list

## Test plan

- [x] Verified: `data=[]` no longer raises IndexError
- [x] Verified: `data=[b'1 2 3']` still processes correctly
- [x] Verified: `data=[b'']` still skips correctly
- [x] Verified: `data=None` handled gracefully
- [x] All 65 email gateway tests pass

Fixes #2137