### PR TITLE
fix(cron): close unawaited coroutine when asyncio.run() hits RuntimeError

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -156,11 +156,13 @@ def _deliver_result(job: dict, content: str) -> None:
         return
 
     # Run the async send in a fresh event loop (safe from any thread)
+    coro = _send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id)
     try:
-        result = asyncio.run(_send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id))
+        result = asyncio.run(coro)
     except RuntimeError:
         # asyncio.run() fails if there's already a running loop in this thread;
-        # spin up a new thread to avoid that.
+        # close the unawaited coroutine and spin up a new thread to avoid that.
+        coro.close()
         import concurrent.futures
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
             future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id))


### PR DESCRIPTION
## Summary

- Create coroutine before the try block and explicitly `coro.close()` in the except path
- Prevents `RuntimeWarning: coroutine was never awaited` when `asyncio.run()` raises RuntimeError due to an already-running event loop

## Test plan

- [x] Verified: abandoned coroutine no longer triggers RuntimeWarning
- [x] Verified: normal path (no RuntimeError) still works
- [x] Verified: fallback thread pool path still works
- [x] All 73 cron tests pass

Fixes #2138