### PR TITLE
fix(toolsets): use typing.Any instead of builtin any in type annotation

### DIFF
--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -19,7 +19,7 @@ Usage:
     all_dists = list_distributions()
 """
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import random
 from toolsets import validate_toolset
 
@@ -220,7 +220,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset distribution by name.
     


### PR DESCRIPTION
## Summary

- Add `Any` to typing import
- Change `Dict[str, any]` to `Dict[str, Any]` in `get_distribution()` return type

## Test plan

- [x] Verified return annotation resolves to `typing.Optional[typing.Dict[str, typing.Any]]`
- [x] Function still returns correct results
- [x] All 15 toolset distribution tests pass

Fixes #2139