### PR TITLE
Fix Ollama effective context detection

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -603,8 +603,89 @@ def _model_id_matches(candidate_id: str, lookup_model: str) -> bool:
     return False
 
 
-def _query_local_context_length(model: str, base_url: str) -> Optional[int]:
-    """Query a local server for the model's context length."""
+def _extract_parameter_context_length(parameters: Any) -> Optional[int]:
+    """Extract an Ollama context override from a parameters string."""
+    if not isinstance(parameters, str):
+        return None
+
+    for pattern in (
+        r"\bnum_ctx\s+(\d+)\b",
+        r"\bcontext_length\s+(\d+)\b",
+    ):
+        match = re.search(pattern, parameters, flags=re.IGNORECASE)
+        if not match:
+            continue
+        ctx = _coerce_reasonable_int(match.group(1))
+        if ctx is not None:
+            return ctx
+    return None
+
+
+def _extract_ollama_context_values(payload: Dict[str, Any]) -> tuple[Optional[int], Optional[int]]:
+    """Return (effective_context, max_context) from an Ollama payload.
+
+    effective_context is the runtime/user-set limit to budget against.
+    max_context is the theoretical model maximum and must only be used as a
+    fallback when no effective runtime value is present.
+    """
+    effective_candidates = (
+        payload.get("current_context_length"),
+        payload.get("context_length"),
+        payload.get("details", {}).get("num_ctx") if isinstance(payload.get("details"), dict) else None,
+        payload.get("context_window"),
+    )
+    for value in effective_candidates:
+        ctx = _coerce_reasonable_int(value)
+        if ctx is not None:
+            return ctx, _coerce_reasonable_int(payload.get("max_context_length"))
+
+    model_info = payload.get("model_info")
+    if isinstance(model_info, dict):
+        for key, value in model_info.items():
+            if "context_length" not in str(key).lower():
+                continue
+            ctx = _coerce_reasonable_int(value)
+            if ctx is not None:
+                return ctx, _coerce_reasonable_int(payload.get("max_context_length"))
+
+    params_ctx = _extract_parameter_context_length(payload.get("parameters"))
+    if params_ctx is not None:
+        return params_ctx, _coerce_reasonable_int(payload.get("max_context_length"))
+
+    max_ctx = _coerce_reasonable_int(payload.get("max_context_length"))
+    return max_ctx, max_ctx
+
+
+def _find_ollama_model(models_payload: Dict[str, Any], lookup_model: str) -> Optional[Dict[str, Any]]:
+    """Find a model entry in Ollama /api/ps or /api/tags payloads."""
+    models = models_payload.get("models")
+    if not isinstance(models, list):
+        return None
+
+    lookup_candidates = {lookup_model}
+    stripped_lookup = _strip_provider_prefix(lookup_model)
+    if stripped_lookup:
+        lookup_candidates.add(stripped_lookup)
+
+    for entry in models:
+        if not isinstance(entry, dict):
+            continue
+        for key in ("name", "model", "id"):
+            candidate = entry.get(key)
+            if not isinstance(candidate, str) or not candidate:
+                continue
+            if any(_model_id_matches(candidate, lookup) for lookup in lookup_candidates):
+                return entry
+    return None
+
+
+def _query_local_context_length_details(model: str, base_url: str) -> tuple[Optional[int], bool]:
+    """Query a local server for the model's context length and cacheability.
+
+    Returns ``(context_length, should_persist)``. Runtime-only context values,
+    such as Ollama's current loaded context from ``/api/ps``, must not be
+    persisted as durable model metadata.
+    """
     import httpx
 
     # Strip recognised provider prefix (e.g., "local:model-name" → "model-name").
@@ -625,25 +706,27 @@ def _query_local_context_length(model: str, base_url: str) -> Optional[int]:
         with httpx.Client(timeout=3.0) as client:
             # Ollama: /api/show returns model details with context info
             if server_type == "ollama":
-                resp = client.post(f"{server_url}/api/show", json={"name": model})
+                resp = client.get(f"{server_url}/api/ps")
                 if resp.status_code == 200:
-                    data = resp.json()
-                    # Check model_info for context length
-                    model_info = data.get("model_info", {})
-                    for key, value in model_info.items():
-                        if "context_length" in key and isinstance(value, (int, float)):
-                            return int(value)
-                    # Check parameters string for num_ctx
-                    params = data.get("parameters", "")
-                    if "num_ctx" in params:
-                        for line in params.split("\n"):
-                            if "num_ctx" in line:
-                                parts = line.strip().split()
-                                if len(parts) >= 2:
-                                    try:
-                                        return int(parts[-1])
-                                    except ValueError:
-                                        pass
+                    running_model = _find_ollama_model(resp.json(), model)
+                    if running_model:
+                        effective_ctx, _max_ctx = _extract_ollama_context_values(running_model)
+                        if effective_ctx is not None:
+                            return effective_ctx, False
+
+                resp = client.post(f"{server_url}/api/show", json={"name": model, "model": model})
+                if resp.status_code == 200:
+                    effective_ctx, _max_ctx = _extract_ollama_context_values(resp.json())
+                    if effective_ctx is not None:
+                        return effective_ctx, True
+
+                resp = client.get(f"{server_url}/api/tags")
+                if resp.status_code == 200:
+                    tagged_model = _find_ollama_model(resp.json(), model)
+                    if tagged_model:
+                        effective_ctx, _max_ctx = _extract_ollama_context_values(tagged_model)
+                        if effective_ctx is not None:
+                            return effective_ctx, True
 
             # LM Studio native API: /api/v1/models returns max_context_length.
             # This is more reliable than the OpenAI-compat /v1/models which
@@ -661,11 +744,11 @@ def _query_local_context_length(model: str, base_url: str) -> Optional[int]:
                                 cfg = inst.get("config", {})
                                 ctx = cfg.get("context_length")
                                 if ctx and isinstance(ctx, (int, float)):
-                                    return int(ctx)
+                                    return int(ctx), True
                             # Fall back to max_context_length (theoretical model max)
                             ctx = m.get("max_context_length") or m.get("context_length")
                             if ctx and isinstance(ctx, (int, float)):
-                                return int(ctx)
+                                return int(ctx), True
 
             # LM Studio / vLLM / llama.cpp: try /v1/models/{model}
             resp = client.get(f"{server_url}/v1/models/{model}")
@@ -674,7 +757,7 @@ def _query_local_context_length(model: str, base_url: str) -> Optional[int]:
                 # vLLM returns max_model_len
                 ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")
                 if ctx and isinstance(ctx, (int, float)):
-                    return int(ctx)
+                    return int(ctx), True
 
             # Try /v1/models and find the model in the list.
             # Use _model_id_matches to handle "publisher/slug" vs bare "slug".
@@ -686,11 +769,17 @@ def _query_local_context_length(model: str, base_url: str) -> Optional[int]:
                     if _model_id_matches(m.get("id", ""), model):
                         ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens")
                         if ctx and isinstance(ctx, (int, float)):
-                            return int(ctx)
+                            return int(ctx), True
     except Exception:
         pass
 
-    return None
+    return None, False
+
+
+def _query_local_context_length(model: str, base_url: str) -> Optional[int]:
+    """Query a local server for the model's context length."""
+    context_length, _should_persist = _query_local_context_length_details(model, base_url)
+    return context_length
 
 
 def get_model_context_length(
@@ -748,9 +837,10 @@ def get_model_context_length(
             # defaults from unrelated providers with similarly named models.
             # But first try querying the local server directly.
             if is_local_endpoint(base_url):
-                local_ctx = _query_local_context_length(model, base_url)
+                local_ctx, should_persist = _query_local_context_length_details(model, base_url)
                 if local_ctx and local_ctx > 0:
-                    save_context_length(model, base_url, local_ctx)
+                    if should_persist:
+                        save_context_length(model, base_url, local_ctx)
                     return local_ctx
             logger.info(
                 "Could not detect context length for model %r at %s — "
@@ -774,9 +864,10 @@ def get_model_context_length(
 
     # 5. Query local server for unknown models before defaulting to 2M
     if base_url and is_local_endpoint(base_url):
-        local_ctx = _query_local_context_length(model, base_url)
+        local_ctx, should_persist = _query_local_context_length_details(model, base_url)
         if local_ctx and local_ctx > 0:
-            save_context_length(model, base_url, local_ctx)
+            if should_persist:
+                save_context_length(model, base_url, local_ctx)
             return local_ctx
 
     # 6. Unknown model — start at highest probe tier

--- a/tests/test_model_metadata_local_ctx.py
+++ b/tests/test_model_metadata_local_ctx.py
@@ -31,16 +31,17 @@ class TestQueryLocalContextLengthOllama:
         """Reads context length from model_info dict in /api/show response."""
         from agent.model_metadata import _query_local_context_length
 
+        ps_resp = self._make_resp(404, {})
         show_resp = self._make_resp(200, {
             "model_info": {"llama.context_length": 131072}
         })
-        models_resp = self._make_resp(404, {})
+        tags_resp = self._make_resp(404, {})
 
         client_mock = MagicMock()
         client_mock.__enter__ = lambda s: client_mock
         client_mock.__exit__ = MagicMock(return_value=False)
         client_mock.post.return_value = show_resp
-        client_mock.get.return_value = models_resp
+        client_mock.get.side_effect = [ps_resp, tags_resp]
 
         with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"), \
              patch("httpx.Client", return_value=client_mock):
@@ -48,21 +49,53 @@ class TestQueryLocalContextLengthOllama:
 
         assert result == 131072
 
-    def test_ollama_parameters_num_ctx(self):
-        """Falls back to num_ctx in parameters string when model_info lacks context_length."""
+    def test_ollama_ps_current_context_beats_model_max(self):
+        """Uses the active runtime context from /api/ps before /api/show metadata."""
         from agent.model_metadata import _query_local_context_length
 
-        show_resp = self._make_resp(200, {
-            "model_info": {},
-            "parameters": "num_ctx 32768\ntemperature 0.7\n"
+        ps_resp = self._make_resp(200, {
+            "models": [
+                {
+                    "name": "qwen3.5:27b",
+                    "current_context_length": 32768,
+                    "max_context_length": 131072,
+                }
+            ]
         })
-        models_resp = self._make_resp(404, {})
+        show_resp = self._make_resp(200, {
+            "model_info": {"qwen.context_length": 131072},
+            "parameters": "num_ctx 65536\n",
+            "max_context_length": 131072,
+        })
 
         client_mock = MagicMock()
         client_mock.__enter__ = lambda s: client_mock
         client_mock.__exit__ = MagicMock(return_value=False)
         client_mock.post.return_value = show_resp
-        client_mock.get.return_value = models_resp
+        client_mock.get.side_effect = [ps_resp]
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("qwen3.5:27b", "http://localhost:11434/v1")
+
+        assert result == 32768
+
+    def test_ollama_parameters_num_ctx(self):
+        """Falls back to num_ctx in parameters string when model_info lacks context_length."""
+        from agent.model_metadata import _query_local_context_length
+
+        ps_resp = self._make_resp(404, {})
+        show_resp = self._make_resp(200, {
+            "model_info": {},
+            "parameters": "num_ctx 32768\ntemperature 0.7\n"
+        })
+        tags_resp = self._make_resp(404, {})
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = show_resp
+        client_mock.get.side_effect = [ps_resp, tags_resp]
 
         with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"), \
              patch("httpx.Client", return_value=client_mock):
@@ -70,18 +103,71 @@ class TestQueryLocalContextLengthOllama:
 
         assert result == 32768
 
+    def test_ollama_show_details_num_ctx_beats_max_context_length(self):
+        """Prefers details.num_ctx over theoretical max_context_length in /api/show."""
+        from agent.model_metadata import _query_local_context_length
+
+        ps_resp = self._make_resp(404, {})
+        show_resp = self._make_resp(200, {
+            "details": {"num_ctx": 16384},
+            "max_context_length": 131072,
+        })
+        tags_resp = self._make_resp(404, {})
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = show_resp
+        client_mock.get.side_effect = [ps_resp, tags_resp]
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("some-model", "http://localhost:11434/v1")
+
+        assert result == 16384
+
+    def test_ollama_tags_fallback_uses_parameters_context_length(self):
+        """Falls back to /api/tags and still parses configured context overrides."""
+        from agent.model_metadata import _query_local_context_length
+
+        ps_resp = self._make_resp(404, {})
+        show_resp = self._make_resp(404, {})
+        tags_resp = self._make_resp(200, {
+            "models": [
+                {
+                    "name": "some-model",
+                    "parameters": "context_length 24576\n",
+                    "max_context_length": 131072,
+                }
+            ]
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = show_resp
+        client_mock.get.side_effect = [ps_resp, tags_resp]
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("some-model", "http://localhost:11434/v1")
+
+        assert result == 24576
+
     def test_ollama_show_404_falls_through(self):
         """When /api/show returns 404, falls through to /v1/models/{model}."""
         from agent.model_metadata import _query_local_context_length
 
+        ps_resp = self._make_resp(404, {})
         show_resp = self._make_resp(404, {})
+        tags_resp = self._make_resp(404, {})
         model_detail_resp = self._make_resp(200, {"max_model_len": 65536})
 
         client_mock = MagicMock()
         client_mock.__enter__ = lambda s: client_mock
         client_mock.__exit__ = MagicMock(return_value=False)
         client_mock.post.return_value = show_resp
-        client_mock.get.return_value = model_detail_resp
+        client_mock.get.side_effect = [ps_resp, tags_resp, model_detail_resp]
 
         with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"), \
              patch("httpx.Client", return_value=client_mock):
@@ -421,7 +507,7 @@ class TestGetModelContextLengthLocalFallback:
              patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
              patch("agent.model_metadata.is_local_endpoint", return_value=True), \
-             patch("agent.model_metadata._query_local_context_length", return_value=131072), \
+             patch("agent.model_metadata._query_local_context_length_details", return_value=(131072, True)), \
              patch("agent.model_metadata.save_context_length") as mock_save:
             result = get_model_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
@@ -435,11 +521,26 @@ class TestGetModelContextLengthLocalFallback:
              patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
              patch("agent.model_metadata.is_local_endpoint", return_value=True), \
-             patch("agent.model_metadata._query_local_context_length", return_value=131072), \
+             patch("agent.model_metadata._query_local_context_length_details", return_value=(131072, True)), \
              patch("agent.model_metadata.save_context_length") as mock_save:
             get_model_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
         mock_save.assert_called_once_with("omnicoder-9b", "http://localhost:11434/v1", 131072)
+
+    def test_local_endpoint_runtime_result_is_not_cached(self):
+        """Ephemeral runtime context values should not poison the persistent cache."""
+        from agent.model_metadata import get_model_context_length
+
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata._query_local_context_length_details", return_value=(32768, False)), \
+             patch("agent.model_metadata.save_context_length") as mock_save:
+            result = get_model_context_length("qwen3.5:27b", "http://localhost:11434/v1")
+
+        assert result == 32768
+        mock_save.assert_not_called()
 
     def test_local_endpoint_server_returns_none_falls_back_to_2m(self):
         """When local server returns None, still falls back to 2M probe tier."""
@@ -449,7 +550,7 @@ class TestGetModelContextLengthLocalFallback:
              patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
              patch("agent.model_metadata.is_local_endpoint", return_value=True), \
-             patch("agent.model_metadata._query_local_context_length", return_value=None):
+             patch("agent.model_metadata._query_local_context_length_details", return_value=(None, False)):
             result = get_model_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
         assert result == CONTEXT_PROBE_TIERS[0]
@@ -474,7 +575,7 @@ class TestGetModelContextLengthLocalFallback:
         from agent.model_metadata import get_model_context_length
 
         with patch("agent.model_metadata.get_cached_context_length", return_value=65536), \
-             patch("agent.model_metadata._query_local_context_length") as mock_query:
+             patch("agent.model_metadata._query_local_context_length_details") as mock_query:
             result = get_model_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
         assert result == 65536
@@ -487,7 +588,7 @@ class TestGetModelContextLengthLocalFallback:
         with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
              patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
-             patch("agent.model_metadata._query_local_context_length") as mock_query:
+             patch("agent.model_metadata._query_local_context_length_details") as mock_query:
             result = get_model_context_length("unknown-xyz-model", "")
 
         mock_query.assert_not_called()


### PR DESCRIPTION
## Summary
- prefer Ollama runtime context over advertised model max when resolving usable context
- query `/api/ps`, then `/api/show`, then `/api/tags` for Ollama-specific metadata
- parse `current_context_length`, `context_length`, `details.num_ctx`, `context_window`, `model_info.*context_length`, and parameter string overrides before falling back to `max_context_length`
- add regression tests covering `/api/ps`, `/api/show`, `/api/tags`, and `num_ctx` precedence

## Verification
- `./.venv/bin/python -m pytest tests/test_model_metadata_local_ctx.py -q`
- `./.venv/bin/python -m pytest tests/agent/test_model_metadata.py -q`
- `./.venv/bin/python -m pytest tests/ -q` *(fails on unrelated pre-existing tests outside this change: `tests/test_cli_new_session.py`, `tests/tools/test_delegate.py`, `tests/hermes_cli/test_gateway_service.py`, `tests/tools/test_transcription.py`, `tests/tools/test_web_tools_config.py`)*