### PR TITLE
fix(gateway): fix compression threshold direction and add hard message limit

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1747,14 +1747,22 @@ class GatewayRunner:
                     _token_source = "actual"
                 else:
                     _approx_tokens = estimate_messages_tokens_rough(history)
-                    # Apply safety factor only for rough estimates
+                    # Rough estimates overestimate tool-heavy content by 30-50%.
+                    # Lower the threshold (not raise it) so compression fires
+                    # conservatively when we don't have real token data.
                     _compress_token_threshold = int(
-                        _compress_token_threshold * 1.4
+                        _compress_token_threshold * 0.7
                     )
-                    _warn_token_threshold = int(_warn_token_threshold * 1.4)
+                    _warn_token_threshold = int(_warn_token_threshold * 0.7)
                     _token_source = "estimated"
 
-                _needs_compress = _approx_tokens >= _compress_token_threshold
+                # Hard safety valve: force compression if message count is very high,
+                # regardless of token estimates (handles death spiral from API disconnects)
+                _HARD_MSG_LIMIT = 400
+                _needs_compress = (
+                    _approx_tokens >= _compress_token_threshold
+                    or _msg_count >= _HARD_MSG_LIMIT
+                )
 
                 if _needs_compress:
                     logger.info(

--- a/run_agent.py
+++ b/run_agent.py
@@ -6060,6 +6060,26 @@ class AIAgent:
                         'prompt is too long',  # Anthropic: "prompt is too long: N tokens > M maximum"
                     ])
 
+                    # Server disconnected without response often means context too large.
+                    # Treat it as a context-length error if the session is large.
+                    is_server_disconnect = (
+                        'server disconnected' in error_msg
+                        or 'peer closed connection' in error_msg
+                        or 'readerror' in error_msg.lower()
+                        or error_type in ('ReadError', 'RemoteProtocolError', 'ServerDisconnectedError')
+                    )
+                    if is_server_disconnect and not is_context_length_error:
+                        ctx_len = getattr(getattr(self, 'context_compressor', None), 'context_length', 200000)
+                        is_large_session = approx_tokens > ctx_len * 0.6 or len(api_messages) > 200
+                        if is_large_session:
+                            is_context_length_error = True
+                            self._vprint(
+                                f"{self.log_prefix}⚠️  Server disconnected with large session "
+                                f"(~{approx_tokens:,} tokens, {len(api_messages)} msgs) — "
+                                f"treating as context-length error, attempting compression.",
+                                force=True,
+                            )
+
                     # Fallback heuristic: Anthropic sometimes returns a generic
                     # 400 invalid_request_error with just "Error" as the message
                     # when the context is too large.  If the error message is very
@@ -6580,27 +6600,29 @@ class AIAgent:
                     _compressor = self.context_compressor
                     _new_tool_msgs = messages[_msg_count_before_tools:]
                     _new_chars = sum(len(str(m.get("content", "") or "")) for m in _new_tool_msgs)
-                    _estimated_next_prompt = (
-                        _compressor.last_prompt_tokens
-                        + _compressor.last_completion_tokens
-                        + _new_chars // 3  # conservative: JSON-heavy tool results ≈ 3 chars/token
-                    )
+                    # If last_prompt_tokens is 0 (stale/no API data), fall back to
+                    # rough estimate to avoid missing compression after API disconnects.
+                    if _compressor.last_prompt_tokens > 0:
+                        _estimated_next_prompt = (
+                            _compressor.last_prompt_tokens
+                            + _compressor.last_completion_tokens
+                            + _new_chars // 3  # conservative: JSON-heavy tool results ≈ 3 chars/token
+                        )
+                    else:
+                        from agent.model_metadata import estimate_messages_tokens_rough
+                        _estimated_next_prompt = estimate_messages_tokens_rough(messages)
 
                     # ── Context pressure warnings (user-facing only) ──────────
-                    # Notify the user (NOT the LLM) as context approaches the
-                    # compaction threshold.  Thresholds are relative to where
-                    # compaction fires, not the raw context window.
-                    # Does not inject into messages — just prints to CLI output
-                    # and fires status_callback for gateway platforms.
                     if _compressor.threshold_tokens > 0:
                         _compaction_progress = _estimated_next_prompt / _compressor.threshold_tokens
                         if _compaction_progress >= 0.85 and not self._context_70_warned:
                             self._context_70_warned = True
-                            self._context_50_warned = True  # skip first tier if we jumped past it
+                            self._context_50_warned = True
                             self._emit_context_pressure(_compaction_progress, _compressor)
                         elif _compaction_progress >= 0.60 and not self._context_50_warned:
                             self._context_50_warned = True
                             self._emit_context_pressure(_compaction_progress, _compressor)
+
 
                     if self.compression_enabled and _compressor.should_compress(_estimated_next_prompt):
                         messages, active_system_prompt = self._compress_context(


### PR DESCRIPTION
Fixes #2153

## Root Cause
Two bugs in gateway session hygiene (`gateway/run.py`):

1. **Inverted threshold direction**: When `last_prompt_tokens = 0` (API disconnected without returning usage), the fallback rough estimate path multiplied the threshold by `1.4x`, making compression *harder* to trigger — the exact opposite of what's needed when we don't have accurate token data.

2. **No hard safety valve**: Sessions could grow to 700+ messages with no forced compression trigger, causing a death spiral where API disconnects prevent token data collection, which prevents compression, which causes more disconnects.

## Fix
1. **Fixed threshold direction**: Changed `* 1.4` to `* 0.7` for rough estimate fallback. When we don't have accurate token data, be *more* aggressive about compression, not less.

2. **Hard message count limit**: Added `_HARD_MSG_LIMIT = 400` — if a session exceeds 400 messages, force compression regardless of token estimates. This breaks the death spiral even when all token-based checks fail.

## Update: All 3 Layers Fixed

**Layer 1 fix** (run_agent.py in-loop compression): When `last_prompt_tokens = 0` (stale after API disconnect), now falls back to rough token estimate instead of using the stale value.

**Layer 2 fix** (run_agent.py error handler): Server disconnect errors (`ReadError`, `RemoteProtocolError`) on large sessions (>60% context or >200 messages) are now treated as context-length errors and trigger compression before retry.

**Layer 3 fix** (gateway/run.py hygiene): Fixed inverted threshold direction (1.4x → 0.7x) and added 400-message hard limit.

