### PR TITLE
fix: use `Any` (typing) instead of `any` (builtin) in get_distribution return type

### DIFF
--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -220,7 +220,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset distribution by name.
     


### PR DESCRIPTION
`get_distribution()` uses `any` (the builtin function) instead of `Any` (from typing) in its return type annotation. `Any` is already imported on line 22.

Fixes #2139