### PR TITLE
fix(display): show spinners and tool progress during streaming mode

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -518,6 +518,10 @@ class AIAgent:
         self.stream_delta_callback = stream_delta_callback
         self._last_reported_tool = None  # Track for "new tool" mode
         
+        # Tool execution state — allows _vprint during tool execution
+        # even when stream consumers are registered (no tokens streaming then)
+        self._executing_tools = False
+
         # Interrupt mechanism for breaking out of tool loops
         self._interrupt_requested = False
         self._interrupt_message = None  # Optional message that triggered interrupt
@@ -1031,12 +1035,16 @@ class AIAgent:
             pass
 
     def _vprint(self, *args, force: bool = False, **kwargs):
-        """Verbose print — suppressed when streaming TTS is active.
+        """Verbose print — suppressed when actively streaming tokens.
 
         Pass ``force=True`` for error/warning messages that should always be
         shown even during streaming playback (TTS or display).
+
+        During tool execution (``_executing_tools`` is True), printing is
+        allowed even with stream consumers registered because no tokens
+        are being streamed at that point.
         """
-        if not force and self._has_stream_consumers():
+        if not force and self._has_stream_consumers() and not self._executing_tools:
             return
         self._safe_print(*args, **kwargs)
 
@@ -4311,14 +4319,19 @@ class AIAgent:
         """
         tool_calls = assistant_message.tool_calls
 
-        if not _should_parallelize_tool_batch(tool_calls):
-            return self._execute_tool_calls_sequential(
+        # Allow _vprint during tool execution even with stream consumers
+        self._executing_tools = True
+        try:
+            if not _should_parallelize_tool_batch(tool_calls):
+                return self._execute_tool_calls_sequential(
+                    assistant_message, messages, effective_task_id, api_call_count
+                )
+
+            return self._execute_tool_calls_concurrent(
                 assistant_message, messages, effective_task_id, api_call_count
             )
-
-        return self._execute_tool_calls_concurrent(
-            assistant_message, messages, effective_task_id, api_call_count
-        )
+        finally:
+            self._executing_tools = False
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str) -> str:
         """Invoke a single tool and return the result string. No display logic.
@@ -5375,14 +5388,17 @@ class AIAgent:
                 self._vprint(f"\n{self.log_prefix}🔄 Making API call #{api_call_count}/{self.max_iterations}...")
                 self._vprint(f"{self.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)")
                 self._vprint(f"{self.log_prefix}   🔧 Available tools: {len(self.tools) if self.tools else 0}")
-            elif not self._has_stream_consumers():
-                # Animated thinking spinner in quiet mode (skip during streaming)
+            else:
+                # Animated thinking spinner in quiet mode
                 face = random.choice(KawaiiSpinner.KAWAII_THINKING)
                 verb = random.choice(KawaiiSpinner.THINKING_VERBS)
                 if self.thinking_callback:
                     # CLI TUI mode: use prompt_toolkit widget instead of raw spinner
+                    # (works in both streaming and non-streaming modes)
                     self.thinking_callback(f"{face} {verb}...")
-                else:
+                elif not self._has_stream_consumers():
+                    # Raw KawaiiSpinner only when no streaming consumers
+                    # (would conflict with streamed token output)
                     spinner_type = random.choice(['brain', 'sparkle', 'pulse', 'moon', 'star'])
                     thinking_spinner = KawaiiSpinner(f"{face} {verb}...", spinner_type=spinner_type)
                     thinking_spinner.start()


### PR DESCRIPTION
## Summary

When streaming is enabled (`display.streaming: true`), the CLI was completely silent during API calls and tool execution — no thinking spinner in the TUI toolbar, no ┊ tool progress lines. Only the reasoning box and streamed response text appeared.

## Root cause

Two blanket suppressions:

1. **Thinking spinner skipped** — the spinner block was gated on `not self._has_stream_consumers()`, so in streaming mode no spinner ever appeared in the TUI toolbar. The raw `KawaiiSpinner` (stdout-based) genuinely conflicts with streamed tokens, but the `thinking_callback` (TUI toolbar widget) works fine alongside streaming.

2. **`_vprint` blanket-suppressed** — `_vprint` returned immediately when stream consumers existed, killing all tool progress output. But during tool execution, no tokens are actively streaming — printing is safe.

## Fix

1. **Fire `thinking_callback` in streaming mode** — the `elif not self._has_stream_consumers()` gate now only applies to the raw `KawaiiSpinner`. The `thinking_callback` fires regardless, so the TUI toolbar shows the kawaii spinner during API calls.

2. **`_executing_tools` flag** — `_execute_tool_calls` sets `self._executing_tools = True` (reset in `finally`). `_vprint` checks this flag and allows output when tools are running, even with stream consumers registered.

## Test plan

```bash
python -m pytest tests/ -n0 -q  # 5524 passed
```

Visual verification: enable streaming (`display.streaming: true`), send a message that triggers tool calls — TUI toolbar should show spinner during API calls, and ┊ tool progress lines should appear during tool execution.