### PR TITLE
fix(agent): align thinking tag detection with stripping — prevents raw XML leaking to users

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1094,23 +1094,30 @@ class AIAgent:
 
     def _has_content_after_think_block(self, content: str) -> bool:
         """
-        Check if content has actual text after any <think></think> blocks.
-        
+        Check if content has actual text after any reasoning/thinking blocks.
+
         This detects cases where the model only outputs reasoning but no actual
         response, which indicates an incomplete generation that should be retried.
-        
+
+        Uses the same tag variants as _strip_think_blocks so that models using
+        <thinking>, <reasoning>, or <REASONING_SCRATCHPAD> (e.g. Qwen, local
+        models) are handled consistently — not just <think> (DeepSeek-R1).
+
         Args:
             content: The assistant message content to check
-            
+
         Returns:
             True if there's meaningful content after think blocks, False otherwise
         """
         if not content:
             return False
-        
-        # Remove all <think>...</think> blocks (including nested ones, non-greedy)
+
+        # Remove all reasoning tag variants (must match _strip_think_blocks)
         cleaned = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL)
-        
+        cleaned = re.sub(r'<thinking>.*?</thinking>', '', cleaned, flags=re.DOTALL | re.IGNORECASE)
+        cleaned = re.sub(r'<reasoning>.*?</reasoning>', '', cleaned, flags=re.DOTALL)
+        cleaned = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', cleaned, flags=re.DOTALL)
+
         # Check if there's any non-whitespace content remaining
         return bool(cleaned.strip())
     

--- a/tests/test_think_block_detection.py
+++ b/tests/test_think_block_detection.py
@@ -1,0 +1,137 @@
+"""Tests for _has_content_after_think_block / _strip_think_blocks consistency.
+
+Ensures both functions recognise the same set of reasoning tag variants so
+that models using <thinking>, <reasoning>, or <REASONING_SCRATCHPAD>
+(Qwen, local models, etc.) are handled consistently.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture
+def agent():
+    """Create a minimal AIAgent with only the methods under test."""
+    with patch("run_agent.AIAgent.__init__", return_value=None):
+        from run_agent import AIAgent
+        a = AIAgent.__new__(AIAgent)
+        return a
+
+
+# ── _has_content_after_think_block ──────────────────────────────────────
+
+class TestHasContentAfterThinkBlock:
+    """The function must return False when the response contains ONLY
+    reasoning tags (any variant) and no user-visible content."""
+
+    def test_empty_string(self, agent):
+        assert agent._has_content_after_think_block("") is False
+
+    def test_none(self, agent):
+        assert agent._has_content_after_think_block(None) is False
+
+    def test_plain_text(self, agent):
+        assert agent._has_content_after_think_block("Hello world") is True
+
+    # ── <think> (DeepSeek-R1 style) ──
+    def test_think_only(self, agent):
+        assert agent._has_content_after_think_block("<think>reasoning</think>") is False
+
+    def test_think_with_content(self, agent):
+        assert agent._has_content_after_think_block(
+            "<think>reasoning</think>\nHere is my answer."
+        ) is True
+
+    # ── <thinking> (Qwen, local models) ──
+    def test_thinking_only(self, agent):
+        """Previously returned True (bug) — <thinking> wasn't stripped."""
+        assert agent._has_content_after_think_block(
+            "<thinking>long reasoning here</thinking>"
+        ) is False
+
+    def test_thinking_with_content(self, agent):
+        assert agent._has_content_after_think_block(
+            "<thinking>reasoning</thinking>\nActual answer."
+        ) is True
+
+    def test_THINKING_upper(self, agent):
+        assert agent._has_content_after_think_block(
+            "<THINKING>reasoning</THINKING>"
+        ) is False
+
+    # ── <reasoning> ──
+    def test_reasoning_only(self, agent):
+        assert agent._has_content_after_think_block(
+            "<reasoning>step by step</reasoning>"
+        ) is False
+
+    def test_reasoning_with_content(self, agent):
+        assert agent._has_content_after_think_block(
+            "<reasoning>step by step</reasoning>\nThe answer is 42."
+        ) is True
+
+    # ── <REASONING_SCRATCHPAD> ──
+    def test_scratchpad_only(self, agent):
+        assert agent._has_content_after_think_block(
+            "<REASONING_SCRATCHPAD>work</REASONING_SCRATCHPAD>"
+        ) is False
+
+    def test_scratchpad_with_content(self, agent):
+        assert agent._has_content_after_think_block(
+            "<REASONING_SCRATCHPAD>work</REASONING_SCRATCHPAD>\nDone."
+        ) is True
+
+    # ── Mixed tags ──
+    def test_mixed_tags_only(self, agent):
+        content = (
+            "<think>step 1</think>\n"
+            "<thinking>step 2</thinking>\n"
+            "<reasoning>step 3</reasoning>"
+        )
+        assert agent._has_content_after_think_block(content) is False
+
+    def test_mixed_tags_with_content(self, agent):
+        content = (
+            "<think>step 1</think>\n"
+            "<thinking>step 2</thinking>\n"
+            "Final answer: 42"
+        )
+        assert agent._has_content_after_think_block(content) is True
+
+    # ── Multiline reasoning ──
+    def test_multiline_thinking(self, agent):
+        content = "<thinking>\nline 1\nline 2\nline 3\n</thinking>"
+        assert agent._has_content_after_think_block(content) is False
+
+    def test_whitespace_only_after_tags(self, agent):
+        content = "<think>reasoning</think>\n   \n  \t  "
+        assert agent._has_content_after_think_block(content) is False
+
+
+# ── Consistency check ───────────────────────────────────────────────────
+
+class TestConsistencyWithStripThinkBlocks:
+    """_has_content_after_think_block(x) should return False whenever
+    _strip_think_blocks(x).strip() is empty, and vice versa."""
+
+    SAMPLES = [
+        "<think>x</think>",
+        "<thinking>x</thinking>",
+        "<THINKING>X</THINKING>",
+        "<reasoning>x</reasoning>",
+        "<REASONING_SCRATCHPAD>x</REASONING_SCRATCHPAD>",
+        "<think>a</think><thinking>b</thinking>",
+        "<think>a</think> real content",
+        "<thinking>a</thinking> real content",
+        "plain text",
+        "",
+    ]
+
+    def test_consistent_detection(self, agent):
+        for sample in self.SAMPLES:
+            stripped = agent._strip_think_blocks(sample).strip()
+            has_content = agent._has_content_after_think_block(sample)
+            assert has_content == bool(stripped), (
+                f"Inconsistency for {sample!r}: "
+                f"_has_content={has_content}, stripped={stripped!r}"
+            )


### PR DESCRIPTION
## Summary

`_has_content_after_think_block()` only stripped `<think>` tags when checking whether a response has real content. Meanwhile, `_strip_think_blocks()` — used everywhere else — also strips `<thinking>`, `<THINKING>`, `<reasoning>`, and `<REASONING_SCRATCHPAD>`.

This inconsistency causes models that use non-`<think>` reasoning tags (Qwen, local models, etc.) to bypass the empty-response retry logic, serving raw XML thinking output directly to users.

## Root Cause

```python
# _has_content_after_think_block — BEFORE (only <think>):
cleaned = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL)

# _strip_think_blocks — handles ALL variants:
content = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL)
content = re.sub(r'<thinking>.*?</thinking>', '', content, flags=re.DOTALL | re.IGNORECASE)
content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL)
content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL)
```

When a model responds with only `<thinking>reasoning here</thinking>` and no actual content:

1. `_has_content_after_think_block` strips `<think>` (no match) → sees `<thinking>...` as "real content" → returns `True`
2. Empty-response retry logic at line 6512 is **never triggered**
3. `_strip_think_blocks` later removes the tags for display → response is empty or garbled
4. User sees raw `<thinking>` XML or gets an empty response without any retry

## Fix

Added the same four regex patterns from `_strip_think_blocks` to `_has_content_after_think_block` so both functions recognize the same tag variants.

## Affected Models

- Qwen (uses `<thinking>`)
- Local models via Ollama/LM Studio that use `<thinking>` or `<reasoning>`
- Any model producing `<REASONING_SCRATCHPAD>` blocks

## Test Plan

- [x] `pytest tests/test_think_block_detection.py -v` — 17 new tests covering all tag variants and a consistency check between both functions
- [x] Tests verify that `_has_content_after_think_block(x)` returns `False` whenever `_strip_think_blocks(x).strip()` is empty (and vice versa)