### PR TITLE
fix: Ollama tool calling and context length detection

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -555,6 +555,9 @@ def _query_local_context_length(model: str, base_url: str) -> Optional[int]:
     """Query a local server for the model's context length."""
     import httpx
 
+    # Keep original for Ollama tag matching (e.g. "model:latest") before
+    # stripping provider prefixes.
+    original_model = model
     # Strip recognised provider prefix (e.g., "local:model-name" → "model-name").
     # Ollama "model:tag" colons (e.g. "qwen3.5:27b") are intentionally preserved.
     model = _strip_provider_prefix(model)
@@ -573,6 +576,22 @@ def _query_local_context_length(model: str, base_url: str) -> Optional[int]:
         with httpx.Client(timeout=3.0) as client:
             # Ollama: /api/show returns model details with context info
             if server_type == "ollama":
+                # Prefer /api/ps for actual loaded context over theoretical max
+                try:
+                    ps_resp = client.get(f"{server_url}/api/ps")
+                    if ps_resp.status_code == 200:
+                        ps_data = ps_resp.json()
+                        for m in ps_data.get("models", []):
+                            m_name = m.get("name", "") or m.get("model", "")
+                            if (m_name == original_model or
+                                    m_name == model or
+                                    m_name.split(":")[0] == original_model.split(":")[0]):
+                                ctx = m.get("context_length")
+                                if isinstance(ctx, (int, float)) and ctx > 0:
+                                    return int(ctx)
+                except Exception:
+                    pass
+
                 resp = client.post(f"{server_url}/api/show", json={"name": model})
                 if resp.status_code == 200:
                     data = resp.json()

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -745,9 +745,9 @@ def get_model_context_length(
 
     Resolution order:
     0. Explicit config override (model.context_length or custom_providers per-model)
-    1. Persistent cache (previously discovered via probing)
-    2. Active endpoint metadata (/models for explicit custom endpoints)
-    3. Local server query (for local endpoints)
+    1. Live local server query (for local endpoints — loaded ctx can change)
+    2. Persistent cache (fallback when local server is unreachable)
+    3. Active endpoint metadata (/models for explicit custom endpoints)
     4. Anthropic /v1/models API (API-key users only, not OAuth)
     5. OpenRouter live API metadata
     6. Nous suffix-match via OpenRouter cache
@@ -764,13 +764,21 @@ def get_model_context_length(
     # local servers actually know about.  Ollama "model:tag" colons are preserved.
     model = _strip_provider_prefix(model)
 
-    # 1. Check persistent cache (model+provider)
+    # 1. For local endpoints, prefer live query over cache (loaded context can
+    #    change between runs due to different VRAM or num_ctx settings).
+    if base_url and is_local_endpoint(base_url):
+        live_ctx = _query_local_context_length(model, base_url)
+        if live_ctx:
+            save_context_length(model, base_url, live_ctx)
+            return live_ctx
+
+    # 2. Check persistent cache (model+provider)
     if base_url:
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
             return cached
 
-    # 2. Active endpoint metadata for explicit custom routes
+    # 3. Active endpoint metadata for explicit custom routes
     if _is_custom_endpoint(base_url):
         endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
         matched = endpoint_metadata.get(model)

--- a/agent/text_tool_call_extraction.py
+++ b/agent/text_tool_call_extraction.py
@@ -1,0 +1,33 @@
+"""Extract tool calls from text content when structured tool_calls are absent."""
+
+from typing import List, Optional, Tuple
+
+
+def extract_text_tool_calls(
+    content: Optional[str],
+    existing_tool_calls: Optional[list],
+) -> Tuple[Optional[str], Optional[list]]:
+    """Parse <tool_call> XML from content when no structured tool_calls exist.
+
+    Returns (cleaned_content, parsed_tool_calls) or (original_content, None).
+    """
+    # Skip if structured tool calls already present
+    if existing_tool_calls:
+        return content, None
+
+    # Skip if no content to parse
+    if not content or "<tool_call>" not in content:
+        return content, None
+
+    from environments.tool_call_parsers.hermes_parser import HermesToolCallParser
+
+    parser = HermesToolCallParser()
+    cleaned, tool_calls = parser.parse(content)
+
+    if tool_calls:
+        # Strip whitespace from cleaned content
+        if cleaned:
+            cleaned = cleaned.strip()
+        return cleaned, tool_calls
+
+    return content, None

--- a/run_agent.py
+++ b/run_agent.py
@@ -6365,7 +6365,17 @@ class AIAgent:
                     }
                 elif hasattr(self, "_codex_incomplete_retries"):
                     self._codex_incomplete_retries = 0
-                
+
+                # --- Text-based tool call extraction (Ollama / local models) ---
+                if not getattr(assistant_message, 'tool_calls', None) and assistant_message.content:
+                    from agent.text_tool_call_extraction import extract_text_tool_calls
+                    _parsed_content, _parsed_tcs = extract_text_tool_calls(
+                        assistant_message.content, assistant_message.tool_calls
+                    )
+                    if _parsed_tcs:
+                        assistant_message.content = _parsed_content
+                        assistant_message.tool_calls = _parsed_tcs
+
                 # Check for tool calls
                 if assistant_message.tool_calls:
                     if not self.quiet_mode:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -185,6 +185,38 @@ class TestGetModelContextLength:
             assert result == 32768  # cache wins over API's 999999
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata._query_local_context_length")
+    def test_live_local_query_beats_stale_cache(self, mock_local_query, mock_fetch, tmp_path):
+        """For local endpoints, a live server response takes priority over cached value."""
+        mock_fetch.return_value = {}
+        mock_local_query.return_value = 8192  # live server reports 8k (e.g. low VRAM run)
+        cache_file = tmp_path / "cache.yaml"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            # Stale cache entry claims 1M (written when VRAM was plentiful)
+            save_context_length("nemotron-mini", "http://localhost:11434", 1048576)
+            result = get_model_context_length(
+                "nemotron-mini", base_url="http://localhost:11434"
+            )
+        # Live query (8192) must win over stale cache (1048576)
+        assert result == 8192
+        mock_local_query.assert_called_once_with("nemotron-mini", "http://localhost:11434")
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata._query_local_context_length")
+    def test_stale_cache_used_when_local_server_unreachable(self, mock_local_query, mock_fetch, tmp_path):
+        """If local server is unreachable, fall back to the persistent cache."""
+        mock_fetch.return_value = {}
+        mock_local_query.return_value = None  # server not running
+        cache_file = tmp_path / "cache.yaml"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            save_context_length("nemotron-mini", "http://localhost:11434", 32768)
+            result = get_model_context_length(
+                "nemotron-mini", base_url="http://localhost:11434"
+            )
+        # Cache (32768) is used since live query returned None
+        assert result == 32768
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     def test_no_base_url_skips_cache(self, mock_fetch, tmp_path):
         """Without base_url, cache lookup is skipped."""
         mock_fetch.return_value = {}

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -31,6 +31,7 @@ from agent.model_metadata import (
     parse_context_limit_from_error,
     save_context_length,
     fetch_model_metadata,
+    detect_local_server_type,
     _MODEL_CACHE_TTL,
 )
 
@@ -633,3 +634,130 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+# =========================================================================
+# detect_local_server_type — synthetic probe response tests
+# =========================================================================
+
+class TestDetectLocalServerType:
+    """detect_local_server_type with mocked httpx.Client responses."""
+
+    def _make_resp(self, status_code, body):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.text = str(body)
+        resp.json.return_value = body
+        return resp
+
+    def _make_client(self, url_to_response):
+        """Return a mock httpx.Client whose .get() dispatches by URL suffix."""
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+
+        def get_side_effect(url, **kwargs):
+            for suffix, resp in url_to_response.items():
+                if url.endswith(suffix):
+                    return resp
+            raise Exception(f"Unexpected URL: {url}")
+
+        client_mock.get.side_effect = get_side_effect
+        return client_mock
+
+    def test_lm_studio_detected_before_ollama(self):
+        """LM Studio's /api/v1/models is checked first; returns 'lm-studio'."""
+        client_mock = self._make_client({
+            "/api/v1/models": self._make_resp(200, {"data": []}),
+        })
+        with patch("httpx.Client", return_value=client_mock):
+            result = detect_local_server_type("http://172.26.16.1:1234/v1")
+        assert result == "lm-studio"
+
+    def test_ollama_requires_models_key_in_response(self):
+        """Ollama probe must find 'models' key; plain 200 is not enough."""
+        client_mock = self._make_client({
+            "/api/v1/models": self._make_resp(404, {}),
+            "/api/tags": self._make_resp(200, {"models": []}),
+        })
+        with patch("httpx.Client", return_value=client_mock):
+            result = detect_local_server_type("http://localhost:11434")
+        assert result == "ollama"
+
+    def test_lm_studio_error_response_not_misidentified_as_ollama(self):
+        """LM Studio returns 200 + {'error': ...} on /api/tags — must NOT return 'ollama'."""
+        def get_side_effect(url, **kwargs):
+            if url.endswith("/api/v1/models"):
+                raise Exception("Connection refused")
+            if url.endswith("/api/tags"):
+                # LM Studio answers /api/tags with 200 + error body
+                return self._make_resp(200, {"error": "Unexpected endpoint"})
+            raise Exception(f"Unexpected URL: {url}")
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.side_effect = get_side_effect
+
+        with patch("httpx.Client", return_value=client_mock):
+            result = detect_local_server_type("http://172.26.16.1:1234/v1")
+        assert result != "ollama"
+
+    def test_ollama_200_without_models_key_not_identified(self):
+        """200 on /api/tags without 'models' key is not enough to identify Ollama."""
+        client_mock = self._make_client({
+            "/api/v1/models": self._make_resp(404, {}),
+            "/api/tags": self._make_resp(200, {"error": "Unexpected endpoint"}),
+        })
+        with patch("httpx.Client", return_value=client_mock):
+            result = detect_local_server_type("http://172.26.16.1:1234")
+        assert result != "ollama"
+
+    def test_lm_studio_detected_when_v1_suffix_in_url(self):
+        """/v1 suffix is stripped before probing; LM Studio still detected."""
+        client_mock = self._make_client({
+            "/api/v1/models": self._make_resp(200, {"data": []}),
+        })
+        with patch("httpx.Client", return_value=client_mock):
+            result = detect_local_server_type("http://172.26.16.1:1234/v1")
+        assert result == "lm-studio"
+
+    def test_llamacpp_detected(self):
+        """llama.cpp identified via /props with 'default_generation_settings' in body."""
+        client_mock = self._make_client({
+            "/api/v1/models": self._make_resp(404, {}),
+            "/api/tags": self._make_resp(404, {}),
+            "/props": self._make_resp(200, {"default_generation_settings": {"n_ctx": 4096}}),
+        })
+        # Override text for /props to include the key
+        props_resp = self._make_resp(200, {})
+        props_resp.text = '{"default_generation_settings": {"n_ctx": 4096}}'
+
+        def get_side_effect(url, **kwargs):
+            if url.endswith("/api/v1/models"):
+                return self._make_resp(404, {})
+            if url.endswith("/api/tags"):
+                return self._make_resp(404, {})
+            if url.endswith("/props"):
+                return props_resp
+            raise Exception(f"Unexpected URL: {url}")
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.side_effect = get_side_effect
+
+        with patch("httpx.Client", return_value=client_mock):
+            result = detect_local_server_type("http://localhost:8080")
+        assert result == "llamacpp"
+
+    def test_all_probes_fail_returns_none(self):
+        """When no probe succeeds, None is returned."""
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.side_effect = Exception("Connection refused")
+
+        with patch("httpx.Client", return_value=client_mock):
+            result = detect_local_server_type("http://localhost:9999")
+        assert result is None

--- a/tests/agent/test_text_tool_call_extraction.py
+++ b/tests/agent/test_text_tool_call_extraction.py
@@ -1,0 +1,83 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.text_tool_call_extraction import extract_text_tool_calls
+
+
+def _make_tool_call(name, arguments):
+    fn = SimpleNamespace(name=name, arguments=json.dumps(arguments))
+    return SimpleNamespace(id="tc-1", type="function", function=fn)
+
+
+def test_no_extraction_when_structured_tool_calls_present():
+    existing = [_make_tool_call("terminal", {"command": "ls"})]
+    content = "some response text"
+    result_content, result_calls = extract_text_tool_calls(content, existing)
+    assert result_content == content
+    assert result_calls is None
+
+
+def test_extracts_single_hermes_tool_call():
+    content = '<tool_call>{"name":"terminal","arguments":{"command":"ls"}}</tool_call>'
+    _, calls = extract_text_tool_calls(content, None)
+    assert calls is not None
+    assert len(calls) == 1
+    assert calls[0].function.name == "terminal"
+    assert json.loads(calls[0].function.arguments) == {"command": "ls"}
+
+
+def test_extracts_multiple_tool_calls():
+    content = (
+        '<tool_call>{"name":"terminal","arguments":{"command":"ls"}}</tool_call>'
+        '<tool_call>{"name":"read_file","arguments":{"path":"/etc/hosts"}}</tool_call>'
+    )
+    _, calls = extract_text_tool_calls(content, None)
+    assert calls is not None
+    assert len(calls) == 2
+
+
+def test_preserves_content_before_tool_call():
+    content = 'Let me check.\n<tool_call>{"name":"terminal","arguments":{"command":"ls"}}</tool_call>'
+    result_content, calls = extract_text_tool_calls(content, None)
+    assert result_content == "Let me check."
+    assert calls is not None
+    assert len(calls) == 1
+
+
+def test_no_extraction_for_plain_text():
+    content = "Hello, how can I help?"
+    result_content, calls = extract_text_tool_calls(content, None)
+    assert result_content == content
+    assert calls is None
+
+
+def test_no_extraction_for_none_content():
+    result_content, calls = extract_text_tool_calls(None, None)
+    assert result_content is None
+    assert calls is None
+
+
+def test_no_extraction_for_empty_content():
+    result_content, calls = extract_text_tool_calls("", None)
+    assert result_content == ""
+    assert calls is None
+
+
+def test_malformed_json_returns_original():
+    content = "<tool_call>not valid json</tool_call>"
+    result_content, calls = extract_text_tool_calls(content, None)
+    assert result_content == content
+    assert calls is None
+
+
+def test_tool_calls_have_required_attributes():
+    content = '<tool_call>{"name":"terminal","arguments":{"command":"pwd"}}</tool_call>'
+    _, calls = extract_text_tool_calls(content, None)
+    assert calls is not None
+    for tc in calls:
+        assert isinstance(tc.id, str)
+        assert isinstance(tc.function.name, str)
+        assert isinstance(tc.function.arguments, str)
+        json.loads(tc.function.arguments)  # must be valid JSON

--- a/tests/test_model_metadata_local_ctx.py
+++ b/tests/test_model_metadata_local_ctx.py
@@ -507,16 +507,28 @@ class TestGetModelContextLengthLocalFallback:
 
         mock_query.assert_not_called()
 
-    def test_cached_result_skips_local_query(self):
-        """Cached context length is returned without querying the local server."""
+    def test_local_endpoint_live_query_takes_priority_over_cache(self):
+        """For local endpoints, live query runs before cache (loaded ctx can change between runs)."""
         from agent.model_metadata import get_model_context_length
 
         with patch("agent.model_metadata.get_cached_context_length", return_value=65536), \
-             patch("agent.model_metadata._query_local_context_length") as mock_query:
+             patch("agent.model_metadata._query_local_context_length", return_value=131072) as mock_query, \
+             patch("agent.model_metadata.save_context_length"):
+            result = get_model_context_length("omnicoder-9b", "http://localhost:11434/v1")
+
+        assert result == 131072
+        mock_query.assert_called_once()
+
+    def test_cached_result_used_as_fallback_when_local_query_returns_none(self):
+        """For local endpoints, cache is used as fallback when the live query returns None."""
+        from agent.model_metadata import get_model_context_length
+
+        with patch("agent.model_metadata.get_cached_context_length", return_value=65536), \
+             patch("agent.model_metadata._query_local_context_length", return_value=None) as mock_query:
             result = get_model_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
         assert result == 65536
-        mock_query.assert_not_called()
+        mock_query.assert_called_once()
 
     def test_no_base_url_does_not_query_local_server(self):
         """When base_url is empty, local server is not queried."""

--- a/tests/test_model_metadata_local_ctx.py
+++ b/tests/test_model_metadata_local_ctx.py
@@ -70,6 +70,44 @@ class TestQueryLocalContextLengthOllama:
 
         assert result == 32768
 
+    def test_ollama_ps_context_overrides_model_info(self):
+        """When Ollama /api/ps reports a loaded model, use its context_length
+        instead of the theoretical max from /api/show model_info."""
+        from agent.model_metadata import _query_local_context_length
+
+        # /api/ps returns the ACTUAL loaded context (65536)
+        ps_resp = self._make_resp(200, {
+            "models": [{
+                "name": "nemotron-3-nano:latest",
+                "model": "nemotron-3-nano:latest",
+                "context_length": 65536,
+                "size_vram": 23925873408,
+            }]
+        })
+
+        # /api/show returns theoretical max from model weights (1048576)
+        show_resp = self._make_resp(200, {
+            "model_info": {
+                "nemotron_h_moe.context_length": 1048576,
+            },
+            "parameters": "temperature                    1\ntop_p                          1",
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.return_value = ps_resp
+        client_mock.post.return_value = show_resp
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("nemotron-3-nano:latest", "http://192.168.1.22:11434")
+
+        assert result == 65536, (
+            f"Expected loaded context (65536) from /api/ps but got {result}. "
+            "model_info theoretical max (1048576) must not win over actual loaded context."
+        )
+
     def test_ollama_show_404_falls_through(self):
         """When /api/show returns 404, falls through to /v1/models/{model}."""
         from agent.model_metadata import _query_local_context_length


### PR DESCRIPTION
## Summary

- **Tool call extraction**: Ollama models return tool calls as `<tool_call>` XML in message content instead of structured `tool_calls` objects. Adds a text extraction layer that delegates to the existing `HermesToolCallParser`, wired into `run_agent.py` after content normalization. Cloud models are unaffected — a guard skips extraction when structured `tool_calls` are already present.
- **Context length from /api/ps**: Ollama's `/api/show` returns the theoretical max context from model weights (e.g. 1M for nemotron-3-nano), but the actual loaded context depends on available VRAM. Now checks `/api/ps` first for the runtime-allocated `context_length` before falling back to `/api/show`.
- **Live query over stale cache**: For local endpoints, the loaded context can change between runs. Now queries the server live before trusting the persistent cache, and updates the cache with fresh values.

Fixes #2074

## Test plan

- [x] 9 unit tests for `extract_text_tool_calls()` covering: structured tool_calls bypass, single/multiple extraction, content preservation, edge cases (None, empty, malformed JSON), attribute validation
- [x] Test that `/api/ps` loaded context (65536) overrides `/api/show` theoretical max (1048576)
- [x] Test that live local query beats stale cached value
- [x] Test that stale cache is used as fallback when local server is unreachable
- [x] 109 total tests pass, 0 regressions
- [x] E2E: test against real Ollama server with tool-calling model