### PR TITLE
fix(cron): add Matrix to scheduler delivery platform_map

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -136,6 +136,7 @@ def _deliver_result(job: dict, content: str) -> None:
         "slack": Platform.SLACK,
         "whatsapp": Platform.WHATSAPP,
         "signal": Platform.SIGNAL,
+        "matrix": Platform.MATRIX,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
     }


### PR DESCRIPTION
## Summary

- Adds `"matrix": Platform.MATRIX` to the `platform_map` in `_deliver_result()` in `cron/scheduler.py`
- Matrix is already a supported gateway platform (`Platform.MATRIX` exists in the enum, `MatrixAdapter` is wired in `gateway/run.py`) but was missing from the cron scheduler's delivery map
- Without this, cron jobs configured to deliver results to Matrix rooms silently fail with "unknown platform"

## Test plan

- [ ] Configure a cron job with `"deliver_to": {"platform": "matrix", "chat_id": "!roomid:server"}`
- [ ] Verify job output is delivered to the Matrix room
- [ ] Verify existing platform deliveries (Telegram, Discord, Slack, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)