### PR TITLE
feat(cron): support per-job max_iterations override

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -340,7 +340,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     prefill_messages = None
 
         # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 90
+        # Per-job override > global config > default
+        max_iterations = job.get("max_iterations") or _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 90
 
         # Provider routing
         pr = _cfg.get("provider_routing", {})


### PR DESCRIPTION
## Summary

- Allows individual cron jobs to specify `max_iterations` in their job definition (e.g., in `jobs.json`)
- Overrides the global `agent.max_turns` / `max_turns` config on a per-job basis
- Follows the existing per-job override pattern already used by `model`, `provider`, and `base_url`

**Fallback chain:** `job.max_iterations` > `config.agent.max_turns` > `config.max_turns` > `90`

### Use case

Research/accumulation jobs that use web search and file tools often need 20+ iterations, while simple notification jobs only need 3-5. Currently all jobs share the same global limit, forcing a compromise that either wastes resources on simple jobs or constrains complex ones.

### Example

```json
{
  "id": "daily-research",
  "name": "Daily Research Digest",
  "prompt": "Research and compile...",
  "max_iterations": 25,
  "schedule": "0 8 * * *"
}
```

## Test plan

- [ ] Job with `max_iterations` set uses that value
- [ ] Job without `max_iterations` falls back to global config
- [ ] Job without `max_iterations` and no global config falls back to 90

🤖 Generated with [Claude Code](https://claude.com/claude-code)