### PR TITLE
fix(gateway): inject PATH into launchd plist for macOS service

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -734,7 +734,9 @@ def generate_launchd_plist() -> str:
     # agent.  launchd provides only a minimal default PATH, so we capture the
     # full PATH at plist-generation time (i.e. from the user's interactive
     # shell) and bake it in.
-    sane_path = f"{venv_bin}:{os.environ['PATH']}"
+    sane_path = ":".join(
+        dict.fromkeys([venv_bin] + [p for p in os.environ["PATH"].split(":") if p])
+    )
 
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -726,9 +726,16 @@ def systemd_status(deep: bool = False, system: bool = False):
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
+    venv_bin = str(PROJECT_ROOT / "venv" / "bin")
     log_dir = get_hermes_home() / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
-    
+    # Prepend the venv bin to the current PATH so that tools installed in the
+    # venv (and user-installed tools like ffmpeg) are found by the launchd
+    # agent.  launchd provides only a minimal default PATH, so we capture the
+    # full PATH at plist-generation time (i.e. from the user's interactive
+    # shell) and bake it in.
+    sane_path = f"{venv_bin}:{os.environ['PATH']}"
+
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -748,6 +755,12 @@ def generate_launchd_plist() -> str:
     
     <key>WorkingDirectory</key>
     <string>{working_dir}</string>
+    
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>{sane_path}</string>
+    </dict>
     
     <key>RunAtLoad</key>
     <true/>

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -146,7 +146,6 @@ class TestLaunchdPlistPath:
             raise AssertionError("PATH key not found in plist")
 
 
-
 # ---------------------------------------------------------------------------
 # cmd_update — macOS launchd detection
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -130,6 +130,22 @@ class TestLaunchdPlistPath:
         plist = gateway_cli.generate_launchd_plist()
         assert "/custom/bin" in plist
 
+    def test_plist_path_deduplicates_venv_bin_when_already_in_path(self, monkeypatch):
+        venv_bin = str(gateway_cli.PROJECT_ROOT / "venv" / "bin")
+        monkeypatch.setenv("PATH", f"{venv_bin}:/usr/bin:/bin")
+        plist = gateway_cli.generate_launchd_plist()
+        lines = plist.splitlines()
+        for i, line in enumerate(lines):
+            if "<key>PATH</key>" in line.strip():
+                path_value = lines[i + 1].strip()
+                path_value = path_value.replace("<string>", "").replace("</string>", "")
+                parts = path_value.split(":")
+                assert parts.count(venv_bin) == 1
+                break
+        else:
+            raise AssertionError("PATH key not found in plist")
+
+
 
 # ---------------------------------------------------------------------------
 # cmd_update — macOS launchd detection

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -101,6 +101,36 @@ class TestLaunchdPlistReplace:
         assert replace_idx == run_idx + 1
 
 
+class TestLaunchdPlistPath:
+    def test_plist_contains_environment_variables(self):
+        plist = gateway_cli.generate_launchd_plist()
+        assert "<key>EnvironmentVariables</key>" in plist
+        assert "<key>PATH</key>" in plist
+
+    def test_plist_path_includes_venv_bin(self):
+        plist = gateway_cli.generate_launchd_plist()
+        venv_bin = str(gateway_cli.PROJECT_ROOT / "venv" / "bin")
+        assert venv_bin in plist
+
+    def test_plist_path_starts_with_venv_bin(self):
+        plist = gateway_cli.generate_launchd_plist()
+        lines = plist.splitlines()
+        for i, line in enumerate(lines):
+            if "<key>PATH</key>" in line.strip():
+                path_value = lines[i + 1].strip()
+                path_value = path_value.replace("<string>", "").replace("</string>", "")
+                venv_bin = str(gateway_cli.PROJECT_ROOT / "venv" / "bin")
+                assert path_value.startswith(venv_bin + ":")
+                break
+        else:
+            raise AssertionError("PATH key not found in plist")
+
+    def test_plist_path_includes_current_env_path(self, monkeypatch):
+        monkeypatch.setenv("PATH", "/custom/bin:/usr/bin:/bin")
+        plist = gateway_cli.generate_launchd_plist()
+        assert "/custom/bin" in plist
+
+
 # ---------------------------------------------------------------------------
 # cmd_update — macOS launchd detection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The launchd plist generated for macOS gateway service did not set `PATH`, so launchd's minimal default (`/usr/bin:/bin:/usr/sbin:/sbin`) was used at runtime
- This caused user-installed tools such as `ffmpeg` (Homebrew) and `node` to be not found, even though they were available in the user's interactive shell
- The systemd unit already sets `PATH` explicitly — this PR applies the same fix to the launchd plist

At plist-generation time (i.e. when the user runs `hermes gateway install` or `hermes gateway start` from their terminal), the full shell `PATH` is captured and baked into the plist, with the venv `bin` directory prepended. This covers all user-installed tools regardless of where they are installed, without hardcoding platform-specific paths like `/opt/homebrew/bin`.

PATH components are deduplicated using `dict.fromkeys()` (preserving order) so that venv/bin appears exactly once even when `generate_launchd_plist()` is called from within a launchd agent session (e.g. when an AI agent triggers `hermes gateway restart`). Without deduplication, each in-process restart would prepend an additional venv/bin, causing `refresh_launchd_plist_if_needed()` to detect a spurious change and rewrite/reload the plist on every restart.

## Test plan

- [x] Added unit tests in `tests/hermes_cli/test_update_gateway_restart.py` (`TestLaunchdPlistPath`): plist contains EnvironmentVariables/PATH key, PATH includes venv bin, PATH starts with venv bin, current process PATH is baked in at generation time, venv/bin is deduplicated when already present in PATH
- [x] On macOS with Homebrew-installed ffmpeg: install gateway service with `hermes gateway install`, confirm ffmpeg is found when a Discord voice message is transcribed
- [x] Confirm `hermes gateway start` detects the plist change via `refresh_launchd_plist_if_needed()` and reloads the service automatically

## Platforms tested

- macOS (Apple Silicon)

Generated with Claude Code