### PR TITLE
fix: don't route invalid_request_error 400s to fallback, skip persist regardless of size

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6123,8 +6123,15 @@ class AIAgent:
                     # Real invalid_request_error responses include a descriptive message;
                     # transient ones contain only "Error" or are empty. (ref: issue #1608)
                     _err_body = getattr(api_error, "body", None) or {}
+                    _err_type = (_err_body.get("error", {}).get("type", "") if isinstance(_err_body, dict) else "")
                     _err_message = (_err_body.get("error", {}).get("message", "") if isinstance(_err_body, dict) else "")
                     _is_generic_400 = (status_code == 400 and _err_message.strip().lower() in ("error", ""))
+                    # invalid_request_error means the request structure itself is rejected —
+                    # e.g. orphaned tool_result blocks, unknown fields, bad message format.
+                    # These will fail identically on every provider: routing to a fallback
+                    # just produces a second identical 400 from a different backend and hides
+                    # the root cause behind an opaque "Provider returned error" message.
+                    _is_invalid_request = (status_code == 400 and _err_type == "invalid_request_error")
                     is_client_status_error = isinstance(status_code, int) and 400 <= status_code < 500 and status_code not in _RETRYABLE_STATUS_CODES and not _is_generic_400
                     is_client_error = (is_local_validation_error or is_client_status_error or any(phrase in error_msg for phrase in [
                         'error code: 401', 'error code: 403',
@@ -6135,9 +6142,13 @@ class AIAgent:
                     ])) and not is_context_length_error
 
                     if is_client_error:
-                        # Try fallback before aborting — a different provider
-                        # may not have the same issue (rate limit, auth, etc.)
-                        if self._try_activate_fallback():
+                        # Try fallback before aborting — a different provider may not
+                        # have the same issue (rate limit, auth, etc.).
+                        # Exception: invalid_request_error is a structural rejection that
+                        # will fail on any provider. Skip fallback and abort immediately
+                        # so the root cause surfaces in the error message rather than being
+                        # masked by a second 400 from the fallback backend.
+                        if not _is_invalid_request and self._try_activate_fallback():
                             retry_count = 0
                             continue
                         self._dump_api_request_debug(
@@ -6146,15 +6157,16 @@ class AIAgent:
                         self._vprint(f"{self.log_prefix}❌ Non-retryable client error detected. Aborting immediately.", force=True)
                         self._vprint(f"{self.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
                         logging.error(f"{self.log_prefix}Non-retryable client error: {api_error}")
-                        # Skip session persistence when the error is likely
-                        # context-overflow related (status 400 + large session).
-                        # Persisting the failed user message would make the
-                        # session even larger, causing the same failure on the
-                        # next attempt. (#1630)
-                        if status_code == 400 and (approx_tokens > 50000 or len(api_messages) > 80):
+                        # Skip session persistence for invalid_request_error 400s regardless
+                        # of session size: these indicate a structural message problem that
+                        # will reproduce on every subsequent request. Persisting the failed
+                        # user message grows the session and guarantees the same failure on
+                        # the next attempt, creating an unrecoverable loop for gateway users.
+                        # Also skip for large sessions (existing behaviour, ref: #1630).
+                        if status_code == 400 and (_is_invalid_request or approx_tokens > 50000 or len(api_messages) > 80):
                             self._vprint(
                                 f"{self.log_prefix}⚠️  Skipping session persistence "
-                                f"for large failed session to prevent growth loop.",
+                                f"for failed session to prevent growth loop.",
                                 force=True,
                             )
                         else:


### PR DESCRIPTION
## Context

This PR addresses two related issues discovered while investigating the `invalid_request_error` 400 failures that have been reported with native Anthropic sessions (#2172 fixes the root cause — orphaned `tool_result` blocks). This PR provides defence-in-depth for that class of error and any other structural 400 that may arise.

Complements #2172 — both should land together.

---

## Problem 1: `invalid_request_error` 400s silently route to fallback, masking the root cause

When Anthropic returns a `400 invalid_request_error` (malformed message structure, orphaned `tool_result` blocks, unknown fields, etc.), the current code calls `_try_activate_fallback()` before aborting.

This produces two bad outcomes:

1. The fallback provider (e.g. OpenRouter) forwards the same malformed request to Anthropic's backend and returns the same 400 — but now attributed to `"Provider returned error / provider_name: Azure"`. The real cause is hidden behind a confusing cross-provider error message.

2. The user (or maintainer) sees an Azure/OpenRouter error and has no indication the problem originated in the request structure, making it very difficult to diagnose.

`invalid_request_error` is a structural rejection — it will fail identically on every provider. There is no point routing it to a fallback.

**Fix:** Detect `invalid_request_error` by checking `error.type` in the response body (alongside the existing `error.message` check for generic 400s). Skip `_try_activate_fallback()` for this error type and abort immediately with the original error intact.

---

## Problem 2: Mid-sized corrupt sessions persist and reproduce the failure on every restart

The existing `#1630` guard skips session persistence when a 400 occurs and the session is large (>50k tokens or >80 messages). This prevents the corrupt session from growing on large conversations.

However, the reported session had ~46 messages and ~29k tokens — below both thresholds. Result: the failed user message was persisted. On the next gateway restart, the session reloaded and the **first new message immediately triggered the same 400**, creating an unrecoverable loop requiring manual session file deletion.

The size thresholds were a reasonable heuristic for context-overflow 400s, but `invalid_request_error` indicates a structural message problem that will reproduce at *any* session size.

**Fix:** Skip session persistence for any `invalid_request_error` 400 regardless of session size, in addition to the existing large-session guard. Error message updated to remove the "large" qualifier.

---

## Changes

`run_agent.py`:
- Extract `_err_type` from the error body alongside the existing `_err_message`
- Define `_is_invalid_request` flag for `400 + type == "invalid_request_error"`
- Gate `_try_activate_fallback()` behind `not _is_invalid_request`
- Add `_is_invalid_request` to the session-persistence skip condition

---

## Test plan

- [ ] Structural 400 (`invalid_request_error`) from primary provider: aborts immediately, does not activate fallback, does not persist session
- [ ] Transient/ambiguous 400 (empty message, `"Error"`): existing behaviour preserved — fallback activated if available
- [ ] Auth/rate-limit errors (401, 403, 429): existing behaviour preserved
- [ ] Large session 400 (>50k tokens or >80 messages): existing skip-persist behaviour preserved
- [ ] Well-formed requests: no behavioural change

---

## Related

- #2172 — strips orphaned `tool_result` blocks in `convert_messages_to_anthropic()` (root cause fix)
- #1630 — original large-session persist skip
