### PR TITLE
fix: add linebreak in gateway stream after tool calls (#2177)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4413,6 +4413,9 @@ class GatewayRunner:
             repeat_count[0] = 0
             
             progress_queue.put(msg)
+
+            if stream_consumer_holder[0] is not None:
+                stream_consumer_holder[0].on_delta("\n\n")
         
         # Background task to send progress messages
         # Accumulates tool lines into a single message that gets edited


### PR DESCRIPTION
What does this PR do?
Fixes a formatting bug where text generated after a tool call is concatenated directly to the tool progress indicator. This injects `\n\n` into the stream delta immediately after a tool finishes, ensuring the LLM's response starts on a clean line.

Related Issue
Fixes #2177 

Type of Change
[x] 🐛 Bug fix (non-breaking change that fixes an issue)

Changes Made
- `gateway/run.py`: Added `stream_consumer_holder[0].on_delta("\n\n")` inside `progress_callback`.

Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] I've tested on my platform: github.dev (Browser environment)

