### PR TITLE
fix(gateway): detect stopped processes and release stale locks on --replace

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5075,6 +5075,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 except (ProcessLookupError, PermissionError):
                     pass
             remove_pid_file()
+            # Also release all scoped locks left by the old process.
+            # Stopped (Ctrl+Z) processes don't release locks on exit,
+            # leaving stale lock files that block the new gateway from starting.
+            try:
+                from gateway.status import release_all_scoped_locks
+                _released = release_all_scoped_locks()
+                if _released:
+                    logger.info("Released %d stale scoped lock(s) from old gateway.", _released)
+            except Exception:
+                pass
         else:
             hermes_home = os.getenv("HERMES_HOME", "~/.hermes")
             logger.error(

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -274,6 +274,21 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     and current_start != existing.get("start_time")
                 ):
                     stale = True
+                # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
+                # processes still respond to os.kill(pid, 0) but are not
+                # actually running. Treat them as stale so --replace works.
+                if not stale:
+                    try:
+                        _proc_status = Path(f"/proc/{existing_pid}/status")
+                        if _proc_status.exists():
+                            for _line in _proc_status.read_text().splitlines():
+                                if _line.startswith("State:"):
+                                    _state = _line.split()[1]
+                                    if _state in ("T", "t"):  # stopped or tracing stop
+                                        stale = True
+                                    break
+                    except (OSError, PermissionError):
+                        pass
         if stale:
             try:
                 lock_path.unlink(missing_ok=True)
@@ -312,6 +327,25 @@ def release_scoped_lock(scope: str, identity: str) -> None:
         lock_path.unlink(missing_ok=True)
     except OSError:
         pass
+
+
+def release_all_scoped_locks() -> int:
+    """Remove all scoped lock files in the lock directory.
+
+    Called during --replace to clean up stale locks left by stopped/killed
+    gateway processes that did not release their locks gracefully.
+    Returns the number of lock files removed.
+    """
+    lock_dir = _get_lock_dir()
+    removed = 0
+    if lock_dir.exists():
+        for lock_file in lock_dir.glob("*.lock"):
+            try:
+                lock_file.unlink(missing_ok=True)
+                removed += 1
+            except OSError:
+                pass
+    return removed
 
 
 def get_running_pid() -> Optional[int]:


### PR DESCRIPTION
Fixes #2178

## Root Cause
Two bugs when `hermes gateway run --replace` encounters a STOPPED (Ctrl+Z) process:

1. `acquire_scoped_lock()` treated stopped processes as alive — `os.kill(pid, 0)` succeeds for stopped processes, so stale lock files were never cleaned up
2. `start_gateway()` with `--replace` removed the PID file but not the scoped lock files in `~/.local/state/hermes/gateway-locks/`

## Fix (Option C: both fixes)

**gateway/status.py — Option B:**
- After `os.kill(pid, 0)` succeeds, check `/proc/<pid>/status` for process state
- If state is `T` (stopped) or `t` (tracing stop), treat as stale and clean up the lock

**gateway/status.py — Option A:**
- Added `release_all_scoped_locks()` function that removes all lock files in the lock directory

**gateway/run.py:**
- After `remove_pid_file()` in `--replace` logic, call `release_all_scoped_locks()` to clean up stale locks from the old gateway
