### PR TITLE
feat: add /queue command to queue prompts without interrupting

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3678,6 +3678,18 @@ class HermesCLI:
             self._handle_stop_command()
         elif canonical == "background":
             self._handle_background_command(cmd_original)
+        elif canonical == "queue":
+            if not self._agent_running:
+                _cprint("  /queue only works while Hermes is busy. Just type your message normally.")
+            else:
+                # Extract prompt after "/queue " or "/q "
+                parts = cmd_original.split(None, 1)
+                payload = parts[1].strip() if len(parts) > 1 else ""
+                if not payload:
+                    _cprint("  Usage: /queue <prompt>")
+                else:
+                    self._pending_input.put(payload)
+                    _cprint(f"  Queued for the next turn: {payload[:80]}{'...' if len(payload) > 80 else ''}")
         elif canonical == "skin":
             self._handle_skin_command(cmd_original)
         elif canonical == "voice":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1369,6 +1369,23 @@ class GatewayRunner:
                     del self._running_agents[_quick_key]
                 return await self._handle_reset_command(event)
 
+            # /queue <prompt> — queue without interrupting
+            if event.get_command() in ("queue", "q"):
+                queued_text = event.get_command_args().strip()
+                if not queued_text:
+                    return "Usage: /queue <prompt>"
+                adapter = self.adapters.get(source.platform)
+                if adapter:
+                    from gateway.platforms.base import MessageEvent as _ME, MessageType as _MT
+                    queued_event = _ME(
+                        text=queued_text,
+                        message_type=_MT.TEXT,
+                        source=event.source,
+                        message_id=event.message_id,
+                    )
+                    adapter._pending_messages[_quick_key] = queued_event
+                return "Queued for the next turn."
+
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])
                 adapter = self.adapters.get(source.platform)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -67,6 +67,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True),
     CommandDef("background", "Run a prompt in the background", "Session",
                aliases=("bg",), args_hint="<prompt>"),
+    CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",
+               aliases=("q",), args_hint="<prompt>"),
     CommandDef("status", "Show session info", "Session",
                gateway_only=True),
     CommandDef("sethome", "Set this chat as the home channel", "Session",


### PR DESCRIPTION
## Summary

Adds `/queue <prompt>` (alias `/q`) — queues a message for the next turn while the agent is busy, without interrupting the current run.

### Behavior
- `/queue do this next` while agent is busy → queued, agent keeps working, prompt runs next turn
- Enter while agent is busy → still interrupts as usual (no behavior change)
- `/queue` with no prompt → shows usage
- `/queue` when agent is idle → tells user to just type normally

### Changes (3 files, +31 lines)
- `hermes_cli/commands.py` — `CommandDef` for `/queue` with alias `/q`
- `cli.py` — handler puts payload into `_pending_input` queue
- `gateway/run.py` — handler in priority interrupt block creates a pending `MessageEvent` on the adapter without calling `.interrupt()`

### Test plan
- [x] 5641 tests pass, zero regressions