### PR TITLE
fix(acp): preserve leading whitespace in streaming chunks

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -356,7 +356,7 @@ class CopilotACPClient:
                 text_parts=text_parts,
                 reasoning_parts=reasoning_parts,
             )
-            return "".join(text_parts).strip(), "".join(reasoning_parts).strip()
+            return "".join(text_parts), "".join(reasoning_parts)
         finally:
             self.close()
 
@@ -380,7 +380,7 @@ class CopilotACPClient:
             content = update.get("content") or {}
             chunk_text = ""
             if isinstance(content, dict):
-                chunk_text = str(content.get("text") or "").strip()
+                chunk_text = str(content.get("text") or "")
             if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
                 text_parts.append(chunk_text)
             elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:


### PR DESCRIPTION
## Summary

Salvage of PR #2145 by @dlkakbs (cherry-picked onto current main with authorship preserved).

Fixes #2049 — LLM responses via copilot-acp were returned with all words concatenated (e.g. `Hey?I'mdoingwell,thanks!`).

**Root cause:** `.strip()` was called on each individual streaming chunk in `_handle_server_message`, which dropped the leading space that separates tokens. A second `.strip()` on the final joined result compounded the issue.

**Fix:** Remove both `.strip()` calls to preserve correct whitespace:
- Line 383: per-chunk `.strip()` removed (critical — this was eating inter-word spaces)
- Line 359: final join `.strip()` removed (cleanup — unnecessary on assembled result)

## Test plan

- All 5641 tests pass
- Verified the two `.strip()` calls are the only changes