### PR TITLE
feat(gateway): add message source tagging for multi-agent clarity

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -155,6 +155,11 @@ def _deliver_result(job: dict, content: str) -> None:
         logger.warning("Job '%s': platform '%s' not configured/enabled", job["id"], platform_name)
         return
 
+    # Message tagging — prepend cron job name for multi-agent clarity
+    job_name = job.get("name", "")
+    if job_name:
+        content = f"[Cron: {job_name}]\n{content}"
+
     # Run the async send in a fresh event loop (safe from any thread)
     try:
         result = asyncio.run(_send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id))

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -292,6 +292,16 @@ class DeliveryRouter:
         send_metadata = dict(metadata or {})
         if target.thread_id and "thread_id" not in send_metadata:
             send_metadata["thread_id"] = target.thread_id
+
+        # Message tagging — prepend source tag for multi-agent clarity
+        source_tag = send_metadata.pop("source_tag", None)
+        if not source_tag:
+            job_name = send_metadata.get("job_name")
+            if job_name:
+                source_tag = f"Cron: {job_name}"
+        if source_tag:
+            content = f"[{source_tag}]\n{content}"
+
         return await adapter.send(target.chat_id, content, metadata=send_metadata or None)
 
 


### PR DESCRIPTION
## Summary
- Prepends source tags to outgoing messages: `[Cron: Heartbeat]`, `[Mother]`, etc.
- Users running multiple agents on one Telegram chat can instantly identify who sent what
- Two small changes: `cron/scheduler.py` (cron tag) + `gateway/delivery.py` (metadata tag)

## Test plan
- [ ] Cron job fires and Telegram message shows `[Cron: job_name]` prefix
- [ ] External delivery with `source_tag` in metadata shows the tag
- [ ] Agent brain responses (no tag) are unaffected

Generated with [Claude Code](https://claude.com/claude-code)