### PR TITLE
fix: infer provider from base URL for models.dev context length lookup

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -151,22 +151,41 @@ def _is_custom_endpoint(base_url: str) -> bool:
     return bool(normalized) and not _is_openrouter_base_url(normalized)
 
 
-def _is_known_provider_base_url(base_url: str) -> bool:
+_URL_TO_PROVIDER: Dict[str, str] = {
+    "api.openai.com": "openai",
+    "chatgpt.com": "openai",
+    "api.anthropic.com": "anthropic",
+    "api.z.ai": "zai",
+    "api.moonshot.ai": "kimi-coding",
+    "api.kimi.com": "kimi-coding",
+    "api.minimax": "minimax",
+    "dashscope.aliyuncs.com": "alibaba",
+    "openrouter.ai": "openrouter",
+    "inference-api.nousresearch.com": "nous",
+    "api.deepseek.com": "deepseek",
+}
+
+
+def _infer_provider_from_url(base_url: str) -> Optional[str]:
+    """Infer the models.dev provider name from a base URL.
+
+    This allows context length resolution via models.dev for custom endpoints
+    like DashScope (Alibaba), Z.AI, Kimi, etc. without requiring the user to
+    explicitly set the provider name in config.
+    """
     normalized = _normalize_base_url(base_url)
     if not normalized:
-        return False
+        return None
     parsed = urlparse(normalized if "://" in normalized else f"https://{normalized}")
     host = parsed.netloc.lower() or parsed.path.lower()
-    known_hosts = (
-        "api.openai.com",
-        "chatgpt.com",
-        "api.anthropic.com",
-        "api.z.ai",
-        "api.moonshot.ai",
-        "api.kimi.com",
-        "api.minimax",
-    )
-    return any(known_host in host for known_host in known_hosts)
+    for url_part, provider in _URL_TO_PROVIDER.items():
+        if url_part in host:
+            return provider
+    return None
+
+
+def _is_known_provider_base_url(base_url: str) -> bool:
+    return _infer_provider_from_url(base_url) is not None
 
 
 def is_local_endpoint(base_url: str) -> bool:
@@ -808,13 +827,21 @@ def get_model_context_length(
     # These are provider-specific and take priority over the generic OR cache,
     # since the same model can have different context limits per provider
     # (e.g. claude-opus-4.6 is 1M on Anthropic but 128K on GitHub Copilot).
-    if provider == "nous":
+    # If provider is generic (openrouter/custom/empty), try to infer from URL.
+    effective_provider = provider
+    if not effective_provider or effective_provider in ("openrouter", "custom"):
+        if base_url:
+            inferred = _infer_provider_from_url(base_url)
+            if inferred:
+                effective_provider = inferred
+
+    if effective_provider == "nous":
         ctx = _resolve_nous_context_length(model)
         if ctx:
             return ctx
-    if provider:
+    if effective_provider:
         from agent.models_dev import lookup_models_dev_context
-        ctx = lookup_models_dev_context(provider, model)
+        ctx = lookup_models_dev_context(effective_provider, model)
         if ctx:
             return ctx
 


### PR DESCRIPTION
## Summary

Custom endpoint users (DashScope/Alibaba, Z.AI, Kimi, DeepSeek, etc.) get incorrect context lengths because their provider resolves as `"openrouter"` or `"custom"`, causing an early return at step 3 with 128K fallback — the models.dev lookup (step 5) is never reached.

**Reported issue:** `qwen3.5-plus` on DashScope (`coding-intl.dashscope.aliyuncs.com`) shows 128K instead of 1M.

### Root cause

`_is_known_provider_base_url()` didn't include DashScope, DeepSeek, OpenRouter, or Nous URLs. When a URL is "not known" and "not local", step 3 early-returns with `DEFAULT_FALLBACK_CONTEXT` (128K), skipping steps 4-8 entirely — including the models.dev lookup that has the correct context length.

### Fix

- Add `_URL_TO_PROVIDER` mapping: 11 known API hostnames to their models.dev provider IDs (DashScope->alibaba, Z.AI->zai, Kimi->kimi-coding, DeepSeek->deepseek, etc.)
- Add `_infer_provider_from_url()` to extract the provider from a base URL
- In step 5, when the explicit provider is generic (`openrouter`/`custom`/empty), infer from the base URL before the models.dev lookup
- Refactor `_is_known_provider_base_url()` to use the same mapping (no duplicate hostname list)

### Behavior change analysis

| Scenario | Before | After | Change |
|----------|--------|-------|--------|
| DashScope + qwen3.5-plus | 128K (early return) | 1M (models.dev) | Fix |
| DeepSeek API | 128K (early return) | Correct (models.dev) | Fix |
| OpenRouter URL with base_url set | 128K (early return) | Correct (step 6 metadata) | Improvement |
| Together/Groq (not mapped) | 128K (early return) | 128K (early return) | No change |
| Local Ollama | Local query | Local query | No change |
| Unknown proxy | 128K fallback | 128K fallback | No change |
| No base_url | Steps 4-8 | Steps 4-8 | No change |

If a mapped URL serves a model not in models.dev, the lookup returns None and falls through to steps 6-8 as before — no regression.

## Test plan

- [x] `_infer_provider_from_url()` verified for all 11 mapped URLs + unknown URLs
- [x] `qwen3.5-plus` on DashScope resolves to 1M (was 128K)
- [x] `glm-4-plus` on Z.AI resolves to 202K
- [x] All 113 model_metadata tests pass
- [x] `_is_known_provider_base_url()` backward compatible for all 7 original URLs