### PR TITLE
fix: prevent 'event loop already running' when async tools run in parallel

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -68,6 +68,10 @@ def _run_async(coro):
     loop so that cached async clients (httpx / AsyncOpenAI) remain bound
     to a live loop and don't trigger "Event loop is closed" on GC.
 
+    When called from a worker thread (parallel tool execution), we detect
+    that we're NOT on the main thread and use asyncio.run() with a fresh
+    loop to avoid contention on the shared persistent loop.
+
     This is the single source of truth for sync->async bridging in tool
     handlers. The RL paths (agent_loop.py, tool_context.py) also provide
     outer thread-pool wrapping as defense-in-depth, but each handler is
@@ -79,10 +83,17 @@ def _run_async(coro):
         loop = None
 
     if loop and loop.is_running():
+        # Inside an async context (gateway, RL env) — run in a fresh thread.
         import concurrent.futures
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
             future = pool.submit(asyncio.run, coro)
             return future.result(timeout=300)
+
+    # If we're on a worker thread (e.g., parallel tool execution),
+    # use asyncio.run() with its own loop to avoid contending with the
+    # shared persistent loop from another parallel worker.
+    if threading.current_thread() is not threading.main_thread():
+        return asyncio.run(coro)
 
     tool_loop = _get_tool_loop()
     return tool_loop.run_until_complete(coro)


### PR DESCRIPTION
## Summary

Fixes `RuntimeError: This event loop is already running` when async tools (like `web_extract`) are executed as part of a parallel tool batch.

### Root cause

When the model returns multiple tool calls, `run_agent.py` runs them concurrently in a `ThreadPoolExecutor` (line 4598). Each worker thread calls `_run_async()` which used a **shared persistent event loop** (`_get_tool_loop()`). If two async tools ran in parallel, the second thread would call `tool_loop.run_until_complete()` while the first thread was still using it → `RuntimeError: This event loop is already running`.

This only happened when:
- Multiple tool calls returned by the model
- At least two are async tools (`web_extract`, `web_search`, etc.)
- They get parallelized (different scopes, no file conflicts)

It didn't reproduce in CLI single-tool-at-a-time usage, only in parallel execution.

### Fix

Detect worker threads (`threading.current_thread() is not threading.main_thread()`) and use `asyncio.run()` with a per-thread fresh loop instead of the shared persistent one. The shared loop is still used for the main thread (CLI sequential path) to keep cached async clients alive.

### Test plan

```
5647 passed, 200 skipped, 23 deselected
```