### PR TITLE
feat: add proxy support for Discord, Slack, and SMS platform senders

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -495,9 +495,11 @@ class DiscordAdapter(BasePlatformAdapter):
             intents.voice_states = True
             
             # Create bot
+            proxy = os.getenv("DISCORD_PROXY") or os.getenv("HTTPS_PROXY")
             self._client = commands.Bot(
                 command_prefix="!",  # Not really used, we handle raw messages
                 intents=intents,
+                proxy=proxy,
             )
             
             # Parse allowed user entries (may contain usernames or IDs)
@@ -1174,8 +1176,9 @@ class DiscordAdapter(BasePlatformAdapter):
             
             # Download the image and send as a Discord file attachment
             # (Discord renders attachments inline, unlike plain URLs)
+            proxy = os.getenv("DISCORD_PROXY") or os.getenv("HTTPS_PROXY")
             async with aiohttp.ClientSession() as session:
-                async with session.get(image_url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+                async with session.get(image_url, proxy=proxy, timeout=aiohttp.ClientTimeout(total=30)) as resp:
                     if resp.status != 200:
                         raise Exception(f"Failed to download image: HTTP {resp.status}")
                     

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -488,10 +488,11 @@ async def _send_discord(token, chat_id, message):
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
+        proxy = os.getenv("DISCORD_PROXY") or os.getenv("HTTPS_PROXY")
         url = f"https://discord.com/api/v10/channels/{chat_id}/messages"
         headers = {"Authorization": f"Bot {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
-            async with session.post(url, headers=headers, json={"content": message}) as resp:
+            async with session.post(url, headers=headers, json={"content": message}, proxy=proxy) as resp:
                 if resp.status not in (200, 201):
                     body = await resp.text()
                     return {"error": f"Discord API error ({resp.status}): {body}"}
@@ -508,10 +509,11 @@ async def _send_slack(token, chat_id, message):
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
+        proxy = os.getenv("HTTPS_PROXY")
         url = "https://slack.com/api/chat.postMessage"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
-            async with session.post(url, headers=headers, json={"channel": chat_id, "text": message}) as resp:
+            async with session.post(url, headers=headers, json={"channel": chat_id, "text": message}, proxy=proxy) as resp:
                 data = await resp.json()
                 if data.get("ok"):
                     return {"success": True, "platform": "slack", "chat_id": chat_id, "message_id": data.get("ts")}
@@ -649,13 +651,14 @@ async def _send_sms(auth_token, chat_id, message):
         url = f"https://api.twilio.com/2010-04-01/Accounts/{account_sid}/Messages.json"
         headers = {"Authorization": f"Basic {encoded}"}
 
+        proxy = os.getenv("HTTPS_PROXY")
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
             form_data = aiohttp.FormData()
             form_data.add_field("From", from_number)
             form_data.add_field("To", chat_id)
             form_data.add_field("Body", message)
 
-            async with session.post(url, data=form_data, headers=headers) as resp:
+            async with session.post(url, data=form_data, headers=headers, proxy=proxy) as resp:
                 body = await resp.json()
                 if resp.status >= 400:
                     error_msg = body.get("message", str(body))


### PR DESCRIPTION
## Summary

Add HTTP proxy support for all aiohttp-based platform connections: Discord gateway (WebSocket), Discord REST API, Slack Web API, and Twilio SMS API.

- Reads `DISCORD_PROXY` env var (with `HTTPS_PROXY` fallback) for Discord connections
- Reads `HTTPS_PROXY` for Slack and SMS (Twilio) connections
- Routes traffic through the proxy when set, no-op when unset (`proxy=None`)

## Motivation

When running hermes-agent behind a forward proxy (e.g. Squid) for egress control, aiohttp-based platform clients bypass the proxy because `aiohttp.ClientSession` does not read `HTTPS_PROXY` by default. This causes DNS resolution failures and connection timeouts for cron job delivery and direct message sending.

The Anthropic/GitHub/OpenRouter SDK clients respect `HTTPS_PROXY`, but Discord, Slack, and SMS connections go direct.

## Changes

**`gateway/platforms/discord.py`** — two patch points:

1. **Bot constructor** (~line 497): read proxy from env and pass to `commands.Bot(proxy=...)`
2. **Image download** (~line 1173): pass `proxy=` to `session.get()` in `send_image()`

**`tools/send_message_tool.py`** — three patch points (used by cron delivery and the `send_message` tool):

3. **`_send_discord()`**: pass `proxy=` to `session.post()` for Discord REST API calls
4. **`_send_slack()`**: pass `proxy=` to `session.post()` for Slack Web API calls
5. **`_send_sms()`**: pass `proxy=` to `session.post()` for Twilio REST API calls

No dependency changes — discord.py >= 2.0 and aiohttp both support the `proxy` kwarg natively.

## Platforms not affected

- **Telegram**: uses `python-telegram-bot` which respects env vars
- **Signal**: uses `httpx` which respects env vars
- **WhatsApp**: connects to localhost bridge (no proxy needed)
- **Email**: uses `smtplib` (not HTTP)

## Test plan

- [x] Deployed behind Squid proxy on internal Docker network (`internal: true`)
- [x] Discord gateway connects successfully through proxy
- [x] Cron job delivery to Discord works through proxy (was failing with DNS resolution errors)
- [x] REST API calls (login, message send) route through proxy
- [x] Verified via squid access log audit — `discord.com` CONNECT tunnels visible
- [x] Without `DISCORD_PROXY`/`HTTPS_PROXY` set, behavior is unchanged (`proxy=None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)