### PR TITLE
fix: crash on None entry in tool_calls list during Anthropic conversion

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -864,6 +864,8 @@ def convert_messages_to_anthropic(
                 else:
                     blocks.append({"type": "text", "text": str(content)})
             for tc in m.get("tool_calls", []):
+                if not tc or not isinstance(tc, dict):
+                    continue
                 fn = tc.get("function", {})
                 args = fn.get("arguments", "{}")
                 try:


### PR DESCRIPTION
## Summary

`convert_messages_to_anthropic` crashes with `AttributeError: 'NoneType' object has no attribute 'get'` when a `tool_calls` list contains a `None` entry.

This can happen from:
- Malformed API response
- Compression artifact
- Corrupt session replay from disk

### Fix

Skip `None` and non-dict entries in the `tool_calls` iteration (line 866):

```python
for tc in m.get("tool_calls", []):
    if not tc or not isinstance(tc, dict):
        continue
```

## Test plan

- [x] Crash reproduced before fix
- [x] Fix verified: None skipped, valid tool_calls preserved
- [x] 76 existing anthropic adapter tests pass
- [x] No behavioral change for well-formed tool_calls