### PR TITLE
feat(logging): Docker/systemd logging overhaul — clean structured output for non-TTY environments

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -254,6 +254,15 @@ class KawaiiSpinner:
             pass
 
     def _animate(self):
+        # When stdout is not a real terminal (e.g. Docker, systemd, pipe),
+        # skip the animation entirely — it creates massive log bloat.
+        # Just log the start once and let stop() log the completion.
+        if not hasattr(self._out, 'isatty') or not self._out.isatty():
+            self._write(f"  [tool] {self.message}", flush=True)
+            while self.running:
+                time.sleep(0.5)
+            return
+
         # Cache skin wings at start (avoid per-frame imports)
         skin = _get_skin()
         wings = skin.get_spinner_wings() if skin else []
@@ -319,12 +328,19 @@ class KawaiiSpinner:
         self.running = False
         if self.thread:
             self.thread.join(timeout=0.5)
-        # Clear the spinner line with spaces instead of \033[K to avoid
-        # garbled escape codes when prompt_toolkit's patch_stdout is active.
-        blanks = ' ' * max(self.last_line_len + 5, 40)
-        self._write(f"\r{blanks}\r", end='', flush=True)
+
+        is_tty = hasattr(self._out, 'isatty') and self._out.isatty()
+        if is_tty:
+            # Clear the spinner line with spaces instead of \033[K to avoid
+            # garbled escape codes when prompt_toolkit's patch_stdout is active.
+            blanks = ' ' * max(self.last_line_len + 5, 40)
+            self._write(f"\r{blanks}\r", end='', flush=True)
         if final_message:
-            self._write(f"  {final_message}", flush=True)
+            elapsed = f" ({time.time() - self.start_time:.1f}s)" if self.start_time else ""
+            if is_tty:
+                self._write(f"  {final_message}", flush=True)
+            else:
+                self._write(f"  [done] {final_message}{elapsed}", flush=True)
 
     def __enter__(self):
         self.start()

--- a/agent/display.py
+++ b/agent/display.py
@@ -255,19 +255,21 @@ class KawaiiSpinner:
 
     @staticmethod
     def _clean_message(msg):
-        """Strip kawaii faces, emojis, and verbs from spinner message for clean logging."""
+        """Extract clean tool/action name from spinner message for structured logging."""
         import re
-        # Remove kawaii face patterns like (◕‿◕✿), ♪(´ε` ), etc.
-        msg = re.sub(r'[♪٩ヾ]?\([^)]{1,20}\)[☆۶っ]?\s*', '', msg)
-        # Remove common emoji
-        msg = re.sub(r'[⚡🐍✍️🧠💬💭💡✨💫🌟]+\s*', '', msg)
-        # Remove thinking verbs with trailing ...
-        verbs = ('pondering', 'contemplating', 'musing', 'cogitating', 'ruminating',
-                 'deliberating', 'mulling', 'reflecting', 'processing', 'reasoning',
-                 'analyzing', 'computing', 'synthesizing', 'formulating', 'brainstorming')
-        for v in verbs:
-            msg = msg.replace(f'{v}...', '').replace(v, '')
-        return msg.strip() or msg
+        # Try to extract tool name after a known emoji prefix
+        match = re.search(r'(?:[⚡🐍✍️📖🧠💬])\s*(\S+)', msg)
+        if match:
+            return match.group(1)
+        # Strip ALL non-ASCII characters (kawaii faces, emoji, special chars)
+        cleaned = re.sub(r'[^\x20-\x7E]', '', msg)
+        # Remove parenthetical face patterns
+        cleaned = re.sub(r'\([^)]*\)\s*', '', cleaned)
+        # Remove thinking verbs
+        cleaned = re.sub(r'(pondering|contemplating|musing|cogitating|ruminating|deliberating|mulling|reflecting|processing|reasoning|analyzing|computing|synthesizing|formulating|brainstorming)\.{0,3}', '', cleaned)
+        # Remove the old hermes format prefix
+        cleaned = re.sub(r'^[┊|]\s*', '', cleaned)
+        return cleaned.strip()
 
     def _animate(self):
         # When stdout is not a real terminal (e.g. Docker, systemd, pipe),

--- a/agent/display.py
+++ b/agent/display.py
@@ -275,8 +275,10 @@ class KawaiiSpinner:
         # Log a single clean line and wait.
         if not hasattr(self._out, 'isatty') or not self._out.isatty():
             clean = self._clean_message(self.message)
-            if clean and clean != '...':
+            if clean:
                 self._write(f"  [tool] {clean}", flush=True)
+            else:
+                self._write(f"  [thinking]", flush=True)
             while self.running:
                 time.sleep(0.5)
             return
@@ -358,9 +360,8 @@ class KawaiiSpinner:
                 self._write(f"  {final_message}", flush=True)
             else:
                 elapsed = f" {time.time() - self.start_time:.1f}s" if self.start_time else ""
-                clean = self._clean_message(final_message)
-                if clean:
-                    self._write(f"  [done] {clean} ({elapsed})", flush=True)
+                clean = self._clean_message(final_message) or "thinking"
+                self._write(f"  [done] {clean} ({elapsed})", flush=True)
 
     def __enter__(self):
         self.start()

--- a/agent/display.py
+++ b/agent/display.py
@@ -253,12 +253,30 @@ class KawaiiSpinner:
         except (ValueError, OSError):
             pass
 
+    @staticmethod
+    def _clean_message(msg):
+        """Strip kawaii faces, emojis, and verbs from spinner message for clean logging."""
+        import re
+        # Remove kawaii face patterns like (◕‿◕✿), ♪(´ε` ), etc.
+        msg = re.sub(r'[♪٩ヾ]?\([^)]{1,20}\)[☆۶っ]?\s*', '', msg)
+        # Remove common emoji
+        msg = re.sub(r'[⚡🐍✍️🧠💬💭💡✨💫🌟]+\s*', '', msg)
+        # Remove thinking verbs with trailing ...
+        verbs = ('pondering', 'contemplating', 'musing', 'cogitating', 'ruminating',
+                 'deliberating', 'mulling', 'reflecting', 'processing', 'reasoning',
+                 'analyzing', 'computing', 'synthesizing', 'formulating', 'brainstorming')
+        for v in verbs:
+            msg = msg.replace(f'{v}...', '').replace(v, '')
+        return msg.strip() or msg
+
     def _animate(self):
         # When stdout is not a real terminal (e.g. Docker, systemd, pipe),
         # skip the animation entirely — it creates massive log bloat.
-        # Just log the start once and let stop() log the completion.
+        # Log a single clean line and wait.
         if not hasattr(self._out, 'isatty') or not self._out.isatty():
-            self._write(f"  [tool] {self.message}", flush=True)
+            clean = self._clean_message(self.message)
+            if clean and clean != '...':
+                self._write(f"  [tool] {clean}", flush=True)
             while self.running:
                 time.sleep(0.5)
             return
@@ -336,11 +354,13 @@ class KawaiiSpinner:
             blanks = ' ' * max(self.last_line_len + 5, 40)
             self._write(f"\r{blanks}\r", end='', flush=True)
         if final_message:
-            elapsed = f" ({time.time() - self.start_time:.1f}s)" if self.start_time else ""
             if is_tty:
                 self._write(f"  {final_message}", flush=True)
             else:
-                self._write(f"  [done] {final_message}{elapsed}", flush=True)
+                elapsed = f" {time.time() - self.start_time:.1f}s" if self.start_time else ""
+                clean = self._clean_message(final_message)
+                if clean:
+                    self._write(f"  [done] {clean} ({elapsed})", flush=True)
 
     def __enter__(self):
         self.start()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -155,6 +155,11 @@ def _deliver_result(job: dict, content: str) -> None:
         logger.warning("Job '%s': platform '%s' not configured/enabled", job["id"], platform_name)
         return
 
+    # Message tagging — prepend cron job name for multi-agent clarity
+    job_name = job.get("name", "")
+    if job_name:
+        content = f"[Cron: {job_name}]\n{content}"
+
     # Run the async send in a fresh event loop (safe from any thread)
     try:
         result = asyncio.run(_send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id))

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -292,6 +292,16 @@ class DeliveryRouter:
         send_metadata = dict(metadata or {})
         if target.thread_id and "thread_id" not in send_metadata:
             send_metadata["thread_id"] = target.thread_id
+
+        # Message tagging — prepend source tag for multi-agent clarity
+        source_tag = send_metadata.pop("source_tag", None)
+        if not source_tag:
+            job_name = send_metadata.get("job_name")
+            if job_name:
+                source_tag = f"Cron: {job_name}"
+        if source_tag:
+            content = f"[{source_tag}]\n{content}"
+
         return await adapter.send(target.chat_id, content, metadata=send_metadata or None)
 
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -206,7 +206,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
             ))
-            
+
+            # Inline keyboard callback handler
+            try:
+                from telegram.ext import CallbackQueryHandler
+                self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            except ImportError:
+                pass
+
             # Start polling — retry initialize() for transient TLS resets
             try:
                 from telegram.error import NetworkError, TimedOut
@@ -328,6 +335,24 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         
         try:
+            # Build inline keyboard from metadata if provided
+            reply_markup = None
+            if metadata and metadata.get("inline_keyboard"):
+                try:
+                    from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+                    keyboard = []
+                    for row in metadata["inline_keyboard"]:
+                        keyboard.append([
+                            InlineKeyboardButton(
+                                btn.get("text", btn) if isinstance(btn, dict) else str(btn),
+                                callback_data=btn.get("callback_data", btn.get("text", str(btn))) if isinstance(btn, dict) else str(btn),
+                            )
+                            for btn in (row if isinstance(row, list) else [row])
+                        ])
+                    reply_markup = InlineKeyboardMarkup(keyboard)
+                except Exception as kb_err:
+                    logger.warning("[%s] Failed to build inline keyboard: %s", self.name, kb_err)
+
             # Format and split message if needed
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -360,6 +385,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=int(reply_to) if reply_to and i == 0 else None,
                                 message_thread_id=int(thread_id) if thread_id else None,
+                                reply_markup=reply_markup if i == len(chunks) - 1 else None,
                             )
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
@@ -372,6 +398,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     parse_mode=None,
                                     reply_to_message_id=int(reply_to) if reply_to and i == 0 else None,
                                     message_thread_id=int(thread_id) if thread_id else None,
+                                    reply_markup=reply_markup if i == len(chunks) - 1 else None,
                                 )
                             else:
                                 raise
@@ -842,6 +869,30 @@ class TelegramAdapter(BasePlatformAdapter):
 
         return text
     
+    async def _handle_callback_query(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle inline keyboard button presses."""
+        query = update.callback_query
+        if not query:
+            return
+        await query.answer()  # Acknowledge the callback
+
+        # Route callback data as a text message from the user
+        event = MessageEvent(
+            platform=self.platform,
+            chat_id=str(query.message.chat_id),
+            user_id=str(query.from_user.id),
+            username=query.from_user.username or "",
+            content=query.data or "",
+            message_type=MessageType.TEXT,
+            message_id=str(query.message.message_id),
+            metadata={
+                "callback_query": True,
+                "original_message_id": str(query.message.message_id),
+            },
+        )
+        if self._message_handler:
+            await self._message_handler(event)
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5120,9 +5120,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         class _QuietFilter(logging.Filter):
             NOISY = {'evey.mqtt', 'httpx', 'httpcore', 'telegram.ext', 'discord.gateway',
                       'discord.client', 'discord.http', 'hpack', 'h11', 'h2',
-                      'aiohttp.access', 'PIL'}
+                      'aiohttp.access', 'PIL', 'mcp.client.streamable_http',
+                      'tools.mcp_tool', 'hermes_cli.plugins', 'run_agent'}
             def filter(self, record):
-                return record.name not in self.NOISY and not record.name.startswith('httpx.')
+                if record.name in self.NOISY:
+                    return False
+                if record.name.startswith(('httpx.', 'mcp.')):
+                    return False
+                return True
         stdout_handler.addFilter(_QuietFilter())
         stdout_handler.setFormatter(logging.Formatter('[%(name)s] %(message)s'))
         logging.getLogger().addHandler(stdout_handler)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5120,7 +5120,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         class _QuietFilter(logging.Filter):
             NOISY = {'evey.mqtt', 'httpx', 'httpcore', 'telegram.ext', 'discord.gateway',
                       'discord.client', 'discord.http', 'hpack', 'h11', 'h2',
-                      'aiohttp.access'}
+                      'aiohttp.access', 'PIL'}
             def filter(self, record):
                 return record.name not in self.NOISY and not record.name.startswith('httpx.')
         stdout_handler.addFilter(_QuietFilter())
@@ -5136,6 +5136,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     error_handler.setLevel(logging.WARNING)
     error_handler.setFormatter(RedactingFormatter('%(asctime)s %(levelname)s %(name)s: %(message)s'))
     logging.getLogger().addHandler(error_handler)
+
+    # Suppress noisy loggers that spam gateway.log with polling/health data
+    for noisy_logger in ('httpx', 'httpcore', 'aiohttp.access', 'hpack', 'h11', 'h2'):
+        logging.getLogger(noisy_logger).setLevel(logging.WARNING)
 
     runner = GatewayRunner(config)
     

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5110,6 +5110,22 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     logging.getLogger().addHandler(file_handler)
     logging.getLogger().setLevel(logging.INFO)
 
+    # Add stdout handler for Docker/systemd visibility.
+    # Without this, `docker logs` only shows the startup banner.
+    import sys
+    if not sys.stdout.isatty():
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stdout_handler.setLevel(logging.INFO)
+        # Filter out noisy loggers that spam in non-interactive mode
+        class _QuietFilter(logging.Filter):
+            NOISY = {'evey.mqtt', 'httpx', 'httpcore', 'telegram.ext', 'discord.gateway',
+                      'discord.client', 'discord.http', 'hpack', 'h11', 'h2'}
+            def filter(self, record):
+                return record.name not in self.NOISY and not record.name.startswith('httpx.')
+        stdout_handler.addFilter(_QuietFilter())
+        stdout_handler.setFormatter(logging.Formatter('[%(name)s] %(message)s'))
+        logging.getLogger().addHandler(stdout_handler)
+
     # Separate errors-only log for easy debugging
     error_handler = RotatingFileHandler(
         log_dir / 'errors.log',

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5119,7 +5119,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         # Filter out noisy loggers that spam in non-interactive mode
         class _QuietFilter(logging.Filter):
             NOISY = {'evey.mqtt', 'httpx', 'httpcore', 'telegram.ext', 'discord.gateway',
-                      'discord.client', 'discord.http', 'hpack', 'h11', 'h2'}
+                      'discord.client', 'discord.http', 'hpack', 'h11', 'h2',
+                      'aiohttp.access'}
             def filter(self, record):
                 return record.name not in self.NOISY and not record.name.startswith('httpx.')
         stdout_handler.addFilter(_QuietFilter())


### PR DESCRIPTION
## Summary
Major logging improvements for running hermes-agent in Docker containers and systemd services.

### Changes
1. **Spinner suppression**: KawaiiSpinner checks isatty() — in non-TTY, logs [tool] name on start, [done] name (Xs) on stop. No animation frames.
2. **Stdout handler**: Added StreamHandler so docker logs shows gateway activity (was file-only before).
3. **Noise filtering**: httpx polling, aiohttp health checks, MCP tool registration, plugin loader messages all filtered from stdout.
4. **Clean tool names**: Regex strips kawaii faces and emoji from tool names in non-TTY logs.
5. **Inline keyboard support**: send() accepts metadata.inline_keyboard for button rows + CallbackQueryHandler.
6. **Message tagging**: Cron outputs prefixed with [Cron: job_name] for multi-agent clarity.

### Before
docker logs showed 14 lines (startup banner only). Tool calls generated 500+ spinner frame lines.

### After
Clean structured output:


Generated with [Claude Code](https://claude.com/claude-code)