### PR TITLE
fix(security): require opt-in for project plugin discovery

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -5,7 +5,8 @@ Hermes Plugin System
 Discovers, loads, and manages plugins from three sources:
 
 1. **User plugins**   – ``~/.hermes/plugins/<name>/``
-2. **Project plugins** – ``./.hermes/plugins/<name>/``
+2. **Project plugins** – ``./.hermes/plugins/<name>/`` (opt-in via
+   ``HERMES_ENABLE_PROJECT_PLUGINS``)
 3. **Pip plugins**     – packages that expose the ``hermes_agent.plugins``
    entry-point group.
 
@@ -60,6 +61,11 @@ VALID_HOOKS: Set[str] = {
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"
 
 _NS_PARENT = "hermes_plugins"
+
+
+def _env_enabled(name: str) -> bool:
+    """Return True when an env var is set to a truthy opt-in value."""
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 # ---------------------------------------------------------------------------
@@ -186,8 +192,9 @@ class PluginManager:
         manifests.extend(self._scan_directory(user_dir, source="user"))
 
         # 2. Project plugins (./.hermes/plugins/)
-        project_dir = Path.cwd() / ".hermes" / "plugins"
-        manifests.extend(self._scan_directory(project_dir, source="project"))
+        if _env_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
+            project_dir = Path.cwd() / ".hermes" / "plugins"
+            manifests.extend(self._scan_directory(project_dir, source="project"))
 
         # 3. Pip / entry-point plugins
         manifests.extend(self._scan_entry_points())

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -67,6 +67,7 @@ class TestPluginDiscovery:
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         monkeypatch.chdir(project_dir)
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "true")
         plugins_dir = project_dir / ".hermes" / "plugins"
         _make_plugin_dir(plugins_dir, "proj_plugin")
 
@@ -75,6 +76,19 @@ class TestPluginDiscovery:
 
         assert "proj_plugin" in mgr._plugins
         assert mgr._plugins["proj_plugin"].enabled
+
+    def test_discover_project_plugins_skipped_by_default(self, tmp_path, monkeypatch):
+        """Project plugins are not discovered unless explicitly enabled."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        monkeypatch.chdir(project_dir)
+        plugins_dir = project_dir / ".hermes" / "plugins"
+        _make_plugin_dir(plugins_dir, "proj_plugin")
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "proj_plugin" not in mgr._plugins
 
     def test_discover_is_idempotent(self, tmp_path, monkeypatch):
         """Calling discover_and_load() twice does not duplicate plugins."""

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -228,6 +228,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `HERMES_QUIET` | Suppress non-essential output (`true`/`false`) |
 | `HERMES_API_TIMEOUT` | LLM API call timeout in seconds (default: `900`) |
 | `HERMES_EXEC_ASK` | Enable execution approval prompts in gateway mode (`true`/`false`) |
+| `HERMES_ENABLE_PROJECT_PLUGINS` | Enable auto-discovery of repo-local plugins from `./.hermes/plugins/` (`true`/`false`, default: `false`) |
 | `HERMES_BACKGROUND_NOTIFICATIONS` | Background process notification mode in gateway: `all` (default), `result`, `error`, `off` |
 | `HERMES_EPHEMERAL_SYSTEM_PROMPT` | Ephemeral system prompt injected at API-call time (never persisted to sessions) |
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -22,6 +22,8 @@ Drop a directory into `~/.hermes/plugins/` with a `plugin.yaml` and Python code:
 
 Start Hermes — your tools appear alongside built-in tools. The model can call them immediately.
 
+Project-local plugins under `./.hermes/plugins/` are disabled by default. Enable them only for trusted repositories by setting `HERMES_ENABLE_PROJECT_PLUGINS=true` before starting Hermes.
+
 ## What plugins can do
 
 | Capability | How |
@@ -38,7 +40,7 @@ Start Hermes — your tools appear alongside built-in tools. The model can call 
 | Source | Path | Use case |
 |--------|------|----------|
 | User | `~/.hermes/plugins/` | Personal plugins |
-| Project | `.hermes/plugins/` | Project-specific plugins |
+| Project | `.hermes/plugins/` | Project-specific plugins (requires `HERMES_ENABLE_PROJECT_PLUGINS=true`) |
 | pip | `hermes_agent.plugins` entry_points | Distributed packages |
 
 ## Available hooks

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -12,13 +12,10 @@ Hermes has a plugin system for adding custom tools, hooks, and integrations with
 
 Drop a directory into `~/.hermes/plugins/` with a `plugin.yaml` and Python code:
 
-```
-~/.hermes/plugins/my-plugin/
-├── plugin.yaml      # manifest
-├── __init__.py      # register() — wires schemas to handlers
-├── schemas.py       # tool schemas (what the LLM sees)
-└── tools.py         # tool handlers (what runs when called)
-```
+- `~/.hermes/plugins/my-plugin/plugin.yaml` — manifest
+- `~/.hermes/plugins/my-plugin/__init__.py` — `register()` wires schemas to handlers
+- `~/.hermes/plugins/my-plugin/schemas.py` — tool schemas (what the LLM sees)
+- `~/.hermes/plugins/my-plugin/tools.py` — tool handlers (what runs when called)
 
 Start Hermes — your tools appear alongside built-in tools. The model can call them immediately.
 

--- a/website/docs/user-guide/messaging/open-webui.md
+++ b/website/docs/user-guide/messaging/open-webui.md
@@ -10,12 +10,13 @@ description: "Connect Open WebUI to Hermes Agent via the OpenAI-compatible API s
 
 ## Architecture
 
-```
-┌──────────────────┐    POST /v1/chat/completions    ┌──────────────────────┐
-│   Open WebUI     │ ──────────────────────────────► │  hermes-agent        │
-│   (browser UI)   │    SSE streaming response       │  gateway API server  │
-│   port 3000      │ ◄────────────────────────────── │  port 8642           │
-└──────────────────┘                                  └──────────────────────┘
+```mermaid
+flowchart LR
+    webui["Open WebUI<br/>browser UI<br/>port 3000"]
+    hermes["hermes-agent<br/>gateway API server<br/>port 8642"]
+
+    webui -->|"POST /v1/chat/completions"| hermes
+    hermes -->|"SSE streaming response"| webui
 ```
 
 Open WebUI connects to Hermes Agent's API server just like it would connect to OpenAI. Your agent handles the requests with its full toolset — terminal, file operations, web search, memory, skills — and returns the final response.


### PR DESCRIPTION
## Summary
- stop auto-loading repo-local plugins from `./.hermes/plugins` by default
- require explicit opt-in via `HERMES_ENABLE_PROJECT_PLUGINS` for project plugin discovery
- keep user-home and entry-point plugin discovery unchanged
- add regression coverage for default-skip and explicit opt-in behavior
- document the new opt-in env var and plugin discovery behavior

## Testing
- `python -m pytest -o addopts='' tests/test_plugins.py::TestPluginDiscovery -q`

## Notes
- this is a narrow hardening change rather than a broader plugin-system redesign
- repo-local plugins continue to work when operators explicitly set `HERMES_ENABLE_PROJECT_PLUGINS=true` before startup