### PR TITLE
feat(cron): prepend [Cron: job_name] tag to delivered output

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -159,6 +159,11 @@ def _deliver_result(job: dict, content: str) -> None:
         logger.warning("Job '%s': platform '%s' not configured/enabled", job["id"], platform_name)
         return
 
+    # Prepend source tag so users can identify cron output vs agent responses
+    job_name = job.get("name", "")
+    if job_name:
+        content = f"[Cron: {job_name}]\n{content}"
+
     # Run the async send in a fresh event loop (safe from any thread)
     try:
         result = asyncio.run(_send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id))


### PR DESCRIPTION
## Summary
Tags all cron job output with the job name before delivery to messaging platforms.

## Problem
When multiple agents share a Telegram/Discord channel, users cannot tell whether a message came from the agent brain, a cron job, or an external tool.

## Fix
Prepend [Cron: job_name] to content in _deliver_result() before platform send. 5 lines added.

## Example


Agent brain responses remain untagged (default voice).

Generated with [Claude Code](https://claude.com/claude-code)