### PR TITLE
fix(gateway): use user role for cron mirror messages to maintain message alternation

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -45,9 +45,14 @@ def mirror_to_session(
             logger.debug("Mirror: no session found for %s:%s:%s", platform, chat_id, thread_id)
             return False
 
+        # Use "user" role for mirrored cron/delivery messages to maintain
+        # proper user/assistant alternation in the conversation history.
+        # Using "assistant" caused two consecutive assistant messages which
+        # confuses models and can cause API rejections on strict providers.
         mirror_msg = {
-            "role": "assistant",
-            "content": message_text,
+            "role": "user",
+            "content": f"[Cron delivery from {source_label}]
+{message_text}",
             "timestamp": datetime.now().isoformat(),
             "mirror": True,
             "mirror_source": source_label,

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -51,8 +51,7 @@ def mirror_to_session(
         # confuses models and can cause API rejections on strict providers.
         mirror_msg = {
             "role": "user",
-            "content": f"[Cron delivery from {source_label}]
-{message_text}",
+            "content": f"[Cron delivery from {source_label}]\n{message_text}",
             "timestamp": datetime.now().isoformat(),
             "mirror": True,
             "mirror_source": source_label,

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -161,8 +161,8 @@ class TestMirrorToSession:
         transcript = sessions_dir / "sess_abc.jsonl"
         assert transcript.exists()
         msg = json.loads(transcript.read_text().strip())
-        assert msg["content"] == "Hello!"
-        assert msg["role"] == "assistant"
+        assert msg["content"] == "[Cron delivery from cli]\nHello!"
+        assert msg["role"] == "user"
         assert msg["mirror"] is True
         assert msg["mirror_source"] == "cli"
 


### PR DESCRIPTION
Fixes #2221

## Root Cause
`gateway/mirror.py` was appending cron delivery messages with `role: "assistant"`. Since the previous message is also `role: "assistant"` (the agent's response), this created two consecutive assistant messages — violating the expected user/assistant alternation.

## Fix
Changed mirror message role from `"assistant"` to `"user"` and added a `[Cron delivery from {source_label}]` prefix so the model understands this is an injected cron result, not a real user message.

## Impact
- Fixes two consecutive assistant messages in gateway sessions
- Prevents API rejections from strict providers that require strict alternation
- Consistent with how the model should process injected cron outputs
