### PR TITLE
fix(model_metadata): use /v1/props endpoint for llama.cpp context detection

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -260,9 +260,11 @@ def detect_local_server_type(base_url: str) -> Optional[str]:
                         pass
             except Exception:
                 pass
-            # llama.cpp exposes /props
+            # llama.cpp exposes /v1/props (older builds used /props without the /v1 prefix)
             try:
-                r = client.get(f"{server_url}/props")
+                r = client.get(f"{server_url}/v1/props")
+                if r.status_code != 200:
+                    r = client.get(f"{server_url}/props")  # fallback for older builds
                 if r.status_code == 200 and "default_generation_settings" in r.text:
                     return "llamacpp"
             except Exception:
@@ -455,8 +457,11 @@ def fetch_endpoint_model_metadata(
             )
             if is_llamacpp:
                 try:
-                    props_url = candidate.rstrip("/").replace("/v1", "") + "/props"
-                    props_resp = requests.get(props_url, headers=headers, timeout=5)
+                    # Try /v1/props first (current llama.cpp); fall back to /props for older builds
+                    base = candidate.rstrip("/").replace("/v1", "")
+                    props_resp = requests.get(base + "/v1/props", headers=headers, timeout=5)
+                    if not props_resp.ok:
+                        props_resp = requests.get(base + "/props", headers=headers, timeout=5)
                     if props_resp.ok:
                         props = props_resp.json()
                         gen_settings = props.get("default_generation_settings", {})


### PR DESCRIPTION
## Problem

Recent versions of llama.cpp moved the server properties endpoint from `/props` to `/v1/props` (consistent with the `/v1` API prefix convention used for all other endpoints).

The server-type detection path (line 265) and the `n_ctx` reading path (line 458) both used the old `/props` URL, which returns **404** on current llama.cpp builds. This caused:
1. Potential misidentification of the server type (though in practice the `/v1/models` check usually catches it first)
2. The allocated context window size falling back to a hardcoded default, resulting in an **incorrect (too small) value** displayed in the TUI context bar — e.g. showing `32K` when the actual allocated context is `64K`

## Fix

Try `/v1/props` first, fall back to `/props` for backward compatibility with older llama.cpp builds. Both paths are handled gracefully with no change to error handling.

## Testing

Verified against llama.cpp build `b5187` (current as of March 2026):
- `/v1/props` returns `200` with `default_generation_settings.n_ctx` correctly set
- `/props` returns `404` on the same build
- After this fix, the TUI context bar correctly shows `64K` for a server started with `--ctx-size 131072 --parallel 2`