### PR TITLE
fix: include conversation_history in JSON session export to prevent message loss

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1328,7 +1328,7 @@ class AIAgent:
         """
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
-        self._save_session_log(messages)
+        self._save_session_log(messages, conversation_history)
         self._flush_messages_to_session_db(messages, conversation_history)
 
     def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
@@ -1701,7 +1701,7 @@ class AIAgent:
         content = re.sub(r'(</think>)\n+', r'\1\n', content)
         return content.strip()
 
-    def _save_session_log(self, messages: List[Dict[str, Any]] = None):
+    def _save_session_log(self, messages: List[Dict[str, Any]] = None, conversation_history: List[Dict] = None):
         """
         Save the full raw session to a JSON file.
 
@@ -1718,9 +1718,10 @@ class AIAgent:
             return
 
         try:
+            all_messages = list(conversation_history or []) + list(messages)
             # Clean assistant content for session logs
             cleaned = []
-            for msg in messages:
+            for msg in all_messages:
                 if msg.get("role") == "assistant" and msg.get("content"):
                     msg = dict(msg)
                     msg["content"] = self._clean_session_content(msg["content"])
@@ -5742,7 +5743,7 @@ class AIAgent:
                                     }
                                     messages.append(continue_msg)
                                     self._session_messages = messages
-                                    self._save_session_log(messages)
+                                    self._save_session_log(messages, conversation_history)
                                     restart_with_length_continuation = True
                                     break
 
@@ -6383,7 +6384,7 @@ class AIAgent:
                         if not self.quiet_mode:
                             self._vprint(f"{self.log_prefix}↻ Codex response incomplete; continuing turn ({self._codex_incomplete_retries}/3)")
                         self._session_messages = messages
-                        self._save_session_log(messages)
+                        self._save_session_log(messages, conversation_history)
                         continue
 
                     self._codex_incomplete_retries = 0
@@ -6611,7 +6612,7 @@ class AIAgent:
                     
                     # Save session log incrementally (so progress is visible even if interrupted)
                     self._session_messages = messages
-                    self._save_session_log(messages)
+                    self._save_session_log(messages, conversation_history)
                     
                     # Continue loop for next response
                     continue
@@ -6749,7 +6750,7 @@ class AIAgent:
                         }
                         messages.append(continue_msg)
                         self._session_messages = messages
-                        self._save_session_log(messages)
+                        self._save_session_log(messages, conversation_history)
                         continue
 
                     codex_ack_continuations = 0


### PR DESCRIPTION
Fixes #2229

## Problem

Legacy JSON session files (`~/.hermes/sessions/*.json`) were missing messages from prior turns in gateway sessions. The root cause: `_save_session_log()` only wrote the current-turn `messages` list, not `conversation_history` (prior turns). In gateway mode, each turn creates a fresh `AIAgent` instance with only new messages in `messages` and the full prior history in `conversation_history`. So JSON exports only captured the last turn, while JSONL/SQLite (which append incrementally) captured everything.

This explains the evidence in the issue: same session appearing as 89 messages in JSON vs 233 messages in JSONL.

## Fix

- Added `conversation_history` parameter to `_save_session_log()`
- JSON export now writes `list(conversation_history or []) + list(messages)` — the complete conversation
- Updated all 5 call sites to pass `conversation_history`

## Changes

- `run_agent.py`: 8 insertions, 7 deletions — single file, no other changes

## Note

Session resume continues to use SQLite (unaffected). This fix makes the JSON export complete and accurate for audit/inspection purposes.