### PR TITLE
fix(agent): include conversation_history in JSON session export to prevent message loss

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,13 @@ hermes-agent/
 ├── toolsets.py           # Toolset definitions, _HERMES_CORE_TOOLS list
 ├── cli.py                # HermesCLI class — interactive CLI orchestrator
 ├── hermes_state.py       # SessionDB — SQLite session store (FTS5 search)
+#
+# SESSION STORAGE NOTE:
+# - JSONL files (~/.hermes/sessions/*.jsonl) — source of truth, append-only, complete
+# - SQLite DB (~/.hermes/sessions/sessions.db) — source of truth for session resume
+# - JSON files (~/.hermes/sessions/session_*.json) — legacy export, lossy in gateway mode
+#   JSON files are overwritten each turn and may miss prior-turn messages in gateway sessions.
+#   Always use JSONL or SQLite for auditing and analysis.
 ├── agent/                # Agent internals
 │   ├── prompt_builder.py     # System prompt assembly
 │   ├── context_compressor.py # Auto context compression

--- a/run_agent.py
+++ b/run_agent.py
@@ -1707,7 +1707,12 @@ class AIAgent:
         except Exception as e:
             if self.verbose_logging:
                 logging.warning(f"Failed to save session log: {e}")
-    
+
+    # NOTE: The JSON session log (session_*.json) is a legacy export.
+    # JSONL files and SQLite DB are the authoritative sources of truth.
+    # Do not use JSON files for session resume or auditing — they may be
+    # incomplete in gateway mode (fixed by including conversation_history above).
+
     def interrupt(self, message: str = None) -> None:
         """
         Request the agent to interrupt its current tool-calling loop.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1273,7 +1273,7 @@ class AIAgent:
         """
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
-        self._save_session_log(messages)
+        self._save_session_log(messages, conversation_history=conversation_history)
         self._flush_messages_to_session_db(messages, conversation_history)
 
     def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
@@ -1646,7 +1646,7 @@ class AIAgent:
         content = re.sub(r'(</think>)\n+', r'\1\n', content)
         return content.strip()
 
-    def _save_session_log(self, messages: List[Dict[str, Any]] = None):
+    def _save_session_log(self, messages: List[Dict[str, Any]] = None, conversation_history: List[Dict[str, Any]] = None):
         """
         Save the full raw session to a JSON file.
 
@@ -1657,15 +1657,28 @@ class AIAgent:
 
         REASONING_SCRATCHPAD tags are converted to <think> blocks for consistency.
         Overwritten after each turn so it always reflects the latest state.
+
+        NOTE: In gateway mode, each turn creates a fresh AIAgent with only
+        new messages in `messages` and the full prior history in
+        `conversation_history`. Both must be combined for a complete export.
         """
         messages = messages or self._session_messages
         if not messages:
             return
 
         try:
+            # Combine conversation_history + messages, deduplicating by object identity
+            # to avoid writing the same messages twice when history overlaps with messages.
+            if conversation_history:
+                history_ids = {id(m) for m in conversation_history}
+                new_msgs = [m for m in messages if id(m) not in history_ids]
+                all_messages = list(conversation_history) + new_msgs
+            else:
+                all_messages = list(messages)
+
             # Clean assistant content for session logs
             cleaned = []
-            for msg in messages:
+            for msg in all_messages:
                 if msg.get("role") == "assistant" and msg.get("content"):
                     msg = dict(msg)
                     msg["content"] = self._clean_session_content(msg["content"])


### PR DESCRIPTION
Fixes #2229

## Root Cause
`_save_session_log()` only wrote the current-turn `messages` list to JSON. In gateway mode, each turn creates a fresh AIAgent with only new messages in `messages` and the full prior history in `conversation_history`. So JSON exports only captured the last turn while JSONL/SQLite captured everything.

This explains: same session appearing as 89 messages in JSON vs 233 messages in JSONL.

## Addresses all 3 recommended options

**Option 2 (Fix JSON export):**
- Added `conversation_history` parameter to `_save_session_log()`
- JSON export now writes `conversation_history + messages` — the complete conversation
- Duplicate prevention via object identity check to avoid writing overlapping messages twice
- Updated `_persist_session()` to pass `conversation_history` through

**Option 3 (Document):**
- Added note to `AGENTS.md` documenting JSONL/SQLite as source of truth
- Added code comment in `run_agent.py` marking JSON export as legacy

**Option 1 (partial):**
- Code clearly marked as legacy — full removal can be a separate PR if desired
