### PR TITLE
fix: add input validation to send_message_tool to prevent crashes

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -55,6 +55,11 @@ SEND_MESSAGE_SCHEMA = {
 
 def send_message_tool(args, **kw):
     """Handle cross-channel send_message tool calls."""
+
+    if not isinstance(args, dict):
+        return json.dumps({
+            "error": "Invalid arguments: expected dictionary"
+    })
     action = args.get("action", "send")
 
     if action == "list":


### PR DESCRIPTION
## What does this PR do?

This PR adds input validation to `send_message_tool` to prevent crashes when invalid or malformed arguments are passed.

Currently, the function assumes `args` is always a dictionary. However, in real-world usage (e.g. LLM outputs, external gateways like Telegram/Discord), this assumption may not hold. If `args` is `None` or not a dictionary, calling `.get()` results in:

```
AttributeError: 'NoneType' object has no attribute 'get'

```

This PR ensures safer handling of such cases by validating input before usage.


## Related Issue

No related issue


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] 🔄 Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


## Changes Made

- Added type validation for `args` in `tools/send_message_tool.py`
- Prevented `.get()` calls on non-dictionary inputs
- Returned safe JSON error response instead of raising runtime exceptions


## How to Test

1. Call `send_message_tool` with valid dictionary input → should behave normally  
2. Call `send_message_tool(None)` → should return JSON error instead of crashing  
3. Call `send_message_tool("invalid")` → should return JSON error safely  
