### PR TITLE
feat: add Alibaba Coding Plan provider with accurate context window limits

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -106,6 +106,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Meta
     "llama": 131072,
     # Qwen
+    "qwen3.5-plus": 169984,  # Alibaba Coding Plan actual API limit
     "qwen": 131072,
     # MiniMax
     "minimax": 204800,
@@ -552,6 +553,7 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
         r'context\s*(?:length|size|window)\s*(?:is|of|:)?\s*(\d{4,})',
         r'(\d{4,})\s*(?:token)?\s*(?:context|limit)',
         r'>\s*(\d{4,})\s*(?:max|limit|token)',  # "250000 tokens > 200000 maximum"
+        r'range of input length should be \[1,\s*(\d+)\]',  # Alibaba/DashScope Coding Plan
         r'(\d{4,})\s*(?:max(?:imum)?)\b',  # "200000 maximum"
     ]
     for pattern in patterns:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -156,6 +156,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://api.anthropic.com",
         api_key_env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
     ),
+    "coding-plan": ProviderConfig(
+        id="coding-plan",
+        name="Alibaba Coding Plan (DashScope)",
+        auth_type="api_key",
+        inference_base_url="https://coding-intl.dashscope.aliyuncs.com/v1",
+        api_key_env_vars=("DASHSCOPE_API_KEY",),
+        base_url_env_var="CODING_PLAN_BASE_URL",
+    ),
     "alibaba": ProviderConfig(
         id="alibaba",
         name="Alibaba Cloud (DashScope)",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -798,6 +798,7 @@ def cmd_model(args):
         "ai-gateway": "AI Gateway",
         "kilocode": "Kilo Code",
         "alibaba": "Alibaba Cloud (DashScope)",
+        "coding-plan": "Alibaba Coding Plan (DashScope)",
         "custom": "Custom endpoint",
     }
     active_label = provider_labels.get(active, active)
@@ -824,6 +825,7 @@ def cmd_model(args):
         ("opencode-go", "OpenCode Go (open models, $10/month subscription)"),
         ("ai-gateway", "AI Gateway (Vercel — 200+ models, pay-per-use)"),
         ("alibaba", "Alibaba Cloud / DashScope (Qwen models, Anthropic-compatible)"),
+        ("coding-plan", "Alibaba Coding Plan / DashScope (OpenAI-compatible, qwen3.5-plus)"),
     ]
 
     # Add user-defined custom providers from config.yaml
@@ -896,7 +898,7 @@ def cmd_model(args):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba"):
+    elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "coding-plan"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -6058,6 +6058,7 @@ class AIAgent:
                         'exceeds the limit', 'context window',
                         'request entity too large',  # OpenRouter/Nous 413 safety net
                         'prompt is too long',  # Anthropic: "prompt is too long: N tokens > M maximum"
+                        'range of input length',  # Alibaba/DashScope Coding Plan
                     ])
 
                     # Fallback heuristic: Anthropic sometimes returns a generic


### PR DESCRIPTION
Fixes #2220

## Problem

Alibaba Coding Plan (DashScope) users hit repeated 400 errors because:
1. Context window reported as 1M tokens, actual API limit is 169,984 tokens
2. Alibaba's error format (`Range of input length should be [1, 169984]`) wasn't recognized by the context error parser, so compression never triggered
3. No dedicated `coding-plan` provider in the setup wizard

## Changes

**`agent/model_metadata.py`**
- Added `qwen3.5-plus: 169984` to `DEFAULT_CONTEXT_LENGTHS` as accurate fallback
- Added Alibaba/DashScope error pattern to `parse_context_limit_from_error()`: `range of input length should be [1, N]`

**`run_agent.py`**
- Added `'range of input length'` to `is_context_length_error` phrase list so Alibaba 400 errors trigger compression instead of aborting

**`hermes_cli/auth.py`**
- Added `coding-plan` entry to `PROVIDER_REGISTRY` with correct OpenAI-compatible base URL (`https://coding-intl.dashscope.aliyuncs.com/v1`) and `DASHSCOPE_API_KEY`

**`hermes_cli/main.py`**
- Added `coding-plan` to setup wizard provider list and selection handler

## How it works after this fix

1. First request: OpenRouter reports 1M context → 400 error → `parse_context_limit_from_error` extracts 169,984 → saves to persistent cache → compression triggers
2. Subsequent requests: cache returns 169,984 directly, no 400 errors
3. `hermes setup` now shows Alibaba Coding Plan as a selectable provider with correct base URL