### PR TITLE
fix(tests): replace FakePath subclass with Path.exists patch for Python 3.12 compatibility

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -290,23 +290,19 @@ class TestEnsureUserSystemdEnv:
         monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
         monkeypatch.setattr(os, "getuid", lambda: 42)
 
-        # Patch Path so /run/user/42 resolves to our tmp dir (which exists)
-        from pathlib import Path as RealPath
-
-        class FakePath(type(RealPath())):
-            def __new__(cls, *args):
-                p = str(args[0]) if args else ""
-                if p == "/run/user/42":
-                    return RealPath.__new__(cls, str(tmp_path))
-                return RealPath.__new__(cls, *args)
-
-        monkeypatch.setattr(gateway_cli, "Path", FakePath)
+        # Patch Path.exists so /run/user/42 appears to exist without requiring
+        # the real filesystem path. The FakePath subclass approach broke on
+        # Python 3.12 where PosixPath.__new__ ignores the redirected path arg.
+        _orig_exists = gateway_cli.Path.exists
+        monkeypatch.setattr(
+            gateway_cli.Path, "exists",
+            lambda self: True if str(self) == "/run/user/42" else _orig_exists(self),
+        )
 
         gateway_cli._ensure_user_systemd_env()
 
         # Function sets the canonical string, not the fake path
         assert os.environ.get("XDG_RUNTIME_DIR") == "/run/user/42"
-
     def test_sets_dbus_address_when_bus_socket_exists(self, tmp_path, monkeypatch):
         runtime = tmp_path / "runtime"
         runtime.mkdir()


### PR DESCRIPTION
Fixes #2243

## Problem

`TestEnsureUserSystemdEnv::test_sets_xdg_runtime_dir_when_missing` fails on Python 3.12. The test used a `FakePath` subclass overriding `__new__` to redirect `/run/user/42` to a temp directory. In Python 3.12, `PosixPath.__new__` ignores the redirected path argument and re-initializes from the original string, so `exists()` returns `False` and `XDG_RUNTIME_DIR` is never set.

## Fix

Replace the `FakePath` subclass with `monkeypatch.setattr(gateway_cli.Path, "exists", ...)` — patches the method directly on the class used by the module under test.

## Changes

- `tests/hermes_cli/test_gateway_service.py`: 4 insertions, 12 deletions — single test method, no production code changes