### PR TITLE
fix(toolsets): use typing.Any instead of builtin any in get_distribution

### DIFF
--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -19,7 +19,7 @@ Usage:
     all_dists = list_distributions()
 """
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import random
 from toolsets import validate_toolset
 
@@ -220,7 +220,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset distribution by name.
     


### PR DESCRIPTION
## Summary
- Import `Any` from `typing` and replace lowercase `any` with `Any` in `get_distribution()` return type annotation
- The builtin `any()` function was used instead of `typing.Any`, which is semantically incorrect for static type checkers

Closes #2139

## Test plan
- [x] Verify `Any` is imported from `typing`
- [x] Verify return annotation uses `typing.Any`
- [ ] Run `pytest tests/` to confirm no regressions