### PR TITLE
fix(cron): close unawaited coroutine when asyncio.run() hits RuntimeError

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -160,11 +160,14 @@ def _deliver_result(job: dict, content: str) -> None:
         return
 
     # Run the async send in a fresh event loop (safe from any thread)
+    coro = _send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id)
     try:
-        result = asyncio.run(_send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id))
+        result = asyncio.run(coro)
     except RuntimeError:
         # asyncio.run() fails if there's already a running loop in this thread;
+        # close the abandoned coroutine to prevent RuntimeWarning, then
         # spin up a new thread to avoid that.
+        coro.close()
         import concurrent.futures
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
             future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id))


### PR DESCRIPTION
## Summary
- Create the coroutine before the `try` block so it can be explicitly closed in the `except RuntimeError` path
- Prevents `RuntimeWarning: coroutine '_send_to_platform' was never awaited` on garbage collection
- The `asyncio.run()` check for a running event loop happens *before* awaiting, so the coroutine was silently abandoned

Closes #2138

## Test plan
- [x] Verify coroutine is created once and closed on RuntimeError
- [x] Verify a new coroutine is created for the ThreadPoolExecutor fallback
- [ ] Run `pytest tests/` to confirm no regressions