### PR TITLE
fix(email): guard against empty IMAP search data to prevent IndexError

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -230,7 +230,7 @@ class EmailAdapter(BasePlatformAdapter):
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
             status, data = imap.uid("search", None, "ALL")
-            if status == "OK" and data[0]:
+            if status == "OK" and data and data[0]:
                 for uid in data[0].split():
                     self._seen_uids.add(uid)
             imap.logout()
@@ -295,7 +295,7 @@ class EmailAdapter(BasePlatformAdapter):
             imap.select("INBOX")
 
             status, data = imap.uid("search", None, "UNSEEN")
-            if status != "OK" or not data[0]:
+            if status != "OK" or not data or not data[0]:
                 imap.logout()
                 return results
 


### PR DESCRIPTION
## Summary
- Add `data and` guard before accessing `data[0]` at both IMAP uid search call sites
- IMAP library can return an empty list when search yields no results, causing `IndexError: list index out of range`
- Affects both `connect()` (line 233) and `_fetch_new_messages()` (line 298)

Closes #2137

## Test plan
- [x] Verify both call sites now check `data` is non-empty before indexing
- [ ] Run `pytest tests/gateway/` to confirm no regressions