### PR TITLE
fix(tools): fix resource leak and double socket close in code_execution_tool

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -300,16 +300,16 @@ def _rpc_server_loop(
                 # their status prints don't leak into the CLI spinner.
                 try:
                     _real_stdout, _real_stderr = sys.stdout, sys.stderr
-                    sys.stdout = open(os.devnull, "w")
-                    sys.stderr = open(os.devnull, "w")
+                    devnull = open(os.devnull, "w")
                     try:
+                        sys.stdout = devnull
+                        sys.stderr = devnull
                         result = handle_function_call(
                             tool_name, tool_args, task_id=task_id
                         )
                     finally:
-                        sys.stdout.close()
-                        sys.stderr.close()
                         sys.stdout, sys.stderr = _real_stdout, _real_stderr
+                        devnull.close()
                 except Exception as exc:
                     logger.error("Tool call failed in sandbox: %s", exc, exc_info=True)
                     result = json.dumps({"error": str(exc)})
@@ -574,6 +574,7 @@ def execute_code(
 
         # Wait for RPC thread to finish
         server_sock.close()  # break accept() so thread exits promptly
+        server_sock = None  # prevent double close in finally
         rpc_thread.join(timeout=3)
 
         # Build response


### PR DESCRIPTION
## Summary
- Use a single `open(os.devnull, "w")` handle for both stdout/stderr suppression, preventing a file handle leak if the second `open()` were to fail
- Set `server_sock = None` after the first `close()` call to prevent the `finally` block from closing it again (which raises `OSError`)

Closes #2136

## Test plan
- [x] Verify single devnull handle is used for both stdout and stderr
- [x] Verify server_sock is set to None after first close
- [ ] Run `pytest tests/tools/` to confirm no regressions