### PR TITLE
fix(toolsets): share visited set across branches in resolve_toolset()

### DIFF
--- a/toolsets.py
+++ b/toolsets.py
@@ -355,24 +355,24 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
             all_tools.update(resolved)
         return list(all_tools)
 
-    # Check for cycles
+    # Check for cycles or already-resolved diamond dependencies
     if name in visited:
-        print(f"⚠️  Circular dependency detected in toolset '{name}'")
         return []
-    
+
     visited.add(name)
-    
+
     # Get toolset definition
     toolset = TOOLSETS.get(name)
     if not toolset:
         return []
-    
+
     # Collect direct tools
     tools = set(toolset.get("tools", []))
-    
-    # Recursively resolve included toolsets
+
+    # Recursively resolve included toolsets (share visited set so diamond
+    # dependencies are resolved once, not once per branch)
     for included_name in toolset.get("includes", []):
-        included_tools = resolve_toolset(included_name, visited.copy())
+        included_tools = resolve_toolset(included_name, visited)
         tools.update(included_tools)
     
     return list(tools)


### PR DESCRIPTION
## Summary
- Pass `visited` directly instead of `visited.copy()` when recursing into included toolsets (line 375)
- This ensures diamond dependencies are resolved once instead of once per branch
- Remove the `print()` warning since hitting a visited name now correctly handles both diamond deps and cycles by returning `[]`
- Keep `.copy()` on line 354 for the `all`/`*` alias since each top-level toolset should be resolved independently

Closes #2134

## Test plan
- [x] Diamond dependency case: toolsets B and C both including D — D resolved once
- [x] Cycle case: A→[B,C], B→C, C→B — no duplicate warnings, no infinite recursion
- [ ] Run `pytest tests/` to confirm no regressions