### PR TITLE
fix: always use assistant role for system error messages

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6887,11 +6887,10 @@ class AIAgent:
                 
                 if not pending_handled:
                     # Error happened before tool processing (e.g. response parsing).
-                    # Choose role to avoid consecutive same-role messages.
-                    last_role = messages[-1].get("role") if messages else None
-                    err_role = "assistant" if last_role == "user" else "user"
+                    # Always use assistant role for system error messages.
+                    # Using role="user" would misattribute system behavior to the user.
                     sys_err_msg = {
-                        "role": err_role,
+                        "role": "assistant",
                         "content": f"[System error during processing: {error_msg}]",
                     }
                     messages.append(sys_err_msg)


### PR DESCRIPTION
## Summary
- System error messages (`[System error during processing: ...]`) were dynamically assigned `role="user"` when the last message was from the assistant
- This misattributes system behavior to the user and can confuse models about conversation state
- Always use `role="assistant"` — consecutive assistant messages are a lesser issue and are handled by `_sanitize_api_messages` at API-call time

Closes #2228

## Test plan
- [x] Verify error messages always use `role="assistant"`
- [ ] Run `pytest tests/` to confirm no regressions