### PR TITLE
feat(transcription): add .aac format support

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -12,7 +12,7 @@ Provides speech-to-text transcription with three providers:
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
 
-Supported input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg
+Supported input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg, aac
 
 Usage::
 
@@ -58,7 +58,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 
-SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg"}
+SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 


### PR DESCRIPTION
## Summary
- Add `.aac` to `SUPPORTED_FORMATS` set in `transcription_tools.py`
- Update docstring to include `aac` in the supported formats list
- All three backends (local faster-whisper, Groq Whisper, OpenAI Whisper) already support AAC natively — this just adds it to the validation allowlist
- AAC is widely used on iOS devices and many messaging platforms (Telegram voice notes, WhatsApp audio)

Closes #1963

## Test plan
- [x] `.aac` added to `SUPPORTED_FORMATS`
- [x] Docstring updated
- [x] Error message auto-includes `.aac` via `sorted(SUPPORTED_FORMATS)` formatting
- [ ] Run `pytest tests/tools/test_transcription.py` to confirm no regressions