### PR TITLE
fix(cron): treat empty agent response as silent instead of delivering fallback text

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -406,7 +406,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         
         final_response = result.get("final_response", "")
         if not final_response:
-            final_response = "(No response generated)"
+            # Treat empty response as silent — the agent had nothing to report.
+            # The output is still saved locally for audit via save_job_output().
+            final_response = ""
         
         output = f"""# Cron Job: {job_name}
 


### PR DESCRIPTION
## Summary
- When a cron agent returns an empty response, it was replaced with `"(No response generated)"` which bypassed the `[SILENT]` delivery check and got sent to Discord/Telegram/etc.
- Now empty responses are left as empty strings, which are falsy — `bool("")` is `False`, so `should_deliver` is `False` and no message is sent
- Output is still saved locally for audit via `save_job_output()`
- Failed jobs still always deliver their error message (that path is unchanged)

Closes #2234

## Test plan
- [x] Empty `final_response` no longer replaced with fallback text
- [x] `should_deliver = bool(deliver_content)` correctly skips delivery for empty string
- [x] Failed jobs still deliver error messages (separate code path)
- [ ] Run `pytest tests/` to confirm no regressions