### PR TITLE
feat: add Alibaba Coding Plan provider with accurate context window limits

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -26,7 +26,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba",
-    "custom", "local",
+    "coding-plan", "custom", "local",
     # Common aliases
     "glm", "z-ai", "z.ai", "zhipu", "github", "github-copilot",
     "github-models", "kimi", "moonshot", "claude", "deep-seek",
@@ -107,6 +107,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     "llama": 131072,
     # Qwen
     "qwen": 131072,
+    # Alibaba Coding Plan — actual API limits differ from advertised model context
+    "coding-plan/qwen3.5-plus": 169984,
+    "coding-plan/qwen3-max": 169984,
     # MiniMax
     "minimax": 204800,
     # GLM
@@ -161,6 +164,8 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.minimax": "minimax",
     "dashscope.aliyuncs.com": "alibaba",
     "dashscope-intl.aliyuncs.com": "alibaba",
+    "coding.dashscope.aliyuncs.com": "coding-plan",
+    "coding-intl.dashscope.aliyuncs.com": "coding-plan",
     "openrouter.ai": "openrouter",
     "inference-api.nousresearch.com": "nous",
     "api.deepseek.com": "deepseek",

--- a/run_agent.py
+++ b/run_agent.py
@@ -6136,6 +6136,7 @@ class AIAgent:
                         'exceeds the limit', 'context window',
                         'request entity too large',  # OpenRouter/Nous 413 safety net
                         'prompt is too long',  # Anthropic: "prompt is too long: N tokens > M maximum"
+                        'range of input length',  # Alibaba Coding Plan: "Range of input length should be [1, N]"
                     ])
 
                     # Fallback heuristic: Anthropic sometimes returns a generic


### PR DESCRIPTION
## Summary
- Add `coding-plan` to recognized provider prefixes in model metadata
- Map `coding-intl.dashscope.aliyuncs.com` and `coding.dashscope.aliyuncs.com` URLs to the `coding-plan` provider for automatic context length resolution
- Add accurate context lengths for Coding Plan models: **169,984 tokens** (based on actual API error messages, not the advertised 1M)
- Add Alibaba-specific error pattern (`Range of input length`) to context length error detection so compression triggers correctly instead of failing in a loop

Closes #2220

## Test plan
- [x] `coding-plan` recognized as provider prefix
- [x] Coding Plan URLs map to correct provider
- [x] Context length for `coding-plan/qwen3.5-plus` returns 169984
- [x] Alibaba `InvalidParameter` errors trigger compression instead of abort
- [ ] Run `pytest tests/` to confirm no regressions