### PR TITLE
fix(vision): increase LLM timeout for vision_analyze to support local models

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -45,6 +45,10 @@ logger = logging.getLogger(__name__)
 
 _debug = DebugSession("vision_tools", env_var="VISION_TOOLS_DEBUG")
 
+# Timeout for the LLM vision call. Local models may need significantly longer
+# than the default 30s due to image encoding overhead on constrained hardware.
+VISION_LLM_TIMEOUT = float(os.getenv("HERMES_VISION_TIMEOUT", "120"))
+
 
 def _validate_image_url(url: str) -> bool:
     """
@@ -298,12 +302,15 @@ async def vision_analyze_tool(
         
         logger.info("Processing image with vision model...")
         
-        # Call the vision API via centralized router
+        # Call the vision API via centralized router.
+        # Use a longer timeout than the default 30s — local models with
+        # vision can take 60s+ for image encoding on constrained hardware.
         call_kwargs = {
             "task": "vision",
             "messages": messages,
             "temperature": 0.1,
             "max_tokens": 2000,
+            "timeout": VISION_LLM_TIMEOUT,
         }
         if model:
             call_kwargs["model"] = model


### PR DESCRIPTION
## Summary
- Increase the vision LLM call timeout from the default 30s to 120s
- Make it configurable via `HERMES_VISION_TIMEOUT` environment variable
- Local vision models (Ollama, llama.cpp, vLLM) can take 60s+ for image encoding on constrained hardware, causing `httpx.ReadTimeout` before the first token is generated

Closes #2107

## Test plan
- [x] Default timeout increased to 120s for vision calls
- [x] Configurable via `HERMES_VISION_TIMEOUT` env var
- [x] Passes `timeout` kwarg to `async_call_llm()` which accepts it
- [ ] Run `pytest tests/tools/` to confirm no regressions