### PR TITLE
feat(cli): add optional message timestamps between exchanges

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1028,6 +1028,8 @@ class HermesCLI:
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", False)
+        # show_timestamps: prepend HH:MM:SS to the separator between exchanges
+        self.show_timestamps = CLI_CONFIG["display"].get("show_timestamps", False)
 
         self.verbose = verbose if verbose is not None else (self.tool_progress_mode == "verbose")
         
@@ -5335,7 +5337,12 @@ class HermesCLI:
         # Add user message to history
         self.conversation_history.append({"role": "user", "content": message})
 
-        ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+        if self.show_timestamps:
+            from datetime import datetime as _dt
+            _ts = _dt.now().strftime("%H:%M:%S")
+            ChatConsole().print(f"[dim]{_ts}[/dim] [{_accent_hex()}]{'─' * 32}[/]")
+        else:
+            ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
         print(flush=True)
         
         try:


### PR DESCRIPTION
## Summary
- Add `display.show_timestamps` config option (default: `false`)
- When enabled, prepends `HH:MM:SS` to the separator line between user/assistant exchanges
- Useful for tracking how long tasks take during long CLI sessions

Enable in `~/.hermes/config.yaml`:
```yaml
display:
  show_timestamps: true
```

Example output:
```
14:32:05 ────────────────────────────────────
```

Closes #1569

## Test plan
- [x] Timestamps shown when `show_timestamps: true` in config
- [x] No change when config option is absent or false
- [x] Uses `datetime.now().strftime("%H:%M:%S")` for consistent formatting
- [ ] Run `pytest tests/` to confirm no regressions