### PR TITLE
fix(gateway): insert linebreak when streaming resumes after tool calls

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -69,6 +69,7 @@ class GatewayStreamConsumer:
         self._edit_supported = True  # Disabled on first edit failure (Signal/Email/HA)
         self._last_edit_time = 0.0
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
+        self._needs_boundary = False  # True after a None delta (tool call pause)
 
     @property
     def already_sent(self) -> bool:
@@ -77,8 +78,21 @@ class GatewayStreamConsumer:
         return self._already_sent
 
     def on_delta(self, text: str) -> None:
-        """Thread-safe callback — called from the agent's worker thread."""
+        """Thread-safe callback — called from the agent's worker thread.
+
+        Receives ``None`` when the agent pauses streaming for tool execution.
+        When new text arrives after a pause, a line break is inserted so
+        the resumed text doesn't concatenate directly onto the prior text.
+        """
+        if text is None:
+            # Agent is about to execute tool calls — mark boundary
+            self._needs_boundary = True
+            return
         if text:
+            if self._needs_boundary:
+                self._needs_boundary = False
+                if self._accumulated and not self._accumulated.endswith("\n"):
+                    self._queue.put("\n\n")
             self._queue.put(text)
 
     def finish(self) -> None:


### PR DESCRIPTION
## Summary
- When the agent streams text, pauses for tool execution, then resumes streaming from the next API call, the resumed text was concatenated directly onto the prior text with no separator
- Track iteration boundaries via the existing `None` delta signal (already fired at line 6639 in `run_agent.py` before tool calls) and insert a `\n\n` when new text arrives after a pause
- No changes needed in `run_agent.py` — the fix is entirely in `GatewayStreamConsumer.on_delta()`

**Before:**
> Let me check the issues.Found 3 related issues...

**After:**
> Let me check the issues.
>
> Found 3 related issues...

Closes #2177

## Test plan
- [x] `on_delta(None)` sets `_needs_boundary = True`
- [x] Next `on_delta(text)` inserts `\n\n` before the text if accumulated doesn't end with newline
- [x] No linebreak inserted if accumulated already ends with newline
- [x] `finish()` path unaffected
- [ ] Run `pytest tests/gateway/` to confirm no regressions