### PR TITLE
fix(tests): replace FakePath subclass with monkeypatch for Python 3.12 compat

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -290,21 +290,17 @@ class TestEnsureUserSystemdEnv:
         monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
         monkeypatch.setattr(os, "getuid", lambda: 42)
 
-        # Patch Path so /run/user/42 resolves to our tmp dir (which exists)
-        from pathlib import Path as RealPath
-
-        class FakePath(type(RealPath())):
-            def __new__(cls, *args):
-                p = str(args[0]) if args else ""
-                if p == "/run/user/42":
-                    return RealPath.__new__(cls, str(tmp_path))
-                return RealPath.__new__(cls, *args)
-
-        monkeypatch.setattr(gateway_cli, "Path", FakePath)
+        # Patch Path.exists so /run/user/42 appears to exist.
+        # Using a FakePath subclass breaks on Python 3.12+ where
+        # PosixPath.__new__ ignores the redirected path argument.
+        _orig_exists = Path.exists
+        monkeypatch.setattr(
+            gateway_cli.Path, "exists",
+            lambda self: True if str(self) == "/run/user/42" else _orig_exists(self),
+        )
 
         gateway_cli._ensure_user_systemd_env()
 
-        # Function sets the canonical string, not the fake path
         assert os.environ.get("XDG_RUNTIME_DIR") == "/run/user/42"
 
     def test_sets_dbus_address_when_bus_socket_exists(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Replace the `FakePath` subclass pattern with a direct `monkeypatch.setattr` on `Path.exists`
- Python 3.12 changed `PosixPath.__new__` to ignore the path argument passed via `super().__new__()`, so `FakePath("/run/user/42")` no longer redirects to the temp directory
- The monkeypatch approach works across all Python versions and is simpler

Closes #2243

## Test plan
- [x] Test uses `monkeypatch.setattr` on `Path.exists` instead of `FakePath` subclass
- [x] Original test assertions unchanged
- [ ] Run `pytest tests/hermes_cli/test_gateway_service.py -k test_sets_xdg_runtime_dir` on Python 3.12