### PR TITLE
fix: bug: system error messages injected with dynamic role, can appear

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6887,11 +6887,10 @@ class AIAgent:
                 
                 if not pending_handled:
                     # Error happened before tool processing (e.g. response parsing).
-                    # Choose role to avoid consecutive same-role messages.
-                    last_role = messages[-1].get("role") if messages else None
-                    err_role = "assistant" if last_role == "user" else "user"
+                    # Always use assistant role for system error messages to avoid
+                    # misattributing system behavior to the user.
                     sys_err_msg = {
-                        "role": err_role,
+                        "role": "assistant",
                         "content": f"[System error during processing: {error_msg}]",
                     }
                     messages.append(sys_err_msg)


### PR DESCRIPTION
## Summary
Fix for #2228: bug: system error messages injected with dynamic role, can appear as role=user

Closes #2228

## Test plan
- [ ] Run pytest to confirm no regressions