### PR TITLE
fix: fail fast when explicit provider has no API key

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1427,8 +1427,19 @@ def call_llm(
             api_key=resolved_api_key,
         )
         if client is None:
-            # Fallback: try openrouter
-            if resolved_provider != "openrouter" and not resolved_base_url:
+            # The provider has no credentials. When the user explicitly chose
+            # a non-OpenRouter provider, silently falling back to OpenRouter
+            # hides the real problem (missing API key). Fail fast instead.
+            explicit = (resolved_provider or "").strip().lower()
+            if explicit and explicit not in ("auto", "openrouter", "custom"):
+                raise RuntimeError(
+                    f"Provider '{explicit}' has no API key configured "
+                    f"(tried: {', '.join(pconfig.api_key_env_vars)}). "
+                    f"Set the {explicit.upper()}_API_KEY environment variable, "
+                    f"or choose a different provider with 'hermes model'."
+                )
+            # For auto/custom, fall back to OpenRouter
+            if not resolved_base_url:
                 logger.warning("Provider %s unavailable, falling back to openrouter",
                                resolved_provider)
                 client, final_model = _get_cached_client(

--- a/run_agent.py
+++ b/run_agent.py
@@ -732,7 +732,19 @@ class AIAgent:
                     if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
                         client_kwargs["default_headers"] = dict(_routed_client._default_headers)
                 else:
-                    # Final fallback: try raw OpenRouter key
+                    # The provider router failed to find credentials.
+                    # When the user explicitly configured a non-OpenRouter provider,
+                    # silently falling back to OpenRouter hides the real problem
+                    # (missing API key). Fail fast with a clear message.
+                    explicit_provider = (self.provider or "").strip().lower()
+                    if explicit_provider and explicit_provider not in ("auto", "openrouter", "custom"):
+                        raise RuntimeError(
+                            f"Provider '{explicit_provider}' is configured in config.yaml "
+                            f"but no API key was found. "
+                            f"Set the {explicit_provider.upper()}_API_KEY environment variable, "
+                            f"or switch to a different provider with 'hermes model'."
+                        )
+                    # For auto/custom/OpenRouter, fall back to raw OpenRouter key
                     client_kwargs = {
                         "api_key": os.getenv("OPENROUTER_API_KEY", ""),
                         "base_url": OPENROUTER_BASE_URL,


### PR DESCRIPTION
## Problem

When a user explicitly sets `provider: minimax` (or any non-OpenRouter provider) in `config.yaml`, but that provider's API key is not configured (e.g. `MINIMAX_API_KEY` is not set), Hermes silently falls back to OpenRouter.

This causes confusing 404 errors because the request goes to OpenRouter with the MiniMax model name, which OpenRouter doesn't recognize.

## Root Cause

Two silent-fallback code paths:
1. `run_agent.py` AIAgent `__init__`: when `resolve_provider_client('minimax')` returns `None` (no key), falls back to raw OpenRouter key
2. `auxiliary_client.py` `call_llm`: same pattern

## Fix

When an **explicit** non-OpenRouter provider (e.g. `minimax`, `anthropic`, `zai`) has no credentials, raise `RuntimeError` with a clear message telling the user which env var to set:

```
RuntimeError: Provider 'minimax' is configured in config.yaml but no API key was found.
Set the MINIMAX_API_KEY environment variable, or switch to a different provider with 'hermes model'.
```

For `auto`/`custom`/`openrouter` providers, the OpenRouter fallback behavior is preserved (appropriate for auto-detection scenarios).

## Testing

Logic tested:
- `'minimax'`: raises error with message to set `MINIMAX_API_KEY`
- `'anthropic'`: raises error with message to set `ANTHROPIC_API_KEY`
- `'auto'`/`'openrouter'`/`'custom'`: falls through to OpenRouter (unchanged behavior)

