### PR TITLE
fix: opencode-go auth config, vision download timeout, gateway send_document

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3361,7 +3361,7 @@ class GatewayRunner:
                 # Send media files
                 for media_path in (media_files or []):
                     try:
-                        await adapter.send_file(
+                        await adapter.send_document(
                             chat_id=source.chat_id,
                             file_path=media_path,
                         )

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -199,9 +199,9 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     "opencode-go": ProviderConfig(
         id="opencode-go",
         name="OpenCode Go",
-        auth_type="***",
+        auth_type="api_key",
         inference_base_url="https://opencode.ai/zen/go/v1",
-        api_key_env_vars=("OPEN...",),
+        api_key_env_vars=("OPENCODE_GO_API_KEY",),
         base_url_env_var="OPENCODE_GO_BASE_URL",
     ),
     "kilocode": ProviderConfig(

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -45,6 +45,10 @@ logger = logging.getLogger(__name__)
 
 _debug = DebugSession("vision_tools", env_var="VISION_TOOLS_DEBUG")
 
+# Configurable HTTP download timeout for _download_image().
+# Separate from HERMES_VISION_TIMEOUT which governs the LLM API call timeout.
+_VISION_DOWNLOAD_TIMEOUT = float(os.getenv("HERMES_VISION_DOWNLOAD_TIMEOUT", "30"))
+
 
 def _validate_image_url(url: str) -> bool:
     """
@@ -97,7 +101,7 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
         try:
             # Download the image with appropriate headers using async httpx
             # Enable follow_redirects to handle image CDNs that redirect (e.g., Imgur, Picsum)
-            async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            async with httpx.AsyncClient(timeout=_VISION_DOWNLOAD_TIMEOUT, follow_redirects=True) as client:
                 response = await client.get(
                     image_url,
                     headers={
@@ -126,6 +130,10 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
                     exc_info=True,
                 )
     
+    if last_error is None:
+        raise RuntimeError(
+            f"_download_image exited retry loop without attempting (max_retries={max_retries})"
+        )
     raise last_error
 
 


### PR DESCRIPTION
## Summary

Three targeted bug fixes, each addressing a separate open issue.

### Fix 1 — hermes_cli/auth.py (Fixes #2204)

The `opencode-go` entry in `PROVIDER_REGISTRY` had placeholder values (`auth_type="***"`, `api_key_env_vars=("OPEN...",)`) preventing the auth system from treating it as an API-key provider. Users saw "no API keys or providers found" despite supplying a valid key.

- `auth_type: "***"` → `"api_key"`
- `api_key_env_vars: ("OPEN...",)` → `("OPENCODE_GO_API_KEY",)`

Matches the pattern of the adjacent `opencode-zen` entry and the env-var already referenced in `hermes_cli/config.py` and `hermes_cli/setup.py`.

### Fix 2 — tools/vision_tools.py (related to #2107)

1. **Configurable image download timeout**: introduced `_VISION_DOWNLOAD_TIMEOUT` constant (default 30 s, override via `HERMES_VISION_DOWNLOAD_TIMEOUT` env var). This complements the LLM-call timeout fixes in PRs #2126/#2257 — those address `async_call_llm`; this one addresses the `httpx.AsyncClient` used to fetch the image itself. Users on slow connections or with self-hosted image servers can now increase the limit without touching code.

2. **Guard `raise None` edge case in `_download_image`**: if `max_retries=0`, the retry loop never runs, `last_error` stays `None`, and `raise last_error` becomes `raise None` → `TypeError`. Now raises a descriptive `RuntimeError` instead.

### Fix 3 — gateway/run.py (Fixes #1803)

`BasePlatformAdapter` (and all concrete platform adapters) expose `send_document()` for file attachments — there is no `send_file()` method anywhere in the class hierarchy. The background-task result handler in `GatewayRunner` was calling `adapter.send_file(...)`, which raises `AttributeError` at runtime. This was silently swallowed by the surrounding `except Exception: pass`, meaning **media files from completed background tasks were never delivered**.

Renaming the call to `adapter.send_document()` restores correct behaviour. On platforms that haven't overridden the base class it falls back to a plain-text file-path message; on Telegram, Discord, Slack, Matrix, etc. it sends a real file attachment.

## Test plan
- [ ] `python -c "from hermes_cli.auth import PROVIDER_REGISTRY; p=PROVIDER_REGISTRY['opencode-go']; assert p.auth_type=='api_key'; assert p.api_key_env_vars==('OPENCODE_GO_API_KEY',)"` passes
- [ ] `HERMES_VISION_DOWNLOAD_TIMEOUT=120` overrides the image download timeout; default 30 s unchanged
- [ ] Background task that produces a file attachment delivers via `send_document` with no `AttributeError`
- [ ] `pytest tests/ -x -q` — no regressions
