### PR TITLE
fix: fail fast when explicit provider has no API key instead of silent OpenRouter fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1427,8 +1427,20 @@ def call_llm(
             api_key=resolved_api_key,
         )
         if client is None:
-            # Fallback: try openrouter
-            if resolved_provider != "openrouter" and not resolved_base_url:
+            # Provider returned no client (no credentials). When the user
+            # explicitly chose a non-OpenRouter provider in config.yaml, silently
+            # falling back to OpenRouter hides the real problem. Fail fast.
+            explicit = (resolved_provider or "").strip().lower()
+            if explicit and explicit not in ("auto", "openrouter", "custom"):
+                env_var = f"{explicit.upper()}_API_KEY"
+                raise RuntimeError(
+                    f"Provider '{explicit}' is set in config.yaml but has no API key "
+                    f"(tried: {', '.join(pconfig.api_key_env_vars)}). "
+                    f"Set the {env_var} environment variable, or "
+                    f"switch to a different provider with `hermes model`."
+                )
+            # For auto/custom, fall back to OpenRouter
+            if not resolved_base_url:
                 logger.warning("Provider %s unavailable, falling back to openrouter",
                                resolved_provider)
                 client, final_model = _get_cached_client(

--- a/run_agent.py
+++ b/run_agent.py
@@ -732,7 +732,21 @@ class AIAgent:
                     if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
                         client_kwargs["default_headers"] = dict(_routed_client._default_headers)
                 else:
-                    # Final fallback: try raw OpenRouter key
+                    # The provider router returned no credentials.
+                    # When the user explicitly chose a non-OpenRouter provider
+                    # (e.g. minimax, anthropic) in config.yaml, silently falling
+                    # back to OpenRouter hides the real problem (missing API key).
+                    # Fail fast with a clear message telling the user exactly
+                    # which env var to set.
+                    explicit = (self.provider or "").strip().lower()
+                    if explicit and explicit not in ("auto", "openrouter", "custom"):
+                        env_var = f"{explicit.upper()}_API_KEY"
+                        raise RuntimeError(
+                            f"Provider '{explicit}' is set in config.yaml but no API key "
+                            f"was found. Set the {env_var} environment variable, or "
+                            f"switch to a different provider with `hermes model`."
+                        )
+                    # For auto/custom/openrouter, fall back to raw OpenRouter key
                     client_kwargs = {
                         "api_key": os.getenv("OPENROUTER_API_KEY", ""),
                         "base_url": OPENROUTER_BASE_URL,


### PR DESCRIPTION
## Problem

When `provider: minimax` (or any non-OpenRouter provider) is set in `config.yaml` but the corresponding API key environment variable (`MINIMAX_API_KEY`) is **not set**, Hermes silently falls back to OpenRouter.

This causes a confusing 404 error because:
1. OpenRouter receives the request with the MiniMax model name
2. OpenRouter tries to route to MiniMax's API but gets a 404 (wrong endpoint or no credentials for that route)
3. The user sees a 404 with no explanation of why Hermes is talking to OpenRouter at all

## Root Cause

Two code paths silently fell back to OpenRouter when a provider had no credentials:

**1. `run_agent.py` AIAgent.__init__** (lines 734-744):
```python
else:
    # Final fallback: try raw OpenRouter key
    client_kwargs = {api_key: ..., base_url: OPENROUTER_BASE_URL}
```

**2. `auxiliary_client.py` `call_llm`** (lines 1429-1435):
```python
if client is None:
    if resolved_provider != "openrouter" and not resolved_base_url:
        logger.warning("Provider %s unavailable, falling back to openrouter")
        client, final_model = _get_cached_client("openrouter", ...)
```

## Fix

In both locations, before falling back to OpenRouter, check if the user explicitly configured a non-OpenRouter provider. If so, **raise RuntimeError with a clear message**:



For `auto`/`custom`/`openrouter` providers, the OpenRouter fallback behavior is preserved — appropriate for auto-detection scenarios where the user hasn't pinned a specific provider.

## Testing

Logic verified:
- `'minimax'` with no key → raises error telling user to set `MINIMAX_API_KEY`
- `'anthropic'` with no key → raises error telling user to set `ANTHROPIC_API_KEY`
- `'auto'`/`'openrouter'`/`'custom'` → falls through to OpenRouter (unchanged)

