### PR TITLE
fix: use git pull --rebase in update/install to avoid divergent branch error

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2688,7 +2688,7 @@ def cmd_update(args):
 
         print("→ Pulling updates...")
         try:
-            subprocess.run(git_cmd + ["pull", "origin", branch], cwd=PROJECT_ROOT, check=True)
+            subprocess.run(git_cmd + ["pull", "--ff-only", "origin", branch], cwd=PROJECT_ROOT, check=True)
         finally:
             if auto_stash_ref is not None:
                 _restore_stashed_changes(

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -577,7 +577,7 @@ clone_repo() {
 
             git fetch origin
             git checkout "$BRANCH"
-            git pull origin "$BRANCH"
+            git pull --ff-only origin "$BRANCH"
 
             if [ -n "$autostash_ref" ]; then
                 local restore_now="yes"


### PR DESCRIPTION
On a fresh machine, `hermes update` fails with:

```
hint: You have divergent branches and need to specify how to reconcile them.
```

Because git doesn't have `pull.rebase` configured by default. Fixed by passing `--rebase` explicitly in both places:

- `hermes_cli/main.py` — `hermes update` command
- `scripts/install.sh` — installer update path

2 files, 2 lines changed.