### PR TITLE
chore: remove dead top-level toolsets config key

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -424,7 +424,7 @@ agent:
 # Toolsets
 # =============================================================================
 # Control which tools the agent has access to.
-# Use "all" to enable everything, or specify individual toolsets.
+# Use `hermes tools` to interactively enable/disable tools per platform.
 
 # =============================================================================
 # Platform Toolsets (per-platform tool configuration)
@@ -533,53 +533,11 @@ platform_toolsets:
 #   debugging    - terminal + web + file (for troubleshooting)
 #   safe         - web + vision + moa (no terminal access)
 
-# -----------------------------------------------------------------------------
-# OPTION 1: Enable all tools (default)
-# -----------------------------------------------------------------------------
-toolsets:
-  - all
-
-# -----------------------------------------------------------------------------
-# OPTION 2: Minimal - just web search and terminal
-# Great for: Simple coding tasks, quick lookups
-# -----------------------------------------------------------------------------
-# toolsets:
-#   - web
-#   - terminal
-
-# -----------------------------------------------------------------------------
-# OPTION 3: Research mode - no execution capabilities
-# Great for: Safe information gathering, research tasks
-# -----------------------------------------------------------------------------
-# toolsets:
-#   - web
-#   - vision
-#   - skills
-
-# -----------------------------------------------------------------------------
-# OPTION 4: Full automation - browser + terminal
-# Great for: Web scraping, automation tasks, testing
-# -----------------------------------------------------------------------------
-# toolsets:
-#   - terminal
-#   - browser
-#   - web
-
-# -----------------------------------------------------------------------------
-# OPTION 5: Creative mode - vision + image generation
-# Great for: Design work, image analysis, creative tasks
-# -----------------------------------------------------------------------------
-# toolsets:
-#   - vision
-#   - image_gen
-#   - web
-
-# -----------------------------------------------------------------------------
-# OPTION 6: Safe mode - no terminal or browser
-# Great for: Restricted environments, untrusted queries
-# -----------------------------------------------------------------------------
-# toolsets:
-#   - safe
+# NOTE: The top-level "toolsets" key is deprecated and ignored.
+# Tool configuration is managed per-platform via platform_toolsets above.
+# Use `hermes tools` to configure interactively, or edit platform_toolsets directly.
+#
+# CLI override: hermes chat --toolsets terminal,web,file
 
 # =============================================================================
 # MCP (Model Context Protocol) Servers

--- a/cli.py
+++ b/cli.py
@@ -211,7 +211,7 @@ def load_cli_config() -> Dict[str, Any]:
                 "hype": "YOOO LET'S GOOOO!!! I am SO PUMPED to help you today! Every question is AMAZING and we're gonna CRUSH IT together! This is gonna be LEGENDARY! ARE YOU READY?! LET'S DO THIS!",
             },
         },
-        "toolsets": ["all"],
+
         "display": {
             "compact": False,
             "resume_display": "full",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1607,7 +1607,6 @@ def show_config():
     print(color("◆ Model", Colors.CYAN, Colors.BOLD))
     print(f"  Model:        {config.get('model', 'not set')}")
     print(f"  Max turns:    {config.get('agent', {}).get('max_turns', DEFAULT_CONFIG['agent']['max_turns'])}")
-    print(f"  Toolsets:     {', '.join(config.get('toolsets', ['all']))}")
     
     # Display
     print()


### PR DESCRIPTION
The top-level `toolsets` key in config.yaml (`toolsets: [all]`) was never read at runtime. Tool selection uses `platform_toolsets` (per-platform) or the `--toolsets` CLI flag. The key existed in `load_cli_config()` defaults and the example config, misleading users into thinking it controlled tool availability.

- Removed from `load_cli_config()` hardcoded defaults
- Removed from `hermes config show` output  
- Replaced in `cli-config.yaml.example` with deprecation note pointing to `platform_toolsets` and `hermes tools`

5672 tests passing.