### PR TITLE
fix:  opencode go provider not function

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -199,9 +199,9 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     "opencode-go": ProviderConfig(
         id="opencode-go",
         name="OpenCode Go",
-        auth_type="***",
+        auth_type="api_key",
         inference_base_url="https://opencode.ai/zen/go/v1",
-        api_key_env_vars=("OPEN...",),
+        api_key_env_vars=("OPENCODE_GO_API_KEY",),
         base_url_env_var="OPENCODE_GO_BASE_URL",
     ),
     "kilocode": ProviderConfig(


### PR DESCRIPTION
## Summary
Fix for #2273: [Bug]: opencode go provider not function

Closes #2273

## Test plan
- [ ] Run pytest to confirm no regressions