### PR TITLE
fix(setup): OpenCode Zen/Go show OpenRouter models instead of their own

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1714,7 +1714,7 @@ def setup_model_provider(config: dict):
             model_cfg = _model_config_dict(config)
             model_cfg["api_mode"] = "chat_completions"
             config["model"] = model_cfg
-        elif selected_provider in ("copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "ai-gateway"):
+        elif selected_provider in ("copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "ai-gateway", "opencode-zen", "opencode-go"):
             _setup_provider_model_selection(
                 config, selected_provider, current_model,
                 prompt_choice, prompt,


### PR DESCRIPTION
After selecting OpenCode Zen or Go in `hermes setup`, the model selection page showed OpenRouter models. These providers weren't in the list that routes to `_setup_provider_model_selection()` — they fell through to the `else` branch which shows the OpenRouter catalog.

Users ended up with an OpenCode API key + OpenRouter model name → `Provider resolver returned an empty API key` on first use.

One-line fix: add `opencode-zen` and `opencode-go` to the provider tuple at line 1717.