### PR TITLE
feat(gateway): add @-mention-only filter for Mattermost channels

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -580,6 +580,24 @@ class MattermostAdapter(BasePlatformAdapter):
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
 
+        # Mention-only mode: skip channel messages that don't @mention the bot.
+        # DMs (type "D") are always processed.
+        if channel_type_raw != "D":
+            mention_patterns = [
+                f"@{self._bot_username}",
+                f"@{self._bot_user_id}",
+            ]
+            has_mention = any(
+                pattern.lower() in message_text.lower()
+                for pattern in mention_patterns
+            )
+            if not has_mention:
+                logger.debug(
+                    "Mattermost: skipping non-DM message without @mention (channel=%s)",
+                    channel_id,
+                )
+                return
+
         # Resolve sender info.
         sender_id = post.get("user_id", "")
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id


### PR DESCRIPTION
## What does this PR do?

Adds @-mention-only filtering to the Mattermost gateway adapter. The bot now only responds to messages in channels and groups when it is explicitly @-mentioned. DMs are always processed without filtering.

Currently, the Mattermost adapter processes **every** message from other users in channels, creating noise and unnecessary API calls. This brings Mattermost in line with Discord and Slack adapters which already filter for mentions.

## Related Issue

Fixes #2174

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/mattermost.py`: Added mention detection in `_handle_post()` after the existing "For channels, check for @mention" comment (line 580). Non-DM messages without a matching `@username` or `@user_id` in the message text are skipped with a debug log.

## How to Test

1. Connect the bot to a Mattermost server with `MATTERMOST_ALLOW_ALL_USERS=true`
2. Send a message in a channel **without** @-mentioning the bot — it should not respond
3. Send a message in a channel **with** `@hermes-agent` — it should respond normally
4. Send a DM to the bot — it should respond without requiring a mention
5. Check logs for `Mattermost: skipping non-DM message without @mention` debug entries

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: Docker (python:3.12-slim on macOS/OrbStack)

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (WebSocket filtering is platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A