### PR TITLE
fix(cron): silent jobs return empty response for delivery skip

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -404,9 +404,10 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         
         result = agent.run_conversation(prompt)
         
-        final_response = result.get("final_response", "")
-        if not final_response:
-            final_response = "(No response generated)"
+        final_response = result.get("final_response", "") or ""
+        # Use a separate variable for log display; keep final_response clean
+        # for delivery logic (empty response = no delivery).
+        logged_response = final_response if final_response else "(No response generated)"
         
         output = f"""# Cron Job: {job_name}
 
@@ -420,7 +421,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
 ## Response
 
-{final_response}
+{logged_response}
 """
         
         logger.info("Job '%s' completed successfully", job_name)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -196,6 +196,47 @@ class TestRunJobSessionPersistence:
         assert kwargs["session_id"].startswith("cron_test-job_")
         fake_db.close.assert_called_once()
 
+    def test_run_job_empty_response_returns_empty_not_placeholder(self, tmp_path):
+        """Empty final_response should stay empty for delivery logic (issue #2234).
+        
+        The placeholder '(No response generated)' should only appear in the
+        output log, not in the returned final_response that's used for delivery.
+        """
+        job = {
+            "id": "silent-job",
+            "name": "silent test",
+            "prompt": "do work via tools only",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            # Agent did work via tools but returned no text
+            mock_agent.run_conversation.return_value = {"final_response": ""}
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        # final_response should be empty for delivery logic to skip
+        assert final_response == ""
+        # But the output log should show the placeholder
+        assert "(No response generated)" in output
+
     def test_run_job_sets_auto_delivery_env_from_dotenv_home_channel(self, tmp_path, monkeypatch):
         job = {
             "id": "test-job",


### PR DESCRIPTION
## Summary

Fixes #2234

Silent cron jobs that complete work via tools but produce no final text response were delivering `(No response generated)` to Discord instead of staying silent.

## Root Cause

In `run_job()`, the placeholder string was overwriting `final_response`:

```python
final_response = result.get("final_response", "")
if not final_response:
    final_response = "(No response generated)"  # overwrites the return value
```

This meant `bool(final_response)` was always `True`, so delivery always proceeded.

## Fix

Separate the log placeholder from the return value:

```python
final_response = result.get("final_response", "") or ""
logged_response = final_response if final_response else "(No response generated)"
```

- `logged_response` is used in the output template for logging
- `final_response` stays clean (empty string when no response)
- Delivery logic correctly skips when `final_response` is empty

## Testing

Added test `test_run_job_empty_response_returns_empty_not_placeholder` that verifies:
- `final_response` is empty when agent returns no text
- `output` (log) still contains the placeholder for visibility