### PR TITLE
feat(skills): add axle lean 4 proof manipulation skill

### DIFF
--- a/skills/mlops/evaluation/axle/SKILL.md
+++ b/skills/mlops/evaluation/axle/SKILL.md
@@ -1,0 +1,400 @@
+---
+name: axle
+description: >-
+  AXLE (Axiom Lean Engine) — CLI and Python client for Lean 4 proof manipulation
+  via the Axiom Math cloud API. Use when verifying proofs, checking Lean code,
+  extracting/merging/renaming theorems, repairing broken proofs, disproving
+  statements, or normalizing Lean files. 14 tools for Lean 4 + Mathlib workflows.
+version: 1.0.0
+author: Orchestra Research
+license: MIT
+dependencies: [axiom-axle]
+metadata:
+  hermes:
+    tags: [Lean 4, Theorem Proving, Mathlib, Formal Verification, Proof Assistant, AXLE, Axiom Math, CLI, Python API]
+---
+
+# AXLE - Lean 4 Proof Manipulation
+
+AXLE provides 14 tools for validating, analyzing, and transforming Lean source code — all running as Lean metaprograms on the Axiom Math cloud infrastructure.
+
+## When to use AXLE
+
+**Use AXLE when:**
+- Verifying a candidate proof against a formal statement
+- Checking if Lean 4 code compiles (remote, no local Lean install needed)
+- Extracting individual theorems from a multi-theorem file with dependency metadata
+- Merging multiple Lean files with deduplication and conflict resolution
+- Repairing broken proofs after a Mathlib version bump
+- Simplifying proofs by removing unused tactics
+- Creating problem sets by stripping proofs to sorry
+- Attempting to disprove false statements
+- Normalizing Lean file formatting before merge operations
+
+**Use alternatives instead:**
+- **Local Lean/Lake**: When you need a full local development environment or IDE integration
+- **lean4checker/Comparator/SafeVerify**: When verifying untrusted/adversarial code (AXLE's verify-proof trusts the Lean environment and can be exploited via metaprogramming)
+- **Pantograph**: When you need machine-to-machine proof interaction beyond AXLE's tool set
+
+## Quick start
+
+**Install**: `axiom-axle` from PyPI (requires Python 3.11+).
+
+Set your API key (optional, increases concurrent request limit from 10 to 20):
+```bash
+export AXLE_API_KEY=your_key_from_https://axle.axiommath.ai/app/console
+```
+
+**Check if code compiles:**
+```bash
+echo 'theorem foo : 1 + 1 = 2 := by norm_num' \
+  | axle check --environment lean-4.28.0 --ignore-imports -
+```
+
+**Verify a proof:**
+```bash
+echo 'theorem foo : 1 + 1 = 2 := by sorry' > statement.lean
+echo 'theorem foo : 1 + 1 = 2 := by norm_num' > proof.lean
+axle verify-proof --environment lean-4.28.0 --ignore-imports statement.lean proof.lean
+```
+
+**Python async client:**
+```python
+from axle import AxleClient
+
+async with AxleClient() as client:
+    result = await client.check(
+        content="theorem foo : 1 + 1 = 2 := by norm_num",
+        environment="lean-4.28.0",
+        ignore_imports=True,
+    )
+    print(result.okay)  # True
+```
+
+## Common workflows
+
+### Workflow 1: Verify proof attempts
+
+Validate that a candidate proof correctly proves a formal statement.
+
+```text
+Proof Verification:
+- [ ] Step 1: Write formal statement (sorried)
+- [ ] Step 2: Write or generate candidate proof
+- [ ] Step 3: Run verify-proof
+- [ ] Step 4: Check results
+```
+
+**Step 1–2: Prepare files**
+
+```bash
+# Statement file (with sorry placeholder)
+cat > statement.lean << 'EOF'
+theorem add_comm_nat : ∀ (a b : Nat), a + b = b + a := by sorry
+EOF
+
+# Candidate proof
+cat > proof.lean << 'EOF'
+theorem add_comm_nat : ∀ (a b : Nat), a + b = b + a := by
+  intros a b; omega
+EOF
+```
+
+**Step 3: Verify**
+
+```bash
+# Both args are FILE PATHS (not inline strings!)
+axle verify-proof --environment lean-4.28.0 --ignore-imports \
+  statement.lean proof.lean
+
+# Or: statement from file, proof from stdin
+cat proof.lean | axle verify-proof --environment lean-4.28.0 \
+  --ignore-imports statement.lean -
+```
+
+**Step 4: Interpret results**
+
+Output includes `okay` (bool), `failed_declarations` (list), and `tool_messages.errors` with specific failure reasons like "Missing required declaration", "Theorem does not match expected signature", or "Declaration uses 'sorry'".
+
+### Workflow 2: Repair proofs after Mathlib update
+
+Fix proofs that broke due to a Lean/Mathlib version change.
+
+```text
+Proof Repair:
+- [ ] Step 1: Normalize the file
+- [ ] Step 2: Run repair-proofs
+- [ ] Step 3: Verify repairs
+```
+
+**Step 1: Normalize**
+
+```bash
+axle normalize --environment lean-4.28.0 --ignore-imports \
+  broken.lean -o normalized.lean
+```
+
+**Step 2: Repair**
+
+```bash
+# Default terminal tactic is grind; customize with --terminal-tactics
+axle repair-proofs --environment lean-4.28.0 --ignore-imports \
+  normalized.lean -o repaired.lean --strict
+```
+
+Three repair strategies run by default:
+- `remove_extraneous_tactics` — remove tactics after proof is complete
+- `apply_terminal_tactics` — replace sorry with grind (or custom tactics)
+- `replace_unsafe_tactics` — replace native_decide with "decide +kernel"
+
+**Step 3: Verify**
+
+```bash
+axle check --environment lean-4.28.0 --ignore-imports repaired.lean --strict
+```
+
+### Workflow 3: Merge multiple proof files
+
+Combine separate Lean files with intelligent deduplication.
+
+```text
+File Merge:
+- [ ] Step 1: Normalize each file
+- [ ] Step 2: Merge
+- [ ] Step 3: Review output
+```
+
+**Step 1: Normalize**
+
+```bash
+for f in *.lean; do
+  axle normalize --environment lean-4.28.0 --ignore-imports "$f" -o "norm_$f"
+done
+```
+
+**Step 2: Merge**
+
+```bash
+axle merge --environment lean-4.28.0 --ignore-imports \
+  norm_*.lean -o merged.lean
+```
+
+The merge algorithm handles: topological ordering, auto-renaming conflicts (A → A_1), deduplication of identical types (even across different names via type_hash), preference for error-free/sorry-free versions, and preserving failed attempts as comments. Use `--include-alts-as-comments` to keep all versions.
+
+## CLI reference
+
+All commands accept Lean code via **file path** or **stdin** (`-`). Positional args are always file paths, never inline strings.
+
+**Global flags** (must go before subcommand): `--json`, `--url URL`, `--version`
+
+**Common flags**: `--environment` (required), `--ignore-imports`, `--timeout-seconds N`, `--strict` (exit code 3 on failure), `-o FILE`
+
+**Exit codes**: 0=success, 1=failure, 2=file exists, 3=strict validation failed, 130=interrupted
+
+### Validation tools
+
+```bash
+# Check if code compiles (also works as REPL: #check, #eval output in lean_messages.infos)
+axle check --environment lean-4.28.0 --ignore-imports FILE_OR_-
+# Options: --mathlib-linter --strict
+
+# Verify proof against formal statement (both args are files)
+axle verify-proof --environment lean-4.28.0 --ignore-imports STATEMENT.lean PROOF.lean
+# Options: --permitted-sorries name1,name2  --no-use-def-eq  --mathlib-linter  --strict
+
+# Attempt to disprove theorems (prove the negation via Plausible)
+axle disprove --environment lean-4.28.0 --ignore-imports FILE_OR_-
+# Options: --names X  --indices X  --terminal-tactics tac1,tac2
+```
+
+### Transformation tools
+
+```bash
+# Strip proofs, replace with sorry (create problem sets)
+axle theorem2sorry --environment lean-4.28.0 --ignore-imports FILE_OR_-
+# Options: --names X  --indices 0,-1  -o FILE
+
+# Convert theorem ↔ lemma keywords
+axle theorem2lemma --environment lean-4.28.0 --ignore-imports --target lemma FILE_OR_-
+# Options: --names X  --indices X  --target theorem|lemma
+
+# Rename declarations (updates all references)
+axle rename --environment lean-4.28.0 --ignore-imports \
+  --declarations '{"old_name": "new_name"}' FILE_OR_-
+# Also: --declarations old=new,foo=bar  or  --declarations-file mapping.json
+
+# Normalize formatting (run before merge)
+axle normalize --environment lean-4.28.0 --ignore-imports FILE_OR_- -o FILE
+# Options: --normalizations remove_sections,expand_decl_names  --no-failsafe
+# Defaults: remove_sections, remove_duplicates, split_open_in_commands
+# Available: + expand_decl_names, normalize_module_comments, normalize_doc_comments
+```
+
+### Analysis tools
+
+```bash
+# Extract individual theorems with full dependency metadata
+axle extract-theorems --environment lean-4.28.0 --ignore-imports FILE_OR_- -d output/ -f
+# Each theorem: signature, type, type_hash, tactic_counts, proof_length, 6 dependency lists
+
+# Simplify proofs (remove unused tactics/haves, rename unused vars)
+axle simplify-theorems --environment lean-4.28.0 --ignore-imports FILE_OR_-
+# Options: --simplifications remove_unused_tactics,remove_unused_haves,rename_unused_vars
+
+# Repair broken proofs
+axle repair-proofs --environment lean-4.28.0 --ignore-imports FILE_OR_- --strict
+# Options: --repairs remove_extraneous_tactics,apply_terminal_tactics,replace_unsafe_tactics
+#          --terminal-tactics grind,omega,simp
+```
+
+### Extraction tools
+
+```bash
+# Extract have statements to standalone lemmas
+axle have2lemma --environment lean-4.28.0 --ignore-imports FILE_OR_-
+# Options: --include-have-body  --no-include-whole-context  --reconstruct-callsite
+#          --verbosity 0|1|2  --names X  --indices X
+
+# Replace have bodies with sorry
+axle have2sorry --environment lean-4.28.0 --ignore-imports FILE_OR_-
+
+# Extract sorry/error positions to standalone lemmas
+axle sorry2lemma --environment lean-4.28.0 --ignore-imports FILE_OR_-
+# Options: --no-extract-sorries  --no-extract-errors  --reconstruct-callsite
+
+# Merge multiple files
+axle merge --environment lean-4.28.0 --ignore-imports f1.lean f2.lean -o merged.lean
+# Options: --include-alts-as-comments  --no-use-def-eq
+```
+
+### Utility
+
+```bash
+# List available Lean environments
+axle environments
+# Available: lean-4.21.0 through lean-4.28.0 (8 versions, all include Mathlib)
+```
+
+## Python API
+
+See [references/python-api.md](references/python-api.md) for full method signatures and response types.
+
+```python
+from axle import AxleClient
+
+async with AxleClient(
+    api_key=None,              # fallback: AXLE_API_KEY env var
+    url=None,                  # fallback: AXLE_API_URL (default: https://axle.axiommath.ai)
+    max_concurrency=None,      # fallback: AXLE_MAX_CONCURRENCY (default: 20)
+    base_timeout_seconds=None, # fallback: AXLE_TIMEOUT_SECONDS (default: 1800, retry window)
+) as client:
+    # Validation
+    r = await client.check(content=code, environment="lean-4.28.0", ignore_imports=True)
+    r = await client.verify_proof(formal_statement=stmt, content=proof, environment="lean-4.28.0")
+    r = await client.disprove(content=code, environment="lean-4.28.0")
+
+    # Transformation
+    r = await client.theorem2sorry(content=code, environment="lean-4.28.0")
+    r = await client.theorem2lemma(content=code, environment="lean-4.28.0", target="lemma")
+    r = await client.rename(content=code, declarations={"old": "new"}, environment="lean-4.28.0")
+    r = await client.normalize(content=code, environment="lean-4.28.0")
+
+    # Analysis & repair
+    r = await client.extract_theorems(content=code, environment="lean-4.28.0")
+    r = await client.simplify_theorems(content=code, environment="lean-4.28.0")
+    r = await client.repair_proofs(content=code, environment="lean-4.28.0")
+    r = await client.merge(documents=[code1, code2], environment="lean-4.28.0")
+
+    # Extraction
+    r = await client.have2lemma(content=code, environment="lean-4.28.0")
+    r = await client.have2sorry(content=code, environment="lean-4.28.0")
+    r = await client.sorry2lemma(content=code, environment="lean-4.28.0")
+
+    # Utility
+    envs = await client.environments()
+    status = client.check_status()  # synchronous health check
+```
+
+**Helper functions** (exported from `axle`):
+```python
+from axle import remove_comments, inline_lean_messages
+
+# Strip comments from Lean code (handles nesting, strings, module docs)
+clean = remove_comments(code, include_module_docs=False, include_docstrings=False)
+
+# Inline compiler messages as comments at source locations
+annotated = inline_lean_messages(code, messages=result.lean_messages.errors)
+```
+
+## Common issues
+
+**Issue: "Imports mismatch: expected '[Mathlib]', got '[]'"**
+
+Add `--ignore-imports` to all commands when your code doesn't start with `import Mathlib`:
+```bash
+axle check --environment lean-4.28.0 --ignore-imports FILE
+```
+
+**Issue: CLI positional argument treated as file path**
+
+All positional args are file paths. Write content to a temp file or pipe via stdin:
+```bash
+# Wrong: axle check --environment lean-4.28.0 'theorem foo ...'
+# Right:
+echo 'theorem foo : True := trivial' | axle check --environment lean-4.28.0 --ignore-imports -
+```
+
+**Issue: verify-proof says "Missing required declaration" but code is correct**
+
+Both args to verify-proof must be file paths. The first arg cannot be stdin:
+```bash
+# Wrong: echo '...' | axle verify-proof --environment lean-4.28.0 - -
+# Right: use a file for statement, stdin for proof
+axle verify-proof --environment lean-4.28.0 --ignore-imports statement.lean -
+```
+
+**Issue: okay=false even though code compiles in Lean**
+
+AXLE is stricter than the Lean compiler. Check `tool_messages.errors` for reasons: native_decide usage, sorry in proofs, type mismatch, banned `open private`, or non-standard axioms.
+
+**Issue: "All executors failed after N attempts"**
+
+Usually an OOM condition. Simplify input, break into smaller files, or reduce timeout:
+```bash
+axle check --environment lean-4.28.0 --ignore-imports --timeout-seconds 300 FILE
+```
+
+**Issue: --json flag not recognized**
+
+`--json` is a global flag that must go before the subcommand:
+```bash
+# Wrong: axle check --json --environment ...
+# Right: axle --json check --environment ...
+```
+
+**Issue: merge produces conflicting non-declaration commands**
+
+`set_option`, `variable`, and `maxHeartbeats` from different files may conflict. Always normalize before merging:
+```bash
+axle normalize --environment lean-4.28.0 --ignore-imports file.lean -o norm_file.lean
+```
+
+## Advanced topics
+
+**verify-proof security**: AXLE trusts the Lean environment. A creative adversary can exploit Lean metaprogramming to make invalid proofs appear valid. For untrusted code, use lean4checker, Comparator, or SafeVerify instead. See [references/security.md](references/security.md).
+
+**Extract-theorems metadata**: Each extracted theorem includes 20+ fields — type_hash for dedup, 6 dependency lists (local/external × type/value/syntactic), tactic_counts, proof_length, and standalone compilation status. See [references/extract-theorems-metadata.md](references/extract-theorems-metadata.md).
+
+**HTTP API**: Direct REST calls to `POST /api/v1/<tool_name>` with JSON body. Environments at `GET /v1/environments`, health at `GET /v1/status`. Auth via `Authorization: Bearer <key>` header. See [references/http-api.md](references/http-api.md).
+
+**Error handling**: Python exceptions: `AxleIsUnavailable` (503, auto-retried), `AxleRateLimitedError` (429, auto-retried), `AxleInvalidArgument` (400), `AxleForbiddenError` (403), `AxleInternalError` (500), `AxleRuntimeError`. Base: `AxleApiError`. Root: `AxleError` (import from `axle.exceptions`). See [references/python-api.md](references/python-api.md).
+
+## Resources
+
+- **Docs**: https://axle.axiommath.ai/v1/docs/
+- **GitHub**: https://github.com/AxiomMath/axiom-lean-engine
+- **Console (API keys)**: https://axle.axiommath.ai/app/console
+- **Web UI**: https://axle.axiommath.ai/
+- **MCP server**: axiom-axle-mcp (separate package)
+- **Lean 4**: https://lean-lang.org/
+- **Mathlib**: https://leanprover-community.github.io/mathlib4_docs/

--- a/skills/mlops/evaluation/axle/references/extract-theorems-metadata.md
+++ b/skills/mlops/evaluation/axle/references/extract-theorems-metadata.md
@@ -1,0 +1,92 @@
+# Extract-Theorems Metadata Reference
+
+Each theorem extracted by `extract_theorems` includes 20+ metadata fields in the `Document` object.
+
+## Identity & positioning
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | str | Theorem name |
+| `declaration` | str | Raw source code of the declaration |
+| `signature` | str | Everything before proof body (e.g., "theorem foo : 1 = 1") |
+| `type` | str | Pretty-printed type (e.g., "∀ (a b : ℕ), a + b = b + a") |
+| `type_hash` | int | Canonical alpha-invariant type hash (for deduplication) |
+| `index` | int | 0-based position in original file (non-contiguous for mutual defs) |
+| `line_pos` | int | 1-based start line number |
+| `end_line_pos` | int | 1-based end line number |
+
+## Content
+
+| Field | Type | Description |
+|---|---|---|
+| `content` | str | Self-contained Lean code (independently compilable with imports) |
+| `tokens` | list[str] | Tokenized source (e.g., ["theorem", "foo", ":", ...]) |
+| `is_sorry` | bool | Whether proof contains sorry |
+
+## Proof complexity
+
+| Field | Type | Description |
+|---|---|---|
+| `proof_length` | int | Approximate number of tactics |
+| `tactic_counts` | dict[str, int] | Per-tactic breakdown (e.g., {"Lean.Parser.Tactic.omega": 1}) |
+
+## Dependency analysis (6 lists)
+
+| Field | Type | Description |
+|---|---|---|
+| `local_type_dependencies` | list[str] | Transitive local deps of the TYPE |
+| `local_value_dependencies` | list[str] | Transitive local deps of the PROOF |
+| `external_type_dependencies` | list[str] | Immediate external deps of the TYPE |
+| `external_value_dependencies` | list[str] | Immediate external deps of the PROOF |
+| `local_syntactic_dependencies` | list[str] | Local constants literally written in source |
+| `external_syntactic_dependencies` | list[str] | External constants literally written in source |
+
+"Syntactic" dependencies are what appears in source code before notation/macro expansion. "Type/value" dependencies include things that emerge from expansion.
+
+## Compilation status
+
+| Field | Type | Description |
+|---|---|---|
+| `document_messages` | Messages | {errors, warnings, infos} from standalone compilation |
+| `theorem_messages` | Messages | {errors, warnings, infos} specific to this theorem |
+
+## Example output
+
+```json
+{
+  "add_comm_test": {
+    "declaration": "theorem add_comm_test : ∀ (a b : Nat), a + b = b + a := by\n  intros a b\n  omega",
+    "content": "import Mathlib\n\ntheorem add_comm_test : ∀ (a b : Nat), a + b = b + a := by\n  intros a b\n  omega",
+    "signature": "theorem add_comm_test : ∀ (a b : Nat), a + b = b + a",
+    "type": "∀ (a b : ℕ), a + b = b + a",
+    "type_hash": 1387679959,
+    "index": 0,
+    "line_pos": 3,
+    "end_line_pos": 5,
+    "is_sorry": false,
+    "proof_length": 2,
+    "tactic_counts": {
+      "Lean.Parser.Tactic.intros": 1,
+      "Lean.Parser.Tactic.omega": 1
+    },
+    "tokens": ["theorem", "add_comm_test", ":", "∀", "(", "a", "b", ":", "Nat", ")", ",", "a", "+", "b", "=", "b", "+", "a", ":=", "by", "intros", "a", "b", "omega"],
+    "external_syntactic_dependencies": ["Nat"],
+    "external_type_dependencies": ["Nat", "Eq", "HAdd.hAdd", "instHAdd", "instAddNat"],
+    "external_value_dependencies": ["Nat", "Decidable.byContradiction", "Eq", "HAdd.hAdd", "instHAdd", "instAddNat", "instDecidableEqNat", "Not"],
+    "local_syntactic_dependencies": [],
+    "local_type_dependencies": [],
+    "local_value_dependencies": ["add_comm_test._proof_1"],
+    "document_messages": {"errors": [], "infos": [], "warnings": []},
+    "theorem_messages": {"errors": [], "infos": [], "warnings": []}
+  }
+}
+```
+
+## CLI usage
+
+```bash
+axle extract-theorems --environment lean-4.28.0 --ignore-imports file.lean -d output/ -f
+```
+
+Flags: `-d DIR` / `--output-dir DIR` (default: `extract_theorems/`), `-f` / `--force` (overwrite).
+No `--names` or `--indices` filtering — always extracts all theorems.

--- a/skills/mlops/evaluation/axle/references/http-api.md
+++ b/skills/mlops/evaluation/axle/references/http-api.md
@@ -1,0 +1,177 @@
+# AXLE HTTP API Reference
+
+## Base URL
+
+```text
+https://axle.axiommath.ai
+```
+
+## Authentication
+
+```text
+Authorization: Bearer your_api_key
+```
+
+Without key: 10 concurrent active requests. With key: 20.
+Get keys at https://axle.axiommath.ai/app/console
+
+## Endpoints
+
+### Utility (GET, no /api prefix)
+
+```bash
+# List environments
+curl https://axle.axiommath.ai/v1/environments
+
+# Health check
+curl https://axle.axiommath.ai/v1/status
+```
+
+### Tools (POST /api/v1/<tool_name>)
+
+All tools use POST with JSON body:
+
+```bash
+curl -X POST https://axle.axiommath.ai/api/v1/check \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $AXLE_API_KEY" \
+  -d '{
+    "content": "import Mathlib\ntheorem foo : 1+1=2 := by norm_num",
+    "environment": "lean-4.28.0"
+  }'
+```
+
+Available endpoints:
+- `POST /api/v1/verify_proof`
+- `POST /api/v1/check`
+- `POST /api/v1/extract_theorems`
+- `POST /api/v1/rename`
+- `POST /api/v1/theorem2lemma`
+- `POST /api/v1/theorem2sorry`
+- `POST /api/v1/merge`
+- `POST /api/v1/simplify_theorems`
+- `POST /api/v1/repair_proofs`
+- `POST /api/v1/have2lemma`
+- `POST /api/v1/have2sorry`
+- `POST /api/v1/sorry2lemma`
+- `POST /api/v1/disprove`
+- `POST /api/v1/normalize`
+
+Note the URL pattern inconsistency: tools use `/api/v1/`, environments uses `/v1/`.
+
+## Common request parameters
+
+All tools accept:
+
+```json
+{
+  "content": "string (required)",
+  "environment": "string (required, e.g., lean-4.28.0)",
+  "timeout_seconds": 120,
+  "ignore_imports": false
+}
+```
+
+`timeout_seconds`: default 120, max 300 for non-admin.
+
+## Common response format
+
+```json
+{
+  "okay": true,
+  "content": "import Mathlib\n\ntheorem foo ...",
+  "lean_messages": {"errors": [], "warnings": [], "infos": []},
+  "tool_messages": {"errors": [], "warnings": [], "infos": []},
+  "failed_declarations": [],
+  "timings": {"parse_ms": 35, "total_ms": 41},
+  "info": {
+    "request_id": "uuid-v4",
+    "environment": "lean-4.28.0",
+    "total_request_time_ms": 47,
+    "queue_time_ms": 4,
+    "execution_time_ms": 42,
+    "cached_response": false
+  }
+}
+```
+
+Not all fields present on all endpoints:
+- `okay` — only on check, verify_proof, repair_proofs
+- `failed_declarations` — only on check, verify_proof
+- `documents` — only on extract_theorems
+- `results`, `disproved_theorems` — only on disprove
+- `lemma_names` — only on have2lemma, sorry2lemma
+- `simplification_stats` — only on simplify_theorems
+- `repair_stats` — only on repair_proofs
+- `normalize_stats` — only on normalize
+
+## Error responses
+
+Fatal errors return one of three top-level error types (each is a separate response format):
+
+```json
+{"user_error": "Invalid argument: ..."}
+```
+```json
+{"internal_error": "Server bug: ..."}
+```
+```json
+{"error": "Runtime failure: timeout/OOM/crash"}
+```
+
+HTTP status codes:
+- 200 — success
+- 400 — invalid argument (user_error)
+- 403 — forbidden (auth issue)
+- 404 — not found
+- 409 — conflict
+- 429 — rate limited (retryable)
+- 500 — internal error (bug)
+- 503 — service unavailable (retryable)
+
+## verify_proof example
+
+```bash
+curl -X POST https://axle.axiommath.ai/api/v1/verify_proof \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $AXLE_API_KEY" \
+  -d '{
+    "formal_statement": "theorem foo : 1 + 1 = 2 := by sorry",
+    "content": "theorem foo : 1 + 1 = 2 := by norm_num",
+    "environment": "lean-4.28.0",
+    "ignore_imports": true,
+    "use_def_eq": true
+  }'
+```
+
+## merge example
+
+```bash
+curl -X POST https://axle.axiommath.ai/api/v1/merge \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $AXLE_API_KEY" \
+  -d '{
+    "documents": [
+      "import Mathlib\ntheorem a : 1 = 1 := rfl",
+      "import Mathlib\ntheorem b : 2 = 2 := rfl"
+    ],
+    "environment": "lean-4.28.0",
+    "ignore_imports": true
+  }'
+```
+
+## Environment response
+
+```json
+[
+  {
+    "name": "lean-4.28.0",
+    "lean_toolchain": "leanprover/lean4:v4.28.0",
+    "repo_url": null,
+    "revision": null,
+    "subdir": null,
+    "imports": "import Mathlib",
+    "description": "Lean 4.28.0 with Mathlib"
+  }
+]
+```

--- a/skills/mlops/evaluation/axle/references/python-api.md
+++ b/skills/mlops/evaluation/axle/references/python-api.md
@@ -1,0 +1,296 @@
+# AXLE Python API Reference
+
+## Client
+
+```python
+from axle import AxleClient
+
+client = AxleClient(
+    api_key=None,              # fallback: AXLE_API_KEY
+    url=None,                  # fallback: AXLE_API_URL (default: https://axle.axiommath.ai)
+    max_concurrency=None,      # fallback: AXLE_MAX_CONCURRENCY (default: 20)
+    base_timeout_seconds=None, # fallback: AXLE_TIMEOUT_SECONDS (default: 1800)
+)
+```
+
+Always use as async context manager: `async with AxleClient() as client:`
+
+The `base_timeout_seconds` is the retry window for 503/429 errors, NOT the per-request timeout. Per-request timeout is controlled by `timeout_seconds` on each method call (default 120, max 300 for non-admin).
+
+Session internals: keepalive_timeout=120s, DNS cache TTL=300s, trust_env=True (respects HTTP_PROXY).
+
+## Method signatures
+
+### Validation
+
+```python
+await client.check(
+    content: str,                    # Lean source code
+    environment: str,                # e.g., "lean-4.28.0"
+    mathlib_linter: bool = False,    # enable Mathlib standard linters
+    ignore_imports: bool = False,    # auto-replace imports with environment defaults
+    timeout_seconds: float = 120,    # per-request timeout (max 300)
+) -> CheckResponse
+# Returns: okay, content, lean_messages, tool_messages, failed_declarations, timings, info
+
+await client.verify_proof(
+    formal_statement: str,           # sorried theorem to verify against
+    content: str,                    # candidate proof
+    environment: str,
+    permitted_sorries: list[str] | None = None,  # names allowed to have sorry
+    mathlib_linter: bool = False,
+    use_def_eq: bool = True,         # kernel reduction for type comparison (False = faster)
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> VerifyProofResponse
+# Returns: okay, content, failed_declarations, lean_messages, tool_messages, timings, info
+# Timings: {total_ms, formal_statement_ms, declarations_ms, candidate_ms}
+
+await client.disprove(
+    content: str,
+    environment: str,
+    names: list[str] | None = None,
+    indices: list[int] | None = None,
+    terminal_tactics: list[str] | None = None,  # default: ["grind"]
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> DisproveResponse
+# Returns: content, lean_messages, tool_messages, results, disproved_theorems, timings, info
+```
+
+### Transformation
+
+```python
+await client.theorem2sorry(
+    content: str,
+    environment: str,
+    names: list[str] | None = None,
+    indices: list[int] | None = None,   # supports negative (-1 = last)
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> Theorem2SorryResponse
+
+await client.theorem2lemma(
+    content: str,
+    environment: str,
+    names: list[str] | None = None,
+    indices: list[int] | None = None,
+    target: str = "lemma",               # "lemma" or "theorem"
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> Theorem2LemmaResponse
+
+await client.rename(
+    content: str,
+    declarations: dict[str, str],        # {"old_name": "new_name"}
+    environment: str,
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> RenameResponse
+
+await client.normalize(
+    content: str,
+    environment: str,
+    normalizations: list[str] | None = None,  # see below
+    failsafe: bool = True,              # return original if normalization breaks code
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> NormalizeResponse
+# normalize_stats shows which passes made changes
+```
+
+Available normalizations: `remove_sections` (default), `remove_duplicates` (default), `split_open_in_commands` (default), `expand_decl_names`, `normalize_module_comments`, `normalize_doc_comments`
+
+### Analysis & repair
+
+```python
+await client.extract_theorems(
+    content: str,
+    environment: str,
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> ExtractTheoremsResponse
+# Returns: content, documents (dict[str, Document]), lean_messages, tool_messages, timings, info
+# No okay field. No names/indices filtering — extracts ALL theorems.
+
+await client.simplify_theorems(
+    content: str,
+    environment: str,
+    names: list[str] | None = None,
+    indices: list[int] | None = None,
+    simplifications: list[str] | None = None,  # default: all
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> SimplifyTheoremsResponse
+# simplification_stats shows counts per strategy
+
+await client.repair_proofs(
+    content: str,
+    environment: str,
+    names: list[str] | None = None,
+    indices: list[int] | None = None,
+    repairs: list[str] | None = None,            # default: all
+    terminal_tactics: list[str] | None = None,   # default: ["grind"]
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> RepairProofsResponse
+# Returns: okay, content, repair_stats, lean_messages, tool_messages, timings, info
+
+await client.merge(
+    documents: list[str],               # list of Lean code strings
+    environment: str,
+    use_def_eq: bool = True,
+    include_alts_as_comments: bool = False,
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> MergeResponse
+# No okay field.
+```
+
+Available simplifications: `remove_unused_tactics`, `remove_unused_haves`, `rename_unused_vars`
+
+Available repairs: `remove_extraneous_tactics`, `apply_terminal_tactics`, `replace_unsafe_tactics`
+
+### Extraction
+
+```python
+await client.have2lemma(
+    content: str,
+    environment: str,
+    names: list[str] | None = None,
+    indices: list[int] | None = None,
+    include_have_body: bool = False,       # include proof (may introduce errors)
+    include_whole_context: bool = True,    # False = minimize context (may miss deps)
+    reconstruct_callsite: bool = False,    # replace have with lemma call (fragile)
+    verbosity: float = 0,                 # 0=default, 1=robust, 2=extra robust (pp.explicit)
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> Have2LemmaResponse
+# Returns: content, lemma_names, lean_messages, tool_messages, timings, info
+
+await client.have2sorry(
+    content: str,
+    environment: str,
+    names: list[str] | None = None,
+    indices: list[int] | None = None,
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> Have2SorryResponse
+
+await client.sorry2lemma(
+    content: str,
+    environment: str,
+    names: list[str] | None = None,
+    indices: list[int] | None = None,
+    extract_sorries: bool = True,
+    extract_errors: bool = True,
+    include_whole_context: bool = True,
+    reconstruct_callsite: bool = False,
+    verbosity: float = 0,
+    ignore_imports: bool = False,
+    timeout_seconds: float = 120,
+) -> Sorry2LemmaResponse
+# Returns: content, lemma_names, lean_messages, tool_messages, timings, info
+```
+
+### Utility
+
+```python
+await client.environments(timeout_seconds=None) -> list[dict]
+# Each: {name, lean_toolchain, repo_url, revision, subdir, imports, description}
+
+client.check_status(timeout_seconds=60) -> dict
+# SYNCHRONOUS (uses requests, not aiohttp). Health check at GET /v1/status.
+
+await client.run_one(method: str, request: dict) -> dict
+# Low-level: call any tool by name, returns raw dict (not typed response)
+```
+
+## Response types
+
+All importable from `axle`:
+
+```python
+from axle import (
+    CheckResponse, VerifyProofResponse, ExtractTheoremsResponse,
+    RenameResponse, MergeResponse, Theorem2LemmaResponse, Theorem2SorryResponse,
+    SimplifyTheoremsResponse, RepairProofsResponse, Have2LemmaResponse,
+    Have2SorryResponse, Sorry2LemmaResponse, DisproveResponse, NormalizeResponse,
+    Document,  # per-theorem metadata from extract_theorems
+)
+# Messages type (NOT in __all__):
+from axle.types import Messages  # .errors, .warnings, .infos (all list[str])
+```
+
+Every response has an `info` field (always present):
+```json
+{
+  "request_id": "uuid-v4",
+  "environment": "lean-4.28.0",
+  "total_request_time_ms": 47,
+  "queue_time_ms": 4,
+  "execution_time_ms": 42,
+  "cached_response": false
+}
+```
+
+Identical requests return `cached_response: true` with faster times.
+
+## Error handling
+
+```python
+from axle.exceptions import AxleError       # Root base (NOT in __all__)
+from axle import (
+    AxleApiError,          # Base for API errors (.status_code, may be None)
+    AxleIsUnavailable,     # 503 — auto-retried (.url, .details attributes)
+    AxleRateLimitedError,  # 429 — auto-retried with exponential backoff
+    AxleInvalidArgument,   # 400
+    AxleForbiddenError,    # 403
+    AxleNotFoundError,     # 404
+    AxleConflictError,     # 409
+    AxleInternalError,     # 500
+    AxleRuntimeError,      # operation failure (timeout, OOM)
+)
+```
+
+Hierarchy:
+- `AxleError` → `AxleIsUnavailable` (retryable, NOT subclass of AxleApiError)
+- `AxleError` → `AxleApiError` → all other exceptions
+
+Auto-retried with exponential backoff (1-15s jitter): 503, 429, connection errors.
+NOT retried: 400, 403, 404, 409, 500.
+
+## Helper functions
+
+```python
+from axle import remove_comments, inline_lean_messages
+
+# Remove comments from Lean code
+clean = remove_comments(
+    code,
+    include_module_docs=False,   # keep /-! ... -/ if True
+    include_docstrings=False,    # keep /-- ... -/ if True
+)
+# Handles: line comments (--), block comments (/- -/), nested blocks,
+# module docs (/-! -/), docstrings (/-- -/), string literal awareness
+
+# Inline compiler messages as comments at source locations
+annotated = inline_lean_messages(
+    code,
+    messages=["file.lean:3:0: error: type mismatch"],
+    prefix="/- ",
+    suffix=" -/",
+)
+# Parses file:line:col format, inserts after corresponding lines
+# Line 0 messages prepended, beyond-end messages appended
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `AXLE_API_KEY` | none | API key (get at axle.axiommath.ai/app/console) |
+| `AXLE_API_URL` | `https://axle.axiommath.ai` | API server URL |
+| `AXLE_TIMEOUT_SECONDS` | 1800 | Retry window for 503/429 (NOT per-request timeout) |
+| `AXLE_MAX_CONCURRENCY` | 20 | Client-side concurrency limit |
+| `AXLE_REQUEST_SOURCE` | `sdk` | Sets X-Request-Source header |

--- a/skills/mlops/evaluation/axle/references/security.md
+++ b/skills/mlops/evaluation/axle/references/security.md
@@ -1,0 +1,42 @@
+# AXLE verify-proof Security Considerations
+
+## Known limitation
+
+AXLE's `verify_proof` trusts the Lean environment to behave correctly. A sufficiently creative adversary can exploit Lean metaprogramming to make invalid proofs appear valid. This is a known limitation that AXLE does not plan to address.
+
+## What AXLE blocks
+
+Despite trusting the environment, AXLE does apply stricter validation than the Lean compiler:
+
+- **open private** command: banned entirely
+- **Unsafe/partial functions**: detected and blocked
+- **Non-standard axioms**: must be in the allowed set of standard axioms
+- **sorry in proofs**: blocked unless listed in `permitted_sorries`
+- **native_decide**: blocked unless axioms `Lean.trustCompiler`, `Lean.ofReduceBool`, `Lean.ofReduceNat` are in `permitted_sorries`
+
+## Verification error patterns
+
+These appear in `tool_messages.errors`:
+- "Missing required declaration '{name}'"
+- "Kind mismatch for '{name}': candidate has {X} but expected {Y}"
+- "Theorem '{name}' does not match expected signature: expected {X}, got {Y}"
+- "Definition '{name}' does not match expected signature: expected {X}, got {Y}"
+- "Unsafe/partial function '{name}' detected"
+- "In '{name}': Axiom '{axiom}' is not in the allowed set of standard axioms"
+- "Declaration '{name}' uses 'sorry' which is not allowed in a valid proof"
+- "Candidate uses banned 'open private' command"
+
+## For untrusted code
+
+Use these alternatives instead of AXLE:
+
+1. **lean4checker** — Lean FRO-developed .olean verifier. Runs proofs in isolated environments.
+2. **Comparator** — Lean FRO-developed gold standard for proof judges.
+3. **SafeVerify** — Battle-tested public proof checker.
+
+These alternatives trade speed for security. They are less susceptible to known exploits.
+
+## use_def_eq parameter
+
+- `True` (default): types compared using definitional equality after kernel reduction. More accurate but slower.
+- `False`: types compared at face value. Faster but may rarely reject valid proofs where types are definitionally equal but syntactically different.


### PR DESCRIPTION
## What does this PR do?

Adds a new skill for **AXLE (Axiom Lean Engine)** — a CLI and Python client for Lean 4 proof manipulation via the Axiom Math cloud API. This skill enables Hermes agents to verify proofs, check Lean code compilation, extract/merge/rename theorems, repair broken proofs, disprove statements, and normalize Lean files using 14 cloud-hosted tools — all without a local Lean installation.

AXLE is particularly useful for AI-driven formal verification workflows, Lean 4 + Mathlib development, and automated proof repair after library updates.

## Type of Change
- [x] New skill

## Changes Made
- Added `skills/mlops/evaluation/axle/SKILL.md` (400 lines) — main skill document covering:
  - When to use AXLE vs alternatives (lean4checker, Comparator, SafeVerify, Pantograph)
  - Quick start with CLI and Python async client
  - 3 detailed workflows: proof verification, proof repair after Mathlib update, multi-file merge
  - Complete CLI reference for all 14 tools (validation, transformation, analysis, extraction, utility)
  - Python API overview with common usage patterns
  - 7 common issues with solutions
  - Advanced topics (security, metadata, HTTP API, error handling)
- Added `skills/mlops/evaluation/axle/references/python-api.md` (296 lines) — full Python API reference with all method signatures, response types, error hierarchy, helper functions, and environment variables
- Added `skills/mlops/evaluation/axle/references/security.md` (42 lines) — verify-proof security considerations, what AXLE blocks, verification error patterns, and recommended alternatives for untrusted code
- Added `skills/mlops/evaluation/axle/references/extract-theorems-metadata.md` (92 lines) — complete Document metadata reference with 20+ fields covering identity, content, proof complexity, 6 dependency lists, and compilation status
- Added `skills/mlops/evaluation/axle/references/http-api.md` (173 lines) — REST API reference with endpoints, authentication, request/response formats, error codes, and examples

## How to Test

1. Install the skill: ensure `skills/mlops/evaluation/axle/` is in the Hermes skills directory
2. Install the AXLE package: `pip install axiom-axle`
3. (Optional) Set API key: `export AXLE_API_KEY=your_key`
4. Test basic check:
   ```bash
   echo 'theorem foo : 1 + 1 = 2 := by norm_num' \
     | axle check --environment lean-4.28.0 --ignore-imports -
   ```
5. Test proof verification:
   ```bash
   echo 'theorem foo : 1 + 1 = 2 := by sorry' > /tmp/stmt.lean
   echo 'theorem foo : 1 + 1 = 2 := by norm_num' > /tmp/proof.lean
   axle verify-proof --environment lean-4.28.0 --ignore-imports /tmp/stmt.lean /tmp/proof.lean
   ```
6. Verify skill loads correctly: ask Hermes agent to "verify this Lean proof" and confirm it loads the AXLE skill

## For New Skills
- [x] SKILL.md follows standard format (YAML frontmatter with name, description, version, author, license, dependencies, tags)
- [x] No unnecessary external dependencies (only `axiom-axle` PyPI package required)
- [x] Tested end-to-end (CLI and Python API workflows verified against live Axiom Math API)
- [ ] Broadly useful to most users (if bundled) — this is a specialized skill for Lean 4 / formal verification workflows
