### PR TITLE
feat(tools): add discord_fetch_message tool

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -157,6 +157,7 @@ def _discover_tools():
         "tools.delegate_tool",
         "tools.process_registry",
         "tools.send_message_tool",
+        "tools.discord_tool",
         "tools.honcho_tools",
         "tools.homeassistant_tool",
     ]

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -1,0 +1,387 @@
+"""Tests for tools/discord_tool.py."""
+
+import asyncio
+import json
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools.discord_tool import (
+    discord_fetch_message_tool,
+    _format_message,
+    _get_discord_token,
+    _handle_parse_link,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_discord_message(
+    message_id="111",
+    channel_id="222",
+    content="Hello world",
+    username="testuser",
+    global_name="Test User",
+    attachments=None,
+    embeds=None,
+    referenced_message=None,
+):
+    return {
+        "id": message_id,
+        "channel_id": channel_id,
+        "content": content,
+        "author": {
+            "id": "999",
+            "username": username,
+            "global_name": global_name,
+            "bot": False,
+        },
+        "timestamp": "2026-03-21T10:00:00.000000+00:00",
+        "edited_timestamp": None,
+        "type": 0,
+        "attachments": attachments or [],
+        "embeds": embeds or [],
+        "referenced_message": referenced_message,
+    }
+
+
+# ---------------------------------------------------------------------------
+# parse_link tests
+# ---------------------------------------------------------------------------
+
+class TestParseLink:
+    def test_full_url_with_message_id(self):
+        result = json.loads(
+            _handle_parse_link(
+                {"url": "https://discord.com/channels/123456789/987654321/555555555"}
+            )
+        )
+        assert result["guild_id"] == "123456789"
+        assert result["channel_id"] == "987654321"
+        assert result["message_id"] == "555555555"
+
+    def test_channel_only_url(self):
+        result = json.loads(
+            _handle_parse_link(
+                {"url": "https://discord.com/channels/111/222"}
+            )
+        )
+        assert result["guild_id"] == "111"
+        assert result["channel_id"] == "222"
+        assert "message_id" not in result
+
+    def test_invalid_url_returns_error(self):
+        result = json.loads(
+            _handle_parse_link({"url": "https://example.com/not-discord"})
+        )
+        assert "error" in result
+
+    def test_missing_url_returns_error(self):
+        result = json.loads(_handle_parse_link({}))
+        assert "error" in result
+
+    def test_tool_dispatch_parse_link(self):
+        result = json.loads(
+            discord_fetch_message_tool(
+                {
+                    "action": "parse_link",
+                    "url": "https://discord.com/channels/1/2/3",
+                }
+            )
+        )
+        assert result["guild_id"] == "1"
+        assert result["channel_id"] == "2"
+        assert result["message_id"] == "3"
+
+
+# ---------------------------------------------------------------------------
+# _format_message tests
+# ---------------------------------------------------------------------------
+
+class TestFormatMessage:
+    def test_basic_message(self):
+        raw = _make_discord_message()
+        result = _format_message(raw)
+        assert result["message_id"] == "111"
+        assert result["channel_id"] == "222"
+        assert result["content"] == "Hello world"
+        assert result["author"]["username"] == "testuser"
+        assert result["author"]["display_name"] == "Test User"
+        assert result["author"]["bot"] is False
+
+    def test_attachments_included(self):
+        raw = _make_discord_message(
+            attachments=[
+                {
+                    "id": "att1",
+                    "filename": "image.png",
+                    "url": "https://cdn.discordapp.com/attachments/image.png",
+                    "content_type": "image/png",
+                    "size": 12345,
+                }
+            ]
+        )
+        result = _format_message(raw)
+        assert len(result["attachments"]) == 1
+        assert result["attachments"][0]["filename"] == "image.png"
+
+    def test_embeds_included(self):
+        raw = _make_discord_message(
+            embeds=[{"title": "Some Title", "description": "Some desc", "url": "https://example.com"}]
+        )
+        result = _format_message(raw)
+        assert len(result["embeds"]) == 1
+        assert result["embeds"][0]["title"] == "Some Title"
+
+    def test_empty_embeds_excluded(self):
+        raw = _make_discord_message(
+            embeds=[{"type": "image", "url": "https://example.com/img.png"}]
+        )
+        result = _format_message(raw)
+        assert "embeds" not in result
+
+    def test_reply_to_included(self):
+        referenced = _make_discord_message(
+            message_id="000",
+            content="Original message here",
+            username="originaluser",
+        )
+        raw = _make_discord_message(referenced_message=referenced)
+        result = _format_message(raw)
+        assert result["reply_to"]["message_id"] == "000"
+        assert result["reply_to"]["author"] == "originaluser"
+        assert "Original message" in result["reply_to"]["content"]
+
+    def test_display_name_falls_back_to_username(self):
+        raw = _make_discord_message(global_name=None)
+        result = _format_message(raw)
+        assert result["author"]["display_name"] == "testuser"
+
+
+# ---------------------------------------------------------------------------
+# fetch action tests
+# ---------------------------------------------------------------------------
+
+class TestFetchAction:
+    def test_missing_channel_id_returns_error(self):
+        result = json.loads(
+            discord_fetch_message_tool(
+                {"action": "fetch", "message_id": "123"}
+            )
+        )
+        assert "error" in result
+        assert "channel_id" in result["error"]
+
+    def test_missing_message_id_returns_error(self):
+        result = json.loads(
+            discord_fetch_message_tool(
+                {"action": "fetch", "channel_id": "456"}
+            )
+        )
+        assert "error" in result
+        assert "message_id" in result["error"]
+
+    def test_no_token_returns_error(self):
+        with patch("tools.discord_tool._get_discord_token", return_value=None):
+            result = json.loads(
+                discord_fetch_message_tool(
+                    {"action": "fetch", "channel_id": "1", "message_id": "2"}
+                )
+            )
+        assert "error" in result
+        assert "token" in result["error"].lower()
+
+    def test_successful_fetch(self):
+        raw = _make_discord_message(message_id="42", channel_id="10", content="Hey!")
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=raw)
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        mock_aiohttp = MagicMock()
+        mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+
+        with patch("tools.discord_tool._get_discord_token", return_value="tok123"), \
+             patch("model_tools._run_async", side_effect=_run), \
+             patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
+            result = json.loads(
+                discord_fetch_message_tool(
+                    {"action": "fetch", "channel_id": "10", "message_id": "42"}
+                )
+            )
+
+        assert result["message_id"] == "42"
+        assert result["content"] == "Hey!"
+
+    def test_404_returns_friendly_error(self):
+        mock_response = MagicMock()
+        mock_response.status = 404
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        mock_aiohttp = MagicMock()
+        mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+
+        with patch("tools.discord_tool._get_discord_token", return_value="tok"), \
+             patch("model_tools._run_async", side_effect=_run), \
+             patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
+            result = json.loads(
+                discord_fetch_message_tool(
+                    {"action": "fetch", "channel_id": "1", "message_id": "99"}
+                )
+            )
+
+        assert "error" in result
+        assert "deleted" in result["error"] or "not found" in result["error"].lower()
+
+    def test_403_returns_permission_error(self):
+        mock_response = MagicMock()
+        mock_response.status = 403
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        mock_aiohttp = MagicMock()
+        mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+
+        with patch("tools.discord_tool._get_discord_token", return_value="tok"), \
+             patch("model_tools._run_async", side_effect=_run), \
+             patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
+            result = json.loads(
+                discord_fetch_message_tool(
+                    {"action": "fetch", "channel_id": "1", "message_id": "99"}
+                )
+            )
+
+        assert "error" in result
+        assert "permission" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# history action tests
+# ---------------------------------------------------------------------------
+
+class TestHistoryAction:
+    def test_missing_channel_id_returns_error(self):
+        result = json.loads(
+            discord_fetch_message_tool({"action": "history"})
+        )
+        assert "error" in result
+        assert "channel_id" in result["error"]
+
+    def test_no_token_returns_error(self):
+        with patch("tools.discord_tool._get_discord_token", return_value=None):
+            result = json.loads(
+                discord_fetch_message_tool(
+                    {"action": "history", "channel_id": "123"}
+                )
+            )
+        assert "error" in result
+
+    def test_limit_clamped_to_100(self):
+        captured_params = {}
+
+        async def mock_fetch(token, channel_id, limit, before):
+            captured_params["limit"] = limit
+            return json.dumps({"channel_id": channel_id, "count": 0, "messages": []})
+
+        with patch("tools.discord_tool._get_discord_token", return_value="tok"), \
+             patch("model_tools._run_async", side_effect=_run), \
+             patch("tools.discord_tool._fetch_history", side_effect=mock_fetch):
+            discord_fetch_message_tool(
+                {"action": "history", "channel_id": "1", "limit": 9999}
+            )
+
+        assert captured_params["limit"] == 100
+
+    def test_successful_history(self):
+        messages = [
+            _make_discord_message(message_id=str(i), content=f"msg {i}")
+            for i in range(3)
+        ]
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=messages)
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        mock_aiohttp = MagicMock()
+        mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+
+        with patch("tools.discord_tool._get_discord_token", return_value="tok"), \
+             patch("model_tools._run_async", side_effect=_run), \
+             patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
+            result = json.loads(
+                discord_fetch_message_tool(
+                    {"action": "history", "channel_id": "222", "limit": 3}
+                )
+            )
+
+        assert result["count"] == 3
+        assert len(result["messages"]) == 3
+        assert result["channel_id"] == "222"
+
+
+# ---------------------------------------------------------------------------
+# Token resolution tests
+# ---------------------------------------------------------------------------
+
+class TestGetDiscordToken:
+    def test_env_var_takes_priority(self):
+        with patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "envtoken"}):
+            assert _get_discord_token() == "envtoken"
+
+    def test_falls_back_to_gateway_config(self):
+        from gateway.config import Platform
+        pconfig = SimpleNamespace(enabled=True, token="cfgtoken")
+        config = SimpleNamespace(platforms={Platform.DISCORD: pconfig})
+
+        with patch.dict(os.environ, {}, clear=False), \
+             patch("os.getenv", side_effect=lambda k, d="": "" if k == "DISCORD_BOT_TOKEN" else os.environ.get(k, d)), \
+             patch("gateway.config.load_gateway_config", return_value=config):
+            # Direct env cleared for this key
+            env_backup = os.environ.pop("DISCORD_BOT_TOKEN", None)
+            try:
+                token = _get_discord_token()
+            finally:
+                if env_backup is not None:
+                    os.environ["DISCORD_BOT_TOKEN"] = env_backup
+
+    def test_returns_none_when_nothing_configured(self):
+        env_backup = os.environ.pop("DISCORD_BOT_TOKEN", None)
+        try:
+            with patch("gateway.config.load_gateway_config", side_effect=Exception("no config")):
+                token = _get_discord_token()
+            assert token is None or token == ""
+        finally:
+            if env_backup is not None:
+                os.environ["DISCORD_BOT_TOKEN"] = env_backup

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -1,0 +1,317 @@
+"""Discord Tool -- fetch messages and channel history from Discord.
+
+Allows the agent to retrieve a Discord message by ID, fetch recent messages
+from a channel, and look up basic channel/server metadata. Requires the bot
+to have Read Message History permission in the target channel.
+"""
+
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+DISCORD_API_BASE = "https://discord.com/api/v10"
+
+
+DISCORD_FETCH_MESSAGE_SCHEMA = {
+    "name": "discord_fetch_message",
+    "description": (
+        "Fetch a Discord message by ID, or retrieve recent messages from a channel.\n\n"
+        "Use this when the user pastes a Discord message link "
+        "(e.g. https://discord.com/channels/GUILD/CHANNEL/MESSAGE) "
+        "or asks you to read a specific Discord message. "
+        "The bot must be in the server and have Read Message History permission.\n\n"
+        "Actions:\n"
+        "- 'fetch': retrieve a single message by message_id + channel_id\n"
+        "- 'history': retrieve recent messages from a channel (up to 100)\n"
+        "- 'parse_link': extract channel_id and message_id from a discord.com URL"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["fetch", "history", "parse_link"],
+                "description": (
+                    "Action to perform: "
+                    "'fetch' retrieves a single message, "
+                    "'history' retrieves recent messages from a channel, "
+                    "'parse_link' extracts IDs from a discord.com URL."
+                ),
+            },
+            "channel_id": {
+                "type": "string",
+                "description": "Discord channel ID (required for fetch and history).",
+            },
+            "message_id": {
+                "type": "string",
+                "description": "Discord message ID (required for fetch).",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Number of messages to retrieve for history (1-100, default 20).",
+            },
+            "before": {
+                "type": "string",
+                "description": "Return messages before this message ID (for history pagination).",
+            },
+            "url": {
+                "type": "string",
+                "description": "Full discord.com message URL to parse (for parse_link action).",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+def discord_fetch_message_tool(args, **kw):
+    """Handle discord_fetch_message tool calls."""
+    action = args.get("action", "fetch")
+
+    if action == "parse_link":
+        return _handle_parse_link(args)
+
+    if action == "history":
+        return _handle_history(args)
+
+    return _handle_fetch(args)
+
+
+def _handle_parse_link(args):
+    """Extract guild_id, channel_id, message_id from a discord.com URL."""
+    import re
+
+    url = args.get("url", "").strip()
+    if not url:
+        return json.dumps({"error": "url is required for parse_link action"})
+
+    # https://discord.com/channels/{guild_id}/{channel_id}/{message_id}
+    match = re.search(
+        r"discord\.com/channels/(\d+)/(\d+)(?:/(\d+))?", url
+    )
+    if not match:
+        return json.dumps({
+            "error": f"Could not parse Discord URL: {url}. "
+            "Expected format: https://discord.com/channels/GUILD_ID/CHANNEL_ID/MESSAGE_ID"
+        })
+
+    result = {
+        "guild_id": match.group(1),
+        "channel_id": match.group(2),
+    }
+    if match.group(3):
+        result["message_id"] = match.group(3)
+
+    return json.dumps(result)
+
+
+def _handle_fetch(args):
+    """Fetch a single Discord message by channel_id + message_id."""
+    channel_id = args.get("channel_id", "").strip()
+    message_id = args.get("message_id", "").strip()
+
+    if not channel_id or not message_id:
+        return json.dumps({
+            "error": "Both channel_id and message_id are required for fetch action. "
+            "If you have a discord.com URL, use action='parse_link' first."
+        })
+
+    token = _get_discord_token()
+    if not token:
+        return json.dumps({
+            "error": "Discord bot token not configured. "
+            "Set DISCORD_BOT_TOKEN in your environment or ~/.hermes/config.yaml."
+        })
+
+    try:
+        from model_tools import _run_async
+        return _run_async(_fetch_message(token, channel_id, message_id))
+    except Exception as e:
+        return json.dumps({"error": f"discord_fetch_message failed: {e}"})
+
+
+def _handle_history(args):
+    """Fetch recent messages from a Discord channel."""
+    channel_id = args.get("channel_id", "").strip()
+    if not channel_id:
+        return json.dumps({"error": "channel_id is required for history action"})
+
+    limit = int(args.get("limit", 20))
+    limit = max(1, min(100, limit))
+    before = args.get("before", "").strip() or None
+
+    token = _get_discord_token()
+    if not token:
+        return json.dumps({
+            "error": "Discord bot token not configured. "
+            "Set DISCORD_BOT_TOKEN in your environment or ~/.hermes/config.yaml."
+        })
+
+    try:
+        from model_tools import _run_async
+        return _run_async(_fetch_history(token, channel_id, limit, before))
+    except Exception as e:
+        return json.dumps({"error": f"discord_fetch_message history failed: {e}"})
+
+
+def _get_discord_token():
+    """Resolve the Discord bot token from env or gateway config."""
+    token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+    if token:
+        return token
+    # Try to load from gateway config (same source used by send_message_tool)
+    try:
+        from gateway.config import load_gateway_config, Platform
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.DISCORD)
+        if pconfig and pconfig.enabled and pconfig.token:
+            return pconfig.token
+    except Exception:
+        pass
+    return None
+
+
+async def _fetch_message(token, channel_id, message_id):
+    """Retrieve a single message via Discord REST API."""
+    try:
+        import aiohttp
+    except ImportError:
+        return json.dumps({"error": "aiohttp not installed. Run: pip install aiohttp"})
+
+    url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}"
+    headers = {"Authorization": f"Bot {token}"}
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers) as resp:
+                if resp.status == 404:
+                    return json.dumps({
+                        "error": f"Message {message_id} not found in channel {channel_id}. "
+                        "It may have been deleted, or the bot may not have access."
+                    })
+                if resp.status == 403:
+                    return json.dumps({
+                        "error": f"Bot lacks permission to read channel {channel_id}. "
+                        "Ensure the bot has 'Read Message History' permission."
+                    })
+                if resp.status != 200:
+                    body = await resp.text()
+                    return json.dumps({
+                        "error": f"Discord API error ({resp.status}): {body}"
+                    })
+                data = await resp.json()
+
+        return json.dumps(_format_message(data))
+    except Exception as e:
+        return json.dumps({"error": f"Discord fetch failed: {e}"})
+
+
+async def _fetch_history(token, channel_id, limit, before):
+    """Retrieve recent messages from a channel via Discord REST API."""
+    try:
+        import aiohttp
+    except ImportError:
+        return json.dumps({"error": "aiohttp not installed. Run: pip install aiohttp"})
+
+    url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
+    headers = {"Authorization": f"Bot {token}"}
+    params = {"limit": limit}
+    if before:
+        params["before"] = before
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers, params=params) as resp:
+                if resp.status == 403:
+                    return json.dumps({
+                        "error": f"Bot lacks permission to read channel {channel_id}. "
+                        "Ensure the bot has 'Read Message History' permission."
+                    })
+                if resp.status != 200:
+                    body = await resp.text()
+                    return json.dumps({
+                        "error": f"Discord API error ({resp.status}): {body}"
+                    })
+                data = await resp.json()
+
+        messages = [_format_message(m) for m in data]
+        return json.dumps({
+            "channel_id": channel_id,
+            "count": len(messages),
+            "messages": messages,
+        })
+    except Exception as e:
+        return json.dumps({"error": f"Discord history fetch failed: {e}"})
+
+
+def _format_message(data):
+    """Normalize a raw Discord message object into a clean dict."""
+    author = data.get("author", {})
+    attachments = [
+        {
+            "id": a.get("id"),
+            "filename": a.get("filename"),
+            "url": a.get("url"),
+            "content_type": a.get("content_type"),
+            "size": a.get("size"),
+        }
+        for a in data.get("attachments", [])
+    ]
+    embeds = [
+        {
+            "title": e.get("title"),
+            "description": e.get("description"),
+            "url": e.get("url"),
+        }
+        for e in data.get("embeds", [])
+        if e.get("title") or e.get("description")
+    ]
+    result = {
+        "message_id": data.get("id"),
+        "channel_id": data.get("channel_id"),
+        "content": data.get("content", ""),
+        "author": {
+            "id": author.get("id"),
+            "username": author.get("username"),
+            "display_name": author.get("global_name") or author.get("username"),
+            "bot": author.get("bot", False),
+        },
+        "timestamp": data.get("timestamp"),
+        "edited_timestamp": data.get("edited_timestamp"),
+        "type": data.get("type", 0),
+    }
+    if attachments:
+        result["attachments"] = attachments
+    if embeds:
+        result["embeds"] = embeds
+    referenced = data.get("referenced_message")
+    if referenced:
+        ref_author = referenced.get("author", {})
+        result["reply_to"] = {
+            "message_id": referenced.get("id"),
+            "author": ref_author.get("username"),
+            "content": referenced.get("content", "")[:200],
+        }
+    return result
+
+
+def _check_discord_fetch_message():
+    """Gate the tool on Discord being configured."""
+    if _get_discord_token():
+        return True
+    return False
+
+
+# --- Registry ---
+from tools.registry import registry
+
+registry.register(
+    name="discord_fetch_message",
+    toolset="messaging",
+    schema=DISCORD_FETCH_MESSAGE_SCHEMA,
+    handler=discord_fetch_message_tool,
+    check_fn=_check_discord_fetch_message,
+    emoji="💬",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -60,6 +60,8 @@ _HERMES_CORE_TOOLS = [
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
     "send_message",
+    # Discord message fetching (gated on DISCORD_BOT_TOKEN via check_fn)
+    "discord_fetch_message",
     # Honcho memory tools (gated on honcho being active via check_fn)
     "honcho_context", "honcho_profile", "honcho_search", "honcho_conclude",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
@@ -131,8 +133,8 @@ TOOLSETS = {
     },
     
     "messaging": {
-        "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
-        "tools": ["send_message"],
+        "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc. Also supports fetching Discord messages by ID.",
+        "tools": ["send_message", "discord_fetch_message"],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary

- Adds a `discord_fetch_message` tool that lets the agent retrieve Discord messages by ID, fetch channel history, and parse `discord.com` URLs
- Token is resolved automatically from `DISCORD_BOT_TOKEN` env var or from the existing Discord gateway config — no extra setup for gateway users

## Motivation

Closes #2105

When a user pastes a Discord message link like `https://discord.com/channels/GUILD/CHANNEL/MESSAGE`, the agent can now resolve and read the actual message content instead of being limited to parsing the URL. This improves conversation continuity when Discord links are shared.

## Changes

- `tools/discord_tool.py` — new tool implementation using Discord REST API v10 via `aiohttp`
- `tests/tools/test_discord_tool.py` — 24 unit tests covering all three actions, error cases (404, 403, missing token), message formatting, and URL parsing
- `model_tools.py` — added `tools.discord_tool` to the `_discover_tools()` import list so the tool self-registers at startup
- `toolsets.py` — added `discord_fetch_message` to `_HERMES_CORE_TOOLS` and the `messaging` toolset

## Tool actions

| action | description |
|--------|-------------|
| `fetch` | Retrieve a single message by `channel_id` + `message_id` |
| `history` | Retrieve recent messages from a channel (1–100, paginated via `before`) |
| `parse_link` | Extract `guild_id`, `channel_id`, `message_id` from a `discord.com` URL |

## Test Plan

- [x] 24 unit tests passing (`pytest tests/tools/test_discord_tool.py` — 24 passed)
- [x] Follows the same patterns as `send_message_tool.py` (aiohttp, registry.register, check_fn gating)
- [x] Error cases handled: 404 (deleted/missing), 403 (no permission), missing token, missing required params

## Notes for Reviewers

The tool reuses the Discord bot token already configured for the gateway adapter (via `gateway.config.load_gateway_config()`), so users running the Discord gateway get this for free. The `check_fn` gates visibility on a token being present, consistent with how `homeassistant_tool` and others work.