### PR TITLE
fix(toolsets): use typing.Any instead of builtin any in get_distribution return type

### DIFF
--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -19,7 +19,7 @@ Usage:
     all_dists = list_distributions()
 """
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import random
 from toolsets import validate_toolset
 
@@ -220,7 +220,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset distribution by name.
     


### PR DESCRIPTION
## Summary

Fixes a type annotation bug in `toolset_distributions.py` where the return type of `get_distribution()` used lowercase `any` (Python's builtin function) instead of `typing.Any`.

## Changes

- `toolset_distributions.py` line 22: add `Any` to the `typing` import
- `toolset_distributions.py` line 223: change `any` → `Any` in the return annotation

## Why

`Dict[str, any]` silently compiles but means nothing useful to type checkers — `any` is the builtin that returns `True` if any element is truthy. This would cause `mypy` / `pyright` to flag the annotation as invalid.

Closes #2139