### PR TITLE
fix(state): add missing thread lock to session_count() and message_count()

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -855,23 +855,25 @@ class SessionDB:
 
     def session_count(self, source: str = None) -> int:
         """Count sessions, optionally filtered by source."""
-        if source:
-            cursor = self._conn.execute(
-                "SELECT COUNT(*) FROM sessions WHERE source = ?", (source,)
-            )
-        else:
-            cursor = self._conn.execute("SELECT COUNT(*) FROM sessions")
-        return cursor.fetchone()[0]
+        with self._lock:
+            if source:
+                cursor = self._conn.execute(
+                    "SELECT COUNT(*) FROM sessions WHERE source = ?", (source,)
+                )
+            else:
+                cursor = self._conn.execute("SELECT COUNT(*) FROM sessions")
+            return cursor.fetchone()[0]
 
     def message_count(self, session_id: str = None) -> int:
         """Count messages, optionally for a specific session."""
-        if session_id:
-            cursor = self._conn.execute(
-                "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
-            )
-        else:
-            cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
-        return cursor.fetchone()[0]
+        with self._lock:
+            if session_id:
+                cursor = self._conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
+                )
+            else:
+                cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
+            return cursor.fetchone()[0]
 
     # =========================================================================
     # Export and cleanup


### PR DESCRIPTION
## Summary

`session_count()` and `message_count()` in `SessionDB` were accessing `self._conn` without holding `self._lock`, breaking the thread-safety guarantee documented on the class.

## Problem

`SessionDB` docstring (line 111) explicitly states:

> Thread-safe for the common gateway pattern (multiple reader threads, single writer via WAL mode). Each method opens its own cursor.

All 22 other database-accessing methods wrap their operations in `with self._lock:`. These two were the only exceptions.

In the gateway's multi-threaded environment (platform reader threads + writer thread), the race condition can cause:
- Cursor interleaving between threads
- `sqlite3.ProgrammingError` on concurrent connection access
- Inconsistent `COUNT(*)` results

## Fix

Wrap both methods with `with self._lock:`, identical to every other method in the class.

## Changes

- `hermes_state.py` lines 856–874: add `with self._lock:` to `session_count()` and `message_count()`

Closes #2130