### PR TITLE
fix(email): guard against IndexError when IMAP search returns empty list

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -230,7 +230,7 @@ class EmailAdapter(BasePlatformAdapter):
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
             status, data = imap.uid("search", None, "ALL")
-            if status == "OK" and data[0]:
+            if status == "OK" and data and data[0]:
                 for uid in data[0].split():
                     self._seen_uids.add(uid)
             imap.logout()
@@ -295,7 +295,7 @@ class EmailAdapter(BasePlatformAdapter):
             imap.select("INBOX")
 
             status, data = imap.uid("search", None, "UNSEEN")
-            if status != "OK" or not data[0]:
+            if status != "OK" or not data or not data[0]:
                 imap.logout()
                 return results
 


### PR DESCRIPTION
## Summary

`imap.uid('search')` returns `data=[]` when the mailbox is empty or has no matching messages. Both call sites accessed `data[0]` without checking whether the list was non-empty first, causing `IndexError: list index out of range`.

## Changes

`gateway/platforms/email.py`:
- Line 233 (`connect` method, ALL search): `if status == "OK" and data[0]:` → `if status == "OK" and data and data[0]:`
- Line 298 (`_fetch_messages` method, UNSEEN search): `if status != "OK" or not data[0]:` → `if status != "OK" or not data or not data[0]:`

## Why

The IMAP spec allows `search` to succeed (`status == "OK"`) with an empty result set (`data == []`). A fresh inbox or an inbox with no unread messages hits this path every time.

Closes #2137