### PR TITLE
fix(cron): close abandoned coroutine when asyncio.run() raises RuntimeError

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -160,11 +160,15 @@ def _deliver_result(job: dict, content: str) -> None:
         return
 
     # Run the async send in a fresh event loop (safe from any thread)
+    coro = _send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id)
     try:
-        result = asyncio.run(_send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id))
+        result = asyncio.run(coro)
     except RuntimeError:
-        # asyncio.run() fails if there's already a running loop in this thread;
-        # spin up a new thread to avoid that.
+        # asyncio.run() checks for a running loop before awaiting the coroutine;
+        # when it raises, the original coro was never started — close it to
+        # prevent "coroutine was never awaited" RuntimeWarning, then retry in a
+        # fresh thread that has no running loop.
+        coro.close()
         import concurrent.futures
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
             future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id))


### PR DESCRIPTION
## Summary

When `asyncio.run()` raises `RuntimeError` (running loop already exists), the coroutine passed to it was created on the same line but never awaited, producing:

```
RuntimeWarning: coroutine '_send_to_platform' was never awaited
```

## Root Cause

`asyncio.run()` checks for a running event loop *before* executing the coroutine. When it raises, the coroutine object has been created but its body has never run. Without an explicit `coro.close()` call, Python emits a `RuntimeWarning` during garbage collection.

## Fix

Create the coroutine object before the `try` block, then call `coro.close()` in the `except RuntimeError` branch before falling back to the `ThreadPoolExecutor` path. The fallback still creates a fresh coroutine for `asyncio.run()` in the new thread.

```python
# Before
try:
    result = asyncio.run(_send_to_platform(...))  # coroutine abandoned if RuntimeError
except RuntimeError:
    ...

# After
coro = _send_to_platform(...)
try:
    result = asyncio.run(coro)
except RuntimeError:
    coro.close()  # clean up the abandoned coroutine
    ...
```

## Changes

- `cron/scheduler.py`: extract coroutine before `try`, add `coro.close()` in `except RuntimeError` branch

Closes #2138