### PR TITLE
fix(tools): resource leak and double socket close in code_execution_tool

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -300,16 +300,16 @@ def _rpc_server_loop(
                 # their status prints don't leak into the CLI spinner.
                 try:
                     _real_stdout, _real_stderr = sys.stdout, sys.stderr
-                    sys.stdout = open(os.devnull, "w")
-                    sys.stderr = open(os.devnull, "w")
+                    _devnull = open(os.devnull, "w")
                     try:
+                        sys.stdout = _devnull
+                        sys.stderr = _devnull
                         result = handle_function_call(
                             tool_name, tool_args, task_id=task_id
                         )
                     finally:
-                        sys.stdout.close()
-                        sys.stderr.close()
                         sys.stdout, sys.stderr = _real_stdout, _real_stderr
+                        _devnull.close()
                 except Exception as exc:
                     logger.error("Tool call failed in sandbox: %s", exc, exc_info=True)
                     result = json.dumps({"error": str(exc)})
@@ -574,6 +574,7 @@ def execute_code(
 
         # Wait for RPC thread to finish
         server_sock.close()  # break accept() so thread exits promptly
+        server_sock = None   # prevent double-close in the finally block
         rpc_thread.join(timeout=3)
 
         # Build response


### PR DESCRIPTION
## Summary

Two resource management bugs in `tools/code_execution_tool.py`.

---

### 1. Resource leak in stdout/stderr suppression (lines 301-315)

Two separate `open(os.devnull, "w")` calls were made on lines 303-304. If the second `open()` raised, the first file handle leaked because the `finally` block was scoped inside the inner `try` — it only ran if both opens succeeded.

**Fix:** Open a single `_devnull` handle before the inner try block, assign it to both `sys.stdout` and `sys.stderr`, and close it in the `finally`.

```python
# Before (leaks if second open raises)
sys.stdout = open(os.devnull, "w")
sys.stderr = open(os.devnull, "w")

# After (single handle, always closed)
_devnull = open(os.devnull, "w")
try:
    sys.stdout = _devnull
    sys.stderr = _devnull
    ...
finally:
    sys.stdout, sys.stderr = _real_stdout, _real_stderr
    _devnull.close()
```

---

### 2. Double socket close (lines 576 + 621)

`server_sock.close()` was called at line 576 (to break `accept()` and let the RPC thread exit), then again unconditionally at line 621 in the `finally` block. The second call raises `OSError: [Errno 9] Bad file descriptor`.

**Fix:** Set `server_sock = None` immediately after the first close. The `finally` guard (`if server_sock is not None:`) then skips the redundant call.

## Changes

- `tools/code_execution_tool.py`: single devnull handle for stdout+stderr suppression; `server_sock = None` after first close

Closes #2136