### PR TITLE
fix(toolsets): pass visited set by reference to prevent diamond dependency duplication

### DIFF
--- a/toolsets.py
+++ b/toolsets.py
@@ -355,24 +355,27 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
             all_tools.update(resolved)
         return list(all_tools)
 
-    # Check for cycles
+    # Check for cycles / already-resolved (diamond deps).
+    # Silently return [] — either this is a diamond (not a bug, tools already
+    # collected via another path) or a genuine cycle (safe to skip).
     if name in visited:
-        print(f"⚠️  Circular dependency detected in toolset '{name}'")
         return []
-    
+
     visited.add(name)
-    
+
     # Get toolset definition
     toolset = TOOLSETS.get(name)
     if not toolset:
         return []
-    
+
     # Collect direct tools
     tools = set(toolset.get("tools", []))
-    
-    # Recursively resolve included toolsets
+
+    # Recursively resolve included toolsets, sharing the visited set across
+    # sibling includes so diamond dependencies are only resolved once and
+    # cycle warnings don't fire multiple times for the same cycle.
     for included_name in toolset.get("includes", []):
-        included_tools = resolve_toolset(included_name, visited.copy())
+        included_tools = resolve_toolset(included_name, visited)
         tools.update(included_tools)
     
     return list(tools)


### PR DESCRIPTION
## Summary

`resolve_toolset()` was calling `visited.copy()` when recursing into each sibling include (line 375). This broke deduplication for diamond dependencies and caused duplicate cycle warnings.

## Problem

With `visited.copy()` per sibling branch:

**Diamond duplication:** If toolsets B and C both include D, resolving A (which includes B and C) resolves D twice — once via B's branch, once via C's — because each branch starts with a fresh copy of visited that doesn't know D was already processed.

**Duplicate cycle warnings:** For a cycle A→[B,C], B→C, C→B the warning fires twice instead of once because B's branch and C's branch each carry an independent visited copy.

**Exponential blowup:** With deep diamond trees, each level of recursion can double the work.

## Fix

Pass `visited` directly instead of `visited.copy()` at line 375, so sibling includes share the same set. The `.copy()` at line 354 (for the `all`/`*` alias) is intentionally kept — each top-level toolset still gets an independent resolution pass.

Also removes the `print()` warning on cycle/already-visited detection: with a shared visited set, hitting a visited name can mean either a diamond (not a bug) or a genuine cycle. Silently returning `[]` is correct in both cases since tools are accumulated into a set.

## Changes

- `toolsets.py` line 375: `visited.copy()` → `visited`
- `toolsets.py` line 358-360: remove misleading `print()` warning

Closes #2134