### PR TITLE
feat(tools): add video analysis via ffmpeg frame extraction + vision LLM

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -256,6 +256,61 @@ def cleanup_document_cache(max_age_hours: int = 24) -> int:
     return removed
 
 
+# ---------------------------------------------------------------------------
+# Video cache utilities
+#
+# Same pattern as image/audio/document cache -- videos from platforms are
+# downloaded here so the video analysis tool can extract frames locally.
+# ---------------------------------------------------------------------------
+
+VIDEO_CACHE_DIR = get_hermes_home() / "video_cache"
+
+
+def get_video_cache_dir() -> Path:
+    """Return the video cache directory, creating it if it doesn't exist."""
+    VIDEO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    return VIDEO_CACHE_DIR
+
+
+def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
+    """
+    Save raw video bytes to the cache and return the absolute file path.
+
+    Args:
+        data: Raw video bytes.
+        ext:  File extension including the dot (e.g. ".mp4", ".mov").
+
+    Returns:
+        Absolute path to the cached video file as a string.
+    """
+    cache_dir = get_video_cache_dir()
+    filename = f"vid_{uuid.uuid4().hex[:12]}{ext}"
+    filepath = cache_dir / filename
+    filepath.write_bytes(data)
+    return str(filepath)
+
+
+def cleanup_video_cache(max_age_hours: int = 24) -> int:
+    """
+    Delete cached videos older than *max_age_hours*.
+
+    Returns the number of files removed.
+    """
+    import time
+
+    cache_dir = get_video_cache_dir()
+    cutoff = time.time() - (max_age_hours * 3600)
+    removed = 0
+    for f in cache_dir.iterdir():
+        if f.is_file() and f.stat().st_mtime < cutoff:
+            try:
+                f.unlink()
+                removed += 1
+            except OSError:
+                pass
+    return removed
+
+
 class MessageType(Enum):
     """Types of incoming messages."""
     TEXT = "text"

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -57,6 +57,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
     cache_audio_from_bytes,
     cache_document_from_bytes,
+    cache_video_from_bytes,
     SUPPORTED_DOCUMENT_TYPES,
 )
 
@@ -1136,6 +1137,40 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.info("[Telegram] Cached user audio at %s", cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache audio: %s", e, exc_info=True)
+
+        # Download video to local cache for frame extraction / analysis
+        elif msg.video:
+            try:
+                # Telegram Bot API limit: 20 MB for file downloads
+                MAX_VIDEO_BYTES = 20 * 1024 * 1024
+                if msg.video.file_size and msg.video.file_size > MAX_VIDEO_BYTES:
+                    size_mb = msg.video.file_size / (1024 * 1024)
+                    note = (
+                        f"[Video too large to download ({size_mb:.1f} MB). "
+                        f"Telegram Bot API limit is 20 MB.]"
+                    )
+                    event.text = f"{note}\n\n{event.text}" if event.text else note
+                    logger.info("[Telegram] Video too large: %.1f MB", size_mb)
+                else:
+                    file_obj = await msg.video.get_file()
+                    video_bytes = await file_obj.download_as_bytearray()
+                    # Determine extension from mime_type
+                    mime = msg.video.mime_type or "video/mp4"
+                    mime_ext_map = {
+                        "video/mp4": ".mp4",
+                        "video/quicktime": ".mov",
+                        "video/webm": ".webm",
+                        "video/x-matroska": ".mkv",
+                        "video/avi": ".avi",
+                        "video/x-msvideo": ".avi",
+                    }
+                    ext = mime_ext_map.get(mime, ".mp4")
+                    cached_path = cache_video_from_bytes(bytes(video_bytes), ext=ext)
+                    event.media_urls = [cached_path]
+                    event.media_types = [mime]
+                    logger.info("[Telegram] Cached user video at %s", cached_path)
+            except Exception as e:
+                logger.warning("[Telegram] Failed to cache video: %s", e, exc_info=True)
 
         # Download document files to cache for agent processing
         elif msg.document:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2033,6 +2033,20 @@ class GatewayRunner:
                 message_text = f"{context_note}\n\n{message_text}"
 
         # -----------------------------------------------------------------
+        # Enrich video messages with a context note for the agent
+        # -----------------------------------------------------------------
+        if event.media_urls:
+            for i, path in enumerate(event.media_urls):
+                mtype = event.media_types[i] if i < len(event.media_types) else ""
+                is_video = mtype.startswith("video/") or event.message_type == MessageType.VIDEO
+                if is_video:
+                    context_note = (
+                        f"[The user sent a video. Saved at: {path}. "
+                        f"Use video_analyze tool with video_path='{path}' to analyze it.]"
+                    )
+                    message_text = f"{context_note}\n\n{message_text}"
+
+        # -----------------------------------------------------------------
         # Inject reply context when user replies to a message not in history.
         # Telegram (and other platforms) let users reply to specific messages,
         # but if the quoted message is from a previous session, cron delivery,
@@ -5077,7 +5091,7 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, interval: int
     image/audio/document cache once per hour.
     """
     from cron.scheduler import tick as cron_tick
-    from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache, cleanup_video_cache
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
     CHANNEL_DIR_EVERY = 5    # ticks — every 5 minutes
@@ -5112,6 +5126,12 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, interval: int
                     logger.info("Document cache cleanup: removed %d stale file(s)", removed)
             except Exception as e:
                 logger.debug("Document cache cleanup error: %s", e)
+            try:
+                removed = cleanup_video_cache(max_age_hours=24)
+                if removed:
+                    logger.info("Video cache cleanup: removed %d stale file(s)", removed)
+            except Exception as e:
+                logger.debug("Video cache cleanup error: %s", e)
 
         stop_event.wait(timeout=interval)
     logger.info("Cron ticker stopped")

--- a/model_tools.py
+++ b/model_tools.py
@@ -141,6 +141,7 @@ def _discover_tools():
         "tools.terminal_tool",
         "tools.file_tools",
         "tools.vision_tools",
+        "tools.video_analysis_tool",
         "tools.mixture_of_agents_tool",
         "tools.image_generation_tool",
         "tools.skills_tool",

--- a/tests/test_video_analysis_tool.py
+++ b/tests/test_video_analysis_tool.py
@@ -1,0 +1,269 @@
+"""Tests for tools/video_analysis_tool.py — frame interval calculation, helpers, and tool registration."""
+
+import json
+import os
+import shutil
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.video_analysis_tool import (
+    VIDEO_ANALYZE_SCHEMA,
+    _calculate_frame_interval,
+    _handle_video_analyze,
+    check_video_requirements,
+    video_analyze_tool,
+)
+
+
+# ---------------------------------------------------------------------------
+# _calculate_frame_interval
+# ---------------------------------------------------------------------------
+
+class TestCalculateFrameInterval:
+    """Pure function — no mocking needed."""
+
+    def test_short_video_uses_1s_tier(self):
+        # < 60s => 1s base interval (capped at 30 frames)
+        assert _calculate_frame_interval(10) == 1.0
+        assert _calculate_frame_interval(29) == 1.0
+
+    def test_medium_video_uses_5s_tier(self):
+        # 60-300s => 5s base interval (capped at 30 frames)
+        assert _calculate_frame_interval(60) == 5.0
+        assert _calculate_frame_interval(120) == 5.0
+
+    def test_long_video_uses_10s_tier(self):
+        # 300s+ => 10s base interval (capped at 30 frames)
+        assert _calculate_frame_interval(300) == 10.0
+
+    def test_max_frames_cap_enforced(self):
+        # Any duration should produce at most 30 frames
+        for duration in [50, 200, 600, 1800, 7200]:
+            interval = _calculate_frame_interval(duration)
+            assert duration / interval <= 30, f"duration={duration} produced too many frames"
+
+    def test_very_long_video_scales_interval(self):
+        # 1800s (30 min) at 10s tier = 180 frames, way over cap
+        interval = _calculate_frame_interval(1800)
+        assert interval == 1800 / 30  # 60s
+
+    def test_cap_kicks_in_for_short_video(self):
+        # 59s / 1s = 59 frames > 30 => interval should be 59/30
+        interval = _calculate_frame_interval(59)
+        assert interval == pytest.approx(59 / 30)
+        assert 59 / interval <= 30
+
+    def test_cap_kicks_in_for_medium_video(self):
+        # 299s / 5s ≈ 60 frames > 30 => interval should be 299/30
+        interval = _calculate_frame_interval(299)
+        assert interval == pytest.approx(299 / 30)
+
+    def test_boundary_60s(self):
+        # Exactly 60s uses medium tier: 60/5 = 12 frames, under cap
+        assert _calculate_frame_interval(60) == 5.0
+
+    def test_boundary_300s(self):
+        # Exactly 300s uses long tier: 300/10 = 30 frames, exactly at cap
+        assert _calculate_frame_interval(300) == 10.0
+
+    def test_very_short_video(self):
+        interval = _calculate_frame_interval(2)
+        assert interval == 1.0
+
+
+# ---------------------------------------------------------------------------
+# ffmpeg / ffprobe detection
+# ---------------------------------------------------------------------------
+
+class TestHasFFmpeg:
+    @patch("shutil.which", return_value="/usr/bin/ffmpeg")
+    def test_ffmpeg_found(self, mock_which):
+        from tools.video_analysis_tool import _has_ffmpeg
+        assert _has_ffmpeg() is True
+
+    @patch("shutil.which", return_value=None)
+    def test_ffmpeg_not_found(self, mock_which):
+        from tools.video_analysis_tool import _has_ffmpeg
+        assert _has_ffmpeg() is False
+
+
+class TestHasFFprobe:
+    @patch("shutil.which", return_value="/usr/bin/ffprobe")
+    def test_ffprobe_found(self, mock_which):
+        from tools.video_analysis_tool import _has_ffprobe
+        assert _has_ffprobe() is True
+
+    @patch("shutil.which", return_value=None)
+    def test_ffprobe_not_found(self, mock_which):
+        from tools.video_analysis_tool import _has_ffprobe
+        assert _has_ffprobe() is False
+
+
+# ---------------------------------------------------------------------------
+# video_analyze_tool — async tests
+# ---------------------------------------------------------------------------
+
+def _make_video(tmp_path):
+    """Create a dummy video file and return its path."""
+    video = tmp_path / "test.mp4"
+    video.write_bytes(b"\x00" * 100)
+    return str(video)
+
+
+class TestVideoAnalyzeTool:
+    @pytest.mark.asyncio
+    async def test_file_not_found(self):
+        result = json.loads(await video_analyze_tool("/nonexistent/video.mp4", "what happens?"))
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("tools.video_analysis_tool._has_ffmpeg", return_value=False)
+    @patch("tools.video_analysis_tool._has_ffprobe", return_value=True)
+    async def test_missing_ffmpeg(self, _probe, _ff, tmp_path):
+        path = _make_video(tmp_path)
+        result = json.loads(await video_analyze_tool(path, "describe"))
+        assert result["success"] is False
+        assert "ffmpeg" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    @patch("tools.video_analysis_tool._has_ffmpeg", return_value=True)
+    @patch("tools.video_analysis_tool._has_ffprobe", return_value=False)
+    async def test_missing_ffprobe(self, _probe, _ff, tmp_path):
+        path = _make_video(tmp_path)
+        result = json.loads(await video_analyze_tool(path, "describe"))
+        assert result["success"] is False
+        assert "ffmpeg" in result["error"].lower() or "ffprobe" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    @patch("tools.video_analysis_tool._has_ffmpeg", return_value=True)
+    @patch("tools.video_analysis_tool._has_ffprobe", return_value=True)
+    @patch("tools.video_analysis_tool._get_video_duration", return_value=10.0)
+    @patch("tools.video_analysis_tool._extract_frames")
+    @patch("tools.video_analysis_tool.async_call_llm")
+    async def test_successful_analysis(self, mock_llm, mock_extract, _dur, _probe, _ff, tmp_path):
+        video_path = _make_video(tmp_path)
+
+        # Create fake frame files in tmp_path (auto-cleaned by pytest)
+        frame_dir = tmp_path / "frames"
+        frame_dir.mkdir()
+        frame_paths = []
+        for i in range(3):
+            fp = frame_dir / f"frame_{i:04d}.jpg"
+            fp.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 50)
+            frame_paths.append(str(fp))
+
+        mock_extract.return_value = frame_paths
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "The video shows a cat playing."
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_llm.return_value = mock_response
+
+        result = json.loads(await video_analyze_tool(video_path, "what happens?"))
+        assert result["success"] is True
+        assert result["analysis"] == "The video shows a cat playing."
+        assert result["duration"] == 10.0
+        assert result["frames_analyzed"] == 3
+        mock_llm.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("tools.video_analysis_tool._has_ffmpeg", return_value=True)
+    @patch("tools.video_analysis_tool._has_ffprobe", return_value=True)
+    @patch("tools.video_analysis_tool._get_video_duration", return_value=10.0)
+    @patch("tools.video_analysis_tool._extract_frames", return_value=[])
+    async def test_no_frames_extracted(self, _ext, _dur, _probe, _ff, tmp_path):
+        path = _make_video(tmp_path)
+        result = json.loads(await video_analyze_tool(path, "describe"))
+        assert result["success"] is False
+        assert "no frames" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_interrupted(self):
+        with patch("tools.interrupt.is_interrupted", return_value=True):
+            result = json.loads(await video_analyze_tool("/any/path.mp4", "q"))
+            assert result["success"] is False
+            assert "interrupt" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# _handle_video_analyze
+# ---------------------------------------------------------------------------
+
+class TestHandleVideoAnalyze:
+    @patch("tools.video_analysis_tool.video_analyze_tool")
+    def test_builds_correct_prompt(self, mock_tool):
+        mock_tool.return_value = "mock_coroutine"
+        args = {"video_path": "/tmp/test.mp4", "question": "What color is the car?"}
+        _handle_video_analyze(args)
+        call_args = mock_tool.call_args
+        prompt = call_args[0][1]
+        assert "What color is the car?" in prompt
+        assert "video_path" not in prompt
+        assert call_args[0][0] == "/tmp/test.mp4"
+
+    @patch.dict(os.environ, {"AUXILIARY_VISION_MODEL": "gpt-4o"})
+    @patch("tools.video_analysis_tool.video_analyze_tool")
+    def test_respects_env_model_override(self, mock_tool):
+        mock_tool.return_value = "mock"
+        _handle_video_analyze({"video_path": "/tmp/v.mp4", "question": "q"})
+        call_args = mock_tool.call_args
+        assert call_args[0][2] == "gpt-4o"  # model arg
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+class TestVideoAnalyzeSchema:
+    def test_schema_has_required_fields(self):
+        assert VIDEO_ANALYZE_SCHEMA["name"] == "video_analyze"
+        assert "parameters" in VIDEO_ANALYZE_SCHEMA
+        props = VIDEO_ANALYZE_SCHEMA["parameters"]["properties"]
+        assert "video_path" in props
+        assert "question" in props
+
+    def test_both_params_required(self):
+        assert set(VIDEO_ANALYZE_SCHEMA["parameters"]["required"]) == {"video_path", "question"}
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+class TestRegistration:
+    def test_video_analyze_registered(self):
+        from tools.registry import registry
+        assert "video_analyze" in registry._tools
+        entry = registry._tools["video_analyze"]
+        assert entry.toolset == "vision"
+        assert entry.is_async is True
+
+    def test_video_analyze_in_vision_toolset(self):
+        from toolsets import resolve_toolset
+        tools = resolve_toolset("vision")
+        assert "video_analyze" in tools
+
+
+# ---------------------------------------------------------------------------
+# check_video_requirements
+# ---------------------------------------------------------------------------
+
+class TestCheckVideoRequirements:
+    @patch("tools.video_analysis_tool._has_ffmpeg", return_value=False)
+    @patch("tools.video_analysis_tool._has_ffprobe", return_value=True)
+    def test_fails_without_ffmpeg(self, _probe, _ff):
+        assert check_video_requirements() is False
+
+    @patch("tools.video_analysis_tool._has_ffmpeg", return_value=True)
+    @patch("tools.video_analysis_tool._has_ffprobe", return_value=False)
+    def test_fails_without_ffprobe(self, _probe, _ff):
+        assert check_video_requirements() is False
+
+    @patch("tools.video_analysis_tool._has_ffmpeg", return_value=True)
+    @patch("tools.video_analysis_tool._has_ffprobe", return_value=True)
+    def test_fails_without_vision_provider(self, _probe, _ff):
+        with patch("agent.auxiliary_client.resolve_vision_provider_client", side_effect=Exception("no provider")):
+            assert check_video_requirements() is False

--- a/tools/video_analysis_tool.py
+++ b/tools/video_analysis_tool.py
@@ -1,0 +1,303 @@
+"""
+Video Analysis Tool
+
+Extracts frames from a video using ffmpeg/ffprobe and analyses them via the
+centralized vision LLM router.  Follows the same registration pattern as
+vision_tools.py.
+"""
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Awaitable, Dict, Optional
+
+from agent.auxiliary_client import async_call_llm
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# ffmpeg / ffprobe helpers
+# ---------------------------------------------------------------------------
+
+def _has_ffmpeg() -> bool:
+    return shutil.which("ffmpeg") is not None
+
+
+def _has_ffprobe() -> bool:
+    return shutil.which("ffprobe") is not None
+
+
+def _get_video_duration(path: str) -> float:
+    """Return the duration of a video file in seconds via ffprobe."""
+    result = subprocess.run(
+        [
+            "ffprobe", "-v", "error",
+            "-show_entries", "format=duration",
+            "-of", "csv=p=0",
+            path,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return float(result.stdout.strip())
+
+
+def _calculate_frame_interval(duration: float) -> float:
+    """Return the interval (seconds) between extracted frames.
+
+    Tiered strategy:
+      <1 min  -> every 1 s
+      1-5 min -> every 5 s
+      5 min+  -> every 10 s
+
+    Hard cap: max 30 frames total — interval is increased proportionally if
+    the naive tier would exceed this.
+    """
+    MAX_FRAMES = 30
+
+    if duration < 60:
+        interval = 1.0
+    elif duration < 300:
+        interval = 5.0
+    else:
+        interval = 10.0
+
+    # Enforce max-frames cap
+    estimated_frames = duration / interval
+    if estimated_frames > MAX_FRAMES:
+        interval = duration / MAX_FRAMES
+
+    return interval
+
+
+def _extract_frames(video_path: str, output_dir: str, interval: float) -> list[str]:
+    """Extract JPEG frames from *video_path* at the given interval.
+
+    Returns a sorted list of absolute paths to the extracted frame files.
+    """
+    pattern = os.path.join(output_dir, "frame_%04d.jpg")
+    subprocess.run(
+        [
+            "ffmpeg", "-i", video_path,
+            "-vf", f"fps=1/{interval},scale=768:-1",
+            "-q:v", "2",
+            pattern,
+        ],
+        capture_output=True,
+        timeout=120,
+        check=True,
+    )
+    frames = sorted(
+        str(p) for p in Path(output_dir).glob("frame_*.jpg")
+    )
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# Main analysis function
+# ---------------------------------------------------------------------------
+
+async def video_analyze_tool(
+    video_path: str,
+    user_prompt: str,
+    model: Optional[str] = None,
+) -> str:
+    """Analyse a video by extracting frames and sending them to a vision LLM.
+
+    Args:
+        video_path: Absolute path to the video file.
+        user_prompt: The user's question or instruction about the video.
+        model: Optional override for the vision model.
+
+    Returns:
+        JSON string with keys: success, analysis, duration, frames_analyzed.
+    """
+    tmp_dir: Optional[str] = None
+    try:
+        from tools.interrupt import is_interrupted
+        if is_interrupted():
+            return json.dumps({"success": False, "error": "Interrupted"})
+
+        path = Path(video_path)
+        if not path.is_file():
+            return json.dumps({
+                "success": False,
+                "error": f"Video file not found: {video_path}",
+                "analysis": "The video file could not be found at the specified path.",
+            })
+
+        if not _has_ffmpeg() or not _has_ffprobe():
+            return json.dumps({
+                "success": False,
+                "error": "ffmpeg/ffprobe not found on PATH",
+                "analysis": (
+                    "Video analysis requires ffmpeg and ffprobe to be installed. "
+                    "Please install ffmpeg (https://ffmpeg.org) and try again."
+                ),
+            })
+
+        # Get duration
+        logger.info("Getting video duration for %s", video_path)
+        duration = await asyncio.to_thread(_get_video_duration, video_path)
+        logger.info("Video duration: %.1f seconds", duration)
+
+        # Calculate frame extraction parameters
+        interval = _calculate_frame_interval(duration)
+        expected_frames = int(duration / interval) + 1
+        logger.info(
+            "Extracting frames: interval=%.1fs, expected=%d",
+            interval, expected_frames,
+        )
+
+        # Extract frames to a temp directory
+        tmp_dir = tempfile.mkdtemp(prefix="hermes_video_frames_")
+        frames = await asyncio.to_thread(
+            _extract_frames, video_path, tmp_dir, interval,
+        )
+
+        if not frames:
+            return json.dumps({
+                "success": False,
+                "error": "No frames extracted from video",
+                "analysis": "ffmpeg did not produce any frames from the video.",
+            })
+
+        logger.info("Extracted %d frames", len(frames))
+
+        # Build multi-image vision message
+        content: list[dict] = []
+
+        # Text block with prompt + metadata
+        meta_text = (
+            f"{user_prompt}\n\n"
+            f"--- Video metadata ---\n"
+            f"Duration: {duration:.1f}s | "
+            f"Frames shown: {len(frames)} | "
+            f"Interval: {interval:.1f}s between frames"
+        )
+        content.append({"type": "text", "text": meta_text})
+
+        # One image_url block per frame (base64 data URL)
+        for frame_path in frames:
+            data = Path(frame_path).read_bytes()
+            b64 = base64.b64encode(data).decode("ascii")
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{b64}"},
+            })
+
+        messages = [{"role": "user", "content": content}]
+
+        logger.info("Calling vision LLM with %d frames ...", len(frames))
+        call_kwargs: dict[str, Any] = {
+            "task": "vision",
+            "messages": messages,
+            "temperature": 0.1,
+            "max_tokens": 4000,
+        }
+        if model:
+            call_kwargs["model"] = model
+
+        response = await async_call_llm(**call_kwargs)
+        analysis = response.choices[0].message.content.strip()
+        logger.info("Video analysis complete (%d chars)", len(analysis))
+
+        return json.dumps({
+            "success": True,
+            "analysis": analysis,
+            "duration": round(duration, 1),
+            "frames_analyzed": len(frames),
+        }, ensure_ascii=False)
+
+    except Exception as e:
+        logger.error("Video analysis failed: %s", e, exc_info=True)
+        return json.dumps({
+            "success": False,
+            "error": str(e),
+            "analysis": f"Video analysis failed: {e}",
+        }, ensure_ascii=False)
+
+    finally:
+        if tmp_dir and os.path.isdir(tmp_dir):
+            try:
+                shutil.rmtree(tmp_dir)
+            except Exception as cleanup_err:
+                logger.warning("Could not clean up temp frames: %s", cleanup_err)
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+def check_video_requirements() -> bool:
+    """Return True if ffmpeg, ffprobe, and a vision provider are all available."""
+    if not (_has_ffmpeg() and _has_ffprobe()):
+        return False
+    try:
+        from agent.auxiliary_client import resolve_vision_provider_client
+        _provider, client, _model = resolve_vision_provider_client()
+        return client is not None
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+from tools.registry import registry
+
+VIDEO_ANALYZE_SCHEMA = {
+    "name": "video_analyze",
+    "description": (
+        "Analyze a video by extracting frames and describing its content "
+        "using AI vision. Requires ffmpeg."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "video_path": {
+                "type": "string",
+                "description": "Absolute local file path to the video.",
+            },
+            "question": {
+                "type": "string",
+                "description": (
+                    "Your question or instruction about the video. "
+                    "The AI will describe the video content and answer this."
+                ),
+            },
+        },
+        "required": ["video_path", "question"],
+    },
+}
+
+
+def _handle_video_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
+    video_path = args.get("video_path", "")
+    question = args.get("question", "")
+    full_prompt = (
+        "You are analyzing frames extracted from a video. "
+        "Describe what happens in the video, then answer the following "
+        f"question:\n\n{question}"
+    )
+    model = os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
+    return video_analyze_tool(video_path, full_prompt, model)
+
+
+registry.register(
+    name="video_analyze",
+    toolset="vision",
+    schema=VIDEO_ANALYZE_SCHEMA,
+    handler=_handle_video_analyze,
+    check_fn=check_video_requirements,
+    is_async=True,
+    emoji="\U0001f3ac",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -36,7 +36,7 @@ _HERMES_CORE_TOOLS = [
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
     # Vision + image generation
-    "vision_analyze", "image_generate",
+    "vision_analyze", "video_analyze", "image_generate",
     # MoA
     "mixture_of_agents",
     # Skills
@@ -85,7 +85,7 @@ TOOLSETS = {
     
     "vision": {
         "description": "Image analysis and vision tools",
-        "tools": ["vision_analyze"],
+        "tools": ["vision_analyze", "video_analyze"],
         "includes": []
     },
     
@@ -237,7 +237,7 @@ TOOLSETS = {
             "web_search", "web_extract",
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
-            "vision_analyze",
+            "vision_analyze", "video_analyze",
             "skills_list", "skill_view", "skill_manage",
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -145,6 +145,7 @@ This page documents the built-in Hermes tool registry as it exists in code. Avai
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
+| `video_analyze` | Analyze a video by extracting frames and describing its content using AI vision. Requires ffmpeg. | ffmpeg, ffprobe |
 | `vision_analyze` | Analyze images using AI vision. Provides a comprehensive description and answers a specific question about the image content. | — |
 
 ## `web` toolset
@@ -159,16 +160,3 @@ This page documents the built-in Hermes tool registry as it exists in code. Avai
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
 | `text_to_speech` | Convert text to speech audio. Returns a MEDIA: path that the platform delivers as a voice message. On Telegram it plays as a voice bubble, on Discord/WhatsApp as an audio attachment. In CLI mode, saves to ~/voice-memos/. Voice and provider… | — |
-
-## `vision` toolset
-
-| Tool | Description | Requires environment |
-|------|-------------|----------------------|
-| `vision_analyze` | Analyze images using AI vision. Provides a comprehensive description and answers a specific question about the image content. | — |
-
-## `web` toolset
-
-| Tool | Description | Requires environment |
-|------|-------------|----------------------|
-| `web_extract` | Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs (arxiv papers, documents, etc.) — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdow… | FIRECRAWL_API_KEY |
-| `web_search` | Search the web for information on any topic. Returns up to 5 relevant results with titles, URLs, and descriptions. | FIRECRAWL_API_KEY |

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -17,8 +17,8 @@ Toolsets are named bundles of tools that you can enable with `hermes chat --tool
 | `debugging` | composite | `patch`, `process`, `read_file`, `search_files`, `terminal`, `web_extract`, `web_search`, `write_file` |
 | `delegation` | core | `delegate_task` |
 | `file` | core | `patch`, `read_file`, `search_files`, `write_file` |
-| `hermes-acp` | platform | `browser_back`, `browser_click`, `browser_close`, `browser_console`, `browser_get_images`, `browser_navigate`, `browser_press`, `browser_scroll`, `browser_snapshot`, `browser_type`, `browser_vision`, `delegate_task`, `execute_code`, `memory`, `patch`, `process`, `read_file`, `search_files`, `session_search`, `skill_manage`, `skill_view`, `skills_list`, `terminal`, `todo`, `vision_analyze`, `web_extract`, `web_search`, `write_file` |
-| `hermes-cli` | platform | `browser_back`, `browser_click`, `browser_close`, `browser_console`, `browser_get_images`, `browser_navigate`, `browser_press`, `browser_scroll`, `browser_snapshot`, `browser_type`, `browser_vision`, `clarify`, `cronjob`, `delegate_task`, `execute_code`, `ha_call_service`, `ha_get_state`, `ha_list_entities`, `ha_list_services`, `honcho_conclude`, `honcho_context`, `honcho_profile`, `honcho_search`, `image_generate`, `memory`, `mixture_of_agents`, `patch`, `process`, `read_file`, `search_files`, `send_message`, `session_search`, `skill_manage`, `skill_view`, `skills_list`, `terminal`, `text_to_speech`, `todo`, `vision_analyze`, `web_extract`, `web_search`, `write_file` |
+| `hermes-acp` | platform | `browser_back`, `browser_click`, `browser_close`, `browser_console`, `browser_get_images`, `browser_navigate`, `browser_press`, `browser_scroll`, `browser_snapshot`, `browser_type`, `browser_vision`, `delegate_task`, `execute_code`, `memory`, `patch`, `process`, `read_file`, `search_files`, `session_search`, `skill_manage`, `skill_view`, `skills_list`, `terminal`, `todo`, `video_analyze`, `vision_analyze`, `web_extract`, `web_search`, `write_file` |
+| `hermes-cli` | platform | `browser_back`, `browser_click`, `browser_close`, `browser_console`, `browser_get_images`, `browser_navigate`, `browser_press`, `browser_scroll`, `browser_snapshot`, `browser_type`, `browser_vision`, `clarify`, `cronjob`, `delegate_task`, `execute_code`, `ha_call_service`, `ha_get_state`, `ha_list_entities`, `ha_list_services`, `honcho_conclude`, `honcho_context`, `honcho_profile`, `honcho_search`, `image_generate`, `memory`, `mixture_of_agents`, `patch`, `process`, `read_file`, `search_files`, `send_message`, `session_search`, `skill_manage`, `skill_view`, `skills_list`, `terminal`, `text_to_speech`, `todo`, `video_analyze`, `vision_analyze`, `web_extract`, `web_search`, `write_file` |
 | `hermes-discord` | platform | _(same as hermes-cli)_ |
 | `hermes-email` | platform | _(same as hermes-cli)_ |
 | `hermes-gateway` | composite | Union of all messaging platform toolsets |
@@ -42,7 +42,7 @@ Toolsets are named bundles of tools that you can enable with `hermes chat --tool
 | `terminal` | core | `process`, `terminal` |
 | `todo` | core | `todo` |
 | `tts` | core | `text_to_speech` |
-| `vision` | core | `vision_analyze` |
+| `vision` | core | `video_analyze`, `vision_analyze` |
 | `web` | core | `web_extract`, `web_search` |
 
 ## Dynamic toolsets


### PR DESCRIPTION
## What does this PR do?

Adds end-to-end video analysis support for the Hermes agent. When a user sends a video on Telegram, it is downloaded, cached locally, and the agent is given a context note with the file path and instructions to use the new `video_analyze` tool. The tool extracts frames using ffmpeg, encodes them as base64, and sends them to the configured vision LLM for multi-frame analysis.

This follows the same pattern as the existing image analysis pipeline (download → cache → enrich → tool), but intentionally skips auto-analysis since processing video frames is more expensive than a single image.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`gateway/platforms/base.py`** — Added `VIDEO_CACHE_DIR`, `get_video_cache_dir()`, `cache_video_from_bytes()`, `cleanup_video_cache()` following the existing image/audio/document cache pattern
- **`gateway/platforms/telegram.py`** — Added `elif msg.video:` download block with 20MB Telegram Bot API size check, MIME-to-extension mapping, and cache write
- **`tools/video_analysis_tool.py`** *(new)* — Frame extraction via ffmpeg (`fps=1/<interval>`, scaled to 768px, JPEG quality 2), tiered interval strategy (<1min: 1s, 1-5min: 5s, 5min+: 10s, hard cap 30 frames), async vision LLM call, tool registration
- **`model_tools.py`** — Added `"tools.video_analysis_tool"` to `_discover_tools()`
- **`toolsets.py`** — Added `"video_analyze"` to `_HERMES_CORE_TOOLS`, `"vision"` toolset, and `"hermes-acp"` preset
- **`gateway/run.py`** — Added video context enrichment block (tells agent a video is available + how to analyze it), added `cleanup_video_cache()` to hourly cron ticker
- **`tests/test_video_analysis_tool.py`** *(new)* — 29 unit tests covering frame interval calculation, ffmpeg detection, async tool flow, handler/schema/registry integration, and requirements checks
- **`website/docs/reference/tools-reference.md`** — Added `video_analyze` to vision toolset documentation, fixed pre-existing duplicate sections
- **`website/docs/reference/toolsets-reference.md`** — Added `video_analyze` to vision, hermes-acp, and hermes-cli toolset listings

## How to Test

1. Install ffmpeg (`winget install ffmpeg` / `brew install ffmpeg` / `apt install ffmpeg`)
2. Start the gateway with Telegram configured
3. Send a short video (<20MB) to the bot on Telegram
4. Verify it downloads to `~/.hermes/video_cache/`
5. The agent should receive a context note and invoke `video_analyze` if the user's caption asks about the video
6. Verify frames are extracted, vision LLM is called, and analysis is returned

**Edge cases:**
- Send a video >20MB → should get a size limit message, no download attempted
- Remove ffmpeg from PATH → `video_analyze` tool should not appear in the agent's toolset (`check_fn` returns False)
- Send a video with no caption → agent receives context note and can decide whether to analyze

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A