### PR TITLE
fix(cli): correct truncated AUXILIARY_WEB_EXTRACT_API_KEY env var name

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -398,7 +398,7 @@ def load_cli_config() -> Dict[str, Any]:
             "provider": "AUXILIARY_WEB_EXTRACT_PROVIDER",
             "model": "AUXILIARY_WEB_EXTRACT_MODEL",
             "base_url": "AUXILIARY_WEB_EXTRACT_BASE_URL",
-            "api_key": "AUXILI..._KEY",
+            "api_key": "AUXILIARY_WEB_EXTRACT_API_KEY",
         },
         "approval": {
             "provider": "AUXILIARY_APPROVAL_PROVIDER",


### PR DESCRIPTION
## What does this PR do?
Fixes a copy-paste error in cli.py where the auxiliary web_extract API key env var name was truncated to `"AUXILI..._KEY"` instead of the correct 
`"AUXILIARY_WEB_EXTRACT_API_KEY"`.

## Root Cause
The gateway/run.py has the correct name (line 150). The CLI version was incorrectly truncated, causing CLI users who configure an auxiliary web_extract model with an API key to have authentication failures - the key is written to a non-existent env var.

## Related Issue
N/A — discovered via code review

## Changes Made
- `cli.py` line 401: `"AUXILI..._KEY"` → `"AUXILIARY_WEB_EXTRACT_API_KEY"`

## Type of Change
- 🐛 Bug fix

## Changes Made

- `cli.py` line 401: corrected truncated env var name `"AUXILI..._KEY"` → `"AUXILIARY_WEB_EXTRACT_API_KEY"` to match `gateway/run.py` line 150

## How to Test

1. Configure auxiliary web_extract model in ~/.hermes/config.yaml with an API key
2. Run hermes CLI
3. Before fix: key was stored in non-existent env var "AUXILI..._KEY", causing auth failures
4. After fix: key correctly stored in AUXILIARY_WEB_EXTRACT_API_KEY

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- pytest — N/A (single char fix, no logic change)
- Tests — N/A
- Platform: macOS 13.0

### Documentation & Housekeeping

- Documentation — N/A
- cli-config.yaml — N/A
- CONTRIBUTING — N/A
- Cross-platform — N/A
- Tool descriptions — N/A
