### PR TITLE
fix: extend None-entry guard to tool_calls loops in run_agent, batch_runner, and mini_swe_runner

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -128,6 +128,7 @@ def _extract_tool_stats(messages: List[Dict[str, Any]]) -> Dict[str, Dict[str, i
         # Track tool calls from assistant messages
         if msg["role"] == "assistant" and "tool_calls" in msg and msg["tool_calls"]:
             for tool_call in msg["tool_calls"]:
+                if not tool_call or not isinstance(tool_call, dict): continue
                 tool_name = tool_call["function"]["name"]
                 tool_call_id = tool_call["id"]
                 

--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -339,6 +339,7 @@ class MiniSWERunner:
                     
                     # Add tool calls in XML format
                     for tool_call in msg["tool_calls"]:
+                        if not tool_call or not isinstance(tool_call, dict): continue
                         try:
                             arguments = json.loads(tool_call["function"]["arguments"]) \
                                 if isinstance(tool_call["function"]["arguments"], str) \

--- a/run_agent.py
+++ b/run_agent.py
@@ -1588,6 +1588,7 @@ class AIAgent:
                     
                     # Add tool calls wrapped in XML tags
                     for tool_call in msg["tool_calls"]:
+                        if not tool_call or not isinstance(tool_call, dict): continue
                         # Parse arguments - should always succeed since we validate during conversation
                         # but keep try-except as safety net
                         try:
@@ -6741,6 +6742,7 @@ class AIAgent:
                                 if msg.get("role") == "assistant" and msg.get("tool_calls"):
                                     tool_names = []
                                     for tc in msg["tool_calls"]:
+                                        if not tc or not isinstance(tc, dict): continue
                                         fn = tc.get("function", {})
                                         tool_names.append(fn.get("name", "unknown"))
                                     msg["content"] = f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
@@ -6783,6 +6785,7 @@ class AIAgent:
                                     if msg.get("role") == "assistant" and msg.get("tool_calls"):
                                         tool_names = []
                                         for tc in msg["tool_calls"]:
+                                            if not tc or not isinstance(tc, dict): continue
                                             fn = tc.get("function", {})
                                             tool_names.append(fn.get("name", "unknown"))
                                         msg["content"] = f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
@@ -6902,6 +6905,7 @@ class AIAgent:
                             if isinstance(m, dict) and m.get("role") == "tool"
                         }
                         for tc in msg["tool_calls"]:
+                            if not tc or not isinstance(tc, dict): continue
                             if tc["id"] not in answered_ids:
                                 err_msg = {
                                     "role": "tool",


### PR DESCRIPTION
## What does this PR do?
PR #2209 added a None-entry guard to `anthropic_adapter.py` for `tool_calls` iteration. The same guard was missing from 5 other call sites that iterate over `tool_calls` lists.

## Root Cause
A `tool_calls` list can contain `None` entries from:
- Malformed API responses
- Session compression artifacts  
- Corrupt session replay from disk

Without the guard, these sites crash with `TypeError: 'NoneType' object is not subscriptable`.

## Changes Made

Added `if not tc or not isinstance(tc, dict): continue` guard to:
- `run_agent.py` line 6904 — error recovery block (CRITICAL: crashes while handling another error)
- `run_agent.py` line 6743 — empty content fallback
- `run_agent.py` line 6786 — same pattern, deeper nesting
- `run_agent.py` line 1590 — trajectory conversion
- `batch_runner.py` line 130 — tool stats tracking
- `mini_swe_runner.py` line 341 — trajectory conversion

## Related Issue
Extends fix from #2209 to remaining call sites.

## Type of Change
- 🐛 Bug fix

## Changes Made

- `run_agent.py` line 6904: added None-entry guard to error recovery block
- `run_agent.py` line 6743: added None-entry guard to empty content fallback
- `run_agent.py` line 6786: added None-entry guard to same pattern (deeper nesting)
- `run_agent.py` line 1590: added None-entry guard to trajectory conversion
- `batch_runner.py` line 130: added None-entry guard to tool stats tracking
- `mini_swe_runner.py` line 341: added None-entry guard to trajectory conversion

## How to Test

1. Create a message with None entry in tool_calls:
   msg = {"role": "assistant", "tool_calls": [None, {"id": "call_1", ...}]}
2. Before fix: TypeError: 'NoneType' object is not subscriptable
3. After fix: None entry skipped, valid tool_calls processed correctly

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- pytest: 5496 passed, 13 pre-existing failures (unrelated to this fix) 
- Tests: N/A (defensive guard, no logic change)
- Platform: macOS 13.0

### Documentation & Housekeeping

- Documentation — N/A
- cli-config — N/A
- CONTRIBUTING — N/A
- Cross-platform — N/A
- Tool descriptions — N/A

## Screenshots / Logs

# Before fix:
TypeError: 'NoneType' object is not subscriptable

# After fix:
processing: {'id': 'call_1', 'function': {'name': 'test', 'arguments': '{}'}}

