### PR TITLE
fix(agent): inject model identity for Alibaba Coding Plan to work around API returning wrong model name

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2200,6 +2200,18 @@ class AIAgent:
             timestamp_line += f"\nProvider: {self.provider}"
         prompt_parts.append(timestamp_line)
 
+        # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
+        # of the requested model. Inject explicit model identity into the system prompt
+        # so the agent can correctly report which model it is (workaround for API bug).
+        if self.provider in ("alibaba-coding-plan", "alibaba-coding-plan-anthropic"):
+            _model_short = self.model.split("/")[-1] if "/" in self.model else self.model
+            prompt_parts.append(
+                f"You are powered by the model named {_model_short}. "
+                f"The exact model ID is {self.model}. "
+                f"When asked what model you are, always answer based on this information, "
+                f"not on any model name returned by the API."
+            )
+
         platform_key = (self.platform or "").lower().strip()
         if platform_key in PLATFORM_HINTS:
             prompt_parts.append(PLATFORM_HINTS[platform_key])


### PR DESCRIPTION
Fixes #2300

## Root Cause
Alibaba Coding Plan API always returns `glm-4.7` as the model name in responses, regardless of the requested model. This causes the agent to incorrectly report its identity to users.

## Fix
When provider is `alibaba-coding-plan` or `alibaba-coding-plan-anthropic`, inject explicit model identity into the system prompt:

"You are powered by the model named qwen3.5-plus. The exact model ID is alibaba-coding-plan/qwen3.5-plus. When asked what model you are, always answer based on this information, not on any model name returned by the API."

This follows the same approach used by OpenCode to work around this API-side bug.
