### PR TITLE
fix: make vision_analyze timeout configurable

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -234,6 +234,54 @@ class TestHandleVisionAnalyze:
 
 
 # ---------------------------------------------------------------------------
+# Configurable vision timeout (AUXILIARY_VISION_TIMEOUT)
+# ---------------------------------------------------------------------------
+
+
+class TestVisionTimeout:
+    """Verify that AUXILIARY_VISION_TIMEOUT env var controls the LLM call timeout."""
+
+    @pytest.mark.asyncio
+    async def test_default_timeout_is_30(self, tmp_path):
+        """Without AUXILIARY_VISION_TIMEOUT, timeout should default to 30."""
+        img = tmp_path / "test.jpg"
+        img.write_bytes(b"\xff\xd8\xff" + b"\x00" * 16)
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "A test description"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_response) as mock_llm,
+        ):
+            os.environ.pop("AUXILIARY_VISION_TIMEOUT", None)
+            await vision_analyze_tool(str(img), "describe", "test/model")
+            call_kwargs = mock_llm.call_args
+            assert call_kwargs.kwargs.get("timeout") == 30.0 or call_kwargs[1].get("timeout") == 30.0
+
+    @pytest.mark.asyncio
+    async def test_custom_timeout_from_env(self, tmp_path):
+        """AUXILIARY_VISION_TIMEOUT=180 should pass timeout=180 to async_call_llm."""
+        img = tmp_path / "test.jpg"
+        img.write_bytes(b"\xff\xd8\xff" + b"\x00" * 16)
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "A test description"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch.dict(os.environ, {"AUXILIARY_VISION_TIMEOUT": "180"}),
+            patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_response) as mock_llm,
+        ):
+            await vision_analyze_tool(str(img), "describe", "test/model")
+            call_kwargs = mock_llm.call_args
+            assert call_kwargs.kwargs.get("timeout") == 180.0 or call_kwargs[1].get("timeout") == 180.0
+
+
+# ---------------------------------------------------------------------------
 # Error logging with exc_info — verify tracebacks are logged
 # ---------------------------------------------------------------------------
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -299,11 +299,14 @@ async def vision_analyze_tool(
         logger.info("Processing image with vision model...")
         
         # Call the vision API via centralized router
+        # Allow configurable timeout via environment variable for slow local models
+        vision_timeout = float(os.getenv("AUXILIARY_VISION_TIMEOUT", "30"))
         call_kwargs = {
             "task": "vision",
             "messages": messages,
             "temperature": 0.1,
             "max_tokens": 2000,
+            "timeout": vision_timeout,
         }
         if model:
             call_kwargs["model"] = model

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -263,6 +263,7 @@ compression:
 | `AUXILIARY_VISION_MODEL` | Override model for vision tasks |
 | `AUXILIARY_VISION_BASE_URL` | Direct OpenAI-compatible endpoint for vision tasks |
 | `AUXILIARY_VISION_API_KEY` | API key paired with `AUXILIARY_VISION_BASE_URL` |
+| `AUXILIARY_VISION_TIMEOUT` | Timeout in seconds for vision analysis LLM calls (default: `30`) |
 | `AUXILIARY_WEB_EXTRACT_PROVIDER` | Override provider for web extraction/summarization |
 | `AUXILIARY_WEB_EXTRACT_MODEL` | Override model for web extraction/summarization |
 | `AUXILIARY_WEB_EXTRACT_BASE_URL` | Direct OpenAI-compatible endpoint for web extraction/summarization |


### PR DESCRIPTION
## Summary
- Fixes #2107 — vision_analyze times out on slow local models due to hardcoded 30s timeout
- Added `AUXILIARY_VISION_TIMEOUT` environment variable to configure the vision LLM call timeout
- Default remains 30s for backward compatibility

## Changes
- `tools/vision_tools.py`: Read `AUXILIARY_VISION_TIMEOUT` env var (default `30`) and pass it to `async_call_llm`
- `tests/tools/test_vision_tools.py`: Added two tests verifying default 30s and custom timeout behavior
- `website/docs/reference/environment-variables.md`: Documented the new env var

## Usage
```bash
# For slow local models, increase the timeout (in seconds)
export AUXILIARY_VISION_TIMEOUT=180
```

## Test plan
- [x] All 45 existing vision tool tests pass
- [x] New test verifies default 30s timeout is preserved
- [x] New test verifies custom timeout from env var is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)