### PR TITLE
fix(gateway): bridge webhook extra.routes from config.yaml to gateway config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -475,6 +475,13 @@ def load_gateway_config() -> GatewayConfig:
                     )
                 if "reply_prefix" in platform_cfg:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
+
+                # Bridge nested extra keys (e.g. webhook.extra.routes, webhook.extra.secret)
+                # These are used directly as PlatformConfig.extra and must be passed through.
+                platform_extra = platform_cfg.get("extra")
+                if isinstance(platform_extra, dict):
+                    bridged.update(platform_extra)
+
                 if not bridged:
                     continue
                 plat_data = platforms_data.setdefault(plat.value, {})


### PR DESCRIPTION
Fixes #2305

## Root Cause
In `load_gateway_config()`, the platform config bridge loop only transferred `unauthorized_dm_behavior` and `reply_prefix` from config.yaml platform sections. The `extra` dict (which contains `routes`, `secret`, etc. for webhook) was never read.

## Fix
Added bridging for the entire `extra` dict from each platform section in config.yaml. This means `platforms.webhook.extra.routes` (and any other `extra` keys) now correctly flow into the gateway config.

## Before
```yaml
platforms:
  webhook:
    extra:
      routes:
        github-pr:
          events: ["pull_request"]
