### PR TITLE
fix(cli): correct truncated AUXILIARY_WEB_EXTRACT_API_KEY env var name

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -398,7 +398,7 @@ def load_cli_config() -> Dict[str, Any]:
             "provider": "AUXILIARY_WEB_EXTRACT_PROVIDER",
             "model": "AUXILIARY_WEB_EXTRACT_MODEL",
             "base_url": "AUXILIARY_WEB_EXTRACT_BASE_URL",
-            "api_key": "AUXILI..._KEY",
+            "api_key": "AUXILIARY_WEB_EXTRACT_API_KEY",
         },
         "approval": {
             "provider": "AUXILIARY_APPROVAL_PROVIDER",


### PR DESCRIPTION
Cherry-picked from PR #2295 by @dlkakbs.

The web_extract auxiliary client api_key env var was literally stored as `AUXILI..._KEY` (three dots in the actual source code) instead of `AUXILIARY_WEB_EXTRACT_API_KEY`. One-line fix.