### PR TITLE
feat(config): add support for nested platform mapping in config.yaml

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -460,6 +460,34 @@ def load_gateway_config() -> GatewayConfig:
             if not isinstance(platforms_data, dict):
                 platforms_data = {}
                 gw_data["platforms"] = platforms_data
+
+            # Primary platform mapping in config.yaml (platforms.<name>).
+            # Merge over legacy gateway.json values so config.yaml wins.
+            yaml_platforms = yaml_cfg.get("platforms")
+            if isinstance(yaml_platforms, dict):
+                for platform_name, platform_data in yaml_platforms.items():
+                    if not isinstance(platform_data, dict):
+                        continue
+
+                    existing_platform_data = platforms_data.get(platform_name)
+                    if not isinstance(existing_platform_data, dict):
+                        existing_platform_data = {}
+
+                    merged_platform_data = dict(existing_platform_data)
+                    merged_platform_data.update(platform_data)
+
+                    existing_extra = existing_platform_data.get("extra")
+                    incoming_extra = platform_data.get("extra")
+                    if isinstance(existing_extra, dict) or isinstance(incoming_extra, dict):
+                        merged_extra: Dict[str, Any] = {}
+                        if isinstance(existing_extra, dict):
+                            merged_extra.update(existing_extra)
+                        if isinstance(incoming_extra, dict):
+                            merged_extra.update(incoming_extra)
+                        merged_platform_data["extra"] = merged_extra
+
+                    platforms_data[platform_name] = merged_platform_data
+
             for plat in Platform:
                 if plat == Platform.LOCAL:
                     continue

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -192,3 +192,28 @@ class TestLoadGatewayConfig:
 
         assert config.unauthorized_dm_behavior == "ignore"
         assert config.platforms[Platform.WHATSAPP].extra["unauthorized_dm_behavior"] == "pair"
+
+    def test_loads_nested_platforms_mapping_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  webhook:\n"
+            "    enabled: true\n"
+            "    extra:\n"
+            "      secret: test-secret\n"
+            "      routes:\n"
+            "        github-pr:\n"
+            "          deliver: log\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        webhook = config.platforms[Platform.WEBHOOK]
+        assert webhook.enabled is True
+        assert webhook.extra["secret"] == "test-secret"
+        assert webhook.extra["routes"]["github-pr"]["deliver"] == "log"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #2305 

## Type of Change

<!-- Check the one that applies. -->

- [x ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

1. Updated loader merge logic in `config.py` so `platforms.*` from `config.yaml` is merged into `gw_data["platforms"]`, including deep merge for `extra`.
2. Added a regression test in `test_config.py` that verifies `platforms.webhook.extra.routes` from `config.yaml` is loaded.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. add sample route to `config.json`
```yaml
platforms:
  webhook:
    enabled: true
    extra:
      secret: "redacted"
      routes:
        github-pr:
          events: ["pull_request"]
          deliver: "log"
```
2. start gateway 
4. check `.hermes/logs/gateway.log` to validate route is loaded

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x ] I've run `pytest tests/ -q` and all tests pass
- [x ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x ] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
2026-03-21 13:56:53,444 INFO gateway.run: Starting Hermes Gateway...
2026-03-21 13:56:53,444 INFO gateway.run: Session storage: /home/actual/.hermes/sessions
2026-03-21 13:56:53,455 INFO gateway.run: Connecting to webhook...
2026-03-21 13:56:53,456 INFO gateway.platforms.webhook: [webhook] Listening on 0.0.0.0:8644 — routes: github-pr
2026-03-21 13:56:53,456 INFO gateway.run: ✓ webhook connected
2026-03-21 13:56:53,500 INFO gateway.run: Connecting to discord...
2026-03-21 13:56:53,503 INFO discord.client: logging in using static token
```

