### PR TITLE
fix(agent): inject model identity for Alibaba Coding Plan

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2329,6 +2329,18 @@ class AIAgent:
             timestamp_line += f"\nProvider: {self.provider}"
         prompt_parts.append(timestamp_line)
 
+        # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
+        # of the requested model. Inject explicit model identity into the system prompt
+        # so the agent can correctly report which model it is (workaround for API bug).
+        if self.provider in ("alibaba-coding-plan", "alibaba-coding-plan-anthropic"):
+            _model_short = self.model.split("/")[-1] if "/" in self.model else self.model
+            prompt_parts.append(
+                f"You are powered by the model named {_model_short}. "
+                f"The exact model ID is {self.model}. "
+                f"When asked what model you are, always answer based on this information, "
+                f"not on any model name returned by the API."
+            )
+
         platform_key = (self.platform or "").lower().strip()
         if platform_key in PLATFORM_HINTS:
             prompt_parts.append(PLATFORM_HINTS[platform_key])


### PR DESCRIPTION
Salvage of PR #2304 by @ygd58. Closes #2300.

Alibaba Coding Plan API always returns `glm-4.7` as the model name regardless of the requested model. This injects explicit model identity into the system prompt for `alibaba-coding-plan` providers only, so the agent correctly reports which model it is.

1 file, +12 lines. Authorship preserved.