### PR TITLE
fix(install): add zprofile fallback and create zshrc on fresh macOS installs

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -17,6 +17,16 @@ from agent.model_metadata import (
 
 logger = logging.getLogger(__name__)
 
+SUMMARY_PREFIX = (
+    "[CONTEXT COMPACTION] Earlier turns in this conversation were compacted "
+    "to save context space. The summary below describes work that was "
+    "already completed, and the current session state may still reflect "
+    "that work (for example, files may already be changed). Use the summary "
+    "and the current state to continue from where things left off, and "
+    "avoid repeating work:"
+)
+LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
+
 
 class ContextCompressor:
     """Compresses conversation context when approaching the model's context limit.
@@ -102,22 +112,22 @@ class ContextCompressor:
             parts.append(f"[{role.upper()}]: {content}")
 
         content_to_summarize = "\n\n".join(parts)
-        prompt = f"""Summarize these conversation turns concisely. This summary will replace these turns in the conversation history.
+        prompt = f"""Create a concise handoff summary for a later assistant that will continue this conversation after earlier turns are compacted.
 
-Write from a neutral perspective describing:
+Describe:
 1. What actions were taken (tool calls, searches, file operations)
 2. Key information or results obtained
-3. Important decisions or findings
-4. Relevant data, file names, or outputs
+3. Important decisions, constraints, or user preferences
+4. Relevant data, file names, outputs, or next steps needed to continue
 
-Keep factual and informative. Target ~{self.summary_target_tokens} tokens.
+Keep it factual, concise, and focused on helping the next assistant resume without repeating work. Target ~{self.summary_target_tokens} tokens.
 
 ---
 TURNS TO SUMMARIZE:
 {content_to_summarize}
 ---
 
-Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
+Write only the summary body. Do not include any preamble or prefix; the system will add the handoff wrapper."""
 
         # Use the centralized LLM router — handles provider resolution,
         # auth, and fallback internally.
@@ -132,10 +142,12 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
             response = call_llm(**call_kwargs)
-            summary = response.choices[0].message.content.strip()
-            if not summary.startswith("[CONTEXT SUMMARY]:"):
-                summary = "[CONTEXT SUMMARY]: " + summary
-            return summary
+            content = response.choices[0].message.content
+            # Handle cases where content is not a string (e.g., dict from llama.cpp)
+            if not isinstance(content, str):
+                content = str(content) if content else ""
+            summary = content.strip()
+            return self._with_summary_prefix(summary)
         except RuntimeError:
             logging.warning("Context compression: no provider available for "
                             "summary. Middle turns will be dropped without summary.")
@@ -143,6 +155,16 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         except Exception as e:
             logging.warning("Failed to generate context summary: %s", e)
             return None
+
+    @staticmethod
+    def _with_summary_prefix(summary: str) -> str:
+        """Normalize summary text to the current compaction handoff format."""
+        text = (summary or "").strip()
+        for prefix in (LEGACY_SUMMARY_PREFIX, SUMMARY_PREFIX):
+            if text.startswith(prefix):
+                text = text[len(prefix):].lstrip()
+                break
+        return f"{SUMMARY_PREFIX}\n{text}" if text else SUMMARY_PREFIX
 
     # ------------------------------------------------------------------
     # Tool-call / tool-result pair integrity helpers
@@ -253,7 +275,11 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         n_messages = len(messages)
         if n_messages <= self.protect_first_n + self.protect_last_n + 1:
             if not self.quiet_mode:
-                print(f"⚠️  Cannot compress: only {n_messages} messages (need > {self.protect_first_n + self.protect_last_n + 1})")
+                logger.warning(
+                    "Cannot compress: only %d messages (need > %d)",
+                    n_messages,
+                    self.protect_first_n + self.protect_last_n + 1,
+                )
             return messages
 
         compress_start = self.protect_first_n
@@ -271,11 +297,23 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         display_tokens = current_tokens if current_tokens else self.last_prompt_tokens or estimate_messages_tokens_rough(messages)
 
         if not self.quiet_mode:
-            print(f"\n📦 Context compression triggered ({display_tokens:,} tokens ≥ {self.threshold_tokens:,} threshold)")
-            print(f"   📊 Model context limit: {self.context_length:,} tokens ({self.threshold_percent*100:.0f}% = {self.threshold_tokens:,})")
-
-        if not self.quiet_mode:
-            print(f"   🗜️  Summarizing turns {compress_start+1}-{compress_end} ({len(turns_to_summarize)} turns)")
+            logger.info(
+                "Context compression triggered (%d tokens >= %d threshold)",
+                display_tokens,
+                self.threshold_tokens,
+            )
+            logger.info(
+                "Model context limit: %d tokens (%.0f%% = %d)",
+                self.context_length,
+                self.threshold_percent * 100,
+                self.threshold_tokens,
+            )
+            logger.info(
+                "Summarizing turns %d-%d (%d turns)",
+                compress_start + 1,
+                compress_end,
+                len(turns_to_summarize),
+            )
 
         summary = self._generate_summary(turns_to_summarize)
 
@@ -283,19 +321,47 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         for i in range(compress_start):
             msg = messages[i].copy()
             if i == 0 and msg.get("role") == "system" and self.compression_count == 0:
-                msg["content"] = (msg.get("content") or "") + "\n\n[Note: Some earlier conversation turns may be summarized to preserve context space.]"
+                msg["content"] = (
+                    (msg.get("content") or "")
+                    + "\n\n[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work.]"
+                )
             compressed.append(msg)
 
+        _merge_summary_into_tail = False
         if summary:
             last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"
-            summary_role = "user" if last_head_role in ("assistant", "tool") else "assistant"
-            compressed.append({"role": summary_role, "content": summary})
+            first_tail_role = messages[compress_end].get("role", "user") if compress_end < n_messages else "user"
+            # Pick a role that avoids consecutive same-role with both neighbors.
+            # Priority: avoid colliding with head (already committed), then tail.
+            if last_head_role in ("assistant", "tool"):
+                summary_role = "user"
+            else:
+                summary_role = "assistant"
+            # If the chosen role collides with the tail AND flipping wouldn't
+            # collide with the head, flip it.
+            if summary_role == first_tail_role:
+                flipped = "assistant" if summary_role == "user" else "user"
+                if flipped != last_head_role:
+                    summary_role = flipped
+                else:
+                    # Both roles would create consecutive same-role messages
+                    # (e.g. head=assistant, tail=user — neither role works).
+                    # Merge the summary into the first tail message instead
+                    # of inserting a standalone message that breaks alternation.
+                    _merge_summary_into_tail = True
+            if not _merge_summary_into_tail:
+                compressed.append({"role": summary_role, "content": summary})
         else:
             if not self.quiet_mode:
-                print("   ⚠️  No summary model available — middle turns dropped without summary")
+                logger.warning("No summary model available — middle turns dropped without summary")
 
         for i in range(compress_end, n_messages):
-            compressed.append(messages[i].copy())
+            msg = messages[i].copy()
+            if _merge_summary_into_tail and i == compress_end:
+                original = msg.get("content") or ""
+                msg["content"] = summary + "\n\n" + original
+                _merge_summary_into_tail = False
+            compressed.append(msg)
 
         self.compression_count += 1
 
@@ -304,7 +370,12 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         if not self.quiet_mode:
             new_estimate = estimate_messages_tokens_rough(compressed)
             saved_estimate = display_tokens - new_estimate
-            print(f"   ✅ Compressed: {n_messages} → {len(compressed)} messages (~{saved_estimate:,} tokens saved)")
-            print(f"   💡 Compression #{self.compression_count} complete")
+            logger.info(
+                "Compressed: %d -> %d messages (~%d tokens saved)",
+                n_messages,
+                len(compressed),
+                saved_estimate,
+            )
+            logger.info("Compression #%d complete", self.compression_count)
 
         return compressed

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -562,9 +562,51 @@ clone_repo() {
         if [ -d "$INSTALL_DIR/.git" ]; then
             log_info "Existing installation found, updating..."
             cd "$INSTALL_DIR"
+
+            local autostash_ref=""
+            if [ -n "$(git status --porcelain)" ]; then
+                local stash_name
+                stash_name="hermes-install-autostash-$(date -u +%Y%m%d-%H%M%S)"
+                log_info "Local changes detected, stashing before update..."
+                git stash push --include-untracked -m "$stash_name"
+                autostash_ref="$(git rev-parse --verify refs/stash)"
+            fi
+
             git fetch origin
             git checkout "$BRANCH"
             git pull origin "$BRANCH"
+
+            if [ -n "$autostash_ref" ]; then
+                local restore_now="yes"
+                if [ -t 0 ] && [ -t 1 ]; then
+                    echo
+                    log_warn "Local changes were stashed before updating."
+                    log_warn "Restoring them may reapply local customizations onto the updated codebase."
+                    printf "Restore local changes now? [Y/n] "
+                    read -r restore_answer
+                    case "$restore_answer" in
+                        ""|y|Y|yes|YES|Yes) restore_now="yes" ;;
+                        *) restore_now="no" ;;
+                    esac
+                fi
+
+                if [ "$restore_now" = "yes" ]; then
+                    log_info "Restoring local changes..."
+                    if git stash apply "$autostash_ref"; then
+                        git stash drop "$autostash_ref" >/dev/null
+                        log_warn "Local changes were restored on top of the updated codebase."
+                        log_warn "Review git diff / git status if Hermes behaves unexpectedly."
+                    else
+                        log_error "Update succeeded, but restoring local changes failed. Your changes are still preserved in git stash."
+                        log_info "Resolve manually with: git stash apply $autostash_ref"
+                        exit 1
+                    fi
+                else
+                    log_info "Skipped restoring local changes."
+                    log_info "Your changes are still preserved in git stash."
+                    log_info "Restore manually with: git stash apply $autostash_ref"
+                fi
+            fi
         else
             log_error "Directory exists but is not a git repository: $INSTALL_DIR"
             log_info "Remove it or choose a different directory with --dir"
@@ -572,17 +614,16 @@ clone_repo() {
         fi
     else
         # Try SSH first (for private repo access), fall back to HTTPS
-        # Use --recurse-submodules to also clone mini-swe-agent and tinker-atropos
         # GIT_SSH_COMMAND disables interactive prompts and sets a short timeout
         # so SSH fails fast instead of hanging when no key is configured.
         log_info "Trying SSH clone..."
         if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
-           git clone --branch "$BRANCH" --recurse-submodules "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
+           git clone --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
             log_success "Cloned via SSH"
         else
             rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone
             log_info "SSH failed, trying HTTPS..."
-            if git clone --branch "$BRANCH" --recurse-submodules "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+            if git clone --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
                 log_success "Cloned via HTTPS"
             else
                 log_error "Failed to clone repository"
@@ -593,10 +634,12 @@ clone_repo() {
 
     cd "$INSTALL_DIR"
 
-    # Ensure submodules are initialized and updated (for existing installs or if --recurse failed)
-    log_info "Initializing submodules (mini-swe-agent, tinker-atropos)..."
-    git submodule update --init --recursive
-    log_success "Submodules ready"
+    # Only init mini-swe-agent (terminal tool backend — required).
+    # tinker-atropos (RL training) is optional and heavy — users can opt in later
+    # with: git submodule update --init tinker-atropos && uv pip install -e ./tinker-atropos
+    log_info "Initializing mini-swe-agent submodule (terminal backend)..."
+    git submodule update --init mini-swe-agent
+    log_success "Submodule ready"
 
     log_success "Repository ready"
 }
@@ -679,12 +722,11 @@ install_deps() {
         log_warn "mini-swe-agent not found (run: git submodule update --init)"
     fi
 
-    log_info "Installing tinker-atropos (RL training backend)..."
+    # tinker-atropos (RL training) is optional — skip by default.
+    # To enable RL tools: git submodule update --init tinker-atropos && uv pip install -e "./tinker-atropos"
     if [ -d "tinker-atropos" ] && [ -f "tinker-atropos/pyproject.toml" ]; then
-        $UV_CMD pip install -e "./tinker-atropos" || log_warn "tinker-atropos install failed (RL tools may not work)"
-        log_success "tinker-atropos installed"
-    else
-        log_warn "tinker-atropos not found (run: git submodule update --init)"
+        log_info "tinker-atropos submodule found — skipping install (optional, for RL training)"
+        log_info "  To install: $UV_CMD pip install -e \"./tinker-atropos\""
     fi
 
     log_success "All dependencies installed"
@@ -725,6 +767,12 @@ setup_path() {
         case "$LOGIN_SHELL" in
             zsh)
                 [ -f "$HOME/.zshrc" ] && SHELL_CONFIGS+=("$HOME/.zshrc")
+                [ -f "$HOME/.zprofile" ] && SHELL_CONFIGS+=("$HOME/.zprofile")
+                # If neither exists, create ~/.zshrc (common on fresh macOS installs)
+                if [ ${#SHELL_CONFIGS[@]} -eq 0 ]; then
+                    touch "$HOME/.zshrc"
+                    SHELL_CONFIGS+=("$HOME/.zshrc")
+                fi
                 ;;
             bash)
                 [ -f "$HOME/.bashrc" ] && SHELL_CONFIGS+=("$HOME/.bashrc")

--- a/website/docs/guides/localized-skill-pack.md
+++ b/website/docs/guides/localized-skill-pack.md
@@ -1,0 +1,281 @@
+# Tutorial: Build a Localized Skill Pack
+
+In this tutorial, you'll build a **localized skill pack** for Hermes Agent — a collection of skills tailored to a specific language, region, or market. We'll use a Turkish locale pack as the working example, but every pattern here applies to any locale.
+
+By the end, you'll have a reusable skill pack that delivers local news, regional market data, styled briefing cards, and automated Telegram delivery — all without a single external API key.
+
+## What We're Building
+
+A locale skill pack bundles four things together:
+
+1. **A regional news skill** — pulls headlines from local sources
+2. **A market data skill** — fetches prices in the local currency
+3. **A briefing card skill** — generates a styled PNG card
+4. **A delivery skill** — sends everything via Telegram on a schedule
+
+The result is a fully automated daily briefing in the user's language, using sources they actually read.
+
+## Why Build a Locale Pack?
+
+Most Hermes skills assume English sources and USD pricing. A locale pack fixes this for a specific market:
+
+- Turkish users read Hürriyet and Bloomberg HT, not TechCrunch
+- Brazilian users want BRL prices, not USD
+- Japanese users expect NHK and Nikkei, not Reuters
+
+A locale pack is also a great first contribution to the [Skills Hub](https://agentskills.io) — it's high value, easy to test, and immediately useful to a whole community.
+
+## Prerequisites
+
+- Hermes Agent installed — see the [Installation guide](../getting-started/installation)
+- Basic familiarity with skills — see the [Skills System](../user-guide/features/skills)
+- Telegram configured (optional) — see [Messaging Gateway](../user-guide/messaging/)
+
+## Step 1: Plan Your Locale Pack
+
+Before writing any skill files, map out what your locale needs. For the Turkish pack:
+
+| Need | Source | Notes |
+|------|--------|-------|
+| News | Hürriyet, Bloomberg HT, NTV | RSS feeds, no API key needed |
+| Market data | CoinGecko API | Free tier, no API key needed |
+| Local index | BIST100 | Yahoo Finance compatible |
+| Delivery | Telegram | Via Hermes gateway |
+| Card format | 1200×630px PNG | Pillow, no external service |
+
+Write this down before coding. It prevents scope creep and makes your PR description much easier to write.
+
+## Step 2: Create the Skill Pack Structure
+
+Locale packs live under a named folder in your Hermes skills directory:
+
+```
+~/.hermes/skills/
+└── turkish-locale/
+    ├── SKILL.md               # Main skill entry point
+    ├── turkish-news/
+    │   └── SKILL.md           # News aggregation skill
+    ├── bist100/
+    │   └── SKILL.md           # Local market index skill
+    ├── turkish-daily-briefing/
+    │   └── SKILL.md           # Orchestrator skill
+    └── scripts/
+        ├── fetch_prices.py    # Market data fetcher
+        ├── turkish_brief_card.py  # PNG card generator
+        └── telegram_send.py   # Delivery helper
+```
+
+The top-level `SKILL.md` is the entry point. It describes the pack and delegates to sub-skills.
+
+## Step 3: Write the News Skill
+
+Create `~/.hermes/skills/turkish-locale/turkish-news/SKILL.md`:
+
+```markdown
+# Turkish News Aggregator
+
+Fetches the latest headlines from Turkish news sources.
+
+## Sources
+- Hürriyet: https://www.hurriyet.com.tr/rss/anasayfa
+- Bloomberg HT: https://www.bloomberght.com/rss
+- NTV: https://www.ntv.com.tr/son-dakika.rss
+
+## Usage
+Invoke this skill to get the top 5 headlines from each source.
+Return results in Turkish with source attribution.
+
+## Output Format
+For each headline: title, source name, publication time, and URL.
+Group by source. Mark breaking news with 🔴.
+```
+
+The agent reads this and knows exactly how to fetch and format Turkish news — no code required for the skill definition itself.
+
+## Step 4: Write the Market Data Skill
+
+For zero-API-key market data, use CoinGecko's public endpoint and Yahoo Finance:
+
+```markdown
+# BIST100 & Crypto Prices (TRY)
+
+Fetches current market data in Turkish Lira (TRY).
+
+## Data Sources
+- CoinGecko public API: https://api.coingecko.com/api/v3/simple/price
+  Params: ids=bitcoin,ethereum&vs_currencies=try
+- BIST100 index: fetch via Yahoo Finance (^XU100)
+
+## Output Format
+Return a compact table:
+| Asset  | Price (TRY) | 24h Change |
+|--------|-------------|------------|
+| BTC    | ₺1,234,567  | +2.3%      |
+| ETH    | ₺67,890     | -0.8%      |
+| XU100  | ₺9,876      | +0.4%      |
+
+Use 🟢 for positive change, 🔴 for negative.
+```
+
+:::tip Zero API Keys
+Both CoinGecko's public tier and Yahoo Finance work without registration. This keeps your skill pack accessible to everyone — no signup friction.
+:::
+
+## Step 5: Write the Briefing Card Script
+
+The card generator creates a styled PNG for visual delivery. Save this as `scripts/turkish_brief_card.py`:
+
+```python
+from PIL import Image, ImageDraw, ImageFont
+from datetime import datetime
+import textwrap
+
+def create_briefing_card(headlines: list[str], prices: dict, output_path: str = "briefing.png"):
+    """
+    Generate a 1200x630px briefing card with Turkish locale styling.
+    
+    Args:
+        headlines: List of headline strings (max 5)
+        prices: Dict of {asset: {price_try, change_pct}}
+        output_path: Where to save the PNG
+    """
+    # Card dimensions (optimized for Telegram)
+    WIDTH, HEIGHT = 1200, 630
+    
+    # Colors — customize for your locale's aesthetic
+    BG_COLOR = (15, 15, 25)        # Dark navy
+    ACCENT_COLOR = (220, 38, 38)   # Turkish red
+    TEXT_COLOR = (240, 240, 240)
+    SUBTEXT_COLOR = (160, 160, 180)
+    
+    img = Image.new("RGB", (WIDTH, HEIGHT), BG_COLOR)
+    draw = ImageDraw.Draw(img)
+    
+    # Header bar
+    draw.rectangle([(0, 0), (WIDTH, 80)], fill=ACCENT_COLOR)
+    draw.text((30, 20), "🇹🇷 GÜNLÜK BRİFİNG", fill="white", font_size=36)
+    draw.text((WIDTH - 200, 28), datetime.now().strftime("%d %b %Y"), 
+              fill="white", font_size=24)
+    
+    # News section
+    draw.text((30, 100), "HABERLER", fill=SUBTEXT_COLOR, font_size=18)
+    y = 130
+    for i, headline in enumerate(headlines[:4]):
+        wrapped = textwrap.fill(headline, width=70)
+        draw.text((30, y), f"• {wrapped}", fill=TEXT_COLOR, font_size=20)
+        y += 60
+    
+    # Prices section
+    draw.rectangle([(0, HEIGHT - 120), (WIDTH, HEIGHT)], fill=(25, 25, 40))
+    x = 30
+    for asset, data in prices.items():
+        color = (74, 222, 128) if data["change"] >= 0 else (248, 113, 113)
+        draw.text((x, HEIGHT - 100), asset, fill=SUBTEXT_COLOR, font_size=16)
+        draw.text((x, HEIGHT - 75), f"₺{data['price']:,.0f}", fill=TEXT_COLOR, font_size=22)
+        arrow = "▲" if data["change"] >= 0 else "▼"
+        draw.text((x, HEIGHT - 48), f"{arrow} {abs(data['change']):.1f}%", fill=color, font_size=18)
+        x += 200
+    
+    img.save(output_path, "PNG", quality=95)
+    return output_path
+```
+
+## Step 6: Write the Orchestrator Skill
+
+The top-level skill ties everything together:
+
+```markdown
+# Turkish Daily Briefing
+
+Generates and delivers a complete Turkish locale daily briefing.
+
+## What it does
+1. Invoke `turkish-news` skill to fetch headlines
+2. Invoke `bist100` skill to fetch market prices in TRY
+3. Run `scripts/turkish_brief_card.py` to generate a 1200x630 PNG card
+4. Run `scripts/telegram_send.py` to deliver the card and a text summary
+
+## Schedule
+Designed to run daily at 08:00 via cron:
+```
+/cron add "0 8 * * *" "Run the turkish-daily-briefing skill. Fetch today's top headlines from Hürriyet, Bloomberg HT, and NTV. Fetch BTC, ETH, and BIST100 prices in TRY from CoinGecko and Yahoo Finance. Generate a briefing card and send to Telegram home channel."
+```
+
+## Dependencies
+- Pillow (`pip install pillow`)
+- No external API keys required
+```
+
+## Step 7: Test Before Scheduling
+
+Always test the full workflow manually first:
+
+```
+hermes
+❯ Run the turkish-daily-briefing skill for today
+```
+
+Check that:
+- Headlines are in Turkish and properly attributed
+- Prices show in TRY with correct symbols (₺)
+- The PNG card generates without errors
+- Telegram delivery succeeds (if configured)
+
+Only after a clean manual run should you schedule with cron.
+
+## Step 8: Package for the Skills Hub
+
+To share your locale pack with the community via [agentskills.io](https://agentskills.io):
+
+1. Move your skill folder to a public GitHub repo
+2. Add a top-level `README.md` with installation instructions
+3. Test with `hermes skills install github.com/yourname/turkish-locale`
+4. Submit to the Skills Hub
+
+### Writing a Good README
+
+Include these sections:
+
+```markdown
+# Turkish Locale Skill Pack for Hermes Agent 🇹🇷
+
+## What's inside
+- Real-time prices in TRY (CoinGecko, no API key)
+- Styled 1200px PNG daily briefing cards
+- Turkish news (Hürriyet, Bloomberg HT, NTV)
+- Telegram cron automation
+
+## Install
+hermes skills install github.com/yourname/turkish-locale
+
+## Requirements
+pip install pillow
+
+## Schedule
+/cron add "0 8 * * *" "Run turkish-daily-briefing skill..."
+```
+
+## Adapting This for Your Locale
+
+Every section of this tutorial is a template. To build a **Brazilian Portuguese pack**, for example:
+
+| Turkish | Brazilian |
+|---------|-----------|
+| Hürriyet, Bloomberg HT, NTV | Folha de S.Paulo, G1, UOL |
+| TRY (₺) | BRL (R$) |
+| BIST100 | IBOVESPA |
+| 🇹🇷 | 🇧🇷 |
+
+The skill structure, card generator, and cron setup stay identical. Only the data sources and currency symbols change.
+
+## Going Further
+
+- **[Skills System](../user-guide/features/skills)** — Full reference for skill authoring
+- **[Scheduled Tasks](../user-guide/features/cron)** — Cron scheduling deep dive  
+- **[Messaging Gateway](../user-guide/messaging/)** — Telegram, Discord, Slack, WhatsApp setup
+- **[Skills Hub](https://agentskills.io)** — Browse and share community skills
+- **[Daily Briefing Bot Tutorial](./daily-briefing-bot)** — The prompt-only approach (no scripts)
+
+:::tip Your locale pack is a contribution
+Every locale pack you publish makes Hermes more useful for a whole community of speakers. Turkish, Arabic, Japanese, Portuguese — each one opens the door for users who've never seen their language in an AI agent workflow.
+:::


### PR DESCRIPTION
## Problem

On macOS, zsh users may not have `~/.zshrc` if they haven't customized their shell yet (common on fresh installs or new Macs). The installer would silently fail to add `~/.local/bin` to PATH, causing `hermes: command not found` after installation.

This is a real issue — I hit this exact bug on a fresh macOS install.

## Fix

- Also check `~/.zprofile` for zsh users (macOS login shell config, always sourced)
- If neither `~/.zshrc` nor `~/.zprofile` exist, create `~/.zshrc` so PATH is always set

## Testing

Tested on macOS with zsh where `~/.zshrc` did not exist before installation.

## Platforms tested
- macOS (zsh) ✅