### PR TITLE
fix: extend None-entry guard to tool_calls loops (salvage #2299)

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -128,6 +128,7 @@ def _extract_tool_stats(messages: List[Dict[str, Any]]) -> Dict[str, Dict[str, i
         # Track tool calls from assistant messages
         if msg["role"] == "assistant" and "tool_calls" in msg and msg["tool_calls"]:
             for tool_call in msg["tool_calls"]:
+                if not tool_call or not isinstance(tool_call, dict): continue
                 tool_name = tool_call["function"]["name"]
                 tool_call_id = tool_call["id"]
                 

--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -339,6 +339,7 @@ class MiniSWERunner:
                     
                     # Add tool calls in XML format
                     for tool_call in msg["tool_calls"]:
+                        if not tool_call or not isinstance(tool_call, dict): continue
                         try:
                             arguments = json.loads(tool_call["function"]["arguments"]) \
                                 if isinstance(tool_call["function"]["arguments"], str) \

--- a/run_agent.py
+++ b/run_agent.py
@@ -1618,6 +1618,7 @@ class AIAgent:
                     
                     # Add tool calls wrapped in XML tags
                     for tool_call in msg["tool_calls"]:
+                        if not tool_call or not isinstance(tool_call, dict): continue
                         # Parse arguments - should always succeed since we validate during conversation
                         # but keep try-except as safety net
                         try:
@@ -6771,6 +6772,7 @@ class AIAgent:
                                 if msg.get("role") == "assistant" and msg.get("tool_calls"):
                                     tool_names = []
                                     for tc in msg["tool_calls"]:
+                                        if not tc or not isinstance(tc, dict): continue
                                         fn = tc.get("function", {})
                                         tool_names.append(fn.get("name", "unknown"))
                                     msg["content"] = f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
@@ -6813,6 +6815,7 @@ class AIAgent:
                                     if msg.get("role") == "assistant" and msg.get("tool_calls"):
                                         tool_names = []
                                         for tc in msg["tool_calls"]:
+                                            if not tc or not isinstance(tc, dict): continue
                                             fn = tc.get("function", {})
                                             tool_names.append(fn.get("name", "unknown"))
                                         msg["content"] = f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
@@ -6932,6 +6935,7 @@ class AIAgent:
                             if isinstance(m, dict) and m.get("role") == "tool"
                         }
                         for tc in msg["tool_calls"]:
+                            if not tc or not isinstance(tc, dict): continue
                             if tc["id"] not in answered_ids:
                                 err_msg = {
                                     "role": "tool",


### PR DESCRIPTION
## Summary
Salvage of PR #2299 by @dlkakbs, cherry-picked onto current main.

Extends the None-entry guard pattern from #2209 (anthropic_adapter.py) to the 6 remaining unguarded `tool_calls` iteration sites:

- `run_agent.py` (4 sites): trajectory conversion, empty-content fallback, deeper nesting fallback, error recovery
- `batch_runner.py`: tool stats tracking
- `mini_swe_runner.py`: trajectory conversion

Each site adds `if not tc or not isinstance(tc, dict): continue` to skip None or non-dict entries that can appear from malformed API responses, compression artifacts, or corrupt session replay.

## Verification
- All 5681 tests pass
- Live interactive CLI smoke test: single + parallel tool calls work correctly
- Direct guard tests: 7/7 pass confirming None entries are skipped and valid tool_calls processed

## Credit
Original work by @dlkakbs in #2299. Contributor authorship preserved via cherry-pick.