### PR TITLE
fix: prevent systemd restart storm on gateway connection failure

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -420,6 +420,8 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=600
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -434,7 +436,7 @@ Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=on-failure
-RestartSec=10
+RestartSec=30
 KillMode=mixed
 KillSignal=SIGTERM
 TimeoutStopSec=60
@@ -448,6 +450,8 @@ WantedBy=multi-user.target
     return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network.target
+StartLimitIntervalSec=600
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -457,7 +461,7 @@ Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=on-failure
-RestartSec=10
+RestartSec=30
 KillMode=mixed
 KillSignal=SIGTERM
 TimeoutStopSec=60

--- a/scripts/hermes-gateway
+++ b/scripts/hermes-gateway
@@ -82,13 +82,15 @@ def generate_systemd_unit() -> str:
     return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network.target
+StartLimitIntervalSec=600
+StartLimitBurst=5
 
 [Service]
 Type=simple
 ExecStart={python_path} {script_path} run
 WorkingDirectory={working_dir}
 Restart=on-failure
-RestartSec=10
+RestartSec=30
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## What does this PR do?
 When the gateway fails to connect (e.g. `PrivilegedIntentsRequired` for Discord or missing bot token), systemd's default `RestartSec=10` with no start rate limit causes hundreds of rapid reconnect attempts, flooding logs and potentially triggering platform-side rate limits. This fix adds proper restart throttling to all three unit templates.

## Related Issue

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
   - `StartLimitIntervalSec=600` + `StartLimitBurst=5` moved to `[Unit]` section (correct per systemd spec)
   - `RestartSec`: `10` → `30`
   - Applied to both templates in `hermes_cli/gateway.py` (system + user) and `scripts/hermes-gateway`

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.  Create Discord bot with incorrect permissions
2.  Verify that the service is crash-looping
3.  Apply the fix. the service fails gracefully, without bombarding the Discord API which may lead to the Discord account being blocked.

   **Tests:** 
I've run pytest tests/ -q — 5700 passed, 3 pre-existing unrelated failures

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q — 5700 passed, 3 pre-existing unrelated failures
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) 
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (systemd is Linux-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

