### PR TITLE
fix(install): add zprofile fallback and create zshrc on fresh macOS installs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -772,6 +772,12 @@ setup_path() {
         case "$LOGIN_SHELL" in
             zsh)
                 [ -f "$HOME/.zshrc" ] && SHELL_CONFIGS+=("$HOME/.zshrc")
+                [ -f "$HOME/.zprofile" ] && SHELL_CONFIGS+=("$HOME/.zprofile")
+                # If neither exists, create ~/.zshrc (common on fresh macOS installs)
+                if [ ${#SHELL_CONFIGS[@]} -eq 0 ]; then
+                    touch "$HOME/.zshrc"
+                    SHELL_CONFIGS+=("$HOME/.zshrc")
+                fi
                 ;;
             bash)
                 [ -f "$HOME/.bashrc" ] && SHELL_CONFIGS+=("$HOME/.bashrc")


### PR DESCRIPTION
## Summary

On macOS, zsh users may not have `~/.zshrc` if they haven't customized their shell yet (common on fresh installs). The installer would silently fail to add `~/.local/bin` to PATH, causing `hermes: command not found` after installation.

- Check `~/.zprofile` as fallback for zsh users (macOS login shell config, always sourced)
- Create `~/.zshrc` if neither config file exists

Cherry-picked from PR #2315 by @erhnysr — the other changes in that PR (context compressor, docs tutorial) were either already on main or unrelated.

Closes #2315