### PR TITLE
feat(mcp): expand ${VAR} refs in env and headers

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -801,6 +801,26 @@ class TestBuildSafeEnv:
         assert result["PATH"] == "/usr/bin"
         assert result["MY_CUSTOM_VAR"] == "hello"
 
+    def test_user_env_expands_brace_refs(self):
+        """User env values expand ${VAR} references from the process env."""
+        from tools.mcp_tool import _build_safe_env
+
+        with patch.dict(
+            "os.environ",
+            {"PATH": "/usr/bin", "MCP_TOKEN": "secret123"},
+            clear=True,
+        ):
+            result = _build_safe_env(
+                {
+                    "API_KEY": "${MCP_TOKEN}",
+                    "MISSING": "${NOT_SET}",
+                }
+            )
+
+        assert result["PATH"] == "/usr/bin"
+        assert result["API_KEY"] == "secret123"
+        assert result["MISSING"] == "${NOT_SET}"
+
     def test_user_env_overrides_safe(self):
         """User env can override safe defaults."""
         from tools.mcp_tool import _build_safe_env
@@ -923,6 +943,49 @@ class TestHTTPConfig:
             with patch("tools.mcp_tool._MCP_HTTP_AVAILABLE", False):
                 with pytest.raises(ImportError, match="HTTP transport"):
                     await server._run_http(config)
+
+        asyncio.run(_test())
+
+    def test_run_http_expands_header_env_refs(self):
+        """HTTP headers expand ${VAR} references before connecting."""
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("remote")
+        config = {
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer ${API_KEY}"},
+        }
+
+        mock_http_cm = MagicMock()
+        mock_http_cm.__aenter__ = AsyncMock(
+            return_value=(MagicMock(), MagicMock(), MagicMock())
+        )
+        mock_http_cm.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+
+        mock_cs_cm = MagicMock()
+        mock_cs_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_cs_cm.__aexit__ = AsyncMock(return_value=False)
+
+        async def fake_discover(self):
+            self._shutdown_event.set()
+
+        async def _test():
+            with patch("tools.mcp_tool._MCP_HTTP_AVAILABLE", True), \
+                 patch("tools.mcp_tool.streamablehttp_client", return_value=mock_http_cm) as mock_http, \
+                 patch("tools.mcp_tool.ClientSession", return_value=mock_cs_cm), \
+                 patch.dict("os.environ", {"API_KEY": "secret123"}, clear=True), \
+                 patch.object(MCPServerTask, "_discover_tools", new=fake_discover):
+                await server._run_http(config)
+
+                mock_http.assert_called_once_with(
+                    "https://example.com/mcp",
+                    headers={"Authorization": "Bearer secret123"},
+                    timeout=60.0,
+                )
+                mock_session.initialize.assert_called_once()
 
         asyncio.run(_test())
 
@@ -2750,3 +2813,81 @@ class TestMCPSelectiveToolLoading:
 
         assert connect_called == []
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _expand_env_vars
+# ---------------------------------------------------------------------------
+
+class TestExpandEnvVars:
+    """Tests for _expand_env_vars() environment variable expansion."""
+
+    def test_expands_brace_syntax(self):
+        """${VAR} syntax is expanded when variable exists."""
+        from tools.mcp_tool import _expand_env_vars
+
+        with patch.dict("os.environ", {"MY_API_KEY": "secret123"}, clear=False):
+            result = _expand_env_vars("Bearer ${MY_API_KEY}")
+            assert result == "Bearer secret123"
+
+    def test_preserves_missing_vars(self):
+        """${VAR} is preserved literally when variable is missing."""
+        from tools.mcp_tool import _expand_env_vars
+
+        # Ensure the var doesn't exist
+        with patch.dict("os.environ", {}, clear=True):
+            result = _expand_env_vars("Bearer ${NONEXISTENT_KEY}")
+            assert result == "Bearer ${NONEXISTENT_KEY}"
+
+    def test_ignores_bare_dollar_syntax(self):
+        """Bare $VAR syntax is NOT expanded (opt-in safety)."""
+        from tools.mcp_tool import _expand_env_vars
+
+        with patch.dict("os.environ", {"VAR": "value"}, clear=False):
+            result = _expand_env_vars("$VAR")
+            assert result == "$VAR"  # unchanged
+
+    def test_expands_dict_values(self):
+        """Dict values are recursively expanded."""
+        from tools.mcp_tool import _expand_env_vars
+
+        with patch.dict("os.environ", {"API_KEY": "mykey"}, clear=False):
+            result = _expand_env_vars({
+                "Authorization": "Bearer ${API_KEY}",
+                "X-Other": "static"
+            })
+            assert result == {"Authorization": "Bearer mykey", "X-Other": "static"}
+
+    def test_expands_list_items(self):
+        """List items are recursively expanded."""
+        from tools.mcp_tool import _expand_env_vars
+
+        with patch.dict("os.environ", {"HOST": "example.com"}, clear=False):
+            result = _expand_env_vars(["${HOST}", "static"])
+            assert result == ["example.com", "static"]
+
+    def test_nested_structures(self):
+        """Nested dicts and lists are expanded recursively."""
+        from tools.mcp_tool import _expand_env_vars
+
+        with patch.dict("os.environ", {"KEY1": "val1", "KEY2": "val2"}, clear=False):
+            result = _expand_env_vars({
+                "headers": {"Auth": "${KEY1}"},
+                "urls": ["${KEY2}", "static"]
+            })
+            assert result == {"headers": {"Auth": "val1"}, "urls": ["val2", "static"]}
+
+    def test_non_string_passthrough(self):
+        """Non-string values pass through unchanged."""
+        from tools.mcp_tool import _expand_env_vars
+
+        result = _expand_env_vars({"count": 42, "enabled": True, "ratio": 3.14})
+        assert result == {"count": 42, "enabled": True, "ratio": 3.14}
+
+    def test_multiple_vars_in_one_string(self):
+        """Multiple ${VAR} occurrences in one string are all expanded."""
+        from tools.mcp_tool import _expand_env_vars
+
+        with patch.dict("os.environ", {"A": "1", "B": "2"}, clear=False):
+            result = _expand_env_vars("${A}-${B}-${A}")
+            assert result == "1-2-1"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -23,11 +23,13 @@ Example config::
         command: "npx"
         args: ["-y", "@modelcontextprotocol/server-github"]
         env:
-          GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
+          # Use ${VAR} syntax to reference environment variables
+          GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_TOKEN}"
       remote_api:
         url: "https://my-mcp-server.example.com/mcp"
         headers:
-          Authorization: "Bearer sk-..."
+          # ${VAR} syntax works in headers too
+          Authorization: "Bearer ${MY_API_KEY}"
         timeout: 180
       analysis:
         command: "npx"
@@ -46,6 +48,7 @@ Features:
     - Stdio transport (command + args) and HTTP/StreamableHTTP transport (url)
     - Automatic reconnection with exponential backoff (up to 5 retries)
     - Environment variable filtering for stdio subprocesses (security)
+    - ${VAR} expansion in env and headers for referencing secrets from environment
     - Credential stripping in error messages returned to the LLM
     - Configurable per-server timeouts for tool calls and connections
     - Thread-safe architecture with dedicated background event loop
@@ -158,14 +161,63 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
 
     This prevents accidentally leaking secrets like API keys, tokens, or
     credentials to MCP server subprocesses.
+
+    Environment variable expansion (${VAR}) is applied to user_env values
+    so configs can reference secrets without hardcoding them.
     """
     env = {}
     for key, value in os.environ.items():
         if key in _SAFE_ENV_KEYS or key.startswith("XDG_"):
             env[key] = value
     if user_env:
-        env.update(user_env)
+        # Expand ${VAR} references in user-provided env values
+        expanded_env = _expand_env_vars(user_env)
+        env.update(expanded_env)
     return env
+
+
+def _expand_env_vars(obj):
+    """Recursively expand ${VAR} environment variable references in strings.
+
+    This enables config.yaml to reference environment variables using the
+    standard ${VAR} syntax, e.g.:
+
+        headers:
+          Authorization: "Bearer ${MY_API_KEY}"
+        env:
+          API_KEY: "${MY_API_KEY}"
+
+    Security considerations:
+    - Only ${VAR} syntax is expanded (explicit opt-in), not $VAR
+    - If VAR is not set, the literal ${VAR} is preserved (aids debugging)
+    - Expanded values are never logged to prevent credential leakage
+    - This should NOT be used on command/args to prevent injection attacks
+
+    Args:
+        obj: A string, dict, list, or other value to process.
+
+    Returns:
+        A copy of obj with all ${VAR} references expanded in string values.
+    """
+    if isinstance(obj, str):
+        # Only expand ${VAR} syntax, leave unmatched refs as-is
+        def replace_var(match):
+            var_name = match.group(1)
+            value = os.environ.get(var_name)
+            if value is None:
+                # Preserve literal ${VAR} if not found - aids debugging
+                return match.group(0)
+            return value
+        return _ENV_VAR_PATTERN.sub(replace_var, obj)
+    elif isinstance(obj, dict):
+        return {k: _expand_env_vars(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_expand_env_vars(item) for item in obj]
+    return obj
+
+
+# Pattern for ${VAR} environment variable references (not $VAR)
+_ENV_VAR_PATTERN = re.compile(r'\$\{(\w+)\}')
 
 
 def _sanitize_error(text: str) -> str:
@@ -750,6 +802,10 @@ class MCPServerTask:
         url = config["url"]
         headers = config.get("headers")
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+
+        # Expand ${VAR} references in headers so configs can reference secrets
+        if headers:
+            headers = _expand_env_vars(headers)
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
         async with streamablehttp_client(

--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -102,7 +102,7 @@ mcp_servers:
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "***"
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_TOKEN}"
     tools:
       include: [list_issues, create_issue, search_code]
 ```
@@ -116,7 +116,7 @@ mcp_servers:
   stripe:
     url: "https://mcp.stripe.com"
     headers:
-      Authorization: "Bearer ***"
+      Authorization: "Bearer ${STRIPE_API_KEY}"
     tools:
       exclude: [delete_customer, refund_payment]
 ```

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -19,11 +19,13 @@ mcp_servers:
   <server_name>:
     command: "..."      # stdio servers
     args: []
-    env: {}
+    env:
+      API_KEY: "${MY_API_KEY}"
 
     # OR
     url: "..."          # HTTP servers
-    headers: {}
+    headers:
+      Authorization: "Bearer ${MY_API_KEY}"
 
     enabled: true
     timeout: 120
@@ -41,9 +43,9 @@ mcp_servers:
 |---|---|---|---|
 | `command` | string | stdio | Executable to launch |
 | `args` | list | stdio | Arguments for the subprocess |
-| `env` | mapping | stdio | Environment passed to the subprocess |
+| `env` | mapping | stdio | Environment passed to the subprocess; `${VAR}` references are expanded from Hermes' process environment |
 | `url` | string | HTTP | Remote MCP endpoint |
-| `headers` | mapping | HTTP | Headers for remote server requests |
+| `headers` | mapping | HTTP | Headers for remote server requests; `${VAR}` references are expanded from Hermes' process environment |
 | `enabled` | bool | both | Skip the server entirely when false |
 | `timeout` | number | both | Tool call timeout |
 | `connect_timeout` | number | both | Initial connection timeout |

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -64,7 +64,7 @@ mcp_servers:
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "***"
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_TOKEN}"
 ```
 
 Use stdio servers when:
@@ -81,7 +81,7 @@ mcp_servers:
   remote_api:
     url: "https://mcp.example.com/mcp"
     headers:
-      Authorization: "Bearer ***"
+      Authorization: "Bearer ${MCP_API_KEY}"
 ```
 
 Use HTTP servers when:
@@ -99,9 +99,9 @@ Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
 |---|---|---|
 | `command` | string | Executable for a stdio MCP server |
 | `args` | list | Arguments for the stdio server |
-| `env` | mapping | Environment variables passed to the stdio server |
+| `env` | mapping | Environment variables passed to the stdio server (`${VAR}` references are expanded from Hermes' process environment) |
 | `url` | string | HTTP MCP endpoint |
-| `headers` | mapping | HTTP headers for remote servers |
+| `headers` | mapping | HTTP headers for remote servers (`${VAR}` references are expanded from Hermes' process environment) |
 | `timeout` | number | Tool call timeout |
 | `connect_timeout` | number | Initial connection timeout |
 | `enabled` | bool | If `false`, Hermes skips the server entirely |
@@ -123,7 +123,7 @@ mcp_servers:
   company_api:
     url: "https://mcp.internal.example.com"
     headers:
-      Authorization: "Bearer ***"
+      Authorization: "Bearer ${INTERNAL_MCP_API_KEY}"
 ```
 
 ## How Hermes registers MCP tools
@@ -191,7 +191,7 @@ mcp_servers:
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "***"
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_TOKEN}"
     tools:
       include: [create_issue, list_issues]
 ```

--- a/website/docs/user-guide/messaging/open-webui.md
+++ b/website/docs/user-guide/messaging/open-webui.md
@@ -10,13 +10,9 @@ description: "Connect Open WebUI to Hermes Agent via the OpenAI-compatible API s
 
 ## Architecture
 
-```
-┌──────────────────┐    POST /v1/chat/completions    ┌──────────────────────┐
-│   Open WebUI     │ ──────────────────────────────► │  hermes-agent        │
-│   (browser UI)   │    SSE streaming response       │  gateway API server  │
-│   port 3000      │ ◄────────────────────────────── │  port 8642           │
-└──────────────────┘                                  └──────────────────────┘
-```
+- Open WebUI runs as the browser UI on port 3000
+- It sends `POST /v1/chat/completions` requests to Hermes Agent's gateway API server on port 8642
+- Hermes streams responses back to Open WebUI over SSE
 
 Open WebUI connects to Hermes Agent's API server just like it would connect to OpenAI. Your agent handles the requests with its full toolset — terminal, file operations, web search, memory, skills — and returns the final response.
 


### PR DESCRIPTION
## Summary

- add `${VAR}` expansion for MCP stdio `env` values and HTTP `headers`
- keep the feature narrowly scoped and explicit: bare `$VAR` is not expanded, and missing vars stay literal
- add focused test coverage and update MCP docs/examples to show the safer pattern

## Motivation

MCP config currently pushes users toward hardcoding secrets in `~/.hermes/config.yaml` for both stdio server env and HTTP headers.

This change lets users reference secrets from the existing process environment while keeping the behavior explicit and predictable.

Example:

```yaml
env:
  GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_TOKEN}"
headers:
  Authorization: "Bearer ${MY_API_KEY}"
```

I checked open/closed issues before putting this up and didn’t find a direct existing issue for this narrower MCP config interpolation behavior.

## Changes

- add `_expand_env_vars()` to recursively expand `${VAR}` in strings, dicts, and lists
- apply expansion in `_build_safe_env(user_env)` for stdio MCP server `env`
- apply expansion in `MCPServerTask._run_http()` for HTTP MCP server `headers`
- intentionally do not expand command/args
- intentionally do not expand bare `$VAR`
- preserve missing `${VAR}` references literally to aid debugging
- update MCP docs/examples to use env-backed secrets instead of hardcoded placeholders
- add tests for helper behavior, stdio env integration, and HTTP header integration
- include one tiny follow-up docs-only fix to remove an invalid pre-existing ASCII diagram in `open-webui.md` so `docs-site-checks` can pass

## Test Plan

- [x] `./venv/bin/python -m pytest tests/tools/test_mcp_tool.py -n 0 -q`
- [x] `git diff --check`
- [x] verified updated MCP docs/examples reflect the new behavior
- [x] fixed the docs lint failure reported by CI (`website/docs/user-guide/messaging/open-webui.md`)

## Notes for Reviewers

- scope is intentionally narrow: only `env` and `headers`
- expansion is explicit opt-in via `${VAR}` syntax only
- missing vars are preserved rather than silently replaced with empty strings
- command/args are left untouched to avoid surprising behavior at process-launch boundaries
- the `open-webui.md` change is a separate docs-lint cleanup commit; the MCP behavior change itself is isolated in the earlier commit(s)
