### PR TITLE
feat(providers): add Featherless as LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,15 @@ OPENCODE_GO_API_KEY=
 # OPENCODE_GO_BASE_URL=https://opencode.ai/zen/go/v1  # Override default base URL
 
 # =============================================================================
+# LLM PROVIDER (Featherless)
+# =============================================================================
+# Featherless provides serverless inference for 30,000+ open-source models
+# OpenAI-compatible API with flat-rate unlimited tokens
+# Get your key at: https://featherless.ai/account/api-keys
+FEATHERLESS_API_KEY=
+# FEATHERLESS_BASE_URL=https://api.featherless.ai/v1  # Override default base URL
+
+# =============================================================================
 # TOOL API KEYS
 # =============================================================================
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -62,6 +62,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
+    "featherless": "MiniMaxAI/MiniMax-M2.5",
 }
 
 # OpenRouter app attribution headers

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -212,6 +212,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("KILOCODE_API_KEY",),
         base_url_env_var="KILOCODE_BASE_URL",
     ),
+    "featherless": ProviderConfig(
+        id="featherless",
+        name="Featherless",
+        auth_type="api_key",
+        inference_base_url="https://api.featherless.ai/v1",
+        api_key_env_vars=("FEATHERLESS_API_KEY",),
+        base_url_env_var="FEATHERLESS_BASE_URL",
+    ),
 }
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -668,6 +668,7 @@ def resolve_provider(
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
+        "featherless-ai": "featherless",
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -197,6 +197,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "qwen3.5-flash",
         "qwen-vl-max",
     ],
+    "featherless": [
+        "Qwen/Qwen2.5-72B-Instruct",
+        "Qwen/Qwen2.5-Coder-32B-Instruct",
+        "NousResearch/Hermes-3-Llama-3.1-70B",
+        "NousResearch/Hermes-3-Llama-3.1-8B",
+        "mistralai/Mistral-Small-24B-Instruct-2501",
+        "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+        "meta-llama/Llama-3.3-70B-Instruct",
+    ],
 }
 
 _PROVIDER_LABELS = {
@@ -216,6 +225,7 @@ _PROVIDER_LABELS = {
     "ai-gateway": "AI Gateway",
     "kilocode": "Kilo Code",
     "alibaba": "Alibaba Cloud (DashScope)",
+    "featherless": "Featherless",
     "custom": "Custom endpoint",
 }
 
@@ -251,6 +261,7 @@ _PROVIDER_ALIASES = {
     "aliyun": "alibaba",
     "qwen": "alibaba",
     "alibaba-cloud": "alibaba",
+    "featherless-ai": "featherless",
 }
 
 

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -44,6 +44,7 @@ class TestProviderRegistry:
         ("minimax-cn", "MiniMax (China)", "api_key"),
         ("ai-gateway", "AI Gateway", "api_key"),
         ("kilocode", "Kilo Code", "api_key"),
+        ("featherless", "Featherless", "api_key"),
     ])
     def test_provider_registered(self, provider_id, name, auth_type):
         assert provider_id in PROVIDER_REGISTRY
@@ -87,6 +88,11 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("KILOCODE_API_KEY",)
         assert pconfig.base_url_env_var == "KILOCODE_BASE_URL"
 
+    def test_featherless_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["featherless"]
+        assert pconfig.api_key_env_vars == ("FEATHERLESS_API_KEY",)
+        assert pconfig.base_url_env_var == "FEATHERLESS_BASE_URL"
+
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
@@ -96,6 +102,7 @@ class TestProviderRegistry:
         assert PROVIDER_REGISTRY["minimax-cn"].inference_base_url == "https://api.minimaxi.com/anthropic"
         assert PROVIDER_REGISTRY["ai-gateway"].inference_base_url == "https://ai-gateway.vercel.sh/v1"
         assert PROVIDER_REGISTRY["kilocode"].inference_base_url == "https://api.kilo.ai/api/gateway"
+        assert PROVIDER_REGISTRY["featherless"].inference_base_url == "https://api.featherless.ai/v1"
 
     def test_oauth_providers_unchanged(self):
         """Ensure we didn't break the existing OAuth providers."""
@@ -116,6 +123,7 @@ PROVIDER_ENV_VARS = (
     "KIMI_API_KEY", "KIMI_BASE_URL", "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
     "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL",
     "KILOCODE_API_KEY", "KILOCODE_BASE_URL",
+    "FEATHERLESS_API_KEY", "FEATHERLESS_BASE_URL",
     "DASHSCOPE_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
     "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN",
     "OPENAI_BASE_URL", "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH",
@@ -183,6 +191,12 @@ class TestResolveProvider:
 
     def test_alias_kilo_gateway(self):
         assert resolve_provider("kilo-gateway") == "kilocode"
+
+    def test_explicit_featherless(self):
+        assert resolve_provider("featherless") == "featherless"
+
+    def test_alias_featherless_ai(self):
+        assert resolve_provider("featherless-ai") == "featherless"
 
     def test_alias_case_insensitive(self):
         assert resolve_provider("GLM") == "zai"


### PR DESCRIPTION
## Summary
- Add Featherless as a new LLM provider with OpenAI-compatible API (`https://api.featherless.ai/v1`)
- Featherless provides serverless inference for 30,000+ open-source HuggingFace models with flat-rate unlimited token pricing
- Uses `MiniMaxAI/MiniMax-M2.5` as default auxiliary model

## Changes
- **hermes_cli/auth.py** — Register `featherless` in `PROVIDER_REGISTRY`
- **hermes_cli/models.py** — Add model catalog, provider label, and `featherless-ai` alias
- **agent/auxiliary_client.py** — Add default auxiliary model for side tasks
- **.env.example** — Add `FEATHERLESS_API_KEY` documentation
- **tests/test_api_key_providers.py** — Add unit tests for registration, env vars, base URL, and provider resolution

## Test plan
- [x] Verified provider registration imports correctly
- [x] Verified model catalog, label, and alias resolve correctly
- [x] Smoke tested live API call with `NousResearch/Hermes-3-Llama-3.1-8B` — response returned successfully
- [x] Run full test suite (`pytest tests/test_api_key_providers.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)