### PR TITLE
fix: whitespace-only env vars bypass web backend detection + clearer Firecrawl error

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -57,6 +57,10 @@ logger = logging.getLogger(__name__)
 
 # ─── Backend Selection ────────────────────────────────────────────────────────
 
+def _has_env(name: str) -> bool:
+    val = os.getenv(name)
+    return bool(val and val.strip())
+
 def _load_web_config() -> dict:
     """Load the ``web:`` section from ~/.hermes/config.yaml."""
     try:
@@ -64,7 +68,6 @@ def _load_web_config() -> dict:
         return load_config().get("web", {})
     except (ImportError, Exception):
         return {}
-
 
 def _get_backend() -> str:
     """Determine which web backend to use.
@@ -76,17 +79,19 @@ def _get_backend() -> str:
     configured = _load_web_config().get("backend", "").lower().strip()
     if configured in ("parallel", "firecrawl", "tavily"):
         return configured
+
     # Fallback for manual / legacy config — use whichever key is present.
-    has_firecrawl = bool(os.getenv("FIRECRAWL_API_KEY") or os.getenv("FIRECRAWL_API_URL"))
-    has_parallel = bool(os.getenv("PARALLEL_API_KEY"))
-    has_tavily = bool(os.getenv("TAVILY_API_KEY"))
+    has_firecrawl = _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL")
+    has_parallel = _has_env("PARALLEL_API_KEY")
+    has_tavily = _has_env("TAVILY_API_KEY")
+
     if has_tavily and not has_firecrawl and not has_parallel:
         return "tavily"
     if has_parallel and not has_firecrawl:
         return "parallel"
+
     # Default to firecrawl (backward compat, or when both are set)
     return "firecrawl"
-
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -105,10 +105,11 @@ def _get_firecrawl_client():
         api_key = os.getenv("FIRECRAWL_API_KEY")
         api_url = os.getenv("FIRECRAWL_API_URL")
         if not api_key and not api_url:
+            logger.error("Firecrawl client initialization failed: missing configuration.")
             raise ValueError(
-                "FIRECRAWL_API_KEY environment variable not set. "
-                "Set it for cloud Firecrawl, or set FIRECRAWL_API_URL "
-                "to use a self-hosted instance."
+                "Firecrawl client not configured. "
+                "Set FIRECRAWL_API_KEY (cloud) or FIRECRAWL_API_URL (self-hosted). "
+                "This tool requires Firecrawl to be available."
             )
         kwargs = {}
         if api_key:
@@ -117,7 +118,6 @@ def _get_firecrawl_client():
             kwargs["api_url"] = api_url
         _firecrawl_client = Firecrawl(**kwargs)
     return _firecrawl_client
-
 
 # ─── Parallel Client ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Salvage of PR #1763 by @JackTheGit (198 commits behind, cherry-picked cleanly).

Two fixes:
1. Whitespace-only env vars (`FIRECRAWL_API_KEY="   "`) were treated as valid config, causing incorrect backend selection. Added `_has_env()` helper that strips whitespace.
2. Firecrawl error message now clearly tells users to set `FIRECRAWL_API_KEY` (cloud) or `FIRECRAWL_API_URL` (self-hosted), with a logger.error call for gateway logs.

1 file, +14/-9. 56 web tool tests pass. Authorship preserved.