### PR TITLE
fix(cli): handle Kitty keyboard protocol Shift+Enter for Ghostty/WezTerm

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6044,6 +6044,7 @@ class HermesCLI:
             """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""
             event.current_buffer.insert_text('\n')
 
+<<<<<<< Updated upstream
         @kb.add('tab', eager=True)
         def handle_tab(event):
             """Tab: accept completion, auto-suggestion, or start completions.
@@ -6080,6 +6081,19 @@ class HermesCLI:
             else:
                 # No menu and no suggestion — start completions from scratch
                 buf.start_completion()
+=======
+        @kb.add('s-enter')
+        def handle_shift_enter(event):
+            """Shift+Enter inserts a newline (standard terminals)."""
+            event.current_buffer.insert_text('\n')
+
+        # Kitty keyboard protocol: Ghostty and other Kitty-protocol terminals
+        # encode Shift+Enter as CSI 13;2u instead of a simple escape sequence.
+        @kb.add('escape', '[', '1', '3', ';', '2', 'u')
+        def handle_kitty_shift_enter(event):
+            """Shift+Enter in Kitty keyboard protocol (Ghostty, WezTerm, etc.)."""
+            event.current_buffer.insert_text('\n')
+>>>>>>> Stashed changes
 
         # --- Clarify tool: arrow-key navigation for multiple-choice questions ---
 


### PR DESCRIPTION
Salvage of PR #1798 by @ygd58 — **cli.py keybinding only**, registry.py apostrophe sanitization excluded as unrelated.

Kitty-protocol terminals (Ghostty, WezTerm) encode Shift+Enter as `CSI 13;2u` instead of plain Enter. Without this binding, raw `[13;2u` text appears in the input buffer. Adds `s-enter` and the Kitty escape sequence as newline-insert bindings.

Harmless in regular terminals — these bindings only fire if the terminal sends the specific sequences. Fixes #1795.