### PR TITLE
fix: resolve merge conflict markers in cli.py breaking hermes startup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6044,7 +6044,18 @@ class HermesCLI:
             """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""
             event.current_buffer.insert_text('\n')
 
-<<<<<<< Updated upstream
+        @kb.add('s-enter')
+        def handle_shift_enter(event):
+            """Shift+Enter inserts a newline (standard terminals)."""
+            event.current_buffer.insert_text('\n')
+
+        # Kitty keyboard protocol: Ghostty and other Kitty-protocol terminals
+        # encode Shift+Enter as CSI 13;2u instead of a simple escape sequence.
+        @kb.add('escape', '[', '1', '3', ';', '2', 'u')
+        def handle_kitty_shift_enter(event):
+            """Shift+Enter in Kitty keyboard protocol (Ghostty, WezTerm, etc.)."""
+            event.current_buffer.insert_text('\n')
+
         @kb.add('tab', eager=True)
         def handle_tab(event):
             """Tab: accept completion, auto-suggestion, or start completions.
@@ -6081,19 +6092,6 @@ class HermesCLI:
             else:
                 # No menu and no suggestion — start completions from scratch
                 buf.start_completion()
-=======
-        @kb.add('s-enter')
-        def handle_shift_enter(event):
-            """Shift+Enter inserts a newline (standard terminals)."""
-            event.current_buffer.insert_text('\n')
-
-        # Kitty keyboard protocol: Ghostty and other Kitty-protocol terminals
-        # encode Shift+Enter as CSI 13;2u instead of a simple escape sequence.
-        @kb.add('escape', '[', '1', '3', ';', '2', 'u')
-        def handle_kitty_shift_enter(event):
-            """Shift+Enter in Kitty keyboard protocol (Ghostty, WezTerm, etc.)."""
-            event.current_buffer.insert_text('\n')
->>>>>>> Stashed changes
 
         # --- Clarify tool: arrow-key navigation for multiple-choice questions ---
 


### PR DESCRIPTION
**URGENT** — PR #2346 was merged with unresolved git conflict markers in cli.py line 6047, causing `SyntaxError: invalid syntax` on startup for anyone who updates.

Resolved by keeping both sides: Shift+Enter keybindings + tab handler.