### PR TITLE
revert: remove Shift+Enter keybindings that crash prompt_toolkit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6044,18 +6044,6 @@ class HermesCLI:
             """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""
             event.current_buffer.insert_text('\n')
 
-        @kb.add('s-enter')
-        def handle_shift_enter(event):
-            """Shift+Enter inserts a newline (standard terminals)."""
-            event.current_buffer.insert_text('\n')
-
-        # Kitty keyboard protocol: Ghostty and other Kitty-protocol terminals
-        # encode Shift+Enter as CSI 13;2u instead of a simple escape sequence.
-        @kb.add('escape', '[', '1', '3', ';', '2', 'u')
-        def handle_kitty_shift_enter(event):
-            """Shift+Enter in Kitty keyboard protocol (Ghostty, WezTerm, etc.)."""
-            event.current_buffer.insert_text('\n')
-
         @kb.add('tab', eager=True)
         def handle_tab(event):
             """Tab: accept completion, auto-suggestion, or start completions.


### PR DESCRIPTION
The `s-enter` key notation from PR #2345 causes `Invalid key: s-enter` crash on startup for some prompt_toolkit versions. Reverts both the `s-enter` and Kitty CSI keybindings entirely.