### PR TITLE
fix: case-insensitive model family matching + compressor init logging

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -93,6 +93,14 @@ class ContextCompressor:
         )
         self.threshold_tokens = int(self.context_length * threshold_percent)
         self.compression_count = 0
+
+        if not quiet_mode:
+            logger.info(
+                "Context compressor initialized: model=%s context_length=%d "
+                "threshold=%d (%.0f%%) provider=%s base_url=%s",
+                model, self.context_length, self.threshold_tokens,
+                threshold_percent * 100, provider or "none", base_url or "none",
+            )
         self._context_probed = False  # True after a step-down from context error
 
         self.last_prompt_tokens = 0

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -855,10 +855,11 @@ def get_model_context_length(
     # Only check `default_model in model` (is the key a substring of the input).
     # The reverse (`model in default_model`) causes shorter names like
     # "claude-sonnet-4" to incorrectly match "claude-sonnet-4-6" and return 1M.
+    model_lower = model.lower()
     for default_model, length in sorted(
         DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
     ):
-        if default_model in model:
+        if default_model in model_lower:
             return length
 
     # 9. Query local server as last resort


### PR DESCRIPTION
Investigating a user report where a 65K context llama.cpp model (Qwen3.5-9B-Q4_K_M.gguf) was compressing on turn 1.

**Bug found:** the hardcoded DEFAULT_CONTEXT_LENGTHS fallback matching was case-sensitive. `"qwen"` didn't match `"Qwen3.5-9B-Q4_K_M.gguf"` because of the capital Q. This meant the model fell through to the 128K default instead of the 131K qwen default — both should prevent turn-1 compression, so the case sensitivity bug is real but may not be the full explanation for the user's issue.

**Diagnostic added:** the compressor now logs its detected context_length, threshold, model, provider, and base_url at initialization. Next time this happens, the logs will immediately show what went wrong.

Ask the user to update and send their gateway logs — the new init log line will tell us exactly what context length was detected.