### PR TITLE
feat(cli): Add fork detection and upstream sync to hermes update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2869,6 +2869,231 @@ def _restore_stashed_changes(
     print("  Review `git diff` / `git status` if Hermes behaves unexpectedly.")
     return True
 
+# =========================================================================
+# Fork detection and upstream management for `hermes update`
+# =========================================================================
+
+OFFICIAL_REPO_URLS = {
+    "https://github.com/NousResearch/hermes-agent.git",
+    "git@github.com:NousResearch/hermes-agent.git",
+    "https://github.com/NousResearch/hermes-agent",
+    "git@github.com:NousResearch/hermes-agent",
+}
+OFFICIAL_REPO_URL = "https://github.com/NousResearch/hermes-agent.git"
+SKIP_UPSTREAM_PROMPT_FILE = ".skip_upstream_prompt"
+
+
+def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
+    """Get the URL of the origin remote, or None if not set."""
+    try:
+        result = subprocess.run(
+            git_cmd + ["remote", "get-url", "origin"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def _is_fork(origin_url: Optional[str]) -> bool:
+    """Check if the origin remote points to a fork (not the official repo)."""
+    if not origin_url:
+        return False
+    # Normalize URL for comparison (strip trailing .git if present)
+    normalized = origin_url.rstrip("/")
+    if normalized.endswith(".git"):
+        normalized = normalized[:-4]
+    for official in OFFICIAL_REPO_URLS:
+        official_normalized = official.rstrip("/")
+        if official_normalized.endswith(".git"):
+            official_normalized = official_normalized[:-4]
+        if normalized == official_normalized:
+            return False
+    return True
+
+
+def _has_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
+    """Check if an 'upstream' remote already exists."""
+    try:
+        result = subprocess.run(
+            git_cmd + ["remote", "get-url", "upstream"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def _add_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
+    """Add the official repo as the 'upstream' remote. Returns True on success."""
+    try:
+        result = subprocess.run(
+            git_cmd + ["remote", "add", "upstream", OFFICIAL_REPO_URL],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def _count_commits_between(git_cmd: list[str], cwd: Path, base: str, head: str) -> int:
+    """Count commits on `head` that are not on `base`. Returns -1 on error."""
+    try:
+        result = subprocess.run(
+            git_cmd + ["rev-list", "--count", f"{base}..{head}"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return int(result.stdout.strip())
+    except Exception:
+        pass
+    return -1
+
+
+def _should_skip_upstream_prompt() -> bool:
+    """Check if user previously declined to add upstream."""
+    hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    return (hermes_home / SKIP_UPSTREAM_PROMPT_FILE).exists()
+
+
+def _mark_skip_upstream_prompt():
+    """Create marker file to skip future upstream prompts."""
+    try:
+        hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+        (hermes_home / SKIP_UPSTREAM_PROMPT_FILE).touch()
+    except Exception:
+        pass
+
+
+def _sync_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
+    """Attempt to push updated main to origin (sync fork).
+
+    Returns True if push succeeded, False otherwise.
+    """
+    try:
+        result = subprocess.run(
+            git_cmd + ["push", "origin", "main", "--force-with-lease"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
+    """Check if fork is behind upstream and sync if safe.
+
+    This implements the fork upstream sync logic:
+    - If upstream remote doesn't exist, ask user if they want to add it
+    - Compare origin/main with upstream/main
+    - If origin/main is strictly behind upstream/main, pull from upstream
+    - Try to sync fork back to origin if possible
+    """
+    has_upstream = _has_upstream_remote(git_cmd, cwd)
+
+    if not has_upstream:
+        # Check if user previously declined
+        if _should_skip_upstream_prompt():
+            return
+
+        # Ask user if they want to add upstream
+        print()
+        print("ℹ Your fork is not tracking the official Hermes repository.")
+        print("  This means you may miss updates from NousResearch/hermes-agent.")
+        print()
+        try:
+            response = input("Add official repo as 'upstream' remote? [Y/n]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            response = "n"
+
+        if response in ("", "y", "yes"):
+            print("→ Adding upstream remote...")
+            if _add_upstream_remote(git_cmd, cwd):
+                print("  ✓ Added upstream: https://github.com/NousResearch/hermes-agent.git")
+                has_upstream = True
+            else:
+                print("  ✗ Failed to add upstream remote. Skipping upstream sync.")
+                return
+        else:
+            print("  Skipped. Run 'git remote add upstream https://github.com/NousResearch/hermes-agent.git' to add later.")
+            _mark_skip_upstream_prompt()
+            return
+
+    # Fetch upstream
+    print()
+    print("→ Fetching upstream...")
+    try:
+        subprocess.run(
+            git_cmd + ["fetch", "upstream", "--quiet"],
+            cwd=cwd,
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        print("  ✗ Failed to fetch upstream. Skipping upstream sync.")
+        return
+
+    # Compare origin/main with upstream/main
+    origin_ahead = _count_commits_between(git_cmd, cwd, "upstream/main", "origin/main")
+    upstream_ahead = _count_commits_between(git_cmd, cwd, "origin/main", "upstream/main")
+
+    if origin_ahead < 0 or upstream_ahead < 0:
+        print("  ✗ Could not compare branches. Skipping upstream sync.")
+        return
+
+    # If origin/main has commits not on upstream, don't trample
+    if origin_ahead > 0:
+        print()
+        print(f"ℹ Your fork has {origin_ahead} commit(s) not on upstream.")
+        print("  Skipping upstream sync to preserve your changes.")
+        print("  If you want to merge upstream changes, run:")
+        print("    git pull upstream main")
+        return
+
+    # If upstream is not ahead, fork is up to date
+    if upstream_ahead == 0:
+        print("  ✓ Fork is up to date with upstream")
+        return
+
+    # origin/main is strictly behind upstream/main (can fast-forward)
+    print()
+    print(f"→ Fork is {upstream_ahead} commit(s) behind upstream")
+    print("→ Pulling from upstream...")
+
+    try:
+        subprocess.run(
+            git_cmd + ["pull", "--ff-only", "upstream", "main"],
+            cwd=cwd,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        print("  ✗ Failed to pull from upstream. You may need to resolve conflicts manually.")
+        return
+
+    print("  ✓ Updated from upstream")
+
+    # Try to sync fork back to origin
+    print("→ Syncing fork...")
+    if _sync_fork_with_upstream(git_cmd, cwd):
+        print("  ✓ Fork synced with upstream")
+    else:
+        print("  ℹ Got updates from upstream but couldn't push to fork (no write access?)")
+        print("    Your local repo is updated, but your fork on GitHub may be behind.")
+
+
 def _invalidate_update_cache():
     """Delete the update-check cache so ``hermes --version`` doesn't
     report a stale "commits behind" count after a successful update."""
@@ -2913,6 +3138,19 @@ def cmd_update(args):
             ["git", "-c", "windows.appendAtomically=false", "config", "windows.appendAtomically", "false"],
             cwd=PROJECT_ROOT, check=False, capture_output=True
         )
+
+    # Detect if we're updating from a fork (before any branch logic)
+    git_cmd_base = ["git"]
+    if sys.platform == "win32":
+        git_cmd_base = ["git", "-c", "windows.appendAtomically=false"]
+
+    origin_url = _get_origin_url(git_cmd_base, PROJECT_ROOT)
+    is_fork = _is_fork(origin_url)
+
+    if is_fork:
+        print("⚠ Updating from fork:")
+        print(f"  {origin_url}")
+        print()
 
     if use_zip_update:
         # ZIP-based update for Windows when git is broken
@@ -3054,6 +3292,10 @@ def cmd_update(args):
         removed = _clear_bytecode_cache(PROJECT_ROOT)
         if removed:
             print(f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}")
+
+        # Fork upstream sync logic (only for main branch on forks)
+        if is_fork and branch == "main":
+            _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
         
         # Reinstall Python dependencies (try .[all] first for optional extras,
         # fall back to . if extras fail — mirrors the install script behavior)


### PR DESCRIPTION
Note: This PR was built and tested by Avery - a Hermes agent, with guidance and review by @francip.

---

## Summary

Adds fork detection and upstream synchronization to the `hermes update` command, ensuring users who clone from a fork can still receive updates from the official NousResearch/hermes-agent repository.

## Problem

When users clone Hermes from a fork instead of the official repository:
- `hermes update` only pulls from the fork
- If the fork is stale/abandoned, users stop receiving updates
- No warning is given that they're not on the official repo

## Solution

### 1. Fork Detection Warning

At the start of `hermes update`, before any branch logic:
- Detect if `origin` remote points to a fork (not `NousResearch/hermes-agent`)
- Show a prominent warning: `Updating from fork: <origin_url>`

### 2. Upstream Remote Management

After pulling from `origin/main` (only on forks, only on main branch):

**If upstream remote doesn't exist:**
- Prompt user to add official repo as upstream
- Respect `~/.hermes/.skip_upstream_prompt` marker file to avoid repeated prompts
- If user declines, create the marker file

**If upstream exists:**
- Fetch upstream
- Compare `origin/main` with `upstream/main`

### 3. Safe Sync Logic

- **If origin has commits not on upstream**: Skip sync (don't trample user's work)
- **If upstream is not ahead**: Fork is up to date, nothing to do
- **If upstream is ahead and origin is strictly behind**: 
  - Pull from upstream with `--ff-only`
  - Attempt to push to origin with `--force-with-lease` (safe force push)
  - If push fails (no write access), local is still updated

### 4. Non-Main Branch Behavior

Non-main branches are unaffected - they simply pull from `origin/<branch>` with no fork/upstream checks.

## Flow Diagram

```
hermes update
    │
    ├─ Not a git repo? → Current behavior (ZIP on Windows, error on *nix)
    │
    ├─ Detect fork (origin != official repo)
    │   └─ If fork: Print "Updating from fork: <url>"
    │
    ├─ Get current branch
    │   └─ If branch not on origin: Fall back to "main"
    │
    ├─ Branch != "main"?
    │   └─ Pull from origin/{branch}, DONE
    │
    ├─ Pull from origin/main (existing behavior)
    │
    └─ Fork AND on main?
        │
        ├─ No upstream remote?
        │   ├─ Skip marker exists? → DONE
        │   ├─ Prompt user to add upstream
        │   │   ├─ No → Create skip marker, DONE
        │   │   └─ Yes → git remote add upstream
        │   │
        ├─ Fetch upstream
        │
        ├─ Compare branches:
        │   ├─ origin ahead of upstream → Skip (preserve user's work), DONE
        │   ├─ origin == upstream → Up to date, DONE
        │   └─ upstream ahead → Pull from upstream, try to sync fork
        │
        └─ Push to origin (--force-with-lease)
            ├─ Success → Fork synced
            └─ Fail → Local updated, fork may be behind (no write access)
```

## New Helper Functions

| Function | Purpose |
|----------|---------|
| `_get_origin_url()` | Get origin remote URL |
| `_is_fork()` | Check if URL matches official repo |
| `_has_upstream_remote()` | Check if upstream remote exists |
| `_add_upstream_remote()` | Add official repo as upstream |
| `_count_commits_between()` | Count commits between two refs |
| `_should_skip_upstream_prompt()` | Check for skip marker file |
| `_mark_skip_upstream_prompt()` | Create skip marker file |
| `_sync_fork_with_upstream()` | Push to origin with --force-with-lease |
| `_sync_with_upstream_if_needed()` | Main orchestrator for upstream sync |

## Constants

```python
OFFICIAL_REPO_URLS = {
    "https://github.com/NousResearch/hermes-agent.git",
    "git@github.com:NousResearch/hermes-agent.git",
    "https://github.com/NousResearch/hermes-agent",
    "git@github.com:NousResearch/hermes-agent",
}
SKIP_UPSTREAM_PROMPT_FILE = ".skip_upstream_prompt"  # Stored in ~/.hermes/
```

## Testing

### Unit Tests
- All existing tests pass (118 related tests, 3 skipped)
- Pre-existing failures in unrelated tests (Discord filter, prompt builder, model slug)

### Manual Integration Tests

Tested in isolated environment with `HERMES_HOME=/tmp/hermes-test-home`:

1. **Fork detection**: Verified `_is_fork()` returns `True` for `kortexa-ai/hermes-agent`
2. **Fork warning**: Confirmed warning displays when updating from fork
3. **Upstream prompt**: Confirmed prompt appears when no upstream exists
4. **Skip marker**: Verified marker file prevents repeated prompts

Test setup:
```bash
# Clone fork to isolated directory
git clone --depth 5 https://github.com/kortexa-ai/hermes-agent.git hermes-test-fork
cd hermes-test-fork
uv venv venv --python 3.11 && source venv/bin/activate
uv pip install -e ".[all]"

# Reset to simulate being behind origin
git reset --hard HEAD~3

# Add upstream for full sync test
git remote add upstream https://github.com/NousResearch/hermes-agent.git

# Run update with isolated home
HERMES_HOME=/tmp/hermes-test-home hermes update
```

## Edge Cases Handled

- User has commits on their fork's main (won't trample
- User doesn't have write access to fork (local still updates)
- Non-interactive terminal (defaults to no for prompts)
- Windows git atomicity issues (existing handling preserved)
- Multiple Hermes installations (uses PROJECT_ROOT, not cwd)

## Files Changed

```
hermes_cli/main.py:
- : +242 lines (8 new functions, 1 modified function)
```
