### PR TITLE
Fix Matrix duplicate messages, image caching, and vision tool conflicts

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -24,6 +24,7 @@ import os
 import re
 import time
 from pathlib import Path
+from collections import deque
 from typing import Any, Dict, List, Optional, Set
 
 from gateway.config import Platform, PlatformConfig
@@ -103,6 +104,23 @@ class MatrixAdapter(BasePlatformAdapter):
         self._dm_rooms: Dict[str, bool] = {}
         # Set of room IDs we've joined
         self._joined_rooms: Set[str] = set()
+        # Event deduplication (bounded deque keeps newest entries)
+        self._processed_events: deque[str] = deque(maxlen=1000)
+        self._processed_events_set: set[str] = set()
+
+    def _is_duplicate_event(self, event_id: str | None) -> bool:
+        """Return True if this event was already processed. Tracks the ID otherwise."""
+        if not event_id:
+            return False
+        if event_id in self._processed_events_set:
+            return True
+        # If the deque is full, the oldest entry gets evicted automatically.
+        if len(self._processed_events) == self._processed_events.maxlen:
+            evicted = self._processed_events[0]
+            self._processed_events_set.discard(evicted)
+        self._processed_events.append(event_id)
+        self._processed_events_set.add(event_id)
+        return False
 
     # ------------------------------------------------------------------
     # Required overrides
@@ -188,7 +206,6 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Register event callbacks.
         client.add_event_callback(self._on_room_message, nio.RoomMessageText)
-        client.add_event_callback(self._on_room_message_media, nio.RoomMessageMedia)
         client.add_event_callback(self._on_room_message_media, nio.RoomMessageImage)
         client.add_event_callback(self._on_room_message_media, nio.RoomMessageAudio)
         client.add_event_callback(self._on_room_message_media, nio.RoomMessageVideo)
@@ -557,7 +574,15 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Ignore own messages.
         if event.sender == self._user_id:
+            logger.debug("Matrix: ignoring own message from %s", event.sender)
             return
+
+        # Deduplicate by event ID (nio can fire the same event more than once).
+        if self._is_duplicate_event(getattr(event, "event_id", None)):
+            logger.debug("Matrix: duplicate event %s, ignoring", event.event_id)
+            return
+
+        logger.debug("Matrix: processing message from %s in room %s", event.sender, room.room_id)
 
         # Startup grace: ignore old messages from initial sync.
         event_ts = getattr(event, "server_timestamp", 0) / 1000.0
@@ -646,6 +671,12 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Ignore own messages.
         if event.sender == self._user_id:
+            logger.debug("Matrix: ignoring own media message from %s", event.sender)
+            return
+
+        # Deduplicate by event ID.
+        if self._is_duplicate_event(getattr(event, "event_id", None)):
+            logger.debug("Matrix: duplicate media event %s, ignoring", event.event_id)
             return
 
         # Startup grace.
@@ -656,7 +687,7 @@ class MatrixAdapter(BasePlatformAdapter):
         body = getattr(event, "body", "") or ""
         url = getattr(event, "url", "")
 
-        # Convert mxc:// to HTTP URL for downstream processing.
+        # Convert mxc:// to HTTP URL for downloading.
         http_url = ""
         if url and url.startswith("mxc://"):
             http_url = self._mxc_to_http(url)
@@ -681,6 +712,30 @@ class MatrixAdapter(BasePlatformAdapter):
         elif event_mimetype:
             media_type = event_mimetype
 
+        # For images, download and cache to local file for vision tool access.
+        # This avoids authentication issues with the Matrix MXC URL.
+        cached_path = None
+        if msg_type == MessageType.PHOTO and url:  # Use the raw MXC URL
+            try:
+                # Determine file extension from MIME type
+                ext_map = {
+                    "image/jpeg": ".jpg",
+                    "image/png": ".png",
+                    "image/gif": ".gif",
+                    "image/webp": ".webp",
+                    "image/bmp": ".bmp",
+                }
+                ext = ext_map.get(event_mimetype, ".jpg")
+                
+                # Download the image using the authenticated Matrix client
+                download_resp = await self._client.download(url)
+                if isinstance(download_resp, nio.DownloadResponse):
+                    from gateway.platforms.base import cache_image_from_bytes
+                    cached_path = cache_image_from_bytes(download_resp.body, ext=ext)
+                    logger.info("[Matrix] Cached user image at %s", cached_path)
+            except Exception as e:
+                logger.warning("[Matrix] Failed to cache image, falling back to HTTP URL: %s", e)
+
         is_dm = self._dm_rooms.get(room.room_id, False)
         if not is_dm and room.member_count == 2:
             is_dm = True
@@ -701,14 +756,18 @@ class MatrixAdapter(BasePlatformAdapter):
             thread_id=thread_id,
         )
 
+        # Use cached local path for images, HTTP URL for other media types
+        media_urls = [cached_path] if cached_path else ([http_url] if http_url else None)
+        media_types = [media_type] if media_urls else None
+
         msg_event = MessageEvent(
             text=body,
             message_type=msg_type,
             source=source,
             raw_message=getattr(event, "source", {}),
             message_id=event.event_id,
-            media_urls=[http_url] if http_url else None,
-            media_types=[media_type] if http_url else None,
+            media_urls=media_urls,
+            media_types=media_types,
         )
 
         await self.handle_message(msg_event)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -142,6 +142,7 @@ if _config_path.exists():
                     "model": "AUXILIARY_VISION_MODEL",
                     "base_url": "AUXILIARY_VISION_BASE_URL",
                     "api_key": "AUXILIARY_VISION_API_KEY",
+                    "timeout": "AUXILIARY_VISION_TIMEOUT",
                 },
                 "web_extract": {
                     "provider": "AUXILIARY_WEB_EXTRACT_PROVIDER",
@@ -172,6 +173,11 @@ if _config_path.exists():
                     os.environ[_env_map["base_url"]] = _base_url
                 if _api_key:
                     os.environ[_env_map["api_key"]] = _api_key
+                _timeout_env = _env_map.get("timeout")
+                if _timeout_env:
+                    _timeout = _task_cfg.get("timeout")
+                    if _timeout is not None:
+                        os.environ[_timeout_env] = str(_timeout)
         _agent_cfg = _cfg.get("agent", {})
         if _agent_cfg and isinstance(_agent_cfg, dict):
             if "max_turns" in _agent_cfg:
@@ -1926,15 +1932,18 @@ class GatewayRunner:
         # Auto-analyze images sent by the user
         #
         # If the user attached image(s), we run the vision tool eagerly so
-        # the conversation model always receives a text description.  The
-        # local file path is also included so the model can re-examine the
-        # image later with a more targeted question via vision_analyze.
+        # the conversation model always receives a text description.
+        # Because the image has already been analyzed, the vision toolset
+        # is disabled for the subsequent agent run to avoid redundant
+        # calls (and deadlocks on single-slot backends like llama.cpp
+        # with --np 1).
         #
         # We filter to image paths only (by media_type) so that non-image
         # attachments (documents, audio, etc.) are not sent to the vision
         # tool even when they appear in the same message.
         # -----------------------------------------------------------------
         message_text = event.text or ""
+        vision_enriched = False
         if event.media_urls:
             image_paths = []
             for i, path in enumerate(event.media_urls):
@@ -1950,6 +1959,7 @@ class GatewayRunner:
                 message_text = await self._enrich_message_with_vision(
                     message_text, image_paths
                 )
+                vision_enriched = True
         
         # -----------------------------------------------------------------
         # Auto-transcribe voice/audio messages sent by the user
@@ -2066,7 +2076,8 @@ class GatewayRunner:
                 history=history,
                 source=source,
                 session_id=session_entry.session_id,
-                session_key=session_key
+                session_key=session_key,
+                disabled_toolsets=["vision"] if vision_enriched else None,
             )
             
             response = agent_result.get("final_response") or ""
@@ -4118,22 +4129,18 @@ class GatewayRunner:
                 if result.get("success"):
                     description = result.get("analysis", "")
                     enriched_parts.append(
-                        f"[The user sent an image~ Here's what I can see:\n{description}]\n"
-                        f"[If you need a closer look, use vision_analyze with "
-                        f"image_url: {path} ~]"
+                        f"[The user sent an image. Here's what I can see:\n{description}]"
                     )
                 else:
                     enriched_parts.append(
-                        "[The user sent an image but I couldn't quite see it "
-                        "this time (>_<) You can try looking at it yourself "
-                        f"with vision_analyze using image_url: {path}]"
+                        "[The user sent an image but vision analysis was "
+                        "unable to process it this time.]"
                     )
             except Exception as e:
                 logger.error("Vision auto-analysis error: %s", e)
                 enriched_parts.append(
-                    f"[The user sent an image but something went wrong when I "
-                    f"tried to look at it~ You can try examining it yourself "
-                    f"with vision_analyze using image_url: {path}]"
+                    "[The user sent an image but vision analysis encountered "
+                    "an error.]"
                 )
 
         # Combine: vision descriptions first, then the user's original text
@@ -4333,6 +4340,7 @@ class GatewayRunner:
         session_id: str,
         session_key: str = None,
         _interrupt_depth: int = 0,
+        disabled_toolsets: List[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -4680,6 +4688,7 @@ class GatewayRunner:
                 quiet_mode=True,
                 verbose_logging=False,
                 enabled_toolsets=enabled_toolsets,
+                disabled_toolsets=disabled_toolsets,
                 ephemeral_system_prompt=combined_ephemeral or None,
                 prefill_messages=self._prefill_messages or None,
                 reasoning_config=reasoning_config,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -182,6 +182,7 @@ DEFAULT_CONFIG = {
             "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"
             "base_url": "",        # direct OpenAI-compatible endpoint (takes precedence over provider)
             "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)
+            "timeout": 300,        # seconds to wait for vision model response (GPU can be slow)
         },
         "web_extract": {
             "provider": "auto",

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -446,3 +446,108 @@ class TestMatrixRequirements:
         monkeypatch.delenv("MATRIX_HOMESERVER", raising=False)
         from gateway.platforms.matrix import check_matrix_requirements
         assert check_matrix_requirements() is False
+
+
+# ---------------------------------------------------------------------------
+# Event deduplication
+# ---------------------------------------------------------------------------
+
+class TestMatrixEventDeduplication:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    def test_first_event_is_not_duplicate(self):
+        assert self.adapter._is_duplicate_event("$event1") is False
+
+    def test_same_event_is_duplicate(self):
+        self.adapter._is_duplicate_event("$event1")
+        assert self.adapter._is_duplicate_event("$event1") is True
+
+    def test_different_events_not_duplicate(self):
+        self.adapter._is_duplicate_event("$event1")
+        assert self.adapter._is_duplicate_event("$event2") is False
+
+    def test_none_event_id_is_not_duplicate(self):
+        """None event IDs should never be considered duplicates."""
+        assert self.adapter._is_duplicate_event(None) is False
+        assert self.adapter._is_duplicate_event(None) is False
+
+    def test_oldest_events_evicted_when_full(self):
+        """When the deque hits maxlen, the oldest entries should be evicted."""
+        # Fill up the deque
+        for i in range(1000):
+            self.adapter._is_duplicate_event(f"$evt_{i}")
+
+        # The oldest event should still be tracked
+        assert self.adapter._is_duplicate_event("$evt_0") is True
+
+        # Adding one more should evict $evt_0
+        self.adapter._is_duplicate_event("$evt_new")
+        assert self.adapter._is_duplicate_event("$evt_0") is False
+
+        # Recent events should still be tracked
+        assert self.adapter._is_duplicate_event("$evt_999") is True
+
+    def test_set_stays_in_sync_with_deque(self):
+        """The backing set should always match the deque contents."""
+        for i in range(1500):
+            self.adapter._is_duplicate_event(f"$evt_{i}")
+
+        assert len(self.adapter._processed_events_set) == len(self.adapter._processed_events)
+        assert self.adapter._processed_events_set == set(self.adapter._processed_events)
+
+    @pytest.mark.asyncio
+    async def test_on_room_message_deduplicates(self):
+        """_on_room_message should skip duplicate events."""
+        self.adapter._user_id = "@bot:example.org"
+        self.adapter._startup_ts = 0.0
+        self.adapter._dm_rooms = {}
+
+        mock_room = MagicMock()
+        mock_room.room_id = "!test:example.org"
+        mock_room.member_count = 2
+
+        mock_event = MagicMock()
+        mock_event.sender = "@alice:example.org"
+        mock_event.event_id = "$dedup_test_1"
+        mock_event.server_timestamp = 9999999999999
+        mock_event.body = "Hello"
+        mock_event.source = {"content": {}}
+
+        with patch.object(self.adapter, "handle_message", new_callable=AsyncMock) as mock_handle:
+            await self.adapter._on_room_message(mock_room, mock_event)
+            await self.adapter._on_room_message(mock_room, mock_event)
+            assert mock_handle.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_on_room_message_media_deduplicates(self):
+        """_on_room_message_media should skip duplicate events."""
+        import nio
+
+        self.adapter._user_id = "@bot:example.org"
+        self.adapter._startup_ts = 0.0
+        self.adapter._dm_rooms = {}
+        self.adapter._client = MagicMock()
+
+        mock_room = MagicMock()
+        mock_room.room_id = "!test:example.org"
+        mock_room.member_count = 2
+
+        mock_event = MagicMock(spec=nio.RoomMessageImage)
+        mock_event.sender = "@alice:example.org"
+        mock_event.event_id = "$media_dedup_1"
+        mock_event.server_timestamp = 9999999999999
+        mock_event.body = "image.png"
+        mock_event.url = "mxc://example.org/abc123"
+        mock_event.content = {"info": {"mimetype": "image/png"}}
+        mock_event.source = {"content": {}}
+
+        mock_download = MagicMock(spec=nio.DownloadResponse)
+        mock_download.body = b"fake image bytes"
+        self.adapter._client.download = AsyncMock(return_value=mock_download)
+
+        with patch.object(self.adapter, "handle_message", new_callable=AsyncMock) as mock_handle, \
+             patch("gateway.platforms.base.cache_image_from_bytes", return_value="/tmp/cached.png"):
+            await self.adapter._on_room_message_media(mock_room, mock_event)
+            await self.adapter._on_room_message_media(mock_room, mock_event)
+            assert mock_handle.call_count == 1

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -298,12 +298,20 @@ async def vision_analyze_tool(
         
         logger.info("Processing image with vision model...")
         
-        # Call the vision API via centralized router
+        # Call the vision API via centralized router.
+        # Timeout is configurable via auxiliary.vision.timeout in config.yaml
+        # or the AUXILIARY_VISION_TIMEOUT env var (default 300s for GPU models).
+        _timeout_str = os.getenv("AUXILIARY_VISION_TIMEOUT", "300")
+        try:
+            _vision_timeout = float(_timeout_str)
+        except ValueError:
+            _vision_timeout = 300.0
         call_kwargs = {
             "task": "vision",
             "messages": messages,
             "temperature": 0.1,
             "max_tokens": 2000,
+            "timeout": _vision_timeout,
         }
         if model:
             call_kwargs["model"] = model


### PR DESCRIPTION
## Summary

- **Fix duplicate message processing in Matrix adapter.** Images were processed twice because both `RoomMessageMedia` and `RoomMessageImage` callbacks were registered, and `RoomMessageImage` inherits from `RoomMessageMedia`. Also added event ID deduplication to both text and media handlers to handle duplicate event firings from nio.
- **Add image caching for Matrix vision support.** Matrix MXC URLs require authentication, so images are now downloaded via the Matrix client and saved locally before being passed to the vision pipeline.
- **Skip redundant vision tool calls.** When a user sends an image, vision enrichment already runs before the agent starts. Previously the agent could call `vision_analyze` again on the same image, which deadlocks on single-slot backends (e.g. llama.cpp with `--np 1`). Now the vision toolset is disabled for that agent turn.
- **Make vision API timeout configurable.** Can be set via `auxiliary.vision.timeout` in config.yaml or the `AUXILIARY_VISION_TIMEOUT` env var (defaults to 300s).

## Test plan

- [x] All 48 Matrix adapter tests pass (including 8 new dedup tests)
- [x] Verify single message processing per event in a live Matrix room
- [x] Verify image messages are cached locally and analyzed once
- [x] Verify sending an image does not deadlock on a single-slot backend
- [x] Verify `AUXILIARY_VISION_TIMEOUT` is picked up from config.yaml / env var

