### PR TITLE
Normalize FIRECRAWL env handling and prevent whitespace-only configs

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -329,3 +329,23 @@ class TestCheckWebApiKey:
         }):
             from tools.web_tools import check_web_api_key
             assert check_web_api_key() is True
+
+def test_firecrawl_api_key_whitespace_is_unset(monkeypatch):
+    """
+    FIRECRAWL_API_KEY with only whitespace should be treated as unset.
+    """
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "   ")
+
+    from tools.web_tools import _get_env_clean
+
+    assert _get_env_clean("FIRECRAWL_API_KEY") is None
+
+def test_backend_selection_ignores_whitespace_firecrawl_key(monkeypatch):
+    """
+    Backend detection should ignore whitespace-only FIRECRAWL_API_KEY.
+    """
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "   ")
+
+    from tools.web_tools import _has_env
+
+    assert _has_env("FIRECRAWL_API_KEY") is False

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -47,6 +47,16 @@ import re
 import asyncio
 from typing import List, Dict, Any, Optional
 import httpx
+
+def _get_env_clean(key: str) -> str | None:
+    """
+    Get environment variable and treat whitespace-only values as unset.
+    """
+    value = os.getenv(key)
+    if value is None:
+        return None
+    value = value.strip()
+    return value if value else None
 from firecrawl import Firecrawl
 from agent.auxiliary_client import async_call_llm
 from tools.debug_helpers import DebugSession
@@ -57,6 +67,10 @@ logger = logging.getLogger(__name__)
 
 # ─── Backend Selection ────────────────────────────────────────────────────────
 
+def _has_env(name: str) -> bool:
+    """Return True if env var is set and not empty/whitespace."""
+    return bool(_get_env_clean(name))
+
 def _load_web_config() -> dict:
     """Load the ``web:`` section from ~/.hermes/config.yaml."""
     try:
@@ -64,7 +78,6 @@ def _load_web_config() -> dict:
         return load_config().get("web", {})
     except (ImportError, Exception):
         return {}
-
 
 def _get_backend() -> str:
     """Determine which web backend to use.
@@ -76,17 +89,19 @@ def _get_backend() -> str:
     configured = _load_web_config().get("backend", "").lower().strip()
     if configured in ("parallel", "firecrawl", "tavily"):
         return configured
+
     # Fallback for manual / legacy config — use whichever key is present.
-    has_firecrawl = bool(os.getenv("FIRECRAWL_API_KEY") or os.getenv("FIRECRAWL_API_URL"))
-    has_parallel = bool(os.getenv("PARALLEL_API_KEY"))
-    has_tavily = bool(os.getenv("TAVILY_API_KEY"))
+    has_firecrawl = _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL")
+    has_parallel = _has_env("PARALLEL_API_KEY")
+    has_tavily = _has_env("TAVILY_API_KEY")
+
     if has_tavily and not has_firecrawl and not has_parallel:
         return "tavily"
     if has_parallel and not has_firecrawl:
         return "parallel"
+
     # Default to firecrawl (backward compat, or when both are set)
     return "firecrawl"
-
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
@@ -102,13 +117,14 @@ def _get_firecrawl_client():
     """
     global _firecrawl_client
     if _firecrawl_client is None:
-        api_key = os.getenv("FIRECRAWL_API_KEY")
-        api_url = os.getenv("FIRECRAWL_API_URL")
+        api_key = _get_env_clean("FIRECRAWL_API_KEY")
+        api_url = _get_env_clean("FIRECRAWL_API_URL")
         if not api_key and not api_url:
+            logger.error("Firecrawl client initialization failed: missing configuration.")
             raise ValueError(
-                "FIRECRAWL_API_KEY environment variable not set. "
-                "Set it for cloud Firecrawl, or set FIRECRAWL_API_URL "
-                "to use a self-hosted instance."
+                "Firecrawl client not configured. "
+                "Set FIRECRAWL_API_KEY (cloud) or FIRECRAWL_API_URL (self-hosted). "
+                "This tool requires Firecrawl to be available."
             )
         kwargs = {}
         if api_key:
@@ -117,7 +133,6 @@ def _get_firecrawl_client():
             kwargs["api_url"] = api_url
         _firecrawl_client = Firecrawl(**kwargs)
     return _firecrawl_client
-
 
 # ─── Parallel Client ─────────────────────────────────────────────────────────
 
@@ -1242,7 +1257,7 @@ async def web_crawl_tool(
             return cleaned_result
 
         # web_crawl requires Firecrawl — Parallel has no crawl API
-        if not (os.getenv("FIRECRAWL_API_KEY") or os.getenv("FIRECRAWL_API_URL")):
+        if not (_get_env_clean("FIRECRAWL_API_KEY") or _get_env_clean("FIRECRAWL_API_URL")):
             return json.dumps({
                 "error": "web_crawl requires Firecrawl. Set FIRECRAWL_API_KEY, "
                          "or use web_search + web_extract instead.",
@@ -1517,15 +1532,14 @@ def check_firecrawl_api_key() -> bool:
     Returns:
         bool: True if API key is set, False otherwise
     """
-    return bool(os.getenv("FIRECRAWL_API_KEY"))
-
+    return bool(_get_env_clean("FIRECRAWL_API_KEY"))
 
 def check_web_api_key() -> bool:
     """Check if any web backend API key is available (Parallel, Firecrawl, or Tavily)."""
     return bool(
         os.getenv("PARALLEL_API_KEY")
-        or os.getenv("FIRECRAWL_API_KEY")
-        or os.getenv("FIRECRAWL_API_URL")
+        or _get_env_clean("FIRECRAWL_API_KEY")
+        or _get_env_clean("FIRECRAWL_API_URL")
         or os.getenv("TAVILY_API_KEY")
     )
 


### PR DESCRIPTION
## Summary

Fixes inconsistent handling of Firecrawl environment variables where
whitespace-only values (e.g. "   ") were treated as valid configuration.

## Changes

- Added `_get_env_clean` helper to normalize environment variables
- Updated `_has_env` to use normalized values
- Replaced direct `os.getenv("FIRECRAWL_*")` checks with normalized handling
- Ensured whitespace-only values are treated as unset across all code paths
- Added tests to verify whitespace-only env values are treated as unset

## Motivation

Previously, whitespace-only environment variables could bypass validation,
leading to incorrect backend detection or silent misconfiguration.

This PR ensures consistent handling across all Firecrawl-related code paths.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Notes

Follow-up to previous fix for whitespace-only environment variables.