### PR TITLE
fix(cli): pass conversation_history in quiet mode with --resume

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7267,7 +7267,10 @@ def main(
                     route_label=turn_route["label"],
                 ):
                     cli.agent.quiet_mode = True
-                    result = cli.agent.run_conversation(query)
+                    result = cli.agent.run_conversation(
+                        user_message=query,
+                        conversation_history=cli.conversation_history,
+                    )
                     response = result.get("final_response", "") if isinstance(result, dict) else str(result)
                     if response:
                         print(response)


### PR DESCRIPTION
Salvage of PR #2081 by @christopher-kapic. Fixes #2106.

`hermes chat -q 'msg' --resume SESSION_ID` loaded session history into `cli.conversation_history` but never passed it to `run_conversation()`, so the model responded without prior context. The interactive mode already handles this correctly.

One-line fix. Authorship preserved.