### PR TITLE
fix(anthropic): remove fine-grained-tool-streaming beta that causes hang on 2nd message

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -42,7 +42,10 @@ def _supports_adaptive_thinking(model: str) -> bool:
 # Beta headers for enhanced features (sent with ALL auth types)
 _COMMON_BETAS = [
     "interleaved-thinking-2025-05-14",
-    "fine-grained-tool-streaming-2025-05-14",
+    # fine-grained-tool-streaming-2025-05-14 removed: causes stream to hang on
+    # turn 2+ when tool_use/tool_result history is present. The extended event
+    # subtypes emitted by this beta are not consumed by the current streaming
+    # loop, causing stream.get_final_message() to block indefinitely. (#2356)
 ]
 
 # Additional beta headers required for OAuth/subscription auth.

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -60,7 +60,7 @@ class TestBuildAnthropicClient:
             assert "oauth-2025-04-20" in betas
             assert "claude-code-20250219" in betas
             assert "interleaved-thinking-2025-05-14" in betas
-            assert "fine-grained-tool-streaming-2025-05-14" in betas
+            # fine-grained-tool-streaming removed: causes hang on turn 2+ (#2356)
             assert "api_key" not in kwargs
 
     def test_api_key_uses_api_key(self):


### PR DESCRIPTION
Fixes #2356

## Root Cause
`fine-grained-tool-streaming-2025-05-14` in `_COMMON_BETAS` causes the streaming loop to hang indefinitely on turn 2+ when tool_use/tool_result history is present.

Turn 1 works because there is no tool history yet. Turn 2 always has it — the beta emits additional event subtypes that the current streaming loop doesn't consume, causing `stream.get_final_message()` to block until the 900s SDK timeout.

## Fix
Removed `fine-grained-tool-streaming-2025-05-14` from `_COMMON_BETAS`. The streaming loop handles `content_block_start`, `text_delta`, and `thinking_delta` correctly without this beta.
