### PR TITLE
fix(signal): use id instead of attachmentId in getAttachment RPC

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -478,7 +478,7 @@ class SignalAdapter(BasePlatformAdapter):
             if any(mt.startswith("audio/") for mt in media_types):
                 msg_type = MessageType.VOICE
             elif any(mt.startswith("image/") for mt in media_types):
-                msg_type = MessageType.IMAGE
+                msg_type = MessageType.PHOTO
 
         # Parse timestamp from envelope data (milliseconds since epoch)
         ts_ms = envelope_data.get("timestamp", 0)
@@ -518,6 +518,13 @@ class SignalAdapter(BasePlatformAdapter):
 
         if not result:
             return None, ""
+
+        # Handle dict response (signal-cli returns {"data": "base64..."})
+        if isinstance(result, dict):
+            result = result.get("data")
+            if not result:
+                logger.warning("Signal: attachment response missing 'data' key")
+                return None, ""
 
         # Result is base64-encoded file content
         raw_data = base64.b64decode(result)

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -513,7 +513,7 @@ class SignalAdapter(BasePlatformAdapter):
         """Fetch an attachment via JSON-RPC and cache it. Returns (path, ext)."""
         result = await self._rpc("getAttachment", {
             "account": self.account,
-            "attachmentId": attachment_id,
+            "id": attachment_id,
         })
 
         if not result:


### PR DESCRIPTION
## Problem
Signal image attachments were not being processed due to multiple issues:

1. signal-cli's getAttachment RPC expects 'id' parameter, not 'attachmentId'
2. signal-cli daemon HTTP mode returns dict format {"data": "base64..."} instead of raw base64
3. MessageType.IMAGE doesn't exist - should be MessageType.PHOTO

## Solution
- Changed "attachmentId" to "id" in getAttachment RPC call
- Added handling for dict response format from signal-cli daemon
- Fixed enum value from IMAGE to PHOTO for consistency with other platforms

## Testing
Manual test with Signal image attachment - images now correctly processed by vision model.