### PR TITLE
 enrich active environment info and harden task id handling

### DIFF
--- a/tests/tools/test_terminal_tool_info.py
+++ b/tests/tools/test_terminal_tool_info.py
@@ -1,0 +1,55 @@
+﻿import importlib
+from pathlib import Path
+
+
+terminal_tool_module = importlib.import_module("tools.terminal_tool")
+
+
+class _DummyBackend:
+    pass
+
+
+class _DummyEnv:
+    def __init__(self, cwd=None, backend=None):
+        self.cwd = cwd
+        self.backend = backend
+
+
+def test_get_active_environments_info_includes_workdirs_and_backends(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_active_environments",
+        {
+            "task-alpha-1234": _DummyEnv(cwd="/tmp/work-a", backend="local"),
+            "task-beta-5678": _DummyEnv(cwd="/tmp/work-b", backend=_DummyBackend),
+        },
+    )
+    monkeypatch.setattr(terminal_tool_module, "_get_scratch_dir", lambda: Path(tmp_path))
+
+    info = terminal_tool_module.get_active_environments_info()
+
+    assert info["count"] == 2
+    assert info["workdirs"]["task-alpha-1234"] == "/tmp/work-a"
+    assert info["workdirs"]["task-beta-5678"] == "/tmp/work-b"
+    assert info["backends"]["task-alpha-1234"] == "local"
+    assert info["backends"]["task-beta-5678"] == "_DummyBackend"
+
+
+def test_get_active_environments_info_handles_non_string_task_ids(monkeypatch, tmp_path):
+    class NonStringTaskId:
+        def __str__(self):
+            return "non-string-id-42"
+
+    task_id = NonStringTaskId()
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_active_environments",
+        {task_id: _DummyEnv(cwd="/tmp/work-c", backend="local")},
+    )
+    monkeypatch.setattr(terminal_tool_module, "_get_scratch_dir", lambda: Path(tmp_path))
+
+    info = terminal_tool_module.get_active_environments_info()
+
+    assert info["count"] == 1
+    assert info["workdirs"][task_id] == "/tmp/work-c"
+    assert info["backends"][task_id] == "local"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -743,13 +743,24 @@ def get_active_environments_info() -> Dict[str, Any]:
         "count": len(_active_environments),
         "task_ids": list(_active_environments.keys()),
         "workdirs": {},
+        "backends": {},
     }
-    
+
     # Calculate total disk usage (per-task to avoid double-counting)
     total_size = 0
-    for task_id in _active_environments.keys():
+    for task_id, env in _active_environments.items():
+        cwd = getattr(env, "cwd", None)
+        if cwd is not None:
+            info["workdirs"][task_id] = cwd
+
+        backend = getattr(env, "backend", None) or getattr(env, "__class__", None)
+        if isinstance(backend, str):
+            info["backends"][task_id] = backend
+        elif backend is not None:
+            info["backends"][task_id] = getattr(backend, "__name__", str(backend))
+
         scratch_dir = _get_scratch_dir()
-        pattern = f"hermes-*{task_id[:8]}*"
+        pattern = f"hermes-*{str(task_id)[:8]}*"
         import glob
         for path in glob.glob(str(scratch_dir / pattern)):
             try:
@@ -757,7 +768,7 @@ def get_active_environments_info() -> Dict[str, Any]:
                 total_size += size
             except OSError as e:
                 logger.debug("Could not stat path %s: %s", path, e)
-    
+
     info["total_disk_usage_mb"] = round(total_size / (1024 * 1024), 2)
     return info
 


### PR DESCRIPTION
This PR enhances tools/terminal_tool.py#get_active_environments_info() by adding backends alongside existing workdirs, populating both from each environment (env.backend or class name, and env.cwd) to improve observability of persistent shells; it also safeguards disk-usage scanning by deriving the pattern prefix from str(task_id)[:8] to avoid errors with non-string task IDs; includes focused tests in tests/tools/test_terminal_tool_info.py to verify the new fields and non-string task ID handling; code-only change with minimal surface area.