### PR TITLE
fix:   Native Anthropic provider hangs on 2nd message — fine-gra

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -42,7 +42,6 @@ def _supports_adaptive_thinking(model: str) -> bool:
 # Beta headers for enhanced features (sent with ALL auth types)
 _COMMON_BETAS = [
     "interleaved-thinking-2025-05-14",
-    "fine-grained-tool-streaming-2025-05-14",
 ]
 
 # Additional beta headers required for OAuth/subscription auth.


### PR DESCRIPTION
## Summary
Fix for #2356: [Bug]:  Native Anthropic provider hangs on 2nd message — fine-grained-tool-streaming beta incompatible with Python SDK streaming loop

Closes #2356

## Test plan
- [ ] Run pytest to confirm no regressions