### PR TITLE
fix(gateway): inject newline separator at stream iteration boundaries

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -77,8 +77,19 @@ class GatewayStreamConsumer:
         return self._already_sent
 
     def on_delta(self, text: str) -> None:
-        """Thread-safe callback — called from the agent's worker thread."""
-        if text:
+        """Thread-safe callback — called from the agent's worker thread.
+
+        Passing None signals an iteration boundary (the agent finished
+        streaming one segment and is about to resume after tool calls).
+        A newline separator is injected so resumed text starts on a new line
+        instead of being concatenated directly onto the previous segment.
+        """
+        if text is None:
+            # Iteration boundary: inject a separator so the next streamed
+            # segment starts on a new line rather than running together.
+            if self._accumulated and not self._accumulated.endswith(chr(10)):
+                self._queue.put(chr(10))
+        elif text:
             self._queue.put(text)
 
     def finish(self) -> None:

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1,0 +1,79 @@
+"""Tests for GatewayStreamConsumer iteration boundary behaviour.
+
+Covers the bug where resumed text after tool calls was concatenated
+directly onto prior streamed content with no separator (issue #2177).
+"""
+
+import queue
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig, _DONE
+
+
+def _make_consumer(accumulated=""):
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(return_value=MagicMock(success=True, message_id="msg_1"))
+    adapter.edit_message = AsyncMock(return_value=MagicMock(success=True))
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="chat_123",
+        config=StreamConsumerConfig(edit_interval=0.0, buffer_threshold=1),
+    )
+    consumer._accumulated = accumulated
+    return consumer
+
+
+class TestOnDeltaBasic:
+    def test_text_enqueued(self):
+        consumer = _make_consumer()
+        consumer.on_delta("hello")
+        assert consumer._queue.get_nowait() == "hello"
+
+    def test_empty_string_not_enqueued(self):
+        consumer = _make_consumer()
+        consumer.on_delta("")
+        assert consumer._queue.empty()
+
+    def test_none_no_separator_when_empty(self):
+        consumer = _make_consumer(accumulated="")
+        consumer.on_delta(None)
+        assert consumer._queue.empty()
+
+
+class TestOnDeltaBoundary:
+    def test_none_injects_newline_when_no_trailing_newline(self):
+        """Core regression test for issue #2177."""
+        consumer = _make_consumer(accumulated="Let me check the issues.")
+        consumer.on_delta(None)
+        item = consumer._queue.get_nowait()
+        assert item == "\n", f"Expected newline separator, got {item!r}"
+
+    def test_none_no_newline_when_already_ends_with_newline(self):
+        consumer = _make_consumer(accumulated="Let me check.\n")
+        consumer.on_delta(None)
+        assert consumer._queue.empty()
+
+    def test_resumed_text_follows_separator(self):
+        consumer = _make_consumer(accumulated="Let me check the issues.")
+        consumer.on_delta(None)
+        consumer.on_delta("Found 3 issues.")
+        newline = consumer._queue.get_nowait()
+        resumed = consumer._queue.get_nowait()
+        assert newline == "\n"
+        assert resumed == "Found 3 issues."
+
+
+class TestFinish:
+    def test_finish_puts_done_sentinel(self):
+        consumer = _make_consumer()
+        consumer.finish()
+        assert consumer._queue.get_nowait() is _DONE
+
+
+class TestAlreadySent:
+    def test_initially_false(self):
+        consumer = _make_consumer()
+        assert consumer.already_sent is False


### PR DESCRIPTION

## What does this PR do?

Fixes a bug where resumed streamed text after tool calls was concatenated directly onto prior content with no separator, making multi-iteration responses unreadable.


## Related Issue

Closes #2177


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)


## Changes Made

- `gateway/stream_consumer.py`: Updated `on_delta()` to treat `None` as an iteration boundary signal. When `None` is received and the buffer does not already end with a newline, a separator is injected into the queue.
- `tests/gateway/test_stream_consumer.py`: New test file — 8 tests covering the boundary injection logic, including the exact regression case from this issue.

No changes to `run_agent.py` — it already emits `stream_delta_callback(None)` at the right point; the consumer just wasn't handling it.


## How to Test

1. Enable gateway streaming (`streaming.enabled: true` in config.yaml)
2. Send a message that triggers a tool call mid-response (e.g. "search for X and summarize")
3. Observe that resumed text after the tool call starts on a new line
4. Run unit tests: `python3 -m pytest tests/gateway/test_stream_consumer.py -v`

## Checklist



### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## Screenshots / Logs

8/8 tests passing: `python3 -m pytest tests/gateway/test_stream_consumer.py -v`


