### PR TITLE
fix(auth): gate Anthropic token refresh to native Anthropic endpoints only

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -681,10 +681,10 @@ class AIAgent:
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
-            # Alibaba/DashScope use their own API key; do not fall back to ANTHROPIC_TOKEN (Fixes #1739 401).
+            # Third-party Anthropic-compatible providers must use their own API key (Fixes #1739, #2374).
             _base = (base_url or "").lower()
-            _is_alibaba_dashscope = (self.provider == "alibaba") or ("dashscope" in _base) or ("aliyuncs" in _base)
-            effective_key = (api_key or "") if _is_alibaba_dashscope else (api_key or resolve_anthropic_token() or "")
+            _skip_anthropic_token = not self._uses_native_anthropic_auth()
+            effective_key = (api_key or "") if _skip_anthropic_token else (api_key or resolve_anthropic_token() or "")
             self.api_key = effective_key
             self._anthropic_api_key = effective_key
             self._anthropic_base_url = base_url
@@ -3340,9 +3340,8 @@ class AIAgent:
     def _try_refresh_anthropic_client_credentials(self) -> bool:
         if self.api_mode != "anthropic_messages" or not hasattr(self, "_anthropic_api_key"):
             return False
-        # Alibaba/DashScope use their own API key; do not refresh from ANTHROPIC_TOKEN (Fixes #1739 401).
-        _base = (getattr(self, "_anthropic_base_url", None) or "").lower()
-        if (self.provider == "alibaba") or ("dashscope" in _base) or ("aliyuncs" in _base):
+        # Third-party Anthropic-compatible providers must not use Anthropic token refresh.
+        if not self._uses_native_anthropic_auth():
             return False
 
         try:
@@ -3768,7 +3767,7 @@ class AIAgent:
             if fb_api_mode == "anthropic_messages":
                 # Build native Anthropic client instead of using OpenAI client
                 from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
-                effective_key = fb_client.api_key or resolve_anthropic_token() or ""
+                effective_key = fb_client.api_key if not self._uses_native_anthropic_auth() else (fb_client.api_key or resolve_anthropic_token() or "")
                 self._anthropic_api_key = effective_key
                 self._anthropic_base_url = getattr(fb_client, "base_url", None)
                 self._anthropic_client = build_anthropic_client(effective_key, self._anthropic_base_url)
@@ -3946,6 +3945,22 @@ class AIAgent:
                 str(msg.get("role", "user") or "user"),
             )
         return transformed
+
+    def _uses_native_anthropic_auth(self) -> bool:
+        """True only for native Anthropic endpoints that should use resolve_anthropic_token().
+
+        Third-party Anthropic-compatible providers (MiniMax, DashScope, custom /anthropic
+        endpoints) must use their own API keys and must never have credentials overwritten
+        by Anthropic OAuth/token resolution.
+
+        Native Anthropic: provider=="anthropic" or base URL contains api.anthropic.com.
+        Everything else: provider-specific key only.
+        """
+        provider = (getattr(self, "provider", "") or "").lower()
+        if provider == "anthropic":
+            return True
+        base = (getattr(self, "_anthropic_base_url", None) or getattr(self, "base_url", "") or "").lower()
+        return "api.anthropic.com" in base
 
     def _anthropic_preserve_dots(self) -> bool:
         """True when using Alibaba/DashScope anthropic-compatible endpoint (model names keep dots, e.g. qwen3.5-plus)."""

--- a/tests/test_minimax_auth.py
+++ b/tests/test_minimax_auth.py
@@ -1,0 +1,59 @@
+"""Tests for _uses_native_anthropic_auth() -- MiniMax and third-party providers
+must not have their API key overwritten by resolve_anthropic_token()."""
+from unittest.mock import patch, MagicMock
+from run_agent import AIAgent
+
+
+def _make_agent(provider, base_url, api_mode="anthropic_messages"):
+    """Instantiate AIAgent with minimal args, bypassing full init."""
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = provider
+    agent.base_url = base_url
+    agent._anthropic_base_url = base_url
+    agent.api_mode = api_mode
+    return agent
+
+
+class TestUsesNativeAnthropicAuth:
+    def test_anthropic_provider_is_native(self):
+        agent = _make_agent("anthropic", "https://api.anthropic.com")
+        assert agent._uses_native_anthropic_auth() is True
+
+    def test_api_anthropic_com_url_is_native(self):
+        agent = _make_agent("custom", "https://api.anthropic.com/v1")
+        assert agent._uses_native_anthropic_auth() is True
+
+    def test_minimax_is_not_native(self):
+        agent = _make_agent("minimax", "https://api.minimax.io/anthropic")
+        assert agent._uses_native_anthropic_auth() is False
+
+    def test_minimax_cn_is_not_native(self):
+        agent = _make_agent("minimax-cn", "https://api.minimax.chat/anthropic")
+        assert agent._uses_native_anthropic_auth() is False
+
+    def test_dashscope_is_not_native(self):
+        agent = _make_agent("alibaba", "https://dashscope.aliyuncs.com/anthropic")
+        assert agent._uses_native_anthropic_auth() is False
+
+    def test_custom_anthropic_compatible_is_not_native(self):
+        agent = _make_agent("custom", "https://my-server.example.com/anthropic")
+        assert agent._uses_native_anthropic_auth() is False
+
+
+class TestRefreshCredentialsSkipsNonNative:
+    def test_minimax_refresh_does_not_call_resolve_anthropic_token(self):
+        agent = _make_agent("minimax", "https://api.minimax.io/anthropic")
+        agent._anthropic_api_key = "minimax-key-123"
+        with patch("agent.anthropic_adapter.resolve_anthropic_token") as mock_resolve:
+            result = agent._try_refresh_anthropic_client_credentials()
+        mock_resolve.assert_not_called()
+        assert result is False
+
+    def test_native_anthropic_refresh_calls_resolve_token_when_key_differs(self):
+        agent = _make_agent("anthropic", "https://api.anthropic.com")
+        agent._anthropic_api_key = "old-token"
+        agent._anthropic_base_url = "https://api.anthropic.com"
+        with patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="new-token") as mock_resolve, \
+             patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()):
+            agent._try_refresh_anthropic_client_credentials()
+        mock_resolve.assert_called_once()

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2907,6 +2907,8 @@ class TestOAuthFlagAfterCredentialRefresh:
 
     def test_oauth_flag_updates_api_key_to_oauth(self, agent):
         """Refreshing from API key to OAuth token must set flag to True."""
+        agent.provider = "anthropic"
+        agent._anthropic_base_url = "https://api.anthropic.com"
         agent.api_mode = "anthropic_messages"
         agent._anthropic_api_key = "sk-ant-api-old"
         agent._anthropic_client = MagicMock()
@@ -2925,6 +2927,8 @@ class TestOAuthFlagAfterCredentialRefresh:
 
     def test_oauth_flag_updates_oauth_to_api_key(self, agent):
         """Refreshing from OAuth to API key must set flag to False."""
+        agent.provider = "anthropic"
+        agent._anthropic_base_url = "https://api.anthropic.com"
         agent.api_mode = "anthropic_messages"
         agent._anthropic_api_key = "sk-ant-setup-old"
         agent._anthropic_client = MagicMock()


### PR DESCRIPTION
Fixes #2374

## Root cause

Three code paths in `run_agent.py` call `resolve_anthropic_token()` for any provider using `api_mode=anthropic_messages`. The existing guard only excluded Alibaba/DashScope. Any other third-party Anthropic-compatible endpoint (MiniMax, custom `/anthropic` proxies) would have its provider API key silently overwritten by an Anthropic OAuth/setup token, causing 401s.

## Fix

Replace the provider-specific DashScope guard with a positive helper `_uses_native_anthropic_auth()` that returns `True` only when:
- `provider == "anthropic"`, or
- base URL contains `api.anthropic.com`

All other providers (MiniMax, DashScope, custom endpoints) return `False` and skip `resolve_anthropic_token()` entirely.

The fix is applied to all three affected paths:
1. AIAgent init — credential resolution on startup
2. `_try_refresh_anthropic_client_credentials()` — token refresh on 401
3. Fallback activation — when primary model fails and fallback uses `anthropic_messages`

DashScope behaviour is preserved — `provider="alibaba"` is not `"anthropic"` and its URLs do not contain `api.anthropic.com`, so `_uses_native_anthropic_auth()` returns `False` as before.

## Tests

- `tests/test_minimax_auth.py` (new): 8 tests covering `_uses_native_anthropic_auth()` for native vs third-party providers, and verifying MiniMax refresh does not call `resolve_anthropic_token()`
- `tests/test_run_agent.py`: updated `TestOAuthFlagAfterCredentialRefresh` to set `provider="anthropic"` so the existing OAuth flag tests correctly exercise the native path