### PR TITLE
fix(gateway): /title command fails when session doesn't exist in SQLite yet

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3578,6 +3578,20 @@ class GatewayRunner:
         if not self._session_db:
             return "Session database not available."
 
+        # Ensure session exists in SQLite DB (it may only exist in session_store
+        # if this is the first command in a new session)
+        existing_title = self._session_db.get_session_title(session_id)
+        if existing_title is None:
+            # Session doesn't exist in DB yet — create it
+            try:
+                self._session_db.create_session(
+                    session_id=session_id,
+                    source=source.platform.value if source.platform else "unknown",
+                    user_id=source.user_id,
+                )
+            except Exception:
+                pass  # Session might already exist, ignore errors
+
         title_arg = event.get_command_args().strip()
         if title_arg:
             # Sanitize the title before setting


### PR DESCRIPTION
## Bug Description
When using /title as the first command in a new Telegram (or other messaging platform) chat, it fails with:

> Session not found in database.

## Root Cause
The gateway maintains two session stores:
1. \+session_store\+ (in-memory) - auto-creates sessions on first access
2. \+_session_db\+ (SQLite via hermes_state.SessionDB) - only gets sessions when the agent runs and flushes messages

When \/title is used before any actual conversation, the session exists in memory but not in SQLite. The `set_session_title()` method does an UPDATE query which returns 0 rows affected, causing the error.

## Fix
Check if the session exists in SQLite before attempting to set the title. If it doesn't exist, create it first using `create_session()`.

## Testing
- Start a new Telegram chat with Hermes
- Send \/title My Session as the first command
- Should now succeed instead of showing 'Session not found in database'