### PR TITLE
fix(tools): resource leak and double socket close in code_execution_tool

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -300,16 +300,16 @@ def _rpc_server_loop(
                 # their status prints don't leak into the CLI spinner.
                 try:
                     _real_stdout, _real_stderr = sys.stdout, sys.stderr
-                    sys.stdout = open(os.devnull, "w")
-                    sys.stderr = open(os.devnull, "w")
+                    devnull = open(os.devnull, "w")
                     try:
+                        sys.stdout = devnull
+                        sys.stderr = devnull
                         result = handle_function_call(
                             tool_name, tool_args, task_id=task_id
                         )
                     finally:
-                        sys.stdout.close()
-                        sys.stderr.close()
                         sys.stdout, sys.stderr = _real_stdout, _real_stderr
+                        devnull.close()
                 except Exception as exc:
                     logger.error("Tool call failed in sandbox: %s", exc, exc_info=True)
                     result = json.dumps({"error": str(exc)})
@@ -574,6 +574,7 @@ def execute_code(
 
         # Wait for RPC thread to finish
         server_sock.close()  # break accept() so thread exits promptly
+        server_sock = None  # prevent double close in finally
         rpc_thread.join(timeout=3)
 
         # Build response


### PR DESCRIPTION
## Summary

Fixes two bugs in the execute_code sandbox RPC server:

1. **Resource leak**: Two separate `open(os.devnull, "w")` calls for stdout/stderr suppression — if the second fails, the first handle leaks. Now uses a single handle for both.

2. **Double close**: `server_sock.close()` called in the try block and again in the finally block. Now sets `server_sock = None` after the first close to prevent the double-close OSError.

Cherry-picked from PR #2250 by @dieutx (cleaner implementation). PR #2140 by @nidhi-singh02 fixed the same issue and was submitted first — both contributors credited.

Fixes #2136

## Test plan
- [x] Full test suite passes (5753 passed)