### PR TITLE
fix: prevent Anthropic token leaking to third-party anthropic_messages providers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -681,10 +681,11 @@ class AIAgent:
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
-            # Alibaba/DashScope use their own API key; do not fall back to ANTHROPIC_TOKEN (Fixes #1739 401).
-            _base = (base_url or "").lower()
-            _is_alibaba_dashscope = (self.provider == "alibaba") or ("dashscope" in _base) or ("aliyuncs" in _base)
-            effective_key = (api_key or "") if _is_alibaba_dashscope else (api_key or resolve_anthropic_token() or "")
+            # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
+            # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.
+            # Falling back would send Anthropic credentials to third-party endpoints (Fixes #1739, #minimax-401).
+            _is_native_anthropic = self.provider == "anthropic"
+            effective_key = (api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or "")
             self.api_key = effective_key
             self._anthropic_api_key = effective_key
             self._anthropic_base_url = base_url
@@ -3340,9 +3341,9 @@ class AIAgent:
     def _try_refresh_anthropic_client_credentials(self) -> bool:
         if self.api_mode != "anthropic_messages" or not hasattr(self, "_anthropic_api_key"):
             return False
-        # Alibaba/DashScope use their own API key; do not refresh from ANTHROPIC_TOKEN (Fixes #1739 401).
-        _base = (getattr(self, "_anthropic_base_url", None) or "").lower()
-        if (self.provider == "alibaba") or ("dashscope" in _base) or ("aliyuncs" in _base):
+        # Only refresh credentials for the native Anthropic provider.
+        # Other anthropic_messages providers (MiniMax, Alibaba, etc.) use their own keys.
+        if self.provider != "anthropic":
             return False
 
         try:
@@ -3768,7 +3769,7 @@ class AIAgent:
             if fb_api_mode == "anthropic_messages":
                 # Build native Anthropic client instead of using OpenAI client
                 from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
-                effective_key = fb_client.api_key or resolve_anthropic_token() or ""
+                effective_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
                 self._anthropic_api_key = effective_key
                 self._anthropic_base_url = getattr(fb_client, "base_url", None)
                 self._anthropic_client = build_anthropic_client(effective_key, self._anthropic_base_url)

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2405,6 +2405,7 @@ class TestAnthropicCredentialRefresh:
             agent = AIAgent(
                 api_key="sk-ant-oat01-stale-token",
                 api_mode="anthropic_messages",
+                provider="anthropic",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -2907,6 +2908,7 @@ class TestOAuthFlagAfterCredentialRefresh:
 
     def test_oauth_flag_updates_api_key_to_oauth(self, agent):
         """Refreshing from API key to OAuth token must set flag to True."""
+        agent.provider = "anthropic"
         agent.api_mode = "anthropic_messages"
         agent._anthropic_api_key = "sk-ant-api-old"
         agent._anthropic_client = MagicMock()
@@ -2925,6 +2927,7 @@ class TestOAuthFlagAfterCredentialRefresh:
 
     def test_oauth_flag_updates_oauth_to_api_key(self, agent):
         """Refreshing from OAuth to API key must set flag to False."""
+        agent.provider = "anthropic"
         agent.api_mode = "anthropic_messages"
         agent._anthropic_api_key = "sk-ant-setup-old"
         agent._anthropic_client = MagicMock()


### PR DESCRIPTION
## Summary

- When a non-Anthropic provider uses `anthropic_messages` API mode (e.g. MiniMax, Alibaba) and the provider's own API key is not set, `resolve_anthropic_token()` fallback kicks in — sending Anthropic OAuth credentials (`sk-ant-oat01...`) to third-party endpoints, causing 401 errors.
- Generalizes the Alibaba-specific guard from #1739 to **all** non-Anthropic `anthropic_messages` providers.
- Now only `provider == "anthropic"` triggers the Anthropic token fallback. Three code paths fixed:
  1. `AIAgent.__init__` — initial credential resolution
  2. `_try_refresh_anthropic_client_credentials` — credential refresh guard
  3. Fallback activation — provider fallback path

## Reproduction

1. Set up MiniMax provider (`hermes setup` → minimax)
2. Have an Anthropic OAuth token active (e.g. from Claude Code)
3. Do **not** set `MINIMAX_API_KEY`
4. Run hermes → 401 error with `sk-ant-oat01...` token sent to `api.minimax.io`

## Test plan

- [x] Isolated logic tests: MiniMax/Alibaba with no key → empty (no leak), Anthropic with no key → fallback works, MiniMax with own key → uses own key
- [x] `tests/test_runtime_provider_resolution.py` — 29/29 passed