### PR TITLE
fix: prevent Anthropic token leaking to third-party anthropic_messages providers (salvage #2383)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -681,10 +681,11 @@ class AIAgent:
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
-            # Alibaba/DashScope use their own API key; do not fall back to ANTHROPIC_TOKEN (Fixes #1739 401).
-            _base = (base_url or "").lower()
-            _is_alibaba_dashscope = (self.provider == "alibaba") or ("dashscope" in _base) or ("aliyuncs" in _base)
-            effective_key = (api_key or "") if _is_alibaba_dashscope else (api_key or resolve_anthropic_token() or "")
+            # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
+            # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.
+            # Falling back would send Anthropic credentials to third-party endpoints (Fixes #1739, #minimax-401).
+            _is_native_anthropic = self.provider == "anthropic"
+            effective_key = (api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or "")
             self.api_key = effective_key
             self._anthropic_api_key = effective_key
             self._anthropic_base_url = base_url
@@ -3340,9 +3341,9 @@ class AIAgent:
     def _try_refresh_anthropic_client_credentials(self) -> bool:
         if self.api_mode != "anthropic_messages" or not hasattr(self, "_anthropic_api_key"):
             return False
-        # Alibaba/DashScope use their own API key; do not refresh from ANTHROPIC_TOKEN (Fixes #1739 401).
-        _base = (getattr(self, "_anthropic_base_url", None) or "").lower()
-        if (self.provider == "alibaba") or ("dashscope" in _base) or ("aliyuncs" in _base):
+        # Only refresh credentials for the native Anthropic provider.
+        # Other anthropic_messages providers (MiniMax, Alibaba, etc.) use their own keys.
+        if self.provider != "anthropic":
             return False
 
         try:
@@ -3768,7 +3769,7 @@ class AIAgent:
             if fb_api_mode == "anthropic_messages":
                 # Build native Anthropic client instead of using OpenAI client
                 from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
-                effective_key = fb_client.api_key or resolve_anthropic_token() or ""
+                effective_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
                 self._anthropic_api_key = effective_key
                 self._anthropic_base_url = getattr(fb_client, "base_url", None)
                 self._anthropic_client = build_anthropic_client(effective_key, self._anthropic_base_url)

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2413,6 +2413,7 @@ class TestAnthropicCredentialRefresh:
         agent._anthropic_client = old_client
         agent._anthropic_api_key = "sk-ant-oat01-stale-token"
         agent._anthropic_base_url = "https://api.anthropic.com"
+        agent.provider = "anthropic"
 
         with (
             patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="sk-ant-oat01-fresh-token"),
@@ -2908,6 +2909,7 @@ class TestOAuthFlagAfterCredentialRefresh:
     def test_oauth_flag_updates_api_key_to_oauth(self, agent):
         """Refreshing from API key to OAuth token must set flag to True."""
         agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"
         agent._anthropic_api_key = "sk-ant-api-old"
         agent._anthropic_client = MagicMock()
         agent._is_anthropic_oauth = False
@@ -2926,6 +2928,7 @@ class TestOAuthFlagAfterCredentialRefresh:
     def test_oauth_flag_updates_oauth_to_api_key(self, agent):
         """Refreshing from OAuth to API key must set flag to False."""
         agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"
         agent._anthropic_api_key = "sk-ant-setup-old"
         agent._anthropic_client = MagicMock()
         agent._is_anthropic_oauth = True


### PR DESCRIPTION
## Summary
Salvage of PR #2383 by @0xbyt4, cherry-picked onto current main.

When a non-Anthropic provider uses `anthropic_messages` API mode (MiniMax, Alibaba, etc.) and the provider's own API key is missing, `resolve_anthropic_token()` fallback was sending Anthropic OAuth credentials to third-party endpoints, causing 401 errors.

Generalizes the Alibaba-specific guard from #1739 to **all** non-Anthropic providers by flipping the logic: only `provider == "anthropic"` triggers the Anthropic token fallback. Three code paths fixed:
1. `AIAgent.__init__` — initial credential resolution
2. `_try_refresh_anthropic_client_credentials` — credential refresh guard
3. `_try_activate_fallback` — fallback activation path (had NO protection before)

### Follow-up fix
3 existing tests (`TestAnthropicCredentialRefresh`, `TestOAuthFlagAfterCredentialRefresh`) needed `agent.provider = "anthropic"` added since the new guard checks this field.

## Verification
- 5773 tests pass (3 previously failing tests fixed)

## Credit
Original work by @0xbyt4 in #2383. Contributor authorship preserved via cherry-pick.