### PR TITLE
fix(redact): safely handle non-string inputs (salvage #2369)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -100,6 +100,10 @@ def redact_sensitive_text(text: str) -> str:
     Safe to call on any string -- non-matching text passes through unchanged.
     Disabled when security.redact_secrets is false in config.yaml.
     """
+    if text is None:
+        return None
+    if not isinstance(text, str):
+        text = str(text)
     if not text:
         return text
     if os.getenv("HERMES_REDACT_SECRETS", "").lower() in ("0", "false", "no", "off"):

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -124,6 +124,13 @@ class TestPassthrough:
     def test_none_returns_none(self):
         assert redact_sensitive_text(None) is None
 
+    def test_non_string_input_int_coerced(self):
+        assert redact_sensitive_text(12345) == "12345"
+
+    def test_non_string_input_dict_coerced_and_redacted(self):
+        result = redact_sensitive_text({"token": "sk-proj-abc123def456ghi789jkl012"})
+        assert "abc123def456" not in result
+
     def test_normal_text_unchanged(self):
         text = "Hello world, this is a normal log message with no secrets."
         assert redact_sensitive_text(text) == text


### PR DESCRIPTION
## Summary

Salvage of PR #2369 by @aydnOktay. Cherry-picked cleanly onto current main.

`redact_sensitive_text()` now handles non-string inputs defensively:
- Returns `None` early for `None` input (explicit check instead of relying on truthiness)
- Coerces other non-string values (int, dict, etc.) to `str` before applying regex patterns
- Prevents `TypeError` crashes when non-string values flow through logging/tool-output paths

Two new tests: int coercion and dict coercion with redaction.

**Tests:** 31/31 redact tests passing.

Credit: @aydnOktay (original author, commit authorship preserved).