### PR TITLE
fix: restore opencode-go provider config corrupted by secret redaction

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -199,9 +199,9 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     "opencode-go": ProviderConfig(
         id="opencode-go",
         name="OpenCode Go",
-        auth_type="***",
+        auth_type="api_key",
         inference_base_url="https://opencode.ai/zen/go/v1",
-        api_key_env_vars=("OPEN...",),
+        api_key_env_vars=("OPENCODE_GO_API_KEY",),
         base_url_env_var="OPENCODE_GO_BASE_URL",
     ),
     "kilocode": ProviderConfig(


### PR DESCRIPTION
## Summary

- `opencode-go` provider in `PROVIDER_REGISTRY` has been broken since commit 35d948b6 (feat: add Kilo Code provider)
- `auth_type` was `"***"` instead of `"api_key"`
- `api_key_env_vars` was `("OPEN...",)` instead of `("OPENCODE_GO_API_KEY",)`
- A secret redaction tool appears to have masked these values during that commit
- OpenCode Go provider is completely non-functional as a result

## Fix

Restore the original values from commit 40e2f8d9 (feat: add OpenCode Zen and OpenCode Go providers).

## Test plan

- [x] `tests/test_api_key_providers.py` — 101/101 passed
- [x] Verified `PROVIDER_REGISTRY['opencode-go']` returns correct values