### PR TITLE
fix(terminal): log disk warning check failures at debug level (salvage #2372)

### DIFF
--- a/tests/tools/test_terminal_disk_usage.py
+++ b/tests/tools/test_terminal_disk_usage.py
@@ -11,7 +11,7 @@ import pytest
 import sys
 import tools.terminal_tool  # noqa: F401 -- ensure module is loaded
 _tt_mod = sys.modules["tools.terminal_tool"]
-from tools.terminal_tool import get_active_environments_info
+from tools.terminal_tool import get_active_environments_info, _check_disk_usage_warning
 
 # 1 MiB of data so the rounded MB value is clearly distinguishable
 _1MB = b"x" * (1024 * 1024)
@@ -62,3 +62,12 @@ class TestDiskUsageGlob:
         # Should be ~2.0 MB total (1 MB per task).
         # With the bug, each task globs everything -> ~4.0 MB.
         assert info["total_disk_usage_mb"] == pytest.approx(2.0, abs=0.1)
+
+
+class TestDiskUsageWarningHardening:
+    def test_check_disk_usage_warning_logs_debug_on_unexpected_error(self):
+        with patch.object(_tt_mod, "_get_scratch_dir", side_effect=RuntimeError("boom")),              patch.object(_tt_mod.logger, "debug") as debug_mock:
+            result = _check_disk_usage_warning()
+
+        assert result is False
+        debug_mock.assert_called()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -75,9 +75,9 @@ DISK_USAGE_WARNING_THRESHOLD_GB = float(os.getenv("TERMINAL_DISK_WARNING_GB", "5
 
 def _check_disk_usage_warning():
     """Check if total disk usage exceeds warning threshold."""
-    scratch_dir = _get_scratch_dir()
-    
     try:
+        scratch_dir = _get_scratch_dir()
+
         # Get total size of hermes directories
         total_bytes = 0
         import glob

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -98,6 +98,7 @@ def _check_disk_usage_warning():
         
         return False
     except Exception as e:
+        logger.debug("Disk usage warning check failed: %s", e, exc_info=True)
         return False
 
 


### PR DESCRIPTION
## Summary
Salvage of PR #2372 by @aydnOktay, cherry-picked onto current main.

Two small hardening improvements to `_check_disk_usage_warning()`:

1. Moved `_get_scratch_dir()` inside the try block so exceptions from it are caught (previously could propagate uncaught)
2. Added `logger.debug(..., exc_info=True)` in the except handler for observability without changing runtime behavior
3. Added regression test verifying fail-safe behavior + debug logging on error

## Verification
- 5788 tests pass (1 new test)

## Credit
Original work by @aydnOktay in #2372. Contributor authorship preserved via cherry-pick.