### PR TITLE
fix(auth): gate Anthropic token refresh to native Anthropic endpoints only

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -681,7 +681,12 @@ class AIAgent:
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
-            effective_key = api_key or resolve_anthropic_token() or ""
+            # Third-party Anthropic-compatible providers (MiniMax, DashScope, etc.)
+            # must keep their own API key — never fall back to resolve_anthropic_token().
+            if self._uses_native_anthropic_auth():
+                effective_key = api_key or resolve_anthropic_token() or ""
+            else:
+                effective_key = api_key or ""
             self.api_key = effective_key
             self._anthropic_api_key = effective_key
             self._anthropic_base_url = base_url
@@ -3195,6 +3200,9 @@ class AIAgent:
     def _try_refresh_anthropic_client_credentials(self) -> bool:
         if self.api_mode != "anthropic_messages" or not hasattr(self, "_anthropic_api_key"):
             return False
+        # Third-party Anthropic-compatible providers must not use Anthropic token refresh.
+        if not self._uses_native_anthropic_auth():
+            return False
 
         try:
             from agent.anthropic_adapter import resolve_anthropic_token, build_anthropic_client
@@ -3619,7 +3627,10 @@ class AIAgent:
             if fb_api_mode == "anthropic_messages":
                 # Build native Anthropic client instead of using OpenAI client
                 from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
-                effective_key = fb_client.api_key or resolve_anthropic_token() or ""
+                if self._uses_native_anthropic_auth():
+                    effective_key = fb_client.api_key or resolve_anthropic_token() or ""
+                else:
+                    effective_key = fb_client.api_key or ""
                 self._anthropic_api_key = effective_key
                 self._anthropic_base_url = getattr(fb_client, "base_url", None)
                 self._anthropic_client = build_anthropic_client(effective_key, self._anthropic_base_url)
@@ -3797,6 +3808,19 @@ class AIAgent:
                 str(msg.get("role", "user") or "user"),
             )
         return transformed
+
+    def _uses_native_anthropic_auth(self) -> bool:
+        """True only for native Anthropic endpoints that should use resolve_anthropic_token().
+
+        Third-party Anthropic-compatible providers (MiniMax, DashScope, custom /anthropic
+        endpoints) must use their own API keys and must never have credentials overwritten
+        by Anthropic OAuth/token resolution.
+        """
+        provider = (getattr(self, "provider", "") or "").lower()
+        if provider == "anthropic":
+            return True
+        base = (getattr(self, "_anthropic_base_url", None) or getattr(self, "base_url", "") or "").lower()
+        return "api.anthropic.com" in base
 
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""

--- a/tests/test_minimax_auth.py
+++ b/tests/test_minimax_auth.py
@@ -1,0 +1,59 @@
+"""Tests for _uses_native_anthropic_auth() -- MiniMax and third-party providers
+must not have their API key overwritten by resolve_anthropic_token()."""
+from unittest.mock import patch, MagicMock
+from run_agent import AIAgent
+
+
+def _make_agent(provider, base_url, api_mode="anthropic_messages"):
+    """Instantiate AIAgent with minimal args, bypassing full init."""
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = provider
+    agent.base_url = base_url
+    agent._anthropic_base_url = base_url
+    agent.api_mode = api_mode
+    return agent
+
+
+class TestUsesNativeAnthropicAuth:
+    def test_anthropic_provider_is_native(self):
+        agent = _make_agent("anthropic", "https://api.anthropic.com")
+        assert agent._uses_native_anthropic_auth() is True
+
+    def test_api_anthropic_com_url_is_native(self):
+        agent = _make_agent("custom", "https://api.anthropic.com/v1")
+        assert agent._uses_native_anthropic_auth() is True
+
+    def test_minimax_is_not_native(self):
+        agent = _make_agent("minimax", "https://api.minimax.io/anthropic")
+        assert agent._uses_native_anthropic_auth() is False
+
+    def test_minimax_cn_is_not_native(self):
+        agent = _make_agent("minimax-cn", "https://api.minimax.chat/anthropic")
+        assert agent._uses_native_anthropic_auth() is False
+
+    def test_dashscope_is_not_native(self):
+        agent = _make_agent("alibaba", "https://dashscope.aliyuncs.com/anthropic")
+        assert agent._uses_native_anthropic_auth() is False
+
+    def test_custom_anthropic_compatible_is_not_native(self):
+        agent = _make_agent("custom", "https://my-server.example.com/anthropic")
+        assert agent._uses_native_anthropic_auth() is False
+
+
+class TestRefreshCredentialsSkipsNonNative:
+    def test_minimax_refresh_does_not_call_resolve_anthropic_token(self):
+        agent = _make_agent("minimax", "https://api.minimax.io/anthropic")
+        agent._anthropic_api_key = "minimax-key-123"
+        with patch("agent.anthropic_adapter.resolve_anthropic_token") as mock_resolve:
+            result = agent._try_refresh_anthropic_client_credentials()
+        mock_resolve.assert_not_called()
+        assert result is False
+
+    def test_native_anthropic_refresh_calls_resolve_token_when_key_differs(self):
+        agent = _make_agent("anthropic", "https://api.anthropic.com")
+        agent._anthropic_api_key = "old-token"
+        agent._anthropic_base_url = "https://api.anthropic.com"
+        with patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="new-token") as mock_resolve, \
+             patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()):
+            agent._try_refresh_anthropic_client_credentials()
+        mock_resolve.assert_called_once()

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2907,6 +2907,8 @@ class TestOAuthFlagAfterCredentialRefresh:
 
     def test_oauth_flag_updates_api_key_to_oauth(self, agent):
         """Refreshing from API key to OAuth token must set flag to True."""
+        agent.provider = "anthropic"
+        agent._anthropic_base_url = "https://api.anthropic.com"
         agent.api_mode = "anthropic_messages"
         agent._anthropic_api_key = "sk-ant-api-old"
         agent._anthropic_client = MagicMock()
@@ -2925,6 +2927,8 @@ class TestOAuthFlagAfterCredentialRefresh:
 
     def test_oauth_flag_updates_oauth_to_api_key(self, agent):
         """Refreshing from OAuth to API key must set flag to False."""
+        agent.provider = "anthropic"
+        agent._anthropic_base_url = "https://api.anthropic.com"
         agent.api_mode = "anthropic_messages"
         agent._anthropic_api_key = "sk-ant-setup-old"
         agent._anthropic_client = MagicMock()


### PR DESCRIPTION
## Summary

Cherry-pick of #2377 by @teyrebaz33, applied cleanly against current main. Closes #2374.

MiniMax and other third-party Anthropic-compatible providers had their API keys overwritten by Anthropic OAuth token resolution (`resolve_anthropic_token()`), causing 401s.

### Changes

Adds `_uses_native_anthropic_auth()` helper — returns True only for `provider=="anthropic"` or `api.anthropic.com` in the URL. Gates all three Anthropic token paths:

1. **Init** — only call `resolve_anthropic_token()` for native Anthropic
2. **Refresh** — early-return False for non-native providers
3. **Fallback activation** — same gating

### Tests (8 new)

- MiniMax, MiniMax-CN, DashScope, custom `/anthropic` all correctly identified as non-native
- Native Anthropic (provider or URL) correctly identified
- Refresh path verified: MiniMax skips token resolution, native Anthropic calls it

All 5694 tests pass (24 pre-existing failures from unrelated stashed work).