### PR TITLE
fix: separate cron log placeholder from delivery response (salvage #2238)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -412,9 +412,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         
         result = agent.run_conversation(prompt)
         
-        final_response = result.get("final_response", "")
-        if not final_response:
-            final_response = "(No response generated)"
+        final_response = result.get("final_response", "") or ""
+        logged_response = final_response or "(No response generated)"
         
         output = f"""# Cron Job: {job_name}
 
@@ -428,7 +427,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
 ## Response
 
-{final_response}
+{logged_response}
 """
         
         logger.info("Job '%s' completed successfully", job_name)


### PR DESCRIPTION
## Summary
Salvage of the scheduler fix from PR #2238 by @iborazzi (the broken `main.py` timestamp changes were excluded).

Silent cron jobs were delivering `(No response generated)` to the user's chat because the placeholder overwrote `final_response`, which is also used for delivery at line 530.

Separates the two purposes:
- `final_response` stays clean (empty string) for the delivery path — empty means `should_deliver = False`, so nothing is sent
- `logged_response` uses the placeholder only for the internal output log saved to disk

Fixes #2234

## Verification
- 5786 passed (25 pre-existing failures on main, confirmed identical with/without this change)
- The excluded `main.py` changes were the same broken timestamp code from PR #1741 (already closed)

## Credit
Original scheduler fix by @iborazzi in #2238. Contributor authorship preserved.