### PR TITLE
feat(cli): make fullscreen mode configurable via display.fullscreen

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -699,6 +699,13 @@ display:
   # Stream tokens to the terminal in real-time. Disable to wait for full responses.
   streaming: true
 
+  # Use alternate screen (fullscreen) mode — like vim or htop.
+  # When enabled, Hermes launches into the terminal's alternate screen buffer,
+  # keeping the session visually isolated from prior shell history.
+  # On exit, the original terminal content is fully restored.
+  # Set to true if you prefer a clean, fullscreen TUI experience.
+  fullscreen: false
+
   # ───────────────────────────────────────────────────────────────────────────
   # Skin / Theme
   # ───────────────────────────────────────────────────────────────────────────

--- a/cli.py
+++ b/cli.py
@@ -6934,11 +6934,12 @@ class HermesCLI:
         style = PTStyle.from_dict(self._build_tui_style_dict())
         
         # Create the application
+        _fullscreen = CLI_CONFIG.get("display", {}).get("fullscreen", False)
         app = Application(
             layout=layout,
             key_bindings=kb,
             style=style,
-            full_screen=False,
+            full_screen=_fullscreen,
             mouse_support=False,
             **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
         )


### PR DESCRIPTION
## Summary

Closes #639

The TUI previously hardcoded `full_screen=False` in the prompt_toolkit `Application`. Users who prefer vim/htop-style alternate screen isolation (session content cleanly separated from prior shell history) had no way to opt in.

## Changes

- `cli-config.yaml.example`: added `display.fullscreen` option (default `false`, backward compatible)
- `cli.py`: reads `CLI_CONFIG["display"]["fullscreen"]` and forwards to `Application(full_screen=...)`

## Usage

```yaml
display:
  fullscreen: true   # enter alternate screen on launch, restore on exit
```

When `fullscreen: true`, Hermes enters the terminal's alternate screen buffer on launch and fully restores the original terminal content on exit — exactly like vim or htop.

Default is `false` to preserve the existing inline behavior.

## Test plan

- [ ] `fullscreen: false` (default): behavior identical to before
- [ ] `fullscreen: true`: Hermes enters alternate screen on launch, original content restored on exit
- [ ] No config key present: falls back to `false` safely