### PR TITLE
chore: publish hermes-agent to PyPI and update ACP registry entry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Build package
+        run: |
+          uv venv .venv --python 3.11
+          source .venv/bin/activate
+          uv pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,12 +1,17 @@
 {
-  "schema_version": 1,
-  "name": "hermes-agent",
-  "display_name": "Hermes Agent",
-  "description": "AI agent by Nous Research with 90+ tools, persistent memory, and multi-platform support",
+  "id": "hermes-agent",
+  "name": "Hermes Agent",
+  "version": "0.4.0",
+  "description": "Open-source AI agent by Nous Research with 90+ tools, persistent memory, multi-platform messaging (Telegram, Discord, Slack, Signal, WhatsApp), cron scheduling, and skill system",
+  "repository": "https://github.com/NousResearch/hermes-agent",
+  "website": "https://hermes-agent.nousresearch.com/docs/",
+  "authors": ["Nous Research"],
+  "license": "MIT",
   "icon": "icon.svg",
   "distribution": {
-    "type": "command",
-    "command": "hermes",
-    "args": ["acp"]
+    "uvx": {
+      "package": "hermes-agent",
+      "args": ["acp"]
+    }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,11 @@ readme = "README.md"
 requires-python = ">=3.11"
 authors = [{ name = "Nous Research" }]
 license = { text = "MIT" }
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+]
 dependencies = [
   # Core
   "openai",
@@ -90,6 +95,10 @@ all = [
 hermes = "hermes_cli.main:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
+
+[project.urls]
+Homepage = "https://github.com/NousResearch/hermes-agent"
+Repository = "https://github.com/NousResearch/hermes-agent"
 
 [tool.setuptools]
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_state", "hermes_time", "mini_swe_runner", "minisweagent_path", "rl_cli", "utils"]


### PR DESCRIPTION
## Summary

Closes #2416

Enables `hermes-agent` to be installed via `uvx` / PyPI, which is required for the ACP registry listing.

## Changes

**`.github/workflows/publish.yml`** — new GitHub Actions workflow that publishes to PyPI on every `v*` tag push, using trusted publishing (no API token needed).

**`pyproject.toml`** — adds standard PyPI classifiers and project URLs (Homepage, Repository).

**`acp_registry/agent.json`** — updates to full ACP format: proper `id`, `version`, `repository`, `website`, `authors` fields, and `uvx` distribution without a pinned version so installs always get the latest release.

## Why no pinned version in uvx?

Pinning `hermes-agent==0.4.0` in the ACP registry means every release needs a registry PR. Using `hermes-agent` (unpinned) lets `uvx` resolve the latest from PyPI automatically.

## Test plan
- [ ] `python -m build` succeeds locally
- [ ] Workflow triggers on `v*` tag push
- [ ] `uvx hermes-agent acp` works once published