### PR TITLE
docs(honcho): add self-hosted / Docker configuration section

### DIFF
--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -25,6 +25,33 @@ Hermes has two memory systems that can work together or be configured separately
 Set `memoryMode` to `honcho` to use Honcho exclusively. See [Memory Modes](#memory-modes) for per-peer configuration.
 
 
+## Self-hosted / Docker
+
+Hermes supports a local Honcho instance (e.g. via Docker) in addition to the hosted API. Point it at your instance using `HONCHO_BASE_URL` — no API key required.
+
+**Via `hermes config`:**
+
+```bash
+hermes config set HONCHO_BASE_URL http://localhost:8000
+```
+
+**Via `~/.honcho/config.json`:**
+
+```json
+{
+  "hosts": {
+    "hermes": {
+      "base_url": "http://localhost:8000",
+      "enabled": true
+    }
+  }
+}
+```
+
+Hermes auto-enables Honcho when either `apiKey` or `base_url` is present, so no further configuration is needed for a local instance.
+
+To run Honcho locally, refer to the [Honcho self-hosting docs](https://docs.honcho.dev).
+
 ## Setup
 
 ### Interactive Setup


### PR DESCRIPTION
## Summary

Closes #2318

Adds a **Self-hosted / Docker** section to the Honcho docs explaining how to use `HONCHO_BASE_URL` to point Hermes at a local Honcho instance.

The feature was already supported in code (`honcho_integration/client.py`) but completely undocumented.

## Changes

- New section in `website/docs/user-guide/features/honcho.md` covering:
  - `hermes config set HONCHO_BASE_URL` method
  - `~/.honcho/config.json` `base_url` field method
  - Note that no API key is needed for local instances
  - Link to Honcho self-hosting docs

## Test plan

- [ ] Doc renders correctly in the Docusaurus site