### PR TITLE
feat: docker_extra_args, message timestamps, and lazy skill loading

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -312,6 +312,7 @@ def _skill_should_show(
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
+    lazy: bool = False,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -362,6 +363,18 @@ def build_skills_system_prompt(
 
     if not skills_by_category:
         return ""
+
+    # Lazy mode: skip the full index, just tell the model to use skills_list
+    if lazy:
+        total = sum(len(v) for v in skills_by_category.values())
+        return (
+            "## Skills (mandatory)\n"
+            f"You have {total} skill(s) available. "
+            "Before replying to complex tasks, call skills_list() to discover relevant skills, "
+            "then load the matching one with skill_view(name) and follow its instructions.\n"
+            "If a skill you loaded was missing steps, had wrong commands, or needed "
+            "pitfalls you discovered, update it with skill_manage(action='patch') before finishing."
+        )
 
     # Read category-level descriptions from DESCRIPTION.md
     # Checks both the exact category path and parent directories

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -129,6 +129,12 @@ terminal:
 #   docker_forward_env:
 #     - "GITHUB_TOKEN"
 #     - "NPM_TOKEN"
+#   # Optional: extra flags passed verbatim to docker run (appended after security defaults).
+#   # Useful for adding capabilities (e.g. apt installs needing SETUID) or custom options.
+#   # Example: add a Linux capability not included by default
+#   # docker_extra_args:
+#   #   - "--cap-add"
+#   #   - "SETUID"
 
 # -----------------------------------------------------------------------------
 # OPTION 4: Singularity/Apptainer container
@@ -698,6 +704,14 @@ display:
   # line-by-line. Tool calls are still captured silently.
   # Stream tokens to the terminal in real-time. Disable to wait for full responses.
   streaming: true
+
+  # Show [HH:MM] timestamps on user input and assistant response labels.
+  # timestamps: false
+
+  # Lazy skill loading: instead of injecting the full skill index into the system
+  # prompt, only tell the model how many skills exist and let it call skills_list()
+  # on demand. Saves tokens when you have many skills but use few per session.
+  # lazy_skills: false
 
   # ───────────────────────────────────────────────────────────────────────────
   # Skin / Theme

--- a/cli.py
+++ b/cli.py
@@ -1042,6 +1042,8 @@ class HermesCLI:
         
         # streaming: stream tokens to the terminal as they arrive (display.streaming in config.yaml)
         self.streaming_enabled = CLI_CONFIG["display"].get("streaming", False)
+        # show_timestamps: prefix user and assistant labels with [HH:MM]
+        self.show_timestamps = CLI_CONFIG["display"].get("timestamps", False)
 
         # Streaming display state
         self._stream_buf = ""        # Partial line buffer for line-buffered rendering
@@ -1648,6 +1650,8 @@ class HermesCLI:
                 self._stream_text_ansi = f"\033[38;2;{_r};{_g};{_b}m"
             except (ValueError, IndexError):
                 self._stream_text_ansi = ""
+            if self.show_timestamps:
+                label = f"{label} {datetime.now().strftime('%H:%M')}"
             w = shutil.get_terminal_size().columns
             fill = w - 2 - len(label)
             _cprint(f"\n{_GOLD}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
@@ -7007,14 +7011,16 @@ class HermesCLI:
                             line_count = full_text.count('\n') + 1
                             print()
                             ChatConsole().print(_user_bar)
+                            _ts_suffix = f" [dim]{datetime.now().strftime('%H:%M')}[/]" if self.show_timestamps else ""
                             ChatConsole().print(
-                                f"[bold {_accent_hex()}]●[/] [bold]{_escape(f'[Pasted text: {line_count} lines]')}[/]"
+                                f"[bold {_accent_hex()}]●[/] [bold]{_escape(f'[Pasted text: {line_count} lines]')}[/]{_ts_suffix}"
                             )
                             user_input = full_text
                         else:
                             print()
                             ChatConsole().print(_user_bar)
-                            ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]")
+                            _ts_suffix = f" [dim]{datetime.now().strftime('%H:%M')}[/]" if self.show_timestamps else ""
+                            ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]{_ts_suffix}")
                     else:
                         _user_bar = f"[{_accent_hex()}]{'─' * 40}[/]"
                         if '\n' in user_input:
@@ -7022,14 +7028,16 @@ class HermesCLI:
                             line_count = user_input.count('\n') + 1
                             print()
                             ChatConsole().print(_user_bar)
+                            _ts_suffix = f" [dim]{datetime.now().strftime('%H:%M')}[/]" if self.show_timestamps else ""
                             ChatConsole().print(
                                 f"[bold {_accent_hex()}]●[/] [bold]{_escape(first_line)}[/] "
-                                f"[dim](+{line_count - 1} lines)[/]"
+                                f"[dim](+{line_count - 1} lines)[/]{_ts_suffix}"
                             )
                         else:
                             print()
                             ChatConsole().print(_user_bar)
-                            ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]")
+                            _ts_suffix = f" [dim]{datetime.now().strftime('%H:%M')}[/]" if self.show_timestamps else ""
+                            ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]{_ts_suffix}")
                     
                     # Show image attachment count
                     if submit_images:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -136,6 +136,7 @@ DEFAULT_CONFIG = {
         # Explicit opt-in: mount the host cwd into /workspace for Docker sessions.
         # Default off because passing host directories into a sandbox weakens isolation.
         "docker_mount_cwd_to_workspace": False,
+        "docker_extra_args": [],        # Extra flags passed verbatim to docker run
         # Persistent shell — keep a long-lived bash shell across execute() calls
         # so cwd/env vars/shell variables survive between commands.
         # Enabled by default for non-local backends (SSH); local is always opt-in
@@ -234,6 +235,8 @@ DEFAULT_CONFIG = {
         "bell_on_complete": False,
         "show_reasoning": False,
         "streaming": False,
+        "timestamps": False,      # Show [HH:MM] on user and assistant labels
+        "lazy_skills": False,     # Load skills on-demand instead of injecting full index in system prompt
         "show_cost": False,       # Show $ cost in the status bar (off by default)
         "skin": "default",
     },

--- a/run_agent.py
+++ b/run_agent.py
@@ -2309,9 +2309,12 @@ class AIAgent:
         has_skills_tools = any(name in self.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
         if has_skills_tools:
             avail_toolsets = {ts for ts, avail in check_toolset_requirements().items() if avail}
+            from hermes_cli.config import CLI_CONFIG as _cli_cfg
+            _lazy_skills = _cli_cfg.get("display", {}).get("lazy_skills", False)
             skills_prompt = build_skills_system_prompt(
                 available_tools=self.valid_tool_names,
                 available_toolsets=avail_toolsets,
+                lazy=_lazy_skills,
             )
         else:
             skills_prompt = ""

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -212,6 +212,7 @@ class DockerEnvironment(BaseEnvironment):
         network: bool = True,
         host_cwd: str = None,
         auto_mount_cwd: bool = False,
+        extra_args: list = None,
     ):
         if cwd == "~":
             cwd = "/root"
@@ -315,7 +316,16 @@ class DockerEnvironment(BaseEnvironment):
             logger.debug("Skipping docker cwd mount: /workspace already mounted by user config")
 
         logger.info(f"Docker volume_args: {volume_args}")
-        all_run_args = list(_SECURITY_ARGS) + writable_args + resource_args + volume_args
+        # User-supplied extra docker run flags (docker_extra_args in config.yaml).
+        # Appended last so they can override defaults if needed.
+        validated_extra = []
+        for arg in (extra_args or []):
+            if not isinstance(arg, str):
+                logger.warning("Ignoring non-string docker_extra_args entry: %r", arg)
+                continue
+            validated_extra.append(arg)
+
+        all_run_args = list(_SECURITY_ARGS) + writable_args + resource_args + volume_args + validated_extra
         logger.info(f"Docker run_args: {all_run_args}")
 
         # Resolve the docker executable once so it works even when

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -534,6 +534,7 @@ def _get_env_config() -> Dict[str, Any]:
         "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
         "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in ("true", "1", "yes"),
         "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
+        "docker_extra_args": _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON"),
     }
 
 
@@ -565,6 +566,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     persistent = cc.get("container_persistent", True)
     volumes = cc.get("docker_volumes", [])
     docker_forward_env = cc.get("docker_forward_env", [])
+    docker_extra_args = cc.get("docker_extra_args", [])
 
     if env_type == "local":
         lc = local_config or {}
@@ -580,6 +582,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             host_cwd=host_cwd,
             auto_mount_cwd=cc.get("docker_mount_cwd_to_workspace", False),
             forward_env=docker_forward_env,
+            extra_args=docker_extra_args,
         )
     
     elif env_type == "singularity":


### PR DESCRIPTION
Three independent quality-of-life improvements, all opt-in and backward compatible.

## 1. `terminal.docker_extra_args`

Pass extra flags verbatim to `docker run`, appended after the hardcoded security defaults.

```yaml
terminal:
  backend: docker
  docker_extra_args:
    - "--cap-add"
    - "SETUID"
```

Also available via `TERMINAL_DOCKER_EXTRA_ARGS='["--cap-add","SETUID"]'`. Entries are validated as strings; non-strings are logged and skipped. Useful for apt packages that need capabilities not granted by the default `--cap-drop ALL` + minimal re-adds, or any other `docker run` flag not exposed by existing config keys.

## 2. `display.timestamps`

Appends `[HH:MM]` to user input labels and the assistant response box header.

```yaml
display:
  timestamps: true
```

Covers all input variants: plain text, multiline, and pasted content. Off by default.

Closes #1569

## 3. `display.lazy_skills`

When enabled, replaces the full skill index in the system prompt with a single-line note telling the model to call `skills_list()` on demand, then `skill_view(name)` to load the one it needs.

```yaml
display:
  lazy_skills: true
```

Saves tokens every session for users with large skill libraries who only use a subset per task. The index can grow to hundreds of lines — this collapses it to ~3 lines regardless of skill count. Off by default.

Closes #2045

## Test plan
- [ ] `docker_extra_args: ["--cap-add", "SETUID"]` appears in `docker run` command
- [ ] `display.timestamps: true` shows `[HH:MM]` on user and assistant labels
- [ ] `display.lazy_skills: true` replaces skill index with count + instruction
- [ ] All three default to `false` / `[]` with no behavior change