### PR TITLE
feat(context): insertion-time tool result trimming with head+tail preservation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -349,6 +349,74 @@ def _inject_honcho_turn_context(content, turn_context: str):
     return f"{text}\n\n{note}"
 
 
+# ---------------------------------------------------------------------------
+# Tool result trimming — insertion-time size management (Issue #415)
+# ---------------------------------------------------------------------------
+
+# Hard ceiling: absolute maximum chars for any single tool result.  This
+# exists as a safety net to prevent catastrophic context explosions (e.g.
+# accidental base64 image dumps).  Results exceeding this are head-truncated.
+_TOOL_RESULT_HARD_LIMIT = 100_000  # ~25K tokens
+
+# Soft trim: tool results longer than this get head+tail trimmed, preserving
+# both the start (context, headers) and end (exit codes, summaries).  The
+# middle is dropped with an indicator.  Set to 0 to disable soft trimming.
+_TOOL_RESULT_SOFT_LIMIT = 12_000   # ~3K tokens
+
+# How many chars to keep from the head and tail when soft-trimming.
+_TOOL_RESULT_HEAD_CHARS = 4_000
+_TOOL_RESULT_TAIL_CHARS = 4_000
+
+
+def _trim_tool_result(
+    result: str,
+    *,
+    soft_limit: int = _TOOL_RESULT_SOFT_LIMIT,
+    hard_limit: int = _TOOL_RESULT_HARD_LIMIT,
+    head_chars: int = _TOOL_RESULT_HEAD_CHARS,
+    tail_chars: int = _TOOL_RESULT_TAIL_CHARS,
+) -> str:
+    """Trim a tool result at insertion time, before it enters the message array.
+
+    Two-stage approach:
+    1. **Soft trim** (default 12K): preserve head + tail, drop middle.
+       Keeps file headers / command context (head) and exit codes /
+       error summaries (tail).
+    2. **Hard cap** (100K): emergency head-only truncation as safety net.
+
+    Messages are never modified after insertion, preserving prompt caching.
+    """
+    if not result:
+        return result
+
+    length = len(result)
+
+    # Stage 1: soft trim with head+tail preservation
+    if soft_limit > 0 and length > soft_limit:
+        # Ensure head + tail don't exceed soft limit
+        keep = min(head_chars, soft_limit // 2)
+        tail = min(tail_chars, soft_limit // 2)
+        dropped = length - keep - tail
+        result = (
+            result[:keep]
+            + f"\n\n[Truncated: showing first {keep:,} and last {tail:,} chars "
+            + f"of {length:,} total ({dropped:,} chars dropped)]\n\n"
+            + result[-tail:]
+        )
+        length = len(result)
+
+    # Stage 2: hard cap (safety net — should rarely fire after soft trim)
+    if length > hard_limit:
+        original_len = length
+        result = (
+            result[:hard_limit]
+            + f"\n\n[Truncated: tool response was {original_len:,} chars, "
+            f"exceeding the {hard_limit:,} char limit]"
+        )
+
+    return result
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -4780,15 +4848,8 @@ class AIAgent:
                     response_preview = function_result[:self.log_prefix_chars] + "..." if len(function_result) > self.log_prefix_chars else function_result
                     print(f"  ✅ Tool {i+1} completed in {tool_duration:.2f}s - {response_preview}")
 
-            # Truncate oversized results
-            MAX_TOOL_RESULT_CHARS = 100_000
-            if len(function_result) > MAX_TOOL_RESULT_CHARS:
-                original_len = len(function_result)
-                function_result = (
-                    function_result[:MAX_TOOL_RESULT_CHARS]
-                    + f"\n\n[Truncated: tool response was {original_len:,} chars, "
-                    f"exceeding the {MAX_TOOL_RESULT_CHARS:,} char limit]"
-                )
+            # Trim oversized results at insertion time (head+tail preserving)
+            function_result = _trim_tool_result(function_result)
 
             # Append tool result message in order
             tool_msg = {
@@ -5029,26 +5090,6 @@ class AIAgent:
                 logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
                 logging.debug(f"Tool result ({len(function_result)} chars): {function_result}")
 
-            # Guard against tools returning absurdly large content that would
-            # blow up the context window. 100K chars ≈ 25K tokens — generous
-            # enough for any reasonable tool output but prevents catastrophic
-            # context explosions (e.g. accidental base64 image dumps).
-            MAX_TOOL_RESULT_CHARS = 100_000
-            if len(function_result) > MAX_TOOL_RESULT_CHARS:
-                original_len = len(function_result)
-                function_result = (
-                    function_result[:MAX_TOOL_RESULT_CHARS]
-                    + f"\n\n[Truncated: tool response was {original_len:,} chars, "
-                    f"exceeding the {MAX_TOOL_RESULT_CHARS:,} char limit]"
-                )
-
-            tool_msg = {
-                "role": "tool",
-                "content": function_result,
-                "tool_call_id": tool_call.id
-            }
-            messages.append(tool_msg)
-
             if not self.quiet_mode:
                 if self.verbose_logging:
                     print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s")
@@ -5056,6 +5097,16 @@ class AIAgent:
                 else:
                     response_preview = function_result[:self.log_prefix_chars] + "..." if len(function_result) > self.log_prefix_chars else function_result
                     print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s - {response_preview}")
+
+            # Trim oversized results at insertion time (head+tail preserving)
+            function_result = _trim_tool_result(function_result)
+
+            tool_msg = {
+                "role": "tool",
+                "content": function_result,
+                "tool_call_id": tool_call.id
+            }
+            messages.append(tool_msg)
 
             if self._interrupt_requested and i < len(assistant_message.tool_calls):
                 remaining = len(assistant_message.tool_calls) - i

--- a/tests/test_tool_result_trimming.py
+++ b/tests/test_tool_result_trimming.py
@@ -1,0 +1,125 @@
+"""Tests for insertion-time tool result trimming (Issue #415).
+
+Verifies that _trim_tool_result() correctly applies soft (head+tail) and hard
+(head-only) trimming at insertion time, before results enter the message array.
+
+Extracts only the target function to avoid heavy run_agent import deps.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def trim_fn():
+    """Import _trim_tool_result without pulling in run_agent's heavy deps."""
+    src = Path(__file__).resolve().parent.parent / "run_agent.py"
+    source = src.read_text()
+
+    # Extract the function and its constants from source
+    # Find the block between the marker comments
+    start = source.index("# Tool result trimming")
+    end = source.index("\nclass AIAgent:")
+    block = source[start:end]
+
+    # Execute just the function definition in an isolated namespace
+    ns = {}
+    exec(block, ns)
+    return ns["_trim_tool_result"]
+
+
+class TestToolResultTrimming:
+    """Test the two-stage trimming: soft (head+tail) then hard (head-only)."""
+
+    def test_short_result_unchanged(self, trim_fn):
+        """Results under the soft limit pass through unmodified."""
+        text = "Hello, world!"
+        assert trim_fn(text) == text
+
+    def test_empty_result_unchanged(self, trim_fn):
+        """Empty results pass through."""
+        assert trim_fn("") == ""
+
+    def test_none_result_unchanged(self, trim_fn):
+        """None input returns None."""
+        assert trim_fn(None) is None
+
+    def test_exact_soft_limit_unchanged(self, trim_fn):
+        """Result exactly at the soft limit is NOT trimmed."""
+        text = "x" * 12_000
+        assert trim_fn(text, soft_limit=12_000) == text
+
+    def test_soft_trim_preserves_head_and_tail(self, trim_fn):
+        """Soft trim keeps the first N and last N chars, drops the middle."""
+        head = "HEAD" * 1000   # 4000 chars
+        middle = "M" * 20_000  # will be dropped
+        tail = "TAIL" * 1000   # 4000 chars
+        text = head + middle + tail
+
+        result = trim_fn(text, soft_limit=12_000, head_chars=4_000, tail_chars=4_000)
+
+        assert result.startswith("HEAD" * 1000)
+        assert result.endswith("TAIL" * 1000)
+        assert "Truncated" in result
+        assert len(result) < len(text)
+
+    def test_soft_trim_indicator_shows_counts(self, trim_fn):
+        """The trim indicator includes original length and kept sizes."""
+        text = "A" * 20_000
+        result = trim_fn(text, soft_limit=10_000, head_chars=3_000, tail_chars=3_000)
+        assert "20,000 total" in result
+        assert "3,000" in result
+
+    def test_hard_cap_fires_as_safety_net(self, trim_fn):
+        """Results exceeding the hard limit get head-truncated."""
+        text = "Z" * 200_000
+        result = trim_fn(text, soft_limit=0, hard_limit=100_000)
+        assert len(result) < 200_000
+        assert "Truncated" in result
+        assert "200,000" in result
+
+    def test_soft_trim_disabled_when_zero(self, trim_fn):
+        """Setting soft_limit=0 disables soft trimming."""
+        text = "A" * 50_000
+        result = trim_fn(text, soft_limit=0, hard_limit=100_000)
+        assert result == text
+
+    def test_soft_then_hard_both_apply(self, trim_fn):
+        """When soft-trimmed result still exceeds hard limit, hard cap applies."""
+        text = "X" * 500_000
+        result = trim_fn(
+            text, soft_limit=200_000, hard_limit=100_000,
+            head_chars=80_000, tail_chars=80_000
+        )
+        assert len(result) <= 100_000 + 200
+
+    def test_head_tail_clamped_to_half_soft_limit(self, trim_fn):
+        """If head_chars or tail_chars exceed soft_limit/2, they are clamped."""
+        text = "A" * 20_000
+        result = trim_fn(text, soft_limit=6_000, head_chars=10_000, tail_chars=10_000)
+        assert result.startswith("A" * 3_000)
+        assert result.endswith("A" * 3_000)
+
+    def test_default_values_work(self, trim_fn):
+        """Default args use sensible 12K soft limit."""
+        short = "x" * 10_000
+        assert trim_fn(short) == short
+
+        long = "x" * 50_000
+        result = trim_fn(long)
+        assert len(result) < 50_000
+        assert "Truncated" in result
+
+    def test_unicode_content_handled(self, trim_fn):
+        """Unicode content is trimmed by char count, not byte count."""
+        text = "\U0001F600" * 20_000
+        result = trim_fn(text, soft_limit=12_000)
+        assert len(result) < 20_000
+
+    def test_multiline_content(self, trim_fn):
+        """Multi-line content trims correctly, preserving first lines."""
+        lines = "\n".join(f"line {i}: {'x' * 100}" for i in range(200))
+        result = trim_fn(lines, soft_limit=5_000)
+        assert "Truncated" in result
+        assert "line 0:" in result


### PR DESCRIPTION
## Summary

Implements **Issue #415** — insertion-time tool result trimming.

Adds a two-stage `_trim_tool_result()` function that runs **before** tool results enter the message array:

1. **Soft trim** (12K chars): preserve head (4K) + tail (4K), drop middle with indicator. Keeps file headers / command context (head) and exit codes / error summaries (tail).
2. **Hard cap** (100K chars): emergency head-only truncation as safety net (unchanged behavior).

### Key design decisions

- Messages are **never modified after insertion**, preserving prompt caching for providers that support it.
- Replaces two identical truncation blocks (parallel + sequential tool paths) with a single shared function.
- Head+tail strategy is more useful than head-only: terminal exit codes, file read errors, and search result counts all appear at the end.
- Display/logging happens before trimming so verbose output shows the full raw result.

### Scope

- `run_agent.py`: +68 lines (function + constants), -21 lines (removed duplication)
- `tests/test_tool_result_trimming.py`: 13 tests covering no-op, head+tail preservation, hard cap, None/empty, unicode, multiline, boundary clamping

Closes #415

## Test plan

- [x] 13/13 new tests pass (`pytest tests/test_tool_result_trimming.py -v`)
- [ ] Manual test: run a tool that produces >12K output (e.g. `cat` a large file), verify head+tail preserved in context
- [ ] Manual test: verify verbose logging still shows full raw result before trimming
- [ ] Verify no regression on existing test suite