### PR TITLE
fix(gateway): resolve UnboundLocalError for 'adapter' in streaming media delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2317,9 +2317,11 @@ class GatewayRunner:
             # delivered without this.
             if agent_result.get("already_sent"):
                 if response:
-                    await self._deliver_media_from_response(
-                        response, event, adapter,
-                    )
+                    _media_adapter = self.adapters.get(source.platform)
+                    if _media_adapter:
+                        await self._deliver_media_from_response(
+                            response, event, _media_adapter,
+                        )
                 return None
 
             return response


### PR DESCRIPTION
## Summary

`_handle_message_with_agent` references a bare `adapter` variable when delivering media files after a streamed response (`already_sent=True`). This variable is never assigned in the method scope, causing:

```
UnboundLocalError: cannot access local variable 'adapter'
where it is not associated with a value
```

This crashes streaming responses that include `MEDIA:` tags, and on some platforms surfaces as a user-visible error on all streaming responses.

## Fix

Resolve the adapter from `self.adapters` using `source.platform`, matching every other adapter reference in the method (lines 1334, 1380, 1395, 1409, 1436, 1802, 1934, etc.).

## Reproduction

1. Enable streaming in gateway config
2. Send any message that triggers a tool call
3. Agent streams response with `already_sent=True`
4. Gateway tries to deliver media files → crashes with UnboundLocalError

## Test plan

- [x] Verified fix resolves the error in production (Telegram gateway)
- [ ] Send message with streaming enabled, confirm no crash
- [ ] Send message that produces MEDIA: output, confirm delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)