### PR TITLE
 fix(copilot): harden direct auth flow and routed host setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
 
+GitHub Copilot is also a first-class provider now: use direct `copilot` support with your GitHub token or `gh auth` login, or use `copilot-acp` to delegate through the local Copilot CLI.
+
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>
 <tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
@@ -42,6 +44,14 @@ After installation:
 ```bash
 source ~/.bashrc    # reload shell (or: source ~/.zshrc)
 hermes              # start chatting!
+```
+
+To switch to GitHub Copilot after install:
+
+```bash
+hermes model
+# Select "GitHub Copilot" for direct API access
+# or "GitHub Copilot ACP" for the local `copilot --acp --stdio` backend
 ```
 
 ---

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -48,6 +48,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from openai import OpenAI
 
 from hermes_cli.config import get_hermes_home
+from hermes_cli.copilot_auth import is_copilot_base_url
 from hermes_constants import OPENROUTER_BASE_URL
 
 logger = logging.getLogger(__name__)
@@ -524,7 +525,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         extra = {}
         if "api.kimi.com" in base_url.lower():
             extra["default_headers"] = {"User-Agent": "KimiCLI/1.0"}
-        elif "api.githubcopilot.com" in base_url.lower():
+        elif is_copilot_base_url(base_url):
             from hermes_cli.models import copilot_default_headers
 
             extra["default_headers"] = copilot_default_headers()
@@ -771,7 +772,7 @@ def _to_async_client(sync_client, model: str):
     base_lower = str(sync_client.base_url).lower()
     if "openrouter" in base_lower:
         async_kwargs["default_headers"] = dict(_OR_HEADERS)
-    elif "api.githubcopilot.com" in base_lower:
+    elif is_copilot_base_url(base_lower):
         from hermes_cli.models import copilot_default_headers
 
         async_kwargs["default_headers"] = copilot_default_headers()
@@ -955,7 +956,7 @@ def resolve_provider_client(
         headers = {}
         if "api.kimi.com" in base_url.lower():
             headers["User-Agent"] = "KimiCLI/1.0"
-        elif "api.githubcopilot.com" in base_url.lower():
+        elif is_copilot_base_url(base_url):
             from hermes_cli.models import copilot_default_headers
 
             headers.update(copilot_default_headers())

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1601,7 +1601,19 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     if pconfig.base_url_env_var:
         env_url = os.getenv(pconfig.base_url_env_var, "").strip()
 
-    if provider_id == "kimi-coding":
+    if provider_id == "copilot" and api_key:
+        exchanged = None
+        try:
+            from hermes_cli.copilot_auth import get_cached_copilot_api_token
+
+            exchanged = get_cached_copilot_api_token(api_key)
+            if exchanged:
+                base_url = str(exchanged.get("base_url") or pconfig.inference_base_url).rstrip("/")
+            else:
+                base_url = pconfig.inference_base_url
+        except Exception:
+            base_url = pconfig.inference_base_url
+    elif provider_id == "kimi-coding":
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
     elif env_url:
         base_url = env_url
@@ -1684,6 +1696,30 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     env_url = ""
     if pconfig.base_url_env_var:
         env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+
+    if provider_id == "copilot":
+        base_url = pconfig.inference_base_url
+        exchanged_api_key = api_key
+        expires_at_ms = None
+        if api_key:
+            try:
+                from hermes_cli.copilot_auth import exchange_copilot_api_token
+
+                exchanged = exchange_copilot_api_token(api_key)
+                exchanged_api_key = str(exchanged.get("token") or "").strip() or api_key
+                base_url = str(exchanged.get("base_url") or pconfig.inference_base_url)
+                expires_at_ms = exchanged.get("expires_at_ms")
+            except Exception:
+                logger.debug("Copilot token exchange failed; falling back to default API host", exc_info=True)
+        return {
+            "provider": provider_id,
+            "api_key": exchanged_api_key,
+            "base_url": base_url.rstrip("/"),
+            "source": key_source or "default",
+            "github_token": api_key,
+            "github_token_source": key_source or "default",
+            "expires_at_ms": expires_at_ms,
+        }
 
     if provider_id == "kimi-coding":
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -321,7 +321,10 @@ def exchange_copilot_api_token(github_token: str, *, timeout: float = 15.0) -> d
         raise ValueError("Copilot token response missing token")
 
     expires_at_ms = _parse_expires_at(payload.get("expires_at"))
-    base_url = derive_copilot_api_base_url(token)
+    endpoints = payload.get("endpoints") or {}
+    base_url = str(endpoints.get("api") or "").strip()
+    if not is_copilot_base_url(base_url):
+        base_url = derive_copilot_api_base_url(token)
     try:
         _save_cached_copilot_api_token(github_token, token, expires_at_ms, base_url)
     except Exception:

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -19,14 +19,20 @@ Credential search order (matching Copilot CLI behaviour):
 from __future__ import annotations
 
 import json
+import hashlib
 import logging
 import os
 import re
 import shutil
 import subprocess
+import tempfile
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlparse
+
+from hermes_cli.config import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +44,8 @@ COPILOT_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
 # Copilot API constants
 COPILOT_TOKEN_EXCHANGE_URL = "https://api.github.com/copilot_internal/v2/token"
 COPILOT_API_BASE_URL = "https://api.githubcopilot.com"
+COPILOT_TOKEN_REFRESH_SKEW_SECONDS = 5 * 60
+_COPILOT_ALLOWED_HOST = "githubcopilot.com"
 
 # Token type prefixes
 _CLASSIC_PAT_PREFIX = "ghp_"
@@ -145,6 +153,185 @@ def _try_gh_cli_token() -> Optional[str]:
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
     return None
+
+
+def _copilot_token_cache_path() -> Path:
+    """Return the on-disk cache path for exchanged Copilot API tokens."""
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    return home / "copilot_token.json"
+
+
+def _token_fingerprint(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _parse_expires_at(value: Any) -> int:
+    """Parse GitHub's expires_at field into epoch milliseconds."""
+    if isinstance(value, (int, float)) and value > 0:
+        numeric = int(value)
+        return numeric if numeric > 10_000_000_000 else numeric * 1000
+    if isinstance(value, str) and value.strip():
+        raw = value.strip()
+        try:
+            parsed = int(raw)
+        except ValueError:
+            try:
+                parsed_dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            except ValueError as exc:
+                raise ValueError("Copilot token response missing expires_at") from exc
+            if parsed_dt.tzinfo is None:
+                parsed_dt = parsed_dt.replace(tzinfo=timezone.utc)
+            return int(parsed_dt.timestamp() * 1000)
+        return parsed if parsed > 10_000_000_000 else parsed * 1000
+    raise ValueError("Copilot token response missing expires_at")
+
+
+def _normalize_host_candidate(value: str) -> str:
+    candidate = (value or "").strip()
+    if not candidate:
+        return ""
+    parsed = urlparse(candidate if "://" in candidate else f"https://{candidate}")
+    return (parsed.hostname or "").strip().lower()
+
+
+def _is_allowed_copilot_host(hostname: str) -> bool:
+    hostname = (hostname or "").strip().lower()
+    return bool(hostname) and (
+        hostname == _COPILOT_ALLOWED_HOST
+        or hostname.endswith(f".{_COPILOT_ALLOWED_HOST}")
+    )
+
+
+def derive_copilot_api_base_url(token: str) -> str:
+    """Best-effort routed Copilot API base URL from the exchanged token payload."""
+    trimmed = (token or "").strip()
+    if not trimmed:
+        return COPILOT_API_BASE_URL
+
+    match = re.search(r"(?:^|;)\s*proxy-ep=([^;\s]+)", trimmed, flags=re.IGNORECASE)
+    proxy_endpoint = match.group(1).strip() if match else ""
+    hostname = _normalize_host_candidate(proxy_endpoint)
+    if not _is_allowed_copilot_host(hostname):
+        return COPILOT_API_BASE_URL
+
+    host = re.sub(r"^proxy\.", "api.", hostname, flags=re.IGNORECASE)
+    return f"https://{host}" if _is_allowed_copilot_host(host) else COPILOT_API_BASE_URL
+
+
+def is_copilot_base_url(base_url: Optional[str]) -> bool:
+    """Return True for routed GitHub Copilot API hosts."""
+    hostname = _normalize_host_candidate(str(base_url or ""))
+    return _is_allowed_copilot_host(hostname)
+
+
+def _load_cached_copilot_api_token(github_token: str) -> Optional[dict[str, Any]]:
+    path = _copilot_token_cache_path()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    cached_token = str(payload.get("token") or "").strip()
+    expires_at_ms = payload.get("expires_at_ms")
+    fingerprint = str(payload.get("github_token_fingerprint") or "")
+    if not cached_token or not isinstance(expires_at_ms, int) or not fingerprint:
+        return None
+    if fingerprint != _token_fingerprint(github_token):
+        return None
+    if expires_at_ms - int(time.time() * 1000) <= COPILOT_TOKEN_REFRESH_SKEW_SECONDS * 1000:
+        return None
+
+    return {
+        "token": cached_token,
+        "expires_at_ms": expires_at_ms,
+        "base_url": str(payload.get("base_url") or "").strip() or derive_copilot_api_base_url(cached_token),
+        "source": f"cache:{path}",
+    }
+
+
+def _save_cached_copilot_api_token(github_token: str, token: str, expires_at_ms: int, base_url: str) -> None:
+    path = _copilot_token_cache_path()
+    payload = {
+        "github_token_fingerprint": _token_fingerprint(github_token),
+        "token": token,
+        "expires_at_ms": int(expires_at_ms),
+        "base_url": base_url,
+        "updated_at_ms": int(time.time() * 1000),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+        try:
+            os.chmod(tmp_path, 0o600)
+        except OSError as exc:
+            logger.warning("Could not set secure permissions on Copilot token cache %s: %s", tmp_path, exc)
+        os.replace(tmp_path, path)
+    finally:
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def get_cached_copilot_api_token(github_token: str) -> Optional[dict[str, Any]]:
+    """Return a valid cached exchanged Copilot token without making network calls."""
+    github_token = (github_token or "").strip()
+    if not github_token:
+        return None
+    return _load_cached_copilot_api_token(github_token)
+
+
+def exchange_copilot_api_token(github_token: str, *, timeout: float = 15.0) -> dict[str, Any]:
+    """Exchange a GitHub OAuth/PAT token for a routed Copilot API token."""
+    import urllib.request
+
+    github_token = (github_token or "").strip()
+    if not github_token:
+        return {
+            "token": "",
+            "base_url": COPILOT_API_BASE_URL,
+            "expires_at_ms": 0,
+            "source": "",
+        }
+
+    cached = _load_cached_copilot_api_token(github_token)
+    if cached:
+        return cached
+
+    req = urllib.request.Request(
+        COPILOT_TOKEN_EXCHANGE_URL,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {github_token}",
+            "User-Agent": "HermesAgent/1.0",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        payload = json.loads(resp.read().decode())
+
+    token = str(payload.get("token") or "").strip()
+    if not token:
+        raise ValueError("Copilot token response missing token")
+
+    expires_at_ms = _parse_expires_at(payload.get("expires_at"))
+    base_url = derive_copilot_api_base_url(token)
+    try:
+        _save_cached_copilot_api_token(github_token, token, expires_at_ms, base_url)
+    except Exception:
+        logger.debug("Failed to cache Copilot token", exc_info=True)
+    return {
+        "token": token,
+        "base_url": base_url,
+        "expires_at_ms": expires_at_ms,
+        "source": COPILOT_TOKEN_EXCHANGE_URL,
+    }
 
 
 # ─── OAuth Device Code Flow ────────────────────────────────────────────────

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1639,6 +1639,7 @@ def _model_flow_copilot(config, current_model=""):
         print("    1. Login with GitHub (OAuth device code flow)")
         print("    2. Enter a token manually")
         print("    3. Cancel")
+        print("  Note: GitHub may show an 'Authorize OpenCode' page for this device flow.")
         print()
         try:
             choice = input("  Choice [1-3]: ").strip()
@@ -1689,17 +1690,18 @@ def _model_flow_copilot(config, current_model=""):
         api_key = creds.get("api_key", "")
         source = creds.get("source", "")
     else:
+        display_token = str(creds.get("github_token") or api_key)
         if source in ("GITHUB_TOKEN", "GH_TOKEN"):
-            print(f"  GitHub token: {api_key[:8]}... ✓ ({source})")
+            print(f"  GitHub token: {display_token[:8]}... ✓ ({source})")
         elif source == "gh auth token":
             print("  GitHub token: ✓ (from `gh auth token`)")
         else:
             print("  GitHub token: ✓")
         print()
 
-    effective_base = pconfig.inference_base_url
+    effective_base = str(creds.get("base_url") or pconfig.inference_base_url).rstrip("/")
 
-    catalog = fetch_github_model_catalog(api_key)
+    catalog = fetch_github_model_catalog(api_key, base_url=effective_base)
     live_models = [item.get("id", "") for item in catalog if item.get("id")] if catalog else fetch_api_models(api_key, effective_base)
     normalized_current_model = normalize_copilot_model_id(
         current_model,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -14,6 +14,8 @@ import urllib.error
 from difflib import get_close_matches
 from typing import Any, Optional
 
+from hermes_cli.copilot_auth import is_copilot_base_url
+
 COPILOT_BASE_URL = "https://api.githubcopilot.com"
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
 COPILOT_EDITOR_VERSION = "vscode/1.104.1"
@@ -534,6 +536,17 @@ def _resolve_copilot_catalog_api_key() -> str:
         return ""
 
 
+def _resolve_copilot_catalog_base_url() -> str:
+    """Best-effort routed Copilot base URL for model-catalog requests."""
+    try:
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        creds = resolve_api_key_provider_credentials("copilot")
+        return str(creds.get("base_url") or "").strip().rstrip("/") or COPILOT_BASE_URL
+    except Exception:
+        return COPILOT_BASE_URL
+
+
 def provider_model_ids(provider: Optional[str]) -> list[str]:
     """Return the best known model catalog for a provider.
 
@@ -549,7 +562,10 @@ def provider_model_ids(provider: Optional[str]) -> list[str]:
         return get_codex_model_ids()
     if normalized in {"copilot", "copilot-acp"}:
         try:
-            live = _fetch_github_models(_resolve_copilot_catalog_api_key())
+            live = _fetch_github_models(
+                _resolve_copilot_catalog_api_key(),
+                base_url=_resolve_copilot_catalog_base_url(),
+            )
             if live:
                 return live
         except Exception:
@@ -696,9 +712,12 @@ def _copilot_catalog_item_is_text_model(item: dict[str, Any]) -> bool:
 
 
 def fetch_github_model_catalog(
-    api_key: Optional[str] = None, timeout: float = 5.0
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    timeout: float = 5.0,
 ) -> Optional[list[dict[str, Any]]]:
     """Fetch the live GitHub Copilot model catalog for this account."""
+    models_url = ((base_url or "").strip().rstrip("/") or _resolve_copilot_catalog_base_url()) + "/models"
     attempts: list[dict[str, str]] = []
     if api_key:
         attempts.append({
@@ -708,7 +727,7 @@ def fetch_github_model_catalog(
     attempts.append(copilot_default_headers())
 
     for headers in attempts:
-        req = urllib.request.Request(COPILOT_MODELS_URL, headers=headers)
+        req = urllib.request.Request(models_url, headers=headers)
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
@@ -733,13 +752,18 @@ def fetch_github_model_catalog(
 def _is_github_models_base_url(base_url: Optional[str]) -> bool:
     normalized = (base_url or "").strip().rstrip("/").lower()
     return (
-        normalized.startswith(COPILOT_BASE_URL)
+        is_copilot_base_url(normalized)
         or normalized.startswith("https://models.github.ai/inference")
     )
 
 
-def _fetch_github_models(api_key: Optional[str] = None, timeout: float = 5.0) -> Optional[list[str]]:
-    catalog = fetch_github_model_catalog(api_key=api_key, timeout=timeout)
+def _fetch_github_models(
+    api_key: Optional[str] = None,
+    *,
+    base_url: Optional[str] = None,
+    timeout: float = 5.0,
+) -> Optional[list[str]]:
+    catalog = fetch_github_model_catalog(api_key=api_key, base_url=base_url, timeout=timeout)
     if not catalog:
         return None
     return [item.get("id", "") for item in catalog if item.get("id")]
@@ -773,7 +797,10 @@ def _copilot_catalog_ids(
     api_key: Optional[str] = None,
 ) -> set[str]:
     if catalog is None and api_key:
-        catalog = fetch_github_model_catalog(api_key=api_key)
+        catalog = fetch_github_model_catalog(
+            api_key=api_key,
+            base_url=_resolve_copilot_catalog_base_url(),
+        )
     if not catalog:
         return set()
     return {
@@ -873,7 +900,10 @@ def copilot_model_api_mode(
 
     # Secondary: check catalog for non-GPT-5 models (Claude via /v1/messages, etc.)
     if catalog is None and api_key:
-        catalog = fetch_github_model_catalog(api_key=api_key)
+        catalog = fetch_github_model_catalog(
+            api_key=api_key,
+            base_url=_resolve_copilot_catalog_base_url(),
+        )
 
     if catalog:
         catalog_entry = next((item for item in catalog if item.get("id") == normalized), None)
@@ -905,7 +935,10 @@ def github_model_reasoning_efforts(
     if catalog is not None:
         catalog_entry = next((item for item in catalog if item.get("id") == normalized), None)
     elif api_key:
-        fetched_catalog = fetch_github_model_catalog(api_key=api_key)
+        fetched_catalog = fetch_github_model_catalog(
+            api_key=api_key,
+            base_url=_resolve_copilot_catalog_base_url(),
+        )
         if fetched_catalog:
             catalog_entry = next((item for item in fetched_catalog if item.get("id") == normalized), None)
 
@@ -951,11 +984,11 @@ def probe_api_models(
         }
 
     if _is_github_models_base_url(normalized):
-        models = _fetch_github_models(api_key=api_key, timeout=timeout)
+        models = _fetch_github_models(api_key=api_key, base_url=normalized, timeout=timeout)
         return {
             "models": models,
-            "probed_url": COPILOT_MODELS_URL,
-            "resolved_base_url": COPILOT_BASE_URL,
+            "probed_url": normalized.rstrip("/") + "/models",
+            "resolved_base_url": normalized.rstrip("/"),
             "suggested_base_url": None,
             "used_fallback": False,
         }
@@ -973,7 +1006,7 @@ def probe_api_models(
     headers: dict[str, str] = {}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
-    if normalized.startswith(COPILOT_BASE_URL):
+    if _is_github_models_base_url(normalized):
         headers.update(copilot_default_headers())
 
     for candidate_base, is_fallback in candidates:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -166,10 +166,10 @@ def _setup_provider_model_selection(config, provider_id, current_model, prompt_c
             try:
                 creds = resolve_api_key_provider_credentials("copilot")
                 api_key = creds.get("api_key", "")
+                base_url = creds.get("base_url", "") or pconfig.inference_base_url
             except Exception:
-                pass
-            base_url = pconfig.inference_base_url
-        catalog = fetch_github_model_catalog(api_key)
+                base_url = pconfig.inference_base_url
+        catalog = fetch_github_model_catalog(api_key, base_url=base_url)
         current_model = normalize_copilot_model_id(
             current_model,
             catalog=catalog,
@@ -1514,8 +1514,9 @@ def setup_model_provider(config: dict):
         if existing_custom:
             save_env_value("OPENAI_BASE_URL", "")
             save_env_value("OPENAI_API_KEY", "")
-        _set_model_provider(config, "copilot", pconfig.inference_base_url)
-        selected_base_url = pconfig.inference_base_url
+        copilot_creds = resolve_api_key_provider_credentials("copilot")
+        selected_base_url = str(copilot_creds.get("base_url") or pconfig.inference_base_url).rstrip("/")
+        _set_model_provider(config, "copilot", selected_base_url)
 
     elif provider_idx == 15:  # GitHub Copilot ACP
         selected_provider = "copilot-acp"

--- a/run_agent.py
+++ b/run_agent.py
@@ -714,7 +714,7 @@ class AIAgent:
                         "X-OpenRouter-Title": "Hermes Agent",
                         "X-OpenRouter-Categories": "productivity,cli-agent",
                     }
-                elif "api.githubcopilot.com" in effective_base.lower():
+                elif self._is_copilot_base_url(effective_base):
                     from hermes_cli.models import copilot_default_headers
 
                     client_kwargs["default_headers"] = copilot_default_headers()
@@ -3981,7 +3981,7 @@ class AIAgent:
 
             is_github_responses = (
                 "models.github.ai" in self.base_url.lower()
-                or "api.githubcopilot.com" in self.base_url.lower()
+                or self._is_copilot_base_url(self.base_url)
             )
 
             # Resolve reasoning effort: config > default (medium)
@@ -4090,7 +4090,7 @@ class AIAgent:
         _is_openrouter = "openrouter" in self._base_url_lower
         _is_github_models = (
             "models.github.ai" in self._base_url_lower
-            or "api.githubcopilot.com" in self._base_url_lower
+            or self._is_copilot_base_url(self._base_url_lower)
         )
 
         # Provider preferences (only, ignore, order, sort) are OpenRouter-
@@ -4141,7 +4141,7 @@ class AIAgent:
             return True
         if "ai-gateway.vercel.sh" in self._base_url_lower:
             return True
-        if "models.github.ai" in self._base_url_lower or "api.githubcopilot.com" in self._base_url_lower:
+        if "models.github.ai" in self._base_url_lower or self._is_copilot_base_url(self._base_url_lower):
             try:
                 from hermes_cli.models import github_model_reasoning_efforts
 
@@ -4163,6 +4163,12 @@ class AIAgent:
             "qwen/qwen3",
         )
         return any(model.startswith(prefix) for prefix in reasoning_model_prefixes)
+
+    @staticmethod
+    def _is_copilot_base_url(base_url: str) -> bool:
+        from hermes_cli.copilot_auth import is_copilot_base_url
+
+        return is_copilot_base_url(base_url)
 
     def _github_models_reasoning_extra_body(self) -> dict | None:
         """Format reasoning payload for GitHub Models/OpenAI-compatible routes."""

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -590,8 +590,9 @@ class TestVisionClientFallback:
                 "hermes_cli.auth.resolve_api_key_provider_credentials",
                 return_value={
                     "provider": "copilot",
-                    "api_key": "gh-cli-token",
-                    "base_url": "https://api.githubcopilot.com",
+                    "api_key": "copilot-api-token",
+                    "github_token": "gh-cli-token",
+                    "base_url": "https://api.individual.githubcopilot.com",
                     "source": "gh auth token",
                 },
             ),
@@ -602,8 +603,8 @@ class TestVisionClientFallback:
         assert client is not None
         assert model == "gpt-5.4"
         call_kwargs = mock_openai.call_args.kwargs
-        assert call_kwargs["api_key"] == "gh-cli-token"
-        assert call_kwargs["base_url"] == "https://api.githubcopilot.com"
+        assert call_kwargs["api_key"] == "copilot-api-token"
+        assert call_kwargs["base_url"] == "https://api.individual.githubcopilot.com"
         assert call_kwargs["default_headers"]["Editor-Version"]
 
     def test_vision_auto_uses_anthropic_when_no_higher_priority_backend(self, monkeypatch):

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -1,6 +1,8 @@
 """Tests for hermes_cli.copilot_auth — Copilot token validation and resolution."""
 
+import json
 import os
+from pathlib import Path
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -143,6 +145,148 @@ class TestRequestHeaders:
         from hermes_cli.copilot_auth import copilot_request_headers
         headers = copilot_request_headers()
         assert "Copilot-Vision-Request" not in headers
+
+
+class TestTokenExchange:
+    def test_derive_copilot_api_base_url_uses_proxy_endpoint(self):
+        from hermes_cli.copilot_auth import derive_copilot_api_base_url
+
+        token = "abc123;proxy-ep=proxy.individual.githubcopilot.com;foo=bar"
+        assert derive_copilot_api_base_url(token) == "https://api.individual.githubcopilot.com"
+
+    def test_derive_copilot_api_base_url_rejects_non_github_hosts(self):
+        from hermes_cli.copilot_auth import derive_copilot_api_base_url, COPILOT_API_BASE_URL
+
+        token = "abc123;proxy-ep=evil-githubcopilot.com.evil.example;foo=bar"
+        assert derive_copilot_api_base_url(token) == COPILOT_API_BASE_URL
+
+    def test_derive_copilot_api_base_url_ignores_path_components(self):
+        from hermes_cli.copilot_auth import derive_copilot_api_base_url
+
+        token = "abc123;proxy-ep=proxy.individual.githubcopilot.com/v1;foo=bar"
+        assert derive_copilot_api_base_url(token) == "https://api.individual.githubcopilot.com"
+
+    def test_is_copilot_base_url_accepts_routed_domains(self):
+        from hermes_cli.copilot_auth import is_copilot_base_url
+
+        assert is_copilot_base_url("https://api.githubcopilot.com")
+        assert is_copilot_base_url("https://api.individual.githubcopilot.com")
+        assert is_copilot_base_url("https://api.business.githubcopilot.com")
+        assert is_copilot_base_url("https://example.com") is False
+        assert is_copilot_base_url("https://evil-githubcopilot.com") is False
+        assert is_copilot_base_url("https://githubcopilot.com.evil.com") is False
+
+    @pytest.mark.parametrize(
+        "raw,expected_ms",
+        [
+            (1718452800, 1718452800000),
+            (1718452800000, 1718452800000),
+            ("1718452800", 1718452800000),
+            ("2024-06-15T12:00:00+00:00", 1718452800000),
+            ("2024-06-15T12:00:00Z", 1718452800000),
+        ],
+    )
+    def test_parse_expires_at_variants(self, raw, expected_ms):
+        from hermes_cli.copilot_auth import _parse_expires_at
+
+        assert _parse_expires_at(raw) == expected_ms
+
+    def test_parse_expires_at_invalid_raises(self):
+        from hermes_cli.copilot_auth import _parse_expires_at
+
+        with pytest.raises(ValueError):
+            _parse_expires_at("not-a-date")
+
+    def test_cache_round_trip_and_fingerprint(self, tmp_path, monkeypatch):
+        from hermes_cli.copilot_auth import (
+            _save_cached_copilot_api_token,
+            get_cached_copilot_api_token,
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _save_cached_copilot_api_token(
+            "gho_source_token",
+            "copilot_runtime_token",
+            4_102_444_800_000,
+            "https://api.individual.githubcopilot.com",
+        )
+
+        cached = get_cached_copilot_api_token("gho_source_token")
+        assert cached is not None
+        assert cached["token"] == "copilot_runtime_token"
+        assert cached["base_url"] == "https://api.individual.githubcopilot.com"
+
+        assert get_cached_copilot_api_token("gho_other_token") is None
+
+    def test_cache_rejects_corrupt_file(self, tmp_path, monkeypatch):
+        from hermes_cli.copilot_auth import get_cached_copilot_api_token
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cache_path = Path(tmp_path) / "copilot_token.json"
+        cache_path.write_text("{bad json", encoding="utf-8")
+
+        assert get_cached_copilot_api_token("gho_source_token") is None
+
+    def test_exchange_copilot_api_token_uses_cache(self, tmp_path, monkeypatch):
+        from hermes_cli.copilot_auth import _save_cached_copilot_api_token, exchange_copilot_api_token
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _save_cached_copilot_api_token(
+            "gho_source_token",
+            "copilot_runtime_token",
+            4_102_444_800_000,
+            "https://api.individual.githubcopilot.com",
+        )
+
+        result = exchange_copilot_api_token("gho_source_token")
+        assert result["token"] == "copilot_runtime_token"
+        assert result["base_url"] == "https://api.individual.githubcopilot.com"
+        assert "cache:" in result["source"]
+
+    def test_exchange_copilot_api_token_fetches_and_saves(self, tmp_path, monkeypatch):
+        from hermes_cli.copilot_auth import exchange_copilot_api_token
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                payload = {
+                    "token": "abc123;proxy-ep=proxy.individual.githubcopilot.com",
+                    "expires_at": "2024-06-15T12:00:00+00:00",
+                }
+                return json.dumps(payload).encode("utf-8")
+
+        with patch("urllib.request.urlopen", return_value=_Resp()):
+            result = exchange_copilot_api_token("gho_source_token")
+
+        assert result["token"] == "abc123;proxy-ep=proxy.individual.githubcopilot.com"
+        assert result["base_url"] == "https://api.individual.githubcopilot.com"
+        assert result["expires_at_ms"] == 1718452800000
+
+    def test_exchange_copilot_api_token_missing_token_raises(self, tmp_path, monkeypatch):
+        from hermes_cli.copilot_auth import exchange_copilot_api_token
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps({"expires_at": 1718452800}).encode("utf-8")
+
+        with patch("urllib.request.urlopen", return_value=_Resp()):
+            with pytest.raises(ValueError, match="missing token"):
+                exchange_copilot_api_token("gho_source_token")
 
 
 class TestCopilotDefaultHeaders:

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -269,6 +269,33 @@ class TestTokenExchange:
         assert result["base_url"] == "https://api.individual.githubcopilot.com"
         assert result["expires_at_ms"] == 1718452800000
 
+    def test_exchange_copilot_api_token_prefers_endpoints_api(self, tmp_path, monkeypatch):
+        from hermes_cli.copilot_auth import exchange_copilot_api_token
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                payload = {
+                    "token": "tid=abc;exp=1718452800;sku=copilot_for_individuals_subscriber",
+                    "expires_at": "2024-06-15T12:00:00+00:00",
+                    "endpoints": {
+                        "api": "https://api.business.githubcopilot.com",
+                    },
+                }
+                return json.dumps(payload).encode("utf-8")
+
+        with patch("urllib.request.urlopen", return_value=_Resp()):
+            result = exchange_copilot_api_token("gho_source_token")
+
+        assert result["base_url"] == "https://api.business.githubcopilot.com"
+
     def test_exchange_copilot_api_token_missing_token_raises(self, tmp_path, monkeypatch):
         from hermes_cli.copilot_auth import exchange_copilot_api_token
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -170,6 +170,19 @@ class TestProviderModelIds:
         assert "gpt-5.4" in ids
         assert "copilot-acp" not in ids
 
+    def test_copilot_uses_routed_base_url_for_live_catalog(self):
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={
+                "api_key": "copilot-api-token",
+                "base_url": "https://api.individual.githubcopilot.com",
+            },
+        ), patch("hermes_cli.models._fetch_github_models", return_value=["gpt-5.4"]) as mock_fetch:
+            ids = provider_model_ids("copilot")
+
+        assert ids == ["gpt-5.4"]
+        assert mock_fetch.call_args.kwargs["base_url"] == "https://api.individual.githubcopilot.com"
+
 
 # -- fetch_api_models --------------------------------------------------------
 
@@ -220,11 +233,11 @@ class TestFetchApiModels:
                 return b'{"data": [{"id": "gpt-5.4", "model_picker_enabled": true, "supported_endpoints": ["/responses"], "capabilities": {"type": "chat", "supports": {"reasoning_effort": ["low", "medium", "high"]}}}, {"id": "claude-sonnet-4.6", "model_picker_enabled": true, "supported_endpoints": ["/chat/completions"], "capabilities": {"type": "chat", "supports": {"reasoning_effort": ["low", "medium", "high"]}}}, {"id": "text-embedding-3-small", "model_picker_enabled": true, "capabilities": {"type": "embedding"}}]}'
 
         with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()) as mock_urlopen:
-            probe = probe_api_models("gh-token", "https://api.githubcopilot.com")
+            probe = probe_api_models("gh-token", "https://api.individual.githubcopilot.com")
 
-        assert mock_urlopen.call_args[0][0].full_url == "https://api.githubcopilot.com/models"
+        assert mock_urlopen.call_args[0][0].full_url == "https://api.individual.githubcopilot.com/models"
         assert probe["models"] == ["gpt-5.4", "claude-sonnet-4.6"]
-        assert probe["resolved_base_url"] == "https://api.githubcopilot.com"
+        assert probe["resolved_base_url"] == "https://api.individual.githubcopilot.com"
         assert probe["used_fallback"] is False
 
     def test_fetch_github_model_catalog_filters_non_chat_models(self):
@@ -275,6 +288,18 @@ class TestCopilotNormalization:
     def test_normalize_old_github_models_slug(self):
         catalog = [{"id": "gpt-4.1"}, {"id": "gpt-5.4"}]
         assert normalize_copilot_model_id("openai/gpt-4.1-mini", catalog=catalog) == "gpt-4.1"
+
+    def test_normalize_direct_model_part_when_catalog_contains_match(self):
+        catalog = [{"id": "claude-sonnet-4.6"}]
+        assert normalize_copilot_model_id("anthropic/claude-sonnet-4.6", catalog=catalog) == "claude-sonnet-4.6"
+
+    def test_copilot_api_mode_messages_only_uses_anthropic_messages(self):
+        catalog = [{
+            "id": "claude-sonnet-4.6",
+            "supported_endpoints": ["/v1/messages"],
+            "capabilities": {"type": "chat"},
+        }]
+        assert copilot_model_api_mode("claude-sonnet-4.6", catalog=catalog) == "anthropic_messages"
 
     def test_copilot_api_mode_gpt5_uses_responses(self):
         """GPT-5+ models should use Responses API (matching opencode)."""
@@ -340,6 +365,16 @@ class TestValidateFormatChecks:
         result = _validate("gpt-5.4", api_models=["openai/gpt-5.4"])
         assert result["accepted"] is True
         assert "not found" in result["message"]
+
+    def test_copilot_validation_normalizes_alias_before_lookup(self):
+        result = _validate(
+            "openai/gpt-4.1-mini",
+            provider="copilot",
+            api_key="copilot-api-token",
+            api_models=["gpt-4.1"],
+        )
+        assert result["accepted"] is True
+        assert result["recognized"] is True
 
 
 # -- validate — API found ----------------------------------------------------

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -279,14 +279,18 @@ def test_setup_copilot_uses_gh_auth_and_saves_provider(tmp_path, monkeypatch):
         "hermes_cli.auth.resolve_api_key_provider_credentials",
         lambda provider_id: {
             "provider": provider_id,
-            "api_key": "gh-cli-token",
-            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-api-token",
+            "github_token": "gh-cli-token",
+            "base_url": "https://api.individual.githubcopilot.com",
             "source": "gh auth token",
         },
     )
-    monkeypatch.setattr(
-        "hermes_cli.models.fetch_github_model_catalog",
-        lambda api_key: [
+    seen = {}
+
+    def fake_fetch_catalog(api_key=None, base_url=None, timeout=5.0):
+        seen["api_key"] = api_key
+        seen["base_url"] = base_url
+        return [
             {
                 "id": "gpt-4.1",
                 "capabilities": {"type": "chat", "supports": {}},
@@ -297,8 +301,9 @@ def test_setup_copilot_uses_gh_auth_and_saves_provider(tmp_path, monkeypatch):
                 "capabilities": {"type": "chat", "supports": {"reasoning_effort": ["low", "medium", "high"]}},
                 "supported_endpoints": ["/responses"],
             },
-        ],
-    )
+        ]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_github_model_catalog", fake_fetch_catalog)
     monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
 
     setup_model_provider(config)
@@ -308,11 +313,69 @@ def test_setup_copilot_uses_gh_auth_and_saves_provider(tmp_path, monkeypatch):
     reloaded = load_config()
 
     assert env.get("GITHUB_TOKEN") is None
+    assert seen["api_key"] == "copilot-api-token"
+    assert seen["base_url"] == "https://api.individual.githubcopilot.com"
     assert reloaded["model"]["provider"] == "copilot"
-    assert reloaded["model"]["base_url"] == "https://api.githubcopilot.com"
+    assert reloaded["model"]["base_url"] == "https://api.individual.githubcopilot.com"
     assert reloaded["model"]["default"] == "gpt-5.4"
     assert reloaded["model"]["api_mode"] == "codex_responses"
     assert reloaded["agent"]["reasoning_effort"] == "high"
+
+
+def test_setup_copilot_normalizes_catalog_alias_selection(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+
+    config = load_config()
+
+    def fake_prompt_choice(question, choices, default=0):
+        if question == "Select your inference provider:":
+            return 14
+        if question == "Select default model:":
+            assert "claude-sonnet-4.6" in choices
+            return choices.index("claude-sonnet-4.6")
+        if question == "Configure vision:":
+            return len(choices) - 1
+        tts_idx = _maybe_keep_current_tts(question, choices)
+        if tts_idx is not None:
+            return tts_idx
+        raise AssertionError(f"Unexpected prompt_choice call: {question}")
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: "")
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: False)
+    monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: None)
+    monkeypatch.setattr("hermes_cli.auth.detect_external_credentials", lambda: [])
+    monkeypatch.setattr("hermes_cli.auth.get_auth_status", lambda provider_id: {"logged_in": provider_id == "copilot"})
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        lambda provider_id: {
+            "provider": provider_id,
+            "api_key": "copilot-api-token",
+            "github_token": "gh-cli-token",
+            "base_url": "https://api.individual.githubcopilot.com",
+            "source": "gh auth token",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_github_model_catalog",
+        lambda api_key=None, base_url=None, timeout=5.0: [
+            {
+                "id": "claude-sonnet-4.6",
+                "capabilities": {"type": "chat", "supports": {}},
+                "supported_endpoints": ["/chat/completions"],
+            },
+        ],
+    )
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+
+    setup_model_provider(config)
+    save_config(config)
+
+    reloaded = load_config()
+    assert reloaded["model"]["provider"] == "copilot"
+    assert reloaded["model"]["default"] == "claude-sonnet-4.6"
+    assert reloaded["model"]["api_mode"] == "chat_completions"
 
 
 def test_setup_copilot_acp_uses_model_picker_and_saves_provider(tmp_path, monkeypatch):
@@ -349,14 +412,15 @@ def test_setup_copilot_acp_uses_model_picker_and_saves_provider(tmp_path, monkey
         "hermes_cli.auth.resolve_api_key_provider_credentials",
         lambda provider_id: {
             "provider": "copilot",
-            "api_key": "gh-cli-token",
-            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-api-token",
+            "github_token": "gh-cli-token",
+            "base_url": "https://api.individual.githubcopilot.com",
             "source": "gh auth token",
         },
     )
     monkeypatch.setattr(
         "hermes_cli.models.fetch_github_model_catalog",
-        lambda api_key: [
+        lambda api_key=None, base_url=None, timeout=5.0: [
             {
                 "id": "gpt-4.1",
                 "capabilities": {"type": "chat", "supports": {}},

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -280,11 +280,20 @@ class TestApiKeyProviderStatus:
 
     def test_copilot_status_uses_gh_cli_token(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_gh_cli_token")
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth.get_cached_copilot_api_token",
+            lambda github_token: {
+                "token": "copilot-runtime-token",
+                "base_url": "https://api.individual.githubcopilot.com",
+                "expires_at_ms": 1_800_000_000_000,
+                "source": "cache:/tmp/copilot_token.json",
+            },
+        )
         status = get_api_key_provider_status("copilot")
         assert status["configured"] is True
         assert status["logged_in"] is True
         assert status["key_source"] == "gh auth token"
-        assert status["base_url"] == "https://api.githubcopilot.com"
+        assert status["base_url"] == "https://api.individual.githubcopilot.com"
 
     def test_get_auth_status_dispatches_to_api_key(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
@@ -334,18 +343,38 @@ class TestResolveApiKeyProviderCredentials:
 
     def test_resolve_copilot_with_github_token(self, monkeypatch):
         monkeypatch.setenv("GITHUB_TOKEN", "gh-env-secret")
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth.exchange_copilot_api_token",
+            lambda github_token, timeout=15.0: {
+                "token": "copilot-api-token",
+                "base_url": "https://api.individual.githubcopilot.com",
+                "expires_at_ms": 1_800_000_000_000,
+                "source": "https://api.github.com/copilot_internal/v2/token",
+            },
+        )
         creds = resolve_api_key_provider_credentials("copilot")
         assert creds["provider"] == "copilot"
-        assert creds["api_key"] == "gh-env-secret"
-        assert creds["base_url"] == "https://api.githubcopilot.com"
+        assert creds["api_key"] == "copilot-api-token"
+        assert creds["github_token"] == "gh-env-secret"
+        assert creds["base_url"] == "https://api.individual.githubcopilot.com"
         assert creds["source"] == "GITHUB_TOKEN"
 
     def test_resolve_copilot_with_gh_cli_fallback(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth.exchange_copilot_api_token",
+            lambda github_token, timeout=15.0: {
+                "token": "copilot-api-token",
+                "base_url": "https://api.business.githubcopilot.com",
+                "expires_at_ms": 1_800_000_000_000,
+                "source": "https://api.github.com/copilot_internal/v2/token",
+            },
+        )
         creds = resolve_api_key_provider_credentials("copilot")
         assert creds["provider"] == "copilot"
-        assert creds["api_key"] == "gho_cli_secret"
-        assert creds["base_url"] == "https://api.githubcopilot.com"
+        assert creds["api_key"] == "copilot-api-token"
+        assert creds["github_token"] == "gho_cli_secret"
+        assert creds["base_url"] == "https://api.business.githubcopilot.com"
         assert creds["source"] == "gh auth token"
 
     def test_try_gh_cli_token_uses_homebrew_path_when_not_on_path(self, monkeypatch):
@@ -516,22 +545,40 @@ class TestRuntimeProviderResolution:
 
     def test_runtime_copilot_uses_gh_cli_token(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth.exchange_copilot_api_token",
+            lambda github_token, timeout=15.0: {
+                "token": "copilot-api-token",
+                "base_url": "https://api.individual.githubcopilot.com",
+                "expires_at_ms": 1_800_000_000_000,
+                "source": "https://api.github.com/copilot_internal/v2/token",
+            },
+        )
         from hermes_cli.runtime_provider import resolve_runtime_provider
         result = resolve_runtime_provider(requested="copilot")
         assert result["provider"] == "copilot"
         assert result["api_mode"] == "chat_completions"
-        assert result["api_key"] == "gho_cli_secret"
-        assert result["base_url"] == "https://api.githubcopilot.com"
+        assert result["api_key"] == "copilot-api-token"
+        assert result["base_url"] == "https://api.individual.githubcopilot.com"
 
     def test_runtime_copilot_uses_responses_for_gpt_5_4(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth.exchange_copilot_api_token",
+            lambda github_token, timeout=15.0: {
+                "token": "copilot-api-token",
+                "base_url": "https://api.individual.githubcopilot.com",
+                "expires_at_ms": 1_800_000_000_000,
+                "source": "https://api.github.com/copilot_internal/v2/token",
+            },
+        )
         monkeypatch.setattr(
             "hermes_cli.runtime_provider._get_model_config",
             lambda: {"provider": "copilot", "default": "gpt-5.4"},
         )
         monkeypatch.setattr(
             "hermes_cli.models.fetch_github_model_catalog",
-            lambda api_key=None, timeout=5.0: [
+            lambda api_key=None, base_url=None, timeout=5.0: [
                 {
                     "id": "gpt-5.4",
                     "supported_endpoints": ["/responses"],

--- a/tests/test_model_provider_persistence.py
+++ b/tests/test_model_provider_persistence.py
@@ -109,8 +109,9 @@ class TestProviderPersistsAfterModelSave:
             "hermes_cli.auth.resolve_api_key_provider_credentials",
             return_value={
                 "provider": "copilot",
-                "api_key": "gh-cli-token",
-                "base_url": "https://api.githubcopilot.com",
+                "api_key": "copilot-api-token",
+                "github_token": "gh-cli-token",
+                "base_url": "https://api.individual.githubcopilot.com",
                 "source": "gh auth token",
             },
         ), patch(
@@ -144,7 +145,7 @@ class TestProviderPersistsAfterModelSave:
         model = config.get("model")
         assert isinstance(model, dict), f"model should be dict, got {type(model)}"
         assert model.get("provider") == "copilot"
-        assert model.get("base_url") == "https://api.githubcopilot.com"
+        assert model.get("base_url") == "https://api.individual.githubcopilot.com"
         assert model.get("default") == "gpt-5.4"
         assert model.get("api_mode") == "codex_responses"
         assert config["agent"]["reasoning_effort"] == "high"
@@ -175,8 +176,9 @@ class TestProviderPersistsAfterModelSave:
             "hermes_cli.auth.resolve_api_key_provider_credentials",
             return_value={
                 "provider": "copilot",
-                "api_key": "gh-cli-token",
-                "base_url": "https://api.githubcopilot.com",
+                "api_key": "copilot-api-token",
+                "github_token": "gh-cli-token",
+                "base_url": "https://api.individual.githubcopilot.com",
                 "source": "gh auth token",
             },
         ), patch(

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -43,6 +43,8 @@ hermes setup       # Or configure everything at once
 |----------|-----------|---------------|
 | **Nous Portal** | Subscription-based, zero-config | OAuth login via `hermes model` |
 | **OpenAI Codex** | ChatGPT OAuth, uses Codex models | Device code auth via `hermes model` |
+| **GitHub Copilot** | Direct Copilot API with your GitHub Copilot subscription | `hermes model`, then use OAuth device login, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`, or `gh auth token` |
+| **GitHub Copilot ACP** | Local Copilot CLI backend via ACP | `hermes model`, requires `copilot --acp --stdio` |
 | **Anthropic** | Claude models directly (Pro/Max or API key) | `hermes model` with Claude Code auth, or an Anthropic API key |
 | **OpenRouter** | Multi-provider routing across many models | Enter your API key |
 | **Z.AI** | GLM / Zhipu-hosted models | Set `GLM_API_KEY` / `ZAI_API_KEY` |
@@ -59,6 +61,39 @@ hermes setup       # Or configure everything at once
 :::tip
 You can switch providers at any time with `hermes model` — no code changes, no lock-in. When configuring a custom endpoint, Hermes will prompt for the context window size and auto-detect it when possible. See [Context Length Detection](../user-guide/configuration.md#context-length-detection) for details.
 :::
+
+### GitHub Copilot Setup Examples
+
+If you want to use GitHub Copilot as your main provider, the usual path is:
+
+```bash
+hermes model
+# Select: GitHub Copilot
+# If no token is found, choose "Login with GitHub"
+# Pick a model from the live Copilot catalog
+```
+
+Hermes checks for Copilot credentials in this order:
+
+1. `COPILOT_GITHUB_TOKEN`
+2. `GH_TOKEN`
+3. `GITHUB_TOKEN`
+4. `gh auth token`
+
+If you already use the GitHub CLI, `gh auth login` is often enough. If not, Hermes can launch the GitHub device-code flow directly from `hermes model`.
+
+When Hermes launches the Copilot device-code flow, GitHub may show an `Authorize OpenCode` page. Hermes currently reuses the same GitHub OAuth client/app used by OpenCode and the Copilot CLI for this login path.
+
+If you prefer the full setup wizard, `hermes setup` exposes the same provider choices and will save the selected Copilot provider, model, and base URL into your Hermes config for future sessions.
+
+For the local Copilot CLI backend instead:
+
+```bash
+hermes model
+# Select: GitHub Copilot ACP
+```
+
+That mode does not call the Copilot HTTP API directly. Hermes starts `copilot --acp --stdio` and delegates turns through the local Copilot CLI.
 
 ## 3. Start Chatting
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -55,6 +55,13 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `HERMES_LOCAL_STT_LANGUAGE` | Default language passed to `HERMES_LOCAL_STT_COMMAND` or auto-detected local `whisper` CLI fallback (default: `en`) |
 | `HERMES_HOME` | Override Hermes config directory (default: `~/.hermes`). Also scopes the gateway PID file and systemd service name, so multiple installations can run concurrently |
 
+### GitHub Copilot Notes
+
+- Hermes resolves Copilot credentials in this order: `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`, then `gh auth token`.
+- Hermes exchanges that GitHub credential for a short-lived Copilot API token before sending model requests.
+- The final Copilot API host may be routed by GitHub, so Hermes may persist a base URL such as `https://api.individual.githubcopilot.com` instead of the generic host.
+- `copilot-acp` is separate from direct `copilot`: ACP uses the local `copilot` CLI process instead of the Copilot HTTP API.
+
 ## Provider Auth (OAuth)
 
 For native Anthropic auth, Hermes prefers Claude Code's own credential files when they exist because those credentials can refresh automatically. Environment variables such as `ANTHROPIC_TOKEN` remain useful as manual overrides, but they are no longer the preferred path for Claude Pro/Max login.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -137,7 +137,32 @@ hermes chat --provider copilot --model gpt-5.4
 3. `GITHUB_TOKEN` environment variable
 4. `gh auth token` CLI fallback
 
-If no token is found, `hermes model` offers an **OAuth device code login** — the same flow used by the Copilot CLI and opencode.
+If no token is found, `hermes model` offers an **OAuth device code login** — the same flow used by the Copilot CLI and OpenCode. GitHub may show an `Authorize OpenCode` page during this step because Hermes currently reuses that GitHub OAuth client/app for the Copilot device-login flow.
+
+**Interactive setup flow (`hermes model`)**:
+
+1. Select `GitHub Copilot`
+2. Hermes checks `COPILOT_GITHUB_TOKEN`, then `GH_TOKEN`, then `GITHUB_TOKEN`, then `gh auth token`
+3. If nothing usable is found, Hermes offers:
+   - Login with GitHub via device code
+   - Enter a token manually
+   - Cancel
+   - During device login, GitHub may show `Authorize OpenCode`
+4. Hermes fetches the live Copilot model catalog for your account
+5. You choose a model
+6. Hermes saves the resolved provider, routed base URL, model, and API mode into `~/.hermes/config.yaml`
+
+**One-shot CLI usage**:
+
+```bash
+# Use GitHub CLI auth if you already have it
+gh auth login
+hermes chat --provider copilot --model gpt-5.4
+
+# Or export a token explicitly
+export COPILOT_GITHUB_TOKEN=gho_xxx
+hermes chat --provider copilot --model claude-sonnet-4.6
+```
 
 :::warning Token types
 The Copilot API does **not** support classic Personal Access Tokens (`ghp_*`). Supported token types:
@@ -151,6 +176,8 @@ The Copilot API does **not** support classic Personal Access Tokens (`ghp_*`). S
 If your `gh auth token` returns a `ghp_*` token, use `hermes model` to authenticate via OAuth instead.
 :::
 
+At runtime Hermes exchanges your GitHub token for a short-lived Copilot API token and follows the routed Copilot host returned by GitHub (for example `api.individual.githubcopilot.com`). This matches the Copilot CLI/OpenClaw flow and avoids pinning requests to a single hard-coded endpoint.
+
 **API routing**: GPT-5+ models (except `gpt-5-mini`) automatically use the Responses API. All other models (GPT-4o, Claude, Gemini, etc.) use Chat Completions. Models are auto-detected from the live Copilot catalog.
 
 **`copilot-acp` — Copilot ACP agent backend**. Spawns the local Copilot CLI as a subprocess:
@@ -159,6 +186,15 @@ If your `gh auth token` returns a `ghp_*` token, use `hermes model` to authentic
 hermes chat --provider copilot-acp --model copilot-acp
 # Requires the GitHub Copilot CLI in PATH and an existing `copilot login` session
 ```
+
+**ACP setup flow (`hermes model`)**:
+
+1. Select `GitHub Copilot ACP`
+2. Hermes checks that the `copilot` CLI is available, or that you overrode it with `HERMES_COPILOT_ACP_COMMAND`
+3. Hermes queries the Copilot catalog when possible so you can still pick a model from the normal model list
+4. At runtime Hermes launches `copilot --acp --stdio` and talks to it through the ACP bridge
+
+Use ACP when you specifically want the local Copilot CLI runtime. Use direct `copilot` when you want Hermes to talk to the Copilot API itself.
 
 **Permanent config:**
 ```yaml

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -176,7 +176,7 @@ The Copilot API does **not** support classic Personal Access Tokens (`ghp_*`). S
 If your `gh auth token` returns a `ghp_*` token, use `hermes model` to authenticate via OAuth instead.
 :::
 
-At runtime Hermes exchanges your GitHub token for a short-lived Copilot API token and follows the routed Copilot host returned by GitHub (for example `api.individual.githubcopilot.com`). This matches the Copilot CLI/OpenClaw flow and avoids pinning requests to a single hard-coded endpoint.
+At runtime Hermes exchanges your GitHub token for a short-lived Copilot API token and follows the routed Copilot host returned by GitHub (for example `api.individual.githubcopilot.com`). This matches the Copilot CLI/OpenCode flow and avoids pinning requests to a single hard-coded endpoint.
 
 **API routing**: GPT-5+ models (except `gpt-5-mini`) automatically use the Responses API. All other models (GPT-4o, Claude, Gemini, etc.) use Chat Completions. Models are auto-detected from the live Copilot catalog.
 


### PR DESCRIPTION
## What does this PR do?

Fixes and hardens Hermes' existing GitHub Copilot provider flow.

Before this change, the direct `copilot` provider used the source GitHub token as the runtime API credential and assumed a fixed `api.githubcopilot.com` base URL. This PR switches that path to the exchanged-token flow used by Copilot clients: Hermes exchanges the GitHub credential via `api.github.com/copilot_internal/v2/token`, uses the short-lived Copilot API token for runtime requests, and follows the routed API host returned by GitHub.


## Related Issue

#1055

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Token exchange and caching** (`hermes_cli/copilot_auth.py`)
- Added `exchange_copilot_api_token()` to exchange the GitHub credential for a short-lived Copilot API token
- Prefer routed host resolution from `endpoints.api` in the exchange response, with legacy `proxy-ep` parsing kept as fallback
- Added on-disk cache handling with fingerprinting, atomic writes, permission hardening, and expiry skew
- Added centralized `is_copilot_base_url()` validation for `*.githubcopilot.com`

**Credential resolution** (`hermes_cli/auth.py`)
- `resolve_api_key_provider_credentials("copilot")` now returns the exchanged runtime token, routed `base_url`, expiry metadata, and original `github_token`
- `get_api_key_provider_status()` uses cached Copilot token info instead of forcing a live exchange

**Model and setup flow** (`hermes_cli/models.py`, `hermes_cli/setup.py`, `hermes_cli/main.py`)
- Copilot catalog fetches, probes, and setup/model flows now use the resolved routed base URL instead of assuming the default host
- The CLI display path now distinguishes the original GitHub credential from the exchanged runtime token

**Runtime host handling** (`run_agent.py`, `agent/auxiliary_client.py`)
- Replaced hardcoded Copilot host checks with the shared `is_copilot_base_url()` validator

**Documentation**
- Updated Copilot setup and usage docs in `README.md` and `website/docs/`
- Documented the current device-login behavior, including that GitHub may show an `Authorize OpenCode` page

**Tests**
- Added coverage for token exchange, cache behavior, expiry parsing, routed host resolution, and model/setup integration
- Updated existing Copilot/provider tests to match the exchanged-token + routed-base-url flow


## How to Test

1. Run the targeted Copilot/provider suite:

```bash
.venv/bin/python -m pytest -o addopts='' \
  tests/hermes_cli/test_copilot_auth.py \
  tests/test_api_key_providers.py \
  tests/hermes_cli/test_model_validation.py \
  tests/hermes_cli/test_setup_model_provider.py \
  tests/test_model_provider_persistence.py \
  tests/agent/test_auxiliary_client.py -q
```

2. Run `hermes model`, select GitHub Copilot, and verify:
   - Hermes can resolve credentials
   - `~/.hermes/copilot_token.json` is created after exchange
   - the saved config uses the resolved Copilot provider/model/base URL

3. Run `hermes setup model` and verify the Copilot path uses the live catalog and persists the resolved base URL


## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Notes

This implementation depends on GitHub's internal Copilot token exchange endpoint (`copilot_internal/v2/token`), which is used by Copilot clients but is not a documented public API. The current device-login flow also reuses the same GitHub OAuth client/app used by OpenCode/Copilot CLI, so GitHub may show an `Authorize OpenCode` page during that flow.