### PR TITLE
fix(gateway): resolve adapter before _deliver_media_from_response

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2317,9 +2317,11 @@ class GatewayRunner:
             # delivered without this.
             if agent_result.get("already_sent"):
                 if response:
-                    await self._deliver_media_from_response(
-                        response, event, adapter,
-                    )
+                    adapter = self.adapters.get(source.platform)
+                    if adapter:
+                        await self._deliver_media_from_response(
+                            response, event, adapter,
+                        )
                 return None
 
             return response


### PR DESCRIPTION
## Bug

When streaming is enabled (`already_sent=True`), `_handle_message_with_agent` calls `_deliver_media_from_response(response, event, adapter)` at line 2321 — but `adapter` is only assigned conditionally earlier in the method (first-message home-channel hint or Discord voice context).

On the normal Telegram/Slack/etc streaming path, `adapter` is never bound, causing:

```
UnboundLocalError: cannot access local variable 'adapter' where it is not associated with a value
```

This crashes **every** streamed response that contains media files.

## Fix

Resolve `adapter` from `self.adapters.get(source.platform)` immediately before the call, with a `None` guard so media delivery degrades gracefully instead of crashing the entire message handler.

## Testing

Verified on a live Telegram gateway — streamed responses now complete without errors.