### PR TITLE
fix: Anthropic OAuth 401 - fix Content-Type, add force retry, wire na…

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -528,10 +528,16 @@ def run_hermes_oauth_login() -> Optional[str]:
     code = splits[0]
     state = splits[1] if len(splits) > 1 else ""
 
+    # Validate CSRF state matches the original verifier
+    if state and state != verifier:
+        print("  State mismatch — possible CSRF. Aborting.")
+        return None
+
     # Exchange code for tokens
     try:
+        import urllib.parse
         import urllib.request
-        exchange_data = json.dumps({
+        exchange_data = urllib.parse.urlencode({
             "grant_type": "authorization_code",
             "client_id": _OAUTH_CLIENT_ID,
             "code": code,
@@ -544,7 +550,7 @@ def run_hermes_oauth_login() -> Optional[str]:
             _OAUTH_TOKEN_URL,
             data=exchange_data,
             headers={
-                "Content-Type": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
                 "User-Agent": f"claude-cli/{_CLAUDE_CODE_VERSION} (external, cli)",
             },
             method="POST",
@@ -608,6 +614,7 @@ def refresh_hermes_oauth_token() -> Optional[str]:
     Returns the new access token, or None if refresh fails.
     """
     import time
+    import urllib.parse
     import urllib.request
 
     creds = read_hermes_oauth_credentials()
@@ -615,7 +622,7 @@ def refresh_hermes_oauth_token() -> Optional[str]:
         return None
 
     try:
-        data = json.dumps({
+        data = urllib.parse.urlencode({
             "grant_type": "refresh_token",
             "refresh_token": creds["refreshToken"],
             "client_id": _OAUTH_CLIENT_ID,
@@ -625,7 +632,7 @@ def refresh_hermes_oauth_token() -> Optional[str]:
             _OAUTH_TOKEN_URL,
             data=data,
             headers={
-                "Content-Type": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
                 "User-Agent": f"claude-cli/{_CLAUDE_CODE_VERSION} (external, cli)",
             },
             method="POST",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2139,30 +2139,47 @@ def _run_anthropic_oauth_flow(save_env_value):
         return False
 
     except FileNotFoundError:
-        # Claude CLI not installed — guide user through manual setup
+        # Claude CLI not installed — offer native OAuth or manual paste
         print()
-        print("  The 'claude' CLI is required for OAuth login.")
+        print("  The 'claude' CLI is not installed.")
         print()
-        print("  To install and authenticate:")
-        print()
-        print("    1. Install Claude Code:  npm install -g @anthropic-ai/claude-code")
-        print("    2. Run:                  claude setup-token")
-        print("    3. Follow the browser prompts to authorize")
-        print("    4. Re-run:               hermes model")
-        print()
-        print("  Or paste an existing setup-token now (sk-ant-oat-...):")
+        print("  Choose an authentication method:")
+        print("    1. Authenticate via browser (no Claude CLI needed)")
+        print("    2. Paste a setup-token manually")
         print()
         try:
-            token = input("  Setup-token (or Enter to cancel): ").strip()
+            choice = input("  Choice [1]: ").strip() or "1"
         except (KeyboardInterrupt, EOFError):
             print()
             return False
-        if token:
-            save_anthropic_oauth_token(token, save_fn=save_env_value)
-            print("  ✓ Setup-token saved.")
-            return True
-        print("  Cancelled — install Claude Code and try again.")
-        return False
+
+        if choice == "1":
+            from agent.anthropic_adapter import run_hermes_oauth_login
+            token = run_hermes_oauth_login()
+            if token:
+                save_anthropic_oauth_token(token, save_fn=save_env_value)
+                print("  ✓ OAuth credentials saved.")
+                return True
+            print("  ⚠ Authentication failed or cancelled.")
+            return False
+        else:
+            print()
+            print("  To install Claude Code: npm install -g @anthropic-ai/claude-code")
+            print("  Then run: claude setup-token")
+            print()
+            print("  Or paste an existing setup-token now (sk-ant-oat-...):")
+            print()
+            try:
+                token = input("  Setup-token (or Enter to cancel): ").strip()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                return False
+            if token:
+                save_anthropic_oauth_token(token, save_fn=save_env_value)
+                print("  ✓ Setup-token saved.")
+                return True
+            print("  Cancelled — install Claude Code and try again.")
+            return False
 
 
 def _model_flow_anthropic(config, current_model=""):

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1322,18 +1322,33 @@ def setup_model_provider(config: dict):
                             print_warning("Skipped — agent won't work without credentials")
                 except FileNotFoundError:
                     print()
-                    print_info("The 'claude' CLI is required for OAuth login.")
+                    print_info("The 'claude' CLI is not installed.")
                     print()
-                    print_info("To install: npm install -g @anthropic-ai/claude-code")
-                    print_info("Then run:   claude setup-token")
-                    print_info("Or paste an existing setup-token below:")
-                    print()
-                    token = prompt("Setup-token (sk-ant-oat-...)", password=True)
-                    if token:
-                        save_anthropic_oauth_token(token, save_fn=save_env_value)
-                        print_success("Setup-token saved")
+                    native_choices = [
+                        "Authenticate via browser (no Claude CLI needed)",
+                        "Paste a setup-token manually",
+                    ]
+                    native_idx = prompt_choice("Choose an option:", native_choices, 0)
+                    if native_idx == 0:
+                        from agent.anthropic_adapter import run_hermes_oauth_login
+                        token = run_hermes_oauth_login()
+                        if token:
+                            save_anthropic_oauth_token(token, save_fn=save_env_value)
+                            print_success("OAuth credentials saved")
+                        else:
+                            print_warning("Authentication failed or cancelled")
                     else:
-                        print_warning("Skipped — install Claude Code and re-run setup")
+                        print()
+                        print_info("To install Claude Code: npm install -g @anthropic-ai/claude-code")
+                        print_info("Then run: claude setup-token")
+                        print_info("Or paste an existing setup-token below:")
+                        print()
+                        token = prompt("Setup-token (sk-ant-oat-...)", password=True)
+                        if token:
+                            save_anthropic_oauth_token(token, save_fn=save_env_value)
+                            print_success("Setup-token saved")
+                        else:
+                            print_warning("Skipped — install Claude Code and re-run setup")
             else:
                 print()
                 print_info("Get an API key at: https://console.anthropic.com/settings/keys")

--- a/run_agent.py
+++ b/run_agent.py
@@ -3338,7 +3338,7 @@ class AIAgent:
 
         return True
 
-    def _try_refresh_anthropic_client_credentials(self) -> bool:
+    def _try_refresh_anthropic_client_credentials(self, *, force: bool = False) -> bool:
         if self.api_mode != "anthropic_messages" or not hasattr(self, "_anthropic_api_key"):
             return False
         # Only refresh credentials for the native Anthropic provider.
@@ -3358,7 +3358,27 @@ class AIAgent:
             return False
         new_token = new_token.strip()
         if new_token == self._anthropic_api_key:
-            return False
+            if not force:
+                return False
+            # Force mode: try all OAuth credential sources regardless of current token type.
+            # The current token may be a stale API key while valid OAuth creds exist in files.
+            try:
+                from agent.anthropic_adapter import (
+                    refresh_hermes_oauth_token, _refresh_oauth_token,
+                    read_claude_code_credentials,
+                )
+                forced_token = refresh_hermes_oauth_token()
+                if not forced_token:
+                    cc_creds = read_claude_code_credentials()
+                    if cc_creds:
+                        forced_token = _refresh_oauth_token(cc_creds)
+                if forced_token and forced_token.strip() != self._anthropic_api_key:
+                    new_token = forced_token.strip()
+                else:
+                    return False
+            except Exception as exc:
+                logger.debug("Anthropic forced credential refresh failed: %s", exc)
+                return False
 
         try:
             self._anthropic_client.close()
@@ -6079,7 +6099,7 @@ class AIAgent:
                     ):
                         anthropic_auth_retry_attempted = True
                         from agent.anthropic_adapter import _is_oauth_token
-                        if self._try_refresh_anthropic_client_credentials():
+                        if self._try_refresh_anthropic_client_credentials(force=True):
                             print(f"{self.log_prefix}🔐 Anthropic credentials refreshed after 401. Retrying request...")
                             continue
                         # Credential refresh didn't help — show diagnostic info


### PR DESCRIPTION
## What does this PR do?

Fixes Anthropic OAuth 401 authentication errors caused by incorrect Content-Type in OAuth token requests and missing force-retry logic.

## Related Issue

Fixes #(none - discovered via debugging)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `agent/anthropic_adapter.py`: Fix Content-Type from `application/json` to `application/x-www-form-urlencoded` in `refresh_hermes_oauth_token()` and `run_hermes_oauth_login()` token exchange (RFC 6749 compliance, matches existing `_refresh_oauth_token()`)
- `agent/anthropic_adapter.py`: Add PKCE state validation in `run_hermes_oauth_login()` to prevent CSRF
- `run_agent.py`: Add `force=True` parameter to `_try_refresh_anthropic_client_credentials()` for 401 retry (matches existing Nous pattern at line 6071)
- `hermes_cli/setup.py` + `hermes_cli/main.py`: Wire up `run_hermes_oauth_login()` as fallback when Claude CLI is not installed

## How to Test

1. Set `provider: anthropic` in cli-config.yaml with expired OAuth credentials
2. Run `hermes chat` — should auto-refresh instead of 401
3. Run `hermes model` → Anthropic → without Claude CLI installed — native OAuth option should appear

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
