### PR TITLE
feat(gateway): add /v1/message session-backed endpoint

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3,6 +3,7 @@ OpenAI-compatible API server platform adapter.
 
 Exposes an HTTP server with endpoints:
 - POST /v1/chat/completions        — OpenAI Chat Completions format (stateless)
+- POST /v1/message                 — Session-backed message endpoint
 - POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id)
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
@@ -24,6 +25,7 @@ import logging
 import os
 import time
 import uuid
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 try:
@@ -38,6 +40,8 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     SendResult,
 )
+
+from gateway.session import SessionSource, SessionStore
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +127,7 @@ class APIServerAdapter(BasePlatformAdapter):
     and routes them through hermes-agent's AIAgent.
     """
 
-    def __init__(self, config: PlatformConfig):
+    def __init__(self, config: PlatformConfig, session_store: Optional[SessionStore] = None):
         super().__init__(config, Platform.API_SERVER)
         extra = config.extra or {}
         self._host: str = extra.get("host", os.getenv("API_SERVER_HOST", DEFAULT_HOST))
@@ -133,6 +137,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
+        self._session_store: Optional[SessionStore] = session_store
         # Conversation name → latest response_id mapping
         self._conversations: Dict[str, str] = {}
 
@@ -170,6 +175,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        platform_hint: str = "api_server",
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -193,10 +199,52 @@ class APIServerAdapter(BasePlatformAdapter):
             verbose_logging=False,
             ephemeral_system_prompt=ephemeral_system_prompt or None,
             session_id=session_id,
-            platform="api_server",
+            platform=platform_hint,
             stream_delta_callback=stream_delta_callback,
         )
         return agent
+
+    # History normalization helper
+    # ------------------------------------------------------------------
+
+    def _normalize_history(self, history: List[Dict]) -> List[Dict]:
+        """
+        Normalize transcript history for agent consumption.
+
+        Copies the same logic used in the gateway runner:
+        - skip entries without ``role``
+        - skip ``role == "session_meta"``
+        - skip ``role == "system"``
+        - preserve rich tool messages (``tool_calls``, ``tool_call_id``,
+          or ``role == "tool"``) after removing only ``timestamp``
+        - reduce simple messages to ``{"role": role, "content": content}``
+          only when content is a non-empty string
+        """
+        agent_history: List[Dict] = []
+        for msg in history:
+            role = msg.get("role")
+            if not role:
+                continue
+
+            if role == "session_meta":
+                continue
+
+            if role == "system":
+                continue
+
+            has_tool_calls = "tool_calls" in msg
+            has_tool_call_id = "tool_call_id" in msg
+            is_tool_message = role == "tool"
+
+            if has_tool_calls or has_tool_call_id or is_tool_message:
+                clean_msg = {k: v for k, v in msg.items() if k != "timestamp"}
+                agent_history.append(clean_msg)
+            else:
+                content = msg.get("content")
+                if content:
+                    agent_history.append({"role": role, "content": content})
+
+        return agent_history
 
     # ------------------------------------------------------------------
     # HTTP Handlers
@@ -693,6 +741,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        platform_hint: str = "api_server",
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -707,11 +756,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
                 stream_delta_callback=stream_delta_callback,
+                platform_hint=platform_hint,
             )
             result = agent.run_conversation(
                 user_message=user_message,
                 conversation_history=conversation_history,
             )
+            result["session_id"] = getattr(agent, "session_id", session_id)
             usage = {
                 "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                 "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
@@ -720,6 +771,215 @@ class APIServerAdapter(BasePlatformAdapter):
             return result, usage
 
         return await loop.run_in_executor(None, _run)
+
+
+    # Session-backed message handler
+    # ------------------------------------------------------------------
+
+    async def _handle_message(self, request: "web.Request") -> "web.Response":
+        """POST /v1/message — session-backed message endpoint."""
+        # 1. Auth check
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        # 2. Session store availability
+        if self._session_store is None:
+            return web.json_response(
+                {
+                    "error": {
+                        "type": "server_error",
+                        "message": "Session store not available",
+                    }
+                },
+                status=500,
+            )
+
+        # 3. Parse JSON body
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response(
+                {
+                    "error": {
+                        "message": "Invalid JSON in request body",
+                        "type": "invalid_request_error",
+                    }
+                },
+                status=400,
+            )
+
+        # 4. Require text — non-empty string after strip
+        text = body.get("text")
+        if not isinstance(text, str) or not text.strip():
+            return web.json_response(
+                {
+                    "error": {
+                        "message": "Missing or empty 'text' field",
+                        "type": "invalid_request_error",
+                    }
+                },
+                status=400,
+            )
+        text = text.strip()
+
+        # 5. Require chat_id
+        chat_id_raw = body.get("chat_id")
+        if not chat_id_raw:
+            return web.json_response(
+                {
+                    "error": {
+                        "message": "Missing 'chat_id' field",
+                        "type": "invalid_request_error",
+                    }
+                },
+                status=400,
+            )
+        chat_id = str(chat_id_raw).strip()
+        if not chat_id:
+            return web.json_response(
+                {
+                    "error": {
+                        "message": "Missing 'chat_id' field",
+                        "type": "invalid_request_error",
+                    }
+                },
+                status=400,
+            )
+
+        # 6. Default user_id to normalized chat_id if not provided
+        user_id = str(body.get("user_id", chat_id)).strip() or chat_id
+
+        # 7. Default platform to "webhook" if not provided
+        platform_name = body.get("platform", "webhook")
+
+        # 8. Convert platform with Platform()
+        try:
+            platform_enum = Platform(platform_name)
+        except (ValueError, KeyError):
+            return web.json_response(
+                {
+                    "error": {
+                        "message": f"Unknown platform: {platform_name}",
+                        "type": "invalid_request_error",
+                    }
+                },
+                status=400,
+            )
+
+        # 9. Construct SessionSource
+        source = SessionSource(
+            platform=platform_enum,
+            chat_id=chat_id,
+            chat_type="dm",
+            user_id=user_id,
+        )
+
+        # 10. Get or create session
+        session_entry = self._session_store.get_or_create_session(source)
+
+        # 11. Load transcript
+        history = self._session_store.load_transcript(session_entry.session_id)
+
+        # 12. Normalize history
+        agent_history = self._normalize_history(history)
+
+        # 13. Record offset
+        history_offset = len(agent_history)
+
+        # 14. Run agent
+        try:
+            result, usage = await self._run_agent(
+                user_message=text,
+                conversation_history=agent_history,
+                session_id=session_entry.session_id,
+                platform_hint=platform_enum.value,
+            )
+        except Exception as e:
+            logger.error(
+                "Error running agent for message endpoint: %s", e, exc_info=True
+            )
+            return web.json_response(
+                {
+                    "error": {
+                        "message": f"Internal server error: {e}",
+                        "type": "server_error",
+                    }
+                },
+                status=500,
+            )
+
+        # 15. Handle session-id rollover
+        effective_session_id = session_entry.session_id
+        result_session_id = result.get("session_id")
+        if result_session_id and result_session_id != session_entry.session_id:
+            session_entry.session_id = result_session_id
+            effective_session_id = result_session_id
+            self._session_store._save()
+
+        # 16. Extract new messages
+        all_messages = result.get("messages", [])
+        if len(all_messages) > history_offset:
+            new_messages = all_messages[history_offset:]
+        else:
+            new_messages = []
+
+        # 17. Compute reply_text
+        reply_text = None
+        for msg in reversed(new_messages):
+            if msg.get("role") == "assistant":
+                content = msg.get("content")
+                if isinstance(content, str) and content:
+                    reply_text = content
+                    break
+        if reply_text is None:
+            reply_text = (
+                result.get("final_response")
+                or result.get("error")
+                or "(No response generated)"
+            )
+
+        # 18. Timestamp
+        ts = datetime.now().isoformat()
+
+        # 19-20. Append to transcript
+        if not new_messages:
+            self._session_store.append_to_transcript(
+                effective_session_id,
+                {
+                    "role": "user",
+                    "content": text,
+                    "timestamp": ts,
+                },
+            )
+            self._session_store.append_to_transcript(
+                effective_session_id,
+                {
+                    "role": "assistant",
+                    "content": reply_text,
+                    "timestamp": ts,
+                },
+            )
+        else:
+            for msg in new_messages:
+                if msg.get("role") == "system":
+                    continue
+                self._session_store.append_to_transcript(
+                    effective_session_id,
+                    {
+                        **msg,
+                        "timestamp": ts,
+                    },
+                )
+
+        # 21. Return response
+        return web.json_response(
+            {
+                "response": reply_text,
+                "session_id": effective_session_id,
+                "ok": True,
+            }
+        )
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface
@@ -737,6 +997,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/models", self._handle_models)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)
+            self._app.router.add_post("/v1/message", self._handle_message)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
             self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1207,7 +1207,7 @@ class GatewayRunner:
             if not check_api_server_requirements():
                 logger.warning("API Server: aiohttp not installed")
                 return None
-            return APIServerAdapter(config)
+            return APIServerAdapter(config, session_store=self.session_store)
 
         elif platform == Platform.WEBHOOK:
             from gateway.platforms.webhook import WebhookAdapter, check_webhook_requirements

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -30,6 +30,8 @@ from gateway.platforms.api_server import (
     cors_middleware,
 )
 
+from gateway.session import SessionSource
+
 
 # ---------------------------------------------------------------------------
 # check_api_server_requirements
@@ -206,6 +208,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/models", adapter._handle_models)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
+    app.router.add_post("/v1/message", adapter._handle_message)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
     return app
@@ -219,6 +222,21 @@ def adapter():
 @pytest.fixture
 def auth_adapter():
     return _make_adapter(api_key="sk-secret")
+
+@pytest.fixture
+def session_adapter():
+    """Create an adapter with a mocked SessionStore."""
+    mock_store = MagicMock()
+    mock_store.get_or_create_session.return_value = MagicMock(
+        session_id="test_session_001",
+        was_auto_reset=False,
+    )
+    mock_store.load_transcript.return_value = []
+    mock_store._save = MagicMock()
+    config = PlatformConfig(enabled=True)
+    adapter = APIServerAdapter(config, session_store=mock_store)
+    return adapter
+
 
 
 # ---------------------------------------------------------------------------
@@ -1297,3 +1315,201 @@ class TestConversationParameter:
                 assert resp.status == 200
                 # Conversation mapping should NOT be set since store=false
                 assert "ephemeral-chat" not in adapter._conversations
+
+
+# ---------------------------------------------------------------------------
+# /v1/message endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestMessageEndpoint:
+    @pytest.mark.asyncio
+    async def test_message_missing_text_returns_400(self, session_adapter):
+        app = _create_app(session_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/message", json={"chat_id": "123"})
+            assert resp.status == 400
+            data = await resp.json()
+            assert "text" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_message_missing_chat_id_returns_400(self, session_adapter):
+        app = _create_app(session_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/message", json={"text": "hello"})
+            assert resp.status == 400
+            data = await resp.json()
+            assert "chat_id" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_message_invalid_platform_returns_400(self, session_adapter):
+        app = _create_app(session_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/message",
+                json={"text": "hello", "chat_id": "123", "platform": "nope"},
+            )
+            assert resp.status == 400
+            data = await resp.json()
+            assert "Unknown platform" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_message_defaults_platform_to_webhook_and_user_id_to_chat_id(
+        self, session_adapter
+    ):
+        app = _create_app(session_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                session_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "Hi", "messages": [], "api_calls": 1},
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/message",
+                    json={"text": "hello", "chat_id": "chat_123"},
+                )
+                assert resp.status == 200
+                # Verify SessionSource was created with defaults
+                call_args = (
+                    session_adapter._session_store.get_or_create_session.call_args
+                )
+                source = call_args[0][0]
+                assert source.platform == Platform.WEBHOOK
+                assert source.user_id == "chat_123"
+
+    @pytest.mark.asyncio
+    async def test_message_without_session_store_returns_500(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/message",
+                json={"text": "hello", "chat_id": "123"},
+            )
+            assert resp.status == 500
+            data = await resp.json()
+            assert "Session store not available" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_message_persists_transcript_and_reuses_session_id_across_requests(
+        self, session_adapter
+    ):
+        mock_messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        session_adapter._session_store.load_transcript.return_value = mock_messages
+
+        app = _create_app(session_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                session_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "Hello!",
+                        "messages": mock_messages,
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+                )
+                resp1 = await cli.post(
+                    "/v1/message",
+                    json={"text": "hi", "chat_id": "c1"},
+                )
+                assert resp1.status == 200
+                data1 = await resp1.json()
+                assert data1["ok"] is True
+
+                # Second request should reuse same session
+                resp2 = await cli.post(
+                    "/v1/message",
+                    json={"text": "follow up", "chat_id": "c1"},
+                )
+                assert resp2.status == 200
+                data2 = await resp2.json()
+                assert data2["session_id"] == data1["session_id"]
+
+                # Second agent call should have received conversation history
+                second_call_kwargs = mock_run.call_args_list[1].kwargs
+                assert len(second_call_kwargs["conversation_history"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_message_filters_session_meta_before_offset_slicing(
+        self, session_adapter
+    ):
+        transcript = [
+            {"role": "session_meta", "source": "telegram", "timestamp": "t"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        session_adapter._session_store.load_transcript.return_value = transcript
+
+        app = _create_app(session_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                session_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "Hello!",
+                        "messages": transcript,
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/message",
+                    json={"text": "hi", "chat_id": "c1"},
+                )
+                assert resp.status == 200
+                # Verify conversation_history passed to agent has no session_meta
+                call_kwargs = mock_run.call_args.kwargs
+                history = call_kwargs["conversation_history"]
+                assert all(m.get("role") != "session_meta" for m in history)
+
+    @pytest.mark.asyncio
+    async def test_message_falls_back_to_final_response_when_new_messages_have_no_assistant_text(
+        self, session_adapter
+    ):
+        # Agent returns messages but new_messages have no assistant text
+        session_adapter._session_store.load_transcript.return_value = [
+            {"role": "user", "content": "hi"},
+        ]
+
+        app = _create_app(session_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                session_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "Final answer",
+                        "messages": [
+                            {"role": "tool", "tool_call_id": "x", "content": "result"},
+                        ],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/message",
+                    json={"text": "hi", "chat_id": "c1"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["response"] == "Final answer"
+
+    @pytest.mark.asyncio
+    async def test_message_requires_auth(self):
+        auth_store = MagicMock()
+        config = PlatformConfig(enabled=True, extra={"key": "sk-secret"})
+        adapter = APIServerAdapter(config, session_store=auth_store)
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/message",
+                json={"text": "hello", "chat_id": "123"},
+            )
+            assert resp.status == 401


### PR DESCRIPTION
## What does this PR do?
The Hermes API server has no way to maintain multi-turn conversations through its HTTP interface. `/v1/responses` stores conversation state in an in-memory `OrderedDict` (lost on every restart), and `/v1/chat/completions` is fully stateless. This means any external client that wants multi-turn context must manage and re-send the entire message history on every request — or lose it.

This PR adds `POST /v1/message`, a session-backed endpoint that routes through the gateway's existing `SessionStore` (SQLite at `~/.hermes/hermes_state.db`). External clients send `{text, chat_id}` and get back `{response, session_id, ok}`. The server handles transcript persistence, history normalization, and `history_offset` slicing — the same session infrastructure that Telegram, Discord, and other platforms already use.

The one-line `run.py` change also fixes a latent bug: `APIServerAdapter` was previously constructed without a `SessionStore` reference, making it impossible for the adapter to access persistent sessions even though `GatewayRunner` has one available.

**Note:** This code was generated with AI assistance. I've reviewed the output, but a human pass over the logic and style would be appreciated before merging.

## Related Issue
No existing issue. Found while running Hermes on a platform with hibernating microVMs (Sprites). After the VM hibernates and restarts, all in-memory session state is lost. This endpoint solves that by using durable storage.
## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
## Changes Made
### 1. New `POST /v1/message` endpoint (`gateway/platforms/api_server.py`)
- New `_handle_message` handler implementing the session-backed message endpoint
- Accepts `{text, chat_id, user_id?, platform?}` — `platform` defaults to `"webhook"`, `user_id` defaults to `chat_id`
- Loads existing transcript from `SessionStore`, normalizes history (strips `session_meta`/`system`, preserves tool messages), runs agent, persists new messages via `history_offset` slicing
- Returns `{"response": "...", "session_id": "...", "ok": true}`
- New `_normalize_history()` helper reuses the same filtering logic as the gateway runner
- `__init__` extended with optional `session_store: SessionStore` parameter
- `_create_agent` and `_run_agent` extended with `platform_hint` parameter
- Route registered in `connect()`
### 2. SessionStore wiring (`gateway/run.py`, line 1210)
- One-line change: `APIServerAdapter(config)` → `APIServerAdapter(config, session_store=self.session_store)`
- Passes the gateway's existing `SessionStore` instance to the API server adapter, consistent with how other platform adapters receive it
### 3. Tests (`tests/gateway/test_api_server.py`)
- New `session_adapter` fixture with mocked `SessionStore`
- 9 new tests covering the endpoint:
  - `test_message_missing_text_returns_400`
  - `test_message_missing_chat_id_returns_400`
  - `test_message_invalid_platform_returns_400`
  - `test_message_defaults_platform_to_webhook_and_user_id_to_chat_id`
  - `test_message_without_session_store_returns_500`
  - `test_message_persists_transcript_and_reuses_session_id_across_requests`
  - `test_message_filters_session_meta_before_offset_slicing`
  - `test_message_falls_back_to_final_response_when_new_messages_have_no_assistant_text`
  - `test_message_requires_auth`
## How to Test
1. **Run the test suite:**
   ```bash
   uv venv venv --python 3.11
   source venv/bin/activate
   uv pip install -e ".[all,dev]"
   pytest tests/gateway/test_api_server.py -v
2. Manual test — first message:
      export API_SERVER_ENABLED=true
   hermes gateway &
   curl -X POST http://localhost:8642/v1/message \
     -H "Content-Type: application/json" \
     -d '{"text": "What files are in the current directory?", "chat_id": "test-user-1"}'
      Expect a 200 with {"response": "...", "session_id": "2026...", "ok": true}.
3. Manual test — session continuity:
      curl -X POST http://localhost:8642/v1/message \
     -H "Content-Type: application/json" \
     -d '{"text": "What did I just ask about?", "chat_id": "test-user-1"}'
      The agent should reference the prior message about listing files, proving the session transcript persisted correctly.

## Checklist

### Code
- [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (feat(gateway):)
- [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass (81 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (darwin)

### Documentation & Housekeeping
- [ ] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [ ] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — no OS-specific code
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

