### PR TITLE
fix(cli): render markdown in non-streaming response panels

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -644,6 +644,7 @@ except Exception:
 
 from rich import box as rich_box
 from rich.console import Console
+from rich.markdown import Markdown
 from rich.markup import escape as _escape
 from rich.panel import Panel
 from rich.text import Text as _RichText
@@ -1721,6 +1722,9 @@ class HermesCLI:
 
         # Inline diff previews for write actions (display.inline_diffs in config.yaml)
         self._inline_diffs_enabled = CLI_CONFIG["display"].get("inline_diffs", True)
+
+        # markdown: render responses as styled markdown (display.markdown in config.yaml)
+        self.markdown_enabled = CLI_CONFIG["display"].get("markdown", True)
 
         # Streaming display state
         self._stream_buf = ""        # Partial line buffer for line-buffered rendering
@@ -6045,9 +6049,11 @@ class HermesCLI:
                         _resp_color = "#CD7F32"
                         _resp_text = "#FFF8DC"
 
+                    # Render as styled markdown when enabled, otherwise plain ANSI text
+                    _response_renderable = Markdown(response) if self.markdown_enabled else _rich_text_from_ansi(response)
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(
-                        _rich_text_from_ansi(response),
+                        _response_renderable,
                         title=f"[{_resp_color} bold]{label} (background #{task_num})[/]",
                         title_align="left",
                         border_style=_resp_color,
@@ -8270,8 +8276,10 @@ class HermesCLI:
                     pass
                 else:
                     _chat_console = ChatConsole()
+                    # Render as styled markdown when enabled, otherwise plain ANSI text
+                    _response_renderable = Markdown(response) if self.markdown_enabled else _rich_text_from_ansi(response)
                     _chat_console.print(Panel(
-                        _rich_text_from_ansi(response),
+                        _response_renderable,
                         title=f"[{_resp_color} bold]{label}[/]",
                         title_align="left",
                         border_style=_resp_color,

--- a/cli.py
+++ b/cli.py
@@ -6177,8 +6177,10 @@ class HermesCLI:
                     except Exception:
                         _resp_color = "#4F6D4A"
 
+                    # Render as styled markdown when enabled, otherwise plain ANSI text
+                    _response_renderable = Markdown(response) if self.markdown_enabled else _rich_text_from_ansi(response)
                     ChatConsole().print(Panel(
-                        _rich_text_from_ansi(response),
+                        _response_renderable,
                         title=f"[{_resp_color} bold]⚕ /btw[/]",
                         title_align="left",
                         border_style=_resp_color,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -556,6 +556,7 @@ DEFAULT_CONFIG = {
         "show_reasoning": False,
         "streaming": False,
         "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
+        "markdown": True,         # Render responses as styled markdown (bold, tables, code blocks)
         "show_cost": False,       # Show $ cost in the status bar (off by default)
         "skin": "default",
         "interim_assistant_messages": True,  # Gateway: show natural mid-turn assistant status messages

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -281,6 +281,7 @@ AUTHOR_MAP = {
     "jarvischer@gmail.com": "maxchernin",
     "levantam.98.2324@gmail.com": "LVT382009",
     "zhurongcheng@rcrai.com": "heykb",
+    "francip@gmail.com": "francip",
 }
 
 


### PR DESCRIPTION
**Note:** This PR was authored and tested by Avery - a Hermes agent, with guidance from @francip.

---

## What Changed

Restored Rich markdown rendering for non-streaming CLI response panels, so regular chat replies and completed background-task replies render headings, emphasis, tables, and fenced code blocks instead of plain text.

**Files:** `cli.py`, `hermes_cli/config.py`

**Changes:**
- Non-streaming main chat responses now render with `Markdown(response)` when `display.markdown` is enabled
- Non-streaming background-task result panels use the same markdown-aware rendering path
- Added `display.markdown: true` to the default CLI config so the toggle exists in config
- Included a screenshot showing the rendered terminal output

### Why

The CLI already had a markdown toggle, but the panel-rendering path was still feeding plain ANSI text into Rich panels. That meant users got raw-ish text presentation in the exact path where markdown should have looked nicest.

This keeps streaming behavior unchanged and fixes the non-streaming path that users actually screenshot and stare at.

### Screenshot

![Rendered markdown in Hermes CLI](https://github.com/kortexa-ai/hermes-agent/releases/download/gh-attach-assets/markdown-rendering-cli.png)

### How to Test

```bash
python -m cli
```

Then ask for a markdown-heavy response, for example:

```text
Give me some markdown with headings, text formatting, a table, and a fenced Python code block.
```

Expected result:
- headings render with Rich styling
- bold / italic / inline code render correctly
- tables render as tables instead of plain text
- fenced code blocks render with syntax highlighting

To verify the fallback still exists:

```yaml
display:
  markdown: false
```

Then rerun the same prompt and confirm the panel uses the non-markdown text path.

### Validation

**Automated:**
```bash
source venv/bin/activate
python -m pytest tests/test_cli_init.py -q
```

Result: `13 passed`

**Manual:**
- Verified non-streaming chat replies render markdown correctly in the CLI
- Verified the screenshot above matches actual terminal output
- Confirmed import / startup sanity with `python -c "from cli import HermesCLI; print('OK')"`

### Platforms Tested

✅ macOS CLI

This change is isolated to Rich renderables in the non-streaming panel path, so it should be portable across platforms that already support the existing CLI rendering.

### Backward Compatibility

✅ Backward compatible
- Streaming output is unchanged
- Users can disable markdown rendering with `display.markdown: false`
- Plain-text fallback path remains intact
