### PR TITLE
feat(discord): debounce rapid inbound text messages

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -495,6 +495,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+                if "debounce_ms" in discord_cfg and not os.getenv("DISCORD_DEBOUNCE_MS"):
+                    os.environ["DISCORD_DEBOUNCE_MS"] = str(discord_cfg["debounce_ms"])
     except Exception:
         pass
 
@@ -748,6 +750,5 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.default_reset_policy.at_hour = int(reset_hour)
         except ValueError:
             pass
-
 
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -426,6 +426,9 @@ class DiscordAdapter(BasePlatformAdapter):
         self._client: Optional[commands.Bot] = None
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
+        self._text_batch_delay_seconds = self._load_text_batch_delay_seconds()
+        self._pending_text_batches: Dict[str, MessageEvent] = {}
+        self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
@@ -441,6 +444,60 @@ class DiscordAdapter(BasePlatformAdapter):
         self._bot_participated_threads: set = self._load_participated_threads()
         # Cap to prevent unbounded growth (Discord threads get archived).
         self._MAX_TRACKED_THREADS = 500
+
+    def _load_text_batch_delay_seconds(self) -> float:
+        """Return the configured Discord text debounce window in seconds."""
+        raw_value = os.getenv("DISCORD_DEBOUNCE_MS")
+        if raw_value in (None, ""):
+            raw_value = self.config.extra.get("debounce_ms", 0)
+        try:
+            debounce_ms = float(raw_value or 0)
+        except (TypeError, ValueError):
+            return 0.0
+        return max(0.0, debounce_ms / 1000.0)
+
+    def _text_batch_key(self, message: DiscordMessage) -> str:
+        """Batch Discord text continuations by raw channel and author."""
+        channel_id = getattr(message.channel, "id", "unknown")
+        author_id = getattr(message.author, "id", "unknown")
+        return f"{channel_id}:{author_id}"
+
+    def _should_batch_text(self, msg_type: MessageType) -> bool:
+        return self._text_batch_delay_seconds > 0 and msg_type == MessageType.TEXT
+
+    def _enqueue_text_event(self, batch_key: str, event: MessageEvent) -> None:
+        """Buffer a Discord text event and reset the flush timer."""
+        existing = self._pending_text_batches.get(batch_key)
+        if existing is None:
+            self._pending_text_batches[batch_key] = event
+        else:
+            if event.text:
+                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+
+        prior_task = self._pending_text_batch_tasks.get(batch_key)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+        self._pending_text_batch_tasks[batch_key] = asyncio.create_task(
+            self._flush_text_batch(batch_key)
+        )
+
+    async def _flush_text_batch(self, batch_key: str) -> None:
+        """Wait for a quiet period, then dispatch the aggregated text event."""
+        current_task = asyncio.current_task()
+        try:
+            await asyncio.sleep(self._text_batch_delay_seconds)
+            event = self._pending_text_batches.pop(batch_key, None)
+            if not event:
+                return
+            logger.info(
+                "[Discord] Flushing text batch %s (%d chars)",
+                batch_key,
+                len(event.text or ""),
+            )
+            await self.handle_message(event)
+        finally:
+            if self._pending_text_batch_tasks.get(batch_key) is current_task:
+                self._pending_text_batch_tasks.pop(batch_key, None)
     
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -593,6 +650,14 @@ class DiscordAdapter(BasePlatformAdapter):
     
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
+        pending_text_tasks = list(self._pending_text_batch_tasks.values())
+        for task in pending_text_tasks:
+            task.cancel()
+        if pending_text_tasks:
+            await asyncio.gather(*pending_text_tasks, return_exceptions=True)
+        self._pending_text_batch_tasks.clear()
+        self._pending_text_batches.clear()
+
         # Clean up all active voice connections before closing the client
         for guild_id in list(self._voice_clients.keys()):
             try:
@@ -1835,6 +1900,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _handle_message(self, message: DiscordMessage) -> None:
         """Handle incoming Discord messages."""
+        batch_key = self._text_batch_key(message)
+        has_pending_text_batch = batch_key in self._pending_text_batches
+
         # In server channels (not DMs), require the bot to be @mentioned
         # UNLESS the channel is in the free-response list or the message is
         # in a thread where the bot has already participated.
@@ -1865,27 +1933,13 @@ class DiscordAdapter(BasePlatformAdapter):
             # the bot has previously participated (auto-created or replied in).
             in_bot_thread = is_thread and thread_id in self._bot_participated_threads
 
-            if require_mention and not is_free_channel and not in_bot_thread:
+            if require_mention and not is_free_channel and not in_bot_thread and not has_pending_text_batch:
                 if self._client.user not in message.mentions:
                     return
 
             if self._client.user and self._client.user in message.mentions:
                 message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
                 message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()
-
-        # Auto-thread: when enabled, automatically create a thread for every
-        # @mention in a text channel so each conversation is isolated (like Slack).
-        # Messages already inside threads or DMs are unaffected.
-        auto_threaded_channel = None
-        if not is_thread and not isinstance(message.channel, discord.DMChannel):
-            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
-            if auto_thread:
-                thread = await self._auto_create_thread(message)
-                if thread:
-                    is_thread = True
-                    thread_id = str(thread.id)
-                    auto_threaded_channel = thread
-                    self._track_thread(thread_id)
 
         # Determine message type
         msg_type = MessageType.TEXT
@@ -1904,7 +1958,21 @@ class DiscordAdapter(BasePlatformAdapter):
                     else:
                         msg_type = MessageType.DOCUMENT
                     break
-        
+
+        # Auto-thread: when enabled, automatically create a thread for every
+        # @mention in a text channel so each conversation is isolated (like Slack).
+        # Messages already inside threads or DMs are unaffected.
+        auto_threaded_channel = None
+        if not is_thread and not isinstance(message.channel, discord.DMChannel):
+            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
+            if auto_thread and not (self._should_batch_text(msg_type) and has_pending_text_batch):
+                thread = await self._auto_create_thread(message)
+                if thread:
+                    is_thread = True
+                    thread_id = str(thread.id)
+                    auto_threaded_channel = thread
+                    self._track_thread(thread_id)
+
         # When auto-threading kicked in, route responses to the new thread
         effective_channel = auto_threaded_channel or message.channel
 
@@ -1990,6 +2058,10 @@ class DiscordAdapter(BasePlatformAdapter):
         # follow-up messages in threads it has already engaged in.
         if thread_id:
             self._track_thread(thread_id)
+
+        if self._should_batch_text(msg_type):
+            self._enqueue_text_event(batch_key, event)
+            return
 
         await self.handle_message(event)
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -1,5 +1,6 @@
-"""Tests for Discord free-response defaults and mention gating."""
+"""Tests for Discord free-response defaults, mention gating, and text batching."""
 
+import asyncio
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -358,3 +359,80 @@ async def test_discord_thread_participation_tracked_on_dispatch(adapter, monkeyp
     await adapter._handle_message(message)
 
     assert "777" in adapter._bot_participated_threads
+
+
+@pytest.mark.asyncio
+async def test_discord_text_messages_are_debounced(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter._text_batch_delay_seconds = 0.05
+
+    first = make_message(channel=FakeTextChannel(channel_id=123), content="part one")
+    second = make_message(channel=FakeTextChannel(channel_id=123), content="part two")
+
+    await adapter._handle_message(first)
+    await asyncio.sleep(0.01)
+    await adapter._handle_message(second)
+
+    adapter.handle_message.assert_not_awaited()
+
+    await asyncio.sleep(0.08)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "part one\npart two"
+
+
+@pytest.mark.asyncio
+async def test_discord_command_bypasses_debounce(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter._text_batch_delay_seconds = 0.05
+
+    message = make_message(channel=FakeTextChannel(channel_id=123), content="/reset")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.message_type == discord_platform.MessageType.COMMAND
+
+
+@pytest.mark.asyncio
+async def test_discord_debounce_disabled_preserves_existing_behavior(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter._text_batch_delay_seconds = 0.0
+
+    first = make_message(channel=FakeTextChannel(channel_id=123), content="first")
+    second = make_message(channel=FakeTextChannel(channel_id=123), content="second")
+
+    await adapter._handle_message(first)
+    await adapter._handle_message(second)
+
+    assert adapter.handle_message.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_discord_auto_thread_not_recreated_for_pending_text_batch(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    adapter._text_batch_delay_seconds = 0.05
+
+    fake_thread = FakeThread(channel_id=999, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    first = make_message(channel=FakeTextChannel(channel_id=123), content="hello")
+    second = make_message(channel=FakeTextChannel(channel_id=123), content="follow-up")
+
+    await adapter._handle_message(first)
+    await asyncio.sleep(0.01)
+    await adapter._handle_message(second)
+    await asyncio.sleep(0.08)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+    assert event.source.thread_id == "999"
+    assert event.text == "hello\nfollow-up"

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -461,3 +461,26 @@ def test_discord_auto_thread_config_bridge(monkeypatch, tmp_path):
 
     import os
     assert os.getenv("DISCORD_AUTO_THREAD") == "true"
+
+
+def test_discord_debounce_config_bridge(monkeypatch, tmp_path):
+    """discord.debounce_ms in config.yaml should be bridged to DISCORD_DEBOUNCE_MS."""
+    import yaml
+    from pathlib import Path
+
+    hermes_dir = tmp_path / ".hermes"
+    hermes_dir.mkdir()
+    config_path = hermes_dir / "config.yaml"
+    config_path.write_text(yaml.dump({
+        "discord": {"debounce_ms": 5000},
+    }))
+
+    monkeypatch.delenv("DISCORD_DEBOUNCE_MS", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_dir))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_DEBOUNCE_MS") == "5000"

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -257,6 +257,7 @@ class TestBlocklistCoverage:
             "DISCORD_REQUIRE_MENTION",
             "DISCORD_FREE_RESPONSE_CHANNELS",
             "DISCORD_AUTO_THREAD",
+            "DISCORD_DEBOUNCE_MS",
             "SLACK_HOME_CHANNEL",
             "SLACK_HOME_CHANNEL_NAME",
             "SLACK_ALLOWED_USERS",

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -93,6 +93,7 @@ def _build_provider_env_blocklist() -> frozenset:
         "DISCORD_REQUIRE_MENTION",
         "DISCORD_FREE_RESPONSE_CHANNELS",
         "DISCORD_AUTO_THREAD",
+        "DISCORD_DEBOUNCE_MS",
         "SLACK_HOME_CHANNEL",
         "SLACK_HOME_CHANNEL_NAME",
         "SLACK_ALLOWED_USERS",


### PR DESCRIPTION
Fixes #2434

## Summary

This adds an opt-in inbound text debounce for Discord gateway messages.

When the same user sends multiple plain-text messages in quick succession,
Hermes can now buffer them briefly and dispatch them as a single turn instead
of triggering one agent run per fragment.

This is especially useful for:

- Discord client-side message splits
- rapid follow-up corrections from the same user
- reducing unnecessary interrupt chains and duplicate LLM calls

The debounce is Discord-only in this PR. Telegram already has adapter-level
text batching, so this change keeps the scope focused on the missing Discord
behavior.

## Fix

Added an opt-in `discord.debounce_ms` / `DISCORD_DEBOUNCE_MS` setting and
implemented text batching in `gateway/platforms/discord.py`.

Behavior:

- only plain text messages are debounced
- `/commands` bypass debounce and dispatch immediately
- existing behavior is preserved when debounce is unset or `0`
- follow-up text fragments reuse the pending batch instead of spawning extra
  auto-thread work

Also updated:

- the Discord config bridge in `gateway/config.py`
- the local subprocess env blocklist for the new runtime env var

## Tests

Added regression coverage for:

- debouncing rapid Discord text messages into a single turn
- command messages bypassing debounce
- preserving existing behavior when debounce is disabled
- config bridging for `discord.debounce_ms`
- env blocklist coverage for `DISCORD_DEBOUNCE_MS`

Verified in a local Python 3.11 virtualenv:

```bash
.venv311/bin/python -m pytest -o addopts='' tests/gateway/test_discord_free_response.py -q
# 19 passed
```

```bash
.venv311/bin/python -m pytest -o addopts='' tests/gateway/test_discord_slash_commands.py -q
# 16 passed
```

```bash
.venv311/bin/python -m pytest -o addopts='' tests/tools/test_local_env_blocklist.py -q
# 14 passed
```

