### PR TITLE
fix: improve error message when PortAudio system library is missing

### DIFF
--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -81,8 +81,15 @@ def detect_audio_environment() -> dict:
                 warnings.append("No audio input/output devices detected")
         except Exception:
             warnings.append("Audio subsystem error (PortAudio cannot query devices)")
-    except (ImportError, OSError):
+    except ImportError:
         warnings.append("Audio libraries not installed (pip install sounddevice numpy)")
+    except OSError:
+        warnings.append(
+            "PortAudio system library not found -- install it first:\n"
+            "  Linux:  sudo apt-get install libportaudio2\n"
+            "  macOS:  brew install portaudio\n"
+            "Then retry /voice on."
+        )
 
     return {
         "available": len(warnings) == 0,


### PR DESCRIPTION
## Problem

When `sounddevice` is installed via pip but the `libportaudio2` system library is not present, `sounddevice` raises an `OSError` (not an `ImportError`). The previous code caught both exceptions together and showed a generic `pip install sounddevice numpy` message — which sends users down the wrong path since the Python package is already installed.

## Fix

Split the `except` clause to handle `ImportError` and `OSError` separately. The `OSError` case now shows a clear, actionable message with the correct system package install commands.

## Reproduction

1. Install hermes-agent with `sounddevice` in the venv
2. Do NOT install `libportaudio2` system package
3. Run `/voice on`
4. Before: sees 'Audio libraries not installed (pip install sounddevice numpy)'
5. After: sees the correct system library install instructions