### PR TITLE
Add inbound gateway message debouncing

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -41,6 +41,16 @@ def _normalize_unauthorized_dm_behavior(value: Any, default: str = "pair") -> st
     return default
 
 
+def _coerce_non_negative_int(value: Any, default: int = 0) -> int:
+    """Coerce a config value to a non-negative integer, falling back safely."""
+    if value is None:
+        return default
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return default
+
+
 class Platform(Enum):
     """Supported messaging platforms."""
     LOCAL = "local"
@@ -225,6 +235,9 @@ class GatewayConfig:
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
 
+    # Inbound message coalescing
+    debounce_ms: int = 0  # Quiet period before dispatching rapid inbound messages
+
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
 
@@ -305,6 +318,7 @@ class GatewayConfig:
             "always_log_local": self.always_log_local,
             "stt_enabled": self.stt_enabled,
             "group_sessions_per_user": self.group_sessions_per_user,
+            "debounce_ms": self.debounce_ms,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
         }
@@ -348,6 +362,7 @@ class GatewayConfig:
             stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
 
         group_sessions_per_user = data.get("group_sessions_per_user")
+        debounce_ms = data.get("debounce_ms")
         unauthorized_dm_behavior = _normalize_unauthorized_dm_behavior(
             data.get("unauthorized_dm_behavior"),
             "pair",
@@ -364,9 +379,23 @@ class GatewayConfig:
             always_log_local=data.get("always_log_local", True),
             stt_enabled=_coerce_bool(stt_enabled, True),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
+            debounce_ms=_coerce_non_negative_int(debounce_ms, 0),
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
         )
+
+    def get_debounce_ms(self, platform: Optional[Platform] = None) -> int:
+        """Return the effective inbound debounce window in milliseconds."""
+        if platform:
+            platform_cfg = self.platforms.get(platform)
+            if platform_cfg:
+                raw = platform_cfg.extra.get("debounce_ms")
+                if raw is not None:
+                    try:
+                        return max(0, int(raw))
+                    except (TypeError, ValueError):
+                        logger.warning("Ignoring invalid %s debounce_ms=%r", platform.value, raw)
+        return max(0, int(self.debounce_ms or 0))
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
         """Return the effective unauthorized-DM behavior for a platform."""
@@ -436,6 +465,13 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(stt_cfg, dict):
                 gw_data["stt"] = stt_cfg
 
+            gateway_cfg = yaml_cfg.get("gateway")
+            if isinstance(gateway_cfg, dict) and "debounce_ms" in gateway_cfg:
+                gw_data["debounce_ms"] = gateway_cfg["debounce_ms"]
+
+            if "debounce_ms" in yaml_cfg:
+                gw_data["debounce_ms"] = yaml_cfg["debounce_ms"]
+
             if "group_sessions_per_user" in yaml_cfg:
                 gw_data["group_sessions_per_user"] = yaml_cfg["group_sessions_per_user"]
 
@@ -471,6 +507,8 @@ def load_gateway_config() -> GatewayConfig:
                         existing = {}
                     # Deep-merge extra dicts so gateway.json defaults survive
                     merged_extra = {**existing.get("extra", {}), **plat_block.get("extra", {})}
+                    if "debounce_ms" in plat_block:
+                        merged_extra["debounce_ms"] = plat_block["debounce_ms"]
                     merged = {**existing, **plat_block}
                     if merged_extra:
                         merged["extra"] = merged_extra
@@ -489,6 +527,8 @@ def load_gateway_config() -> GatewayConfig:
                         platform_cfg.get("unauthorized_dm_behavior"),
                         gw_data.get("unauthorized_dm_behavior", "pair"),
                     )
+                if "debounce_ms" in platform_cfg:
+                    bridged["debounce_ms"] = platform_cfg["debounce_ms"]
                 if "reply_prefix" in platform_cfg:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
                 if not bridged:
@@ -784,6 +824,4 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.default_reset_policy.at_hour = int(reset_hour)
         except ValueError:
             pass
-
-
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -357,6 +357,8 @@ class BasePlatformAdapter(ABC):
         # Key: session_key (e.g., chat_id), Value: (event, asyncio.Event for interrupt)
         self._active_sessions: Dict[str, asyncio.Event] = {}
         self._pending_messages: Dict[str, MessageEvent] = {}
+        self._pending_debounced_messages: Dict[str, MessageEvent] = {}
+        self._pending_debounce_tasks: Dict[str, asyncio.Task] = {}
         # Background message-processing tasks spawned by handle_message().
         # Gateway shutdown cancels these so an old gateway instance doesn't keep
         # working on a task after --replace or manual restarts.
@@ -827,6 +829,87 @@ class BasePlatformAdapter(ABC):
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
         )
+
+        debounce_ms = self._get_inbound_debounce_ms()
+        if debounce_ms > 0 and self._should_debounce_event(event):
+            self._enqueue_debounced_message(session_key, event, debounce_ms)
+            return
+
+        await self._handle_message_now(event, session_key)
+
+    def _get_inbound_debounce_ms(self) -> int:
+        """Return the configured inbound debounce window in milliseconds."""
+        raw = self.config.extra.get("debounce_ms", 0)
+        try:
+            return max(0, int(raw or 0))
+        except (TypeError, ValueError):
+            logger.warning("[%s] Ignoring invalid debounce_ms=%r", self.name, raw)
+            return 0
+
+    @staticmethod
+    def _should_debounce_event(event: MessageEvent) -> bool:
+        """Return True when an inbound event should wait for a quiet period."""
+        return not event.is_command()
+
+    def _merge_debounced_event(self, existing: MessageEvent, incoming: MessageEvent) -> MessageEvent:
+        """Merge a follow-up inbound event into an existing pending batch."""
+        if incoming.text:
+            if existing.text:
+                incoming_text = incoming.text.strip()
+                if incoming_text:
+                    existing.text = f"{existing.text}\n\n{incoming_text}"
+            else:
+                existing.text = incoming.text
+
+        if incoming.media_urls:
+            existing.media_urls.extend(incoming.media_urls)
+            existing.media_types.extend(incoming.media_types)
+
+        if existing.message_type == MessageType.TEXT and incoming.message_type != MessageType.TEXT:
+            existing.message_type = incoming.message_type
+        existing.raw_message = incoming.raw_message or existing.raw_message
+        existing.message_id = incoming.message_id or existing.message_id
+        existing.reply_to_message_id = incoming.reply_to_message_id or existing.reply_to_message_id
+        existing.reply_to_text = incoming.reply_to_text or existing.reply_to_text
+        existing.timestamp = incoming.timestamp
+        return existing
+
+    def _enqueue_debounced_message(self, session_key: str, event: MessageEvent, debounce_ms: int) -> None:
+        """Buffer an inbound message until the session goes quiet."""
+        existing = self._pending_debounced_messages.get(session_key)
+        if existing is None:
+            self._pending_debounced_messages[session_key] = event
+        else:
+            self._merge_debounced_event(existing, event)
+
+        prior_task = self._pending_debounce_tasks.get(session_key)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+        self._pending_debounce_tasks[session_key] = asyncio.create_task(
+            self._flush_debounced_message(session_key, debounce_ms / 1000.0)
+        )
+
+    async def _flush_debounced_message(self, session_key: str, delay_seconds: float) -> None:
+        """Wait for the debounce window to expire, then dispatch the merged event."""
+        current_task = asyncio.current_task()
+        try:
+            await asyncio.sleep(delay_seconds)
+            event = self._pending_debounced_messages.pop(session_key, None)
+            if not event:
+                return
+            logger.info(
+                "[%s] Flushing debounced inbound batch for %s (%d chars)",
+                self.name,
+                session_key,
+                len(event.text or ""),
+            )
+            await self._handle_message_now(event, session_key)
+        finally:
+            if self._pending_debounce_tasks.get(session_key) is current_task:
+                self._pending_debounce_tasks.pop(session_key, None)
+
+    async def _handle_message_now(self, event: MessageEvent, session_key: str) -> None:
+        """Dispatch an inbound event immediately using interrupt-aware session logic."""
         
         # Check if there's already an active handler for this session
         if session_key in self._active_sessions:
@@ -1138,6 +1221,13 @@ class BasePlatformAdapter(ABC):
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
         self._background_tasks.clear()
+        debounce_tasks = [task for task in self._pending_debounce_tasks.values() if not task.done()]
+        for task in debounce_tasks:
+            task.cancel()
+        if debounce_tasks:
+            await asyncio.gather(*debounce_tasks, return_exceptions=True)
+        self._pending_debounce_tasks.clear()
+        self._pending_debounced_messages.clear()
         self._pending_messages.clear()
         self._active_sessions.clear()
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -835,6 +835,9 @@ class BasePlatformAdapter(ABC):
             self._enqueue_debounced_message(session_key, event, debounce_ms)
             return
 
+        if event.is_command():
+            self._clear_debounced_message(session_key)
+
         await self._handle_message_now(event, session_key)
 
     def _get_inbound_debounce_ms(self) -> int:
@@ -888,6 +891,13 @@ class BasePlatformAdapter(ABC):
         self._pending_debounce_tasks[session_key] = asyncio.create_task(
             self._flush_debounced_message(session_key, debounce_ms / 1000.0)
         )
+
+    def _clear_debounced_message(self, session_key: str) -> None:
+        """Drop any queued debounced message for this session."""
+        self._pending_debounced_messages.pop(session_key, None)
+        task = self._pending_debounce_tasks.pop(session_key, None)
+        if task and not task.done():
+            task.cancel()
 
     async def _flush_debounced_message(self, session_key: str, delay_seconds: float) -> None:
         """Wait for the debounce window to expire, then dispatch the merged event."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1124,6 +1124,10 @@ class GatewayRunner:
                 "group_sessions_per_user",
                 self.config.group_sessions_per_user,
             )
+            config.extra.setdefault(
+                "debounce_ms",
+                getattr(self.config, "get_debounce_ms", lambda _platform=None: 0)(platform),
+            )
 
         if platform == Platform.TELEGRAM:
             from gateway.platforms.telegram import TelegramAdapter, check_telegram_requirements

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1124,10 +1124,11 @@ class GatewayRunner:
                 "group_sessions_per_user",
                 self.config.group_sessions_per_user,
             )
-            config.extra.setdefault(
-                "debounce_ms",
-                getattr(self.config, "get_debounce_ms", lambda _platform=None: 0)(platform),
-            )
+            config.extra["debounce_ms"] = getattr(
+                self.config,
+                "get_debounce_ms",
+                lambda _platform=None: 0,
+            )(platform)
 
         if platform == Platform.TELEGRAM:
             from gateway.platforms.telegram import TelegramAdapter, check_telegram_requirements

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -105,6 +105,7 @@ class TestGatewayConfigRoundtrip:
             reset_triggers=["/new"],
             quick_commands={"limits": {"type": "exec", "command": "echo ok"}},
             group_sessions_per_user=False,
+            debounce_ms=5000,
         )
         d = config.to_dict()
         restored = GatewayConfig.from_dict(d)
@@ -114,6 +115,7 @@ class TestGatewayConfigRoundtrip:
         assert restored.reset_triggers == ["/new"]
         assert restored.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
         assert restored.group_sessions_per_user is False
+        assert restored.debounce_ms == 5000
 
     def test_roundtrip_preserves_unauthorized_dm_behavior(self):
         config = GatewayConfig(
@@ -162,6 +164,57 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.group_sessions_per_user is False
+
+    def test_bridges_gateway_debounce_ms_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  debounce_ms: 5000\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.debounce_ms == 5000
+
+    def test_platform_debounce_ms_overrides_global(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  debounce_ms: 5000\n"
+            "discord:\n"
+            "  debounce_ms: 1500\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.get_debounce_ms() == 5000
+        assert config.get_debounce_ms(Platform.DISCORD) == 1500
+
+    def test_invalid_debounce_ms_falls_back_safely(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  debounce_ms: nope\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.debounce_ms == 0
 
     def test_invalid_quick_commands_in_config_yaml_are_ignored(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_inbound_debounce.py
+++ b/tests/gateway/test_inbound_debounce.py
@@ -1,0 +1,106 @@
+"""Tests for gateway inbound message debouncing."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource, build_session_key
+
+
+class DummyDebounceAdapter(BasePlatformAdapter):
+    def __init__(self, debounce_ms=0):
+        super().__init__(
+            PlatformConfig(enabled=True, token="fake-token", extra={"debounce_ms": debounce_ms}),
+            Platform.TELEGRAM,
+        )
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="1")
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+def _make_event(text: str, *, chat_id: str = "12345", message_id: str = "1") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"),
+        message_id=message_id,
+    )
+
+
+class TestInboundDebounce:
+    @pytest.mark.asyncio
+    async def test_rapid_messages_are_coalesced_into_single_dispatch(self):
+        adapter = DummyDebounceAdapter(debounce_ms=50)
+        adapter.set_message_handler(AsyncMock(return_value=None))
+        adapter._handle_message_now = AsyncMock()
+
+        await adapter.handle_message(_make_event("part one", message_id="1"))
+        await asyncio.sleep(0.01)
+        await adapter.handle_message(_make_event("part two", message_id="2"))
+        await asyncio.sleep(0.08)
+
+        adapter._handle_message_now.assert_called_once()
+        dispatched_event, dispatched_key = adapter._handle_message_now.call_args.args
+        assert "part one" in dispatched_event.text
+        assert "part two" in dispatched_event.text
+        assert dispatched_event.message_id == "2"
+        assert dispatched_key == build_session_key(dispatched_event.source)
+
+    @pytest.mark.asyncio
+    async def test_commands_bypass_debounce(self):
+        adapter = DummyDebounceAdapter(debounce_ms=5000)
+        adapter.set_message_handler(AsyncMock(return_value=None))
+        adapter._handle_message_now = AsyncMock()
+
+        await adapter.handle_message(
+            MessageEvent(
+                text="/status",
+                message_type=MessageType.COMMAND,
+                source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"),
+                message_id="cmd-1",
+            )
+        )
+
+        adapter._handle_message_now.assert_awaited_once()
+        assert adapter._pending_debounced_messages == {}
+
+    @pytest.mark.asyncio
+    async def test_repeated_identical_messages_are_preserved(self):
+        adapter = DummyDebounceAdapter(debounce_ms=50)
+        adapter.set_message_handler(AsyncMock(return_value=None))
+        adapter._handle_message_now = AsyncMock()
+
+        await adapter.handle_message(_make_event("ok", message_id="1"))
+        await asyncio.sleep(0.01)
+        await adapter.handle_message(_make_event("ok", message_id="2"))
+        await asyncio.sleep(0.08)
+
+        dispatched_event = adapter._handle_message_now.call_args.args[0]
+        assert dispatched_event.text == "ok\n\nok"
+
+    @pytest.mark.asyncio
+    async def test_cancel_background_tasks_clears_pending_debounce(self):
+        adapter = DummyDebounceAdapter(debounce_ms=1000)
+        adapter.set_message_handler(AsyncMock(return_value=None))
+        adapter._handle_message_now = AsyncMock()
+
+        await adapter.handle_message(_make_event("hello"))
+        assert adapter._pending_debounced_messages
+        assert adapter._pending_debounce_tasks
+
+        await adapter.cancel_background_tasks()
+
+        assert adapter._pending_debounced_messages == {}
+        assert adapter._pending_debounce_tasks == {}

--- a/tests/gateway/test_inbound_debounce.py
+++ b/tests/gateway/test_inbound_debounce.py
@@ -2,11 +2,13 @@
 
 import asyncio
 from unittest.mock import AsyncMock
+from unittest.mock import patch
 
 import pytest
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
 from gateway.session import SessionSource, build_session_key
 
 
@@ -77,6 +79,29 @@ class TestInboundDebounce:
         assert adapter._pending_debounced_messages == {}
 
     @pytest.mark.asyncio
+    async def test_command_clears_queued_debounced_message(self):
+        adapter = DummyDebounceAdapter(debounce_ms=5000)
+        adapter.set_message_handler(AsyncMock(return_value=None))
+        adapter._handle_message_now = AsyncMock()
+
+        await adapter.handle_message(_make_event("queued prompt", message_id="1"))
+        session_key = build_session_key(_make_event("queued prompt").source)
+        assert session_key in adapter._pending_debounced_messages
+
+        await adapter.handle_message(
+            MessageEvent(
+                text="/reset",
+                message_type=MessageType.COMMAND,
+                source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"),
+                message_id="cmd-1",
+            )
+        )
+
+        assert session_key not in adapter._pending_debounced_messages
+        assert session_key not in adapter._pending_debounce_tasks
+        adapter._handle_message_now.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_repeated_identical_messages_are_preserved(self):
         adapter = DummyDebounceAdapter(debounce_ms=50)
         adapter.set_message_handler(AsyncMock(return_value=None))
@@ -104,3 +129,20 @@ class TestInboundDebounce:
 
         assert adapter._pending_debounced_messages == {}
         assert adapter._pending_debounce_tasks == {}
+
+
+class TestAdapterDebounceConfig:
+    def test_create_adapter_overrides_invalid_platform_debounce_with_resolved_fallback(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            debounce_ms=5000,
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token", extra={"debounce_ms": "nope"})},
+        )
+
+        adapter_config = runner.config.platforms[Platform.TELEGRAM]
+
+        with patch("gateway.platforms.telegram.check_telegram_requirements", return_value=True), \
+             patch("gateway.platforms.telegram.TelegramAdapter", side_effect=lambda cfg: cfg):
+            created = runner._create_adapter(Platform.TELEGRAM, adapter_config)
+
+        assert created.extra["debounce_ms"] == 5000


### PR DESCRIPTION
## Summary
- add a gateway-wide `debounce_ms` setting plus per-platform overrides
- debounce inbound adapter events before the existing interrupt logic so rapid bursts coalesce into one turn
- add regression tests for config loading, command bypass, repeated-message preservation, and debounce cleanup

Closes #2434.

## Review
- self-review pass caught and fixed two issues before PR: duplicate rapid messages were being collapsed incorrectly, and invalid `debounce_ms` config values could raise instead of degrading safely

## Verification
- `python -m pytest tests/gateway/test_inbound_debounce.py tests/gateway/test_config.py tests/gateway/test_telegram_text_batching.py tests/gateway/test_base_topic_sessions.py tests/gateway/test_interrupt_key_match.py tests/gateway/test_session_race_guard.py tests/gateway/test_telegram_photo_interrupts.py -q`
  - passed (`43 passed`)
- `python -m pytest tests/ -q`
  - repo-wide run still has 6 unrelated existing failures outside this change area
