### PR TITLE
fix: fail fast when explicit provider has no API key instead of silent OpenRouter fallback (salvage #2272)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1451,8 +1451,18 @@ def call_llm(
             api_key=resolved_api_key,
         )
         if client is None:
-            # Fallback: try openrouter
-            if resolved_provider != "openrouter" and not resolved_base_url:
+            # When the user explicitly chose a non-OpenRouter provider but no
+            # credentials were found, fail fast instead of silently routing
+            # through OpenRouter (which causes confusing 404s).
+            _explicit = (resolved_provider or "").strip().lower()
+            if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                raise RuntimeError(
+                    f"Provider '{_explicit}' is set in config.yaml but no API key "
+                    f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                    f"variable, or switch to a different provider with `hermes model`."
+                )
+            # For auto/custom, fall back to OpenRouter
+            if not resolved_base_url:
                 logger.warning("Provider %s unavailable, falling back to openrouter",
                                resolved_provider)
                 client, final_model = _get_cached_client(
@@ -1534,7 +1544,14 @@ async def async_call_llm(
             api_key=resolved_api_key,
         )
         if client is None:
-            if resolved_provider != "openrouter" and not resolved_base_url:
+            _explicit = (resolved_provider or "").strip().lower()
+            if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                raise RuntimeError(
+                    f"Provider '{_explicit}' is set in config.yaml but no API key "
+                    f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                    f"variable, or switch to a different provider with `hermes model`."
+                )
+            if not resolved_base_url:
                 logger.warning("Provider %s unavailable, falling back to openrouter",
                                resolved_provider)
                 client, final_model = _get_cached_client(

--- a/run_agent.py
+++ b/run_agent.py
@@ -736,6 +736,16 @@ class AIAgent:
                     if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
                         client_kwargs["default_headers"] = dict(_routed_client._default_headers)
                 else:
+                    # When the user explicitly chose a non-OpenRouter provider
+                    # but no credentials were found, fail fast with a clear
+                    # message instead of silently routing through OpenRouter.
+                    _explicit = (self.provider or "").strip().lower()
+                    if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                        raise RuntimeError(
+                            f"Provider '{_explicit}' is set in config.yaml but no API key "
+                            f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                            f"variable, or switch to a different provider with `hermes model`."
+                        )
                     # Final fallback: try raw OpenRouter key
                     client_kwargs = {
                         "api_key": os.getenv("OPENROUTER_API_KEY", ""),


### PR DESCRIPTION
## Summary
Based on PR #2272 by @StefanIsMe, applied manually to fix bugs in the original and extend coverage.

When a non-OpenRouter provider (e.g. `minimax`, `anthropic`) is set in config.yaml but its API key is missing, Hermes silently fell back to OpenRouter. This caused confusing 404 errors because OpenRouter received the request with the wrong model/endpoint.

Now checks `provider not in ('auto', 'openrouter', 'custom')` before falling back. Explicit providers raise `RuntimeError` with a clear message naming the missing env var. Auto/openrouter/custom providers still fall through to OpenRouter as before.

### Changes from original PR
- Fixed `pconfig.api_key_env_vars` NameError in auxiliary_client.py (variable doesn't exist in that scope)
- Extended the fix to `call_llm_streaming` — the original PR only covered `call_llm` but the same silent fallback existed in the streaming path
- Applied against current main (original was 116 commits behind)

### Three code paths fixed
1. `run_agent.py` `AIAgent.__init__` — main client initialization
2. `agent/auxiliary_client.py` `call_llm` — sync auxiliary calls
3. `agent/auxiliary_client.py` `call_llm_streaming` — async auxiliary calls (not in original PR)

## Verification
- 5785 passed (26 pre-existing failures on main, confirmed identical)

## Credit
Original idea and run_agent.py fix by @StefanIsMe in #2272.