### PR TITLE
fix(deps): add dingtalk-stream to optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ mcp = ["mcp>=1.2.0"]
 homeassistant = ["aiohttp>=3.9.0"]
 sms = ["aiohttp>=3.9.0"]
 acp = ["agent-client-protocol>=0.8.1,<1.0"]
+dingtalk = ["dingtalk-stream>=0.1.0"]
 rl = [
   "atroposlib @ git+https://github.com/NousResearch/atropos.git",
   "tinker @ git+https://github.com/thinking-machines-lab/tinker.git",
@@ -84,6 +85,7 @@ all = [
   "hermes-agent[sms]",
   "hermes-agent[acp]",
   "hermes-agent[voice]",
+  "hermes-agent[dingtalk]",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Cherry-picked from PR #2065 by @ygd58. Fixes #2062.

`dingtalk-stream` required by `gateway/platforms/dingtalk.py` but missing from `pyproject.toml`. Adds `dingtalk` extras group + includes it in `[all]`.