### PR TITLE
Add Claude-style @ context completions

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -17,7 +17,11 @@ REFERENCE_PATTERN = re.compile(
     r"""(?<![\w/])@(?:
     (?P<simple>diff|staged)\b|
     (?P<kind>file|folder|git|url):
-    (?P<value>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|(?:\\.|[^\s])+)
+    (?P<value>
+        "(?:[^"\\]|\\.)*"(?:\:\d+(?:-\d+)?)?|
+        '(?:[^'\\]|\\.)*'(?:\:\d+(?:-\d+)?)?|
+        (?:\\.|[^\s])+
+    )
     )""",
     re.VERBOSE,
 )
@@ -66,15 +70,18 @@ def parse_context_references(message: str) -> list[ContextReference]:
             continue
 
         kind = match.group("kind")
-        value = _decode_reference_value(_strip_trailing_punctuation(match.group("value") or ""))
+        raw_value = _strip_trailing_punctuation(match.group("value") or "")
         line_start = None
         line_end = None
-        target = value
+        target = _decode_reference_value(raw_value)
 
         if kind == "file":
-            range_match = re.match(r"^(?P<path>.+?):(?P<start>\d+)(?:-(?P<end>\d+))?$", value)
+            range_match = re.match(
+                r'^(?P<path>"(?:[^"\\]|\\.)*"|\'(?:[^\'\\]|\\.)*\'|.+?):(?P<start>\d+)(?:-(?P<end>\d+))?$',
+                raw_value,
+            )
             if range_match:
-                target = range_match.group("path")
+                target = _decode_reference_value(range_match.group("path"))
                 line_start = int(range_match.group("start"))
                 line_end = int(range_match.group("end") or range_match.group("start"))
 

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -14,7 +14,12 @@ from typing import Awaitable, Callable
 from agent.model_metadata import estimate_tokens_rough
 
 REFERENCE_PATTERN = re.compile(
-    r"(?<![\w/])@(?:(?P<simple>diff|staged)\b|(?P<kind>file|folder|git|url):(?P<value>\S+))"
+    r"""(?<![\w/])@(?:
+    (?P<simple>diff|staged)\b|
+    (?P<kind>file|folder|git|url):
+    (?P<value>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|(?:\\.|[^\s])+)
+    )""",
+    re.VERBOSE,
 )
 TRAILING_PUNCTUATION = ",.;!?"
 
@@ -61,7 +66,7 @@ def parse_context_references(message: str) -> list[ContextReference]:
             continue
 
         kind = match.group("kind")
-        value = _strip_trailing_punctuation(match.group("value") or "")
+        value = _decode_reference_value(_strip_trailing_punctuation(match.group("value") or ""))
         line_start = None
         line_end = None
         target = value
@@ -316,6 +321,8 @@ def _resolve_path(cwd: Path, target: str, *, allowed_root: Path | None = None) -
 
 
 def _strip_trailing_punctuation(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value
     stripped = value.rstrip(TRAILING_PUNCTUATION)
     while stripped.endswith((")", "]", "}")):
         closer = stripped[-1]
@@ -325,6 +332,12 @@ def _strip_trailing_punctuation(value: str) -> str:
             continue
         break
     return stripped
+
+
+def _decode_reference_value(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return re.sub(r"\\(.)", r"\1", value)
 
 
 def _remove_reference_tokens(message: str, refs: list[ContextReference]) -> str:

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -320,8 +320,12 @@ def _resolve_path(cwd: Path, target: str, *, allowed_root: Path | None = None) -
     return resolved
 
 
+def _is_quoted(value: str) -> bool:
+    return len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}
+
+
 def _strip_trailing_punctuation(value: str) -> str:
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+    if _is_quoted(value):
         return value
     stripped = value.rstrip(TRAILING_PUNCTUATION)
     while stripped.endswith((")", "]", "}")):
@@ -335,7 +339,7 @@ def _strip_trailing_punctuation(value: str) -> str:
 
 
 def _decode_reference_value(value: str) -> str:
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+    if _is_quoted(value):
         value = value[1:-1]
     return re.sub(r"\\(.)", r"\1", value)
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -362,6 +362,10 @@ class _PathToken:
 class SlashCommandCompleter(Completer):
     """Autocomplete for built-in slash commands, subcommands, and skill commands."""
 
+    _ignore_cache: dict[tuple[str, tuple[str, ...]], set[str]] = {}
+    _hermesignore_cache: dict[str, tuple[float, list[tuple[str, list[str]]]]] = {}
+    _git_root_cache: dict[str, tuple[float, str | None]] = {}
+
     def __init__(
         self,
         skill_commands_provider: Callable[[], Mapping[str, dict[str, Any]]] | None = None,
@@ -450,6 +454,12 @@ class SlashCommandCompleter(Completer):
         """
         if not entries:
             return set()
+
+        cache_key = (os.path.abspath(search_dir), tuple(sorted(entries)))
+        cached = SlashCommandCompleter._ignore_cache.get(cache_key)
+        if cached is not None:
+            return set(cached)
+
         paths = [os.path.join(search_dir, e) for e in entries]
         ignored: set[str] = set()
         try:
@@ -476,13 +486,23 @@ class SlashCommandCompleter(Completer):
                         ignored.add(entry)
                         break
 
+        SlashCommandCompleter._ignore_cache[cache_key] = set(ignored)
         return ignored
 
     @staticmethod
     def _hermesignore_patterns(search_dir: str) -> list[tuple[str, list[str]]]:
         """Collect ``.hermesignore`` patterns from ``search_dir`` and ancestors."""
-        patterns_by_dir: list[tuple[str, list[str]]] = []
         current = os.path.abspath(search_dir)
+        cache = SlashCommandCompleter._hermesignore_cache.get(current)
+        if cache is not None:
+            cached_mtime, cached_patterns = cache
+            try:
+                if os.path.getmtime(os.path.join(current, ".hermesignore")) == cached_mtime:
+                    return list(cached_patterns)
+            except OSError:
+                pass
+
+        patterns_by_dir: list[tuple[str, list[str]]] = []
         git_root = SlashCommandCompleter._find_git_root(search_dir)
         stop_dir = os.path.abspath(git_root) if git_root else os.path.abspath(os.sep)
 
@@ -505,11 +525,21 @@ class SlashCommandCompleter(Completer):
                 break
             current = parent
 
+        try:
+            mtime = os.path.getmtime(os.path.join(os.path.abspath(search_dir), ".hermesignore"))
+        except OSError:
+            mtime = 0.0
+        SlashCommandCompleter._hermesignore_cache[os.path.abspath(search_dir)] = (mtime, list(patterns_by_dir))
         return patterns_by_dir
 
     @staticmethod
     def _find_git_root(path: str) -> str | None:
         """Return the git repo root for *path*, or None."""
+        abspath = os.path.abspath(path)
+        cache = SlashCommandCompleter._git_root_cache.get(abspath)
+        if cache is not None:
+            _mtime, cached_root = cache
+            return cached_root
         try:
             result = subprocess.run(
                 ["git", "rev-parse", "--show-toplevel"],
@@ -519,9 +549,12 @@ class SlashCommandCompleter(Completer):
                 cwd=path,
             )
             if result.returncode == 0:
-                return result.stdout.strip()
+                root = result.stdout.strip()
+                SlashCommandCompleter._git_root_cache[abspath] = (0.0, root)
+                return root
         except (OSError, subprocess.TimeoutExpired):
             pass
+        SlashCommandCompleter._git_root_cache[abspath] = (0.0, None)
         return None
 
     @staticmethod

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -429,7 +429,7 @@ class SlashCommandCompleter(Completer):
         word = SlashCommandCompleter._last_shell_token(text)
         if not word.startswith("@"):
             return None
-        if word.startswith(("@file:", "@folder:")):
+        if word.startswith(("@file:", "@folder:", "@git:", "@url:")):
             return None
         return word
 
@@ -464,7 +464,7 @@ class SlashCommandCompleter(Completer):
 
         for ignore_dir, patterns in SlashCommandCompleter._hermesignore_patterns(search_dir):
             rel_entries = [os.path.relpath(os.path.join(search_dir, entry), ignore_dir) for entry in entries]
-            for entry, rel_entry in zip(entries, rel_entries, strict=False):
+            for entry, rel_entry in zip(entries, rel_entries, strict=True):
                 for pattern in patterns:
                     if _hermesignore_match(pattern, entry) or _hermesignore_match(pattern, rel_entry):
                         ignored.add(entry)
@@ -486,8 +486,8 @@ class SlashCommandCompleter(Completer):
                 try:
                     with open(ignore_file, encoding="utf-8") as f:
                         patterns = [
-                            line.strip() for line in f
-                            if line.strip() and not line.startswith("#")
+                            stripped for line in f
+                            if (stripped := line.strip()) and not stripped.startswith("#")
                         ]
                     patterns_by_dir.append((current, patterns))
                 except OSError:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -516,7 +516,10 @@ class SlashCommandCompleter(Completer):
             else:
                 display_path = os.path.relpath(full_path)
 
-            completion_text = f"@folder:{display_path}/" if is_dir else f"@file:{display_path}"
+            completion_text = SlashCommandCompleter._render_context_reference(
+                display_path,
+                is_dir=is_dir,
+            )
             suffix = "/" if is_dir else ""
             meta = "context dir" if is_dir else f"context {_file_size_label(full_path)}".strip()
 
@@ -532,6 +535,21 @@ class SlashCommandCompleter(Completer):
 
         for _score, completion in sorted(matches, key=lambda item: item[0])[:limit]:
             yield completion
+
+    @staticmethod
+    def _render_context_reference(path: str, *, is_dir: bool) -> str:
+        """Render a parser-compatible ``@file:``/``@folder:`` reference."""
+        prefix = "@folder:" if is_dir else "@file:"
+        rendered_path = f"{path}/" if is_dir and not path.endswith("/") else path
+
+        if any(ch.isspace() for ch in rendered_path):
+            if '"' not in rendered_path:
+                return f'{prefix}"{rendered_path}"'
+            if "'" not in rendered_path:
+                return f"{prefix}'{rendered_path}'"
+
+        rendered_path = re.sub(r'([\\\s])', r'\\\1', rendered_path)
+        return f"{prefix}{rendered_path}"
 
     @staticmethod
     def _last_shell_token(text: str) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -385,23 +385,35 @@ class SlashCommandCompleter(Completer):
         """
         if not text:
             return None
-        # Walk backwards to find the start of the current "word".
-        # Words are delimited by spaces, but paths can contain almost anything.
-        i = len(text) - 1
-        while i >= 0 and text[i] != " ":
-            i -= 1
-        word = text[i + 1:]
+        word = SlashCommandCompleter._last_shell_token(text)
         if not word:
             return None
-        # Only trigger path completion for path-like tokens
-        if word.startswith(("./", "../", "~/", "/")) or "/" in word:
+        parsed = SlashCommandCompleter._parse_path_token(word)
+        if parsed and parsed.is_path_like():
             return word
         return None
 
     @staticmethod
+    def _extract_context_word(text: str) -> str | None:
+        """Extract a bare ``@`` context token for Claude Code-style suggestions."""
+        if not text:
+            return None
+        word = SlashCommandCompleter._last_shell_token(text)
+        if not word.startswith("@"):
+            return None
+        if word.startswith(("@file:", "@folder:")):
+            return None
+        return word
+
+    @staticmethod
     def _path_completions(word: str, limit: int = 30):
         """Yield Completion objects for file paths matching *word*."""
-        expanded = os.path.expanduser(word)
+        parsed = SlashCommandCompleter._parse_path_token(word)
+        if parsed is None:
+            return
+
+        lookup_word = parsed.lookup_word()
+        expanded = os.path.expanduser(lookup_word)
         # Split into directory part and prefix to match inside it
         if expanded.endswith("/"):
             search_dir = expanded
@@ -415,21 +427,19 @@ class SlashCommandCompleter(Completer):
         except OSError:
             return
 
-        count = 0
-        prefix_lower = prefix.lower()
+        matches: list[tuple[tuple[int, int, int, str], Completion]] = []
         for entry in sorted(entries):
-            if prefix and not entry.lower().startswith(prefix_lower):
+            score = SlashCommandCompleter._fuzzy_match_score(entry, prefix)
+            if score is None:
                 continue
-            if count >= limit:
-                break
 
             full_path = os.path.join(search_dir, entry)
             is_dir = os.path.isdir(full_path)
 
             # Build the completion text (what replaces the typed word)
-            if word.startswith("~"):
+            if lookup_word.startswith("~"):
                 display_path = "~/" + os.path.relpath(full_path, os.path.expanduser("~"))
-            elif os.path.isabs(word):
+            elif os.path.isabs(lookup_word):
                 display_path = full_path
             else:
                 # Keep relative
@@ -440,14 +450,169 @@ class SlashCommandCompleter(Completer):
 
             suffix = "/" if is_dir else ""
             meta = "dir" if is_dir else _file_size_label(full_path)
+            completion_text = parsed.render(display_path)
 
-            yield Completion(
-                display_path,
-                start_position=-len(word),
-                display=entry + suffix,
-                display_meta=meta,
+            matches.append((
+                score,
+                Completion(
+                    completion_text,
+                    start_position=-len(word),
+                    display=entry + suffix,
+                    display_meta=meta,
+                ),
             )
-            count += 1
+            )
+
+        for _score, completion in sorted(matches, key=lambda item: item[0])[:limit]:
+            yield completion
+
+    @staticmethod
+    def _context_completions(word: str, limit: int = 30):
+        """Yield Claude Code-style context completions for bare ``@`` tokens."""
+        lowered = word.lower()
+        static_refs = (
+            ("@diff", "Git working tree diff"),
+            ("@staged", "Git staged diff"),
+            ("@file:", "Attach a file"),
+            ("@folder:", "Attach a folder"),
+        )
+
+        for candidate, meta in static_refs:
+            if candidate.lower().startswith(lowered) and candidate.lower() != lowered:
+                yield Completion(
+                    candidate,
+                    start_position=-len(word),
+                    display=candidate,
+                    display_meta=meta,
+                )
+
+        query = word[1:]
+        expanded = os.path.expanduser(query or ".")
+        if expanded.endswith("/"):
+            search_dir = expanded
+            prefix = ""
+        else:
+            search_dir = os.path.dirname(expanded) or "."
+            prefix = os.path.basename(expanded)
+
+        try:
+            entries = os.listdir(search_dir)
+        except OSError:
+            return
+
+        matches: list[tuple[tuple[int, int, int, str], Completion]] = []
+        for entry in sorted(entries):
+            score = SlashCommandCompleter._fuzzy_match_score(entry, prefix)
+            if score is None:
+                continue
+
+            full_path = os.path.join(search_dir, entry)
+            is_dir = os.path.isdir(full_path)
+
+            if query.startswith("~"):
+                display_path = "~/" + os.path.relpath(full_path, os.path.expanduser("~"))
+            elif os.path.isabs(query):
+                display_path = full_path
+            else:
+                display_path = os.path.relpath(full_path)
+
+            completion_text = f"@folder:{display_path}/" if is_dir else f"@file:{display_path}"
+            suffix = "/" if is_dir else ""
+            meta = "context dir" if is_dir else f"context {_file_size_label(full_path)}".strip()
+
+            matches.append((
+                score,
+                Completion(
+                    completion_text,
+                    start_position=-len(word),
+                    display=entry + suffix,
+                    display_meta=meta,
+                ),
+            ))
+
+        for _score, completion in sorted(matches, key=lambda item: item[0])[:limit]:
+            yield completion
+
+    @staticmethod
+    def _last_shell_token(text: str) -> str:
+        """Return the final shell-like token, preserving quotes and escapes."""
+        last_start = 0
+        quote: str | None = None
+        escaped = False
+
+        for i, ch in enumerate(text):
+            if escaped:
+                escaped = False
+                continue
+            if ch == "\\":
+                escaped = True
+                continue
+            if quote:
+                if ch == quote:
+                    quote = None
+                continue
+            if ch in {"'", '"'}:
+                quote = ch
+                continue
+            if ch.isspace():
+                last_start = i + 1
+
+        return text[last_start:]
+
+    @staticmethod
+    def _parse_path_token(word: str) -> "_PathToken | None":
+        prefixes = ("@file:", "@folder:")
+        reference_prefix = ""
+        path_text = word
+        for prefix in prefixes:
+            if word.startswith(prefix):
+                reference_prefix = prefix
+                path_text = word[len(prefix):]
+                break
+
+        quote = ""
+        if path_text.startswith(("'", '"')):
+            quote = path_text[0]
+            path_text = path_text[1:]
+
+        closing_quote = bool(quote) and path_text.endswith(quote)
+        if closing_quote:
+            path_text = path_text[:-1]
+
+        keep_escaped = "\\" in path_text
+        unescaped = re.sub(r"\\(.)", r"\1", path_text)
+
+        token = _PathToken(
+            raw=word,
+            reference_prefix=reference_prefix,
+            quote=quote,
+            close_quote=closing_quote,
+            keep_escaped=keep_escaped,
+            path=unescaped,
+        )
+        return token if token.is_path_like() else None
+
+    @staticmethod
+    def _fuzzy_match_score(candidate: str, query: str) -> tuple[int, int, int, str] | None:
+        """Return a sortable fuzzy-match score or None when there is no match."""
+        normalized_candidate = re.sub(r"[^a-z0-9]", "", candidate.lower())
+        normalized_query = re.sub(r"[^a-z0-9]", "", query.lower())
+
+        if not normalized_query:
+            return (0, 0, len(normalized_candidate), candidate.lower())
+
+        positions: list[int] = []
+        idx = 0
+        for ch in normalized_query:
+            found = normalized_candidate.find(ch, idx)
+            if found == -1:
+                return None
+            positions.append(found)
+            idx = found + 1
+
+        start = positions[0]
+        span = positions[-1] - positions[0] + 1
+        return (start, span, len(normalized_candidate), candidate.lower())
 
     def get_completions(self, document, complete_event):
         text = document.text_before_cursor
@@ -456,6 +621,10 @@ class SlashCommandCompleter(Completer):
             path_word = self._extract_path_word(text)
             if path_word is not None:
                 yield from self._path_completions(path_word)
+                return
+            context_word = self._extract_context_word(text)
+            if context_word is not None:
+                yield from self._context_completions(context_word)
             return
 
         # Check if we're completing a subcommand (base command already typed)
@@ -545,6 +714,34 @@ class SlashCommandCompleter(Completer):
                     display=cmd,
                     display_meta=f"⚡ {short_desc}",
                 )
+
+
+@dataclass(frozen=True)
+class _PathToken:
+    raw: str
+    reference_prefix: str = ""
+    quote: str = ""
+    close_quote: bool = False
+    keep_escaped: bool = False
+    path: str = ""
+
+    def is_path_like(self) -> bool:
+        if self.reference_prefix:
+            return True
+        return self.path.startswith(("./", "../", "~/", "/")) or "/" in self.path
+
+    def lookup_word(self) -> str:
+        return self.path or "."
+
+    def render(self, path: str) -> str:
+        rendered = path
+        if self.keep_escaped:
+            rendered = re.sub(r'([\\\s])', r'\\\1', rendered)
+        if self.quote:
+            rendered = f"{self.quote}{rendered}"
+            if self.close_quote:
+                rendered += self.quote
+        return f"{self.reference_prefix}{rendered}"
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -342,6 +342,12 @@ class _PathToken:
     def lookup_word(self) -> str:
         return self.path or "."
 
+    def wants_directory(self) -> bool:
+        return self.reference_prefix == "@folder:"
+
+    def wants_file(self) -> bool:
+        return self.reference_prefix == "@file:"
+
     def render(self, path: str) -> str:
         rendered = path
         if self.keep_escaped:
@@ -576,6 +582,10 @@ class SlashCommandCompleter(Completer):
         for _score, entry, full_path, display_path, is_dir in (
             SlashCommandCompleter._list_matching_entries(parsed.lookup_word())[:limit]
         ):
+            if parsed.wants_directory() and not is_dir:
+                continue
+            if parsed.wants_file() and is_dir:
+                continue
             if is_dir:
                 display_path += "/"
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -438,6 +438,8 @@ class SlashCommandCompleter(Completer):
         """Return the subset of *entries* ignored by ``.gitignore`` / ``.hermesignore``.
 
         Uses ``git check-ignore`` which honours all gitignore layers.
+        Also walks upward through ``.hermesignore`` files so nested ignore rules
+        are applied relative to the directory that defined them.
         Falls back to an empty set outside git repos or on any error.
         """
         if not entries:
@@ -460,26 +462,44 @@ class SlashCommandCompleter(Completer):
         except (OSError, subprocess.TimeoutExpired):
             pass
 
-        hermesignore = os.path.join(search_dir, ".hermesignore")
-        if not os.path.isfile(hermesignore):
-            git_root = SlashCommandCompleter._find_git_root(search_dir)
-            if git_root:
-                hermesignore = os.path.join(git_root, ".hermesignore")
-
-        try:
-            with open(hermesignore) as f:
-                patterns = [
-                    line.strip() for line in f
-                    if line.strip() and not line.startswith("#")
-                ]
-            for entry in entries:
+        for ignore_dir, patterns in SlashCommandCompleter._hermesignore_patterns(search_dir):
+            rel_entries = [os.path.relpath(os.path.join(search_dir, entry), ignore_dir) for entry in entries]
+            for entry, rel_entry in zip(entries, rel_entries, strict=False):
                 for pattern in patterns:
-                    if _hermesignore_match(pattern, entry):
+                    if _hermesignore_match(pattern, entry) or _hermesignore_match(pattern, rel_entry):
                         ignored.add(entry)
-        except OSError:
-            pass
+                        break
 
         return ignored
+
+    @staticmethod
+    def _hermesignore_patterns(search_dir: str) -> list[tuple[str, list[str]]]:
+        """Collect ``.hermesignore`` patterns from ``search_dir`` and ancestors."""
+        patterns_by_dir: list[tuple[str, list[str]]] = []
+        current = os.path.abspath(search_dir)
+        git_root = SlashCommandCompleter._find_git_root(search_dir)
+        stop_dir = os.path.abspath(git_root) if git_root else os.path.abspath(os.sep)
+
+        while True:
+            ignore_file = os.path.join(current, ".hermesignore")
+            if os.path.isfile(ignore_file):
+                try:
+                    with open(ignore_file, encoding="utf-8") as f:
+                        patterns = [
+                            line.strip() for line in f
+                            if line.strip() and not line.startswith("#")
+                        ]
+                    patterns_by_dir.append((current, patterns))
+                except OSError:
+                    pass
+            if current == stop_dir:
+                break
+            parent = os.path.dirname(current)
+            if parent == current:
+                break
+            current = parent
+
+        return patterns_by_dir
 
     @staticmethod
     def _find_git_root(path: str) -> str | None:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -13,8 +13,7 @@ from __future__ import annotations
 import os
 import re
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass, field
-from pathlib import Path
+from dataclasses import dataclass
 from typing import Any
 
 from prompt_toolkit.auto_suggest import AutoSuggest, Suggestion
@@ -325,6 +324,34 @@ def slack_subcommand_map() -> dict[str, str]:
 # Autocomplete
 # ---------------------------------------------------------------------------
 
+@dataclass(frozen=True)
+class _PathToken:
+    raw: str
+    reference_prefix: str = ""
+    quote: str = ""
+    close_quote: bool = False
+    keep_escaped: bool = False
+    path: str = ""
+
+    def is_path_like(self) -> bool:
+        if self.reference_prefix:
+            return True
+        return self.path.startswith(("./", "../", "~/", "/")) or "/" in self.path
+
+    def lookup_word(self) -> str:
+        return self.path or "."
+
+    def render(self, path: str) -> str:
+        rendered = path
+        if self.keep_escaped:
+            rendered = re.sub(r'([\\\s])', r'\\\1', rendered)
+        if self.quote:
+            rendered = f"{self.quote}{rendered}"
+            if self.close_quote:
+                rendered += self.quote
+        return f"{self.reference_prefix}{rendered}"
+
+
 class SlashCommandCompleter(Completer):
     """Autocomplete for built-in slash commands, subcommands, and skill commands."""
 
@@ -406,15 +433,15 @@ class SlashCommandCompleter(Completer):
         return word
 
     @staticmethod
-    def _path_completions(word: str, limit: int = 30):
-        """Yield Completion objects for file paths matching *word*."""
-        parsed = SlashCommandCompleter._parse_path_token(word)
-        if parsed is None:
-            return
+    def _list_matching_entries(
+        lookup_word: str,
+    ) -> list[tuple[tuple[int, int, int, str], str, str, str, bool]]:
+        """List directory entries fuzzy-matching the basename of *lookup_word*.
 
-        lookup_word = parsed.lookup_word()
+        Returns a score-sorted list of
+        ``(score, entry, full_path, display_path, is_dir)`` tuples.
+        """
         expanded = os.path.expanduser(lookup_word)
-        # Split into directory part and prefix to match inside it
         if expanded.endswith("/"):
             search_dir = expanded
             prefix = ""
@@ -425,9 +452,9 @@ class SlashCommandCompleter(Completer):
         try:
             entries = os.listdir(search_dir)
         except OSError:
-            return
+            return []
 
-        matches: list[tuple[tuple[int, int, int, str], Completion]] = []
+        matches: list[tuple[tuple[int, int, int, str], str, str, str, bool]] = []
         for entry in sorted(entries):
             score = SlashCommandCompleter._fuzzy_match_score(entry, prefix)
             if score is None:
@@ -436,35 +463,40 @@ class SlashCommandCompleter(Completer):
             full_path = os.path.join(search_dir, entry)
             is_dir = os.path.isdir(full_path)
 
-            # Build the completion text (what replaces the typed word)
             if lookup_word.startswith("~"):
                 display_path = "~/" + os.path.relpath(full_path, os.path.expanduser("~"))
             elif os.path.isabs(lookup_word):
                 display_path = full_path
             else:
-                # Keep relative
                 display_path = os.path.relpath(full_path)
 
+            matches.append((score, entry, full_path, display_path, is_dir))
+
+        matches.sort(key=lambda item: item[0])
+        return matches
+
+    @staticmethod
+    def _path_completions(word: str, limit: int = 30):
+        """Yield Completion objects for file paths matching *word*."""
+        parsed = SlashCommandCompleter._parse_path_token(word)
+        if parsed is None:
+            return
+
+        for _score, entry, full_path, display_path, is_dir in (
+            SlashCommandCompleter._list_matching_entries(parsed.lookup_word())[:limit]
+        ):
             if is_dir:
                 display_path += "/"
 
             suffix = "/" if is_dir else ""
             meta = "dir" if is_dir else _file_size_label(full_path)
-            completion_text = parsed.render(display_path)
 
-            matches.append((
-                score,
-                Completion(
-                    completion_text,
-                    start_position=-len(word),
-                    display=entry + suffix,
-                    display_meta=meta,
-                ),
+            yield Completion(
+                parsed.render(display_path),
+                start_position=-len(word),
+                display=entry + suffix,
+                display_meta=meta,
             )
-            )
-
-        for _score, completion in sorted(matches, key=lambda item: item[0])[:limit]:
-            yield completion
 
     @staticmethod
     def _context_completions(word: str, limit: int = 30):
@@ -487,35 +519,9 @@ class SlashCommandCompleter(Completer):
                 )
 
         query = word[1:]
-        expanded = os.path.expanduser(query or ".")
-        if expanded.endswith("/"):
-            search_dir = expanded
-            prefix = ""
-        else:
-            search_dir = os.path.dirname(expanded) or "."
-            prefix = os.path.basename(expanded)
-
-        try:
-            entries = os.listdir(search_dir)
-        except OSError:
-            return
-
-        matches: list[tuple[tuple[int, int, int, str], Completion]] = []
-        for entry in sorted(entries):
-            score = SlashCommandCompleter._fuzzy_match_score(entry, prefix)
-            if score is None:
-                continue
-
-            full_path = os.path.join(search_dir, entry)
-            is_dir = os.path.isdir(full_path)
-
-            if query.startswith("~"):
-                display_path = "~/" + os.path.relpath(full_path, os.path.expanduser("~"))
-            elif os.path.isabs(query):
-                display_path = full_path
-            else:
-                display_path = os.path.relpath(full_path)
-
+        for _score, entry, full_path, display_path, is_dir in (
+            SlashCommandCompleter._list_matching_entries(query or ".")[:limit]
+        ):
             completion_text = SlashCommandCompleter._render_context_reference(
                 display_path,
                 is_dir=is_dir,
@@ -523,18 +529,12 @@ class SlashCommandCompleter(Completer):
             suffix = "/" if is_dir else ""
             meta = "context dir" if is_dir else f"context {_file_size_label(full_path)}".strip()
 
-            matches.append((
-                score,
-                Completion(
-                    completion_text,
-                    start_position=-len(word),
-                    display=entry + suffix,
-                    display_meta=meta,
-                ),
-            ))
-
-        for _score, completion in sorted(matches, key=lambda item: item[0])[:limit]:
-            yield completion
+            yield Completion(
+                completion_text,
+                start_position=-len(word),
+                display=entry + suffix,
+                display_meta=meta,
+            )
 
     @staticmethod
     def _render_context_reference(path: str, *, is_dir: bool) -> str:
@@ -542,13 +542,18 @@ class SlashCommandCompleter(Completer):
         prefix = "@folder:" if is_dir else "@file:"
         rendered_path = f"{path}/" if is_dir and not path.endswith("/") else path
 
-        if any(ch.isspace() for ch in rendered_path):
+        has_whitespace = any(ch.isspace() for ch in rendered_path)
+        if has_whitespace:
             if '"' not in rendered_path:
                 return f'{prefix}"{rendered_path}"'
             if "'" not in rendered_path:
                 return f"{prefix}'{rendered_path}'"
+            # Both quote types present -- escape backslashes first, then
+            # whitespace, so existing backslashes are not double-escaped.
+            rendered_path = rendered_path.replace("\\", "\\\\")
+            rendered_path = re.sub(r'(\s)', r'\\\1', rendered_path)
+            return f"{prefix}{rendered_path}"
 
-        rendered_path = re.sub(r'([\\\s])', r'\\\1', rendered_path)
         return f"{prefix}{rendered_path}"
 
     @staticmethod
@@ -732,34 +737,6 @@ class SlashCommandCompleter(Completer):
                     display=cmd,
                     display_meta=f"⚡ {short_desc}",
                 )
-
-
-@dataclass(frozen=True)
-class _PathToken:
-    raw: str
-    reference_prefix: str = ""
-    quote: str = ""
-    close_quote: bool = False
-    keep_escaped: bool = False
-    path: str = ""
-
-    def is_path_like(self) -> bool:
-        if self.reference_prefix:
-            return True
-        return self.path.startswith(("./", "../", "~/", "/")) or "/" in self.path
-
-    def lookup_word(self) -> str:
-        return self.path or "."
-
-    def render(self, path: str) -> str:
-        rendered = path
-        if self.keep_escaped:
-            rendered = re.sub(r'([\\\s])', r'\\\1', rendered)
-        if self.quote:
-            rendered = f"{self.quote}{rendered}"
-            if self.close_quote:
-                rendered += self.quote
-        return f"{self.reference_prefix}{rendered}"
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -433,6 +434,71 @@ class SlashCommandCompleter(Completer):
         return word
 
     @staticmethod
+    def _ignored_entries(search_dir: str, entries: list[str]) -> set[str]:
+        """Return the subset of *entries* ignored by ``.gitignore`` / ``.hermesignore``.
+
+        Uses ``git check-ignore`` which honours all gitignore layers.
+        Falls back to an empty set outside git repos or on any error.
+        """
+        if not entries:
+            return set()
+        paths = [os.path.join(search_dir, e) for e in entries]
+        ignored: set[str] = set()
+        try:
+            result = subprocess.run(
+                ["git", "check-ignore", "--stdin", "-z"],
+                input="\0".join(paths),
+                capture_output=True,
+                text=True,
+                timeout=2,
+                cwd=search_dir,
+            )
+            if result.stdout:
+                for p in result.stdout.split("\0"):
+                    if p:
+                        ignored.add(os.path.basename(p))
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+        hermesignore = os.path.join(search_dir, ".hermesignore")
+        if not os.path.isfile(hermesignore):
+            git_root = SlashCommandCompleter._find_git_root(search_dir)
+            if git_root:
+                hermesignore = os.path.join(git_root, ".hermesignore")
+
+        try:
+            with open(hermesignore) as f:
+                patterns = [
+                    line.strip() for line in f
+                    if line.strip() and not line.startswith("#")
+                ]
+            for entry in entries:
+                for pattern in patterns:
+                    if _hermesignore_match(pattern, entry):
+                        ignored.add(entry)
+        except OSError:
+            pass
+
+        return ignored
+
+    @staticmethod
+    def _find_git_root(path: str) -> str | None:
+        """Return the git repo root for *path*, or None."""
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                cwd=path,
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+        return None
+
+    @staticmethod
     def _list_matching_entries(
         lookup_word: str,
     ) -> list[tuple[tuple[int, int, int, str], str, str, str, bool]]:
@@ -440,6 +506,7 @@ class SlashCommandCompleter(Completer):
 
         Returns a score-sorted list of
         ``(score, entry, full_path, display_path, is_dir)`` tuples.
+        Entries ignored by ``.gitignore`` or ``.hermesignore`` are excluded.
         """
         expanded = os.path.expanduser(lookup_word)
         if expanded.endswith("/"):
@@ -454,8 +521,12 @@ class SlashCommandCompleter(Completer):
         except OSError:
             return []
 
+        ignored = SlashCommandCompleter._ignored_entries(search_dir, entries)
+
         matches: list[tuple[tuple[int, int, int, str], str, str, str, bool]] = []
         for entry in sorted(entries):
+            if entry in ignored:
+                continue
             score = SlashCommandCompleter._fuzzy_match_score(entry, prefix)
             if score is None:
                 continue
@@ -507,6 +578,8 @@ class SlashCommandCompleter(Completer):
             ("@staged", "Git staged diff"),
             ("@file:", "Attach a file"),
             ("@folder:", "Attach a folder"),
+            ("@git:", "Git log with diffs (e.g. @git:5)"),
+            ("@url:", "Fetch web content"),
         )
 
         for candidate, meta in static_refs:
@@ -527,7 +600,7 @@ class SlashCommandCompleter(Completer):
                 is_dir=is_dir,
             )
             suffix = "/" if is_dir else ""
-            meta = "context dir" if is_dir else f"context {_file_size_label(full_path)}".strip()
+            meta = "dir" if is_dir else _token_estimate_label(full_path)
 
             yield Completion(
                 completion_text,
@@ -823,6 +896,23 @@ class SlashCommandAutoSuggest(AutoSuggest):
         return None
 
 
+def _hermesignore_match(pattern: str, entry: str) -> bool:
+    """Check if *entry* matches a simple .hermesignore *pattern*.
+
+    Supports basic gitignore-style patterns: exact names, directory markers
+    (trailing ``/``), and leading/trailing ``*`` wildcards.
+    """
+    if pattern.endswith("/"):
+        return entry == pattern[:-1]
+    if pattern.startswith("*") and pattern.endswith("*"):
+        return pattern[1:-1] in entry
+    if pattern.startswith("*"):
+        return entry.endswith(pattern[1:])
+    if pattern.endswith("*"):
+        return entry.startswith(pattern[:-1])
+    return entry == pattern
+
+
 def _file_size_label(path: str) -> str:
     """Return a compact human-readable file size, or '' on error."""
     try:
@@ -836,3 +926,17 @@ def _file_size_label(path: str) -> str:
     if size < 1024 * 1024 * 1024:
         return f"{size / (1024 * 1024):.1f}M"
     return f"{size / (1024 * 1024 * 1024):.1f}G"
+
+
+def _token_estimate_label(path: str) -> str:
+    """Return a compact token estimate label (``~N tokens``), or file size as fallback."""
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return ""
+    tokens = max(1, size // 4)
+    if tokens < 1000:
+        return f"~{tokens} tok"
+    if tokens < 1_000_000:
+        return f"~{tokens / 1000:.1f}K tok"
+    return f"~{tokens / 1_000_000:.1f}M tok"

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -259,6 +259,19 @@ class TestContextCompletions:
 
         assert any(c.text == "@folder:src/" for c in completions)
 
+    def test_bare_context_path_with_spaces_uses_quoted_reference(self, tmp_path):
+        target = tmp_path / "Screen Shot.png"
+        target.touch()
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            completions = list(SlashCommandCompleter._context_completions("@scrsh"))
+        finally:
+            os.chdir(old_cwd)
+
+        assert any(c.text == '@file:"Screen Shot.png"' for c in completions)
+
 
 class TestIntegration:
     """Test the completer produces path completions via the prompt_toolkit API."""

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -59,6 +59,43 @@ class TestExtractPathWord:
     def test_just_tilde_slash(self):
         assert SlashCommandCompleter._extract_path_word("~/") == "~/"
 
+    def test_quoted_path_with_spaces(self):
+        assert (
+            SlashCommandCompleter._extract_path_word('see "/tmp/Screen Shot 2026')
+            == '"/tmp/Screen Shot 2026'
+        )
+
+    def test_escaped_spaces_path(self):
+        assert (
+            SlashCommandCompleter._extract_path_word(
+                r"see /tmp/Screen\ Shot\ 2026"
+            )
+            == r"/tmp/Screen\ Shot\ 2026"
+        )
+
+    def test_context_file_reference_path(self):
+        assert (
+            SlashCommandCompleter._extract_path_word("review @file:src/ma")
+            == "@file:src/ma"
+        )
+
+    def test_context_folder_reference_path(self):
+        assert (
+            SlashCommandCompleter._extract_path_word("review @folder:src/")
+            == "@folder:src/"
+        )
+
+
+class TestExtractContextWord:
+    def test_bare_context_trigger(self):
+        assert SlashCommandCompleter._extract_context_word("review @") == "@"
+
+    def test_bare_context_path_fragment(self):
+        assert SlashCommandCompleter._extract_context_word("review @src") == "@src"
+
+    def test_explicit_context_file_reference_is_not_bare_trigger(self):
+        assert SlashCommandCompleter._extract_context_word("review @file:src/main.py") is None
+
 
 class TestPathCompletions:
     def test_lists_current_directory(self, tmp_path):
@@ -125,6 +162,103 @@ class TestPathCompletions:
         names = _display_names(completions)
         assert "README.md" in names
 
+    def test_fuzzy_match_non_contiguous_filename(self, tmp_path):
+        (tmp_path / "Screenshot 2026-03-22 at 4.27.40 PM.png").touch()
+        (tmp_path / "notes.txt").touch()
+
+        completions = list(SlashCommandCompleter._path_completions(f"{tmp_path}/scsh"))
+        names = _display_names(completions)
+
+        assert "Screenshot 2026-03-22 at 4.27.40 PM.png" in names
+        assert "notes.txt" not in names
+
+    def test_fuzzy_match_orders_better_match_first(self, tmp_path):
+        (tmp_path / "screen-capture.png").touch()
+        (tmp_path / "super-complex-screenshot.png").touch()
+
+        completions = list(SlashCommandCompleter._path_completions(f"{tmp_path}/scrcap"))
+        names = _display_names(completions)
+
+        assert names[0] == "screen-capture.png"
+
+    def test_preserves_escaped_spaces_in_completion_text(self, tmp_path):
+        target = tmp_path / "Screenshot 2026-03-22 at 4.27.40 PM.png"
+        target.touch()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(
+                str(target).replace(" ", r"\ ").rsplit(".", 1)[0]
+            )
+        )
+
+        assert any(c.text == str(target).replace(" ", r"\ ") for c in completions)
+
+    def test_preserves_opening_quote_in_completion_text(self, tmp_path):
+        target = tmp_path / "Screenshot 2026-03-22 at 4.27.40 PM.png"
+        target.touch()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(f'"{tmp_path}/Screen')
+        )
+
+        assert any(c.text == f'"{target}' for c in completions)
+
+    def test_completes_context_file_references(self, tmp_path):
+        target = tmp_path / "main.py"
+        target.touch()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(f"@file:{tmp_path}/ma")
+        )
+
+        assert any(c.text == f"@file:{target}" for c in completions)
+
+    def test_completes_context_folder_references(self, tmp_path):
+        target = tmp_path / "src"
+        target.mkdir()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(f"@folder:{tmp_path}/s")
+        )
+
+        assert any(c.text == f"@folder:{target}/" for c in completions)
+
+
+class TestContextCompletions:
+    def test_lists_static_context_references(self):
+        completions = list(SlashCommandCompleter._context_completions("@"))
+        texts = [c.text for c in completions]
+        assert "@diff" in texts
+        assert "@staged" in texts
+        assert "@file:" in texts
+        assert "@folder:" in texts
+
+    def test_bare_context_path_completes_to_file_reference(self, tmp_path):
+        target = tmp_path / "main.py"
+        target.touch()
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            completions = list(SlashCommandCompleter._context_completions("@ma"))
+        finally:
+            os.chdir(old_cwd)
+
+        assert any(c.text == "@file:main.py" for c in completions)
+
+    def test_bare_context_path_completes_to_folder_reference(self, tmp_path):
+        target = tmp_path / "src"
+        target.mkdir()
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            completions = list(SlashCommandCompleter._context_completions("@sr"))
+        finally:
+            os.chdir(old_cwd)
+
+        assert any(c.text == "@folder:src/" for c in completions)
+
 
 class TestIntegration:
     """Test the completer produces path completions via the prompt_toolkit API."""
@@ -162,6 +296,31 @@ class TestIntegration:
         names = _display_names(completions)
         # /etc/hosts should exist on Linux
         assert any("host" in n.lower() for n in names)
+
+    def test_context_file_reference_triggers_completion(self, completer, tmp_path):
+        target = tmp_path / "main.py"
+        target.touch()
+
+        doc = Document(f"check @file:{tmp_path}/ma", cursor_position=len(f"check @file:{tmp_path}/ma"))
+        event = MagicMock()
+        completions = list(completer.get_completions(doc, event))
+
+        assert any(c.text == f"@file:{target}" for c in completions)
+
+    def test_bare_context_trigger_shows_context_completion(self, completer, tmp_path):
+        target = tmp_path / "main.py"
+        target.touch()
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            doc = Document("check @ma", cursor_position=len("check @ma"))
+            event = MagicMock()
+            completions = list(completer.get_completions(doc, event))
+        finally:
+            os.chdir(old_cwd)
+
+        assert any(c.text == "@file:main.py" for c in completions)
 
 
 class TestFileSizeLabel:

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -228,6 +228,30 @@ class TestPathCompletions:
 
         assert any(c.text == f"@folder:{target}/" for c in completions)
 
+    def test_context_file_completions_exclude_directories(self, tmp_path):
+        (tmp_path / "main.py").touch()
+        (tmp_path / "main_dir").mkdir()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(f"@file:{tmp_path}/ma")
+        )
+        texts = [c.text for c in completions]
+
+        assert f"@file:{tmp_path}/main.py" in texts
+        assert f"@file:{tmp_path}/main_dir/" not in texts
+
+    def test_context_folder_completions_exclude_files(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src.txt").touch()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(f"@folder:{tmp_path}/sr")
+        )
+        texts = [c.text for c in completions]
+
+        assert f"@folder:{tmp_path}/src/" in texts
+        assert f"@folder:{tmp_path}/src.txt" not in texts
+
 
 class TestContextCompletions:
     def test_lists_static_context_references(self):

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -7,7 +7,12 @@ import pytest
 from prompt_toolkit.document import Document
 from prompt_toolkit.formatted_text import to_plain_text
 
-from hermes_cli.commands import SlashCommandCompleter, _file_size_label
+from hermes_cli.commands import (
+    SlashCommandCompleter,
+    _file_size_label,
+    _hermesignore_match,
+    _token_estimate_label,
+)
 
 
 def _display_names(completions):
@@ -354,3 +359,131 @@ class TestFileSizeLabel:
 
     def test_nonexistent(self):
         assert _file_size_label("/nonexistent_xyz") == ""
+
+
+class TestTokenEstimateLabel:
+    def test_small_file(self, tmp_path):
+        f = tmp_path / "tiny.txt"
+        f.write_text("hello world")
+        label = _token_estimate_label(str(f))
+        assert label.startswith("~")
+        assert "tok" in label
+
+    def test_large_file(self, tmp_path):
+        f = tmp_path / "big.txt"
+        f.write_bytes(b"x" * 40_000)
+        label = _token_estimate_label(str(f))
+        assert "K tok" in label
+
+    def test_nonexistent(self):
+        assert _token_estimate_label("/nonexistent_xyz") == ""
+
+
+class TestHermesignoreMatch:
+    def test_exact_name(self):
+        assert _hermesignore_match("node_modules", "node_modules")
+        assert not _hermesignore_match("node_modules", "node_mod")
+
+    def test_directory_pattern(self):
+        assert _hermesignore_match("build/", "build")
+        assert not _hermesignore_match("build/", "builder")
+
+    def test_leading_wildcard(self):
+        assert _hermesignore_match("*.pyc", "test.pyc")
+        assert not _hermesignore_match("*.pyc", "test.py")
+
+    def test_trailing_wildcard(self):
+        assert _hermesignore_match("test_*", "test_foo")
+        assert not _hermesignore_match("test_*", "my_test")
+
+    def test_surrounding_wildcards(self):
+        assert _hermesignore_match("*cache*", "my_cache_dir")
+        assert not _hermesignore_match("*cache*", "my_dir")
+
+
+class TestIgnoredEntries:
+    def test_gitignored_files_excluded_from_completions(self, tmp_path):
+        """Files in .gitignore should not appear in completions."""
+        import subprocess as sp
+
+        sp.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        (tmp_path / ".gitignore").write_text("ignored.txt\n")
+        (tmp_path / "ignored.txt").touch()
+        (tmp_path / "visible.txt").touch()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(f"{tmp_path}/")
+        )
+        names = _display_names(completions)
+        assert "visible.txt" in names
+        assert "ignored.txt" not in names
+
+    def test_hermesignore_excludes_files(self, tmp_path):
+        """Files matching .hermesignore patterns should not appear."""
+        import subprocess as sp
+
+        sp.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        (tmp_path / ".hermesignore").write_text("*.log\nsecrets/\n")
+        (tmp_path / "app.log").touch()
+        (tmp_path / "app.py").touch()
+        (tmp_path / "secrets").mkdir()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(f"{tmp_path}/")
+        )
+        names = _display_names(completions)
+        assert "app.py" in names
+        assert "app.log" not in names
+        assert "secrets/" not in names
+
+    def test_context_completions_also_respect_gitignore(self, tmp_path):
+        """Bare @ context completions should also filter gitignored entries."""
+        import subprocess as sp
+
+        sp.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        (tmp_path / ".gitignore").write_text("node_modules\n")
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / "src").mkdir()
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            completions = list(SlashCommandCompleter._context_completions("@"))
+            names = _display_names(completions)
+        finally:
+            os.chdir(old_cwd)
+
+        assert "src/" in names
+        assert "node_modules/" not in names
+
+
+class TestStaticContextCompletions:
+    def test_includes_git_reference(self):
+        completions = list(SlashCommandCompleter._context_completions("@gi"))
+        texts = [c.text for c in completions]
+        assert "@git:" in texts
+
+    def test_includes_url_reference(self):
+        completions = list(SlashCommandCompleter._context_completions("@ur"))
+        texts = [c.text for c in completions]
+        assert "@url:" in texts
+
+    def test_all_static_refs_present(self):
+        completions = list(SlashCommandCompleter._context_completions("@"))
+        texts = [c.text for c in completions]
+        for expected in ("@diff", "@staged", "@file:", "@folder:", "@git:", "@url:"):
+            assert expected in texts
+
+    def test_context_completions_show_token_estimate(self, tmp_path):
+        target = tmp_path / "main.py"
+        target.write_text("print('hello')\n" * 100)
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            completions = list(SlashCommandCompleter._context_completions("@ma"))
+            metas = _display_metas(completions)
+        finally:
+            os.chdir(old_cwd)
+
+        assert any("tok" in m for m in metas)

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -436,6 +436,25 @@ class TestIgnoredEntries:
         assert "app.log" not in names
         assert "secrets/" not in names
 
+    def test_nested_hermesignore_excludes_files(self, tmp_path):
+        import subprocess as sp
+
+        sp.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        nested = tmp_path / "workspace" / "src"
+        nested.mkdir(parents=True)
+        (tmp_path / "workspace" / ".hermesignore").write_text("*.tmp\ncache/\n")
+        (nested / "good.py").touch()
+        (nested / "bad.tmp").touch()
+        (nested / "cache").mkdir()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(f"{nested}/")
+        )
+        names = _display_names(completions)
+        assert "good.py" in names
+        assert "bad.tmp" not in names
+        assert "cache/" not in names
+
     def test_context_completions_also_respect_gitignore(self, tmp_path):
         """Bare @ context completions should also filter gitignored entries."""
         import subprocess as sp

--- a/tests/test_context_references.py
+++ b/tests/test_context_references.py
@@ -95,6 +95,17 @@ def test_parse_references_supports_quoted_and_escaped_paths():
     assert refs[1].target == "docs/My Folder/"
 
 
+def test_parse_quoted_file_reference_preserves_line_ranges():
+    from agent.context_references import parse_context_references
+
+    refs = parse_context_references('review @file:"docs/Screen Shot.txt":10-20')
+
+    assert [ref.kind for ref in refs] == ["file"]
+    assert refs[0].target == "docs/Screen Shot.txt"
+    assert refs[0].line_start == 10
+    assert refs[0].line_end == 20
+
+
 def test_expand_file_range_and_folder_listing(sample_repo: Path):
     from agent.context_references import preprocess_context_references
 

--- a/tests/test_context_references.py
+++ b/tests/test_context_references.py
@@ -106,6 +106,17 @@ def test_parse_quoted_file_reference_preserves_line_ranges():
     assert refs[0].line_end == 20
 
 
+def test_parse_quoted_file_reference_strips_trailing_punctuation_with_range():
+    from agent.context_references import parse_context_references
+
+    refs = parse_context_references('review @file:"docs/Screen Shot.txt":10-20, please')
+
+    assert [ref.kind for ref in refs] == ["file"]
+    assert refs[0].target == "docs/Screen Shot.txt"
+    assert refs[0].line_start == 10
+    assert refs[0].line_end == 20
+
+
 def test_expand_file_range_and_folder_listing(sample_repo: Path):
     from agent.context_references import preprocess_context_references
 

--- a/tests/test_context_references.py
+++ b/tests/test_context_references.py
@@ -83,6 +83,18 @@ def test_parse_references_strips_trailing_punctuation():
     assert refs[1].target == "https://example.com/docs"
 
 
+def test_parse_references_supports_quoted_and_escaped_paths():
+    from agent.context_references import parse_context_references
+
+    refs = parse_context_references(
+        r'review @file:"docs/Screen Shot.png" and @folder:docs/My\ Folder/'
+    )
+
+    assert [ref.kind for ref in refs] == ["file", "folder"]
+    assert refs[0].target == "docs/Screen Shot.png"
+    assert refs[1].target == "docs/My Folder/"
+
+
 def test_expand_file_range_and_folder_listing(sample_repo: Path):
     from agent.context_references import preprocess_context_references
 
@@ -219,3 +231,21 @@ def test_restricts_paths_to_allowed_root(tmp_path: Path):
     assert "```\noutside\n```" not in result.message
     assert "inside" in result.message
     assert any("outside the allowed workspace" in warning for warning in result.warnings)
+
+
+def test_expand_quoted_file_reference_with_spaces(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    spaced = repo / "Screen Shot.txt"
+    spaced.write_text("pixels\n", encoding="utf-8")
+
+    result = preprocess_context_references(
+        'inspect @file:"Screen Shot.txt"',
+        cwd=repo,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert "pixels" in result.message


### PR DESCRIPTION
## Summary
- add Claude Code-style bare `@` context completions in the CLI input box
- suggest files and folders as Hermes context references (`@file:...`, `@folder:...`)
- include quick static completions for `@diff`, `@staged`, `@git:`, and `@url:`
- filter completion candidates through `.gitignore` and nested `.hermesignore` files
- show token estimate hints for file completions instead of file size

## Notes
- this changes completion UX only; submit-time context expansion still uses Hermes' existing explicit reference syntax
- `.hermesignore` support now walks ancestor directories and applies patterns relative to the ignore file that defined them

## Verification
- `python -m pytest tests/hermes_cli/test_path_completion.py tests/test_context_references.py -q`
  - passed (`72 passed`)
