### PR TITLE
fix(cron): support Telegram topic delivery via platform:chat_id:thread_id format (salvage #2037)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -80,11 +80,16 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
         }
 
     if ":" in deliver:
-        platform_name, chat_id = deliver.split(":", 1)
+        platform_name, rest = deliver.split(":", 1)
+        # Check for thread_id suffix (e.g. "telegram:-1003724596514:17")
+        if ":" in rest:
+            chat_id, thread_id = rest.split(":", 1)
+        else:
+            chat_id, thread_id = rest, None
         return {
             "platform": platform_name,
             "chat_id": chat_id,
-            "thread_id": None,
+            "thread_id": thread_id,
         }
 
     platform_name = deliver

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -62,6 +62,28 @@ class TestResolveDeliveryTarget:
             "thread_id": "17585",
         }
 
+    def test_explicit_telegram_topic_target_with_thread_id(self):
+        """deliver: 'telegram:chat_id:thread_id' parses correctly."""
+        job = {
+            "deliver": "telegram:-1003724596514:17",
+        }
+        assert _resolve_delivery_target(job) == {
+            "platform": "telegram",
+            "chat_id": "-1003724596514",
+            "thread_id": "17",
+        }
+
+    def test_explicit_telegram_chat_id_without_thread_id(self):
+        """deliver: 'telegram:chat_id' sets thread_id to None."""
+        job = {
+            "deliver": "telegram:-1003724596514",
+        }
+        assert _resolve_delivery_target(job) == {
+            "platform": "telegram",
+            "chat_id": "-1003724596514",
+            "thread_id": None,
+        }
+
     def test_bare_platform_uses_matching_origin_chat(self):
         job = {
             "deliver": "telegram",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -370,7 +370,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "deliver": {
                 "type": "string",
-                "description": "Delivery target: origin, local, telegram, discord, slack, whatsapp, signal, matrix, mattermost, homeassistant, dingtalk, email, sms, or platform:chat_id"
+                "description": "Delivery target: origin, local, telegram, discord, slack, whatsapp, signal, matrix, mattermost, homeassistant, dingtalk, email, sms, or platform:chat_id or platform:chat_id:thread_id for Telegram topics. Examples: 'origin', 'local', 'telegram', 'telegram:-1001234567890:17585', 'discord:#engineering'"
             },
             "model": {
                 "type": "string",


### PR DESCRIPTION
## Summary
Salvage of PR #2037 by @alexferrari88, cherry-picked onto current main.

Cron job delivery to Telegram topics (forum threads) was broken — `_resolve_delivery_target()` always set `thread_id=None` when parsing the `platform:chat_id` format, so `deliver: telegram:-1003724596514:17` lost the thread ID.

### Fix
Parses the optional `:thread_id` suffix from explicit deliver targets. Handles negative Telegram chat IDs correctly via `split(':', 1)`.

- `telegram:-1003724596514:17` → chat_id=`-1003724596514`, thread_id=`17`
- `telegram:-1003724596514` → chat_id=`-1003724596514`, thread_id=`None`
- `discord:#engineering` → unchanged behavior

### Changes
- `cron/scheduler.py`: parse thread_id from deliver target
- `tests/cron/test_scheduler.py`: 2 new tests
- `tools/cronjob_tools.py`: updated schema description with thread_id format + examples

## Verification
- 5791 passed (pre-existing failures identical to main)
- Scheduler tests: 34/34 passed

## Credit
Original work by @alexferrari88 in #2037. Contributor authorship preserved via cherry-pick.