### PR TITLE
fix(compression): remove hardcoded gemini-3-flash-preview as default summary model

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -180,7 +180,7 @@ def load_cli_config() -> Dict[str, Any]:
         "compression": {
             "enabled": True,      # Auto-compress when approaching context limit
             "threshold": 0.50,    # Compress at 50% of model's context limit
-            "summary_model": "google/gemini-3-flash-preview",  # Fast/cheap model for summaries
+            "summary_model": "",  # Model for summaries (empty = use main model)
         },
         "smart_model_routing": {
             "enabled": False,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -159,7 +159,7 @@ DEFAULT_CONFIG = {
     "compression": {
         "enabled": True,
         "threshold": 0.50,
-        "summary_model": "google/gemini-3-flash-preview",
+        "summary_model": "",  # empty = use main configured model
         "summary_provider": "auto",
         "summary_base_url": None,
     },
@@ -1659,7 +1659,8 @@ def show_config():
     print(f"  Enabled:      {'yes' if enabled else 'no'}")
     if enabled:
         print(f"  Threshold:    {compression.get('threshold', 0.50) * 100:.0f}%")
-        print(f"  Model:        {compression.get('summary_model', 'google/gemini-3-flash-preview')}")
+        _sm = compression.get('summary_model', '') or '(main model)'
+        print(f"  Model:        {_sm}")
         comp_provider = compression.get('summary_provider', 'auto')
         if comp_provider != 'auto':
             print(f"  Provider:     {comp_provider}")


### PR DESCRIPTION
## Summary

Fixes #2453

The `DEFAULT_CONFIG` in `cli.py` and `hermes_cli/config.py` was hardcoding `google/gemini-3-flash-preview` as the `summary_model` for context compression. This caused unexpected OpenRouter credits to be consumed on gemini for users who configured a different provider/model — because the compression task would silently route through OpenRouter regardless of the user's settings.

## Root Cause

```python
# Before (both cli.py and hermes_cli/config.py)
"compression": {
    "summary_model": "google/gemini-3-flash-preview",  # always used OpenRouter
}
```

The `call_llm(task="compression")` resolution chain in `auxiliary_client.py` reads `compression.summary_model` from config. Since it was always set to the gemini model, it would resolve to OpenRouter even if the user's main provider was Anthropic, Mistral, etc.

## Fix

Set `summary_model` to an empty string in the defaults. The existing `call_llm` resolution chain already handles empty/None correctly: it falls through to `summary_provider` (default: `auto`), which in turn resolves to the user's main configured provider and model.

Users who want a dedicated cheap model for compression can still explicitly configure it:

```yaml
compression:
  summary_model: google/gemini-3-flash-preview  # optional, opt-in
```

## Changes

- `cli.py`: `summary_model` default `"google/gemini-3-flash-preview"` -> `""`
- `hermes_cli/config.py`: same default change
- `hermes_cli/config.py`: `show_config()` now displays `(main model)` when `summary_model` is unset