### PR TITLE
fix: add missing get_registry() function for CLI /stop command

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -799,6 +799,15 @@ class ProcessRegistry:
 process_registry = ProcessRegistry()
 
 
+def get_registry() -> ProcessRegistry:
+    """Get the global process registry instance.
+    
+    Used by CLI commands (e.g., /stop) to access the process registry
+    for listing and managing background processes.
+    """
+    return process_registry
+
+
 # ---------------------------------------------------------------------------
 # Registry -- the "process" tool schema + handler
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The CLI imports `get_registry` from `tools.process_registry` but the function was never defined:

```
Error: cannot import name 'get_registry' from 'tools.process_registry'
```

This causes the `/stop` command to fail.

## Solution

Added the missing `get_registry()` function that returns the module-level `process_registry` singleton.

## Testing

- Syntax check passed: `python -m py_compile tools/process_registry.py`
- Function returns the correct singleton instance

## Files Changed

- `tools/process_registry.py`: Added `get_registry()` function (9 lines)