### PR TITLE
fix: respect DashScope v1 runtime mode for alibaba (salvage #2024)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -381,19 +381,6 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
-    # Alibaba Cloud / DashScope (Anthropic-compatible endpoint)
-    if provider == "alibaba":
-        creds = resolve_api_key_provider_credentials(provider)
-        base_url = creds.get("base_url", "").rstrip("/") or "https://dashscope-intl.aliyuncs.com/apps/anthropic"
-        return {
-            "provider": "alibaba",
-            "api_mode": "anthropic_messages",
-            "base_url": base_url,
-            "api_key": creds.get("api_key", ""),
-            "source": creds.get("source", "env"),
-            "requested_provider": requested_provider,
-        }
-
     # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -534,6 +534,34 @@ def test_minimax_explicit_api_mode_respected(monkeypatch):
     assert resolved["api_mode"] == "chat_completions"
 
 
+def test_alibaba_default_anthropic_endpoint_uses_anthropic_messages(monkeypatch):
+    """Alibaba with default /apps/anthropic URL should use anthropic_messages mode."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+    monkeypatch.delenv("DASHSCOPE_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://dashscope-intl.aliyuncs.com/apps/anthropic"
+
+
+def test_alibaba_openai_compatible_v1_endpoint_stays_chat_completions(monkeypatch):
+    """Alibaba with /v1 coding endpoint should use chat_completions mode."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+    monkeypatch.setenv("DASHSCOPE_BASE_URL", "https://coding-intl.dashscope.aliyuncs.com/v1")
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://coding-intl.dashscope.aliyuncs.com/v1"
+
+
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     """Custom providers should accept api_mode: anthropic_messages."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-anthropic-proxy")


### PR DESCRIPTION
## Summary
Based on PR #2024 by @kshitijk4poor, applied manually onto current main.

The Alibaba provider had a hardcoded branch in `resolve_runtime_provider()` that always forced `api_mode='anthropic_messages'`, regardless of the configured base URL. This broke the OpenAI-compatible DashScope coding endpoint (`/v1`) because setup saved the URL correctly but runtime forced Anthropic mode.

### Fix
Removes the Alibaba-specific branch and lets it go through the generic API-key provider path, which already handles mode detection correctly:
- Default URL `/apps/anthropic` → detected by `endswith('/anthropic')` → `anthropic_messages`
- Coding URL `/v1` → no match → `chat_completions` (correct)

### Tests
2 new tests verifying both Alibaba endpoint modes.

## Verification
- Runtime provider tests: 31/31 passed

## Credit
Original work by @kshitijk4poor in #2024. Contributor authorship preserved.