### PR TITLE
fix: replace production print() calls with logger in rl_training_tool (salvage #1981)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -381,19 +381,6 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
-    # Alibaba Cloud / DashScope (Anthropic-compatible endpoint)
-    if provider == "alibaba":
-        creds = resolve_api_key_provider_credentials(provider)
-        base_url = creds.get("base_url", "").rstrip("/") or "https://dashscope-intl.aliyuncs.com/apps/anthropic"
-        return {
-            "provider": "alibaba",
-            "api_mode": "anthropic_messages",
-            "base_url": base_url,
-            "api_key": creds.get("api_key", ""),
-            "source": creds.get("source", "env"),
-            "requested_provider": requested_provider,
-        }
-
     # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":

--- a/skills/productivity/ocr-and-documents/SKILL.md
+++ b/skills/productivity/ocr-and-documents/SKILL.md
@@ -122,6 +122,44 @@ web_extract(urls=["https://arxiv.org/pdf/2402.03300"])
 web_search(query="arxiv GRPO reinforcement learning 2026")
 ```
 
+## Split, Merge & Search
+
+pymupdf handles these natively — use `execute_code` or inline Python:
+
+```python
+# Split: extract pages 1-5 to a new PDF
+import pymupdf
+doc = pymupdf.open("report.pdf")
+new = pymupdf.open()
+for i in range(5):
+    new.insert_pdf(doc, from_page=i, to_page=i)
+new.save("pages_1-5.pdf")
+```
+
+```python
+# Merge multiple PDFs
+import pymupdf
+result = pymupdf.open()
+for path in ["a.pdf", "b.pdf", "c.pdf"]:
+    result.insert_pdf(pymupdf.open(path))
+result.save("merged.pdf")
+```
+
+```python
+# Search for text across all pages
+import pymupdf
+doc = pymupdf.open("report.pdf")
+for i, page in enumerate(doc):
+    results = page.search_for("revenue")
+    if results:
+        print(f"Page {i+1}: {len(results)} match(es)")
+        print(page.get_text("text"))
+```
+
+No extra dependencies needed — pymupdf covers split, merge, search, and text extraction in one package.
+
+---
+
 ## Notes
 
 - `web_extract` is always first choice for URLs

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -534,6 +534,34 @@ def test_minimax_explicit_api_mode_respected(monkeypatch):
     assert resolved["api_mode"] == "chat_completions"
 
 
+def test_alibaba_default_anthropic_endpoint_uses_anthropic_messages(monkeypatch):
+    """Alibaba with default /apps/anthropic URL should use anthropic_messages mode."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+    monkeypatch.delenv("DASHSCOPE_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://dashscope-intl.aliyuncs.com/apps/anthropic"
+
+
+def test_alibaba_openai_compatible_v1_endpoint_stays_chat_completions(monkeypatch):
+    """Alibaba with /v1 coding endpoint should use chat_completions mode."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+    monkeypatch.setenv("DASHSCOPE_BASE_URL", "https://coding-intl.dashscope.aliyuncs.com/v1")
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://coding-intl.dashscope.aliyuncs.com/v1"
+
+
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     """Custom providers should accept api_mode: anthropic_messages."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-anthropic-proxy")

--- a/tools/rl_training_tool.py
+++ b/tools/rl_training_tool.py
@@ -37,11 +37,14 @@ import subprocess
 import sys
 import time
 import uuid
+import logging
 from datetime import datetime
 import yaml
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 # ============================================================================
 # Path Configuration
@@ -206,7 +209,7 @@ def _scan_environments() -> List[EnvironmentInfo]:
                             ))
                             break
         except Exception as e:
-            print(f"Warning: Could not parse {py_file}: {e}")
+            logger.warning("Could not parse %s: %s", py_file, e)
     
     return environments
 
@@ -243,7 +246,7 @@ def _get_env_config_fields(env_file_path: str) -> Dict[str, Dict[str, Any]]:
             config_class = type(env_config)
         except Exception as config_error:
             # Fallback: try to import BaseEnvConfig directly from atroposlib
-            print(f"Note: config_init failed ({config_error}), using BaseEnvConfig defaults")
+            logger.info("config_init failed (%s), using BaseEnvConfig defaults", config_error)
             try:
                 from atroposlib.envs.base import BaseEnvConfig
                 config_class = BaseEnvConfig
@@ -291,7 +294,7 @@ def _get_env_config_fields(env_file_path: str) -> Dict[str, Dict[str, Any]]:
         return fields
         
     except Exception as e:
-        print(f"Warning: Could not introspect environment config: {e}")
+        logger.warning("Could not introspect environment config: %s", e)
         return {}
 
 
@@ -324,7 +327,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
     
     try:
         # Step 1: Start the Atropos API server (run-api)
-        print(f"[{run_id}] Starting Atropos API server (run-api)...")
+        logger.info("[%s] Starting Atropos API server (run-api)...", run_id)
         
         # File must stay open while the subprocess runs; we store the handle
         # on run_state so _stop_training_run() can close it when done.
@@ -346,10 +349,10 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
             _stop_training_run(run_state)
             return
         
-        print(f"[{run_id}] Atropos API server started")
+        logger.info("[%s] Atropos API server started", run_id)
         
         # Step 2: Start the Tinker trainer
-        print(f"[{run_id}] Starting Tinker trainer: launch_training.py --config {config_path}")
+        logger.info("[%s] Starting Tinker trainer: launch_training.py --config %s", run_id, config_path)
         
         trainer_log_file = open(trainer_log, "w")  # closed by _stop_training_run
         run_state.trainer_log_file = trainer_log_file
@@ -362,7 +365,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         )
         
         # Wait for trainer to initialize (it starts FastAPI inference server on 8001)
-        print(f"[{run_id}] Waiting 30 seconds for trainer to initialize...")
+        logger.info("[%s] Waiting 30 seconds for trainer to initialize...", run_id)
         await asyncio.sleep(30)
         
         if run_state.trainer_process.poll() is not None:
@@ -371,10 +374,10 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
             _stop_training_run(run_state)
             return
         
-        print(f"[{run_id}] Trainer started, inference server on port 8001")
+        logger.info("[%s] Trainer started, inference server on port 8001", run_id)
         
         # Step 3: Start the environment
-        print(f"[{run_id}] Waiting 90 more seconds before starting environment...")
+        logger.info("[%s] Waiting 90 more seconds before starting environment...", run_id)
         await asyncio.sleep(90)
         
         # Find the environment file
@@ -390,7 +393,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
             _stop_training_run(run_state)
             return
         
-        print(f"[{run_id}] Starting environment: {env_info.file_path} serve")
+        logger.info("[%s] Starting environment: %s serve", run_id, env_info.file_path)
         
         env_log_file = open(env_log, "w")  # closed by _stop_training_run
         run_state.env_log_file = env_log_file
@@ -412,7 +415,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         
         run_state.status = "running"
         run_state.start_time = time.time()
-        print(f"[{run_id}] Training run started successfully!")
+        logger.info("[%s] Training run started successfully!", run_id)
         
         # Start background monitoring
         asyncio.create_task(_monitor_training_run(run_state))
@@ -460,7 +463,7 @@ def _stop_training_run(run_state: RunState):
     """Stop all processes for a training run."""
     # Stop in reverse order: env -> trainer -> api
     if run_state.env_process and run_state.env_process.poll() is None:
-        print(f"[{run_state.run_id}] Stopping environment process...")
+        logger.info("[%s] Stopping environment process...", run_state.run_id)
         run_state.env_process.terminate()
         try:
             run_state.env_process.wait(timeout=10)
@@ -468,7 +471,7 @@ def _stop_training_run(run_state: RunState):
             run_state.env_process.kill()
     
     if run_state.trainer_process and run_state.trainer_process.poll() is None:
-        print(f"[{run_state.run_id}] Stopping trainer process...")
+        logger.info("[%s] Stopping trainer process...", run_state.run_id)
         run_state.trainer_process.terminate()
         try:
             run_state.trainer_process.wait(timeout=10)
@@ -476,7 +479,7 @@ def _stop_training_run(run_state: RunState):
             run_state.trainer_process.kill()
     
     if run_state.api_process and run_state.api_process.poll() is None:
-        print(f"[{run_state.run_id}] Stopping API server...")
+        logger.info("[%s] Stopping API server...", run_state.run_id)
         run_state.api_process.terminate()
         try:
             run_state.api_process.wait(timeout=10)


### PR DESCRIPTION
## Summary
Salvage of PR #1981 by @memosr, cherry-picked onto current main.

Replaces bare `print()` calls in production code paths of `tools/rl_training_tool.py` with proper `logger.info()` and `logger.warning()` calls. Adds `import logging` and module-level logger.

The remaining `print()` calls in `rl_test_inference()` are intentional interactive output and were correctly left alone by the contributor.

## Verification
- rl_training_tool tests: 12/12 passed

## Credit
Original work by @memosr in #1981. Contributor authorship preserved via cherry-pick.