### PR TITLE
fix: /stop command crash + UnboundLocalError in streaming media delivery

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2328,10 +2328,9 @@ class HermesCLI:
         Inspired by OpenAI Codex's separation of interrupt (stop current turn)
         from /stop (clean up background processes). See openai/codex#14602.
         """
-        from tools.process_registry import get_registry
+        from tools.process_registry import process_registry
 
-        registry = get_registry()
-        processes = registry.list_processes()
+        processes = process_registry.list_sessions()
         running = [p for p in processes if p.get("status") == "running"]
 
         if not running:
@@ -2339,7 +2338,7 @@ class HermesCLI:
             return
 
         print(f"  Stopping {len(running)} background process(es)...")
-        killed = registry.kill_all()
+        killed = process_registry.kill_all()
         print(f"  ✅ Stopped {killed} process(es).")
 
     def _handle_paste_command(self):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2317,9 +2317,11 @@ class GatewayRunner:
             # delivered without this.
             if agent_result.get("already_sent"):
                 if response:
-                    await self._deliver_media_from_response(
-                        response, event, adapter,
-                    )
+                    _media_adapter = self.adapters.get(source.platform)
+                    if _media_adapter:
+                        await self._deliver_media_from_response(
+                            response, event, _media_adapter,
+                        )
                 return None
 
             return response


### PR DESCRIPTION
Two fixes from the open PR scan:

**1. /stop crashes with ImportError (#2458)**
CLI imported non-existent `get_registry()` from `process_registry`. Fixed to use the actual `process_registry` singleton and `list_sessions()` method.

**2. Streaming media delivery uses undefined variable (#2424)**
Our PR #2382 called `_deliver_media_from_response(adapter=adapter)` but `adapter` wasn't defined in that scope — it would crash with `UnboundLocalError` when streaming mode delivered MEDIA: tags. Fixed to resolve via `self.adapters.get(source.platform)`.

2 files, +8/-7.