### PR TITLE
fix(compression): remove hardcoded gemini-3-flash-preview as default summary model

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -180,7 +180,7 @@ def load_cli_config() -> Dict[str, Any]:
         "compression": {
             "enabled": True,      # Auto-compress when approaching context limit
             "threshold": 0.50,    # Compress at 50% of model's context limit
-            "summary_model": "google/gemini-3-flash-preview",  # Fast/cheap model for summaries
+            "summary_model": "",  # Model for summaries (empty = use main model)
         },
         "smart_model_routing": {
             "enabled": False,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -159,7 +159,7 @@ DEFAULT_CONFIG = {
     "compression": {
         "enabled": True,
         "threshold": 0.50,
-        "summary_model": "google/gemini-3-flash-preview",
+        "summary_model": "",  # empty = use main configured model
         "summary_provider": "auto",
         "summary_base_url": None,
     },
@@ -1659,7 +1659,8 @@ def show_config():
     print(f"  Enabled:      {'yes' if enabled else 'no'}")
     if enabled:
         print(f"  Threshold:    {compression.get('threshold', 0.50) * 100:.0f}%")
-        print(f"  Model:        {compression.get('summary_model', 'google/gemini-3-flash-preview')}")
+        _sm = compression.get('summary_model', '') or '(main model)'
+        print(f"  Model:        {_sm}")
         comp_provider = compression.get('summary_provider', 'auto')
         if comp_provider != 'auto':
             print(f"  Provider:     {comp_provider}")


### PR DESCRIPTION
Salvage of PR #2457 by @Mibayy. Fixes #2453.

The default config hardcoded `google/gemini-3-flash-preview` as the compression summary model, causing unexpected OpenRouter charges for users on other providers. Now defaults to empty string, which falls through to the user's configured main model.

Users who want a dedicated cheap model can still set it explicitly in config.yaml.