### PR TITLE
fix(gateway): process /queue'd messages after agent completion

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5209,22 +5209,31 @@ class GatewayRunner:
                     self._effective_model = None
                     self._effective_provider = None
 
-            # Check if we were interrupted and have a pending message
+            # Check if we were interrupted OR have a queued message (/queue).
             result = result_holder[0]
             adapter = self.adapters.get(source.platform)
             
-            # Get pending message from adapter if interrupted.
+            # Get pending message from adapter.
             # Use session_key (not source.chat_id) to match adapter's storage keys.
             pending = None
-            if result and result.get("interrupted") and adapter:
-                pending_event = adapter.get_pending_message(session_key) if session_key else None
-                if pending_event:
-                    pending = pending_event.text
-                elif result.get("interrupt_message"):
-                    pending = result.get("interrupt_message")
+            if result and adapter and session_key:
+                if result.get("interrupted"):
+                    # Interrupted — consume the interrupt message
+                    pending_event = adapter.get_pending_message(session_key)
+                    if pending_event:
+                        pending = pending_event.text
+                    elif result.get("interrupt_message"):
+                        pending = result.get("interrupt_message")
+                else:
+                    # Normal completion — check for /queue'd messages that were
+                    # stored without triggering an interrupt.
+                    pending_event = adapter.get_pending_message(session_key)
+                    if pending_event:
+                        pending = pending_event.text
+                        logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
             
             if pending:
-                logger.debug("Processing interrupted message: '%s...'", pending[:40])
+                logger.debug("Processing pending message: '%s...'", pending[:40])
                 
                 # Clear the adapter's interrupt event so the next _run_agent call
                 # doesn't immediately re-trigger the interrupt before the new agent
@@ -5246,11 +5255,25 @@ class GatewayRunner:
                         adapter.queue_message(session_key, pending)
                     return result_holder[0] or {"final_response": response, "messages": history}
 
-                # Don't send the interrupted response to the user — it's just noise
-                # like "Operation interrupted." They already know they sent a new
-                # message, so go straight to processing it.
-                
-                # Now process the pending message with updated history
+                was_interrupted = result.get("interrupted")
+                if not was_interrupted:
+                    # Queued message after normal completion — deliver the first
+                    # response before processing the queued follow-up.
+                    # Skip if streaming already delivered it.
+                    _sc = stream_consumer_holder[0]
+                    _already_streamed = _sc and getattr(_sc, "already_sent", False)
+                    first_response = result.get("final_response", "")
+                    if first_response and not _already_streamed:
+                        try:
+                            await adapter.send(source.chat_id, first_response,
+                                               metadata=getattr(event, "metadata", None))
+                        except Exception as e:
+                            logger.warning("Failed to send first response before queued message: %s", e)
+                # else: interrupted — discard the interrupted response ("Operation
+                # interrupted." is just noise; the user already knows they sent a
+                # new message).
+
+                # Process the pending message with updated history
                 updated_history = result.get("messages", history)
                 return await self._run_agent(
                     message=pending,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -381,19 +381,6 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
-    # Alibaba Cloud / DashScope (Anthropic-compatible endpoint)
-    if provider == "alibaba":
-        creds = resolve_api_key_provider_credentials(provider)
-        base_url = creds.get("base_url", "").rstrip("/") or "https://dashscope-intl.aliyuncs.com/apps/anthropic"
-        return {
-            "provider": "alibaba",
-            "api_mode": "anthropic_messages",
-            "base_url": base_url,
-            "api_key": creds.get("api_key", ""),
-            "source": creds.get("source", "env"),
-            "requested_provider": requested_provider,
-        }
-
     # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":

--- a/skills/productivity/ocr-and-documents/SKILL.md
+++ b/skills/productivity/ocr-and-documents/SKILL.md
@@ -122,6 +122,44 @@ web_extract(urls=["https://arxiv.org/pdf/2402.03300"])
 web_search(query="arxiv GRPO reinforcement learning 2026")
 ```
 
+## Split, Merge & Search
+
+pymupdf handles these natively — use `execute_code` or inline Python:
+
+```python
+# Split: extract pages 1-5 to a new PDF
+import pymupdf
+doc = pymupdf.open("report.pdf")
+new = pymupdf.open()
+for i in range(5):
+    new.insert_pdf(doc, from_page=i, to_page=i)
+new.save("pages_1-5.pdf")
+```
+
+```python
+# Merge multiple PDFs
+import pymupdf
+result = pymupdf.open()
+for path in ["a.pdf", "b.pdf", "c.pdf"]:
+    result.insert_pdf(pymupdf.open(path))
+result.save("merged.pdf")
+```
+
+```python
+# Search for text across all pages
+import pymupdf
+doc = pymupdf.open("report.pdf")
+for i, page in enumerate(doc):
+    results = page.search_for("revenue")
+    if results:
+        print(f"Page {i+1}: {len(results)} match(es)")
+        print(page.get_text("text"))
+```
+
+No extra dependencies needed — pymupdf covers split, merge, search, and text extraction in one package.
+
+---
+
 ## Notes
 
 - `web_extract` is always first choice for URLs

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -1,0 +1,165 @@
+"""Tests for /queue message consumption after normal agent completion.
+
+Verifies that messages queued via /queue (which store in
+adapter._pending_messages WITHOUT triggering an interrupt) are consumed
+after the agent finishes its current task — not silently dropped.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    PlatformConfig,
+    Platform,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal adapter for testing pending message storage
+# ---------------------------------------------------------------------------
+
+class _StubAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        from gateway.platforms.base import SendResult
+        return SendResult(success=True, message_id="msg-1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestQueueMessageStorage:
+    """Verify /queue stores messages correctly in adapter._pending_messages."""
+
+    def test_queue_stores_message_in_pending(self):
+        adapter = _StubAdapter()
+        session_key = "telegram:user:123"
+        event = MessageEvent(
+            text="do this next",
+            message_type=MessageType.TEXT,
+            source=MagicMock(chat_id="123", platform=Platform.TELEGRAM),
+            message_id="q1",
+        )
+        adapter._pending_messages[session_key] = event
+
+        assert session_key in adapter._pending_messages
+        assert adapter._pending_messages[session_key].text == "do this next"
+
+    def test_get_pending_message_consumes_and_clears(self):
+        adapter = _StubAdapter()
+        session_key = "telegram:user:123"
+        event = MessageEvent(
+            text="queued prompt",
+            message_type=MessageType.TEXT,
+            source=MagicMock(chat_id="123", platform=Platform.TELEGRAM),
+            message_id="q2",
+        )
+        adapter._pending_messages[session_key] = event
+
+        retrieved = adapter.get_pending_message(session_key)
+        assert retrieved is not None
+        assert retrieved.text == "queued prompt"
+        # Should be consumed (cleared)
+        assert adapter.get_pending_message(session_key) is None
+
+    def test_queue_does_not_set_interrupt_event(self):
+        """The whole point of /queue — no interrupt signal."""
+        adapter = _StubAdapter()
+        session_key = "telegram:user:123"
+
+        # Simulate an active session (agent running)
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        # Store a queued message (what /queue does)
+        event = MessageEvent(
+            text="queued",
+            message_type=MessageType.TEXT,
+            source=MagicMock(),
+            message_id="q3",
+        )
+        adapter._pending_messages[session_key] = event
+
+        # The interrupt event should NOT be set
+        assert not adapter._active_sessions[session_key].is_set()
+        assert not adapter.has_pending_interrupt(session_key)
+
+    def test_regular_message_sets_interrupt_event(self):
+        """Contrast: regular messages DO trigger interrupt."""
+        adapter = _StubAdapter()
+        session_key = "telegram:user:123"
+
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        # Simulate regular message arrival (what handle_message does)
+        event = MessageEvent(
+            text="new message",
+            message_type=MessageType.TEXT,
+            source=MagicMock(),
+            message_id="m1",
+        )
+        adapter._pending_messages[session_key] = event
+        adapter._active_sessions[session_key].set()  # this is what handle_message does
+
+        assert adapter.has_pending_interrupt(session_key)
+
+
+class TestQueueConsumptionAfterCompletion:
+    """Verify that pending messages are consumed after normal completion."""
+
+    def test_pending_message_available_after_normal_completion(self):
+        """After agent finishes without interrupt, pending message should
+        still be retrievable from adapter._pending_messages."""
+        adapter = _StubAdapter()
+        session_key = "telegram:user:123"
+
+        # Simulate: agent starts, /queue stores a message, agent finishes
+        adapter._active_sessions[session_key] = asyncio.Event()
+        event = MessageEvent(
+            text="process this after",
+            message_type=MessageType.TEXT,
+            source=MagicMock(),
+            message_id="q4",
+        )
+        adapter._pending_messages[session_key] = event
+
+        # Agent finishes (no interrupt)
+        del adapter._active_sessions[session_key]
+
+        # The queued message should still be retrievable
+        retrieved = adapter.get_pending_message(session_key)
+        assert retrieved is not None
+        assert retrieved.text == "process this after"
+
+    def test_multiple_queues_last_one_wins(self):
+        """If user /queue's multiple times, last message overwrites."""
+        adapter = _StubAdapter()
+        session_key = "telegram:user:123"
+
+        for text in ["first", "second", "third"]:
+            event = MessageEvent(
+                text=text,
+                message_type=MessageType.TEXT,
+                source=MagicMock(),
+                message_id=f"q-{text}",
+            )
+            adapter._pending_messages[session_key] = event
+
+        retrieved = adapter.get_pending_message(session_key)
+        assert retrieved.text == "third"

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -534,6 +534,34 @@ def test_minimax_explicit_api_mode_respected(monkeypatch):
     assert resolved["api_mode"] == "chat_completions"
 
 
+def test_alibaba_default_anthropic_endpoint_uses_anthropic_messages(monkeypatch):
+    """Alibaba with default /apps/anthropic URL should use anthropic_messages mode."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+    monkeypatch.delenv("DASHSCOPE_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://dashscope-intl.aliyuncs.com/apps/anthropic"
+
+
+def test_alibaba_openai_compatible_v1_endpoint_stays_chat_completions(monkeypatch):
+    """Alibaba with /v1 coding endpoint should use chat_completions mode."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+    monkeypatch.setenv("DASHSCOPE_BASE_URL", "https://coding-intl.dashscope.aliyuncs.com/v1")
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://coding-intl.dashscope.aliyuncs.com/v1"
+
+
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     """Custom providers should accept api_mode: anthropic_messages."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-anthropic-proxy")

--- a/tools/rl_training_tool.py
+++ b/tools/rl_training_tool.py
@@ -37,11 +37,14 @@ import subprocess
 import sys
 import time
 import uuid
+import logging
 from datetime import datetime
 import yaml
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 # ============================================================================
 # Path Configuration
@@ -206,7 +209,7 @@ def _scan_environments() -> List[EnvironmentInfo]:
                             ))
                             break
         except Exception as e:
-            print(f"Warning: Could not parse {py_file}: {e}")
+            logger.warning("Could not parse %s: %s", py_file, e)
     
     return environments
 
@@ -243,7 +246,7 @@ def _get_env_config_fields(env_file_path: str) -> Dict[str, Dict[str, Any]]:
             config_class = type(env_config)
         except Exception as config_error:
             # Fallback: try to import BaseEnvConfig directly from atroposlib
-            print(f"Note: config_init failed ({config_error}), using BaseEnvConfig defaults")
+            logger.info("config_init failed (%s), using BaseEnvConfig defaults", config_error)
             try:
                 from atroposlib.envs.base import BaseEnvConfig
                 config_class = BaseEnvConfig
@@ -291,7 +294,7 @@ def _get_env_config_fields(env_file_path: str) -> Dict[str, Dict[str, Any]]:
         return fields
         
     except Exception as e:
-        print(f"Warning: Could not introspect environment config: {e}")
+        logger.warning("Could not introspect environment config: %s", e)
         return {}
 
 
@@ -324,7 +327,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
     
     try:
         # Step 1: Start the Atropos API server (run-api)
-        print(f"[{run_id}] Starting Atropos API server (run-api)...")
+        logger.info("[%s] Starting Atropos API server (run-api)...", run_id)
         
         # File must stay open while the subprocess runs; we store the handle
         # on run_state so _stop_training_run() can close it when done.
@@ -346,10 +349,10 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
             _stop_training_run(run_state)
             return
         
-        print(f"[{run_id}] Atropos API server started")
+        logger.info("[%s] Atropos API server started", run_id)
         
         # Step 2: Start the Tinker trainer
-        print(f"[{run_id}] Starting Tinker trainer: launch_training.py --config {config_path}")
+        logger.info("[%s] Starting Tinker trainer: launch_training.py --config %s", run_id, config_path)
         
         trainer_log_file = open(trainer_log, "w")  # closed by _stop_training_run
         run_state.trainer_log_file = trainer_log_file
@@ -362,7 +365,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         )
         
         # Wait for trainer to initialize (it starts FastAPI inference server on 8001)
-        print(f"[{run_id}] Waiting 30 seconds for trainer to initialize...")
+        logger.info("[%s] Waiting 30 seconds for trainer to initialize...", run_id)
         await asyncio.sleep(30)
         
         if run_state.trainer_process.poll() is not None:
@@ -371,10 +374,10 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
             _stop_training_run(run_state)
             return
         
-        print(f"[{run_id}] Trainer started, inference server on port 8001")
+        logger.info("[%s] Trainer started, inference server on port 8001", run_id)
         
         # Step 3: Start the environment
-        print(f"[{run_id}] Waiting 90 more seconds before starting environment...")
+        logger.info("[%s] Waiting 90 more seconds before starting environment...", run_id)
         await asyncio.sleep(90)
         
         # Find the environment file
@@ -390,7 +393,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
             _stop_training_run(run_state)
             return
         
-        print(f"[{run_id}] Starting environment: {env_info.file_path} serve")
+        logger.info("[%s] Starting environment: %s serve", run_id, env_info.file_path)
         
         env_log_file = open(env_log, "w")  # closed by _stop_training_run
         run_state.env_log_file = env_log_file
@@ -412,7 +415,7 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         
         run_state.status = "running"
         run_state.start_time = time.time()
-        print(f"[{run_id}] Training run started successfully!")
+        logger.info("[%s] Training run started successfully!", run_id)
         
         # Start background monitoring
         asyncio.create_task(_monitor_training_run(run_state))
@@ -460,7 +463,7 @@ def _stop_training_run(run_state: RunState):
     """Stop all processes for a training run."""
     # Stop in reverse order: env -> trainer -> api
     if run_state.env_process and run_state.env_process.poll() is None:
-        print(f"[{run_state.run_id}] Stopping environment process...")
+        logger.info("[%s] Stopping environment process...", run_state.run_id)
         run_state.env_process.terminate()
         try:
             run_state.env_process.wait(timeout=10)
@@ -468,7 +471,7 @@ def _stop_training_run(run_state: RunState):
             run_state.env_process.kill()
     
     if run_state.trainer_process and run_state.trainer_process.poll() is None:
-        print(f"[{run_state.run_id}] Stopping trainer process...")
+        logger.info("[%s] Stopping trainer process...", run_state.run_id)
         run_state.trainer_process.terminate()
         try:
             run_state.trainer_process.wait(timeout=10)
@@ -476,7 +479,7 @@ def _stop_training_run(run_state: RunState):
             run_state.trainer_process.kill()
     
     if run_state.api_process and run_state.api_process.poll() is None:
-        print(f"[{run_state.run_id}] Stopping API server...")
+        logger.info("[%s] Stopping API server...", run_state.run_id)
         run_state.api_process.terminate()
         try:
             run_state.api_process.wait(timeout=10)


### PR DESCRIPTION
## Problem

`/queue` stored messages in `adapter._pending_messages` but never consumed them after normal agent completion. The consumption path only checked pending messages when `result.get('interrupted')` was True. Since `/queue` deliberately doesn't set the interrupt event, queued messages were silently dropped.

The message would sit in `_pending_messages` until either overwritten by a real interrupt (causing out-of-context delivery) or cleared by `/reset`.

Reported by GhostMode on Discord.

## Fix

After agent completion, check `adapter._pending_messages` regardless of interrupt status:

- **Interrupted**: consume pending message and recurse (existing behavior, unchanged)
- **Normal completion with queued message**: deliver the first response, then recurse to process the queued follow-up
- **Normal completion, no queue**: no change

For queued messages, the first response must be delivered before recursing (unlike interrupts where the first response is discarded as noise). Checks `stream_consumer.already_sent` to avoid double-delivery when streaming is active.

## Changes

`gateway/run.py` `_run_agent()`:
- Broadened pending message check from `if interrupted` to `if interrupted OR normal completion`
- Added direct `adapter.send()` for queued message path (with streaming guard)
- Updated log messages to say "pending" instead of "interrupted"

## Verification
- Gateway tests: 1330 passed (10 pre-existing failures identical to main)