### PR TITLE
fix(telegram): recover polling after network interruption

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -130,6 +130,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._token_lock_identity: Optional[str] = None
         self._polling_error_task: Optional[asyncio.Task] = None
         self._polling_conflict_count: int = 0
+        self._polling_runtime_error_count: int = 0
         self._polling_error_callback_ref = None
 
     @staticmethod
@@ -139,6 +140,37 @@ class TelegramAdapter(BasePlatformAdapter):
             error.__class__.__name__.lower() == "conflict"
             or "terminated by other getupdates request" in text
             or "another bot instance is running" in text
+        )
+
+    @staticmethod
+    def _looks_like_network_error(error: Exception) -> bool:
+        if isinstance(error, (asyncio.TimeoutError, TimeoutError, OSError, ConnectionError)):
+            return True
+        error_name = error.__class__.__name__.lower()
+        if error_name in {"networkerror", "timedout"}:
+            return True
+        text = str(error).lower()
+        return any(
+            marker in text
+            for marker in (
+                "temporary failure in name resolution",
+                "network is unreachable",
+                "connection reset",
+                "connection aborted",
+                "connection refused",
+                "timed out",
+                "timeout",
+                "tls",
+                "ssl",
+                "reset by peer",
+            )
+        )
+
+    async def _restart_polling(self, *, drop_pending_updates: bool) -> None:
+        await self._app.updater.start_polling(
+            allowed_updates=Update.ALL_TYPES,
+            drop_pending_updates=drop_pending_updates,
+            error_callback=self._polling_error_callback_ref,
         )
 
     async def _handle_polling_conflict(self, error: Exception) -> None:
@@ -167,11 +199,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 pass
             await asyncio.sleep(RETRY_DELAY)
             try:
-                await self._app.updater.start_polling(
-                    allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=False,
-                    error_callback=self._polling_error_callback_ref,
-                )
+                await self._restart_polling(drop_pending_updates=False)
                 logger.info("[%s] Telegram polling resumed after conflict retry %d", self.name, self._polling_conflict_count)
                 self._polling_conflict_count = 0  # reset on success
                 return
@@ -195,6 +223,50 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._app.updater.stop()
         except Exception as stop_error:
             logger.warning("[%s] Failed stopping Telegram polling after conflict: %s", self.name, stop_error, exc_info=True)
+        await self._notify_fatal_error()
+
+    async def _handle_polling_network_error(self, error: Exception) -> None:
+        if self.has_fatal_error:
+            return
+
+        self._polling_runtime_error_count += 1
+        max_retries = 10
+        retry_delay = min(60, 5 * (2 ** (self._polling_runtime_error_count - 1)))
+
+        logger.warning(
+            "[%s] Telegram polling network error (%d/%d), retrying in %ds. Error: %s",
+            self.name,
+            self._polling_runtime_error_count,
+            max_retries,
+            retry_delay,
+            error,
+        )
+
+        try:
+            if self._app and self._app.updater and self._app.updater.running:
+                await self._app.updater.stop()
+        except Exception as stop_error:
+            logger.warning("[%s] Failed stopping Telegram polling before restart: %s", self.name, stop_error, exc_info=True)
+
+        await asyncio.sleep(retry_delay)
+
+        try:
+            await self._restart_polling(drop_pending_updates=False)
+            logger.info("[%s] Telegram polling resumed after network error", self.name)
+            self._polling_runtime_error_count = 0
+            self._mark_connected()
+            return
+        except Exception as retry_err:
+            logger.warning("[%s] Telegram polling restart failed: %s", self.name, retry_err)
+
+        if self._polling_runtime_error_count <= max_retries:
+            return
+
+        message = (
+            "Telegram polling stopped after repeated network reconnect attempts. "
+            f"Last error: {error}"
+        )
+        self._set_fatal_error("telegram_polling_reconnect_failed", message, retryable=True)
         await self._notify_fatal_error()
 
     async def connect(self) -> bool:
@@ -276,21 +348,20 @@ class TelegramAdapter(BasePlatformAdapter):
             loop = asyncio.get_running_loop()
 
             def _polling_error_callback(error: Exception) -> None:
-                if not self._looks_like_polling_conflict(error):
-                    logger.error("[%s] Telegram polling error: %s", self.name, error, exc_info=True)
-                    return
                 if self._polling_error_task and not self._polling_error_task.done():
                     return
-                self._polling_error_task = loop.create_task(self._handle_polling_conflict(error))
+                if self._looks_like_polling_conflict(error):
+                    self._polling_error_task = loop.create_task(self._handle_polling_conflict(error))
+                    return
+                if self._looks_like_network_error(error):
+                    self._polling_error_task = loop.create_task(self._handle_polling_network_error(error))
+                    return
+                logger.error("[%s] Telegram polling error: %s", self.name, error, exc_info=True)
 
             # Store reference for retry use in _handle_polling_conflict
             self._polling_error_callback_ref = _polling_error_callback
 
-            await self._app.updater.start_polling(
-                allowed_updates=Update.ALL_TYPES,
-                drop_pending_updates=True,
-                error_callback=_polling_error_callback,
-            )
+            await self._restart_polling(drop_pending_updates=True)
             
             # Register bot commands so Telegram shows a hint menu when users type /
             # List is derived from the central COMMAND_REGISTRY — adding a new

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -385,23 +385,35 @@ class SlashCommandCompleter(Completer):
         """
         if not text:
             return None
-        # Walk backwards to find the start of the current "word".
-        # Words are delimited by spaces, but paths can contain almost anything.
-        i = len(text) - 1
-        while i >= 0 and text[i] != " ":
-            i -= 1
-        word = text[i + 1:]
+        word = SlashCommandCompleter._last_shell_token(text)
         if not word:
             return None
-        # Only trigger path completion for path-like tokens
-        if word.startswith(("./", "../", "~/", "/")) or "/" in word:
+        parsed = SlashCommandCompleter._parse_path_token(word)
+        if parsed and parsed.is_path_like():
             return word
         return None
 
     @staticmethod
+    def _extract_context_word(text: str) -> str | None:
+        """Extract a bare ``@`` context token for Claude Code-style suggestions."""
+        if not text:
+            return None
+        word = SlashCommandCompleter._last_shell_token(text)
+        if not word.startswith("@"):
+            return None
+        if word.startswith(("@file:", "@folder:")):
+            return None
+        return word
+
+    @staticmethod
     def _path_completions(word: str, limit: int = 30):
         """Yield Completion objects for file paths matching *word*."""
-        expanded = os.path.expanduser(word)
+        parsed = SlashCommandCompleter._parse_path_token(word)
+        if parsed is None:
+            return
+
+        lookup_word = parsed.lookup_word()
+        expanded = os.path.expanduser(lookup_word)
         # Split into directory part and prefix to match inside it
         if expanded.endswith("/"):
             search_dir = expanded
@@ -415,21 +427,19 @@ class SlashCommandCompleter(Completer):
         except OSError:
             return
 
-        count = 0
-        prefix_lower = prefix.lower()
+        matches: list[tuple[tuple[int, int, int, str], Completion]] = []
         for entry in sorted(entries):
-            if prefix and not entry.lower().startswith(prefix_lower):
+            score = SlashCommandCompleter._fuzzy_match_score(entry, prefix)
+            if score is None:
                 continue
-            if count >= limit:
-                break
 
             full_path = os.path.join(search_dir, entry)
             is_dir = os.path.isdir(full_path)
 
             # Build the completion text (what replaces the typed word)
-            if word.startswith("~"):
+            if lookup_word.startswith("~"):
                 display_path = "~/" + os.path.relpath(full_path, os.path.expanduser("~"))
-            elif os.path.isabs(word):
+            elif os.path.isabs(lookup_word):
                 display_path = full_path
             else:
                 # Keep relative
@@ -440,14 +450,169 @@ class SlashCommandCompleter(Completer):
 
             suffix = "/" if is_dir else ""
             meta = "dir" if is_dir else _file_size_label(full_path)
+            completion_text = parsed.render(display_path)
 
-            yield Completion(
-                display_path,
-                start_position=-len(word),
-                display=entry + suffix,
-                display_meta=meta,
+            matches.append((
+                score,
+                Completion(
+                    completion_text,
+                    start_position=-len(word),
+                    display=entry + suffix,
+                    display_meta=meta,
+                ),
             )
-            count += 1
+            )
+
+        for _score, completion in sorted(matches, key=lambda item: item[0])[:limit]:
+            yield completion
+
+    @staticmethod
+    def _context_completions(word: str, limit: int = 30):
+        """Yield Claude Code-style context completions for bare ``@`` tokens."""
+        lowered = word.lower()
+        static_refs = (
+            ("@diff", "Git working tree diff"),
+            ("@staged", "Git staged diff"),
+            ("@file:", "Attach a file"),
+            ("@folder:", "Attach a folder"),
+        )
+
+        for candidate, meta in static_refs:
+            if candidate.lower().startswith(lowered) and candidate.lower() != lowered:
+                yield Completion(
+                    candidate,
+                    start_position=-len(word),
+                    display=candidate,
+                    display_meta=meta,
+                )
+
+        query = word[1:]
+        expanded = os.path.expanduser(query or ".")
+        if expanded.endswith("/"):
+            search_dir = expanded
+            prefix = ""
+        else:
+            search_dir = os.path.dirname(expanded) or "."
+            prefix = os.path.basename(expanded)
+
+        try:
+            entries = os.listdir(search_dir)
+        except OSError:
+            return
+
+        matches: list[tuple[tuple[int, int, int, str], Completion]] = []
+        for entry in sorted(entries):
+            score = SlashCommandCompleter._fuzzy_match_score(entry, prefix)
+            if score is None:
+                continue
+
+            full_path = os.path.join(search_dir, entry)
+            is_dir = os.path.isdir(full_path)
+
+            if query.startswith("~"):
+                display_path = "~/" + os.path.relpath(full_path, os.path.expanduser("~"))
+            elif os.path.isabs(query):
+                display_path = full_path
+            else:
+                display_path = os.path.relpath(full_path)
+
+            completion_text = f"@folder:{display_path}/" if is_dir else f"@file:{display_path}"
+            suffix = "/" if is_dir else ""
+            meta = "context dir" if is_dir else f"context {_file_size_label(full_path)}".strip()
+
+            matches.append((
+                score,
+                Completion(
+                    completion_text,
+                    start_position=-len(word),
+                    display=entry + suffix,
+                    display_meta=meta,
+                ),
+            ))
+
+        for _score, completion in sorted(matches, key=lambda item: item[0])[:limit]:
+            yield completion
+
+    @staticmethod
+    def _last_shell_token(text: str) -> str:
+        """Return the final shell-like token, preserving quotes and escapes."""
+        last_start = 0
+        quote: str | None = None
+        escaped = False
+
+        for i, ch in enumerate(text):
+            if escaped:
+                escaped = False
+                continue
+            if ch == "\\":
+                escaped = True
+                continue
+            if quote:
+                if ch == quote:
+                    quote = None
+                continue
+            if ch in {"'", '"'}:
+                quote = ch
+                continue
+            if ch.isspace():
+                last_start = i + 1
+
+        return text[last_start:]
+
+    @staticmethod
+    def _parse_path_token(word: str) -> "_PathToken | None":
+        prefixes = ("@file:", "@folder:")
+        reference_prefix = ""
+        path_text = word
+        for prefix in prefixes:
+            if word.startswith(prefix):
+                reference_prefix = prefix
+                path_text = word[len(prefix):]
+                break
+
+        quote = ""
+        if path_text.startswith(("'", '"')):
+            quote = path_text[0]
+            path_text = path_text[1:]
+
+        closing_quote = bool(quote) and path_text.endswith(quote)
+        if closing_quote:
+            path_text = path_text[:-1]
+
+        keep_escaped = "\\" in path_text
+        unescaped = re.sub(r"\\(.)", r"\1", path_text)
+
+        token = _PathToken(
+            raw=word,
+            reference_prefix=reference_prefix,
+            quote=quote,
+            close_quote=closing_quote,
+            keep_escaped=keep_escaped,
+            path=unescaped,
+        )
+        return token if token.is_path_like() else None
+
+    @staticmethod
+    def _fuzzy_match_score(candidate: str, query: str) -> tuple[int, int, int, str] | None:
+        """Return a sortable fuzzy-match score or None when there is no match."""
+        normalized_candidate = re.sub(r"[^a-z0-9]", "", candidate.lower())
+        normalized_query = re.sub(r"[^a-z0-9]", "", query.lower())
+
+        if not normalized_query:
+            return (0, 0, len(normalized_candidate), candidate.lower())
+
+        positions: list[int] = []
+        idx = 0
+        for ch in normalized_query:
+            found = normalized_candidate.find(ch, idx)
+            if found == -1:
+                return None
+            positions.append(found)
+            idx = found + 1
+
+        start = positions[0]
+        span = positions[-1] - positions[0] + 1
+        return (start, span, len(normalized_candidate), candidate.lower())
 
     def get_completions(self, document, complete_event):
         text = document.text_before_cursor
@@ -456,6 +621,10 @@ class SlashCommandCompleter(Completer):
             path_word = self._extract_path_word(text)
             if path_word is not None:
                 yield from self._path_completions(path_word)
+                return
+            context_word = self._extract_context_word(text)
+            if context_word is not None:
+                yield from self._context_completions(context_word)
             return
 
         # Check if we're completing a subcommand (base command already typed)
@@ -545,6 +714,34 @@ class SlashCommandCompleter(Completer):
                     display=cmd,
                     display_meta=f"⚡ {short_desc}",
                 )
+
+
+@dataclass(frozen=True)
+class _PathToken:
+    raw: str
+    reference_prefix: str = ""
+    quote: str = ""
+    close_quote: bool = False
+    keep_escaped: bool = False
+    path: str = ""
+
+    def is_path_like(self) -> bool:
+        if self.reference_prefix:
+            return True
+        return self.path.startswith(("./", "../", "~/", "/")) or "/" in self.path
+
+    def lookup_word(self) -> str:
+        return self.path or "."
+
+    def render(self, path: str) -> str:
+        rendered = path
+        if self.keep_escaped:
+            rendered = re.sub(r'([\\\s])', r'\\\1', rendered)
+        if self.quote:
+            rendered = f"{self.quote}{rendered}"
+            if self.close_quote:
+                rendered += self.quote
+        return f"{self.reference_prefix}{rendered}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -29,6 +29,10 @@ _ensure_telegram_mock()
 from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
 
 
+async def _instant_sleep(*_args, **_kwargs):
+    await asyncio.get_running_loop().run_in_executor(None, lambda: None)
+
+
 @pytest.mark.asyncio
 async def test_connect_rejects_same_host_token_lock(monkeypatch):
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="secret-token"))
@@ -86,7 +90,7 @@ async def test_polling_conflict_retries_before_fatal(monkeypatch):
     monkeypatch.setattr("gateway.platforms.telegram.Application", SimpleNamespace(builder=MagicMock(return_value=builder)))
 
     # Speed up retries for testing
-    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
 
     ok = await adapter.connect()
 
@@ -159,7 +163,7 @@ async def test_polling_conflict_becomes_fatal_after_retries(monkeypatch):
     monkeypatch.setattr("gateway.platforms.telegram.Application", SimpleNamespace(builder=MagicMock(return_value=builder)))
 
     # Speed up retries for testing
-    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
 
     ok = await adapter.connect()
     assert ok is True
@@ -182,6 +186,172 @@ async def test_polling_conflict_becomes_fatal_after_retries(monkeypatch):
     )
     assert adapter.has_fatal_error is True
     fatal_handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_conflict_polling_error_restarts_polling(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    captured = {}
+
+    async def fake_start_polling(**kwargs):
+        captured["error_callback"] = kwargs["error_callback"]
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=fake_start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(set_my_commands=AsyncMock())
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr("gateway.platforms.telegram.Application", SimpleNamespace(builder=MagicMock(return_value=builder)))
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    assert callable(captured["error_callback"])
+
+    network_error = type("NetworkError", (Exception,), {})
+    captured["error_callback"](network_error("Temporary failure in name resolution"))
+
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    assert adapter.has_fatal_error is False
+    assert updater.stop.await_count == 1
+    assert updater.start_polling.await_count == 2
+    assert adapter._polling_runtime_error_count == 0
+
+
+@pytest.mark.asyncio
+async def test_non_conflict_polling_error_becomes_retryable_fatal_after_retries(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    captured = {}
+    call_count = {"n": 0}
+
+    async def failing_start_polling(**kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            captured["error_callback"] = kwargs["error_callback"]
+            return
+        raise RuntimeError("Network unreachable")
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=failing_start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(set_my_commands=AsyncMock())
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr("gateway.platforms.telegram.Application", SimpleNamespace(builder=MagicMock(return_value=builder)))
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    ok = await adapter.connect()
+    assert ok is True
+
+    network_error = type("NetworkError", (Exception,), {})
+
+    for _ in range(11):
+        await adapter._handle_polling_network_error(network_error("Network unreachable"))
+
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_code == "telegram_polling_reconnect_failed"
+    assert adapter.fatal_error_retryable is True
+    fatal_handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_network_polling_error_is_logged_without_restart(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    captured = {}
+
+    async def fake_start_polling(**kwargs):
+        captured["error_callback"] = kwargs["error_callback"]
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=fake_start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(set_my_commands=AsyncMock())
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr("gateway.platforms.telegram.Application", SimpleNamespace(builder=MagicMock(return_value=builder)))
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    error_log = MagicMock()
+    monkeypatch.setattr("gateway.platforms.telegram.logger.error", error_log)
+
+    ok = await adapter.connect()
+    assert ok is True
+
+    unknown_error = RuntimeError("unexpected parser failure")
+    captured["error_callback"](unknown_error)
+    await asyncio.sleep(0)
+
+    updater.stop.assert_not_awaited()
+    assert updater.start_polling.await_count == 1
+    assert adapter._polling_runtime_error_count == 0
+    assert adapter.has_fatal_error is False
+    error_log.assert_called()
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -59,6 +59,43 @@ class TestExtractPathWord:
     def test_just_tilde_slash(self):
         assert SlashCommandCompleter._extract_path_word("~/") == "~/"
 
+    def test_quoted_path_with_spaces(self):
+        assert (
+            SlashCommandCompleter._extract_path_word('see "/tmp/Screen Shot 2026')
+            == '"/tmp/Screen Shot 2026'
+        )
+
+    def test_escaped_spaces_path(self):
+        assert (
+            SlashCommandCompleter._extract_path_word(
+                r"see /tmp/Screen\ Shot\ 2026"
+            )
+            == r"/tmp/Screen\ Shot\ 2026"
+        )
+
+    def test_context_file_reference_path(self):
+        assert (
+            SlashCommandCompleter._extract_path_word("review @file:src/ma")
+            == "@file:src/ma"
+        )
+
+    def test_context_folder_reference_path(self):
+        assert (
+            SlashCommandCompleter._extract_path_word("review @folder:src/")
+            == "@folder:src/"
+        )
+
+
+class TestExtractContextWord:
+    def test_bare_context_trigger(self):
+        assert SlashCommandCompleter._extract_context_word("review @") == "@"
+
+    def test_bare_context_path_fragment(self):
+        assert SlashCommandCompleter._extract_context_word("review @src") == "@src"
+
+    def test_explicit_context_file_reference_is_not_bare_trigger(self):
+        assert SlashCommandCompleter._extract_context_word("review @file:src/main.py") is None
+
 
 class TestPathCompletions:
     def test_lists_current_directory(self, tmp_path):
@@ -125,6 +162,103 @@ class TestPathCompletions:
         names = _display_names(completions)
         assert "README.md" in names
 
+    def test_fuzzy_match_non_contiguous_filename(self, tmp_path):
+        (tmp_path / "Screenshot 2026-03-22 at 4.27.40 PM.png").touch()
+        (tmp_path / "notes.txt").touch()
+
+        completions = list(SlashCommandCompleter._path_completions(f"{tmp_path}/scsh"))
+        names = _display_names(completions)
+
+        assert "Screenshot 2026-03-22 at 4.27.40 PM.png" in names
+        assert "notes.txt" not in names
+
+    def test_fuzzy_match_orders_better_match_first(self, tmp_path):
+        (tmp_path / "screen-capture.png").touch()
+        (tmp_path / "super-complex-screenshot.png").touch()
+
+        completions = list(SlashCommandCompleter._path_completions(f"{tmp_path}/scrcap"))
+        names = _display_names(completions)
+
+        assert names[0] == "screen-capture.png"
+
+    def test_preserves_escaped_spaces_in_completion_text(self, tmp_path):
+        target = tmp_path / "Screenshot 2026-03-22 at 4.27.40 PM.png"
+        target.touch()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(
+                str(target).replace(" ", r"\ ").rsplit(".", 1)[0]
+            )
+        )
+
+        assert any(c.text == str(target).replace(" ", r"\ ") for c in completions)
+
+    def test_preserves_opening_quote_in_completion_text(self, tmp_path):
+        target = tmp_path / "Screenshot 2026-03-22 at 4.27.40 PM.png"
+        target.touch()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(f'"{tmp_path}/Screen')
+        )
+
+        assert any(c.text == f'"{target}' for c in completions)
+
+    def test_completes_context_file_references(self, tmp_path):
+        target = tmp_path / "main.py"
+        target.touch()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(f"@file:{tmp_path}/ma")
+        )
+
+        assert any(c.text == f"@file:{target}" for c in completions)
+
+    def test_completes_context_folder_references(self, tmp_path):
+        target = tmp_path / "src"
+        target.mkdir()
+
+        completions = list(
+            SlashCommandCompleter._path_completions(f"@folder:{tmp_path}/s")
+        )
+
+        assert any(c.text == f"@folder:{target}/" for c in completions)
+
+
+class TestContextCompletions:
+    def test_lists_static_context_references(self):
+        completions = list(SlashCommandCompleter._context_completions("@"))
+        texts = [c.text for c in completions]
+        assert "@diff" in texts
+        assert "@staged" in texts
+        assert "@file:" in texts
+        assert "@folder:" in texts
+
+    def test_bare_context_path_completes_to_file_reference(self, tmp_path):
+        target = tmp_path / "main.py"
+        target.touch()
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            completions = list(SlashCommandCompleter._context_completions("@ma"))
+        finally:
+            os.chdir(old_cwd)
+
+        assert any(c.text == "@file:main.py" for c in completions)
+
+    def test_bare_context_path_completes_to_folder_reference(self, tmp_path):
+        target = tmp_path / "src"
+        target.mkdir()
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            completions = list(SlashCommandCompleter._context_completions("@sr"))
+        finally:
+            os.chdir(old_cwd)
+
+        assert any(c.text == "@folder:src/" for c in completions)
+
 
 class TestIntegration:
     """Test the completer produces path completions via the prompt_toolkit API."""
@@ -162,6 +296,31 @@ class TestIntegration:
         names = _display_names(completions)
         # /etc/hosts should exist on Linux
         assert any("host" in n.lower() for n in names)
+
+    def test_context_file_reference_triggers_completion(self, completer, tmp_path):
+        target = tmp_path / "main.py"
+        target.touch()
+
+        doc = Document(f"check @file:{tmp_path}/ma", cursor_position=len(f"check @file:{tmp_path}/ma"))
+        event = MagicMock()
+        completions = list(completer.get_completions(doc, event))
+
+        assert any(c.text == f"@file:{target}" for c in completions)
+
+    def test_bare_context_trigger_shows_context_completion(self, completer, tmp_path):
+        target = tmp_path / "main.py"
+        target.touch()
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            doc = Document("check @ma", cursor_position=len("check @ma"))
+            event = MagicMock()
+            completions = list(completer.get_completions(doc, event))
+        finally:
+            os.chdir(old_cwd)
+
+        assert any(c.text == "@file:main.py" for c in completions)
 
 
 class TestFileSizeLabel:


### PR DESCRIPTION
## Summary
Fixes #2476

Telegram polling previously only recovered from 409 conflict errors. After a Mac sleep/wake, WiFi switch, or VPN reconnect, `python-telegram-bot` could raise transient network polling errors, Hermes would log them, and the polling loop could remain dead while the gateway process stayed alive.

This change:
- classifies transient Telegram polling network failures separately from 409 conflicts
- retries polling restart with bounded exponential backoff
- preserves the existing conflict-specific recovery path
- marks the adapter retryable-fatal after reconnect exhaustion so service managers can restart the gateway
- adds regression coverage for reconnect success, reconnect exhaustion, and non-network polling errors

## Verification
- `source .venv/bin/activate && python -m pytest tests/gateway/test_telegram_conflict.py -q`
  - passed (`8 passed`)
- `source .venv/bin/activate && python -m pytest tests/gateway/test_runner_startup_failures.py tests/gateway/test_runner_fatal_adapter.py -q`
  - passed (`4 passed`)

## Notes
- I also ran `source .venv/bin/activate && python -m pytest tests/ -q`, but the workspace has broad unrelated baseline failures outside this change area, so only targeted gateway verification is included here.
