### PR TITLE
feat(tts): add speed config option for OpenAI TTS provider

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -247,13 +247,16 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     else:
         response_format = "mp3"
 
+    speed = oai_config.get("speed", 1.0)
+
     OpenAIClient = _import_openai_client()
-    client = OpenAIClient(api_key=api_key, base_url=base_url)
+    client = OpenAIClient(api_key=*** base_url=base_url)
     response = client.audio.speech.create(
         model=model,
         voice=voice,
         input=text,
         response_format=response_format,
+        speed=speed,
     )
 
     response.stream_to_file(output_path)


### PR DESCRIPTION
## Summary

- Add `speed` config option for the OpenAI TTS provider
- Speed is read from `tts.openai.speed` in `~/.hermes/config.yaml` and passed to the OpenAI `audio.speech.create` API call

## Motivation

The OpenAI TTS API supports a `speed` parameter (range 0.25–4.0) but it was not exposed via Hermes config. This makes it impossible to tune playback speed without post-processing the audio.

## Changes

- `tools/tts_tool.py`: read `speed` from `oai_config` (defaults to `1.0`) and pass it to `client.audio.speech.create()`

## Test Plan

- [ ] Set `tts.openai.speed: 1.25` in `config.yaml` and verify TTS plays at increased speed
- [ ] Omit the key and verify it defaults to `1.0` (no change in behavior)

## Notes for Reviewers

Minimal change — one new config read and one extra kwarg to the existing API call. No breaking changes.
