### PR TITLE
fix: make vision_analyze timeout configurable via config.yaml (salvage #2306)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -182,6 +182,7 @@ DEFAULT_CONFIG = {
             "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"
             "base_url": "",        # direct OpenAI-compatible endpoint (takes precedence over provider)
             "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)
+            "timeout": 30,         # seconds — increase for slow local vision models
         },
         "web_extract": {
             "provider": "auto",

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -298,12 +298,23 @@ async def vision_analyze_tool(
         
         logger.info("Processing image with vision model...")
         
-        # Call the vision API via centralized router
+        # Call the vision API via centralized router.
+        # Read timeout from config.yaml (auxiliary.vision.timeout), default 30s.
+        vision_timeout = 30.0
+        try:
+            from hermes_cli.config import load_config
+            _cfg = load_config()
+            _vt = _cfg.get("auxiliary", {}).get("vision", {}).get("timeout")
+            if _vt is not None:
+                vision_timeout = float(_vt)
+        except Exception:
+            pass
         call_kwargs = {
             "task": "vision",
             "messages": messages,
             "temperature": 0.1,
             "max_tokens": 2000,
+            "timeout": vision_timeout,
         }
         if model:
             call_kwargs["model"] = model

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -907,6 +907,7 @@ auxiliary:
     model: ""                  # e.g. "openai/gpt-4o", "google/gemini-2.5-flash"
     base_url: ""               # Custom OpenAI-compatible endpoint (overrides provider)
     api_key: ""                # API key for base_url (falls back to OPENAI_API_KEY)
+    timeout: 30                # seconds — increase for slow local vision models
 
   # Web page summarization + browser page text extraction
   web_extract:


### PR DESCRIPTION
## Summary
Based on PR #2306. Reimplemented to use config.yaml instead of an env var (non-secrets belong in config).

Reads `auxiliary.vision.timeout` from config.yaml (default: 30s) and passes it to `async_call_llm`. Useful for slow local vision models that need more than 30 seconds.

```yaml
auxiliary:
  vision:
    timeout: 120  # seconds
```

### Changes
- `hermes_cli/config.py`: added `timeout: 30` to `DEFAULT_CONFIG["auxiliary"]["vision"]`
- `tools/vision_tools.py`: reads timeout from config, passes to `async_call_llm`
- `website/docs/user-guide/configuration.md`: documented in auxiliary config reference

## Verification
- Vision tests: 43/43 passed

## Credit
Original idea from PR #2306.