### PR TITLE
feat(gateway): inbound message debounce to merge rapid messages into one turn

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -228,6 +228,9 @@ class GatewayConfig:
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
 
+    # Inbound message debounce — buffer rapid messages from the same sender
+    # and merge them into a single turn. 0 = disabled.
+    inbound_debounce_ms: int = 0
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
 
@@ -307,6 +310,7 @@ class GatewayConfig:
             "group_sessions_per_user": self.group_sessions_per_user,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
+            "inbound_debounce_ms": self.inbound_debounce_ms,
         }
     
     @classmethod
@@ -366,6 +370,7 @@ class GatewayConfig:
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+            inbound_debounce_ms=int(data.get("inbound_debounce_ms", 0)),
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -448,6 +453,8 @@ def load_gateway_config() -> GatewayConfig:
 
             if "always_log_local" in yaml_cfg:
                 gw_data["always_log_local"] = yaml_cfg["always_log_local"]
+            if "inbound_debounce_ms" in yaml_cfg:
+                gw_data["inbound_debounce_ms"] = int(yaml_cfg["inbound_debounce_ms"])
 
             if "unauthorized_dm_behavior" in yaml_cfg:
                 gw_data["unauthorized_dm_behavior"] = _normalize_unauthorized_dm_behavior(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1101,11 +1101,13 @@ class GatewayRunner:
         self._pending_messages.clear()
         self._pending_approvals.clear()
         # Cancel any pending debounce timers
-        for task in list(self._debounce_tasks.values()):
+        for task in list(getattr(self, "_debounce_tasks", {}).values()):
             if not task.done():
                 task.cancel()
-        self._debounce_tasks.clear()
-        self._debounce_buffers.clear()
+        if hasattr(self, "_debounce_tasks"):
+            self._debounce_tasks.clear()
+        if hasattr(self, "_debounce_buffers"):
+            self._debounce_buffers.clear()
         self._shutdown_all_gateway_honcho()
         self._shutdown_event.set()
         
@@ -1391,10 +1393,10 @@ class GatewayRunner:
                     adapter.get_pending_message(_quick_key)  # consume and discard
                 self._pending_messages.pop(_quick_key, None)
                 # Cancel any pending debounce timer for this session
-                _dt = self._debounce_tasks.pop(_quick_key, None)
+                _dt = getattr(self, "_debounce_tasks", {}).pop(_quick_key, None)
                 if _dt and not _dt.done():
                     _dt.cancel()
-                self._debounce_buffers.pop(_quick_key, None)
+                getattr(self, "_debounce_buffers", {}).pop(_quick_key, None)
                 # Clean up the running agent entry so the reset handler
                 # doesn't think an agent is still active.
                 if _quick_key in self._running_agents:
@@ -1654,11 +1656,11 @@ class GatewayRunner:
         _debounce_ms = getattr(self.config, "inbound_debounce_ms", 0)
         if _debounce_ms > 0 and event.message_type == MessageType.TEXT:
             # Cancel any existing pending timer for this session
-            existing_task = self._debounce_tasks.get(_quick_key)
+            existing_task = getattr(self, "_debounce_tasks", {}).get(_quick_key)
             if existing_task and not existing_task.done():
                 existing_task.cancel()
             # Append to buffer
-            self._debounce_buffers.setdefault(_quick_key, []).append(event)
+            getattr(self, "_debounce_buffers", {}).setdefault(_quick_key, []).append(event)
             # Start new timer — flush after debounce window
             async def _debounce_timer(ms: float, key: str) -> None:
                 try:
@@ -1666,10 +1668,11 @@ class GatewayRunner:
                     await self._flush_debounce_buffer(key)
                 except asyncio.CancelledError:
                     pass  # Superseded by a newer message
-            self._debounce_tasks[_quick_key] = asyncio.create_task(
-                _debounce_timer(_debounce_ms, _quick_key),
-                name=f"debounce-{_quick_key[:20]}",
-            )
+            if hasattr(self, "_debounce_tasks"):
+                self._debounce_tasks[_quick_key] = asyncio.create_task(
+                    _debounce_timer(_debounce_ms, _quick_key),
+                    name=f"debounce-{_quick_key[:20]}",
+                )
             return None
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there
@@ -2419,8 +2422,8 @@ class GatewayRunner:
     async def _flush_debounce_buffer(self, session_key: str) -> None:
         """Fire after debounce window expires: merge buffered events and dispatch."""
         try:
-            events = self._debounce_buffers.pop(session_key, [])
-            self._debounce_tasks.pop(session_key, None)
+            events = getattr(self, "_debounce_buffers", {}).pop(session_key, [])
+            getattr(self, "_debounce_tasks", {}).pop(session_key, None)
             if not events:
                 return
             # Merge text from all buffered events into the first event

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -343,6 +343,9 @@ class GatewayRunner:
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
+        # Inbound debounce: buffer rapid messages before dispatching to agent
+        self._debounce_tasks: Dict[str, Any] = {}   # session_key -> asyncio.Task
+        self._debounce_buffers: Dict[str, list] = {}  # session_key -> [event, ...]
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -1097,6 +1100,12 @@ class GatewayRunner:
         self._running_agents.clear()
         self._pending_messages.clear()
         self._pending_approvals.clear()
+        # Cancel any pending debounce timers
+        for task in list(self._debounce_tasks.values()):
+            if not task.done():
+                task.cancel()
+        self._debounce_tasks.clear()
+        self._debounce_buffers.clear()
         self._shutdown_all_gateway_honcho()
         self._shutdown_event.set()
         
@@ -1381,6 +1390,11 @@ class GatewayRunner:
                 if adapter and hasattr(adapter, 'get_pending_message'):
                     adapter.get_pending_message(_quick_key)  # consume and discard
                 self._pending_messages.pop(_quick_key, None)
+                # Cancel any pending debounce timer for this session
+                _dt = self._debounce_tasks.pop(_quick_key, None)
+                if _dt and not _dt.done():
+                    _dt.cancel()
+                self._debounce_buffers.pop(_quick_key, None)
                 # Clean up the running agent entry so the reset handler
                 # doesn't think an agent is still active.
                 if _quick_key in self._running_agents:
@@ -1633,6 +1647,30 @@ class GatewayRunner:
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
 
+        # ── Inbound debounce ───────────────────────────────────────────
+        # When inbound_debounce_ms > 0, buffer rapid messages from the same
+        # sender and dispatch them as a single merged turn after the window.
+        # Only applies when no agent is currently running for this session.
+        _debounce_ms = getattr(self.config, "inbound_debounce_ms", 0)
+        if _debounce_ms > 0 and event.message_type == MessageType.TEXT:
+            # Cancel any existing pending timer for this session
+            existing_task = self._debounce_tasks.get(_quick_key)
+            if existing_task and not existing_task.done():
+                existing_task.cancel()
+            # Append to buffer
+            self._debounce_buffers.setdefault(_quick_key, []).append(event)
+            # Start new timer — flush after debounce window
+            async def _debounce_timer(ms: float, key: str) -> None:
+                try:
+                    await asyncio.sleep(ms / 1000)
+                    await self._flush_debounce_buffer(key)
+                except asyncio.CancelledError:
+                    pass  # Superseded by a newer message
+            self._debounce_tasks[_quick_key] = asyncio.create_task(
+                _debounce_timer(_debounce_ms, _quick_key),
+                name=f"debounce-{_quick_key[:20]}",
+            )
+            return None
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there
         # are numerous await points (hooks, vision enrichment, STT,
@@ -2378,6 +2416,32 @@ class GatewayRunner:
             # Clear session env
             self._clear_session_env()
     
+    async def _flush_debounce_buffer(self, session_key: str) -> None:
+        """Fire after debounce window expires: merge buffered events and dispatch."""
+        try:
+            events = self._debounce_buffers.pop(session_key, [])
+            self._debounce_tasks.pop(session_key, None)
+            if not events:
+                return
+            # Merge text from all buffered events into the first event
+            base_event = events[0]
+            if len(events) > 1:
+                merged_parts = [e.text for e in events if e.text]
+                if merged_parts:
+                    base_event = type(base_event)(
+                        text="\n".join(merged_parts),
+                        message_type=base_event.message_type,
+                        source=base_event.source,
+                        message_id=base_event.message_id,
+                        media_urls=base_event.media_urls,
+                        media_types=base_event.media_types,
+                    )
+            await self.handle_message(base_event)
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.debug("Debounce flush failed for %s: %s", session_key, e)
+
     async def _handle_reset_command(self, event: MessageEvent) -> str:
         """Handle /new or /reset command."""
         source = event.source

--- a/tests/gateway/test_debounce.py
+++ b/tests/gateway/test_debounce.py
@@ -1,0 +1,131 @@
+"""Tests for gateway inbound message debounce."""
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from gateway.config import GatewayConfig, load_gateway_config
+from gateway.run import GatewayRunner
+
+
+class TestDebounceConfig:
+    def test_default_debounce_ms_is_zero(self):
+        cfg = GatewayConfig()
+        assert cfg.inbound_debounce_ms == 0
+
+    def test_debounce_ms_from_dict(self):
+        cfg = GatewayConfig.from_dict({"inbound_debounce_ms": 3000})
+        assert cfg.inbound_debounce_ms == 3000
+
+    def test_debounce_ms_to_dict(self):
+        cfg = GatewayConfig(inbound_debounce_ms=5000)
+        d = cfg.to_dict()
+        assert d["inbound_debounce_ms"] == 5000
+
+    def test_debounce_ms_roundtrip(self):
+        cfg = GatewayConfig(inbound_debounce_ms=1500)
+        restored = GatewayConfig.from_dict(cfg.to_dict())
+        assert restored.inbound_debounce_ms == 1500
+
+    def test_load_gateway_config_debounce_from_yaml(self, tmp_path, monkeypatch):
+        import yaml
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("inbound_debounce_ms: 2000\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Patch get_hermes_home to return tmp_path
+        import gateway.config as gc
+        monkeypatch.setattr(gc, "get_hermes_home", lambda: tmp_path)
+        cfg = load_gateway_config()
+        assert cfg.inbound_debounce_ms == 2000
+
+
+class TestDebounceBuffering:
+    def _make_runner(self, debounce_ms=500):
+        cfg = GatewayConfig(inbound_debounce_ms=debounce_ms)
+        with patch("gateway.run.load_gateway_config", return_value=cfg), \
+             patch("gateway.run.SessionStore"), \
+             patch("gateway.run.DeliveryRouter"), \
+             patch("gateway.pairing.PairingStore"), \
+             patch("hermes_state.SessionDB", side_effect=Exception("no db")):
+            runner = GatewayRunner(config=cfg)
+        return runner
+
+    def _make_event(self, text="hello", msg_type=None):
+        from gateway.platforms.base import MessageEvent, MessageType, SessionSource, Platform
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", user_id="u1")
+        return MessageEvent(
+            text=text,
+            message_type=msg_type or MessageType.TEXT,
+            source=source,
+            message_id="msg1",
+        )
+
+    @pytest.mark.asyncio
+    async def test_debounce_disabled_by_default(self):
+        runner = self._make_runner(debounce_ms=0)
+        event = self._make_event()
+        runner.handle_message = AsyncMock(return_value="response")
+        # When disabled, messages go through immediately (no buffering)
+        assert runner._debounce_tasks == {}
+        assert runner._debounce_buffers == {}
+
+    @pytest.mark.asyncio
+    async def test_debounce_buffers_message(self):
+        runner = self._make_runner(debounce_ms=500)
+        event = self._make_event()
+        session_key = "telegram:123:u1"
+
+        # Simulate debounce path directly
+        runner._debounce_buffers.setdefault(session_key, []).append(event)
+        assert len(runner._debounce_buffers[session_key]) == 1
+
+    @pytest.mark.asyncio
+    async def test_flush_merges_messages(self):
+        runner = self._make_runner(debounce_ms=500)
+        from gateway.platforms.base import MessageEvent, MessageType, SessionSource, Platform
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", user_id="u1")
+        session_key = "telegram:123:u1"
+
+        e1 = MessageEvent(text="part 1", message_type=MessageType.TEXT, source=source, message_id="1")
+        e2 = MessageEvent(text="part 2", message_type=MessageType.TEXT, source=source, message_id="2")
+
+        runner._debounce_buffers[session_key] = [e1, e2]
+        runner.handle_message = AsyncMock(return_value=None)
+
+        await runner._flush_debounce_buffer(session_key)
+
+        runner.handle_message.assert_called_once()
+        merged_event = runner.handle_message.call_args[0][0]
+        assert "part 1" in merged_event.text
+        assert "part 2" in merged_event.text
+
+    @pytest.mark.asyncio
+    async def test_flush_single_message_unchanged(self):
+        runner = self._make_runner(debounce_ms=500)
+        from gateway.platforms.base import MessageEvent, MessageType, SessionSource, Platform
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", user_id="u1")
+        session_key = "telegram:123:u1"
+
+        e1 = MessageEvent(text="single message", message_type=MessageType.TEXT, source=source, message_id="1")
+        runner._debounce_buffers[session_key] = [e1]
+        runner.handle_message = AsyncMock(return_value=None)
+
+        await runner._flush_debounce_buffer(session_key)
+
+        runner.handle_message.assert_called_once()
+        sent_event = runner.handle_message.call_args[0][0]
+        assert sent_event.text == "single message"
+
+    @pytest.mark.asyncio
+    async def test_flush_clears_buffer(self):
+        runner = self._make_runner(debounce_ms=500)
+        from gateway.platforms.base import MessageEvent, MessageType, SessionSource, Platform
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", user_id="u1")
+        session_key = "telegram:123:u1"
+
+        e1 = MessageEvent(text="msg", message_type=MessageType.TEXT, source=source, message_id="1")
+        runner._debounce_buffers[session_key] = [e1]
+        runner.handle_message = AsyncMock(return_value=None)
+
+        await runner._flush_debounce_buffer(session_key)
+
+        assert session_key not in runner._debounce_buffers
+        assert session_key not in runner._debounce_tasks


### PR DESCRIPTION
Closes #2434

## Problem

Discord auto-splits messages >2000 chars into multiple rapid-fire updates. Each fragment triggers a separate agent turn — causing fragmented responses, wasted API calls, and lost context.

## Solution

Configurable `inbound_debounce_ms` that buffers rapid consecutive text messages from the same sender and merges them into a single turn after the window expires.

```yaml
# config.yaml
inbound_debounce_ms: 3000  # 3 seconds
```

## Implementation

- `GatewayConfig.inbound_debounce_ms` (default 0 = disabled, backward compatible)
- `GatewayRunner._debounce_tasks` / `_debounce_buffers` — per session key
- `_flush_debounce_buffer()` — merges event texts with newline, dispatches once
- Each new message cancels the existing timer and restarts the window
- Only TEXT messages are debounced; photo/voice pass through immediately
- Only applies when no agent is running — priority interrupt path takes precedence
- Debounce tasks are cancelled cleanly on `/new`, `/reset`, and gateway shutdown

## Not included (V2)

Per-platform config (`discord.debounce_ms`, `telegram.debounce_ms`) — global setting covers the main use case.