### PR TITLE
feat: add account limits to /usage

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import httpx
+
+from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
+from hermes_cli.auth import _read_codex_tokens, resolve_codex_runtime_credentials
+from hermes_cli.runtime_provider import resolve_runtime_provider
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class AccountUsageWindow:
+    label: str
+    used_percent: Optional[float] = None
+    reset_at: Optional[datetime] = None
+    window_seconds: Optional[int] = None
+    detail: Optional[str] = None
+
+    @property
+    def remaining_percent(self) -> Optional[float]:
+        if self.used_percent is None:
+            return None
+        return max(0.0, 100.0 - float(self.used_percent))
+
+
+@dataclass(frozen=True)
+class AccountUsageSnapshot:
+    provider: str
+    source: str
+    fetched_at: datetime
+    title: str = "Account limits"
+    plan: Optional[str] = None
+    windows: tuple[AccountUsageWindow, ...] = ()
+    details: tuple[str, ...] = ()
+    unavailable_reason: Optional[str] = None
+
+    @property
+    def available(self) -> bool:
+        return bool(self.windows or self.details) and not self.unavailable_reason
+
+
+def _title_case_slug(value: Optional[str]) -> Optional[str]:
+    cleaned = str(value or "").strip()
+    if not cleaned:
+        return None
+    return cleaned.replace("_", " ").replace("-", " ").title()
+
+
+def _parse_dt(value: Any) -> Optional[datetime]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(text)
+            return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
+    return None
+
+
+def _format_reset(dt: Optional[datetime]) -> str:
+    if not dt:
+        return "unknown"
+    local_dt = dt.astimezone()
+    delta = dt - _utc_now()
+    total_seconds = int(delta.total_seconds())
+    if total_seconds <= 0:
+        return f"now ({local_dt.strftime('%Y-%m-%d %H:%M %Z')})"
+    hours, rem = divmod(total_seconds, 3600)
+    minutes = rem // 60
+    if hours >= 24:
+        days, hours = divmod(hours, 24)
+        rel = f"in {days}d {hours}h"
+    elif hours > 0:
+        rel = f"in {hours}h {minutes}m"
+    else:
+        rel = f"in {minutes}m"
+    return f"{rel} ({local_dt.strftime('%Y-%m-%d %H:%M %Z')})"
+
+
+def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, markdown: bool = False) -> list[str]:
+    if not snapshot:
+        return []
+    header = f"📈 {'**' if markdown else ''}{snapshot.title}{'**' if markdown else ''}"
+    lines = [header]
+    if snapshot.plan:
+        lines.append(f"Provider: {snapshot.provider} ({snapshot.plan})")
+    else:
+        lines.append(f"Provider: {snapshot.provider}")
+    for window in snapshot.windows:
+        if window.used_percent is None:
+            base = f"{window.label}: unavailable"
+        else:
+            remaining = max(0, round(100 - float(window.used_percent)))
+            used = max(0, round(float(window.used_percent)))
+            base = f"{window.label}: {remaining}% remaining ({used}% used)"
+        if window.reset_at:
+            base += f" • resets {_format_reset(window.reset_at)}"
+        elif window.detail:
+            base += f" • {window.detail}"
+        lines.append(base)
+    for detail in snapshot.details:
+        lines.append(detail)
+    if snapshot.unavailable_reason:
+        lines.append(f"Unavailable: {snapshot.unavailable_reason}")
+    return lines
+
+
+def _resolve_codex_usage_url(base_url: str) -> str:
+    normalized = (base_url or "").strip().rstrip("/")
+    if not normalized:
+        normalized = "https://chatgpt.com/backend-api/codex"
+    if normalized.endswith("/codex"):
+        normalized = normalized[: -len("/codex")]
+    if "/backend-api" in normalized:
+        return normalized + "/wham/usage"
+    return normalized + "/api/codex/usage"
+
+
+def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
+    creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+    token_data = _read_codex_tokens()
+    tokens = token_data.get("tokens") or {}
+    account_id = str(tokens.get("account_id", "") or "").strip() or None
+    headers = {
+        "Authorization": f"Bearer {creds['api_key']}",
+        "Accept": "application/json",
+        "User-Agent": "codex-cli",
+    }
+    if account_id:
+        headers["ChatGPT-Account-Id"] = account_id
+    with httpx.Client(timeout=15.0) as client:
+        response = client.get(_resolve_codex_usage_url(creds.get("base_url", "")), headers=headers)
+        response.raise_for_status()
+    payload = response.json() or {}
+    rate_limit = payload.get("rate_limit") or {}
+    windows: list[AccountUsageWindow] = []
+    for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
+        window = rate_limit.get(key) or {}
+        used = window.get("used_percent")
+        if used is None:
+            continue
+        windows.append(
+            AccountUsageWindow(
+                label=label,
+                used_percent=float(used),
+                reset_at=_parse_dt(window.get("reset_at")),
+                window_seconds=window.get("limit_window_seconds"),
+            )
+        )
+    details: list[str] = []
+    credits = payload.get("credits") or {}
+    if credits.get("has_credits"):
+        balance = credits.get("balance")
+        if isinstance(balance, (int, float)):
+            details.append(f"Credits balance: ${float(balance):.2f}")
+        elif credits.get("unlimited"):
+            details.append("Credits balance: unlimited")
+    return AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=_utc_now(),
+        plan=_title_case_slug(payload.get("plan_type")),
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
+def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
+    token = (resolve_anthropic_token() or "").strip()
+    if not token:
+        return None
+    if not _is_oauth_token(token):
+        return AccountUsageSnapshot(
+            provider="anthropic",
+            source="oauth_usage_api",
+            fetched_at=_utc_now(),
+            unavailable_reason="Anthropic account limits are only available for OAuth-backed Claude accounts.",
+        )
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "anthropic-beta": "oauth-2025-04-20",
+        "User-Agent": "claude-code/2.1.0",
+    }
+    with httpx.Client(timeout=15.0) as client:
+        response = client.get("https://api.anthropic.com/api/oauth/usage", headers=headers)
+        response.raise_for_status()
+    payload = response.json() or {}
+    windows: list[AccountUsageWindow] = []
+    mapping = (
+        ("five_hour", "Current session"),
+        ("seven_day", "Current week"),
+        ("seven_day_opus", "Opus week"),
+        ("seven_day_sonnet", "Sonnet week"),
+    )
+    for key, label in mapping:
+        window = payload.get(key) or {}
+        util = window.get("utilization")
+        if util is None:
+            continue
+        used = float(util) * 100 if float(util) <= 1 else float(util)
+        windows.append(
+            AccountUsageWindow(
+                label=label,
+                used_percent=used,
+                reset_at=_parse_dt(window.get("resets_at")),
+            )
+        )
+    details: list[str] = []
+    extra = payload.get("extra_usage") or {}
+    if extra.get("is_enabled"):
+        used_credits = extra.get("used_credits")
+        monthly_limit = extra.get("monthly_limit")
+        currency = extra.get("currency") or "USD"
+        if isinstance(used_credits, (int, float)) and isinstance(monthly_limit, (int, float)):
+            details.append(
+                f"Extra usage: {used_credits:.2f} / {monthly_limit:.2f} {currency}"
+            )
+    return AccountUsageSnapshot(
+        provider="anthropic",
+        source="oauth_usage_api",
+        fetched_at=_utc_now(),
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
+def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
+    runtime = resolve_runtime_provider(
+        requested="openrouter",
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
+    )
+    token = str(runtime.get("api_key", "") or "").strip()
+    if not token:
+        return None
+    normalized = str(runtime.get("base_url", "") or "").rstrip("/")
+    credits_url = f"{normalized}/credits"
+    key_url = f"{normalized}/key"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    with httpx.Client(timeout=10.0) as client:
+        credits_resp = client.get(credits_url, headers=headers)
+        credits_resp.raise_for_status()
+        credits = (credits_resp.json() or {}).get("data") or {}
+        try:
+            key_resp = client.get(key_url, headers=headers)
+            key_resp.raise_for_status()
+            key_data = (key_resp.json() or {}).get("data") or {}
+        except Exception:
+            key_data = {}
+    total_credits = float(credits.get("total_credits") or 0.0)
+    total_usage = float(credits.get("total_usage") or 0.0)
+    details = [f"Credits balance: ${max(0.0, total_credits - total_usage):.2f}"]
+    windows: list[AccountUsageWindow] = []
+    limit = key_data.get("limit")
+    usage = key_data.get("usage")
+    if isinstance(limit, (int, float)) and limit > 0 and isinstance(usage, (int, float)):
+        used_percent = (float(usage) / float(limit)) * 100
+        rate = key_data.get("rate_limit") or {}
+        detail = None
+        if rate.get("requests") and rate.get("interval"):
+            detail = f"{rate['requests']} requests / {rate['interval']}"
+        windows.append(
+            AccountUsageWindow(
+                label="API key quota",
+                used_percent=used_percent,
+                detail=detail,
+            )
+        )
+    return AccountUsageSnapshot(
+        provider="openrouter",
+        source="credits_api",
+        fetched_at=_utc_now(),
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
+def fetch_account_usage(
+    provider: Optional[str],
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Optional[AccountUsageSnapshot]:
+    normalized = str(provider or "").strip().lower()
+    if normalized in {"", "auto", "custom"}:
+        return None
+    try:
+        if normalized == "openai-codex":
+            return _fetch_codex_account_usage()
+        if normalized == "anthropic":
+            return _fetch_anthropic_account_usage()
+        if normalized == "openrouter":
+            return _fetch_openrouter_account_usage(base_url, api_key)
+    except Exception:
+        return None
+    return None

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -20,14 +20,7 @@ class AccountUsageWindow:
     label: str
     used_percent: Optional[float] = None
     reset_at: Optional[datetime] = None
-    window_seconds: Optional[int] = None
     detail: Optional[str] = None
-
-    @property
-    def remaining_percent(self) -> Optional[float]:
-        if self.used_percent is None:
-            return None
-        return max(0.0, 100.0 - float(self.used_percent))
 
 
 @dataclass(frozen=True)
@@ -159,7 +152,6 @@ def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
                 label=label,
                 used_percent=float(used),
                 reset_at=_parse_dt(window.get("reset_at")),
-                window_seconds=window.get("limit_window_seconds"),
             )
         )
     details: list[str] = []

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -272,20 +272,38 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     details = [f"Credits balance: ${max(0.0, total_credits - total_usage):.2f}"]
     windows: list[AccountUsageWindow] = []
     limit = key_data.get("limit")
+    limit_remaining = key_data.get("limit_remaining")
+    limit_reset = str(key_data.get("limit_reset") or "").strip()
     usage = key_data.get("usage")
-    if isinstance(limit, (int, float)) and limit > 0 and isinstance(usage, (int, float)):
-        used_percent = (float(usage) / float(limit)) * 100
-        rate = key_data.get("rate_limit") or {}
-        detail = None
-        if rate.get("requests") and rate.get("interval"):
-            detail = f"{rate['requests']} requests / {rate['interval']}"
+    if (
+        isinstance(limit, (int, float))
+        and float(limit) > 0
+        and isinstance(limit_remaining, (int, float))
+        and 0 <= float(limit_remaining) <= float(limit)
+    ):
+        limit_value = float(limit)
+        remaining_value = float(limit_remaining)
+        used_percent = ((limit_value - remaining_value) / limit_value) * 100
+        detail_parts = [f"${remaining_value:.2f} of ${limit_value:.2f} remaining"]
+        if limit_reset:
+            detail_parts.append(f"resets {limit_reset}")
         windows.append(
             AccountUsageWindow(
                 label="API key quota",
                 used_percent=used_percent,
-                detail=detail,
+                detail=" • ".join(detail_parts),
             )
         )
+    if isinstance(usage, (int, float)):
+        usage_parts = [f"API key usage: ${float(usage):.2f} total"]
+        for value, label in (
+            (key_data.get("usage_daily"), "today"),
+            (key_data.get("usage_weekly"), "this week"),
+            (key_data.get("usage_monthly"), "this month"),
+        ):
+            if isinstance(value, (int, float)) and float(value) > 0:
+                usage_parts.append(f"${float(value):.2f} {label}")
+        details.append(" • ".join(usage_parts))
     return AccountUsageSnapshot(
         provider="openrouter",
         source="credits_api",

--- a/cli.py
+++ b/cli.py
@@ -64,6 +64,7 @@ from agent.usage_pricing import (
     format_duration_compact,
     format_token_count_compact,
 )
+from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from hermes_cli.banner import _format_context_length
 
 _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
@@ -4370,73 +4371,94 @@ class HermesCLI:
             print(f"  ❌ Compression failed: {e}")
 
     def _show_usage(self):
-        """Show cumulative token usage for the current session."""
-        if not self.agent:
-            print("(._.) No active agent -- send a message first.")
-            return
-
+        """Show cumulative token usage for the current session plus account limits."""
         agent = self.agent
-        input_tokens = getattr(agent, "session_input_tokens", 0) or 0
-        output_tokens = getattr(agent, "session_output_tokens", 0) or 0
-        cache_read_tokens = getattr(agent, "session_cache_read_tokens", 0) or 0
-        cache_write_tokens = getattr(agent, "session_cache_write_tokens", 0) or 0
-        prompt = agent.session_prompt_tokens
-        completion = agent.session_completion_tokens
-        total = agent.session_total_tokens
-        calls = agent.session_api_calls
+        session_lines: list[str] = []
 
-        if calls == 0:
-            print("(._.) No API calls made yet in this session.")
+        if agent:
+            input_tokens = getattr(agent, "session_input_tokens", 0) or 0
+            output_tokens = getattr(agent, "session_output_tokens", 0) or 0
+            cache_read_tokens = getattr(agent, "session_cache_read_tokens", 0) or 0
+            cache_write_tokens = getattr(agent, "session_cache_write_tokens", 0) or 0
+            prompt = agent.session_prompt_tokens
+            completion = agent.session_completion_tokens
+            total = agent.session_total_tokens
+            calls = agent.session_api_calls
+
+            if calls > 0:
+                compressor = agent.context_compressor
+                last_prompt = compressor.last_prompt_tokens
+                ctx_len = compressor.context_length
+                pct = (last_prompt / ctx_len * 100) if ctx_len else 0
+                compressions = compressor.compression_count
+
+                msg_count = len(self.conversation_history)
+                cost_result = estimate_usage_cost(
+                    agent.model,
+                    CanonicalUsage(
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                        cache_read_tokens=cache_read_tokens,
+                        cache_write_tokens=cache_write_tokens,
+                    ),
+                    provider=getattr(agent, "provider", None),
+                    base_url=getattr(agent, "base_url", None),
+                )
+                elapsed = format_duration_compact((datetime.now() - self.session_start).total_seconds())
+
+                session_lines.extend([
+                    "  📊 Session Token Usage",
+                    f"  {'─' * 40}",
+                    f"  Model:                     {agent.model}",
+                    f"  Input tokens:              {input_tokens:>10,}",
+                    f"  Cache read tokens:         {cache_read_tokens:>10,}",
+                    f"  Cache write tokens:        {cache_write_tokens:>10,}",
+                    f"  Output tokens:             {output_tokens:>10,}",
+                    f"  Prompt tokens (total):     {prompt:>10,}",
+                    f"  Completion tokens:         {completion:>10,}",
+                    f"  Total tokens:              {total:>10,}",
+                    f"  API calls:                 {calls:>10,}",
+                    f"  Session duration:          {elapsed:>10}",
+                    f"  Cost status:              {cost_result.status:>10}",
+                    f"  Cost source:              {cost_result.source:>10}",
+                ])
+                if cost_result.amount_usd is not None:
+                    prefix = "~" if cost_result.status == "estimated" else ""
+                    session_lines.append(f"  Total cost:              {prefix}${float(cost_result.amount_usd):>10.4f}")
+                elif cost_result.status == "included":
+                    session_lines.append(f"  Total cost:              {'included':>10}")
+                else:
+                    session_lines.append(f"  Total cost:              {'n/a':>10}")
+                session_lines.extend([
+                    f"  {'─' * 40}",
+                    f"  Current context:  {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)",
+                    f"  Messages:         {msg_count}",
+                    f"  Compressions:     {compressions}",
+                ])
+                if cost_result.status == "unknown":
+                    session_lines.append(f"  Note:             Pricing unknown for {agent.model}")
+
+        provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
+        base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
+        api_key = getattr(self, "api_key", None)
+        account_snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+        account_lines = [f"  {line}" for line in render_account_usage_lines(account_snapshot)]
+
+        if not session_lines and not account_lines:
+            if agent:
+                print("(._.) No API calls made yet in this session.")
+            else:
+                print("(._.) No active agent -- send a message first.")
             return
 
-        # Current context window state
-        compressor = agent.context_compressor
-        last_prompt = compressor.last_prompt_tokens
-        ctx_len = compressor.context_length
-        pct = (last_prompt / ctx_len * 100) if ctx_len else 0
-        compressions = compressor.compression_count
-
-        msg_count = len(self.conversation_history)
-        cost_result = estimate_usage_cost(
-            agent.model,
-            CanonicalUsage(
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cache_read_tokens=cache_read_tokens,
-                cache_write_tokens=cache_write_tokens,
-            ),
-            provider=getattr(agent, "provider", None),
-            base_url=getattr(agent, "base_url", None),
-        )
-        elapsed = format_duration_compact((datetime.now() - self.session_start).total_seconds())
-
-        print(f"  📊 Session Token Usage")
-        print(f"  {'─' * 40}")
-        print(f"  Model:                     {agent.model}")
-        print(f"  Input tokens:              {input_tokens:>10,}")
-        print(f"  Cache read tokens:         {cache_read_tokens:>10,}")
-        print(f"  Cache write tokens:        {cache_write_tokens:>10,}")
-        print(f"  Output tokens:             {output_tokens:>10,}")
-        print(f"  Prompt tokens (total):     {prompt:>10,}")
-        print(f"  Completion tokens:         {completion:>10,}")
-        print(f"  Total tokens:              {total:>10,}")
-        print(f"  API calls:                 {calls:>10,}")
-        print(f"  Session duration:          {elapsed:>10}")
-        print(f"  Cost status:              {cost_result.status:>10}")
-        print(f"  Cost source:              {cost_result.source:>10}")
-        if cost_result.amount_usd is not None:
-            prefix = "~" if cost_result.status == "estimated" else ""
-            print(f"  Total cost:              {prefix}${float(cost_result.amount_usd):>10.4f}")
-        elif cost_result.status == "included":
-            print(f"  Total cost:              {'included':>10}")
-        else:
-            print(f"  Total cost:              {'n/a':>10}")
-        print(f"  {'─' * 40}")
-        print(f"  Current context:  {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")
-        print(f"  Messages:         {msg_count}")
-        print(f"  Compressions:     {compressions}")
-        if cost_result.status == "unknown":
-            print(f"  Note:             Pricing unknown for {agent.model}")
+        if session_lines:
+            for line in session_lines:
+                print(line)
+        if account_lines:
+            if session_lines:
+                print()
+            for line in account_lines:
+                print(line)
 
         if self.verbose:
             logging.getLogger().setLevel(logging.DEBUG)

--- a/cli.py
+++ b/cli.py
@@ -3931,45 +3931,10 @@ class HermesCLI:
                 if not response and result and result.get("error"):
                     response = f"Error: {result['error']}"
 
-                # Display result in the CLI (thread-safe via patch_stdout)
-                print()
-                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
-                _cprint(f"  ✅ Background task #{task_num} complete")
-                _cprint(f"  Prompt: \"{prompt[:60]}{'...' if len(prompt) > 60 else ''}\"")
-                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
-                if response:
-                    try:
-                        from hermes_cli.skin_engine import get_active_skin
-                        _skin = get_active_skin()
-                        label = _skin.get_branding("response_label", "⚕ Hermes")
-                        _resp_color = _skin.get_color("response_border", "#CD7F32")
-                        _resp_text = _skin.get_color("banner_text", "#FFF8DC")
-                    except Exception:
-                        label = "⚕ Hermes"
-                        _resp_color = "#CD7F32"
-                        _resp_text = "#FFF8DC"
-
-                    _chat_console = ChatConsole()
-                    _chat_console.print(Panel(
-                        _rich_text_from_ansi(response),
-                        title=f"[{_resp_color} bold]{label} (background #{task_num})[/]",
-                        title_align="left",
-                        border_style=_resp_color,
-                        style=_resp_text,
-                        box=rich_box.HORIZONTALS,
-                        padding=(1, 2),
-                    ))
-                else:
-                    _cprint("  (No response generated)")
-
-                # Play bell if enabled
-                if self.bell_on_complete:
-                    sys.stdout.write("\a")
-                    sys.stdout.flush()
+                self._display_background_result(task_num, prompt, response)
 
             except Exception as e:
-                print()
-                _cprint(f"  ❌ Background task #{task_num} failed: {e}")
+                self._background_fallback_write("", f"Background task #{task_num} failed: {e}")
             finally:
                 self._background_tasks.pop(task_id, None)
                 if self._app:
@@ -3978,6 +3943,64 @@ class HermesCLI:
         thread = threading.Thread(target=run_background, daemon=True, name=f"bg-task-{task_id}")
         self._background_tasks[task_id] = thread
         thread.start()
+
+    def _background_fallback_write(self, *lines: str) -> None:
+        target = getattr(sys, "__stdout__", None) or sys.stdout
+        if not target or getattr(target, "closed", False):
+            return
+        for line in lines:
+            target.write(f"{line}\n")
+        target.flush()
+
+    def _display_background_result(self, task_num: int, prompt: str, response: str) -> None:
+        try:
+            print()
+            ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+            _cprint(f"  ✅ Background task #{task_num} complete")
+            _cprint(f"  Prompt: \"{prompt[:60]}{'...' if len(prompt) > 60 else ''}\"")
+            ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+            if response:
+                try:
+                    from hermes_cli.skin_engine import get_active_skin
+                    _skin = get_active_skin()
+                    label = _skin.get_branding("response_label", "⚕ Hermes")
+                    _resp_color = _skin.get_color("response_border", "#CD7F32")
+                    _resp_text = _skin.get_color("banner_text", "#FFF8DC")
+                except Exception:
+                    label = "⚕ Hermes"
+                    _resp_color = "#CD7F32"
+                    _resp_text = "#FFF8DC"
+
+                _chat_console = ChatConsole()
+                _chat_console.print(Panel(
+                    _rich_text_from_ansi(response),
+                    title=f"[{_resp_color} bold]{label} (background #{task_num})[/]",
+                    title_align="left",
+                    border_style=_resp_color,
+                    style=_resp_text,
+                    box=rich_box.HORIZONTALS,
+                    padding=(1, 2),
+                ))
+            else:
+                _cprint("  (No response generated)")
+        except (OSError, ValueError):
+            preview = f"\"{prompt[:60]}{'...' if len(prompt) > 60 else ''}\""
+            self._background_fallback_write(
+                "",
+                f"Background task #{task_num} complete",
+                f"Prompt: {preview}",
+            )
+            if response:
+                self._background_fallback_write(response)
+            else:
+                self._background_fallback_write("(No response generated)")
+
+        if self.bell_on_complete:
+            try:
+                sys.stdout.write("\a")
+                sys.stdout.flush()
+            except (OSError, ValueError):
+                pass
 
     @staticmethod
     def _try_launch_chrome_debug(port: int, system: str) -> bool:
@@ -4438,9 +4461,14 @@ class HermesCLI:
                 if cost_result.status == "unknown":
                     session_lines.append(f"  Note:             Pricing unknown for {agent.model}")
 
-        provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
-        base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
-        api_key = getattr(self, "api_key", None)
+        if agent:
+            provider = getattr(agent, "provider", None)
+            base_url = getattr(agent, "base_url", None)
+            api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
+        else:
+            provider = getattr(self, "provider", None)
+            base_url = getattr(self, "base_url", None)
+            api_key = getattr(self, "api_key", None)
         account_snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
         account_lines = [f"  {line}" for line in render_account_usage_lines(account_snapshot)]
 
@@ -4468,6 +4496,7 @@ class HermesCLI:
             logging.getLogger().setLevel(logging.INFO)
             for quiet_logger in ('tools', 'minisweagent', 'run_agent', 'trajectory_compressor', 'cron', 'hermes_cli'):
                 logging.getLogger(quiet_logger).setLevel(logging.ERROR)
+
 
     def _show_insights(self, command: str = "/insights"):
         """Show usage insights and analytics from session history."""

--- a/cli.py
+++ b/cli.py
@@ -13,6 +13,7 @@ Usage:
     python cli.py --list-tools             # List available tools and exit
 """
 
+import concurrent.futures
 import logging
 import os
 import shutil
@@ -4469,24 +4470,31 @@ class HermesCLI:
             provider = getattr(self, "provider", None)
             base_url = getattr(self, "base_url", None)
             api_key = getattr(self, "api_key", None)
-        account_snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+
+        if session_lines:
+            for line in session_lines:
+                print(line)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
+            try:
+                account_snapshot = _pool.submit(
+                    fetch_account_usage, provider, base_url=base_url, api_key=api_key,
+                ).result(timeout=10.0)
+            except (concurrent.futures.TimeoutError, Exception):
+                account_snapshot = None
         account_lines = [f"  {line}" for line in render_account_usage_lines(account_snapshot)]
+
+        if account_lines:
+            if session_lines:
+                print()
+            for line in account_lines:
+                print(line)
 
         if not session_lines and not account_lines:
             if agent:
                 print("(._.) No API calls made yet in this session.")
             else:
                 print("(._.) No active agent -- send a message first.")
-            return
-
-        if session_lines:
-            for line in session_lines:
-                print(line)
-        if account_lines:
-            if session_lines:
-                print()
-            for line in account_lines:
-                print(line)
 
         if self.verbose:
             logging.getLogger().setLevel(logging.DEBUG)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29,6 +29,8 @@ from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
 
+from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
 # Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
@@ -3850,6 +3852,14 @@ class GatewayRunner:
         session_key = self._session_key_for_source(source)
 
         agent = self._running_agents.get(session_key)
+        account_lines: list[str] = []
+        provider = getattr(agent, "provider", None)
+        base_url = getattr(agent, "base_url", None)
+        api_key = getattr(agent, "api_key", None)
+        account_snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+        if account_snapshot:
+            account_lines = render_account_usage_lines(account_snapshot, markdown=True)
+
         if agent and hasattr(agent, "session_total_tokens") and agent.session_api_calls > 0:
             lines = [
                 "📊 **Session Token Usage**",
@@ -3864,6 +3874,8 @@ class GatewayRunner:
                 lines.append(f"Context: {ctx.last_prompt_tokens:,} / {ctx.context_length:,} ({pct:.0f}%)")
             if ctx.compression_count:
                 lines.append(f"Compressions: {ctx.compression_count}")
+            if account_lines:
+                lines.extend(["", *account_lines])
             return "\n".join(lines)
 
         # No running agent -- check session history for a rough count
@@ -3873,12 +3885,17 @@ class GatewayRunner:
             from agent.model_metadata import estimate_messages_tokens_rough
             msgs = [m for m in history if m.get("role") in ("user", "assistant") and m.get("content")]
             approx = estimate_messages_tokens_rough(msgs)
-            return (
-                f"📊 **Session Info**\n"
-                f"Messages: {len(msgs)}\n"
-                f"Estimated context: ~{approx:,} tokens\n"
-                f"_(Detailed usage available during active conversations)_"
-            )
+            lines = [
+                "📊 **Session Info**",
+                f"Messages: {len(msgs)}",
+                f"Estimated context: ~{approx:,} tokens",
+                "_(Detailed usage available during active conversations)_",
+            ]
+            if account_lines:
+                lines.extend(["", *account_lines])
+            return "\n".join(lines)
+        if account_lines:
+            return "\n".join(account_lines)
         return "No usage data available for this session."
 
     async def _handle_insights_command(self, event: MessageEvent) -> str:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3850,13 +3850,28 @@ class GatewayRunner:
         """Handle /usage command -- show token usage for the session's last agent run."""
         source = event.source
         session_key = self._session_key_for_source(source)
+        session_entry = self.session_store.get_or_create_session(source)
 
         agent = self._running_agents.get(session_key)
         account_lines: list[str] = []
         provider = getattr(agent, "provider", None)
         base_url = getattr(agent, "base_url", None)
         api_key = getattr(agent, "api_key", None)
-        account_snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+        if not provider and self._session_db and session_entry:
+            try:
+                persisted = self._session_db.get_session(session_entry.session_id) or {}
+            except Exception:
+                persisted = {}
+            provider = provider or persisted.get("billing_provider")
+            base_url = base_url or persisted.get("billing_base_url")
+        account_snapshot = None
+        if provider:
+            account_snapshot = await asyncio.to_thread(
+                fetch_account_usage,
+                provider,
+                base_url=base_url,
+                api_key=api_key,
+            )
         if account_snapshot:
             account_lines = render_account_usage_lines(account_snapshot, markdown=True)
 
@@ -3879,7 +3894,6 @@ class GatewayRunner:
             return "\n".join(lines)
 
         # No running agent -- check session history for a rough count
-        session_entry = self.session_store.get_or_create_session(source)
         history = self.session_store.load_transcript(session_entry.session_id)
         if history:
             from agent.model_metadata import estimate_messages_tokens_rough

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -138,3 +138,49 @@ async def test_handle_message_persists_agent_token_counts(monkeypatch):
         provider=None,
         base_url=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_usage_command_includes_account_section(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    running_agent = MagicMock()
+    running_agent.provider = "openai-codex"
+    running_agent.base_url = "https://chatgpt.com/backend-api/codex"
+    running_agent.api_key = "unused"
+    running_agent.session_prompt_tokens = 100
+    running_agent.session_completion_tokens = 25
+    running_agent.session_total_tokens = 125
+    running_agent.session_api_calls = 2
+    running_agent.context_compressor = SimpleNamespace(
+        last_prompt_tokens=100,
+        context_length=1000,
+        compression_count=0,
+    )
+    runner._running_agents[build_session_key(_make_source())] = running_agent
+
+    monkeypatch.setattr(
+        "gateway.run.fetch_account_usage",
+        lambda provider, base_url=None, api_key=None: object(),
+    )
+    monkeypatch.setattr(
+        "gateway.run.render_account_usage_lines",
+        lambda snapshot, markdown=False: [
+            "📈 **Account limits**",
+            "Provider: openai-codex (Pro)",
+            "Session: 85% remaining (15% used)",
+        ],
+    )
+
+    result = await runner._handle_usage_command(_make_event("/usage"))
+
+    assert "📊 **Session Token Usage**" in result
+    assert "📈 **Account limits**" in result
+    assert "Provider: openai-codex (Pro)" in result

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -184,3 +184,49 @@ async def test_usage_command_includes_account_section(monkeypatch):
     assert "📊 **Session Token Usage**" in result
     assert "📈 **Account limits**" in result
     assert "Provider: openai-codex (Pro)" in result
+
+
+@pytest.mark.asyncio
+async def test_usage_command_uses_persisted_provider_when_agent_not_running(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner.session_store.load_transcript.return_value = [{"role": "user", "content": "earlier"}]
+    runner._session_db = MagicMock()
+    runner._session_db.get_session.return_value = {
+        "billing_provider": "openai-codex",
+        "billing_base_url": "https://chatgpt.com/backend-api/codex",
+    }
+
+    calls = {}
+
+    async def _fake_to_thread(fn, *args, **kwargs):
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _fake_to_thread)
+    monkeypatch.setattr(
+        "gateway.run.fetch_account_usage",
+        lambda provider, base_url=None, api_key=None: object(),
+    )
+    monkeypatch.setattr(
+        "gateway.run.render_account_usage_lines",
+        lambda snapshot, markdown=False: [
+            "📈 **Account limits**",
+            "Provider: openai-codex (Pro)",
+        ],
+    )
+
+    result = await runner._handle_usage_command(_make_event("/usage"))
+
+    assert calls["args"] == ("openai-codex",)
+    assert calls["kwargs"]["base_url"] == "https://chatgpt.com/backend-api/codex"
+    assert "📊 **Session Info**" in result
+    assert "📈 **Account limits**" in result

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -1,0 +1,104 @@
+from datetime import datetime, timezone
+
+from agent.account_usage import (
+    AccountUsageSnapshot,
+    AccountUsageWindow,
+    fetch_account_usage,
+    render_account_usage_lines,
+)
+
+
+class _Response:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class _Client:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, headers=None):
+        return _Response(self._payload)
+
+
+def test_fetch_account_usage_codex(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "access-token",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage._read_codex_tokens",
+        lambda: {"tokens": {"account_id": "acct_123"}},
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "plan_type": "pro",
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 15,
+                        "reset_at": 1_900_000_000,
+                        "limit_window_seconds": 18000,
+                    },
+                    "secondary_window": {
+                        "used_percent": 40,
+                        "reset_at": 1_900_500_000,
+                        "limit_window_seconds": 604800,
+                    },
+                },
+                "credits": {"has_credits": True, "balance": 12.5},
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert snapshot.plan == "Pro"
+    assert len(snapshot.windows) == 2
+    assert snapshot.windows[0].label == "Session"
+    assert snapshot.windows[0].used_percent == 15.0
+    assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
+    assert "Credits balance: $12.50" in snapshot.details
+
+
+def test_render_account_usage_lines_includes_reset_and_provider():
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        plan="Pro",
+        windows=(
+            AccountUsageWindow(
+                label="Session",
+                used_percent=25,
+                reset_at=datetime.now(timezone.utc),
+            ),
+        ),
+        details=("Credits balance: $9.99",),
+    )
+    lines = render_account_usage_lines(snapshot)
+
+    assert lines[0] == "📈 Account limits"
+    assert "openai-codex (Pro)" in lines[1]
+    assert "Session: 75% remaining (25% used)" in lines[2]
+    assert "Credits balance: $9.99" in lines[3]

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -35,6 +35,20 @@ class _Client:
         return _Response(self._payload)
 
 
+class _RoutingClient:
+    def __init__(self, payloads):
+        self._payloads = payloads
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, headers=None):
+        return _Response(self._payloads[url])
+
+
 def test_fetch_account_usage_codex(monkeypatch):
     monkeypatch.setattr(
         "agent.account_usage.resolve_codex_runtime_credentials",
@@ -102,3 +116,88 @@ def test_render_account_usage_lines_includes_reset_and_provider():
     assert "openai-codex (Pro)" in lines[1]
     assert "Session: 75% remaining (25% used)" in lines[2]
     assert "Credits balance: $9.99" in lines[3]
+
+
+def test_fetch_account_usage_openrouter_uses_limit_remaining_and_ignores_deprecated_rate_limit(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_runtime_provider",
+        lambda requested, explicit_base_url=None, explicit_api_key=None: {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-test",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=10.0: _RoutingClient(
+            {
+                "https://openrouter.ai/api/v1/credits": {
+                    "data": {"total_credits": 300.0, "total_usage": 10.92}
+                },
+                "https://openrouter.ai/api/v1/key": {
+                    "data": {
+                        "limit": 100.0,
+                        "limit_remaining": 70.0,
+                        "limit_reset": "monthly",
+                        "usage": 12.5,
+                        "usage_daily": 0.5,
+                        "usage_weekly": 2.0,
+                        "usage_monthly": 8.0,
+                        "rate_limit": {"requests": -1, "interval": "10s"},
+                    }
+                },
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("openrouter")
+
+    assert snapshot is not None
+    assert snapshot.windows == (
+        AccountUsageWindow(
+            label="API key quota",
+            used_percent=30.0,
+            detail="$70.00 of $100.00 remaining • resets monthly",
+        ),
+    )
+    assert "Credits balance: $289.08" in snapshot.details
+    assert "API key usage: $12.50 total • $0.50 today • $2.00 this week • $8.00 this month" in snapshot.details
+    assert all("-1 requests / 10s" not in line for line in render_account_usage_lines(snapshot))
+
+
+def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_runtime_provider",
+        lambda requested, explicit_base_url=None, explicit_api_key=None: {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-test",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=10.0: _RoutingClient(
+            {
+                "https://openrouter.ai/api/v1/credits": {
+                    "data": {"total_credits": 100.0, "total_usage": 25.5}
+                },
+                "https://openrouter.ai/api/v1/key": {
+                    "data": {
+                        "limit": None,
+                        "limit_remaining": None,
+                        "usage": 25.5,
+                        "usage_daily": 1.25,
+                        "usage_weekly": 4.5,
+                        "usage_monthly": 18.0,
+                    }
+                },
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("openrouter")
+
+    assert snapshot is not None
+    assert snapshot.windows == ()
+    assert "Credits balance: $74.50" in snapshot.details
+    assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details

--- a/tests/test_cli_background_output.py
+++ b/tests/test_cli_background_output.py
@@ -1,0 +1,25 @@
+from io import StringIO
+
+from cli import HermesCLI
+
+
+def test_display_background_result_falls_back_when_console_write_fails(monkeypatch):
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.bell_on_complete = False
+
+    class BrokenConsole:
+        def print(self, *args, **kwargs):
+            raise ValueError("I/O operation on closed file")
+
+    fallback = StringIO()
+
+    monkeypatch.setattr("cli.ChatConsole", lambda: BrokenConsole())
+    monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
+    monkeypatch.setattr("sys.__stdout__", fallback, raising=False)
+
+    cli_obj._display_background_result(1, "/usage", "done")
+
+    output = fallback.getvalue()
+    assert "Background task #1 complete" in output
+    assert '/usage' in output
+    assert "done" in output

--- a/tests/test_cli_status_bar.py
+++ b/tests/test_cli_status_bar.py
@@ -181,6 +181,33 @@ class TestCLIUsageReport:
         assert "Provider: openai-codex (Pro)" in output
         assert "Session: 85% remaining (15% used)" in output
 
+    def test_show_usage_does_not_fall_back_to_cli_provider_when_agent_provider_missing(self, monkeypatch):
+        cli_obj = _attach_agent(
+            _make_cli(model="glm-5"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            compressions=1,
+        )
+        cli_obj.agent.provider = None
+        cli_obj.provider = "openrouter"
+
+        seen = {}
+
+        def _fake_fetch(provider, base_url=None, api_key=None):
+            seen["provider"] = provider
+            return None
+
+        monkeypatch.setattr("cli.fetch_account_usage", _fake_fetch)
+        monkeypatch.setattr("cli.render_account_usage_lines", lambda snapshot: [])
+
+        cli_obj._show_usage()
+
+        assert seen["provider"] is None
+
     def test_show_usage_marks_unknown_pricing(self, capsys):
         cli_obj = _attach_agent(
             _make_cli(model="local/my-custom-model"),

--- a/tests/test_cli_status_bar.py
+++ b/tests/test_cli_status_bar.py
@@ -10,6 +10,7 @@ def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
     cli_obj.session_start = datetime.now() - timedelta(minutes=14, seconds=32)
     cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
     cli_obj.agent = None
+    cli_obj.verbose = False
     return cli_obj
 
 
@@ -144,6 +145,41 @@ class TestCLIUsageReport:
         assert "0.064" in output
         assert "Session duration:" in output
         assert "Compressions:" in output
+
+    def test_show_usage_includes_account_section_when_available(self, capsys, monkeypatch):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.3-codex"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            compressions=1,
+        )
+        cli_obj.agent.provider = "openai-codex"
+        cli_obj.agent.base_url = "https://chatgpt.com/backend-api/codex"
+        cli_obj.api_key = "unused"
+
+        monkeypatch.setattr(
+            "cli.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: object(),
+        )
+        monkeypatch.setattr(
+            "cli.render_account_usage_lines",
+            lambda snapshot: [
+                "📈 Account limits",
+                "Provider: openai-codex (Pro)",
+                "Session: 85% remaining (15% used)",
+            ],
+        )
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "📈 Account limits" in output
+        assert "Provider: openai-codex (Pro)" in output
+        assert "Session: 85% remaining (15% used)" in output
 
     def test_show_usage_marks_unknown_pricing(self, capsys):
         cli_obj = _attach_agent(


### PR DESCRIPTION
## Summary
- extend `/usage` in both CLI and gateway to append an `Account limits` section after the existing session token report
- keep the original session-scoped usage output intact while adding provider/account-scoped usage when the active provider exposes it
- add provider-specific usage adapters for OpenAI Codex, Anthropic OAuth accounts, and OpenRouter
- harden gateway and CLI behavior so account usage lookup does not block the async gateway loop, still works after a turn completes, and does not fail background output rendering

## What `/usage` Does Now
`/usage` now reports two layers of usage in one command:

1. Session usage
   This is the existing Hermes session report. It includes model, input/output/cache tokens, prompt and completion totals, API calls, session duration, current context occupancy, and pricing/cost status for the current conversation.

2. Account limits
   This is new. Hermes tries to fetch provider-side quota or account usage data for the active provider and appends it under the session usage block.

## Provider Behavior
### OpenAI Codex
- fetches account usage windows from the Codex usage API
- renders the primary window as `Session` and the secondary window as `Weekly`
- includes reset timestamps when the API provides them
- includes credits balance when available

### Anthropic
- uses the OAuth usage API for Claude accounts
- renders available utilization windows such as current session / current week depending on the payload
- includes reset timestamps when available
- if the user is not on an OAuth-backed Claude account, `/usage` reports that account limits are unavailable for that auth mode instead of fabricating data

### OpenRouter
- fetches account-wide credits from `/credits`
- fetches API-key-specific metadata from `/key`
- shows `Credits balance` as remaining account credits
- shows `API key quota` only when the key has a meaningful configured spend limit
- shows `API key usage` details from the key metadata, including daily / weekly / monthly breakdowns when available

Important OpenRouter correction in this PR:
- do not treat deprecated `rate_limit` fields as quota data
- do not interpret all-time key `usage` as percent-used quota
- compute key quota from `limit` and `limit_remaining` instead

## Implementation Notes
- introduced a shared account-usage model and renderer in `agent/account_usage.py`
- wired CLI `/usage` to append account usage lines when available
- wired gateway `/usage` to do the same for messaging platforms
- moved gateway account lookup off the async event loop via `asyncio.to_thread(...)`
- added fallback to persisted billing provider/base URL in gateway sessions so `/usage` can still show account limits even when no live agent instance is resident
- hardened CLI background result rendering so closed prompt-toolkit stdout proxies fall back to plain stdout instead of failing with `I/O operation on closed file`
- avoided misleading CLI fallback behavior where an active session could accidentally show account data for the shell default provider instead of the actual routed provider

## Why This Exists
The original `/usage` only answered: "how many tokens has this Hermes session used?"

This change also answers:
- what provider account am I using right now?
- how much of that account or API-key budget is consumed?
- how much remains?
- when does it reset, if the provider exposes a reset time?

That makes `/usage` closer to a practical quota/debugging command instead of only a token counter.

## Test Plan
- `/Users/kshitij/Projects/hermes-agent/.venv/bin/python -m pytest tests/test_account_usage.py tests/test_cli_status_bar.py tests/test_cli_background_output.py tests/gateway/test_status_command.py -q`
