### PR TITLE
fix: use separate httpx connection pools for Telegram polling and API…

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -25,6 +25,7 @@ try:
         filters,
     )
     from telegram.constants import ParseMode, ChatType
+    from telegram.request import HTTPXRequest
     TELEGRAM_AVAILABLE = True
 except ImportError:
     TELEGRAM_AVAILABLE = False
@@ -37,6 +38,7 @@ except ImportError:
     filters = None
     ParseMode = None
     ChatType = None
+    HTTPXRequest = None
 
     # Mock ContextTypes so type annotations using ContextTypes.DEFAULT_TYPE
     # don't crash during class definition when the library isn't installed.
@@ -230,8 +232,21 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._set_fatal_error("telegram_token_lock", message, retryable=False)
                 return False
 
-            # Build the application
-            self._app = Application.builder().token(self.config.token).build()
+            # Build the application with separate connection pools for
+            # regular API requests and long-poll get_updates.  Without this,
+            # rapid edit_message_text calls during streaming can evict the
+            # idle polling connection, causing httpx.ReadError crashes.
+            request = HTTPXRequest(connection_pool_size=8)
+            get_updates_request = HTTPXRequest(connection_pool_size=2)
+
+            self._app = (
+                Application.builder()
+                .token(self.config.token)
+                .request(request)
+                .get_updates_request(get_updates_request)
+                .get_updates_read_timeout(30)
+                .build()
+            )
             self._bot = self._app.bot
             
             # Register handlers

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -76,7 +76,7 @@ def _ensure_telegram_mock():
     telegram_mod.constants.ChatType.CHANNEL = "channel"
     telegram_mod.constants.ChatType.PRIVATE = "private"
 
-    for name in ("telegram", "telegram.ext", "telegram.constants"):
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
         sys.modules.setdefault(name, telegram_mod)
 
 

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -20,7 +20,7 @@ def _ensure_telegram_mock():
     telegram_mod.constants.ChatType.CHANNEL = "channel"
     telegram_mod.constants.ChatType.PRIVATE = "private"
 
-    for name in ("telegram", "telegram.ext", "telegram.constants"):
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
         sys.modules.setdefault(name, telegram_mod)
 
 
@@ -82,6 +82,9 @@ async def test_polling_conflict_retries_before_fatal(monkeypatch):
     )
     builder = MagicMock()
     builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.get_updates_read_timeout.return_value = builder
     builder.build.return_value = app
     monkeypatch.setattr("gateway.platforms.telegram.Application", SimpleNamespace(builder=MagicMock(return_value=builder)))
 
@@ -155,6 +158,9 @@ async def test_polling_conflict_becomes_fatal_after_retries(monkeypatch):
     )
     builder = MagicMock()
     builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.get_updates_read_timeout.return_value = builder
     builder.build.return_value = app
     monkeypatch.setattr("gateway.platforms.telegram.Application", SimpleNamespace(builder=MagicMock(return_value=builder)))
 
@@ -199,6 +205,9 @@ async def test_connect_marks_retryable_fatal_error_for_startup_network_failure(m
 
     builder = MagicMock()
     builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.get_updates_read_timeout.return_value = builder
     app = SimpleNamespace(
         bot=SimpleNamespace(),
         updater=SimpleNamespace(),

--- a/tests/gateway/test_telegram_connection_pool.py
+++ b/tests/gateway/test_telegram_connection_pool.py
@@ -1,0 +1,109 @@
+"""Regression test: Telegram adapter must use separate connection pools
+for regular API requests and long-poll get_updates to prevent
+httpx.ReadError when streaming edits saturate the shared pool."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_connect_uses_separate_connection_pools(monkeypatch):
+    """connect() must configure separate HTTPXRequest instances for
+    regular API traffic and get_updates polling."""
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    # Track HTTPXRequest instantiations
+    created_requests = []
+
+    class FakeHTTPXRequest:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            created_requests.append(self)
+
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.HTTPXRequest", FakeHTTPXRequest,
+    )
+
+    async def fake_start_polling(**kwargs):
+        pass
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=fake_start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(set_my_commands=AsyncMock())
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.get_updates_read_timeout.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+    assert ok is True
+
+    # Two separate HTTPXRequest instances must have been created
+    assert len(created_requests) == 2, (
+        f"Expected 2 HTTPXRequest instances (api + polling), got {len(created_requests)}"
+    )
+
+    # The main request should have a larger pool
+    api_req = created_requests[0]
+    assert api_req.kwargs.get("connection_pool_size", 0) > 1
+
+    # The get_updates request should be a separate instance
+    polling_req = created_requests[1]
+    assert polling_req is not api_req
+
+    # Builder must have been called with both request instances
+    builder.request.assert_called_once_with(api_req)
+    builder.get_updates_request.assert_called_once_with(polling_req)
+    builder.get_updates_read_timeout.assert_called_once()

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -45,7 +45,7 @@ def _ensure_telegram_mock():
     telegram_mod.constants.ChatType.CHANNEL = "channel"
     telegram_mod.constants.ChatType.PRIVATE = "private"
 
-    for name in ("telegram", "telegram.ext", "telegram.constants"):
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
         sys.modules.setdefault(name, telegram_mod)
 
 

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -28,7 +28,7 @@ def _ensure_telegram_mock():
     mod.constants.ChatType.SUPERGROUP = "supergroup"
     mod.constants.ChatType.CHANNEL = "channel"
     mod.constants.ChatType.PRIVATE = "private"
-    for name in ("telegram", "telegram.ext", "telegram.constants"):
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
         sys.modules.setdefault(name, mod)
 
 


### PR DESCRIPTION
## Summary

- configure separate httpx connection pools for Telegram API requests and `get_updates` long-polling, preventing streaming edit bursts from evicting the idle polling connection
- use `HTTPXRequest(connection_pool_size=8)` for regular API traffic (sends, edits) and a dedicated `HTTPXRequest(connection_pool_size=2)` for polling
- set explicit `get_updates_read_timeout(30)` to match the long-poll timeout
- add `telegram.request` to mock module registrations in all 5 telegram test files
- add regression test verifying two separate `HTTPXRequest` instances are created and passed to the application builder

## Testing

```
./.venv/bin/python -m pytest tests/gateway/test_telegram_conflict.py tests/gateway/test_telegram_connection_pool.py -q
```


Fixes #2489