### PR TITLE
fix(gateway): chdir to messaging working directory for context file resolution

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -203,6 +203,17 @@ _configured_cwd = os.environ.get("TERMINAL_CWD", "")
 if not _configured_cwd or _configured_cwd in (".", "auto", "cwd"):
     messaging_cwd = os.getenv("MESSAGING_CWD") or str(Path.home())
     os.environ["TERMINAL_CWD"] = messaging_cwd
+else:
+    messaging_cwd = _configured_cwd
+
+# Change process working directory so context file loaders (AGENTS.md,
+# HERMES.md, .cursorrules) resolve relative to the user's project, not
+# the hermes-agent installation directory.
+if os.getenv("MESSAGING_CWD") or (_configured_cwd and _configured_cwd not in (".", "auto", "cwd")):
+    try:
+        os.chdir(messaging_cwd)
+    except OSError:
+        pass
 
 from gateway.config import (
     Platform,


### PR DESCRIPTION
## Bug

The gateway sets `TERMINAL_CWD` from `MESSAGING_CWD` (or config) so the terminal tool runs commands in the user's project directory. However, it never actually calls `os.chdir()` to change the process working directory.

`build_context_files_prompt()` in `agent/prompt_builder.py` accepts an optional `cwd` parameter, but it is called without one from `run_agent.py`, so it falls back to `os.getcwd()` — which still points to the hermes-agent installation directory (e.g. `~/.hermes/hermes-agent/`).

**Result:** On messaging platforms, context files (`AGENTS.md`, `HERMES.md`, `.cursorrules`) are loaded from the hermes-agent repo directory instead of the user's configured working directory. The wrong project context is silently injected into every conversation.

## Fix

Add `os.chdir(messaging_cwd)` right after setting `TERMINAL_CWD`, so both the terminal tool and the context file loaders resolve paths from the same directory.

Also adds an `else` branch so `messaging_cwd` is defined when `TERMINAL_CWD` was already explicitly configured.

## Testing

- `python -m pytest tests/gateway/ -q` — 1369 passed
- Verified that `AGENTS.md` in the user's home directory is loaded instead of the repo's own `AGENTS.md`