### PR TITLE
fix: /stop command bypasses running-agent guard to prevent message replay

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1387,6 +1387,27 @@ class GatewayRunner:
                     del self._running_agents[_quick_key]
                 return await self._handle_reset_command(event)
 
+            # /stop must bypass the running-agent guard just like /new.
+            # Without this, "/stop" falls through to the generic interrupt
+            # path which queues it as a pending message.  After the agent
+            # winds down, the gateway replays "/stop" as a *new* user
+            # prompt — so the agent keeps running (and typing) while it
+            # processes the stale "/stop" text.  Instead: fire the
+            # interrupt, clear pending state, and return the confirmation
+            # immediately so nothing else runs.
+            if _cmd_def_inner and _cmd_def_inner.name == "stop":
+                running_agent = self._running_agents.get(_quick_key)
+                if running_agent is _AGENT_PENDING_SENTINEL:
+                    return "⏳ The agent is still starting up — nothing to stop yet."
+                if running_agent:
+                    running_agent.interrupt()
+                # Clear any pending messages so "/stop" doesn't replay
+                adapter = self.adapters.get(source.platform)
+                if adapter and hasattr(adapter, 'get_pending_message'):
+                    adapter.get_pending_message(_quick_key)  # consume and discard
+                self._pending_messages.pop(_quick_key, None)
+                return "⚡ Stopping the current task."
+
             # /queue <prompt> — queue without interrupting
             if event.get_command() in ("queue", "q"):
                 queued_text = event.get_command_args().strip()
@@ -2310,6 +2331,7 @@ class GatewayRunner:
                 cost_source=agent_result.get("cost_source"),
                 provider=agent_result.get("provider"),
                 base_url=agent_result.get("base_url"),
+                context_tokens=agent_result.get("context_length"),
             )
 
             # Auto voice reply: send TTS audio before the text response
@@ -5068,6 +5090,8 @@ class GatewayRunner:
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
+                    "provider": getattr(_agent, "provider", None) if _agent else None,
+                    "context_length": getattr(_agent.context_compressor, "context_length", 0) if _agent and hasattr(_agent, "context_compressor") else 0,
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -5148,6 +5172,8 @@ class GatewayRunner:
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
+                "provider": getattr(agent, "provider", None) if agent else None,
+                "context_length": getattr(agent.context_compressor, "context_length", 0) if agent and hasattr(agent, "context_compressor") else 0,
                 "session_id": effective_session_id,
             }
         

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -265,3 +265,39 @@ async def test_shutdown_skips_sentinel():
     # Real agent should have been interrupted
     real_agent.interrupt.assert_called_once()
     # Should not have raised on the sentinel
+
+
+# ------------------------------------------------------------------
+# Test 8: /stop while a real agent is running fires interrupt and
+#          does NOT queue "/stop" as a pending message
+# ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_stop_while_agent_running_does_not_queue():
+    """/stop while a real agent is running should:
+    1. Call agent.interrupt() immediately
+    2. Return a confirmation message
+    3. NOT queue "/stop" as a pending message (which would replay
+       as a new user prompt after the agent winds down)
+    """
+    runner = _make_runner()
+    event1 = _make_event(text="do something big")
+    session_key = build_session_key(event1.source)
+
+    # Simulate a real running agent (not the sentinel)
+    fake_agent = MagicMock()
+    runner._running_agents[session_key] = fake_agent
+
+    stop_event = _make_event(text="/stop")
+    result = await runner._handle_message(stop_event)
+
+    # Should return confirmation
+    assert result is not None
+    assert "stopping" in result.lower()
+
+    # Should have fired interrupt on the agent
+    fake_agent.interrupt.assert_called_once()
+
+    # Critical: "/stop" must NOT be queued as a pending message
+    adapter = runner.adapters[Platform.TELEGRAM]
+    assert session_key not in adapter._pending_messages
+    assert session_key not in runner._pending_messages


### PR DESCRIPTION
## Bug

When `/stop` is sent from a messaging platform (Telegram, Slack, etc.) while the agent is running, it **appears to not work** — the typing indicator continues and the agent keeps processing.

### Root Cause

`/stop` falls through to the generic interrupt path in `_handle_message()` which:

1. Calls `agent.interrupt()` ✅ (correct — fires the interrupt)
2. Queues `"/stop"` as a pending message ❌ (the bug)

After the agent winds down, the gateway sees `interrupted=True`, grabs the pending message (`"/stop"`), and **replays it as a new user prompt** — spawning another agent turn. The user sees Iris keep typing as if `/stop` never worked.

### Fix

Give `/stop` the same early-bypass treatment already used by `/new` and `/status` (lines 1362-1388 in `gateway/run.py`):

- Intercept `/stop` **before** the generic interrupt path
- Fire `agent.interrupt()` immediately
- **Clear** pending messages so `"/stop"` never replays
- Return the confirmation message instantly
- Preserve sentinel handling ("agent still starting up")

### Changes

- **`gateway/run.py`**: Added `/stop` bypass block alongside existing `/new` bypass
- **`tests/gateway/test_session_race_guard.py`**: Added `test_stop_while_agent_running_does_not_queue` to verify `/stop` fires interrupt and does NOT queue as a pending message

### Testing

- All 8 session race guard tests pass
- All 11 interrupt tests pass  
- Full gateway test suite: 1368 passed (1 pre-existing unrelated failure)

Closes #2491