### PR TITLE
fix(gateway): recover from hung agents — /stop hard-kills session lock

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1362,6 +1362,28 @@ class GatewayRunner:
             if event.get_command() == "status":
                 return await self._handle_status_command(event)
 
+            # /stop must hard-kill the session when an agent is running.
+            # A soft interrupt (agent.interrupt()) doesn't help when the agent
+            # is truly hung — the executor thread is blocked and never checks
+            # _interrupt_requested.  Force-clean _running_agents so the session
+            # is unlocked and subsequent messages are processed normally.
+            from hermes_cli.commands import resolve_command as _resolve_stop_cmd
+            _stop_cmd = event.get_command()
+            _stop_def = _resolve_stop_cmd(_stop_cmd) if _stop_cmd else None
+            if _stop_def and _stop_def.name == "stop":
+                running_agent = self._running_agents.get(_quick_key)
+                if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+                    running_agent.interrupt("Stop requested")
+                # Force-clean: remove the session lock regardless of agent state
+                adapter = self.adapters.get(source.platform)
+                if adapter and hasattr(adapter, 'get_pending_message'):
+                    adapter.get_pending_message(_quick_key)  # consume and discard
+                self._pending_messages.pop(_quick_key, None)
+                if _quick_key in self._running_agents:
+                    del self._running_agents[_quick_key]
+                logger.info("HARD STOP for session %s — session lock released", _quick_key[:20])
+                return "⚡ Force-stopped. The session is unlocked — you can send a new message."
+
             # /reset and /new must bypass the running-agent guard so they
             # actually dispatch as commands instead of being queued as user
             # text (which would be fed back to the agent with the same
@@ -1429,8 +1451,11 @@ class GatewayRunner:
             if running_agent is _AGENT_PENDING_SENTINEL:
                 # Agent is being set up but not ready yet.
                 if event.get_command() == "stop":
-                    # Nothing to interrupt — agent hasn't started yet.
-                    return "⏳ The agent is still starting up — nothing to stop yet."
+                    # Force-clean the sentinel so the session is unlocked.
+                    if _quick_key in self._running_agents:
+                        del self._running_agents[_quick_key]
+                    logger.info("HARD STOP (pending) for session %s — sentinel cleared", _quick_key[:20])
+                    return "⚡ Force-stopped. The agent was still starting — session unlocked."
                 # Queue the message so it will be picked up after the
                 # agent starts.
                 adapter = self.adapters.get(source.platform)
@@ -4527,6 +4552,7 @@ class GatewayRunner:
         logger.debug("Process watcher ended: %s", session_id)
 
     _MAX_INTERRUPT_DEPTH = 3  # Cap recursive interrupt handling (#816)
+    _AGENT_RUN_TIMEOUT = 600  # 10 minutes — hard timeout for run_in_executor (#2491)
 
     @staticmethod
     def _agent_config_signature(
@@ -5205,9 +5231,35 @@ class GatewayRunner:
         interrupt_monitor = asyncio.create_task(monitor_for_interrupt())
         
         try:
-            # Run in thread pool to not block
+            # Run in thread pool to not block.
+            # Wrap in wait_for to prevent hung agents from locking the
+            # session forever.  When the timeout fires, the finally block
+            # cleans up _running_agents so the session is unlocked.
             loop = asyncio.get_event_loop()
-            response = await loop.run_in_executor(None, run_sync)
+            try:
+                response = await asyncio.wait_for(
+                    loop.run_in_executor(None, run_sync),
+                    timeout=self._AGENT_RUN_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Agent run timed out after %ds for session %s — force-killing",
+                    self._AGENT_RUN_TIMEOUT, session_key,
+                )
+                # Try to interrupt the hung agent so the thread can exit
+                agent = agent_holder[0]
+                if agent:
+                    agent.interrupt("Agent timed out")
+                response = {
+                    "final_response": (
+                        "⚠️ The agent timed out after "
+                        f"{self._AGENT_RUN_TIMEOUT // 60} minutes and was stopped. "
+                        "Send a new message to continue."
+                    ),
+                    "messages": [],
+                    "api_calls": 0,
+                    "tools": tools_holder[0] or [],
+                }
 
             # Track fallback model state: if the agent switched to a
             # fallback model during this run, persist it so /model shows

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -198,12 +198,12 @@ async def test_command_messages_do_not_leave_sentinel():
 
 
 # ------------------------------------------------------------------
-# Test 6: /stop during sentinel returns helpful message
+# Test 6: /stop during sentinel force-cleans and unlocks session
 # ------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_stop_during_sentinel_returns_message():
+async def test_stop_during_sentinel_force_cleans_session():
     """If /stop arrives while the sentinel is set (agent still starting),
-    it should return a helpful message instead of crashing or queuing."""
+    it should force-clean the sentinel and unlock the session."""
     runner = _make_runner()
     event1 = _make_event(text="hello")
     session_key = build_session_key(event1.source)
@@ -221,11 +221,16 @@ async def test_stop_during_sentinel_returns_message():
         # Sentinel should be set
         assert runner._running_agents.get(session_key) is _AGENT_PENDING_SENTINEL
 
-        # Send /stop — should get a message, not crash
+        # Send /stop — should force-clean the sentinel
         stop_event = _make_event(text="/stop")
         result = await runner._handle_message(stop_event)
         assert result is not None, "/stop during sentinel should return a message"
-        assert "starting up" in result.lower()
+        assert "force-stopped" in result.lower() or "unlocked" in result.lower()
+
+        # Sentinel must be cleaned up
+        assert session_key not in runner._running_agents, (
+            "/stop must remove sentinel so the session is unlocked"
+        )
 
         # Should NOT be queued as pending
         adapter = runner.adapters[Platform.TELEGRAM]
@@ -233,6 +238,73 @@ async def test_stop_during_sentinel_returns_message():
 
         barrier.set()
         await task1
+
+
+# ------------------------------------------------------------------
+# Test 6b: /stop hard-kills a running agent and unlocks session
+# ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_stop_hard_kills_running_agent():
+    """When /stop arrives while a real agent is running, it must:
+    1. Call interrupt() on the agent
+    2. Force-clean _running_agents to unlock the session
+    3. Return a confirmation message
+    This fixes the bug where a hung agent kept the session locked
+    forever — showing 'writing...' but never producing output."""
+    runner = _make_runner()
+    session_key = build_session_key(
+        SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+    )
+
+    # Simulate a running (possibly hung) agent
+    fake_agent = MagicMock()
+    runner._running_agents[session_key] = fake_agent
+
+    # Send /stop
+    stop_event = _make_event(text="/stop")
+    result = await runner._handle_message(stop_event)
+
+    # Agent must have been interrupted
+    fake_agent.interrupt.assert_called_once_with("Stop requested")
+
+    # Session must be unlocked
+    assert session_key not in runner._running_agents, (
+        "/stop must remove the agent from _running_agents so the session is unlocked"
+    )
+
+    # Must return a confirmation
+    assert result is not None
+    assert "force-stopped" in result.lower() or "unlocked" in result.lower()
+
+
+# ------------------------------------------------------------------
+# Test 6c: /stop clears pending messages to prevent stale replays
+# ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_stop_clears_pending_messages():
+    """When /stop hard-kills a running agent, any pending messages
+    queued during the run must be discarded."""
+    runner = _make_runner()
+    session_key = build_session_key(
+        SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+    )
+
+    fake_agent = MagicMock()
+    runner._running_agents[session_key] = fake_agent
+    runner._pending_messages[session_key] = "some queued text"
+
+    # Queue a pending message in the adapter too
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter._pending_messages[session_key] = _make_event(text="queued")
+    adapter.get_pending_message = MagicMock(return_value=_make_event(text="queued"))
+    adapter.has_pending_interrupt = MagicMock(return_value=False)
+
+    stop_event = _make_event(text="/stop")
+    await runner._handle_message(stop_event)
+
+    # Pending messages must be cleared
+    assert session_key not in runner._pending_messages
+    adapter.get_pending_message.assert_called_once_with(session_key)
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When the agent hangs on a messaging platform (Telegram, Discord, etc.), the bot shows **"writing..." indefinitely** and **no command can break the deadlock** — not `/stop`, not `/new`, not `/reset`. The session is permanently locked until the gateway is restarted.

This happened in practice: the agent crashed silently, Telegram showed "writing..." for hours, and every command sent was either swallowed or called `interrupt()` on an unresponsive agent.

### Root Cause

`_run_agent()` calls `loop.run_in_executor(None, run_sync)` with **no timeout** (L5210). When the executor thread hangs (deadlocked API call, frozen tool, unresponsive provider):

1. The `finally` block never runs → `_running_agents[session_key]` is never cleaned up
2. All subsequent messages hit the PRIORITY handling block (L1361) which calls `agent.interrupt()` on the hung agent — a no-op since the agent never checks `_interrupt_requested`
3. The session is permanently locked — the only recovery is restarting the gateway

## Solution

Three complementary fixes:

### 1. `/stop` hard-kills the session lock

When `/stop` arrives while an agent is running, it now **force-cleans `_running_agents`** regardless of agent state (same pattern `/new` already uses):
- Calls `agent.interrupt()` for a graceful attempt
- Deletes `_running_agents[key]` to unlock the session
- Clears pending messages to prevent stale replays
- Returns `"⚡ Force-stopped. The session is unlocked"`

This works even when the agent is truly hung because the lock is released independently.

### 2. 10-minute timeout on `run_in_executor`

Wraps the executor call in `asyncio.wait_for(..., timeout=600)`:
- Prevents agents from blocking forever
- On timeout, interrupts the agent and returns an error message
- The `finally` block runs normally, cleaning up all resources

### 3. `/stop` during PENDING_SENTINEL also force-cleans

Previously returned `"⏳ still starting up"` without clearing the sentinel. Now removes it so the session is unlocked.

## Tests

- Updated existing test for `/stop` during sentinel to verify force-clean behavior
- Added test: `/stop` hard-kills a running agent and unlocks the session
- Added test: `/stop` clears pending messages to prevent stale replays
- All 1350 existing gateway tests pass