### PR TITLE
Normalize OPENROUTER_API_KEY handling (ignore whitespace-only values)

### DIFF
--- a/tests/tools/test_openrouter_client.py
+++ b/tests/tools/test_openrouter_client.py
@@ -5,6 +5,7 @@ def test_openrouter_api_key_whitespace_is_unset(monkeypatch):
 
     assert check_api_key() is False
 
+
 def test_openrouter_api_key_valid(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
 

--- a/tests/tools/test_openrouter_client.py
+++ b/tests/tools/test_openrouter_client.py
@@ -1,0 +1,13 @@
+def test_openrouter_api_key_whitespace_is_unset(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "   ")
+
+    from tools.openrouter_client import check_api_key
+
+    assert check_api_key() is False
+
+def test_openrouter_api_key_valid(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+
+    from tools.openrouter_client import check_api_key
+
+    assert check_api_key() is True

--- a/tools/openrouter_client.py
+++ b/tools/openrouter_client.py
@@ -30,4 +30,5 @@ def get_async_client():
 
 def check_api_key() -> bool:
     """Check whether the OpenRouter API key is present."""
-    return bool(os.getenv("OPENROUTER_API_KEY"))
+    value = os.getenv("OPENROUTER_API_KEY")
+    return bool(value and value.strip())


### PR DESCRIPTION
## Summary
Fixes handling of `OPENROUTER_API_KEY` where whitespace-only values were treated as valid.

## Changes
- Normalize `OPENROUTER_API_KEY` checks to ignore whitespace-only values
- Add tests covering whitespace-only and valid values

## Motivation
Whitespace-only environment variables could previously pass validation, leading to misconfiguration.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)