### PR TITLE
Normalize FAL_KEY env handling (ignore whitespace-only values)

### DIFF
--- a/tests/tools/test_image_generation_env.py
+++ b/tests/tools/test_image_generation_env.py
@@ -1,0 +1,14 @@
+def test_fal_key_whitespace_is_unset(monkeypatch):
+    monkeypatch.setenv("FAL_KEY", "   ")
+
+    from tools.image_generation_tool import check_fal_api_key
+
+    assert check_fal_api_key() is False
+
+
+def test_fal_key_valid(monkeypatch):
+    monkeypatch.setenv("FAL_KEY", "sk-test")
+
+    from tools.image_generation_tool import check_fal_api_key
+
+    assert check_fal_api_key() is True

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -280,7 +280,8 @@ def image_generate_tool(
             raise ValueError("Prompt is required and must be a non-empty string")
         
         # Check API key availability
-        if not os.getenv("FAL_KEY"):
+        value = os.getenv("FAL_KEY")
+        if not value or not value.strip():
             raise ValueError("FAL_KEY environment variable not set")
         
         # Validate other parameters
@@ -400,7 +401,8 @@ def check_fal_api_key() -> bool:
     Returns:
         bool: True if API key is set, False otherwise
     """
-    return bool(os.getenv("FAL_KEY"))
+    value = os.getenv("FAL_KEY")
+    return bool(value and value.strip())
 
 
 def check_image_generation_requirements() -> bool:


### PR DESCRIPTION
## Summary
Fixes handling of `FAL_KEY` where whitespace-only values were treated as valid.

## Changes
- Normalize `FAL_KEY` checks to ignore whitespace-only values
- Update validation to treat empty/whitespace values as unset
- Add tests covering whitespace-only and valid values

## Motivation
Whitespace-only environment variables could previously pass validation, leading to runtime errors or misconfiguration.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## How to Test
```bash
pytest tests/tools/test_image_generation_env.py -q