### PR TITLE
fix(model_metadata): Copilot context resolves to 128k instead of 400k

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -164,6 +164,8 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "openrouter.ai": "openrouter",
     "inference-api.nousresearch.com": "nous",
     "api.deepseek.com": "deepseek",
+    "api.githubcopilot.com": "copilot",
+    "models.github.ai": "copilot",
 }
 
 
@@ -788,8 +790,12 @@ def get_model_context_length(
         if cached is not None:
             return cached
 
-    # 2. Active endpoint metadata for explicit custom routes
-    if _is_custom_endpoint(base_url):
+    # 2. Active endpoint metadata for truly custom/unknown endpoints.
+    # Known providers (Copilot, OpenAI, Anthropic, etc.) skip this — their
+    # /models endpoint may report a provider-imposed limit (e.g. Copilot
+    # returns 128k) instead of the model's full context (400k).  models.dev
+    # has the correct per-provider values and is checked at step 5+.
+    if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url):
         endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
         matched = endpoint_metadata.get(model)
         if not matched:


### PR DESCRIPTION
## Bug

gpt-5.4 via GitHub Copilot resolves to 128k context instead of the correct 400k. models.dev correctly reports 400k context / 272k input / 128k output, but the resolver never reaches models.dev because it returns early from the endpoint metadata probe.

**Root cause:** The Copilot `/models` endpoint returns `context_length: 128000` (the provider-imposed output limit). Since `_is_custom_endpoint` returns True for any non-OpenRouter URL, the resolver probes the endpoint at step 2 — before the models.dev lookup at step 7 — and the wrong value wins.

## Fix

1. Add `api.githubcopilot.com` and `models.github.ai` to `_URL_TO_PROVIDER` so they're recognized as known providers
2. Skip the endpoint metadata probe for known providers — their `/models` response is unreliable for context length; models.dev has the correct per-provider data

This also fixes the same class of bug for any known provider whose `/models` endpoint reports a limit lower than the model's actual context.

Reported by danny [DUMB].

## Test plan
- [x] All 94 model metadata tests pass