### PR TITLE
chore: remove unused imports, dead code, and stale comments

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -448,7 +448,6 @@ from rich import box as rich_box
 from rich.console import Console
 from rich.markup import escape as _escape
 from rich.panel import Panel
-from rich.table import Table
 from rich.text import Text as _RichText
 
 import fire
@@ -460,12 +459,12 @@ from model_tools import get_tool_definitions, get_toolset_for_tool
 # Extracted CLI modules (Phase 3)
 from hermes_cli.banner import (
     cprint as _cprint, _GOLD, _BOLD, _DIM, _RST,
-    VERSION, RELEASE_DATE, HERMES_AGENT_LOGO, HERMES_CADUCEUS, COMPACT_BANNER,
+    HERMES_AGENT_LOGO, HERMES_CADUCEUS, COMPACT_BANNER,
     build_welcome_banner,
 )
 from hermes_cli.commands import COMMANDS, SlashCommandCompleter, SlashCommandAutoSuggest
 from hermes_cli import callbacks as _callbacks
-from toolsets import get_all_toolsets, get_toolset_info, resolve_toolset, validate_toolset
+from toolsets import get_all_toolsets, get_toolset_info, validate_toolset
 
 # Cron job system for scheduled tasks (execution is handled by the gateway)
 from cron import get_job
@@ -884,7 +883,6 @@ def _build_compact_banner() -> str:
 
 from agent.skill_commands import (
     scan_skill_commands,
-    get_skill_commands,
     build_skill_invocation_message,
     build_plan_path,
     build_preloaded_skills_prompt,

--- a/model_tools.py
+++ b/model_tools.py
@@ -22,7 +22,6 @@ Public API (signatures preserved from the original 2,400-line version):
 
 import json
 import asyncio
-import os
 import logging
 import threading
 from typing import Dict, Any, List, Optional, Tuple

--- a/run_agent.py
+++ b/run_agent.py
@@ -70,7 +70,7 @@ from tools.browser_tool import cleanup_browser
 
 import requests
 
-from hermes_constants import OPENROUTER_BASE_URL, OPENROUTER_MODELS_URL
+from hermes_constants import OPENROUTER_BASE_URL
 
 # Agent internals extracted to agent/ package for modularity
 from agent.prompt_builder import (
@@ -78,7 +78,7 @@ from agent.prompt_builder import (
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
 )
 from agent.model_metadata import (
-    fetch_model_metadata, get_model_context_length,
+    fetch_model_metadata,
     estimate_tokens_rough, estimate_messages_tokens_rough,
     get_next_probe_tier, parse_context_limit_from_error,
     save_context_length,

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -614,19 +614,6 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, str]:
     return session_info
 
 
-def _get_session_name(task_id: Optional[str] = None) -> str:
-    """
-    Get the session name for agent-browser CLI.
-    
-    Args:
-        task_id: Unique identifier for the task
-        
-    Returns:
-        Session name for agent-browser
-    """
-    session_info = _get_session_info(task_id)
-    return session_info["session_name"]
-
 
 def _find_agent_browser() -> str:
     """

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -31,15 +31,12 @@ import json
 import logging
 import os
 import platform
-import signal
 import sys
 import time
 import threading
 import atexit
 import shutil
 import subprocess
-import tempfile
-import uuid
 from pathlib import Path
 from typing import Optional, Dict, Any
 
@@ -51,7 +48,7 @@ logger = logging.getLogger(__name__)
 # The terminal tool polls this during command execution so it can kill
 # long-running subprocesses immediately instead of blocking until timeout.
 # ---------------------------------------------------------------------------
-from tools.interrupt import set_interrupt as set_interrupt_event, is_interrupted, _interrupt_event
+from tools.interrupt import is_interrupted, _interrupt_event
 
 
 # Add mini-swe-agent to path if not installed. In git worktrees the populated
@@ -131,11 +128,8 @@ def set_approval_callback(cb):
 
 # Dangerous command detection + approval now consolidated in tools/approval.py
 from tools.approval import (
-    detect_dangerous_command as _detect_dangerous_command,
     check_dangerous_command as _check_dangerous_command_impl,
     check_all_command_guards as _check_all_guards_impl,
-    load_permanent_allowlist as _load_permanent_allowlist,
-    DANGEROUS_PATTERNS,
 )
 
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -36,10 +36,6 @@ Usage:
     crawl_data = web_crawl_tool("example.com", "Find contact information")
 """
 
-#TODO: Search Capabilities over the scraped pages
-#TODO: Store the pages in something
-#TODO: Tool to see what pages are available/saved to search over
-
 import json
 import logging
 import os

--- a/toolsets.py
+++ b/toolsets.py
@@ -226,7 +226,6 @@ TOOLSETS = {
     # ==========================================================================
     # Full Hermes toolsets (CLI + messaging platforms)
     #
-    # All platforms share the same core tools. Messaging platforms add
     # All platforms share the same core tools (including send_message,
     # which is gated on gateway running via its check_fn).
     # ==========================================================================
@@ -535,33 +534,6 @@ def get_toolset_info(name: str) -> Dict[str, Any]:
     }
 
 
-def print_toolset_tree(name: str, indent: int = 0) -> None:
-    """
-    Print a tree view of a toolset and its composition.
-    
-    Args:
-        name (str): Toolset name
-        indent (int): Current indentation level
-    """
-    prefix = "  " * indent
-    toolset = get_toolset(name)
-    
-    if not toolset:
-        print(f"{prefix}❌ Unknown toolset: {name}")
-        return
-    
-    # Print toolset name and description
-    print(f"{prefix}📦 {name}: {toolset['description']}")
-    
-    # Print direct tools
-    if toolset["tools"]:
-        print(f"{prefix}  🔧 Tools: {', '.join(toolset['tools'])}")
-    
-    # Print included toolsets
-    if toolset["includes"]:
-        print(f"{prefix}  📂 Includes:")
-        for included in toolset["includes"]:
-            print_toolset_tree(included, indent + 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Mechanical cleanup — no behavior changes, -59 lines.

**Unused imports removed (11):**
| File | Import |
|------|--------|
| `model_tools.py` | `import os` |
| `run_agent.py` | `OPENROUTER_MODELS_URL` |
| `run_agent.py` | `get_model_context_length` |
| `cli.py` | `Table` (rich), `VERSION`, `RELEASE_DATE`, `resolve_toolset`, `get_skill_commands` |
| `terminal_tool.py` | `signal`, `uuid`, `tempfile`, `set_interrupt_event`, `DANGEROUS_PATTERNS`, `_load_permanent_allowlist`, `_detect_dangerous_command` |

**Dead code removed (2):**
- `toolsets.py`: `print_toolset_tree()` — zero callers anywhere in the codebase
- `browser_tool.py`: `_get_session_name()` — never called, superseded by `_get_session_info()`

**Stale comments removed (2):**
- `toolsets.py`: duplicated/garbled comment line
- `web_tools.py`: 3 aspirational TODO comments from early development

219 tests pass (model_tools + cli_init + run_agent). All 7 files compile clean.