### PR TITLE
feat(cli): add Shift+Enter for multiline input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -48,8 +48,18 @@ from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.widgets import TextArea
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.keys import Keys
 from prompt_toolkit import print_formatted_text as _pt_print
 from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+
+# Register Shift+Enter so it inserts a newline (like Alt+Enter / Ctrl+Enter).
+# Terminals using the kitty keyboard protocol or xterm's modifyOtherKeys send
+# distinct escape sequences for Shift+Enter. Map both formats to (Escape, ControlM)
+# which triggers the existing 'escape','enter' keybinding below.
+ANSI_SEQUENCES["\x1b[13;2u"] = (Keys.Escape, Keys.ControlM)     # kitty protocol
+ANSI_SEQUENCES["\x1b[27;2;13~"] = (Keys.Escape, Keys.ControlM)  # xterm format
+
 try:
     from prompt_toolkit.cursor_shapes import CursorShape
     _STEADY_CURSOR = CursorShape.BLOCK  # Non-blinking block cursor


### PR DESCRIPTION
## What does this PR do?

Registers Shift+Enter as a newline keybinding in the CLI, matching the existing behaviour of Alt+Enter and Ctrl+Enter. Previously, Shift+Enter either submitted the input (xterm format was mapped to plain `Keys.ControlM`) or was ignored entirely (kitty protocol sequence was unmapped).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `cli.py` (lines 51–60): Added imports for `Keys`, `ANSI_SEQUENCES`, and registered two escape sequences at module level:
  - `\x1b[13;2u` → kitty keyboard protocol (iTerm2, Kitty, WezTerm, Ghostty)
  - `\x1b[27;2;13~` → xterm modifyOtherKeys format
- Both map to `(Keys.Escape, Keys.ControlM)`, which triggers the existing `handle_alt_enter` keybinding that calls `event.current_buffer.insert_text('\n')`

## How to Test

1. Open Hermes CLI in a terminal that supports the kitty keyboard protocol (iTerm2, Kitty, WezTerm, or Ghostty)
2. Type some text, press Shift+Enter — a newline should be inserted
3. Press Enter — the full multiline input should submit
4. Verify Alt+Enter and Ctrl+Enter still work as before
5. In a terminal without kitty protocol support, Shift+Enter should still submit (no regression — the escape sequence simply isn't sent)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(cli): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (6 pre-existing failures unrelated to this change — model config, credential resolution, transcription)
- [ ] I've added tests for my changes — N/A (escape sequence registration is a static mapping; testable only with a real terminal emulator)
- [x] I've tested on my platform: macOS 15.x (Ghostty)

### Documentation & Housekeeping

- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — terminals without kitty protocol support are unaffected; the escape sequences are simply never sent, so there is no regression
- [ ] I've updated tool descriptions/schemas — N/A