### PR TITLE
feat: implement system-reminder injection pattern (#519)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2462,6 +2462,27 @@ class AIAgent:
         return truncated
 
     @staticmethod
+    def _inject_system_reminder(messages: List[Dict[str, Any]], content: str, position: str = "last_user"):
+        """Inject a system reminder into the conversation history.
+        
+        Appends a formatted <system-reminder> block to the specified message
+        to ensure the model pays attention to it at the end of the context window.
+        """
+        if not messages:
+            return
+
+        reminder = f"\n\n<system-reminder>\n{content}\n</system-reminder>"
+        
+        if position == "last_user":
+            # Find the last message from the user (or tool) and append
+            for msg in reversed(messages):
+                if msg.get("role") in ("user", "tool") and isinstance(msg.get("content"), str):
+                    msg["content"] += reminder
+                    break
+        elif position == "new_user":
+            messages.append({"role": "user", "content": reminder})    
+
+    @staticmethod
     def _deduplicate_tool_calls(tool_calls: list) -> list:
         """Remove duplicate (tool_name, arguments) pairs within a single turn.
 
@@ -4773,6 +4794,13 @@ class AIAgent:
                 if is_error:
                     result_preview = function_result[:200] if len(function_result) > 200 else function_result
                     logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
+                    
+                    function_result += (
+                        "\n\n<system-reminder>\n"
+                        "The tool execution failed. Please analyze the error, reconsider your approach, "
+                        "and try a DIFFERENT method or parameter set. Do not repeat the exact same action."
+                        "\n</system-reminder>"
+                    )
 
                 if self.verbose_logging:
                     logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
@@ -5033,7 +5061,15 @@ class AIAgent:
             # in the UI always have a corresponding detailed entry on disk.
             _is_error_result, _ = _detect_tool_failure(function_name, function_result)
             if _is_error_result:
+                result_preview = function_result[:200] if len(function_result) > 200 else function_result
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
+                
+                function_result += (
+                    "\n\n<system-reminder>\n"
+                    "The tool execution failed. Please analyze the error, reconsider your approach, "
+                    "and try a DIFFERENT method or parameter set. Do not repeat the exact same action."
+                    "\n</system-reminder>"
+                )
 
             if self.verbose_logging:
                 logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
@@ -5105,7 +5141,7 @@ class AIAgent:
                 print(f"{self.log_prefix}{tier}: {remaining} iterations remaining")
 
     def _get_budget_warning(self, api_call_count: int) -> Optional[str]:
-        """Return a budget pressure string, or None if not yet needed.
+        """Return a budget pressure string formatted as a system reminder, or None if not yet needed.
 
         Two-tier system:
           - Caution (70%): nudge to consolidate work
@@ -5117,14 +5153,19 @@ class AIAgent:
         remaining = self.max_iterations - api_call_count
         if progress >= self._budget_warning_threshold:
             return (
-                f"[BUDGET WARNING: Iteration {api_call_count}/{self.max_iterations}. "
-                f"Only {remaining} iteration(s) left. "
-                "Provide your final response NOW. No more tool calls unless absolutely critical.]"
+                "<system-reminder>\n"
+                f"BUDGET WARNING: Iteration {api_call_count}/{self.max_iterations}. "
+                f"Only {remaining} iteration(s) left.\n"
+                "Provide your final response NOW summarizing what you've accomplished. "
+                "No more tool calls unless absolutely critical."
+                "\n</system-reminder>"
             )
         if progress >= self._budget_caution_threshold:
             return (
-                f"[BUDGET: Iteration {api_call_count}/{self.max_iterations}. "
-                f"{remaining} iterations left. Start consolidating your work.]"
+                "<system-reminder>\n"
+                f"BUDGET CAUTION: Iteration {api_call_count}/{self.max_iterations}. "
+                f"{remaining} iterations left. Start consolidating your work and preparing your final answer."
+                "\n</system-reminder>"
             )
         return None
 
@@ -5171,12 +5212,10 @@ class AIAgent:
         """Request a summary when max iterations are reached. Returns the final response text."""
         print(f"⚠️  Reached maximum iterations ({self.max_iterations}). Requesting summary...")
 
-        summary_request = (
-            "You've reached the maximum number of tool-calling iterations allowed. "
-            "Please provide a final response summarizing what you've found and accomplished so far, "
-            "without calling any more tools."
-        )
-        messages.append({"role": "user", "content": summary_request})
+        messages.append({
+            "role": "assistant",
+            "content": "I've reached my iteration limit. Let me summarize what I've accomplished and what remains..."
+        })
 
         try:
             # Build API messages, stripping internal-only fields


### PR DESCRIPTION
What does this PR do?
Implements the <system-reminder> XML tag injection pattern (inspired by Kilocode) to improve model instruction-following via attention recency bias.

Specifically, this covers Phases 1-3 from the issue:
Phase 1: Added _inject_system_reminder infrastructure.
Phase 2: Wrapped tool error recovery and iteration budget warnings in <system-reminder> tags to forcefully guide the model.
Phase 3: Updated _handle_max_iterations to use an assistant role prefix instead of a user prompt for stopping behavior.

Related Issue
Fixes #519

Type of Change
[ ] 🐛 Bug fix (non-breaking change that fixes an issue)
[x] ✨ New feature (non-breaking change that adds functionality)
[ ] 🔒 Security fix
[ ] 📝 Documentation update
[ ] ✅ Tests (adding or improving test coverage)
[ ] ♻️ Refactor (no behavior change)
[ ] 🎯 New skill (bundled or hub)

Changes Made
-run_agent.py: Added @staticmethod def _inject_system_reminder.
-run_agent.py: Updated _execute_tool_calls_concurrent & _execute_tool_calls_sequential to inject reminders on _is_error_result.
-run_agent.py: Updated _get_budget_warning to wrap strings in tags, and refactored _handle_max_iterations to append an assistant message.

How to Test
Run the agent with a strict turn limit and trigger a missing tool (e.g., browser without Chrome):
python run_agent.py --max_turns=2 --verbose --query="Search the web for quantum computing"
Verify the tool error is followed by <system-reminder> The tool execution failed... </system-reminder>.
Verify the budget warning triggers correctly.
Verify that upon hitting max iterations, the agent outputs the forced assistant prefix: "I've reached my iteration limit. Let me summarize..."

Checklist
Code
[x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
[x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
[x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
[x] My PR contains only changes related to this fix/feature (no unrelated commits)
[x] I've run pytest tests/ -q and all tests pass
[ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
[x] I've tested on my platform: GitHub Codespaces (Linux)

Documentation & Housekeeping
[x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
[x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
[x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
[x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
[x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Screenshots / Logs
Here is the CLI output proving the tool error injection, budget warning injection, and the assistant prefix trigger all working perfectly together:
<img width="1170" height="352" alt="56665" src="https://github.com/user-attachments/assets/58228c9d-61c7-4897-aaa3-a25c1bc5b995" />
