### PR TITLE
fix(cli): auto-detect context length for custom providers when not specified

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1197,13 +1197,18 @@ def _model_flow_custom(config):
     if not context_length and model_name:
         try:
             from agent.model_metadata import get_model_context_length
-            detected = get_model_context_length(model_name)
+            from hermes_cli.banner import _format_context_length
+            detected = get_model_context_length(
+                model_name,
+                base_url=effective_url,
+                api_key=effective_key or "",
+            )
             default_ctx = get_model_context_length("")  # get default
             if detected and detected != default_ctx:
                 context_length = detected
-                print(f"  💡 Context length auto-detected: {context_length:,} tokens")
+                print(f"  💡 Context length auto-detected: {_format_context_length(context_length)}")
             else:
-                print(f"  📏 Context length: using default 128,000 tokens (could not auto-detect for {model_name!r})")
+                print(f"  📏 Context length: using default 128K tokens (override with model.context_length in config.yaml)")
         except Exception:
             pass
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1201,9 +1201,9 @@ def _model_flow_custom(config):
             default_ctx = get_model_context_length("")  # get default
             if detected and detected != default_ctx:
                 context_length = detected
-                print(f"  🔍 Auto-detected context length: {context_length:,} tokens")
+                print(f"  💡 Context length auto-detected: {context_length:,} tokens")
             else:
-                print(f"  ℹ️  Using default context length: 128,000 tokens (could not auto-detect for {model_name!r})")
+                print(f"  📏 Context length: using default 128,000 tokens (could not auto-detect for {model_name!r})")
         except Exception:
             pass
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1193,6 +1193,20 @@ def _model_flow_custom(config):
     if api_key:
         save_env_value("OPENAI_API_KEY", api_key)
 
+    # Auto-detect context length if not provided
+    if not context_length and model_name:
+        try:
+            from agent.model_metadata import get_model_context_length
+            detected = get_model_context_length(model_name)
+            default_ctx = get_model_context_length("")  # get default
+            if detected and detected != default_ctx:
+                context_length = detected
+                print(f"  🔍 Auto-detected context length: {context_length:,} tokens")
+            else:
+                print(f"  ℹ️  Using default context length: 128,000 tokens (could not auto-detect for {model_name!r})")
+        except Exception:
+            pass
+
     if model_name:
         _save_model_choice(model_name)
 

--- a/tests/test_custom_provider_context_detection.py
+++ b/tests/test_custom_provider_context_detection.py
@@ -1,0 +1,58 @@
+"""Tests for custom provider context length auto-detection (#2513)."""
+import pytest
+from unittest.mock import patch
+
+
+class TestCustomProviderContextDetection:
+
+    def test_autodetect_known_model(self):
+        from agent.model_metadata import get_model_context_length
+        result = get_model_context_length("anthropic/claude-opus-4-6")
+        assert result > 0
+
+    def test_autodetect_unknown_model_returns_default(self):
+        from agent.model_metadata import get_model_context_length
+        result = get_model_context_length("unknown/totally-fake-model-xyz")
+        assert result > 0
+
+    def test_save_custom_provider_with_context_length(self):
+        import tempfile, os
+        import yaml
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.yaml"
+            config_path.write_text("{}")
+
+            with patch("hermes_cli.config.get_config_path", return_value=config_path):
+                from hermes_cli.main import _save_custom_provider
+                _save_custom_provider(
+                    base_url="http://localhost:11434/v1",
+                    model="llama3.1",
+                    context_length=131072,
+                )
+                saved = yaml.safe_load(config_path.read_text()) or {}
+                providers = saved.get("custom_providers", [])
+                assert len(providers) == 1
+                assert providers[0]["models"]["llama3.1"]["context_length"] == 131072
+
+    def test_save_custom_provider_without_context_length(self):
+        import tempfile
+        import yaml
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.yaml"
+            config_path.write_text("{}")
+
+            with patch("hermes_cli.config.get_config_path", return_value=config_path):
+                from hermes_cli.main import _save_custom_provider
+                _save_custom_provider(
+                    base_url="http://localhost:11434/v1",
+                    model="llama3.1",
+                    context_length=None,
+                )
+                saved = yaml.safe_load(config_path.read_text()) or {}
+                providers = saved.get("custom_providers", [])
+                assert len(providers) == 1
+                assert "models" not in providers[0]


### PR DESCRIPTION
Fixes #2513

## Problem
When saving a custom provider via /model without specifying a context length, users had no feedback on what context window was being used.

## Fix
After the user leaves context length blank, attempt auto-detection via `get_model_context_length(model_name)`:
- If detected: show `💡 Context length auto-detected: X tokens` and save to config
- If not detected: show `📏 Context length: using default 128,000 tokens`

## Tests
Added `tests/test_custom_provider_context_detection.py` with 4 tests:
- Auto-detection for known models
- Default fallback for unknown models  
- `_save_custom_provider` with context_length
- `_save_custom_provider` without context_length

