### PR TITLE
fix(slack): formatting consistency, table conversion, thread reply fix

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -198,6 +198,7 @@ class SlackAdapter(BasePlatformAdapter):
         """Edit a previously sent Slack message."""
         if not self._app:
             return SendResult(success=False, error="Not connected")
+        content = self.format_message(content)
         try:
             await self._app.client.chat_update(
                 channel=chat_id,
@@ -362,7 +363,42 @@ class SlackAdapter(BasePlatformAdapter):
         #    no extra escaping happens to the > character)
         # Slack uses the same > prefix, so this is a no-op for content.
 
-        # 9) Restore placeholders in reverse order
+        # 9) Convert markdown tables into fenced code blocks
+        def _convert_tables(text: str) -> str:
+            lines = text.split('\n')
+            result = []
+            i = 0
+            while i < len(lines):
+                line = lines[i]
+                # Detect start of a markdown table row
+                if re.match(r'^\|.*\|', line):
+                    table_lines = []
+                    while i < len(lines) and re.match(r'^\|.*\|', lines[i]):
+                        table_lines.append(lines[i])
+                        i += 1
+                    # Filter out separator rows (lines with only |, -, :, space)
+                    data_rows = [
+                        l for l in table_lines
+                        if not re.match(r'^[\|\-\:\s]+$', l)
+                    ]
+                    if data_rows:
+                        result.append('```')
+                        for row in data_rows:
+                            # Strip leading/trailing pipes and spaces
+                            cells = re.split(r'\s*\|\s*', row.strip().strip('|'))
+                            result.append('  '.join(cells))
+                        result.append('```')
+                    continue
+                result.append(line)
+                i += 1
+            return '\n'.join(result)
+
+        text = _convert_tables(text)
+
+        # 10) Strip horizontal rules (--- / *** / ___ with 3+ chars)
+        text = re.sub(r'^(?:-{3,}|\*{3,}|_{3,})\s*$', '', text, flags=re.MULTILINE)
+
+        # 11) Restore placeholders in reverse order
         for key in reversed(list(placeholders.keys())):
             text = text.replace(key, placeholders[key])
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5283,7 +5283,7 @@ class GatewayRunner:
                     if first_response and not _already_streamed:
                         try:
                             await adapter.send(source.chat_id, first_response,
-                                               metadata=getattr(event, "metadata", None))
+                                               metadata={"thread_id": source.thread_id} if getattr(source, "thread_id", None) else None)
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                 # else: interrupted — discard the interrupted response ("Operation


### PR DESCRIPTION
## Summary

This PR fixes three bugs in the Hermes Slack gateway.

---

### Bug 1 — `edit_message()` skips `format_message()` (streaming sends raw markdown)

**File:** `gateway/platforms/slack.py`

`edit_message()` was calling `chat_update` with raw markdown content, bypassing the `format_message()` conversion that translates standard markdown to Slack mrkdwn. This meant streamed message edits would show `**bold**` instead of `*bold*`, `## Header` instead of bold text, etc.

**Fix:** Added `content = self.format_message(content)` as the first line after the not-connected guard in `edit_message()`.

---

### Bug 2 — Markdown tables and horizontal rules leak through `format_message()`

**File:** `gateway/platforms/slack.py`

`format_message()` had no handling for markdown tables (`| col | col |`) or horizontal rules (`---`, `***`, `___`), so these were passed through as-is to Slack, where they render as raw text.

**Fix:** Added two new conversion steps in `format_message()` before placeholder restoration:
1. **Table conversion** — consecutive lines matching `^\|.*\|` are detected, separator rows (containing only `-`, `:`, `|`, space) are stripped, and data rows are formatted into a fenced code block (``````) with cells joined by two spaces.
2. **Horizontal rule stripping** — lines consisting solely of `---`, `***`, or `___` (3+ chars) are removed.

---

### Bug 3 — Wrong thread replies (interrupt/follow-up path)

**File:** `gateway/run.py` (~line 5285)

In the interrupt/follow-up path, when sending the first response before processing a queued message, `adapter.send()` was using `getattr(event, "metadata", None)` for thread metadata. The `event` object at that point may not carry correct thread context, causing replies to land in the wrong thread or at the channel level.

**Fix:** Replaced with `{"thread_id": source.thread_id} if getattr(source, "thread_id", None) else None` so the reply always targets the correct source thread.

---

## Tests

All 1378 gateway tests pass:
```
1378 passed, 95 warnings in 12.79s
```