### PR TITLE
fix(discord): typing indicator task not cleaned up after API error

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1276,6 +1276,8 @@ class DiscordAdapter(BasePlatformAdapter):
                     await asyncio.sleep(8)
             except asyncio.CancelledError:
                 pass
+            finally:
+                self._typing_tasks.pop(chat_id, None)
 
         self._typing_tasks[chat_id] = asyncio.create_task(_typing_loop())
 

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 import sys
@@ -78,3 +79,61 @@ async def test_send_retries_without_reference_when_reply_target_is_system_messag
     assert channel.send.await_count == 2
     assert send_calls[0]["reference"] is ref_msg
     assert send_calls[1]["reference"] is None
+
+
+# ---------------------------------------------------------------------------
+# Typing indicator task lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_typing_task_removed_after_api_error():
+    """When typing API call fails, stale task must be removed so typing can restart."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = MagicMock()
+    adapter._client.http = MagicMock()
+    adapter._client.http.request = AsyncMock(side_effect=Exception("rate limited"))
+    adapter._typing_tasks = {}
+
+    await adapter.send_typing("12345")
+    await asyncio.sleep(0.1)
+
+    assert "12345" not in adapter._typing_tasks, \
+        "Stale task should be removed after API error"
+
+
+@pytest.mark.asyncio
+async def test_typing_restartable_after_error():
+    """After a typing error, send_typing should start a new task (not blocked by stale entry)."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = MagicMock()
+    adapter._client.http = MagicMock()
+    adapter._typing_tasks = {}
+
+    # First call fails
+    adapter._client.http.request = AsyncMock(side_effect=Exception("503"))
+    await adapter.send_typing("12345")
+    await asyncio.sleep(0.1)
+
+    # Second call should work
+    adapter._client.http.request = AsyncMock()
+    await adapter.send_typing("12345")
+
+    assert "12345" in adapter._typing_tasks, \
+        "Should restart typing after previous failure"
+
+
+@pytest.mark.asyncio
+async def test_typing_stop_cleans_up():
+    """stop_typing should remove the task from _typing_tasks."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = MagicMock()
+    adapter._client.http = MagicMock()
+    adapter._client.http.request = AsyncMock()
+    adapter._typing_tasks = {}
+
+    await adapter.send_typing("12345")
+    assert "12345" in adapter._typing_tasks
+
+    await adapter.stop_typing("12345")
+    assert "12345" not in adapter._typing_tasks


### PR DESCRIPTION
## Summary

When the Discord typing API call fails (429 rate limit, network error, HTTP 403), `_typing_loop` returns early but the completed task remains in `_typing_tasks`. Subsequent `send_typing` calls see the stale entry and return immediately, leaving no typing indicator for the rest of the agent invocation.

### Root cause

```python
async def _typing_loop() -> None:
    try:
        while True:
            try:
                await self._client.http.request(route)
            except Exception as e:
                return  # exits, but _typing_tasks[chat_id] NOT removed
    except asyncio.CancelledError:
        pass
    # no finally -> stale task stays in dict
```

### Fix

Add `finally` block to always remove the task from `_typing_tasks`:

```python
finally:
    self._typing_tasks.pop(chat_id, None)
```

### Impact

Users see no typing indicator for the remainder of an agent invocation (potentially 30+ seconds) after any transient Discord API error. The next user message creates a fresh request so the issue is per-invocation, not permanent.

## Test plan

- [x] 4 tests pass (1 existing + 3 new in `test_discord_send.py`)
- [x] Task removed after API error
- [x] Typing restartable after failure (not blocked by stale entry)
- [x] stop_typing cleans up correctly
- [x] 1 line change, fully isolated to `_typing_loop`