### PR TITLE
fix: /stop bypasses all replay paths to prevent message replay

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -856,6 +856,18 @@ class BasePlatformAdapter(ABC):
                     self._pending_messages[session_key] = event
                 return  # Don't interrupt now - will run after current task completes
 
+            # /stop command: fire the interrupt but do NOT queue the event.
+            # Queuing '/stop' would cause it to be replayed as a user prompt
+            # after the agent winds down (via monitor_for_interrupt or adapter replay).
+            # Also clear any already-queued follow-up so it doesn't replay after stop.
+            if event.get_command() == 'stop':
+                print(f"[{self.name}] 🛑 /stop while session {session_key} is active - interrupt only, no queue")
+                self._pending_messages.pop(session_key, None)
+                self._active_sessions[session_key].set()
+                _thread_md = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+                asyncio.create_task(self.send(event.source.chat_id, "⚙️ Agent was aborted.", metadata=_thread_md))
+                return
+
             # Default behavior for non-photo follow-ups: interrupt the running agent
             print(f"[{self.name}] ⚡ New message while session {session_key} is active - triggering interrupt")
             self._pending_messages[session_key] = event

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1359,20 +1359,33 @@ class GatewayRunner:
         # let the adapter-level batching/queueing logic absorb them.
         _quick_key = self._session_key_for_source(source)
         if _quick_key in self._running_agents:
-            if event.get_command() == "status":
-                return await self._handle_status_command(event)
-
-            # /reset and /new must bypass the running-agent guard so they
-            # actually dispatch as commands instead of being queued as user
-            # text (which would be fed back to the agent with the same
-            # broken history — #2170).  Interrupt the agent first, then
-            # clear the adapter's pending queue so the stale "/reset" text
-            # doesn't get re-processed as a user message after the
-            # interrupt completes.
+            # Resolve the command once for all bypass checks below.
             from hermes_cli.commands import resolve_command as _resolve_cmd_inner
             _evt_cmd = event.get_command()
             _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
-            if _cmd_def_inner and _cmd_def_inner.name == "new":
+            _canonical_inner = _cmd_def_inner.name if _cmd_def_inner else None
+
+            if _canonical_inner == "status":
+                return await self._handle_status_command(event)
+
+            # /stop: interrupt the agent and return immediately.
+            # Must not fall through to the generic interrupt path which
+            # queues the text as a pending message — "/stop" would be
+            # replayed as a user prompt after the agent winds down.
+            if _canonical_inner == "stop":
+                running_agent = self._running_agents.get(_quick_key)
+                if running_agent is _AGENT_PENDING_SENTINEL:
+                    return "⏳ The agent is still starting up — nothing to stop yet."
+                if running_agent:
+                    running_agent.interrupt()
+                # Clear any pre-queued follow-up so it doesn't replay after stop.
+                adapter = self.adapters.get(source.platform)
+                if adapter and hasattr(adapter, 'get_pending_message'):
+                    adapter.get_pending_message(_quick_key)
+                self._pending_messages.pop(_quick_key, None)
+                return "⚡ Stopping the current task."
+
+            if _canonical_inner == "new":
                 running_agent = self._running_agents.get(_quick_key)
                 if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
                     running_agent.interrupt("Session reset requested")
@@ -1428,9 +1441,7 @@ class GatewayRunner:
             running_agent = self._running_agents.get(_quick_key)
             if running_agent is _AGENT_PENDING_SENTINEL:
                 # Agent is being set up but not ready yet.
-                if event.get_command() == "stop":
-                    # Nothing to interrupt — agent hasn't started yet.
-                    return "⏳ The agent is still starting up — nothing to stop yet."
+                # Note: /stop is already intercepted above.
                 # Queue the message so it will be picked up after the
                 # agent starts.
                 adapter = self.adapters.get(source.platform)
@@ -2310,6 +2321,7 @@ class GatewayRunner:
                 cost_source=agent_result.get("cost_source"),
                 provider=agent_result.get("provider"),
                 base_url=agent_result.get("base_url"),
+                context_tokens=agent_result.get("context_length"),
             )
 
             # Auto voice reply: send TTS audio before the text response
@@ -2464,19 +2476,12 @@ class GatewayRunner:
         return "\n".join(lines)
     
     async def _handle_stop_command(self, event: MessageEvent) -> str:
-        """Handle /stop command - interrupt a running agent."""
-        source = event.source
-        session_entry = self.session_store.get_or_create_session(source)
-        session_key = session_entry.session_key
-        
-        agent = self._running_agents.get(session_key)
-        if agent is _AGENT_PENDING_SENTINEL:
-            return "⏳ The agent is still starting up — nothing to stop yet."
-        if agent:
-            agent.interrupt()
-            return "⚡ Stopping the current task... The agent will finish its current step and respond."
-        else:
-            return "No active task to stop."
+        """Handle /stop when no agent is currently running.
+
+        When an agent IS running, /stop is intercepted earlier in
+        _handle_message() and never reaches this method.
+        """
+        return "No active task to stop."
     
     async def _handle_help_command(self, event: MessageEvent) -> str:
         """Handle /help command - list available commands."""
@@ -5068,6 +5073,8 @@ class GatewayRunner:
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
+                    "provider": getattr(_agent, "provider", None) if _agent else None,
+                    "context_length": getattr(_agent.context_compressor, "context_length", 0) if _agent and hasattr(_agent, "context_compressor") else 0,
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -5148,6 +5155,8 @@ class GatewayRunner:
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
+                "provider": getattr(agent, "provider", None) if agent else None,
+                "context_length": getattr(agent.context_compressor, "context_length", 0) if agent and hasattr(agent, "context_compressor") else 0,
                 "session_id": effective_session_id,
             }
         

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
 from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
 from gateway.session import SessionSource, build_session_key
 
@@ -265,3 +265,96 @@ async def test_shutdown_skips_sentinel():
     # Real agent should have been interrupted
     real_agent.interrupt.assert_called_once()
     # Should not have raised on the sentinel
+
+
+# ------------------------------------------------------------------
+# Test 8: /stop while agent running — interrupt, don't queue
+# ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_stop_while_running_interrupts_without_queuing():
+    """/stop while an agent is running should fire interrupt and return
+    immediately — NOT queue "/stop" as a pending message for replay."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_event().source)
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    fake_agent = MagicMock()
+    runner._running_agents[session_key] = fake_agent
+
+    result = await runner._handle_message(_make_event(text="/stop"))
+
+    assert result is not None
+    assert "stopping" in result.lower()
+    fake_agent.interrupt.assert_called_once_with()
+    assert session_key not in adapter._pending_messages
+    assert session_key not in runner._pending_messages
+
+
+# ------------------------------------------------------------------
+# Test 9: Adapter-level /stop — interrupt fires, nothing queued
+# ------------------------------------------------------------------
+class _ConcreteAdapter(BasePlatformAdapter):
+    """Minimal concrete adapter for testing BasePlatformAdapter.handle_message."""
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="1")
+
+    async def get_chat_info(self, chat_id):
+        return {"name": "test", "type": "dm"}
+
+
+@pytest.mark.asyncio
+async def test_adapter_stop_sets_interrupt_without_queuing():
+    """/stop through BasePlatformAdapter.handle_message() while a session
+    is active must fire the interrupt event but NOT store anything in
+    _pending_messages — preventing replay via monitor_for_interrupt,
+    _run_agent, or _process_message_background."""
+    config = PlatformConfig(enabled=True, token="***")
+    adapter = _ConcreteAdapter(config, Platform.TELEGRAM)
+    # Register a dummy message handler so handle_message doesn't bail early
+    adapter.set_message_handler(AsyncMock())
+
+    event = _make_event(text="/stop")
+    session_key = build_session_key(event.source)
+
+    # Simulate an active session with an interrupt event
+    interrupt_event = asyncio.Event()
+    adapter._active_sessions[session_key] = interrupt_event
+
+    await adapter.handle_message(event)
+
+    # Interrupt must have fired
+    assert interrupt_event.is_set(), "Interrupt event should be set for /stop"
+    # /stop must NOT be queued
+    assert session_key not in adapter._pending_messages, (
+        "/stop must not be stored in _pending_messages"
+    )
+
+
+@pytest.mark.asyncio
+async def test_adapter_non_stop_command_still_queued():
+    """Non-stop messages through the active-session branch should still be
+    queued in _pending_messages (regression guard)."""
+    config = PlatformConfig(enabled=True, token="***")
+    adapter = _ConcreteAdapter(config, Platform.TELEGRAM)
+    adapter.set_message_handler(AsyncMock())
+
+    event = _make_event(text="please continue")
+    session_key = build_session_key(event.source)
+
+    interrupt_event = asyncio.Event()
+    adapter._active_sessions[session_key] = interrupt_event
+
+    await adapter.handle_message(event)
+
+    assert interrupt_event.is_set(), "Interrupt event should be set for follow-up messages"
+    assert session_key in adapter._pending_messages, (
+        "Non-stop messages must still be queued in _pending_messages"
+    )
+    assert adapter._pending_messages[session_key] is event


### PR DESCRIPTION
## Bug

When /stop is sent from chat while the agent is running, the text "/stop" gets queued and replayed as a user prompt after the agent winds down — making it appear as if /stop didn't work.

## Root Cause

Three replay paths existed:
1. _handle_message() running-agent guard queued "/stop" as pending text
2. BasePlatformAdapter.handle_message() queued "/stop" in adapter _pending_messages, which monitor_for_interrupt and _run_agent replayed
3. _process_message_background() replayed queued events after handler return

## Fix

Intercept /stop at both layers before it enters any queue.

- **base.py**: adapter fires interrupt event, clears any pre-queued follow-up, sends "⚙️ Agent was aborted." confirmation, does NOT store /stop in _pending_messages (kills paths 2+3 at the source)
- **run.py**: runner guard intercepts /stop before generic interrupt path, clears pending messages (kills path 1, defense-in-depth for non-adapter callers)

All tests pass. Closes #2491