### PR TITLE
fix(discord): stop persistent typing loop after response completes

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1130,6 +1130,14 @@ class BasePlatformAdapter(ABC):
                 await typing_task
             except asyncio.CancelledError:
                 pass
+            # Stop any persistent platform-level typing loop (e.g. Discord's
+            # _typing_loop). Must happen AFTER cancelling _keep_typing to avoid
+            # a race where _keep_typing re-spawns the loop right before being
+            # cancelled.
+            try:
+                await self.stop_typing(event.source.chat_id)
+            except Exception:
+                pass
             # Clean up session tracking
             if session_key in self._active_sessions:
                 del self._active_sessions[session_key]

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1136,8 +1136,14 @@ class BasePlatformAdapter(ABC):
             # cancelled.
             try:
                 await self.stop_typing(event.source.chat_id)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(
+                    "Error while stopping typing indicator for chat %s on adapter %s: %s",
+                    event.source.chat_id,
+                    getattr(self, "name", type(self).__name__),
+                    e,
+                    exc_info=True,
+                )
             # Clean up session tracking
             if session_key in self._active_sessions:
                 del self._active_sessions[session_key]


### PR DESCRIPTION
## What does this PR do?

Discord's "typing..." indicator stays active indefinitely after the bot responds. The `finally` block in `base.py` cancels `_keep_typing` but never calls `stop_typing()`, so the Discord-level `_typing_loop` task (stored in `_typing_tasks`) keeps running forever.

This PR calls `stop_typing()` after `_keep_typing` is fully cancelled and awaited, ensuring the Discord background typing task is cleaned up. The order matters: calling `stop_typing()` *after* cancelling `_keep_typing` prevents a race where `_keep_typing`'s last iteration re-spawns a new `_typing_loop` right before being cancelled.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: Added `await self.stop_typing(event.source.chat_id)` in the `finally` block, after cancelling and awaiting `_keep_typing`

## How to Test

1. Configure Hermes with a Discord bot token and test via a DM
2. Send a message and observe the "typing..." indicator while the bot processes
3. After the bot responds, confirm the typing indicator disappears (previously it would remain indefinitely)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (2 pre-existing failures and 4 import errors unrelated to this change)
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.3.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (`stop_typing` is async/pure-Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix: Discord typing indicator persists indefinitely after bot response.  
After fix: Typing indicator stops as soon as the response is delivered.