### PR TITLE
fix(mcp): suppress benign 'Event loop is closed' noise on shutdown

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -906,6 +906,21 @@ _mcp_thread: Optional[threading.Thread] = None
 _lock = threading.Lock()
 
 
+def _mcp_loop_exception_handler(loop, context):
+    """Suppress benign 'Event loop is closed' noise during shutdown.
+
+    When the MCP event loop is stopped and closed, httpx/httpcore async
+    transports may fire __del__ finalizers that call call_soon() on the
+    dead loop.  asyncio catches that RuntimeError and routes it here.
+    We silence it because the connection is being torn down anyway; all
+    other exceptions are forwarded to the default handler.
+    """
+    exc = context.get("exception")
+    if isinstance(exc, RuntimeError) and "Event loop is closed" in str(exc):
+        return  # benign shutdown race — suppress
+    loop.default_exception_handler(context)
+
+
 def _ensure_mcp_loop():
     """Start the background event loop thread if not already running."""
     global _mcp_loop, _mcp_thread
@@ -913,6 +928,7 @@ def _ensure_mcp_loop():
         if _mcp_loop is not None and _mcp_loop.is_running():
             return
         _mcp_loop = asyncio.new_event_loop()
+        _mcp_loop.set_exception_handler(_mcp_loop_exception_handler)
         _mcp_thread = threading.Thread(
             target=_mcp_loop.run_forever,
             name="mcp-event-loop",


### PR DESCRIPTION
## Problem

Closes #2537

HTTP MCP servers (StreamableHTTP transport) print `Unhandled exception in event loop: Event loop is closed` on every session exit. This is pure stderr noise but alarming and may mask real errors.

**Root cause:** When `_stop_mcp_loop()` stops and closes the MCP background loop, httpx/httpcore async transports held by `streamablehttp_client` fire `__del__` finalizers that call `call_soon()` on the now-dead loop. asyncio catches the `RuntimeError` and routes it to the loop's exception handler, which by default prints it to stderr. The connection teardown is a no-op at this point — safe to ignore.

## Fix

Install a custom exception handler on the MCP event loop at creation time in `_ensure_mcp_loop()`:

```python
def _mcp_loop_exception_handler(loop, context):
    exc = context.get("exception")
    if isinstance(exc, RuntimeError) and "Event loop is closed" in str(exc):
        return  # benign shutdown race — suppress
    loop.default_exception_handler(context)
```

This silently drops `RuntimeError('Event loop is closed')` and forwards all other exceptions to the default handler, preserving visibility into real errors.

## Testing

- All 142 existing MCP tool tests pass (`tests/tools/test_mcp_tool.py`)
- No new tests needed — this suppresses a `stderr` print path that has no observable side-effects

## Pattern

Same class of async shutdown race fixed previously in:
- `model_tools.py` (ab6abc2c) — persistent event loop for tool handlers  
- `agent/auxiliary_client.py` — stale async client cache invalidation