### PR TITLE
test: cover bare @ path fragment completion

### DIFF
--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -163,6 +163,24 @@ class TestIntegration:
         # /etc/hosts should exist on Linux
         assert any("host" in n.lower() for n in names)
 
+    def test_bare_context_path_fragment_returns_context_reference(self, completer, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        target = src_dir / "main.py"
+        target.touch()
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            doc = Document("check @src/ma", cursor_position=len("check @src/ma"))
+            event = MagicMock()
+            completions = list(completer.get_completions(doc, event))
+        finally:
+            os.chdir(old_cwd)
+
+        assert any(c.text == "@file:src/main.py" for c in completions)
+        assert all(c.text != "src/main.py" for c in completions)
+
 
 class TestFileSizeLabel:
     def test_bytes(self, tmp_path):


### PR DESCRIPTION
## Summary
- add regression coverage for bare `@...` context completion when the token includes a path segment
- assert that `@src/ma` produces a parser-compatible `@file:src/main.py` completion instead of a raw `src/main.py` path insertion

## Context
A review on the feature branch called out a real failure mode: if non-slash input falls back to plain path completion before bare `@` context completion, nested references like `review @src/ma` can stop producing parser-compatible context references.

Latest `main` already behaves correctly here, but it did not have explicit coverage for this case. This PR locks that behavior in so future completer changes do not regress back to raw path insertion.

## Why This Matters
Bare `@` completion is only useful if it keeps returning references the context parser understands. If a nested path fragment completes to `src/main.py` instead of `@file:src/main.py`, the feature silently degrades right at the point where users are most likely to rely on it for real files.

## Test Plan
- `source /Users/kshitij/Projects/hermes-agent/.venv/bin/activate && python -m pytest tests/hermes_cli/test_path_completion.py -q`
