### PR TITLE
feat(models): add glm-5-turbo to zai provider curated model list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -87,6 +87,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "zai": [
         "glm-5",
+        "glm-5-turbo",
         "glm-4.7",
         "glm-4.5",
         "glm-4.5-flash",


### PR DESCRIPTION
## Summary

Adds `glm-5-turbo` to the `_PROVIDER_MODELS["zai"]` curated model list.

Currently `glm-5-turbo` is listed in `_OPENROUTER_UPSTREAM_MODELS` but missing from the direct zai provider list. This means `/model zai:glm-5-turbo` fails validation, even though the model is available on the z.ai API.

## Test

- `/model zai:glm-5-turbo` now validates and persists correctly