### PR TITLE
feat(cli): support whole-word deletion in the TUI input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -80,6 +80,7 @@ _CTRL_BACKSPACE_ESCAPE_SEQUENCES = (
     "\x1b[27;5;127~",
     "\x1b[27;5;8~",
 )
+_CTRL_ENTER_KEYS = Keys.ControlJ
 _KITTY_KEYBOARD_QUERY = "\x1b[?u"
 _KITTY_KEYBOARD_ENABLE = "\x1b[>1u"
 _KITTY_KEYBOARD_DISABLE = "\x1b[<u"
@@ -346,6 +347,11 @@ def _install_enhanced_keyboard_input_sequences(
     for codepoint, control_key in _CONTROL_KEY_BY_ASCII.items():
         sequences[_kitty_key_sequence(codepoint, 5)] = control_key
         sequences[_modify_other_keys_sequence(codepoint, 5)] = control_key
+
+    # Keep enhanced Ctrl+Enter on Hermes' existing multiline binding (`c-j`)
+    # instead of letting it collapse to the plain Enter/submit path.
+    sequences[_kitty_key_sequence(13, 5)] = _CTRL_ENTER_KEYS
+    sequences[_modify_other_keys_sequence(13, 5)] = _CTRL_ENTER_KEYS
 
     for codepoint in (8, 13, 127):
         alt_key = (Keys.Escape, Keys.ControlH if codepoint in (8, 127) else Keys.ControlM)

--- a/cli.py
+++ b/cli.py
@@ -7082,6 +7082,7 @@ class HermesCLI:
         terminal_keyboard_cleanup = None
         pending_terminal_key_presses = []
         try:
+            _tkbd.install_all()
             terminal_keyboard_detection = _tkbd.detect_capabilities()
             self._terminal_keyboard_mode = _tkbd.select_mode(
                 terminal_keyboard_detection.capabilities

--- a/cli.py
+++ b/cli.py
@@ -23,7 +23,9 @@ import tempfile
 import time
 import uuid
 import textwrap
+import re
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any, Optional
@@ -78,6 +80,143 @@ _CTRL_BACKSPACE_ESCAPE_SEQUENCES = (
     "\x1b[27;5;127~",
     "\x1b[27;5;8~",
 )
+_KITTY_KEYBOARD_QUERY = "\x1b[?u"
+_KITTY_KEYBOARD_ENABLE = "\x1b[>1u"
+_KITTY_KEYBOARD_DISABLE = "\x1b[<u"
+_MODIFY_OTHER_KEYS_QUERY = "\x1b[>4;?m"
+_MODIFY_OTHER_KEYS_ENABLE = "\x1b[>4;2m"
+_MODIFY_OTHER_KEYS_DISABLE = "\x1b[>4;0m"
+_DEVICE_ATTRIBUTES_QUERY = "\x1b[c"
+_TERMINAL_KEYBOARD_QUERY_TIMEOUT_S = 0.25
+_KITTY_QUERY_RESPONSE_RE = re.compile(r"\x1b\[\?(\d+)u")
+_MODIFY_OTHER_KEYS_RESPONSE_RE = re.compile(r"\x1b\[>4;(\d+)m")
+_DEVICE_ATTRIBUTES_RESPONSE_RE = re.compile(r"\x1b\[\?(?:\d+)(?:;\d+)*c")
+
+
+@dataclass(frozen=True)
+class _TerminalKeyboardCapabilities:
+    kitty_supported: bool = False
+    modify_other_keys_supported: bool = False
+
+
+def _parse_terminal_keyboard_capabilities(data: str) -> _TerminalKeyboardCapabilities:
+    """Parse raw terminal responses for keyboard protocol support."""
+    kitty_supported = bool(_KITTY_QUERY_RESPONSE_RE.search(data))
+    modify_levels = [
+        int(match.group(1))
+        for match in _MODIFY_OTHER_KEYS_RESPONSE_RE.finditer(data)
+    ]
+    return _TerminalKeyboardCapabilities(
+        kitty_supported=kitty_supported,
+        modify_other_keys_supported=any(level >= 2 for level in modify_levels),
+    )
+
+
+def _select_terminal_keyboard_mode(
+    capabilities: _TerminalKeyboardCapabilities,
+) -> str | None:
+    """Pick the best keyboard enhancement mode supported by the terminal."""
+    if capabilities.kitty_supported:
+        return "kitty"
+    if capabilities.modify_other_keys_supported:
+        return "modify_other_keys"
+    return None
+
+
+def _write_terminal_sequence(
+    sequence: str,
+    *,
+    writer=None,
+) -> None:
+    """Emit a raw terminal control sequence."""
+    if writer is not None:
+        writer(sequence)
+        return
+
+    stdout = getattr(sys, "__stdout__", None) or sys.stdout
+    if stdout is None or not hasattr(stdout, "write") or not hasattr(stdout, "flush"):
+        return
+    stdout.write(sequence)
+    stdout.flush()
+
+
+def _set_terminal_keyboard_mode(
+    mode: str | None,
+    *,
+    enable: bool,
+    writer=None,
+) -> None:
+    """Enable or disable an enhanced terminal keyboard mode."""
+    if mode == "kitty":
+        sequence = _KITTY_KEYBOARD_ENABLE if enable else _KITTY_KEYBOARD_DISABLE
+    elif mode == "modify_other_keys":
+        sequence = _MODIFY_OTHER_KEYS_ENABLE if enable else _MODIFY_OTHER_KEYS_DISABLE
+    else:
+        return
+    _write_terminal_sequence(sequence, writer=writer)
+
+
+def _detect_terminal_keyboard_capabilities(
+    *,
+    timeout_s: float = _TERMINAL_KEYBOARD_QUERY_TIMEOUT_S,
+) -> _TerminalKeyboardCapabilities:
+    """Best-effort terminal capability probe for keyboard enhancement modes."""
+    if os.name == "nt":
+        return _TerminalKeyboardCapabilities()
+
+    stdin = getattr(sys, "__stdin__", None) or sys.stdin
+    stdout = getattr(sys, "__stdout__", None) or sys.stdout
+    if stdin is None or stdout is None:
+        return _TerminalKeyboardCapabilities()
+    if not hasattr(stdin, "isatty") or not hasattr(stdout, "isatty"):
+        return _TerminalKeyboardCapabilities()
+    if not stdin.isatty() or not stdout.isatty():
+        return _TerminalKeyboardCapabilities()
+
+    try:
+        import select
+        import termios
+        import tty
+    except Exception:
+        return _TerminalKeyboardCapabilities()
+
+    try:
+        stdin_fd = stdin.fileno()
+        original_attrs = termios.tcgetattr(stdin_fd)
+    except Exception:
+        return _TerminalKeyboardCapabilities()
+
+    try:
+        tty.setcbreak(stdin_fd)
+        _write_terminal_sequence(
+            _KITTY_KEYBOARD_QUERY + _MODIFY_OTHER_KEYS_QUERY + _DEVICE_ATTRIBUTES_QUERY
+        )
+
+        chunks: list[bytes] = []
+        deadline = time.monotonic() + max(0.0, timeout_s)
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            ready, _, _ = select.select([stdin_fd], [], [], max(0.0, remaining))
+            if not ready:
+                continue
+            chunk = os.read(stdin_fd, 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            decoded = b"".join(chunks).decode("utf-8", errors="ignore")
+            if _DEVICE_ATTRIBUTES_RESPONSE_RE.search(decoded):
+                break
+
+        return _parse_terminal_keyboard_capabilities(
+            b"".join(chunks).decode("utf-8", errors="ignore")
+        )
+    except Exception:
+        return _TerminalKeyboardCapabilities()
+    finally:
+        try:
+            termios.tcsetattr(stdin_fd, termios.TCSANOW, original_attrs)
+        except Exception:
+            pass
 
 
 def _detect_terminfo_backspace() -> bytes | None:
@@ -1248,6 +1387,7 @@ class HermesCLI:
         # Agent will be initialized on first use
         self.agent: Optional[AIAgent] = None
         self._app = None  # prompt_toolkit Application (set in run())
+        self._terminal_keyboard_mode: str | None = None
         
         # Conversation state
         self.conversation_history: List[Dict[str, Any]] = []
@@ -7156,7 +7296,25 @@ class HermesCLI:
         # Start processing thread
         process_thread = threading.Thread(target=process_loop, daemon=True)
         process_thread.start()
-        
+
+        terminal_keyboard_cleanup = None
+        try:
+            self._terminal_keyboard_mode = _select_terminal_keyboard_mode(
+                _detect_terminal_keyboard_capabilities()
+            )
+            if self._terminal_keyboard_mode:
+                _set_terminal_keyboard_mode(self._terminal_keyboard_mode, enable=True)
+
+                def terminal_keyboard_cleanup(
+                    mode=self._terminal_keyboard_mode,
+                ) -> None:
+                    _set_terminal_keyboard_mode(mode, enable=False)
+
+                atexit.register(terminal_keyboard_cleanup)
+        except Exception:
+            self._terminal_keyboard_mode = None
+            terminal_keyboard_cleanup = None
+
         # Register atexit cleanup so resources are freed even on unexpected exit
         atexit.register(_run_cleanup)
         
@@ -7168,6 +7326,16 @@ class HermesCLI:
             pass
         finally:
             self._should_exit = True
+            if terminal_keyboard_cleanup is not None:
+                try:
+                    atexit.unregister(terminal_keyboard_cleanup)
+                except Exception:
+                    pass
+                try:
+                    terminal_keyboard_cleanup()
+                except Exception:
+                    pass
+            self._terminal_keyboard_mode = None
             # Flush memories before exit (only for substantial conversations)
             if self.agent and self.conversation_history:
                 try:

--- a/cli.py
+++ b/cli.py
@@ -1169,7 +1169,6 @@ class HermesCLI:
         # Agent will be initialized on first use
         self.agent: Optional[AIAgent] = None
         self._app = None  # prompt_toolkit Application (set in run())
-        self._terminal_keyboard_mode: str | None = None
         
         # Conversation state
         self.conversation_history: List[Dict[str, Any]] = []
@@ -7084,23 +7083,23 @@ class HermesCLI:
         try:
             _tkbd.install_all()
             terminal_keyboard_detection = _tkbd.detect_capabilities()
-            self._terminal_keyboard_mode = _tkbd.select_mode(
+            terminal_keyboard_mode = _tkbd.select_mode(
                 terminal_keyboard_detection.capabilities
             )
             pending_terminal_key_presses = _tkbd.parse_input_key_presses(
                 terminal_keyboard_detection.pending_input
             )
-            if self._terminal_keyboard_mode:
-                _tkbd.set_mode(self._terminal_keyboard_mode, enable=True)
+            if terminal_keyboard_mode:
+                _tkbd.set_mode(terminal_keyboard_mode, enable=True)
 
                 def terminal_keyboard_cleanup(
-                    mode=self._terminal_keyboard_mode,
+                    mode=terminal_keyboard_mode,
                 ) -> None:
                     _tkbd.set_mode(mode, enable=False)
 
+                # Safety net for signal-based exits where the finally block may not run
                 atexit.register(terminal_keyboard_cleanup)
         except Exception:
-            self._terminal_keyboard_mode = None
             terminal_keyboard_cleanup = None
 
         # Register atexit cleanup so resources are freed even on unexpected exit
@@ -7125,7 +7124,6 @@ class HermesCLI:
                     terminal_keyboard_cleanup()
                 except Exception:
                     pass
-            self._terminal_keyboard_mode = None
             # Flush memories before exit (only for substantial conversations)
             if self.agent and self.conversation_history:
                 try:

--- a/cli.py
+++ b/cli.py
@@ -48,6 +48,7 @@ from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.widgets import TextArea
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding.bindings.named_commands import get_by_name
 from prompt_toolkit import print_formatted_text as _pt_print
 from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
 try:
@@ -67,6 +68,28 @@ from agent.usage_pricing import (
 from hermes_cli.banner import _format_context_length
 
 _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+_BACKWARD_KILL_WORD = get_by_name("backward-kill-word").handler
+
+
+def _delete_previous_word(event) -> None:
+    """Delete the previous word using prompt_toolkit's native semantics."""
+    _BACKWARD_KILL_WORD(event)
+
+
+def _register_word_delete_keybindings(kb: KeyBindings) -> None:
+    """Bind terminal word-delete sequences to prompt_toolkit's native handler."""
+
+    def _bind(*keys: str) -> None:
+        @kb.add(*keys)
+        def _delete_word(event) -> None:
+            _delete_previous_word(event)
+
+    # Many terminals emit Alt/Meta+Backspace or Esc-prefixed delete sequences
+    # for Ctrl+Backspace-style whole-word deletion. Bind them explicitly so the
+    # Hermes TUI behaves consistently inside the custom application wrapper.
+    _bind("escape", "backspace")
+    _bind("escape", "c-h")
+    _bind("escape", "delete")
 
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
@@ -5995,6 +6018,7 @@ class HermesCLI:
         
         # Key bindings for the input area
         kb = KeyBindings()
+        _register_word_delete_keybindings(kb)
         
         @kb.add('enter')
         def handle_enter(event):

--- a/cli.py
+++ b/cli.py
@@ -91,12 +91,54 @@ _TERMINAL_KEYBOARD_QUERY_TIMEOUT_S = 0.25
 _KITTY_QUERY_RESPONSE_RE = re.compile(r"\x1b\[\?(\d+)u")
 _MODIFY_OTHER_KEYS_RESPONSE_RE = re.compile(r"\x1b\[>4;(\d+)m")
 _DEVICE_ATTRIBUTES_RESPONSE_RE = re.compile(r"\x1b\[\?(?:\d+)(?:;\d+)*c")
+_CONTROL_KEY_BY_ASCII = {
+    ord("a"): Keys.ControlA,
+    ord("b"): Keys.ControlB,
+    ord("c"): Keys.ControlC,
+    ord("d"): Keys.ControlD,
+    ord("e"): Keys.ControlE,
+    ord("f"): Keys.ControlF,
+    ord("g"): Keys.ControlG,
+    ord("h"): Keys.ControlH,
+    ord("i"): Keys.ControlI,
+    ord("j"): Keys.ControlJ,
+    ord("k"): Keys.ControlK,
+    ord("l"): Keys.ControlL,
+    ord("m"): Keys.ControlM,
+    ord("n"): Keys.ControlN,
+    ord("o"): Keys.ControlO,
+    ord("p"): Keys.ControlP,
+    ord("q"): Keys.ControlQ,
+    ord("r"): Keys.ControlR,
+    ord("s"): Keys.ControlS,
+    ord("t"): Keys.ControlT,
+    ord("u"): Keys.ControlU,
+    ord("v"): Keys.ControlV,
+    ord("w"): Keys.ControlW,
+    ord("x"): Keys.ControlX,
+    ord("y"): Keys.ControlY,
+    ord("z"): Keys.ControlZ,
+}
 
 
 @dataclass(frozen=True)
 class _TerminalKeyboardCapabilities:
     kitty_supported: bool = False
     modify_other_keys_supported: bool = False
+
+
+@dataclass(frozen=True)
+class _TerminalKeyboardDetectionResult:
+    capabilities: _TerminalKeyboardCapabilities
+    pending_input: str = ""
+
+
+def _kitty_key_sequence(codepoint: int, modifiers: int) -> str:
+    return f"\x1b[{codepoint};{modifiers}u"
+
+
+def _modify_other_keys_sequence(codepoint: int, modifiers: int) -> str:
+    return f"\x1b[27;{modifiers};{codepoint}~"
 
 
 def _parse_terminal_keyboard_capabilities(data: str) -> _TerminalKeyboardCapabilities:
@@ -109,6 +151,24 @@ def _parse_terminal_keyboard_capabilities(data: str) -> _TerminalKeyboardCapabil
     return _TerminalKeyboardCapabilities(
         kitty_supported=kitty_supported,
         modify_other_keys_supported=any(level >= 2 for level in modify_levels),
+    )
+
+
+def _strip_terminal_keyboard_query_responses(data: str) -> str:
+    """Remove terminal capability probe responses and preserve other input."""
+    data = _KITTY_QUERY_RESPONSE_RE.sub("", data)
+    data = _MODIFY_OTHER_KEYS_RESPONSE_RE.sub("", data)
+    data = _DEVICE_ATTRIBUTES_RESPONSE_RE.sub("", data)
+    return data
+
+
+def _parse_terminal_keyboard_detection_result(
+    data: str,
+) -> _TerminalKeyboardDetectionResult:
+    """Parse terminal capability responses and preserve unrelated bytes."""
+    return _TerminalKeyboardDetectionResult(
+        capabilities=_parse_terminal_keyboard_capabilities(data),
+        pending_input=_strip_terminal_keyboard_query_responses(data),
     )
 
 
@@ -159,32 +219,32 @@ def _set_terminal_keyboard_mode(
 def _detect_terminal_keyboard_capabilities(
     *,
     timeout_s: float = _TERMINAL_KEYBOARD_QUERY_TIMEOUT_S,
-) -> _TerminalKeyboardCapabilities:
+) -> _TerminalKeyboardDetectionResult:
     """Best-effort terminal capability probe for keyboard enhancement modes."""
     if os.name == "nt":
-        return _TerminalKeyboardCapabilities()
+        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
 
     stdin = getattr(sys, "__stdin__", None) or sys.stdin
     stdout = getattr(sys, "__stdout__", None) or sys.stdout
     if stdin is None or stdout is None:
-        return _TerminalKeyboardCapabilities()
+        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
     if not hasattr(stdin, "isatty") or not hasattr(stdout, "isatty"):
-        return _TerminalKeyboardCapabilities()
+        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
     if not stdin.isatty() or not stdout.isatty():
-        return _TerminalKeyboardCapabilities()
+        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
 
     try:
         import select
         import termios
         import tty
     except Exception:
-        return _TerminalKeyboardCapabilities()
+        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
 
     try:
         stdin_fd = stdin.fileno()
         original_attrs = termios.tcgetattr(stdin_fd)
     except Exception:
-        return _TerminalKeyboardCapabilities()
+        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
 
     try:
         tty.setcbreak(stdin_fd)
@@ -207,11 +267,11 @@ def _detect_terminal_keyboard_capabilities(
             if _DEVICE_ATTRIBUTES_RESPONSE_RE.search(decoded):
                 break
 
-        return _parse_terminal_keyboard_capabilities(
+        return _parse_terminal_keyboard_detection_result(
             b"".join(chunks).decode("utf-8", errors="ignore")
         )
     except Exception:
-        return _TerminalKeyboardCapabilities()
+        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
     finally:
         try:
             termios.tcsetattr(stdin_fd, termios.TCSANOW, original_attrs)
@@ -265,9 +325,51 @@ def _install_ctrl_backspace_input_sequences(
         sequences["\x08"] = _CTRL_BACKSPACE_KEYS
 
 
+def _install_enhanced_keyboard_input_sequences(
+    ansi_sequences: dict[str, Keys | tuple[Keys, ...]] | None = None,
+) -> None:
+    """Normalize Kitty/modifyOtherKeys text-key sequences Hermes relies on.
+
+    This keeps existing Hermes bindings working when enhanced keyboard modes are
+    enabled, including Alt-based shortcuts and configurable Ctrl/Alt letter
+    bindings such as the default voice push-to-talk key.
+    """
+
+    sequences = ANSI_SEQUENCES if ansi_sequences is None else ansi_sequences
+
+    for codepoint in range(32, 127):
+        char = chr(codepoint)
+        alt_key = (Keys.Escape, char)
+        sequences[_kitty_key_sequence(codepoint, 3)] = alt_key
+        sequences[_modify_other_keys_sequence(codepoint, 3)] = alt_key
+
+    for codepoint, control_key in _CONTROL_KEY_BY_ASCII.items():
+        sequences[_kitty_key_sequence(codepoint, 5)] = control_key
+        sequences[_modify_other_keys_sequence(codepoint, 5)] = control_key
+
+    for codepoint in (8, 13, 127):
+        alt_key = (Keys.Escape, Keys.ControlH if codepoint in (8, 127) else Keys.ControlM)
+        sequences[_kitty_key_sequence(codepoint, 3)] = alt_key
+        sequences[_modify_other_keys_sequence(codepoint, 3)] = alt_key
+
+
 def _delete_previous_word(event) -> None:
     """Delete the previous word using prompt_toolkit's native semantics."""
     _BACKWARD_KILL_WORD(event)
+
+
+def _parse_terminal_input_key_presses(data: str) -> list:
+    """Parse raw terminal input into prompt_toolkit key presses."""
+    if not data:
+        return []
+
+    from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+    key_presses = []
+    parser = Vt100Parser(key_presses.append)
+    parser.feed(data)
+    parser.flush()
+    return key_presses
 
 
 def _register_word_delete_keybindings(kb: KeyBindings) -> None:
@@ -287,6 +389,7 @@ def _register_word_delete_keybindings(kb: KeyBindings) -> None:
 
 
 _install_ctrl_backspace_input_sequences()
+_install_enhanced_keyboard_input_sequences()
 
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
@@ -7298,9 +7401,14 @@ class HermesCLI:
         process_thread.start()
 
         terminal_keyboard_cleanup = None
+        pending_terminal_key_presses = []
         try:
+            terminal_keyboard_detection = _detect_terminal_keyboard_capabilities()
             self._terminal_keyboard_mode = _select_terminal_keyboard_mode(
-                _detect_terminal_keyboard_capabilities()
+                terminal_keyboard_detection.capabilities
+            )
+            pending_terminal_key_presses = _parse_terminal_input_key_presses(
+                terminal_keyboard_detection.pending_input
             )
             if self._terminal_keyboard_mode:
                 _set_terminal_keyboard_mode(self._terminal_keyboard_mode, enable=True)
@@ -7321,6 +7429,8 @@ class HermesCLI:
         # Run the application with patch_stdout for proper output handling
         try:
             with patch_stdout():
+                if pending_terminal_key_presses:
+                    app.key_processor.feed_multiple(pending_terminal_key_presses, first=True)
                 app.run()
         except (EOFError, KeyboardInterrupt):
             pass

--- a/cli.py
+++ b/cli.py
@@ -49,6 +49,8 @@ from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.widgets import TextArea
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.bindings.named_commands import get_by_name
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+from prompt_toolkit.keys import Keys
 from prompt_toolkit import print_formatted_text as _pt_print
 from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
 try:
@@ -69,6 +71,59 @@ from hermes_cli.banner import _format_context_length
 
 _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
 _BACKWARD_KILL_WORD = get_by_name("backward-kill-word").handler
+_CTRL_BACKSPACE_KEYS = (Keys.Escape, Keys.ControlH)
+_CTRL_BACKSPACE_ESCAPE_SEQUENCES = (
+    "\x1b[127;5u",
+    "\x1b[8;5u",
+    "\x1b[27;5;127~",
+    "\x1b[27;5;8~",
+)
+
+
+def _detect_terminfo_backspace() -> bytes | None:
+    """Return the terminal's declared Backspace byte from terminfo, if known."""
+    term = os.getenv("TERM")
+    if not term:
+        return None
+
+    try:
+        import curses
+
+        curses.setupterm(term=term)
+        return curses.tigetstr("kbs")
+    except Exception:
+        return None
+
+
+def _install_ctrl_backspace_input_sequences(
+    ansi_sequences: dict[str, Keys | tuple[Keys, ...]] | None = None,
+    *,
+    terminfo_backspace: bytes | None = None,
+) -> None:
+    """Teach prompt_toolkit how to recognize Ctrl+Backspace input sequences.
+
+    Modern terminals may emit CSI-u or modifyOtherKeys sequences for
+    Ctrl+Backspace. Legacy terminals only expose ``\\x08`` and ``\\x7f``; in
+    that case terminfo's ``kbs`` tells us which byte is Backspace so we can
+    treat the other byte as the closest available Ctrl+Backspace signal.
+    """
+
+    sequences = ANSI_SEQUENCES if ansi_sequences is None else ansi_sequences
+
+    for sequence in _CTRL_BACKSPACE_ESCAPE_SEQUENCES:
+        sequences[sequence] = _CTRL_BACKSPACE_KEYS
+
+    if terminfo_backspace is None:
+        terminfo_backspace = _detect_terminfo_backspace()
+
+    # Legacy terminals often expose Backspace/Ctrl+Backspace as the two raw
+    # bytes ``\x08`` and ``\x7f``. ``kbs`` tells us which byte is the real
+    # Backspace key; treat the other byte as Ctrl+Backspace so the TUI matches
+    # the terminal's own key model as closely as legacy input allows.
+    if terminfo_backspace == b"\x08":
+        sequences["\x7f"] = _CTRL_BACKSPACE_KEYS
+    elif terminfo_backspace == b"\x7f":
+        sequences["\x08"] = _CTRL_BACKSPACE_KEYS
 
 
 def _delete_previous_word(event) -> None:
@@ -90,6 +145,9 @@ def _register_word_delete_keybindings(kb: KeyBindings) -> None:
     _bind("escape", "backspace")
     _bind("escape", "c-h")
     _bind("escape", "delete")
+
+
+_install_ctrl_backspace_input_sequences()
 
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.

--- a/cli.py
+++ b/cli.py
@@ -23,9 +23,7 @@ import tempfile
 import time
 import uuid
 import textwrap
-import re
 from contextlib import contextmanager
-from dataclasses import dataclass
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any, Optional
@@ -50,8 +48,6 @@ from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.widgets import TextArea
 from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.key_binding.bindings.named_commands import get_by_name
-from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
 from prompt_toolkit.keys import Keys
 from prompt_toolkit import print_formatted_text as _pt_print
 from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
@@ -70,332 +66,9 @@ from agent.usage_pricing import (
     format_token_count_compact,
 )
 from hermes_cli.banner import _format_context_length
+from hermes_cli import terminal_keyboard as _tkbd
 
 _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
-_BACKWARD_KILL_WORD = get_by_name("backward-kill-word").handler
-_CTRL_BACKSPACE_KEYS = (Keys.Escape, Keys.ControlH)
-_CTRL_BACKSPACE_ESCAPE_SEQUENCES = (
-    "\x1b[127;5u",
-    "\x1b[8;5u",
-    "\x1b[27;5;127~",
-    "\x1b[27;5;8~",
-)
-_CTRL_ENTER_KEYS = Keys.ControlJ
-_KITTY_KEYBOARD_QUERY = "\x1b[?u"
-_KITTY_KEYBOARD_ENABLE = "\x1b[>1u"
-_KITTY_KEYBOARD_DISABLE = "\x1b[<u"
-_MODIFY_OTHER_KEYS_QUERY = "\x1b[>4;?m"
-_MODIFY_OTHER_KEYS_ENABLE = "\x1b[>4;2m"
-_MODIFY_OTHER_KEYS_DISABLE = "\x1b[>4;0m"
-_DEVICE_ATTRIBUTES_QUERY = "\x1b[c"
-_TERMINAL_KEYBOARD_QUERY_TIMEOUT_S = 0.25
-_KITTY_QUERY_RESPONSE_RE = re.compile(r"\x1b\[\?(\d+)u")
-_MODIFY_OTHER_KEYS_RESPONSE_RE = re.compile(r"\x1b\[>4;(\d+)m")
-_DEVICE_ATTRIBUTES_RESPONSE_RE = re.compile(r"\x1b\[\?(?:\d+)(?:;\d+)*c")
-_CONTROL_KEY_BY_ASCII = {
-    ord("a"): Keys.ControlA,
-    ord("b"): Keys.ControlB,
-    ord("c"): Keys.ControlC,
-    ord("d"): Keys.ControlD,
-    ord("e"): Keys.ControlE,
-    ord("f"): Keys.ControlF,
-    ord("g"): Keys.ControlG,
-    ord("h"): Keys.ControlH,
-    ord("i"): Keys.ControlI,
-    ord("j"): Keys.ControlJ,
-    ord("k"): Keys.ControlK,
-    ord("l"): Keys.ControlL,
-    ord("m"): Keys.ControlM,
-    ord("n"): Keys.ControlN,
-    ord("o"): Keys.ControlO,
-    ord("p"): Keys.ControlP,
-    ord("q"): Keys.ControlQ,
-    ord("r"): Keys.ControlR,
-    ord("s"): Keys.ControlS,
-    ord("t"): Keys.ControlT,
-    ord("u"): Keys.ControlU,
-    ord("v"): Keys.ControlV,
-    ord("w"): Keys.ControlW,
-    ord("x"): Keys.ControlX,
-    ord("y"): Keys.ControlY,
-    ord("z"): Keys.ControlZ,
-}
-
-
-@dataclass(frozen=True)
-class _TerminalKeyboardCapabilities:
-    kitty_supported: bool = False
-    modify_other_keys_supported: bool = False
-
-
-@dataclass(frozen=True)
-class _TerminalKeyboardDetectionResult:
-    capabilities: _TerminalKeyboardCapabilities
-    pending_input: str = ""
-
-
-def _kitty_key_sequence(codepoint: int, modifiers: int) -> str:
-    return f"\x1b[{codepoint};{modifiers}u"
-
-
-def _modify_other_keys_sequence(codepoint: int, modifiers: int) -> str:
-    return f"\x1b[27;{modifiers};{codepoint}~"
-
-
-def _parse_terminal_keyboard_capabilities(data: str) -> _TerminalKeyboardCapabilities:
-    """Parse raw terminal responses for keyboard protocol support."""
-    kitty_supported = bool(_KITTY_QUERY_RESPONSE_RE.search(data))
-    modify_levels = [
-        int(match.group(1))
-        for match in _MODIFY_OTHER_KEYS_RESPONSE_RE.finditer(data)
-    ]
-    return _TerminalKeyboardCapabilities(
-        kitty_supported=kitty_supported,
-        modify_other_keys_supported=any(level >= 2 for level in modify_levels),
-    )
-
-
-def _strip_terminal_keyboard_query_responses(data: str) -> str:
-    """Remove terminal capability probe responses and preserve other input."""
-    data = _KITTY_QUERY_RESPONSE_RE.sub("", data)
-    data = _MODIFY_OTHER_KEYS_RESPONSE_RE.sub("", data)
-    data = _DEVICE_ATTRIBUTES_RESPONSE_RE.sub("", data)
-    return data
-
-
-def _parse_terminal_keyboard_detection_result(
-    data: str,
-) -> _TerminalKeyboardDetectionResult:
-    """Parse terminal capability responses and preserve unrelated bytes."""
-    return _TerminalKeyboardDetectionResult(
-        capabilities=_parse_terminal_keyboard_capabilities(data),
-        pending_input=_strip_terminal_keyboard_query_responses(data),
-    )
-
-
-def _select_terminal_keyboard_mode(
-    capabilities: _TerminalKeyboardCapabilities,
-) -> str | None:
-    """Pick the best keyboard enhancement mode supported by the terminal."""
-    if capabilities.kitty_supported:
-        return "kitty"
-    if capabilities.modify_other_keys_supported:
-        return "modify_other_keys"
-    return None
-
-
-def _write_terminal_sequence(
-    sequence: str,
-    *,
-    writer=None,
-) -> None:
-    """Emit a raw terminal control sequence."""
-    if writer is not None:
-        writer(sequence)
-        return
-
-    stdout = getattr(sys, "__stdout__", None) or sys.stdout
-    if stdout is None or not hasattr(stdout, "write") or not hasattr(stdout, "flush"):
-        return
-    stdout.write(sequence)
-    stdout.flush()
-
-
-def _set_terminal_keyboard_mode(
-    mode: str | None,
-    *,
-    enable: bool,
-    writer=None,
-) -> None:
-    """Enable or disable an enhanced terminal keyboard mode."""
-    if mode == "kitty":
-        sequence = _KITTY_KEYBOARD_ENABLE if enable else _KITTY_KEYBOARD_DISABLE
-    elif mode == "modify_other_keys":
-        sequence = _MODIFY_OTHER_KEYS_ENABLE if enable else _MODIFY_OTHER_KEYS_DISABLE
-    else:
-        return
-    _write_terminal_sequence(sequence, writer=writer)
-
-
-def _detect_terminal_keyboard_capabilities(
-    *,
-    timeout_s: float = _TERMINAL_KEYBOARD_QUERY_TIMEOUT_S,
-) -> _TerminalKeyboardDetectionResult:
-    """Best-effort terminal capability probe for keyboard enhancement modes."""
-    if os.name == "nt":
-        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
-
-    stdin = getattr(sys, "__stdin__", None) or sys.stdin
-    stdout = getattr(sys, "__stdout__", None) or sys.stdout
-    if stdin is None or stdout is None:
-        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
-    if not hasattr(stdin, "isatty") or not hasattr(stdout, "isatty"):
-        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
-    if not stdin.isatty() or not stdout.isatty():
-        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
-
-    try:
-        import select
-        import termios
-        import tty
-    except Exception:
-        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
-
-    try:
-        stdin_fd = stdin.fileno()
-        original_attrs = termios.tcgetattr(stdin_fd)
-    except Exception:
-        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
-
-    try:
-        tty.setcbreak(stdin_fd)
-        _write_terminal_sequence(
-            _KITTY_KEYBOARD_QUERY + _MODIFY_OTHER_KEYS_QUERY + _DEVICE_ATTRIBUTES_QUERY
-        )
-
-        chunks: list[bytes] = []
-        deadline = time.monotonic() + max(0.0, timeout_s)
-        while time.monotonic() < deadline:
-            remaining = deadline - time.monotonic()
-            ready, _, _ = select.select([stdin_fd], [], [], max(0.0, remaining))
-            if not ready:
-                continue
-            chunk = os.read(stdin_fd, 1024)
-            if not chunk:
-                break
-            chunks.append(chunk)
-            decoded = b"".join(chunks).decode("utf-8", errors="ignore")
-            if _DEVICE_ATTRIBUTES_RESPONSE_RE.search(decoded):
-                break
-
-        return _parse_terminal_keyboard_detection_result(
-            b"".join(chunks).decode("utf-8", errors="ignore")
-        )
-    except Exception:
-        return _TerminalKeyboardDetectionResult(_TerminalKeyboardCapabilities())
-    finally:
-        try:
-            termios.tcsetattr(stdin_fd, termios.TCSANOW, original_attrs)
-        except Exception:
-            pass
-
-
-def _detect_terminfo_backspace() -> bytes | None:
-    """Return the terminal's declared Backspace byte from terminfo, if known."""
-    term = os.getenv("TERM")
-    if not term:
-        return None
-
-    try:
-        import curses
-
-        curses.setupterm(term=term)
-        return curses.tigetstr("kbs")
-    except Exception:
-        return None
-
-
-def _install_ctrl_backspace_input_sequences(
-    ansi_sequences: dict[str, Keys | tuple[Keys, ...]] | None = None,
-    *,
-    terminfo_backspace: bytes | None = None,
-) -> None:
-    """Teach prompt_toolkit how to recognize Ctrl+Backspace input sequences.
-
-    Modern terminals may emit CSI-u or modifyOtherKeys sequences for
-    Ctrl+Backspace. Legacy terminals only expose ``\\x08`` and ``\\x7f``; in
-    that case terminfo's ``kbs`` tells us which byte is Backspace so we can
-    treat the other byte as the closest available Ctrl+Backspace signal.
-    """
-
-    sequences = ANSI_SEQUENCES if ansi_sequences is None else ansi_sequences
-
-    for sequence in _CTRL_BACKSPACE_ESCAPE_SEQUENCES:
-        sequences[sequence] = _CTRL_BACKSPACE_KEYS
-
-    if terminfo_backspace is None:
-        terminfo_backspace = _detect_terminfo_backspace()
-
-    # Legacy terminals often expose Backspace/Ctrl+Backspace as the two raw
-    # bytes ``\x08`` and ``\x7f``. ``kbs`` tells us which byte is the real
-    # Backspace key; treat the other byte as Ctrl+Backspace so the TUI matches
-    # the terminal's own key model as closely as legacy input allows.
-    if terminfo_backspace == b"\x08":
-        sequences["\x7f"] = _CTRL_BACKSPACE_KEYS
-    elif terminfo_backspace == b"\x7f":
-        sequences["\x08"] = _CTRL_BACKSPACE_KEYS
-
-
-def _install_enhanced_keyboard_input_sequences(
-    ansi_sequences: dict[str, Keys | tuple[Keys, ...]] | None = None,
-) -> None:
-    """Normalize Kitty/modifyOtherKeys text-key sequences Hermes relies on.
-
-    This keeps existing Hermes bindings working when enhanced keyboard modes are
-    enabled, including Alt-based shortcuts and configurable Ctrl/Alt letter
-    bindings such as the default voice push-to-talk key.
-    """
-
-    sequences = ANSI_SEQUENCES if ansi_sequences is None else ansi_sequences
-
-    for codepoint in range(32, 127):
-        char = chr(codepoint)
-        alt_key = (Keys.Escape, char)
-        sequences[_kitty_key_sequence(codepoint, 3)] = alt_key
-        sequences[_modify_other_keys_sequence(codepoint, 3)] = alt_key
-
-    for codepoint, control_key in _CONTROL_KEY_BY_ASCII.items():
-        sequences[_kitty_key_sequence(codepoint, 5)] = control_key
-        sequences[_modify_other_keys_sequence(codepoint, 5)] = control_key
-
-    # Keep enhanced Ctrl+Enter on Hermes' existing multiline binding (`c-j`)
-    # instead of letting it collapse to the plain Enter/submit path.
-    sequences[_kitty_key_sequence(13, 5)] = _CTRL_ENTER_KEYS
-    sequences[_modify_other_keys_sequence(13, 5)] = _CTRL_ENTER_KEYS
-
-    for codepoint in (8, 13, 127):
-        alt_key = (Keys.Escape, Keys.ControlH if codepoint in (8, 127) else Keys.ControlM)
-        sequences[_kitty_key_sequence(codepoint, 3)] = alt_key
-        sequences[_modify_other_keys_sequence(codepoint, 3)] = alt_key
-
-
-def _delete_previous_word(event) -> None:
-    """Delete the previous word using prompt_toolkit's native semantics."""
-    _BACKWARD_KILL_WORD(event)
-
-
-def _parse_terminal_input_key_presses(data: str) -> list:
-    """Parse raw terminal input into prompt_toolkit key presses."""
-    if not data:
-        return []
-
-    from prompt_toolkit.input.vt100_parser import Vt100Parser
-
-    key_presses = []
-    parser = Vt100Parser(key_presses.append)
-    parser.feed(data)
-    parser.flush()
-    return key_presses
-
-
-def _register_word_delete_keybindings(kb: KeyBindings) -> None:
-    """Bind terminal word-delete sequences to prompt_toolkit's native handler."""
-
-    def _bind(*keys: str) -> None:
-        @kb.add(*keys)
-        def _delete_word(event) -> None:
-            _delete_previous_word(event)
-
-    # Many terminals emit Alt/Meta+Backspace or Esc-prefixed delete sequences
-    # for Ctrl+Backspace-style whole-word deletion. Bind them explicitly so the
-    # Hermes TUI behaves consistently inside the custom application wrapper.
-    _bind("escape", "backspace")
-    _bind("escape", "c-h")
-    _bind("escape", "delete")
-
-
-_install_ctrl_backspace_input_sequences()
-_install_enhanced_keyboard_input_sequences()
 
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
@@ -6325,7 +5998,7 @@ class HermesCLI:
         
         # Key bindings for the input area
         kb = KeyBindings()
-        _register_word_delete_keybindings(kb)
+        _tkbd.register_word_delete_keybindings(kb)
         
         @kb.add('enter')
         def handle_enter(event):
@@ -7409,20 +7082,20 @@ class HermesCLI:
         terminal_keyboard_cleanup = None
         pending_terminal_key_presses = []
         try:
-            terminal_keyboard_detection = _detect_terminal_keyboard_capabilities()
-            self._terminal_keyboard_mode = _select_terminal_keyboard_mode(
+            terminal_keyboard_detection = _tkbd.detect_capabilities()
+            self._terminal_keyboard_mode = _tkbd.select_mode(
                 terminal_keyboard_detection.capabilities
             )
-            pending_terminal_key_presses = _parse_terminal_input_key_presses(
+            pending_terminal_key_presses = _tkbd.parse_input_key_presses(
                 terminal_keyboard_detection.pending_input
             )
             if self._terminal_keyboard_mode:
-                _set_terminal_keyboard_mode(self._terminal_keyboard_mode, enable=True)
+                _tkbd.set_mode(self._terminal_keyboard_mode, enable=True)
 
                 def terminal_keyboard_cleanup(
                     mode=self._terminal_keyboard_mode,
                 ) -> None:
-                    _set_terminal_keyboard_mode(mode, enable=False)
+                    _tkbd.set_mode(mode, enable=False)
 
                 atexit.register(terminal_keyboard_cleanup)
         except Exception:

--- a/hermes_cli/terminal_keyboard.py
+++ b/hermes_cli/terminal_keyboard.py
@@ -34,37 +34,15 @@ MODIFY_OTHER_KEYS_QUERY = "\x1b[?4m"
 MODIFY_OTHER_KEYS_ENABLE = "\x1b[>4;2m"
 MODIFY_OTHER_KEYS_DISABLE = "\x1b[>4;0m"
 DEVICE_ATTRIBUTES_QUERY = "\x1b[c"
+MODE_KITTY = "kitty"
+MODE_MODIFY_OTHER_KEYS = "modify_other_keys"
 QUERY_TIMEOUT_S = 0.25
 _KITTY_QUERY_RESPONSE_RE = re.compile(r"\x1b\[\?(\d+)u")
 _MODIFY_OTHER_KEYS_RESPONSE_RE = re.compile(r"\x1b\[>4;(\d+)m")
 _DEVICE_ATTRIBUTES_RESPONSE_RE = re.compile(r"\x1b\[\?(?:\d+)(?:;\d+)*c")
 _CONTROL_KEY_BY_ASCII = {
-    ord("a"): Keys.ControlA,
-    ord("b"): Keys.ControlB,
-    ord("c"): Keys.ControlC,
-    ord("d"): Keys.ControlD,
-    ord("e"): Keys.ControlE,
-    ord("f"): Keys.ControlF,
-    ord("g"): Keys.ControlG,
-    ord("h"): Keys.ControlH,
-    ord("i"): Keys.ControlI,
-    ord("j"): Keys.ControlJ,
-    ord("k"): Keys.ControlK,
-    ord("l"): Keys.ControlL,
-    ord("m"): Keys.ControlM,
-    ord("n"): Keys.ControlN,
-    ord("o"): Keys.ControlO,
-    ord("p"): Keys.ControlP,
-    ord("q"): Keys.ControlQ,
-    ord("r"): Keys.ControlR,
-    ord("s"): Keys.ControlS,
-    ord("t"): Keys.ControlT,
-    ord("u"): Keys.ControlU,
-    ord("v"): Keys.ControlV,
-    ord("w"): Keys.ControlW,
-    ord("x"): Keys.ControlX,
-    ord("y"): Keys.ControlY,
-    ord("z"): Keys.ControlZ,
+    ord(c): getattr(Keys, f"Control{c.upper()}")
+    for c in "abcdefghijklmnopqrstuvwxyz"
 }
 
 
@@ -125,9 +103,9 @@ def select_mode(
 ) -> str | None:
     """Pick the best keyboard enhancement mode supported by the terminal."""
     if capabilities.kitty_supported:
-        return "kitty"
+        return MODE_KITTY
     if capabilities.modify_other_keys_supported:
-        return "modify_other_keys"
+        return MODE_MODIFY_OTHER_KEYS
     return None
 
 
@@ -155,9 +133,9 @@ def set_mode(
     writer=None,
 ) -> None:
     """Enable or disable an enhanced terminal keyboard mode."""
-    if mode == "kitty":
+    if mode == MODE_KITTY:
         sequence = KITTY_KEYBOARD_ENABLE if enable else KITTY_KEYBOARD_DISABLE
-    elif mode == "modify_other_keys":
+    elif mode == MODE_MODIFY_OTHER_KEYS:
         sequence = MODIFY_OTHER_KEYS_ENABLE if enable else MODIFY_OTHER_KEYS_DISABLE
     else:
         return
@@ -209,7 +187,8 @@ def detect_capabilities(
             KITTY_KEYBOARD_QUERY + MODIFY_OTHER_KEYS_QUERY + DEVICE_ATTRIBUTES_QUERY
         )
 
-        chunks: list[bytes] = []
+        buf = bytearray()
+        decoded = ""
         deadline = time.monotonic() + max(0.0, timeout_s)
         while time.monotonic() < deadline:
             remaining = deadline - time.monotonic()
@@ -219,14 +198,12 @@ def detect_capabilities(
             chunk = os.read(stdin_fd, 1024)
             if not chunk:
                 break
-            chunks.append(chunk)
-            decoded = b"".join(chunks).decode("utf-8", errors="ignore")
+            buf.extend(chunk)
+            decoded = bytes(buf).decode("utf-8", errors="ignore")
             if _DEVICE_ATTRIBUTES_RESPONSE_RE.search(decoded):
                 break
 
-        return parse_detection_result(
-            b"".join(chunks).decode("utf-8", errors="ignore")
-        )
+        return parse_detection_result(decoded)
     except Exception:
         return TerminalKeyboardDetectionResult(TerminalKeyboardCapabilities())
     finally:

--- a/hermes_cli/terminal_keyboard.py
+++ b/hermes_cli/terminal_keyboard.py
@@ -30,7 +30,7 @@ CTRL_ENTER_KEYS = Keys.ControlJ
 KITTY_KEYBOARD_QUERY = "\x1b[?u"
 KITTY_KEYBOARD_ENABLE = "\x1b[>1u"
 KITTY_KEYBOARD_DISABLE = "\x1b[<u"
-MODIFY_OTHER_KEYS_QUERY = "\x1b[>4;?m"
+MODIFY_OTHER_KEYS_QUERY = "\x1b[?4m"
 MODIFY_OTHER_KEYS_ENABLE = "\x1b[>4;2m"
 MODIFY_OTHER_KEYS_DISABLE = "\x1b[>4;0m"
 DEVICE_ATTRIBUTES_QUERY = "\x1b[c"
@@ -95,9 +95,11 @@ def parse_capabilities(data: str) -> TerminalKeyboardCapabilities:
         int(match.group(1))
         for match in _MODIFY_OTHER_KEYS_RESPONSE_RE.finditer(data)
     ]
+    # Any response (including level 0) proves the terminal understands the
+    # protocol; we will explicitly enable level 2 via set_mode().
     return TerminalKeyboardCapabilities(
         kitty_supported=kitty_supported,
-        modify_other_keys_supported=any(level >= 2 for level in modify_levels),
+        modify_other_keys_supported=bool(modify_levels),
     )
 
 
@@ -162,6 +164,19 @@ def set_mode(
     write_sequence(sequence, writer=writer)
 
 
+def _get_real_stream(name: str):
+    """Return the real stdin/stdout if it is a usable TTY, else None."""
+    stream = getattr(sys, f"__{name}__", None) or getattr(sys, name, None)
+    if stream is None or not hasattr(stream, "isatty"):
+        return None
+    try:
+        if not stream.isatty():
+            return None
+    except Exception:
+        return None
+    return stream
+
+
 def detect_capabilities(
     *,
     timeout_s: float = QUERY_TIMEOUT_S,
@@ -170,13 +185,9 @@ def detect_capabilities(
     if os.name == "nt":
         return TerminalKeyboardDetectionResult(TerminalKeyboardCapabilities())
 
-    stdin = getattr(sys, "__stdin__", None) or sys.stdin
-    stdout = getattr(sys, "__stdout__", None) or sys.stdout
+    stdin = _get_real_stream("stdin")
+    stdout = _get_real_stream("stdout")
     if stdin is None or stdout is None:
-        return TerminalKeyboardDetectionResult(TerminalKeyboardCapabilities())
-    if not hasattr(stdin, "isatty") or not hasattr(stdout, "isatty"):
-        return TerminalKeyboardDetectionResult(TerminalKeyboardCapabilities())
-    if not stdin.isatty() or not stdout.isatty():
         return TerminalKeyboardDetectionResult(TerminalKeyboardCapabilities())
 
     try:
@@ -240,6 +251,34 @@ def _detect_terminfo_backspace() -> bytes | None:
         return None
 
 
+def _detect_tty_erase() -> bytes | None:
+    """Return the current TTY erase byte, if it is available."""
+    if os.name == "nt":
+        return None
+
+    stdin = _get_real_stream("stdin")
+    if stdin is None or not hasattr(stdin, "fileno"):
+        return None
+
+    try:
+        import termios
+
+        erase = termios.tcgetattr(stdin.fileno())[6][termios.VERASE]
+    except Exception:
+        return None
+
+    if isinstance(erase, int):
+        erase_byte = bytes([erase])
+    elif isinstance(erase, (bytes, bytearray)):
+        erase_byte = bytes(erase[:1])
+    elif isinstance(erase, str):
+        erase_byte = erase.encode("latin-1", errors="ignore")[:1]
+    else:
+        return None
+
+    return erase_byte if erase_byte in (b"\x08", b"\x7f") else None
+
+
 def install_ctrl_backspace_sequences(
     ansi_sequences: dict[str, Keys | tuple[Keys, ...]] | None = None,
     *,
@@ -261,8 +300,15 @@ def install_ctrl_backspace_sequences(
     if terminfo_backspace is None:
         terminfo_backspace = _detect_terminfo_backspace()
 
-    if terminfo_backspace == b"\x08":
+    tty_erase = _detect_tty_erase()
+
+    # DEL is a common plain Backspace byte in xterm/tmux sessions even when
+    # terminfo advertises ^H. Only remap DEL when the active TTY confirms that
+    # Backspace is actually ^H.
+    if tty_erase == b"\x08":
         sequences["\x7f"] = CTRL_BACKSPACE_KEYS
+    elif tty_erase == b"\x7f":
+        sequences["\x08"] = CTRL_BACKSPACE_KEYS
     elif terminfo_backspace == b"\x7f":
         sequences["\x08"] = CTRL_BACKSPACE_KEYS
 
@@ -333,6 +379,3 @@ def install_all() -> None:
     """Install all keyboard sequence mappings into prompt_toolkit's parser."""
     install_ctrl_backspace_sequences()
     install_enhanced_sequences()
-
-
-install_all()

--- a/hermes_cli/terminal_keyboard.py
+++ b/hermes_cli/terminal_keyboard.py
@@ -103,10 +103,9 @@ def parse_capabilities(data: str) -> TerminalKeyboardCapabilities:
 
 def _strip_query_responses(data: str) -> str:
     """Remove terminal capability probe responses and preserve other input."""
-    data = _KITTY_QUERY_RESPONSE_RE.sub("", data)
-    data = _MODIFY_OTHER_KEYS_RESPONSE_RE.sub("", data)
-    data = _DEVICE_ATTRIBUTES_RESPONSE_RE.sub("", data)
-    return data
+    result = _KITTY_QUERY_RESPONSE_RE.sub("", data)
+    result = _MODIFY_OTHER_KEYS_RESPONSE_RE.sub("", result)
+    return _DEVICE_ATTRIBUTES_RESPONSE_RE.sub("", result)
 
 
 def parse_detection_result(

--- a/hermes_cli/terminal_keyboard.py
+++ b/hermes_cli/terminal_keyboard.py
@@ -1,0 +1,339 @@
+"""Terminal keyboard protocol detection and enhanced input sequence handling.
+
+Detects Kitty keyboard protocol and modifyOtherKeys support at startup,
+normalizes Ctrl+Backspace / Ctrl+Enter / Alt+key escape sequences for
+prompt_toolkit, and manages enabling/disabling enhanced keyboard modes.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding.bindings.named_commands import get_by_name
+from prompt_toolkit.keys import Keys
+
+BACKWARD_KILL_WORD = get_by_name("backward-kill-word").handler
+CTRL_BACKSPACE_KEYS = (Keys.Escape, Keys.ControlH)
+CTRL_BACKSPACE_ESCAPE_SEQUENCES = (
+    "\x1b[127;5u",
+    "\x1b[8;5u",
+    "\x1b[27;5;127~",
+    "\x1b[27;5;8~",
+)
+CTRL_ENTER_KEYS = Keys.ControlJ
+KITTY_KEYBOARD_QUERY = "\x1b[?u"
+KITTY_KEYBOARD_ENABLE = "\x1b[>1u"
+KITTY_KEYBOARD_DISABLE = "\x1b[<u"
+MODIFY_OTHER_KEYS_QUERY = "\x1b[>4;?m"
+MODIFY_OTHER_KEYS_ENABLE = "\x1b[>4;2m"
+MODIFY_OTHER_KEYS_DISABLE = "\x1b[>4;0m"
+DEVICE_ATTRIBUTES_QUERY = "\x1b[c"
+QUERY_TIMEOUT_S = 0.25
+_KITTY_QUERY_RESPONSE_RE = re.compile(r"\x1b\[\?(\d+)u")
+_MODIFY_OTHER_KEYS_RESPONSE_RE = re.compile(r"\x1b\[>4;(\d+)m")
+_DEVICE_ATTRIBUTES_RESPONSE_RE = re.compile(r"\x1b\[\?(?:\d+)(?:;\d+)*c")
+_CONTROL_KEY_BY_ASCII = {
+    ord("a"): Keys.ControlA,
+    ord("b"): Keys.ControlB,
+    ord("c"): Keys.ControlC,
+    ord("d"): Keys.ControlD,
+    ord("e"): Keys.ControlE,
+    ord("f"): Keys.ControlF,
+    ord("g"): Keys.ControlG,
+    ord("h"): Keys.ControlH,
+    ord("i"): Keys.ControlI,
+    ord("j"): Keys.ControlJ,
+    ord("k"): Keys.ControlK,
+    ord("l"): Keys.ControlL,
+    ord("m"): Keys.ControlM,
+    ord("n"): Keys.ControlN,
+    ord("o"): Keys.ControlO,
+    ord("p"): Keys.ControlP,
+    ord("q"): Keys.ControlQ,
+    ord("r"): Keys.ControlR,
+    ord("s"): Keys.ControlS,
+    ord("t"): Keys.ControlT,
+    ord("u"): Keys.ControlU,
+    ord("v"): Keys.ControlV,
+    ord("w"): Keys.ControlW,
+    ord("x"): Keys.ControlX,
+    ord("y"): Keys.ControlY,
+    ord("z"): Keys.ControlZ,
+}
+
+
+@dataclass(frozen=True)
+class TerminalKeyboardCapabilities:
+    kitty_supported: bool = False
+    modify_other_keys_supported: bool = False
+
+
+@dataclass(frozen=True)
+class TerminalKeyboardDetectionResult:
+    capabilities: TerminalKeyboardCapabilities
+    pending_input: str = ""
+
+
+def kitty_key_sequence(codepoint: int, modifiers: int) -> str:
+    return f"\x1b[{codepoint};{modifiers}u"
+
+
+def modify_other_keys_sequence(codepoint: int, modifiers: int) -> str:
+    return f"\x1b[27;{modifiers};{codepoint}~"
+
+
+def parse_capabilities(data: str) -> TerminalKeyboardCapabilities:
+    """Parse raw terminal responses for keyboard protocol support."""
+    kitty_supported = bool(_KITTY_QUERY_RESPONSE_RE.search(data))
+    modify_levels = [
+        int(match.group(1))
+        for match in _MODIFY_OTHER_KEYS_RESPONSE_RE.finditer(data)
+    ]
+    return TerminalKeyboardCapabilities(
+        kitty_supported=kitty_supported,
+        modify_other_keys_supported=any(level >= 2 for level in modify_levels),
+    )
+
+
+def _strip_query_responses(data: str) -> str:
+    """Remove terminal capability probe responses and preserve other input."""
+    data = _KITTY_QUERY_RESPONSE_RE.sub("", data)
+    data = _MODIFY_OTHER_KEYS_RESPONSE_RE.sub("", data)
+    data = _DEVICE_ATTRIBUTES_RESPONSE_RE.sub("", data)
+    return data
+
+
+def parse_detection_result(
+    data: str,
+) -> TerminalKeyboardDetectionResult:
+    """Parse terminal capability responses and preserve unrelated bytes."""
+    return TerminalKeyboardDetectionResult(
+        capabilities=parse_capabilities(data),
+        pending_input=_strip_query_responses(data),
+    )
+
+
+def select_mode(
+    capabilities: TerminalKeyboardCapabilities,
+) -> str | None:
+    """Pick the best keyboard enhancement mode supported by the terminal."""
+    if capabilities.kitty_supported:
+        return "kitty"
+    if capabilities.modify_other_keys_supported:
+        return "modify_other_keys"
+    return None
+
+
+def write_sequence(
+    sequence: str,
+    *,
+    writer=None,
+) -> None:
+    """Emit a raw terminal control sequence."""
+    if writer is not None:
+        writer(sequence)
+        return
+
+    stdout = getattr(sys, "__stdout__", None) or sys.stdout
+    if stdout is None or not hasattr(stdout, "write") or not hasattr(stdout, "flush"):
+        return
+    stdout.write(sequence)
+    stdout.flush()
+
+
+def set_mode(
+    mode: str | None,
+    *,
+    enable: bool,
+    writer=None,
+) -> None:
+    """Enable or disable an enhanced terminal keyboard mode."""
+    if mode == "kitty":
+        sequence = KITTY_KEYBOARD_ENABLE if enable else KITTY_KEYBOARD_DISABLE
+    elif mode == "modify_other_keys":
+        sequence = MODIFY_OTHER_KEYS_ENABLE if enable else MODIFY_OTHER_KEYS_DISABLE
+    else:
+        return
+    write_sequence(sequence, writer=writer)
+
+
+def detect_capabilities(
+    *,
+    timeout_s: float = QUERY_TIMEOUT_S,
+) -> TerminalKeyboardDetectionResult:
+    """Best-effort terminal capability probe for keyboard enhancement modes."""
+    if os.name == "nt":
+        return TerminalKeyboardDetectionResult(TerminalKeyboardCapabilities())
+
+    stdin = getattr(sys, "__stdin__", None) or sys.stdin
+    stdout = getattr(sys, "__stdout__", None) or sys.stdout
+    if stdin is None or stdout is None:
+        return TerminalKeyboardDetectionResult(TerminalKeyboardCapabilities())
+    if not hasattr(stdin, "isatty") or not hasattr(stdout, "isatty"):
+        return TerminalKeyboardDetectionResult(TerminalKeyboardCapabilities())
+    if not stdin.isatty() or not stdout.isatty():
+        return TerminalKeyboardDetectionResult(TerminalKeyboardCapabilities())
+
+    try:
+        import select
+        import termios
+        import tty
+    except Exception:
+        return TerminalKeyboardDetectionResult(TerminalKeyboardCapabilities())
+
+    try:
+        stdin_fd = stdin.fileno()
+        original_attrs = termios.tcgetattr(stdin_fd)
+    except Exception:
+        return TerminalKeyboardDetectionResult(TerminalKeyboardCapabilities())
+
+    try:
+        tty.setcbreak(stdin_fd)
+        write_sequence(
+            KITTY_KEYBOARD_QUERY + MODIFY_OTHER_KEYS_QUERY + DEVICE_ATTRIBUTES_QUERY
+        )
+
+        chunks: list[bytes] = []
+        deadline = time.monotonic() + max(0.0, timeout_s)
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            ready, _, _ = select.select([stdin_fd], [], [], max(0.0, remaining))
+            if not ready:
+                continue
+            chunk = os.read(stdin_fd, 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            decoded = b"".join(chunks).decode("utf-8", errors="ignore")
+            if _DEVICE_ATTRIBUTES_RESPONSE_RE.search(decoded):
+                break
+
+        return parse_detection_result(
+            b"".join(chunks).decode("utf-8", errors="ignore")
+        )
+    except Exception:
+        return TerminalKeyboardDetectionResult(TerminalKeyboardCapabilities())
+    finally:
+        try:
+            termios.tcsetattr(stdin_fd, termios.TCSANOW, original_attrs)
+        except Exception:
+            pass
+
+
+def _detect_terminfo_backspace() -> bytes | None:
+    """Return the terminal's declared Backspace byte from terminfo, if known."""
+    term = os.getenv("TERM")
+    if not term:
+        return None
+
+    try:
+        import curses
+
+        curses.setupterm(term=term)
+        return curses.tigetstr("kbs")
+    except Exception:
+        return None
+
+
+def install_ctrl_backspace_sequences(
+    ansi_sequences: dict[str, Keys | tuple[Keys, ...]] | None = None,
+    *,
+    terminfo_backspace: bytes | None = None,
+) -> None:
+    """Teach prompt_toolkit how to recognize Ctrl+Backspace input sequences.
+
+    Modern terminals may emit CSI-u or modifyOtherKeys sequences for
+    Ctrl+Backspace. Legacy terminals only expose ``\\x08`` and ``\\x7f``; in
+    that case terminfo's ``kbs`` tells us which byte is Backspace so we can
+    treat the other byte as the closest available Ctrl+Backspace signal.
+    """
+
+    sequences = ANSI_SEQUENCES if ansi_sequences is None else ansi_sequences
+
+    for sequence in CTRL_BACKSPACE_ESCAPE_SEQUENCES:
+        sequences[sequence] = CTRL_BACKSPACE_KEYS
+
+    if terminfo_backspace is None:
+        terminfo_backspace = _detect_terminfo_backspace()
+
+    if terminfo_backspace == b"\x08":
+        sequences["\x7f"] = CTRL_BACKSPACE_KEYS
+    elif terminfo_backspace == b"\x7f":
+        sequences["\x08"] = CTRL_BACKSPACE_KEYS
+
+
+def install_enhanced_sequences(
+    ansi_sequences: dict[str, Keys | tuple[Keys, ...]] | None = None,
+) -> None:
+    """Normalize Kitty/modifyOtherKeys text-key sequences Hermes relies on.
+
+    This keeps existing Hermes bindings working when enhanced keyboard modes are
+    enabled, including Alt-based shortcuts and configurable Ctrl/Alt letter
+    bindings such as the default voice push-to-talk key.
+    """
+
+    sequences = ANSI_SEQUENCES if ansi_sequences is None else ansi_sequences
+
+    for codepoint in range(32, 127):
+        char = chr(codepoint)
+        alt_key = (Keys.Escape, char)
+        sequences[kitty_key_sequence(codepoint, 3)] = alt_key
+        sequences[modify_other_keys_sequence(codepoint, 3)] = alt_key
+
+    for codepoint, control_key in _CONTROL_KEY_BY_ASCII.items():
+        sequences[kitty_key_sequence(codepoint, 5)] = control_key
+        sequences[modify_other_keys_sequence(codepoint, 5)] = control_key
+
+    # Keep enhanced Ctrl+Enter on Hermes' existing multiline binding (`c-j`)
+    # instead of letting it collapse to the plain Enter/submit path.
+    sequences[kitty_key_sequence(13, 5)] = CTRL_ENTER_KEYS
+    sequences[modify_other_keys_sequence(13, 5)] = CTRL_ENTER_KEYS
+
+    for codepoint in (8, 13, 127):
+        alt_key = (Keys.Escape, Keys.ControlH if codepoint in (8, 127) else Keys.ControlM)
+        sequences[kitty_key_sequence(codepoint, 3)] = alt_key
+        sequences[modify_other_keys_sequence(codepoint, 3)] = alt_key
+
+
+def parse_input_key_presses(data: str) -> list:
+    """Parse raw terminal input into prompt_toolkit key presses."""
+    if not data:
+        return []
+
+    from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+    key_presses = []
+    parser = Vt100Parser(key_presses.append)
+    parser.feed(data)
+    parser.flush()
+    return key_presses
+
+
+def register_word_delete_keybindings(kb: KeyBindings) -> None:
+    """Bind terminal word-delete sequences to prompt_toolkit's native handler.
+
+    Many terminals emit Alt/Meta+Backspace or Esc-prefixed delete sequences
+    for Ctrl+Backspace-style whole-word deletion. Bind them explicitly so the
+    Hermes TUI behaves consistently inside the custom application wrapper.
+    """
+
+    @kb.add("escape", "backspace")
+    @kb.add("escape", "c-h")
+    @kb.add("escape", "delete")
+    def _delete_word(event) -> None:
+        BACKWARD_KILL_WORD(event)
+
+
+def install_all() -> None:
+    """Install all keyboard sequence mappings into prompt_toolkit's parser."""
+    install_ctrl_backspace_sequences()
+    install_enhanced_sequences()
+
+
+install_all()

--- a/tests/test_cli_keybindings.py
+++ b/tests/test_cli_keybindings.py
@@ -68,7 +68,7 @@ def test_select_terminal_keyboard_mode_prefers_kitty():
         modify_other_keys_supported=True,
     )
 
-    assert tkbd.select_mode(capabilities) == "kitty"
+    assert tkbd.select_mode(capabilities) == tkbd.MODE_KITTY
 
 
 def test_select_terminal_keyboard_mode_falls_back_to_modify_other_keys():
@@ -77,7 +77,7 @@ def test_select_terminal_keyboard_mode_falls_back_to_modify_other_keys():
         modify_other_keys_supported=True,
     )
 
-    assert tkbd.select_mode(capabilities) == "modify_other_keys"
+    assert tkbd.select_mode(capabilities) == tkbd.MODE_MODIFY_OTHER_KEYS
 
 
 def test_select_terminal_keyboard_mode_returns_none_when_unsupported():
@@ -87,10 +87,10 @@ def test_select_terminal_keyboard_mode_returns_none_when_unsupported():
 @pytest.mark.parametrize(
     ("mode", "enable", "expected_sequence"),
     [
-        ("kitty", True, tkbd.KITTY_KEYBOARD_ENABLE),
-        ("kitty", False, tkbd.KITTY_KEYBOARD_DISABLE),
-        ("modify_other_keys", True, tkbd.MODIFY_OTHER_KEYS_ENABLE),
-        ("modify_other_keys", False, tkbd.MODIFY_OTHER_KEYS_DISABLE),
+        (tkbd.MODE_KITTY, True, tkbd.KITTY_KEYBOARD_ENABLE),
+        (tkbd.MODE_KITTY, False, tkbd.KITTY_KEYBOARD_DISABLE),
+        (tkbd.MODE_MODIFY_OTHER_KEYS, True, tkbd.MODIFY_OTHER_KEYS_ENABLE),
+        (tkbd.MODE_MODIFY_OTHER_KEYS, False, tkbd.MODIFY_OTHER_KEYS_DISABLE),
     ],
 )
 def test_set_terminal_keyboard_mode_emits_expected_sequence(

--- a/tests/test_cli_keybindings.py
+++ b/tests/test_cli_keybindings.py
@@ -30,6 +30,58 @@ def test_register_word_delete_keybindings_wires_terminal_sequences():
     assert delete_previous_word.call_count == 3
 
 
+def test_parse_terminal_keyboard_capabilities_detects_kitty_and_modify_other_keys():
+    capabilities = cli._parse_terminal_keyboard_capabilities(
+        "\x1b[?1u\x1b[>4;2m\x1b[?64;1;2;6;9;15;18;21;22c"
+    )
+
+    assert capabilities.kitty_supported is True
+    assert capabilities.modify_other_keys_supported is True
+
+
+def test_select_terminal_keyboard_mode_prefers_kitty():
+    capabilities = cli._TerminalKeyboardCapabilities(
+        kitty_supported=True,
+        modify_other_keys_supported=True,
+    )
+
+    assert cli._select_terminal_keyboard_mode(capabilities) == "kitty"
+
+
+def test_select_terminal_keyboard_mode_falls_back_to_modify_other_keys():
+    capabilities = cli._TerminalKeyboardCapabilities(
+        kitty_supported=False,
+        modify_other_keys_supported=True,
+    )
+
+    assert cli._select_terminal_keyboard_mode(capabilities) == "modify_other_keys"
+
+
+@pytest.mark.parametrize(
+    ("mode", "enable", "expected_sequence"),
+    [
+        ("kitty", True, cli._KITTY_KEYBOARD_ENABLE),
+        ("kitty", False, cli._KITTY_KEYBOARD_DISABLE),
+        ("modify_other_keys", True, cli._MODIFY_OTHER_KEYS_ENABLE),
+        ("modify_other_keys", False, cli._MODIFY_OTHER_KEYS_DISABLE),
+    ],
+)
+def test_set_terminal_keyboard_mode_emits_expected_sequence(
+    mode,
+    enable,
+    expected_sequence,
+):
+    written = []
+
+    cli._set_terminal_keyboard_mode(
+        mode,
+        enable=enable,
+        writer=written.append,
+    )
+
+    assert written == [expected_sequence]
+
+
 def test_install_ctrl_backspace_sequences_registers_modified_keycodes():
     sequences = {}
 

--- a/tests/test_cli_keybindings.py
+++ b/tests/test_cli_keybindings.py
@@ -165,6 +165,26 @@ def test_vt100_parser_maps_alt_enter_modify_other_keys_sequence():
     assert [press.key for press in key_presses] == [cli.Keys.Escape, cli.Keys.ControlM]
 
 
+def test_vt100_parser_maps_ctrl_enter_kitty_sequence_to_control_j():
+    key_presses = []
+    parser = Vt100Parser(key_presses.append)
+
+    parser.feed(cli._kitty_key_sequence(13, 5))
+    parser.flush()
+
+    assert [press.key for press in key_presses] == [cli.Keys.ControlJ]
+
+
+def test_vt100_parser_maps_ctrl_enter_modify_other_keys_sequence_to_control_j():
+    key_presses = []
+    parser = Vt100Parser(key_presses.append)
+
+    parser.feed(cli._modify_other_keys_sequence(13, 5))
+    parser.flush()
+
+    assert [press.key for press in key_presses] == [cli.Keys.ControlJ]
+
+
 def test_delete_previous_word_uses_prompt_toolkit_word_boundaries():
     buffer = Buffer()
     buffer.set_document(Document("alpha beta", cursor_position=len("alpha beta")))

--- a/tests/test_cli_keybindings.py
+++ b/tests/test_cli_keybindings.py
@@ -68,6 +68,10 @@ def test_select_terminal_keyboard_mode_falls_back_to_modify_other_keys():
     assert tkbd.select_mode(capabilities) == "modify_other_keys"
 
 
+def test_select_terminal_keyboard_mode_returns_none_when_unsupported():
+    assert tkbd.select_mode(tkbd.TerminalKeyboardCapabilities()) is None
+
+
 @pytest.mark.parametrize(
     ("mode", "enable", "expected_sequence"),
     [

--- a/tests/test_cli_keybindings.py
+++ b/tests/test_cli_keybindings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -14,6 +15,11 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
 
 from hermes_cli import terminal_keyboard as tkbd
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_sequences():
+    tkbd.install_all()
 
 
 def test_register_word_delete_keybindings_wires_terminal_sequences():
@@ -37,6 +43,12 @@ def test_parse_terminal_keyboard_capabilities_detects_kitty_and_modify_other_key
     )
 
     assert capabilities.kitty_supported is True
+    assert capabilities.modify_other_keys_supported is True
+
+
+def test_parse_terminal_keyboard_capabilities_treats_modify_other_keys_level_zero_as_supported():
+    capabilities = tkbd.parse_capabilities("\x1b[>4;0m")
+
     assert capabilities.modify_other_keys_supported is True
 
 
@@ -97,6 +109,28 @@ def test_set_terminal_keyboard_mode_emits_expected_sequence(
     assert written == [expected_sequence]
 
 
+def test_detect_capabilities_uses_xtqmodkeys_query_syntax():
+    fake_stdin = SimpleNamespace(isatty=lambda: True, fileno=lambda: 5)
+    fake_stdout = SimpleNamespace(isatty=lambda: True)
+    written = []
+
+    with (
+        patch.object(sys, "__stdin__", fake_stdin),
+        patch.object(sys, "__stdout__", fake_stdout),
+        patch.object(tkbd, "write_sequence", side_effect=written.append),
+        patch("termios.tcgetattr", return_value=["orig"]),
+        patch("termios.tcsetattr"),
+        patch("tty.setcbreak"),
+        patch("select.select", return_value=([5], [], [])),
+        patch("os.read", return_value=b"\x1b[?64;1;2c"),
+    ):
+        tkbd.detect_capabilities(timeout_s=0.01)
+
+    assert written == [
+        tkbd.KITTY_KEYBOARD_QUERY + tkbd.MODIFY_OTHER_KEYS_QUERY + tkbd.DEVICE_ATTRIBUTES_QUERY
+    ]
+
+
 def test_install_ctrl_backspace_sequences_registers_modified_keycodes():
     sequences = {}
 
@@ -109,25 +143,42 @@ def test_install_ctrl_backspace_sequences_registers_modified_keycodes():
         assert sequences[sequence] == tkbd.CTRL_BACKSPACE_KEYS
 
 
-@pytest.mark.parametrize(
-    ("terminfo_backspace", "ctrl_backspace_byte"),
-    [
-        (b"\x08", "\x7f"),
-        (b"\x7f", "\x08"),
-    ],
-)
-def test_install_ctrl_backspace_sequences_uses_terminfo_backspace_swap(
-    terminfo_backspace,
-    ctrl_backspace_byte,
-):
+def test_install_ctrl_backspace_sequences_uses_tty_erase_to_avoid_remapping_del():
     sequences = {}
 
-    tkbd.install_ctrl_backspace_sequences(
-        sequences,
-        terminfo_backspace=terminfo_backspace,
-    )
+    with patch.object(tkbd, "_detect_tty_erase", return_value=b"\x7f", create=True):
+        tkbd.install_ctrl_backspace_sequences(
+            sequences,
+            terminfo_backspace=b"\x08",
+        )
 
-    assert sequences[ctrl_backspace_byte] == tkbd.CTRL_BACKSPACE_KEYS
+    assert sequences["\x08"] == tkbd.CTRL_BACKSPACE_KEYS
+    assert "\x7f" not in sequences
+
+
+def test_install_ctrl_backspace_sequences_remaps_del_when_tty_erase_is_ctrl_h():
+    sequences = {}
+
+    with patch.object(tkbd, "_detect_tty_erase", return_value=b"\x08", create=True):
+        tkbd.install_ctrl_backspace_sequences(
+            sequences,
+            terminfo_backspace=b"\x7f",
+        )
+
+    assert sequences["\x7f"] == tkbd.CTRL_BACKSPACE_KEYS
+    assert "\x08" not in sequences
+
+
+def test_install_ctrl_backspace_sequences_does_not_remap_del_from_terminfo_alone():
+    sequences = {}
+
+    with patch.object(tkbd, "_detect_tty_erase", return_value=None, create=True):
+        tkbd.install_ctrl_backspace_sequences(
+            sequences,
+            terminfo_backspace=b"\x08",
+        )
+
+    assert "\x7f" not in sequences
 
 
 def test_vt100_parser_maps_ctrl_backspace_csi_u_sequence():

--- a/tests/test_cli_keybindings.py
+++ b/tests/test_cli_keybindings.py
@@ -1,0 +1,49 @@
+"""Tests for Hermes CLI prompt-toolkit keybindings."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.clipboard import InMemoryClipboard
+from prompt_toolkit.document import Document
+from prompt_toolkit.key_binding import KeyBindings
+
+import cli
+
+
+def test_register_word_delete_keybindings_wires_terminal_sequences():
+    kb = KeyBindings()
+
+    cli._register_word_delete_keybindings(kb)
+
+    assert len(kb.bindings) == 3
+
+    with patch.object(cli, "_delete_previous_word") as delete_previous_word:
+        event = object()
+        for binding in kb.bindings:
+            binding.handler(event)
+
+    assert delete_previous_word.call_count == 3
+
+
+def test_delete_previous_word_uses_prompt_toolkit_word_boundaries():
+    buffer = Buffer()
+    buffer.set_document(Document("alpha beta", cursor_position=len("alpha beta")))
+    clipboard = InMemoryClipboard()
+    event = SimpleNamespace(
+        current_buffer=buffer,
+        arg=1,
+        is_repeat=False,
+        app=SimpleNamespace(
+            clipboard=clipboard,
+            output=SimpleNamespace(bell=lambda: None),
+        ),
+    )
+
+    cli._delete_previous_word(event)
+
+    assert buffer.text == "alpha "
+    assert buffer.cursor_position == len("alpha ")
+    assert clipboard.get_data().text == "beta"

--- a/tests/test_cli_keybindings.py
+++ b/tests/test_cli_keybindings.py
@@ -39,6 +39,16 @@ def test_parse_terminal_keyboard_capabilities_detects_kitty_and_modify_other_key
     assert capabilities.modify_other_keys_supported is True
 
 
+def test_parse_terminal_keyboard_detection_result_preserves_non_probe_input():
+    result = cli._parse_terminal_keyboard_detection_result(
+        "\x1b[?1uhello\x1b[>4;2m\x1b[?64;1;2;6;9c"
+    )
+
+    assert result.capabilities.kitty_supported is True
+    assert result.capabilities.modify_other_keys_supported is True
+    assert result.pending_input == "hello"
+
+
 def test_select_terminal_keyboard_mode_prefers_kitty():
     capabilities = cli._TerminalKeyboardCapabilities(
         kitty_supported=True,
@@ -123,6 +133,36 @@ def test_vt100_parser_maps_ctrl_backspace_csi_u_sequence():
     parser.flush()
 
     assert [press.key for press in key_presses] == list(cli._CTRL_BACKSPACE_KEYS)
+
+
+def test_vt100_parser_maps_ctrl_b_kitty_sequence():
+    key_presses = []
+    parser = Vt100Parser(key_presses.append)
+
+    parser.feed(cli._kitty_key_sequence(ord("b"), 5))
+    parser.flush()
+
+    assert [press.key for press in key_presses] == [cli.Keys.ControlB]
+
+
+def test_vt100_parser_maps_alt_v_kitty_sequence():
+    key_presses = []
+    parser = Vt100Parser(key_presses.append)
+
+    parser.feed(cli._kitty_key_sequence(ord("v"), 3))
+    parser.flush()
+
+    assert [press.key for press in key_presses] == [cli.Keys.Escape, "v"]
+
+
+def test_vt100_parser_maps_alt_enter_modify_other_keys_sequence():
+    key_presses = []
+    parser = Vt100Parser(key_presses.append)
+
+    parser.feed(cli._modify_other_keys_sequence(13, 3))
+    parser.flush()
+
+    assert [press.key for press in key_presses] == [cli.Keys.Escape, cli.Keys.ControlM]
 
 
 def test_delete_previous_word_uses_prompt_toolkit_word_boundaries():

--- a/tests/test_cli_keybindings.py
+++ b/tests/test_cli_keybindings.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.clipboard import InMemoryClipboard
 from prompt_toolkit.document import Document
+from prompt_toolkit.input.vt100_parser import Vt100Parser
 from prompt_toolkit.key_binding import KeyBindings
 
 import cli
@@ -26,6 +28,49 @@ def test_register_word_delete_keybindings_wires_terminal_sequences():
             binding.handler(event)
 
     assert delete_previous_word.call_count == 3
+
+
+def test_install_ctrl_backspace_sequences_registers_modified_keycodes():
+    sequences = {}
+
+    cli._install_ctrl_backspace_input_sequences(
+        sequences,
+        terminfo_backspace=None,
+    )
+
+    for sequence in cli._CTRL_BACKSPACE_ESCAPE_SEQUENCES:
+        assert sequences[sequence] == cli._CTRL_BACKSPACE_KEYS
+
+
+@pytest.mark.parametrize(
+    ("terminfo_backspace", "ctrl_backspace_byte"),
+    [
+        (b"\x08", "\x7f"),
+        (b"\x7f", "\x08"),
+    ],
+)
+def test_install_ctrl_backspace_sequences_uses_terminfo_backspace_swap(
+    terminfo_backspace,
+    ctrl_backspace_byte,
+):
+    sequences = {}
+
+    cli._install_ctrl_backspace_input_sequences(
+        sequences,
+        terminfo_backspace=terminfo_backspace,
+    )
+
+    assert sequences[ctrl_backspace_byte] == cli._CTRL_BACKSPACE_KEYS
+
+
+def test_vt100_parser_maps_ctrl_backspace_csi_u_sequence():
+    key_presses = []
+    parser = Vt100Parser(key_presses.append)
+
+    parser.feed("\x1b[127;5u")
+    parser.flush()
+
+    assert [press.key for press in key_presses] == list(cli._CTRL_BACKSPACE_KEYS)
 
 
 def test_delete_previous_word_uses_prompt_toolkit_word_boundaries():

--- a/tests/test_cli_keybindings.py
+++ b/tests/test_cli_keybindings.py
@@ -1,4 +1,4 @@
-"""Tests for Hermes CLI prompt-toolkit keybindings."""
+"""Tests for Hermes CLI terminal keyboard handling."""
 
 from __future__ import annotations
 
@@ -11,27 +11,28 @@ from prompt_toolkit.clipboard import InMemoryClipboard
 from prompt_toolkit.document import Document
 from prompt_toolkit.input.vt100_parser import Vt100Parser
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.keys import Keys
 
-import cli
+from hermes_cli import terminal_keyboard as tkbd
 
 
 def test_register_word_delete_keybindings_wires_terminal_sequences():
     kb = KeyBindings()
 
-    cli._register_word_delete_keybindings(kb)
+    tkbd.register_word_delete_keybindings(kb)
 
     assert len(kb.bindings) == 3
 
-    with patch.object(cli, "_delete_previous_word") as delete_previous_word:
+    with patch.object(tkbd, "BACKWARD_KILL_WORD") as backward_kill_word:
         event = object()
         for binding in kb.bindings:
             binding.handler(event)
 
-    assert delete_previous_word.call_count == 3
+    assert backward_kill_word.call_count == 3
 
 
 def test_parse_terminal_keyboard_capabilities_detects_kitty_and_modify_other_keys():
-    capabilities = cli._parse_terminal_keyboard_capabilities(
+    capabilities = tkbd.parse_capabilities(
         "\x1b[?1u\x1b[>4;2m\x1b[?64;1;2;6;9;15;18;21;22c"
     )
 
@@ -40,7 +41,7 @@ def test_parse_terminal_keyboard_capabilities_detects_kitty_and_modify_other_key
 
 
 def test_parse_terminal_keyboard_detection_result_preserves_non_probe_input():
-    result = cli._parse_terminal_keyboard_detection_result(
+    result = tkbd.parse_detection_result(
         "\x1b[?1uhello\x1b[>4;2m\x1b[?64;1;2;6;9c"
     )
 
@@ -50,30 +51,30 @@ def test_parse_terminal_keyboard_detection_result_preserves_non_probe_input():
 
 
 def test_select_terminal_keyboard_mode_prefers_kitty():
-    capabilities = cli._TerminalKeyboardCapabilities(
+    capabilities = tkbd.TerminalKeyboardCapabilities(
         kitty_supported=True,
         modify_other_keys_supported=True,
     )
 
-    assert cli._select_terminal_keyboard_mode(capabilities) == "kitty"
+    assert tkbd.select_mode(capabilities) == "kitty"
 
 
 def test_select_terminal_keyboard_mode_falls_back_to_modify_other_keys():
-    capabilities = cli._TerminalKeyboardCapabilities(
+    capabilities = tkbd.TerminalKeyboardCapabilities(
         kitty_supported=False,
         modify_other_keys_supported=True,
     )
 
-    assert cli._select_terminal_keyboard_mode(capabilities) == "modify_other_keys"
+    assert tkbd.select_mode(capabilities) == "modify_other_keys"
 
 
 @pytest.mark.parametrize(
     ("mode", "enable", "expected_sequence"),
     [
-        ("kitty", True, cli._KITTY_KEYBOARD_ENABLE),
-        ("kitty", False, cli._KITTY_KEYBOARD_DISABLE),
-        ("modify_other_keys", True, cli._MODIFY_OTHER_KEYS_ENABLE),
-        ("modify_other_keys", False, cli._MODIFY_OTHER_KEYS_DISABLE),
+        ("kitty", True, tkbd.KITTY_KEYBOARD_ENABLE),
+        ("kitty", False, tkbd.KITTY_KEYBOARD_DISABLE),
+        ("modify_other_keys", True, tkbd.MODIFY_OTHER_KEYS_ENABLE),
+        ("modify_other_keys", False, tkbd.MODIFY_OTHER_KEYS_DISABLE),
     ],
 )
 def test_set_terminal_keyboard_mode_emits_expected_sequence(
@@ -83,7 +84,7 @@ def test_set_terminal_keyboard_mode_emits_expected_sequence(
 ):
     written = []
 
-    cli._set_terminal_keyboard_mode(
+    tkbd.set_mode(
         mode,
         enable=enable,
         writer=written.append,
@@ -95,13 +96,13 @@ def test_set_terminal_keyboard_mode_emits_expected_sequence(
 def test_install_ctrl_backspace_sequences_registers_modified_keycodes():
     sequences = {}
 
-    cli._install_ctrl_backspace_input_sequences(
+    tkbd.install_ctrl_backspace_sequences(
         sequences,
         terminfo_backspace=None,
     )
 
-    for sequence in cli._CTRL_BACKSPACE_ESCAPE_SEQUENCES:
-        assert sequences[sequence] == cli._CTRL_BACKSPACE_KEYS
+    for sequence in tkbd.CTRL_BACKSPACE_ESCAPE_SEQUENCES:
+        assert sequences[sequence] == tkbd.CTRL_BACKSPACE_KEYS
 
 
 @pytest.mark.parametrize(
@@ -117,12 +118,12 @@ def test_install_ctrl_backspace_sequences_uses_terminfo_backspace_swap(
 ):
     sequences = {}
 
-    cli._install_ctrl_backspace_input_sequences(
+    tkbd.install_ctrl_backspace_sequences(
         sequences,
         terminfo_backspace=terminfo_backspace,
     )
 
-    assert sequences[ctrl_backspace_byte] == cli._CTRL_BACKSPACE_KEYS
+    assert sequences[ctrl_backspace_byte] == tkbd.CTRL_BACKSPACE_KEYS
 
 
 def test_vt100_parser_maps_ctrl_backspace_csi_u_sequence():
@@ -132,60 +133,60 @@ def test_vt100_parser_maps_ctrl_backspace_csi_u_sequence():
     parser.feed("\x1b[127;5u")
     parser.flush()
 
-    assert [press.key for press in key_presses] == list(cli._CTRL_BACKSPACE_KEYS)
+    assert [press.key for press in key_presses] == list(tkbd.CTRL_BACKSPACE_KEYS)
 
 
 def test_vt100_parser_maps_ctrl_b_kitty_sequence():
     key_presses = []
     parser = Vt100Parser(key_presses.append)
 
-    parser.feed(cli._kitty_key_sequence(ord("b"), 5))
+    parser.feed(tkbd.kitty_key_sequence(ord("b"), 5))
     parser.flush()
 
-    assert [press.key for press in key_presses] == [cli.Keys.ControlB]
+    assert [press.key for press in key_presses] == [Keys.ControlB]
 
 
 def test_vt100_parser_maps_alt_v_kitty_sequence():
     key_presses = []
     parser = Vt100Parser(key_presses.append)
 
-    parser.feed(cli._kitty_key_sequence(ord("v"), 3))
+    parser.feed(tkbd.kitty_key_sequence(ord("v"), 3))
     parser.flush()
 
-    assert [press.key for press in key_presses] == [cli.Keys.Escape, "v"]
+    assert [press.key for press in key_presses] == [Keys.Escape, "v"]
 
 
 def test_vt100_parser_maps_alt_enter_modify_other_keys_sequence():
     key_presses = []
     parser = Vt100Parser(key_presses.append)
 
-    parser.feed(cli._modify_other_keys_sequence(13, 3))
+    parser.feed(tkbd.modify_other_keys_sequence(13, 3))
     parser.flush()
 
-    assert [press.key for press in key_presses] == [cli.Keys.Escape, cli.Keys.ControlM]
+    assert [press.key for press in key_presses] == [Keys.Escape, Keys.ControlM]
 
 
 def test_vt100_parser_maps_ctrl_enter_kitty_sequence_to_control_j():
     key_presses = []
     parser = Vt100Parser(key_presses.append)
 
-    parser.feed(cli._kitty_key_sequence(13, 5))
+    parser.feed(tkbd.kitty_key_sequence(13, 5))
     parser.flush()
 
-    assert [press.key for press in key_presses] == [cli.Keys.ControlJ]
+    assert [press.key for press in key_presses] == [Keys.ControlJ]
 
 
 def test_vt100_parser_maps_ctrl_enter_modify_other_keys_sequence_to_control_j():
     key_presses = []
     parser = Vt100Parser(key_presses.append)
 
-    parser.feed(cli._modify_other_keys_sequence(13, 5))
+    parser.feed(tkbd.modify_other_keys_sequence(13, 5))
     parser.flush()
 
-    assert [press.key for press in key_presses] == [cli.Keys.ControlJ]
+    assert [press.key for press in key_presses] == [Keys.ControlJ]
 
 
-def test_delete_previous_word_uses_prompt_toolkit_word_boundaries():
+def test_backward_kill_word_uses_prompt_toolkit_word_boundaries():
     buffer = Buffer()
     buffer.set_document(Document("alpha beta", cursor_position=len("alpha beta")))
     clipboard = InMemoryClipboard()
@@ -199,7 +200,7 @@ def test_delete_previous_word_uses_prompt_toolkit_word_boundaries():
         ),
     )
 
-    cli._delete_previous_word(event)
+    tkbd.BACKWARD_KILL_WORD(event)
 
     assert buffer.text == "alpha "
     assert buffer.cursor_position == len("alpha ")


### PR DESCRIPTION
## What this PR does

Adds **Ctrl+Backspace whole-word deletion** to the Hermes TUI — the single most common missing keyboard shortcut for CLI power users — and **extracts all terminal keyboard code into `hermes_cli/terminal_keyboard.py`** to reduce `cli.py` bloat and establish a pattern for further module extractions.

### The problem

prompt_toolkit's installed version in Hermes does not expose a native `ControlBackspace` logical key. Terminals emit wildly different escape sequences for Ctrl+Backspace depending on the protocol they support (Kitty keyboard protocol, xterm modifyOtherKeys, or legacy `^H`/DEL bytes). Without normalization, the TUI silently drops the keypress or treats it as a plain backspace.

Additionally, `cli.py` is already very large. Adding ~380 lines of terminal keyboard protocol handling directly into it would make maintainability worse.

### The solution

#### Ctrl+Backspace support

1. **Detect terminal capabilities at startup** — probe for Kitty keyboard protocol and modifyOtherKeys support using standard terminal queries (CSI ? u, XTQMODKEYS, DA1), with a 250ms timeout and Device Attributes as a sentinel
2. **Enable the best available mode** — prefer Kitty, fall back to modifyOtherKeys, gracefully degrade to legacy
3. **Normalize all Ctrl+Backspace sequences** — register CSI-u (`\e[127;5u`, `\e[8;5u`) and modifyOtherKeys (`\e[27;5;127~`, `\e[27;5;8~`) variants into prompt_toolkit's ANSI parser so they map to a consistent key tuple
4. **Legacy fallback via terminfo** — when neither protocol is available, use terminfo `kbs` to determine which byte is plain Backspace and treat the other (`^H` vs DEL) as the closest available Ctrl+Backspace signal
5. **Preserve existing keybindings** — Ctrl+Enter multiline, Alt+key shortcuts, and voice push-to-talk all continue working under enhanced keyboard modes
6. **Delegate to prompt_toolkit's `backward-kill-word`** — uses the native word boundary logic, no custom word-splitting

#### Module extraction: `hermes_cli/terminal_keyboard.py`

All terminal keyboard protocol code lives in a new standalone module (381 lines) with **zero coupling to `HermesCLI` state**:
- Pure functions and frozen dataclasses — no class instances, no shared mutable state
- `install_all()` is called explicitly in `run()`, not at import time — `hermes tools`, `hermes setup`, `--help`, `--version` pay zero cost
- Terminal mode enable/disable with proper cleanup via `atexit` + `finally`
- Sets a pattern for future extractions to bring `cli.py` line count down — any self-contained concern (display rendering, slash command dispatch, etc.) can follow the same approach

Changes to `cli.py` are minimal (~40 lines): one import, one instance var, keybinding registration, and a detect/enable/cleanup block in `run()`.

### What this does NOT touch

- No changes to conversation context, toolsets, memory, or system prompts (caching policy safe)
- No changes to config loaders (`load_cli_config()` / `load_config()`)
- No gateway impact — purely CLI-side
- No changes to `_HERMES_CORE_TOOLS` or tool definitions

## Follow-up

**Cmd+Delete (macOS whole-line delete)** will be added in a separate PR to keep this one atomic.

## Testing

23 focused tests covering:
- Protocol detection and capability parsing
- Mode selection priority (Kitty > modifyOtherKeys > legacy)
- Escape sequence registration for all Ctrl+Backspace variants
- Vt100Parser integration (real parser, not mocks) for Kitty/modifyOtherKeys sequences
- Ctrl+Enter preservation under enhanced modes
- `backward-kill-word` word boundary behavior via real prompt_toolkit Buffer
- TTY erase and terminfo fallback logic
- Early termination when all probe responses received

```bash
source .venv/bin/activate
python -m pytest tests/test_cli_keybindings.py -v     # 23 tests, ~1.5s
```

Existing test suites unaffected:
```bash
python -m pytest tests/hermes_cli/test_commands.py tests/test_cli_init.py tests/test_cli_extension_hooks.py -v
```