### PR TITLE
Integrate huggingface/skills into the Hermes Skills Hub

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -53,7 +53,9 @@ class TestResolveTrustLevel:
     def test_trusted_repos(self):
         assert _resolve_trust_level("openai/skills") == "trusted"
         assert _resolve_trust_level("anthropics/skills") == "trusted"
+        assert _resolve_trust_level("huggingface/skills") == "trusted"
         assert _resolve_trust_level("openai/skills/some-skill") == "trusted"
+        assert _resolve_trust_level("huggingface/skills/hf-cli") == "trusted"
 
     def test_community_default(self):
         assert _resolve_trust_level("random-user/my-skill") == "community"

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -99,6 +99,14 @@ class TestTrustLevelFor:
         # No path part — still resolves repo correctly
         assert result in ("trusted", "community")
 
+    def test_huggingface_repo_is_trusted(self):
+        src = self._source()
+        assert src.trust_level_for("huggingface/skills/hf-cli") == "trusted"
+
+    def test_default_taps_include_huggingface_skills(self):
+        src = self._source()
+        assert {"repo": "huggingface/skills", "path": "skills/"} in src.taps
+
 
 # ---------------------------------------------------------------------------
 # SkillsShSource

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -10,7 +10,7 @@ based on both the scan verdict and the source's trust level.
 
 Trust levels:
   - builtin:   Ships with Hermes. Never scanned, always trusted.
-  - trusted:   openai/skills and anthropics/skills only. Caution verdicts allowed.
+  - trusted:   openai/skills, anthropics/skills, and huggingface/skills. Caution verdicts allowed.
   - community: Everything else. Any findings = blocked unless --force.
 
 Usage:
@@ -36,7 +36,7 @@ from typing import List, Tuple
 # Hardcoded trust configuration
 # ---------------------------------------------------------------------------
 
-TRUSTED_REPOS = {"openai/skills", "anthropics/skills"}
+TRUSTED_REPOS = {"openai/skills", "anthropics/skills", "huggingface/skills"}
 
 INSTALL_POLICY = {
     #                  safe      caution    dangerous

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -249,6 +249,7 @@ class GitHubSource(SkillSource):
     DEFAULT_TAPS = [
         {"repo": "openai/skills", "path": "skills/"},
         {"repo": "anthropics/skills", "path": "skills/"},
+        {"repo": "huggingface/skills", "path": "skills/"},
         {"repo": "VoltAgent/awesome-agent-skills", "path": "skills/"},
     ]
 

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -172,7 +172,7 @@ All hub-installed skills go through a security scanner that checks for:
 Trust levels:
 - `builtin` — ships with Hermes (always trusted)
 - `official` — from `optional-skills/` in the repo (builtin trust, no third-party warning)
-- `trusted` — from openai/skills, anthropics/skills
+- `trusted` — from openai/skills, anthropics/skills, huggingface/skills
 - `community` — non-dangerous findings can be overridden with `--force`; `dangerous` verdicts remain blocked
 
 Hermes can now consume third-party skills from multiple external discovery models:

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -168,6 +168,7 @@ hermes skills search kubernetes
 hermes skills search react --source skills-sh
 hermes skills search https://mintlify.com/docs --source well-known
 hermes skills install openai/skills/k8s
+hermes skills install huggingface/skills/hf-cli
 hermes skills install official/security/1password
 hermes skills install skills-sh/vercel-labs/json-render/json-render-react --force
 ```

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -277,11 +277,13 @@ Hermes can install directly from GitHub repositories and GitHub-based taps. This
 
 - OpenAI skills: [openai/skills](https://github.com/openai/skills)
 - Anthropic skills: [anthropics/skills](https://github.com/anthropics/skills)
+- Hugging Face skills: [huggingface/skills](https://github.com/huggingface/skills)
 - Example community tap source: [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)
 - Example:
 
 ```bash
 hermes skills install openai/skills/k8s
+hermes skills install huggingface/skills/hf-cli
 hermes skills tap add myorg/skills-repo
 ```
 
@@ -340,7 +342,7 @@ Important behavior:
 |-------|--------|--------|
 | `builtin` | Ships with Hermes | Always trusted |
 | `official` | `optional-skills/` in the repo | Builtin trust, no third-party warning |
-| `trusted` | Trusted registries/repos such as `openai/skills`, `anthropics/skills` | More permissive policy than community sources |
+| `trusted` | Trusted registries/repos such as `openai/skills`, `anthropics/skills`, `huggingface/skills` | More permissive policy than community sources |
 | `community` | Everything else (`skills.sh`, well-known endpoints, custom GitHub repos, most marketplaces) | Non-dangerous findings can be overridden with `--force`; `dangerous` verdicts stay blocked |
 
 ### Update lifecycle


### PR DESCRIPTION
## Summary
- add `huggingface/skills` to the default GitHub Skills Hub taps so its `skills/` catalog is discoverable by default
- classify `huggingface/skills` as a trusted external skills source alongside the existing major official repos
- update docs and examples to show Hugging Face skill installs and the expanded trusted-source set

## Validation
- `source /Users/kshitij/Projects/hermes-agent/.venv/bin/activate && python -m pytest tests/tools/test_skills_guard.py tests/tools/test_skills_hub.py -q`
- `source /Users/kshitij/Projects/hermes-agent/.venv/bin/activate && python -m pytest tests/ -q -n 0 -x` on this branch
- `source /Users/kshitij/Projects/hermes-agent/.venv/bin/activate && python -m pytest tests/ -q -n 0 -x` on `main`

## Notes
- The focused skills-hub tests pass.
- The full suite has a pre-existing failure on both this branch and `main`: `tests/agent/test_prompt_builder.py::TestBuildContextFilesPrompt::test_claude_md_uppercase_takes_priority`.