### PR TITLE
feat: Windows QoL & security improvements

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,0 +1,86 @@
+name: Windows Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: windows-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-windows:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          uv venv .venv --python 3.11
+          .venv\Scripts\activate
+          uv pip install -e ".[all,dev,windows]"
+
+      - name: Run Windows compatibility tests
+        shell: pwsh
+        run: |
+          .venv\Scripts\activate
+          python -m pytest tests/tools/test_windows_compat.py tests/tools/test_clipboard.py -v --tb=short -p no:xdist
+        env:
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""
+          NOUS_API_KEY: ""
+
+      - name: Verify critical imports on Windows
+        shell: pwsh
+        run: |
+          .venv\Scripts\activate
+          python -c "from tools.memory_tool import MemoryStore; print('OK: memory_tool')"
+          python -c "from hermes_cli.clipboard import save_clipboard_image, get_clipboard_text; print('OK: clipboard')"
+          python -c "from tools.code_execution_tool import SANDBOX_AVAILABLE; print(f'OK: code_execution (sandbox={SANDBOX_AVAILABLE})')"
+          python -c "from agent.display import write_tty; print('OK: display')"
+          python -c "from hermes_cli.config import _secure_file, get_env_value; print('OK: config')"
+          python -c "from tools.shell_quote import shell_quote; print(f'OK: shell_quote({shell_quote(\"hello world\")})')"
+
+      - name: Compile-check all modified files
+        shell: pwsh
+        run: |
+          .venv\Scripts\activate
+          python -c @"
+          import py_compile, sys
+          files = [
+              'tools/memory_tool.py',
+              'hermes_cli/gateway.py',
+              'hermes_cli/config.py',
+              'hermes_cli/status.py',
+              'hermes_cli/clipboard.py',
+              'gateway/status.py',
+              'tools/environments/local.py',
+              'tools/environments/persistent_shell.py',
+              'tools/code_execution_tool.py',
+              'tools/shell_quote.py',
+              'tools/transcription_tools.py',
+              'agent/display.py',
+              'cli.py',
+          ]
+          failed = False
+          for f in files:
+              try:
+                  py_compile.compile(f, doraise=True)
+                  print(f'OK: {f}')
+              except Exception as e:
+                  print(f'FAIL: {f} -> {e}')
+                  failed = True
+          if failed:
+              sys.exit(1)
+          "@

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 
 Works on Linux, macOS, and WSL2. The installer handles everything — Python, Node.js, dependencies, and the `hermes` command. No prerequisites except git.
 
-> **Windows:** Native Windows is not supported. Please install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run the command above.
+> **Windows:** Native Windows 10/11 is supported. Install via PowerShell: `irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex`
+> See [WINDOWS.md](WINDOWS.md) for details.
 
 After installation:
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1,0 +1,119 @@
+# Hermes on Windows
+
+Native Windows support for Hermes Agent. Works on Windows 10 (build 17134+)
+and Windows 11 with Python 3.11+.
+
+## Installation
+
+### Quick Install (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
+```
+
+This installs Python (via uv), Git, Node.js, and sets up Hermes in
+`%LOCALAPPDATA%\hermes`.
+
+### Manual Install
+
+```powershell
+git clone https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+pip install -e ".[windows,pty]"
+hermes setup
+```
+
+The `[windows]` extra installs `keyring` for secure credential storage
+via Windows Credential Manager.
+
+## Features
+
+### What Works
+
+- **CLI chat** — full interactive prompt with multiline, autocomplete, history
+- **Clipboard paste** — Ctrl+V to paste screenshots directly into Hermes
+  (Ctrl+PrtScn → Ctrl+V workflow). Also supports `/paste` command and Alt+V.
+- **All tools** — terminal, file, search, browser, vision, code execution,
+  MCP servers, voice mode, cron jobs
+- **Code execution sandbox** — uses AF_UNIX sockets (available on Windows 10+)
+- **Gateway** — messaging gateway with Telegram, Discord, Slack, etc.
+- **Gateway service** — auto-start via Windows Task Scheduler
+- **Credential security** — API keys stored in Windows Credential Manager
+  (via keyring) instead of plaintext files
+- **File protection** — config files secured via icacls (owner-only ACLs)
+- **Git Bash shell** — terminal tool finds Git Bash automatically
+
+### Windows-Specific Notes
+
+**Clipboard image paste:**
+Copy a screenshot (Ctrl+PrtScn or Win+Shift+S), then Ctrl+V in Hermes.
+You'll see `📎 Image #1 attached from clipboard`. Type your message and
+press Enter to send with the image.
+
+**Terminal tool:**
+Uses Git Bash under the hood. Install Git for Windows if you haven't:
+https://git-scm.com/download/win
+
+Override the path if needed:
+```
+set HERMES_GIT_BASH_PATH=C:\Program Files\Git\bin\bash.exe
+```
+
+**Gateway service:**
+```powershell
+hermes gateway install   # Creates Windows scheduled task (runs at logon)
+hermes gateway start     # Start the task
+hermes gateway stop      # Stop the task + kill processes
+hermes gateway uninstall # Remove the scheduled task
+```
+
+The task appears as "HermesGateway" in Task Scheduler.
+
+**Credential storage:**
+With keyring installed (`pip install keyring`), API keys are stored in
+Windows Credential Manager instead of `~/.hermes/.env`. View stored
+credentials in Control Panel → Credential Manager → Windows Credentials.
+
+## Troubleshooting
+
+### "No module named fcntl"
+Old issue, fixed. All file locking now uses `msvcrt` on Windows with
+`fcntl` fallback on Unix.
+
+### Code execution tool shows as disabled
+The sandbox requires AF_UNIX sockets. These are available on Windows 10
+build 17134+ (April 2018 Update). If you're on an older build, the
+sandbox will be disabled but all other tools work normally.
+
+### Git Bash not found
+Install Git for Windows, or set the path explicitly:
+```
+set HERMES_GIT_BASH_PATH=C:\path\to\bash.exe
+```
+
+### Gateway won't start as a service
+Task Scheduler requires the user to be logged in (ONLOGON trigger).
+If you need it to run as a background service regardless of login,
+consider NSSM (Non-Sucking Service Manager):
+```
+nssm install HermesGateway "C:\path\to\python.exe" "-m hermes_cli.main gateway run"
+```
+
+### Slow clipboard paste
+First clipboard operation may take 5-15 seconds while PowerShell cold-starts.
+Subsequent operations are fast (PowerShell stays cached).
+
+### Voice mode issues
+Install espeak-ng for TTS: `choco install espeak-ng` (requires Chocolatey).
+For STT, set `VOICE_TOOLS_OPENAI_KEY` or install faster-whisper locally.
+
+## Architecture Notes
+
+- File locking: `msvcrt.locking()` (Windows) / `fcntl.flock()` (Unix)
+- Process management: `taskkill /F /T /PID` (Windows) / `pkill -P` (Unix)
+- Terminal device: `CON` (Windows) / `/dev/tty` (Unix)
+- Temp files: `%TEMP%\hermes-*` (Windows) / `/tmp/hermes-*` (Unix)
+- Credential store: Windows Credential Manager via keyring / `.env` fallback
+- File permissions: `icacls` (Windows) / `chmod` (Unix)
+- Service management: Task Scheduler (Windows) / systemd (Linux) / launchd (macOS)
+- Shell quoting: cmd.exe double-quote escaping / shlex.quote (Unix)

--- a/agent/display.py
+++ b/agent/display.py
@@ -620,11 +620,19 @@ def honcho_session_line(workspace: str, session_name: str) -> str:
 
 
 def write_tty(text: str) -> None:
-    """Write directly to /dev/tty, bypassing stdout capture."""
+    """Write directly to the terminal, bypassing stdout capture.
+
+    Uses /dev/tty on Unix, CON on Windows, with stdout fallback.
+    """
     try:
-        fd = os.open("/dev/tty", os.O_WRONLY)
-        os.write(fd, text.encode("utf-8"))
-        os.close(fd)
+        if sys.platform == "win32":
+            # Windows: CON is the console device
+            with open("CON", "w", encoding="utf-8") as f:
+                f.write(text)
+        else:
+            fd = os.open("/dev/tty", os.O_WRONLY)
+            os.write(fd, text.encode("utf-8"))
+            os.close(fd)
     except OSError:
         sys.stdout.write(text)
         sys.stdout.flush()

--- a/cli.py
+++ b/cli.py
@@ -2340,21 +2340,46 @@ class HermesCLI:
         print(f"  ✅ Stopped {killed} process(es).")
 
     def _handle_paste_command(self):
-        """Handle /paste — explicitly check clipboard for an image.
+        """Handle /paste — check clipboard for images or text.
 
         This is the reliable fallback for terminals where BracketedPaste
         doesn't fire for image-only clipboard content (e.g., VSCode terminal,
-        Windows Terminal with WSL2).
+        Windows Terminal with WSL2).  Also handles text paste on terminals
+        where Ctrl+V sends raw 0x16 instead of triggering a paste event.
+
+        Priority: image first (since text paste usually works via terminal),
+        then text as fallback.
         """
-        from hermes_cli.clipboard import has_clipboard_image
+        from hermes_cli.clipboard import has_clipboard_image, get_clipboard_text
         if has_clipboard_image():
             if self._try_attach_clipboard_image():
                 n = len(self._attached_images)
                 _cprint(f"  📎 Image #{n} attached from clipboard")
             else:
                 _cprint(f"  {_DIM}(>_<) Clipboard has an image but extraction failed{_RST}")
+            return
+
+        # No image — try text
+        text = get_clipboard_text()
+        if text:
+            line_count = text.count('\n') + 1
+            char_count = len(text)
+            if char_count > 200:
+                preview = text[:200].replace('\n', '↵ ') + "..."
+            else:
+                preview = text.replace('\n', '↵ ')
+            _cprint(f"  📋 Pasted {char_count} chars ({line_count} lines) from clipboard")
+            _cprint(f"  {_DIM}{preview}{_RST}")
+            # Insert into the input buffer if we have access to the app
+            if hasattr(self, '_app') and self._app and self._app.layout:
+                try:
+                    buf = self._app.layout.current_buffer
+                    if buf:
+                        buf.insert_text(text)
+                except Exception:
+                    pass
         else:
-            _cprint(f"  {_DIM}(._.) No image found in clipboard{_RST}")
+            _cprint(f"  {_DIM}(._.) Nothing found in clipboard{_RST}")
 
     def _preprocess_images_with_vision(self, text: str, images: list) -> str:
         """Analyze attached images via the vision tool and return enriched text.
@@ -2504,7 +2529,10 @@ class HermesCLI:
 
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
         _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
-        _cprint(f"  {_DIM}Paste image: Alt+V (or /paste){_RST}\n")
+        if sys.platform == "win32":
+            _cprint(f"  {_DIM}Paste image: Ctrl+V (or /paste){_RST}\n")
+        else:
+            _cprint(f"  {_DIM}Paste image: Alt+V, Ctrl+V (or /paste){_RST}\n")
     
     def show_tools(self):
         """Display available tools with kawaii ASCII art."""
@@ -3377,7 +3405,7 @@ class HermesCLI:
             print("  To start the gateway:")
             print("    python cli.py --gateway")
             print()
-            print("  Configuration file: ~/.hermes/config.yaml")
+            print(f"  Configuration file: {_hermes_home / 'config.yaml'}")
             print()
             
         except Exception as e:
@@ -3387,7 +3415,7 @@ class HermesCLI:
             print("    1. Set environment variables:")
             print("       TELEGRAM_BOT_TOKEN=your_token")
             print("       DISCORD_BOT_TOKEN=your_token")
-            print("    2. Or configure settings in ~/.hermes/config.yaml")
+            print(f"    2. Or configure settings in {_hermes_home / 'config.yaml'}")
             print()
     
     def process_command(self, command: str) -> bool:
@@ -3695,7 +3723,7 @@ class HermesCLI:
                 plugins = mgr.list_plugins()
                 if not plugins:
                     print("No plugins installed.")
-                    print(f"Drop plugin directories into ~/.hermes/plugins/ to get started.")
+                    print(f"Drop plugin directories into {_hermes_home / 'plugins'} to get started.")
                 else:
                     print(f"Plugins ({len(plugins)}):")
                     for p in plugins:
@@ -3738,13 +3766,21 @@ class HermesCLI:
             if base_cmd.lstrip("/") in quick_commands:
                 qcmd = quick_commands[base_cmd.lstrip("/")]
                 if qcmd.get("type") == "exec":
-                    import subprocess
+                    import subprocess, shlex as _shlex
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            # Parse command into args list to avoid shell injection.
+                            # On Windows, shlex.split may not handle all cmd.exe syntax,
+                            # so fall back to shell=True only on Windows.
+                            if sys.platform == "win32":
+                                _run_args = {"args": exec_cmd, "shell": True}
+                            else:
+                                _run_args = {"args": _shlex.split(exec_cmd), "shell": False}
                             result = subprocess.run(
-                                exec_cmd, shell=True, capture_output=True,
-                                text=True, timeout=30
+                                capture_output=True,
+                                text=True, timeout=30,
+                                **_run_args,
                             )
                             output = result.stdout.strip() or result.stderr.strip()
                             if output:
@@ -4200,7 +4236,7 @@ class HermesCLI:
                 source = f" ({s['source']})" if s["source"] == "user" else ""
                 print(f"   {marker} {s['name']}{source} — {s['description']}")
             print(f"\n  Usage: /skin <name>")
-            print(f"  Custom skins: drop a YAML file in ~/.hermes/skins/\n")
+            print(f"  Custom skins: drop a YAML file in {_hermes_home / 'skins'}\n")
             return
 
         new_skin = parts[1].strip().lower()
@@ -4540,6 +4576,7 @@ class HermesCLI:
             # Capture old server names
             with _lock:
                 old_servers = set(_servers.keys())
+
 
             if not self._command_running:
                 print("🔄 Reloading MCP servers...")
@@ -5533,7 +5570,7 @@ class HermesCLI:
                             break
                     except queue.Empty:
                         # Force prompt_toolkit to flush any pending stdout
-                        # output from the agent thread.  Without this, the
+                        # output from the agent thread. Without this, the
                         # StdoutProxy buffer only flushes on renderer passes
                         # triggered by input events — on macOS this causes
                         # the CLI to appear frozen until the user types. (#1624)
@@ -5708,7 +5745,7 @@ class HermesCLI:
                 stop_event.set()
             if tts_thread is not None and tts_thread.is_alive():
                 tts_thread.join(timeout=5)
-    
+
     def _print_exit_summary(self):
         """Print session resume info on exit, similar to Claude Code."""
         print()
@@ -6345,6 +6382,15 @@ class HermesCLI:
                 event.app.invalidate()
         from prompt_toolkit.keys import Keys
 
+        def _attach_and_notify(event) -> bool:
+            """Try to attach a clipboard image; print confirmation if found."""
+            if self._try_attach_clipboard_image():
+                n = len(self._attached_images)
+                _cprint(f"\n  📎 Image #{n} attached from clipboard (type message + Enter to send)")
+                event.app.invalidate()
+                return True
+            return False
+
         @kb.add(Keys.BracketedPaste, eager=True)
         def handle_paste(event):
             """Handle terminal paste — detect clipboard images.
@@ -6354,24 +6400,34 @@ class HermesCLI:
             clipboard for an image on every paste event.
             """
             pasted_text = event.data or ""
-            if self._try_attach_clipboard_image():
-                event.app.invalidate()
+            _attach_and_notify(event)
             if pasted_text:
                 event.current_buffer.insert_text(pasted_text)
 
         @kb.add('c-v')
         def handle_ctrl_v(event):
-            """Fallback image paste for terminals without bracketed paste.
+            """Ctrl+V paste — works on native Windows and Linux terminals.
 
-            On Linux terminals (GNOME Terminal, Konsole, etc.), Ctrl+V
-            sends raw byte 0x16 instead of triggering a paste.  This
-            binding catches that and checks the clipboard for images.
-            On terminals that DO intercept Ctrl+V for paste (macOS
-            Terminal, iTerm2, VSCode, Windows Terminal), the bracketed
-            paste handler fires instead and this binding never triggers.
+            On native Windows: Windows Terminal intercepts Ctrl+V for
+            text paste (handled by BracketedPaste or direct insertion).
+            But when the clipboard has only an image, Windows Terminal
+            does nothing and the keystroke reaches prompt_toolkit — so
+            this handler picks it up and attaches the image.
+
+            On Linux terminals: Ctrl+V sends raw 0x16 which prompt_toolkit
+            sees as c-v.  We check for images first, then fall back to
+            text paste from clipboard.
             """
-            if self._try_attach_clipboard_image():
-                event.app.invalidate()
+            if _attach_and_notify(event):
+                return
+            # No image — try text paste from clipboard
+            try:
+                from hermes_cli.clipboard import get_clipboard_text
+                text = get_clipboard_text()
+                if text:
+                    event.current_buffer.insert_text(text)
+            except Exception:
+                pass
 
         @kb.add('escape', 'v')
         def handle_alt_v(event):
@@ -6383,11 +6439,27 @@ class HermesCLI:
             on WSL2, VSCode, and any terminal over SSH where Ctrl+V
             can't reach the application for image-only clipboard.
             """
-            if self._try_attach_clipboard_image():
-                event.app.invalidate()
-            else:
+            if not _attach_and_notify(event):
                 # No image found — show a hint
                 pass  # silent when no image (avoid noise on accidental press)
+
+        if sys.platform == "win32":
+            @kb.add('s-insert')
+            def handle_shift_insert(event):
+                """Shift+Insert — alternative paste on Windows.
+
+                Some Windows users use Shift+Insert to paste.  Handle
+                clipboard images here too.
+                """
+                if _attach_and_notify(event):
+                    return
+                try:
+                    from hermes_cli.clipboard import get_clipboard_text
+                    text = get_clipboard_text()
+                    if text:
+                        event.current_buffer.insert_text(text)
+                except Exception:
+                    pass
 
         # Dynamic prompt: shows Hermes symbol when agent is working,
         # or answer prompt when clarify freetext mode is active.
@@ -6478,9 +6550,12 @@ class HermesCLI:
             line_count = text.count('\n')
             chars_added = len(text) - _prev_text_len[0]
             _prev_text_len[0] = len(text)
-            # Heuristic: a real paste adds many characters at once (not just a
-            # single newline from Alt+Enter) AND the result has 5+ lines.
-            if line_count >= 5 and chars_added > 1 and not text.startswith('/'):
+            # Heuristic: a real paste adds many characters at once.
+            # Require both a substantial character count AND multiple lines to
+            # avoid false positives from multiline typing (Alt+Enter) or short
+            # pastes.  The threshold of 10+ lines and 200+ chars at once
+            # catches code/log pastes while leaving normal input alone.
+            if line_count >= 10 and chars_added >= 200 and not text.startswith('/'):
                 _paste_counter[0] += 1
                 # Save to temp file
                 paste_dir = _hermes_home / "pastes"
@@ -7338,3 +7413,4 @@ def main(
 
 if __name__ == "__main__":
     fire.Fire(main)
+

--- a/docs/plans/windows-qol-plan.md
+++ b/docs/plans/windows-qol-plan.md
@@ -1,0 +1,168 @@
+# Windows QoL & Security Plan for Hermes
+## Generated: 2026-03-22
+
+Based on a full codebase audit (compatibility, security, existing Windows work).
+
+---
+
+## Phase 1: Stop the Crashes (Critical Fixes)
+*Estimated effort: 1-2 sessions*
+
+### 1.1 memory_tool.py — bare `import fcntl`
+- **File:** `tools/memory_tool.py:26`
+- **Problem:** Module-level `import fcntl` with no guard. Entire memory tool
+  fails to import on Windows.
+- **Fix:** Add try/except with msvcrt fallback (same pattern as auth.py,
+  scheduler.py). Update `_file_lock()` to use msvcrt.locking().
+
+### 1.2 gateway.py — signal.SIGKILL without platform guard
+- **File:** `hermes_cli/gateway.py:883`
+- **Problem:** `os.kill(pid, signal.SIGKILL)` in `_wait_for_gateway_exit()`.
+  SIGKILL doesn't exist on Windows. AttributeError on any gateway shutdown.
+- **Fix:** Guard with `signal.SIGTERM` on win32.
+
+### 1.3 Hardcoded /tmp paths
+- **Files:** `tools/environments/local.py:321`, `persistent_shell.py:47`
+- **Problem:** `/tmp/hermes-local-*` and `/tmp/hermes-persistent-*` don't
+  resolve on Windows.
+- **Fix:** Replace with `tempfile.gettempdir()` + prefix.
+
+### 1.4 agent/display.py — /dev/tty
+- **Problem:** `os.open("/dev/tty", os.O_WRONLY)` crashes on Windows.
+- **Fix:** Use `"CON"` on Windows, fallback to sys.stderr.
+
+---
+
+## Phase 2: Security Hardening (High Priority)
+*Estimated effort: 2-3 sessions*
+
+### 2.1 Credential storage — use Windows Credential Manager
+- **Problem:** auth.json and .env store API keys, OAuth tokens, SUDO_PASSWORD
+  in plaintext. Unix chmod(0o600) is a no-op on Windows — any local user can
+  read them.
+- **Fix:** Integrate `keyring` library (uses Windows Credential Manager/DPAPI
+  automatically). Store secrets in WCM, keep only non-sensitive config in files.
+- **Scope:** hermes_cli/auth.py, hermes_cli/setup.py, .env handling
+
+### 2.2 MCP config secrets
+- **Problem:** MCP server configs embed API keys directly in config.yaml.
+- **Fix:** Support `$ENV{VAR_NAME}` references in MCP config, resolve at
+  runtime. Keep secrets in env vars or WCM, not in the config file.
+
+### 2.3 shell=True with user-configurable commands
+- **File:** `cli.py:3694` (quick commands)
+- **Problem:** User-configurable commands run with `shell=True`. On Windows,
+  this invokes cmd.exe with unreliable escaping.
+- **Fix:** Use `subprocess.run()` with list args where possible. For commands
+  that need shell features, validate/sanitize input.
+
+### 2.4 shlex.quote() on Windows
+- **File:** `tools/transcription_tools.py`
+- **Problem:** `shlex.quote()` produces Unix-style quoting that doesn't
+  protect against cmd.exe injection.
+- **Fix:** Add a `_win_quote()` helper that uses `^` escaping for cmd.exe
+  special chars, or avoid shell=True entirely.
+
+### 2.5 SMS webhook binds to 0.0.0.0
+- **File:** `gateway/platforms/sms.py`
+- **Problem:** Webhook server binds all interfaces, exposing it to the network.
+- **Fix:** Default to 127.0.0.1, require explicit config to bind externally.
+
+---
+
+## Phase 3: Feature Parity (Medium Priority)
+*Estimated effort: 3-5 sessions*
+
+### 3.1 Gateway service management for Windows
+- **Problem:** Gateway install/start/stop is entirely systemd-based (~700 lines).
+  On Windows: "not supported".
+- **Fix options (pick one):**
+  a) **Task Scheduler** — `schtasks` for auto-start, simplest
+  b) **Windows Service** via NSSM — most robust, like systemd
+  c) **Startup folder shortcut** — lowest friction for non-technical users
+- **Recommendation:** Start with Task Scheduler (a), add NSSM option later.
+
+### 3.2 Gateway status on Windows
+- **File:** `hermes_cli/status.py`
+- **Problem:** Uses /proc/{pid}/stat (Linux procfs). Shows "N/A" on Windows.
+- **Fix:** Use `tasklist` or `wmic` to find gateway process by name/PID.
+  Or use `psutil` if it's already a dependency.
+
+### 3.3 Code execution sandbox on Windows
+- **Problem:** Sandbox uses Unix Domain Sockets, disabled entirely on Windows
+  (`SANDBOX_AVAILABLE = sys.platform != "win32"`).
+- **Fix:** Implement Named Pipes IPC for Windows. Or use TCP localhost as a
+  simpler alternative that works cross-platform.
+
+### 3.4 Process killing on Windows
+- **File:** `tools/environments/local.py:350-353`
+- **Problem:** `pkill -P` for killing shell children doesn't exist on Windows.
+- **Fix:** Use `taskkill /F /T /PID` on Windows (kill process tree).
+
+---
+
+## Phase 4: Polish & Documentation
+*Estimated effort: 1-2 sessions*
+
+### 4.1 Create WINDOWS.md
+- **Problem:** README says "Native Windows is not supported" but there's a
+  full PowerShell installer and significant Windows code. Confusing.
+- **Fix:** Write WINDOWS.md covering: installation, known limitations,
+  workarounds, how to report Windows-specific issues.
+
+### 4.2 Windows CI
+- **Problem:** No Windows CI pipeline. Regressions go unnoticed.
+- **Fix:** Add GitHub Actions `windows-latest` job running the test suite.
+  Start with just `test_windows_compat.py` and clipboard tests.
+
+### 4.3 Expand test_windows_compat.py
+- **Problem:** Only tests 4 files for POSIX guards. Many gaps.
+- **Fix:** Add tests for:
+  - memory_tool fcntl fallback
+  - clipboard Windows path
+  - _find_bash() Windows discovery
+  - gateway status on Windows
+  - temp path resolution
+
+### 4.4 Fix startup hint text
+- Show Windows-specific keyboard shortcuts
+- Show Windows-specific paths (LOCALAPPDATA vs ~/.hermes)
+- Detect and warn about missing Git Bash
+
+### 4.5 Voice temp file cleanup
+- **Problem:** STT temp files persist in %TEMP% without cleanup.
+- **Fix:** Use `tempfile.NamedTemporaryFile(delete=True)` or explicit
+  cleanup in a finally block.
+
+---
+
+## Execution Order (Recommended)
+
+```
+Week 1:  Phase 1 (crashes)     — unblocks daily use
+         Phase 2.1 (keyring)   — biggest security win
+Week 2:  Phase 2.2-2.5         — remaining security
+         Phase 3.4 (pkill)     — process management
+Week 3:  Phase 3.1-3.2         — gateway on Windows
+         Phase 4.1 (docs)      — WINDOWS.md
+Week 4:  Phase 3.3 (sandbox)   — code execution
+         Phase 4.2-4.5         — CI, tests, polish
+```
+
+---
+
+## What's Already Working Well
+
+These are done and don't need changes:
+
+- ✔ Clipboard image/text paste (macOS, Windows, WSL, Linux)
+- ✔ PowerShell path resolution with caching
+- ✔ Ctrl+V image paste on Windows Terminal
+- ✔ fcntl→msvcrt fallback in auth.py, scheduler.py
+- ✔ _IS_WINDOWS guards in process_registry, local env, code_execution
+- ✔ Git Bash discovery for shell tool
+- ✔ pywinpty conditional dependency
+- ✔ Platform-aware skill filtering
+- ✔ PowerShell installer (scripts/install.ps1)
+- ✔ WhatsApp platform Windows process management
+- ✔ UTF-8 encoding on file I/O

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -105,7 +105,9 @@ class SmsAdapter(BasePlatformAdapter):
 
         self._runner = web.AppRunner(app)
         await self._runner.setup()
-        site = web.TCPSite(self._runner, "0.0.0.0", self._webhook_port)
+        # Bind to localhost by default for security; override with HERMES_SMS_BIND_HOST
+        _bind_host = os.environ.get("HERMES_SMS_BIND_HOST", "127.0.0.1")
+        site = web.TCPSite(self._runner, _bind_host, self._webhook_port)
         await site.start()
         self._http_session = aiohttp.ClientSession()
         self._running = True

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -58,6 +58,23 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
 
 def _get_process_start_time(pid: int) -> Optional[int]:
     """Return the kernel start time for a process when available."""
+    if sys.platform == "win32":
+        # Windows: use wmic to get process creation date
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["wmic", "process", "where", f"ProcessId={pid}",
+                 "get", "CreationDate", "/VALUE"],
+                capture_output=True, text=True, timeout=5,
+            )
+            for line in r.stdout.splitlines():
+                if line.startswith("CreationDate="):
+                    # WMIC returns YYYYMMDDHHmmss.ffffff format
+                    return hash(line.split("=", 1)[1].strip())
+        except Exception:
+            pass
+        return None
+
     stat_path = Path(f"/proc/{pid}/stat")
     try:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
@@ -68,6 +85,21 @@ def _get_process_start_time(pid: int) -> Optional[int]:
 
 def _read_process_cmdline(pid: int) -> Optional[str]:
     """Return the process command line as a space-separated string."""
+    if sys.platform == "win32":
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["wmic", "process", "where", f"ProcessId={pid}",
+                 "get", "CommandLine", "/VALUE"],
+                capture_output=True, text=True, timeout=5,
+            )
+            for line in r.stdout.splitlines():
+                if line.startswith("CommandLine="):
+                    return line.split("=", 1)[1].strip()
+        except Exception:
+            pass
+        return None
+
     cmdline_path = Path(f"/proc/{pid}/cmdline")
     try:
         raw = cmdline_path.read_bytes()
@@ -277,7 +309,8 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                 # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
                 # processes still respond to os.kill(pid, 0) but are not
                 # actually running. Treat them as stale so --replace works.
-                if not stale:
+                if not stale and sys.platform != "win32":
+                    # Check for stopped processes (Unix only — /proc)
                     try:
                         _proc_status = Path(f"/proc/{existing_pid}/status")
                         if _proc_status.exists():

--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -1,19 +1,20 @@
-"""Clipboard image extraction for macOS, Linux, and WSL2.
+"""Clipboard image and text extraction for macOS, Windows, Linux, and WSL2.
 
-Provides a single function `save_clipboard_image(dest)` that checks the
-system clipboard for image data, saves it to *dest* as PNG, and returns
-True on success.  No external Python dependencies — uses only OS-level
-CLI tools that ship with the platform (or are commonly installed).
+Provides functions for extracting images and text from the system clipboard.
+No external Python dependencies — uses only OS-level CLI tools that ship
+with the platform (or are commonly installed).
 
 Platform support:
-  macOS  — osascript (always available), pngpaste (if installed)
-  WSL2   — powershell.exe via .NET System.Windows.Forms.Clipboard
-  Linux  — wl-paste (Wayland), xclip (X11)
+  macOS   — osascript (always available), pngpaste (if installed), pbpaste (text)
+  Windows — PowerShell with .NET System.Windows.Forms.Clipboard (native win32)
+  WSL2    — powershell.exe via .NET System.Windows.Forms.Clipboard
+  Linux   — wl-paste (Wayland), xclip (X11)
 """
 
 import base64
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -22,6 +23,9 @@ logger = logging.getLogger(__name__)
 
 # Cache WSL detection (checked once per process)
 _wsl_detected: bool | None = None
+
+# Cache powershell.exe path for WSL (resolved once)
+_powershell_path: str | None = None
 
 
 def save_clipboard_image(dest: Path) -> bool:
@@ -32,6 +36,8 @@ def save_clipboard_image(dest: Path) -> bool:
     dest.parent.mkdir(parents=True, exist_ok=True)
     if sys.platform == "darwin":
         return _macos_save(dest)
+    if sys.platform == "win32":
+        return _windows_save(dest)
     return _linux_save(dest)
 
 
@@ -42,11 +48,49 @@ def has_clipboard_image() -> bool:
     """
     if sys.platform == "darwin":
         return _macos_has_image()
+    if sys.platform == "win32":
+        return _windows_has_image()
     if _is_wsl():
         return _wsl_has_image()
     if os.environ.get("WAYLAND_DISPLAY"):
         return _wayland_has_image()
     return _xclip_has_image()
+
+
+def get_clipboard_text() -> str | None:
+    """Get text content from the system clipboard.
+
+    Returns the text string if clipboard contains text, None otherwise.
+    """
+    if sys.platform == "darwin":
+        return _macos_get_text()
+    if sys.platform == "win32":
+        return _windows_get_text()
+    if _is_wsl():
+        text = _wsl_get_text()
+        if text is not None:
+            return text
+        # Fall through to wl-paste/xclip for WSLg
+    if os.environ.get("WAYLAND_DISPLAY"):
+        text = _wayland_get_text()
+        if text is not None:
+            return text
+    return _xclip_get_text()
+
+
+def has_clipboard_text() -> bool:
+    """Quick check: does the clipboard currently contain text?"""
+    if sys.platform == "darwin":
+        return _macos_has_text()
+    if sys.platform == "win32":
+        return _windows_has_text()
+    if _is_wsl():
+        if _wsl_has_text():
+            return True
+    if os.environ.get("WAYLAND_DISPLAY"):
+        if _wayland_has_text():
+            return True
+    return _xclip_has_text()
 
 
 # ── macOS ────────────────────────────────────────────────────────────────
@@ -112,6 +156,32 @@ def _macos_osascript(dest: Path) -> bool:
     return False
 
 
+def _macos_get_text() -> str | None:
+    """Get text from macOS clipboard via pbpaste."""
+    try:
+        r = subprocess.run(
+            ["pbpaste"],
+            capture_output=True, text=True, timeout=3,
+        )
+        if r.returncode == 0 and r.stdout:
+            return r.stdout
+    except Exception as e:
+        logger.debug("pbpaste failed: %s", e)
+    return None
+
+
+def _macos_has_text() -> bool:
+    """Check if macOS clipboard has text content."""
+    try:
+        info = subprocess.run(
+            ["osascript", "-e", "clipboard info"],
+            capture_output=True, text=True, timeout=3,
+        )
+        return "«class utf8»" in info.stdout or "«class ut16»" in info.stdout
+    except Exception:
+        return False
+
+
 # ── Linux ────────────────────────────────────────────────────────────────
 
 def _is_wsl() -> bool:
@@ -141,6 +211,122 @@ def _linux_save(dest: Path) -> bool:
     return _xclip_save(dest)
 
 
+# ── Native Windows (sys.platform == "win32") ────────────────────────────
+
+# PowerShell commands for native Windows — same .NET approach as WSL
+# but invokes "powershell" (not "powershell.exe") since we're native.
+_PS_WIN_CHECK_IMAGE = (
+    "Add-Type -AssemblyName System.Windows.Forms;"
+    "[System.Windows.Forms.Clipboard]::ContainsImage()"
+)
+
+_PS_WIN_EXTRACT_IMAGE = (
+    "Add-Type -AssemblyName System.Windows.Forms;"
+    "Add-Type -AssemblyName System.Drawing;"
+    "$img = [System.Windows.Forms.Clipboard]::GetImage();"
+    "if ($null -eq $img) { exit 1 }"
+    "$ms = New-Object System.IO.MemoryStream;"
+    "$img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png);"
+    "[System.Convert]::ToBase64String($ms.ToArray())"
+)
+
+_PS_WIN_CHECK_TEXT = (
+    "Add-Type -AssemblyName System.Windows.Forms;"
+    "[System.Windows.Forms.Clipboard]::ContainsText()"
+)
+
+_PS_WIN_GET_TEXT = (
+    "Add-Type -AssemblyName System.Windows.Forms;"
+    "$t = [System.Windows.Forms.Clipboard]::GetText();"
+    "if ($t) { $t } else { exit 1 }"
+)
+
+
+def _find_powershell_native() -> str:
+    """Find PowerShell on native Windows."""
+    # Prefer pwsh (PowerShell 7+) over Windows PowerShell 5.1
+    for cmd in ("pwsh", "powershell"):
+        if shutil.which(cmd):
+            return cmd
+    return "powershell"
+
+
+def _windows_has_image() -> bool:
+    """Check if Windows clipboard has an image (native win32)."""
+    try:
+        ps = _find_powershell_native()
+        r = subprocess.run(
+            [ps, "-NoProfile", "-NonInteractive", "-Command",
+             _PS_WIN_CHECK_IMAGE],
+            capture_output=True, text=True, timeout=10,
+        )
+        return r.returncode == 0 and "True" in r.stdout
+    except FileNotFoundError:
+        logger.debug("PowerShell not found — Windows clipboard unavailable")
+    except Exception as e:
+        logger.debug("Windows clipboard check failed: %s", e)
+    return False
+
+
+def _windows_save(dest: Path) -> bool:
+    """Extract clipboard image on native Windows via PowerShell."""
+    try:
+        ps = _find_powershell_native()
+        r = subprocess.run(
+            [ps, "-NoProfile", "-NonInteractive", "-Command",
+             _PS_WIN_EXTRACT_IMAGE],
+            capture_output=True, text=True, timeout=20,
+        )
+        if r.returncode != 0:
+            return False
+
+        b64_data = r.stdout.strip()
+        if not b64_data:
+            return False
+
+        png_bytes = base64.b64decode(b64_data)
+        dest.write_bytes(png_bytes)
+        return dest.exists() and dest.stat().st_size > 0
+
+    except FileNotFoundError:
+        logger.debug("PowerShell not found — Windows clipboard unavailable")
+    except Exception as e:
+        logger.debug("Windows clipboard extraction failed: %s", e)
+        dest.unlink(missing_ok=True)
+    return False
+
+
+def _windows_has_text() -> bool:
+    """Check if Windows clipboard has text (native win32)."""
+    try:
+        ps = _find_powershell_native()
+        r = subprocess.run(
+            [ps, "-NoProfile", "-NonInteractive", "-Command",
+             _PS_WIN_CHECK_TEXT],
+            capture_output=True, text=True, timeout=10,
+        )
+        return r.returncode == 0 and "True" in r.stdout
+    except Exception as e:
+        logger.debug("Windows text clipboard check failed: %s", e)
+    return False
+
+
+def _windows_get_text() -> str | None:
+    """Get text from Windows clipboard (native win32)."""
+    try:
+        ps = _find_powershell_native()
+        r = subprocess.run(
+            [ps, "-NoProfile", "-NonInteractive", "-Command",
+             _PS_WIN_GET_TEXT],
+            capture_output=True, text=True, timeout=10,
+        )
+        if r.returncode == 0 and r.stdout:
+            return r.stdout.rstrip("\r\n")
+    except Exception as e:
+        logger.debug("Windows text clipboard get failed: %s", e)
+    return None
+
+
 # ── WSL2 (powershell.exe) ────────────────────────────────────────────────
 
 # PowerShell script: get clipboard image as base64-encoded PNG on stdout.
@@ -160,14 +346,59 @@ _PS_EXTRACT_IMAGE = (
     "[System.Convert]::ToBase64String($ms.ToArray())"
 )
 
+_PS_CHECK_TEXT = (
+    "Add-Type -AssemblyName System.Windows.Forms;"
+    "[System.Windows.Forms.Clipboard]::ContainsText()"
+)
+
+_PS_GET_TEXT = (
+    "Add-Type -AssemblyName System.Windows.Forms;"
+    "$t = [System.Windows.Forms.Clipboard]::GetText();"
+    "if ($t) { $t } else { exit 1 }"
+)
+
+
+def _find_powershell_wsl() -> str:
+    """Find powershell.exe accessible from WSL.
+
+    Tries in order:
+    1. powershell.exe on PATH (works if Windows PATH is appended to WSL PATH)
+    2. Common Windows install locations via /mnt/c/
+    """
+    global _powershell_path
+    if _powershell_path is not None:
+        return _powershell_path
+
+    # Check PATH first
+    path = shutil.which("powershell.exe")
+    if path:
+        _powershell_path = path
+        return path
+
+    # Try common Windows install locations
+    common_paths = [
+        "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+        "/mnt/c/Windows/SysWOW64/WindowsPowerShell/v1.0/powershell.exe",
+    ]
+    for p in common_paths:
+        if os.path.isfile(p) and os.access(p, os.X_OK):
+            _powershell_path = p
+            logger.debug("Found powershell.exe at %s (not on PATH)", p)
+            return p
+
+    # Last resort — just return the name and let subprocess raise FileNotFoundError
+    _powershell_path = "powershell.exe"
+    return _powershell_path
+
 
 def _wsl_has_image() -> bool:
     """Check if Windows clipboard has an image (via powershell.exe)."""
     try:
+        ps = _find_powershell_wsl()
         r = subprocess.run(
-            ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
+            [ps, "-NoProfile", "-NonInteractive", "-Command",
              _PS_CHECK_IMAGE],
-            capture_output=True, text=True, timeout=8,
+            capture_output=True, text=True, timeout=15,
         )
         return r.returncode == 0 and "True" in r.stdout
     except FileNotFoundError:
@@ -180,10 +411,11 @@ def _wsl_has_image() -> bool:
 def _wsl_save(dest: Path) -> bool:
     """Extract clipboard image via powershell.exe → base64 → decode to PNG."""
     try:
+        ps = _find_powershell_wsl()
         r = subprocess.run(
-            ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
+            [ps, "-NoProfile", "-NonInteractive", "-Command",
              _PS_EXTRACT_IMAGE],
-            capture_output=True, text=True, timeout=15,
+            capture_output=True, text=True, timeout=25,
         )
         if r.returncode != 0:
             return False
@@ -202,6 +434,42 @@ def _wsl_save(dest: Path) -> bool:
         logger.debug("WSL clipboard extraction failed: %s", e)
         dest.unlink(missing_ok=True)
     return False
+
+
+def _wsl_has_text() -> bool:
+    """Check if Windows clipboard has text (via powershell.exe from WSL)."""
+    try:
+        ps = _find_powershell_wsl()
+        r = subprocess.run(
+            [ps, "-NoProfile", "-NonInteractive", "-Command",
+             _PS_CHECK_TEXT],
+            capture_output=True, text=True, timeout=15,
+        )
+        return r.returncode == 0 and "True" in r.stdout
+    except FileNotFoundError:
+        logger.debug("powershell.exe not found — WSL text clipboard unavailable")
+    except Exception as e:
+        logger.debug("WSL text clipboard check failed: %s", e)
+    return False
+
+
+def _wsl_get_text() -> str | None:
+    """Get text from Windows clipboard via powershell.exe from WSL."""
+    try:
+        ps = _find_powershell_wsl()
+        r = subprocess.run(
+            [ps, "-NoProfile", "-NonInteractive", "-Command",
+             _PS_GET_TEXT],
+            capture_output=True, text=True, timeout=15,
+        )
+        if r.returncode == 0 and r.stdout:
+            # PowerShell on Windows uses \r\n — normalize to \n
+            return r.stdout.rstrip("\r\n").replace("\r\n", "\n")
+    except FileNotFoundError:
+        logger.debug("powershell.exe not found — WSL text clipboard unavailable")
+    except Exception as e:
+        logger.debug("WSL text clipboard get failed: %s", e)
+    return None
 
 
 # ── Wayland (wl-paste) ──────────────────────────────────────────────────
@@ -270,6 +538,38 @@ def _wayland_save(dest: Path) -> bool:
         logger.debug("wl-paste clipboard extraction failed: %s", e)
         dest.unlink(missing_ok=True)
     return False
+
+
+def _wayland_has_text() -> bool:
+    """Check if Wayland clipboard has text content."""
+    try:
+        r = subprocess.run(
+            ["wl-paste", "--list-types"],
+            capture_output=True, text=True, timeout=3,
+        )
+        if r.returncode != 0:
+            return False
+        types = r.stdout.splitlines()
+        return any(t.startswith("text/") or t == "STRING" or t == "UTF8_STRING"
+                    for t in types)
+    except Exception:
+        return False
+
+
+def _wayland_get_text() -> str | None:
+    """Get text from Wayland clipboard via wl-paste."""
+    try:
+        r = subprocess.run(
+            ["wl-paste", "--no-newline"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if r.returncode == 0 and r.stdout:
+            return r.stdout
+    except FileNotFoundError:
+        logger.debug("wl-paste not installed — Wayland text clipboard unavailable")
+    except Exception as e:
+        logger.debug("wl-paste text extraction failed: %s", e)
+    return None
 
 
 def _convert_to_png(path: Path) -> bool:
@@ -358,3 +658,35 @@ def _xclip_save(dest: Path) -> bool:
         logger.debug("xclip image extraction failed: %s", e)
         dest.unlink(missing_ok=True)
     return False
+
+
+def _xclip_has_text() -> bool:
+    """Check if X11 clipboard has text content."""
+    try:
+        r = subprocess.run(
+            ["xclip", "-selection", "clipboard", "-t", "TARGETS", "-o"],
+            capture_output=True, text=True, timeout=3,
+        )
+        if r.returncode != 0:
+            return False
+        targets = r.stdout.splitlines()
+        return any(t in ("UTF8_STRING", "STRING", "text/plain")
+                    for t in targets)
+    except Exception:
+        return False
+
+
+def _xclip_get_text() -> str | None:
+    """Get text from X11 clipboard via xclip."""
+    try:
+        r = subprocess.run(
+            ["xclip", "-selection", "clipboard", "-o"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if r.returncode == 0 and r.stdout:
+            return r.stdout
+    except FileNotFoundError:
+        logger.debug("xclip not installed — X11 text clipboard unavailable")
+    except Exception as e:
+        logger.debug("xclip text extraction failed: %s", e)
+    return None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -66,18 +66,49 @@ def get_project_root() -> Path:
     """Get the project installation directory."""
     return Path(__file__).parent.parent.resolve()
 
-def _secure_dir(path):
-    """Set directory to owner-only access (0700). No-op on Windows."""
+def _win_restrict_acl(path_str: str) -> bool:
+    """Restrict a file/dir to the current user only via icacls (Windows).
+
+    Removes inherited permissions, grants the current user full control,
+    and denies access to everyone else. Returns True on success.
+    """
     try:
-        os.chmod(path, 0o700)
+        import subprocess
+        username = os.environ.get("USERNAME", "")
+        if not username:
+            return False
+        # Disable inheritance, remove all inherited ACEs, grant current user full
+        subprocess.run(
+            ["icacls", path_str, "/inheritance:r",
+             "/grant:r", f"{username}:(OI)(CI)F" if os.path.isdir(path_str) else f"{username}:F",
+             "/remove:g", "Everyone", "/remove:g", "BUILTIN\\Users",
+             "/remove:g", "Authenticated Users"],
+            capture_output=True, timeout=10,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _secure_dir(path):
+    """Set directory to owner-only access (0700 on Unix, icacls on Windows)."""
+    try:
+        if _IS_WINDOWS:
+            _win_restrict_acl(str(path))
+        else:
+            os.chmod(path, 0o700)
     except (OSError, NotImplementedError):
         pass
 
 
 def _secure_file(path):
-    """Set file to owner-only read/write (0600). No-op on Windows."""
+    """Set file to owner-only read/write (0600 on Unix, icacls on Windows)."""
     try:
-        if os.path.exists(str(path)):
+        if not os.path.exists(str(path)):
+            return
+        if _IS_WINDOWS:
+            _win_restrict_acl(str(path))
+        else:
             os.chmod(path, 0o600)
     except (OSError, NotImplementedError):
         pass
@@ -1532,25 +1563,107 @@ def save_anthropic_api_key(value: str, save_fn=None):
     writer("ANTHROPIC_TOKEN", "")
 
 
+# ---------------------------------------------------------------------------
+# Keyring integration — optional, used on Windows for secure credential storage
+# ---------------------------------------------------------------------------
+
+_KEYRING_SERVICE = "hermes-agent"
+_keyring_available: Optional[bool] = None
+
+
+def _has_keyring() -> bool:
+    """Check if keyring library is available and functional."""
+    global _keyring_available
+    if _keyring_available is not None:
+        return _keyring_available
+    try:
+        import keyring
+        # Verify it can actually access a backend (not just imported)
+        keyring.get_credential(_KEYRING_SERVICE, "")
+        _keyring_available = True
+    except Exception:
+        _keyring_available = False
+    return _keyring_available
+
+
+def _keyring_set(key: str, value: str) -> bool:
+    """Store a secret in the OS credential manager. Returns True on success."""
+    try:
+        import keyring
+        keyring.set_password(_KEYRING_SERVICE, key, value)
+        return True
+    except Exception:
+        return False
+
+
+def _keyring_get(key: str) -> Optional[str]:
+    """Retrieve a secret from the OS credential manager."""
+    try:
+        import keyring
+        val = keyring.get_password(_KEYRING_SERVICE, key)
+        return val if val else None
+    except Exception:
+        return None
+
+
+def _keyring_delete(key: str) -> bool:
+    """Remove a secret from the OS credential manager."""
+    try:
+        import keyring
+        keyring.delete_password(_KEYRING_SERVICE, key)
+        return True
+    except Exception:
+        return False
+
+
 def save_env_value_secure(key: str, value: str) -> Dict[str, Any]:
-    save_env_value(key, value)
+    """Save a secret, preferring OS credential manager on Windows.
+
+    On Windows with keyring available: stores in Windows Credential Manager
+    and saves a placeholder in .env so load_env() knows the key exists.
+    On other platforms or without keyring: falls back to .env file.
+    """
+    stored_in_keyring = False
+    if _IS_WINDOWS and value and _has_keyring():
+        stored_in_keyring = _keyring_set(key, value)
+        if stored_in_keyring:
+            # Save placeholder so env-scanning code knows this key is set
+            save_env_value(key, f"<stored-in-credential-manager>")
+            os.environ[key] = value
+
+    if not stored_in_keyring:
+        save_env_value(key, value)
+
     return {
         "success": True,
         "stored_as": key,
         "validated": False,
+        "keyring": stored_in_keyring,
     }
 
 
-
 def get_env_value(key: str) -> Optional[str]:
-    """Get a value from ~/.hermes/.env or environment."""
-    # Check environment first
-    if key in os.environ:
-        return os.environ[key]
-    
-    # Then check .env file
+    """Get a value from environment, keyring, or ~/.hermes/.env."""
+    # Check environment first (runtime overrides always win)
+    val = os.environ.get(key)
+    if val and val != "<stored-in-credential-manager>":
+        return val
+
+    # On Windows, check keyring before falling back to .env
+    if _IS_WINDOWS and _has_keyring():
+        kr_val = _keyring_get(key)
+        if kr_val:
+            # Cache in os.environ for the rest of this process
+            os.environ[key] = kr_val
+            return kr_val
+
+    # Fall back to .env file
     env_vars = load_env()
-    return env_vars.get(key)
+    file_val = env_vars.get(key)
+    if file_val and file_val != "<stored-in-credential-manager>":
+        return file_val
+
+    return None
 
 
 # =============================================================================

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -880,8 +880,9 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float = 5.0):
         if not force_sent and time.monotonic() >= force_deadline:
             # Grace period expired — force-kill the specific PID.
             try:
-                os.kill(pid, signal.SIGKILL)
-                print(f"⚠ Gateway PID {pid} did not exit gracefully; sent SIGKILL")
+                _sig = signal.SIGTERM if sys.platform == "win32" else signal.SIGKILL
+                os.kill(pid, _sig)
+                print(f"⚠ Gateway PID {pid} did not exit gracefully; sent {_sig.name}")
             except (ProcessLookupError, PermissionError):
                 return  # Already gone or we can't touch it.
             force_sent = True
@@ -1384,6 +1385,8 @@ def _is_service_installed() -> bool:
         return get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()
     elif is_macos():
         return get_launchd_plist_path().exists()
+    elif is_windows():
+        return _win_schtasks_exists()
     return False
 
 
@@ -1660,6 +1663,17 @@ def gateway_setup():
                     if is_linux():
                         print_info("  Or as a boot-time service: sudo hermes gateway install --system")
                     print_info("  Or run in foreground:  hermes gateway")
+            elif is_windows():
+                if prompt_yes_no("Install gateway as a Windows scheduled task (runs at logon)?", True):
+                    try:
+                        windows_task_install()
+                        windows_task_start()
+                    except Exception as e:
+                        print_error(f"  Install failed: {e}")
+                        print_info("  You can try manually: hermes gateway install")
+                else:
+                    print_info("  You can install later: hermes gateway install")
+                    print_info("  Or run in foreground:  hermes gateway")
             else:
                 print_info("  Service install not supported on this platform.")
                 print_info("  Run in foreground: hermes gateway")
@@ -1668,6 +1682,110 @@ def gateway_setup():
         print_info("No platforms configured. Run 'hermes gateway setup' when ready.")
 
     print()
+
+
+# =============================================================================
+# Windows (Task Scheduler)
+# =============================================================================
+
+_WIN_TASK_NAME = "HermesGateway"
+
+
+def _win_schtasks_exists() -> bool:
+    """Check if the Hermes gateway task exists in Windows Task Scheduler."""
+    try:
+        r = subprocess.run(
+            ["schtasks", "/Query", "/TN", _WIN_TASK_NAME],
+            capture_output=True, text=True, timeout=10,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def windows_task_install(force: bool = False):
+    """Install the Hermes gateway as a Windows Task Scheduler task.
+
+    Creates a task that runs at logon and restarts on failure.
+    """
+    if _win_schtasks_exists() and not force:
+        print(f"✓ Task '{_WIN_TASK_NAME}' already exists. Use --force to reinstall.")
+        return
+
+    python = get_python_path()
+    hermes_home = str(get_hermes_home())
+
+    # Build the command to run
+    cmd = f'"{python}" -m hermes_cli.main gateway run'
+
+    # Remove existing task if reinstalling
+    if _win_schtasks_exists():
+        subprocess.run(
+            ["schtasks", "/Delete", "/TN", _WIN_TASK_NAME, "/F"],
+            capture_output=True, timeout=10,
+        )
+
+    # Create task that runs at logon
+    result = subprocess.run(
+        ["schtasks", "/Create",
+         "/TN", _WIN_TASK_NAME,
+         "/TR", cmd,
+         "/SC", "ONLOGON",
+         "/RL", "LIMITED",
+         "/F"],
+        capture_output=True, text=True, timeout=15,
+    )
+
+    if result.returncode == 0:
+        print(f"✓ Installed gateway as Windows scheduled task '{_WIN_TASK_NAME}'")
+        print(f"  Runs at: user logon")
+        print(f"  Python:  {python}")
+        print(f"  Home:    {hermes_home}")
+    else:
+        err = result.stderr.strip() or result.stdout.strip()
+        print(f"✗ Failed to create scheduled task: {err}")
+        print("  Try running as Administrator, or start manually: hermes gateway run")
+
+
+def windows_task_uninstall():
+    """Remove the Hermes gateway scheduled task."""
+    if not _win_schtasks_exists():
+        print(f"✗ Task '{_WIN_TASK_NAME}' not found")
+        return
+
+    result = subprocess.run(
+        ["schtasks", "/Delete", "/TN", _WIN_TASK_NAME, "/F"],
+        capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode == 0:
+        print(f"✓ Removed scheduled task '{_WIN_TASK_NAME}'")
+    else:
+        print(f"✗ Failed to remove task: {result.stderr.strip()}")
+
+
+def windows_task_start():
+    """Start the gateway scheduled task."""
+    if not _win_schtasks_exists():
+        print(f"✗ Task '{_WIN_TASK_NAME}' not installed. Run: hermes gateway install")
+        return
+
+    result = subprocess.run(
+        ["schtasks", "/Run", "/TN", _WIN_TASK_NAME],
+        capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode == 0:
+        print(f"✓ Started gateway task '{_WIN_TASK_NAME}'")
+    else:
+        print(f"✗ Failed to start task: {result.stderr.strip()}")
+
+
+def windows_task_stop():
+    """Stop the gateway scheduled task."""
+    if _win_schtasks_exists():
+        subprocess.run(
+            ["schtasks", "/End", "/TN", _WIN_TASK_NAME],
+            capture_output=True, text=True, timeout=10,
+        )
 
 
 # =============================================================================
@@ -1698,6 +1816,8 @@ def gateway_command(args):
             systemd_install(force=force, system=system, run_as_user=run_as_user)
         elif is_macos():
             launchd_install(force)
+        elif is_windows():
+            windows_task_install(force=force)
         else:
             print("Service installation not supported on this platform.")
             print("Run manually: hermes gateway run")
@@ -1709,6 +1829,8 @@ def gateway_command(args):
             systemd_uninstall(system=system)
         elif is_macos():
             launchd_uninstall()
+        elif is_windows():
+            windows_task_uninstall()
         else:
             print("Not supported on this platform.")
             sys.exit(1)
@@ -1719,6 +1841,8 @@ def gateway_command(args):
             systemd_start(system=system)
         elif is_macos():
             launchd_start()
+        elif is_windows():
+            windows_task_start()
         else:
             print("Not supported on this platform.")
             sys.exit(1)
@@ -1740,6 +1864,9 @@ def gateway_command(args):
                 service_available = True
             except subprocess.CalledProcessError:
                 pass
+        elif is_windows() and _win_schtasks_exists():
+            windows_task_stop()
+            service_available = True
 
         killed = kill_gateway_processes()
         if not service_available:

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -300,6 +300,18 @@ def show_status(args):
         is_loaded = result.returncode == 0
         print(f"  Status:       {check_mark(is_loaded)} {'loaded' if is_loaded else 'not loaded'}")
         print(f"  Manager:      launchd")
+    elif sys.platform == 'win32':
+        try:
+            from hermes_cli.gateway import find_gateway_pids
+            gw_pids = find_gateway_pids()
+            is_running = len(gw_pids) > 0
+            print(f"  Status:       {check_mark(is_running)} {'running' if is_running else 'stopped'}")
+            if gw_pids:
+                print(f"  PIDs:         {', '.join(str(p) for p in gw_pids)}")
+            print(f"  Manager:      Windows process")
+        except Exception:
+            print(f"  Status:       {color('unknown', Colors.DIM)}")
+            print(f"  Manager:      Windows process")
     else:
         print(f"  Status:       {color('N/A', Colors.DIM)}")
         print(f"  Manager:      (not supported on this platform)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ pty = [
   "ptyprocess>=0.7.0; sys_platform != 'win32'",
   "pywinpty>=2.0.0; sys_platform == 'win32'",
 ]
+windows = ["keyring>=25.0.0; sys_platform == 'win32'"]
 honcho = ["honcho-ai>=2.0.1"]
 mcp = ["mcp>=1.2.0"]
 homeassistant = ["aiohttp>=3.9.0"]

--- a/tests/tools/test_clipboard.py
+++ b/tests/tools/test_clipboard.py
@@ -20,17 +20,32 @@ import pytest
 from hermes_cli.clipboard import (
     save_clipboard_image,
     has_clipboard_image,
+    get_clipboard_text,
+    has_clipboard_text,
     _is_wsl,
     _linux_save,
     _macos_pngpaste,
     _macos_osascript,
     _macos_has_image,
+    _macos_get_text,
+    _macos_has_text,
     _xclip_save,
     _xclip_has_image,
+    _xclip_get_text,
+    _xclip_has_text,
     _wsl_save,
     _wsl_has_image,
+    _wsl_get_text,
+    _wsl_has_text,
     _wayland_save,
     _wayland_has_image,
+    _wayland_get_text,
+    _wayland_has_text,
+    _windows_save,
+    _windows_has_image,
+    _windows_get_text,
+    _windows_has_text,
+    _find_powershell_wsl,
     _convert_to_png,
 )
 
@@ -56,6 +71,14 @@ class TestSaveClipboardImage:
         with patch("hermes_cli.clipboard.sys") as mock_sys:
             mock_sys.platform = "linux"
             with patch("hermes_cli.clipboard._linux_save", return_value=False) as m:
+                save_clipboard_image(dest)
+                m.assert_called_once_with(dest)
+
+    def test_dispatches_to_windows_on_win32(self, tmp_path):
+        dest = tmp_path / "out.png"
+        with patch("hermes_cli.clipboard.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            with patch("hermes_cli.clipboard._windows_save", return_value=False) as m:
                 save_clipboard_image(dest)
                 m.assert_called_once_with(dest)
 
@@ -875,3 +898,317 @@ class TestQueueRouting:
         is_command = isinstance(user_input, str) and user_input.startswith("/")
         assert is_command is False
         assert len(submit_images) == 1
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Level 5: Native Windows clipboard support
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestWindowsHasImage:
+    def test_clipboard_has_image(self):
+        with patch("hermes_cli.clipboard._find_powershell_native", return_value="powershell"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="True\n", returncode=0)
+                assert _windows_has_image() is True
+
+    def test_clipboard_no_image(self):
+        with patch("hermes_cli.clipboard._find_powershell_native", return_value="powershell"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="False\n", returncode=0)
+                assert _windows_has_image() is False
+
+    def test_powershell_not_found(self):
+        with patch("hermes_cli.clipboard._find_powershell_native", return_value="powershell"):
+            with patch("hermes_cli.clipboard.subprocess.run", side_effect=FileNotFoundError):
+                assert _windows_has_image() is False
+
+
+class TestWindowsSave:
+    def test_successful_extraction(self, tmp_path):
+        dest = tmp_path / "out.png"
+        b64_png = base64.b64encode(FAKE_PNG).decode()
+        with patch("hermes_cli.clipboard._find_powershell_native", return_value="powershell"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout=b64_png + "\n", returncode=0)
+                assert _windows_save(dest) is True
+        assert dest.read_bytes() == FAKE_PNG
+
+    def test_no_image_returns_false(self, tmp_path):
+        dest = tmp_path / "out.png"
+        with patch("hermes_cli.clipboard._find_powershell_native", return_value="powershell"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="", returncode=1)
+                assert _windows_save(dest) is False
+
+    def test_powershell_not_found(self, tmp_path):
+        dest = tmp_path / "out.png"
+        with patch("hermes_cli.clipboard._find_powershell_native", return_value="powershell"):
+            with patch("hermes_cli.clipboard.subprocess.run", side_effect=FileNotFoundError):
+                assert _windows_save(dest) is False
+
+
+class TestWindowsText:
+    def test_has_text(self):
+        with patch("hermes_cli.clipboard._find_powershell_native", return_value="powershell"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="True\n", returncode=0)
+                assert _windows_has_text() is True
+
+    def test_no_text(self):
+        with patch("hermes_cli.clipboard._find_powershell_native", return_value="powershell"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="False\n", returncode=0)
+                assert _windows_has_text() is False
+
+    def test_get_text(self):
+        with patch("hermes_cli.clipboard._find_powershell_native", return_value="powershell"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="Hello World\r\n", returncode=0)
+                assert _windows_get_text() == "Hello World"
+
+    def test_get_text_empty(self):
+        with patch("hermes_cli.clipboard._find_powershell_native", return_value="powershell"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="", returncode=1)
+                assert _windows_get_text() is None
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Level 6: Text clipboard functions — WSL, Wayland, X11, macOS
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestWslText:
+    def test_has_text(self):
+        with patch("hermes_cli.clipboard._find_powershell_wsl", return_value="powershell.exe"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="True\n", returncode=0)
+                assert _wsl_has_text() is True
+
+    def test_no_text(self):
+        with patch("hermes_cli.clipboard._find_powershell_wsl", return_value="powershell.exe"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="False\n", returncode=0)
+                assert _wsl_has_text() is False
+
+    def test_get_text(self):
+        with patch("hermes_cli.clipboard._find_powershell_wsl", return_value="powershell.exe"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="Hello from Windows\r\n", returncode=0)
+                result = _wsl_get_text()
+                assert result == "Hello from Windows"
+
+    def test_get_text_normalizes_crlf(self):
+        with patch("hermes_cli.clipboard._find_powershell_wsl", return_value="powershell.exe"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="line1\r\nline2\r\nline3\r\n", returncode=0)
+                result = _wsl_get_text()
+                assert result == "line1\nline2\nline3"
+
+    def test_get_text_powershell_not_found(self):
+        with patch("hermes_cli.clipboard._find_powershell_wsl", return_value="powershell.exe"):
+            with patch("hermes_cli.clipboard.subprocess.run", side_effect=FileNotFoundError):
+                assert _wsl_get_text() is None
+
+
+class TestWaylandText:
+    def test_has_text(self):
+        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="text/plain\ntext/html\n", returncode=0
+            )
+            assert _wayland_has_text() is True
+
+    def test_has_utf8_string(self):
+        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="UTF8_STRING\n", returncode=0
+            )
+            assert _wayland_has_text() is True
+
+    def test_no_text(self):
+        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="image/png\n", returncode=0
+            )
+            assert _wayland_has_text() is False
+
+    def test_get_text(self):
+        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="clipboard text", returncode=0)
+            assert _wayland_get_text() == "clipboard text"
+
+    def test_get_text_not_installed(self):
+        with patch("hermes_cli.clipboard.subprocess.run", side_effect=FileNotFoundError):
+            assert _wayland_get_text() is None
+
+
+class TestXclipText:
+    def test_has_text(self):
+        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="UTF8_STRING\ntext/plain\n", returncode=0
+            )
+            assert _xclip_has_text() is True
+
+    def test_no_text(self):
+        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="image/png\n", returncode=0
+            )
+            assert _xclip_has_text() is False
+
+    def test_get_text(self):
+        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="xclip text", returncode=0)
+            assert _xclip_get_text() == "xclip text"
+
+    def test_get_text_not_installed(self):
+        with patch("hermes_cli.clipboard.subprocess.run", side_effect=FileNotFoundError):
+            assert _xclip_get_text() is None
+
+
+class TestMacosText:
+    def test_has_text_utf8(self):
+        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="«class utf8», «class ut16»", returncode=0
+            )
+            assert _macos_has_text() is True
+
+    def test_has_text_ut16(self):
+        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="«class PNGf», «class ut16»", returncode=0
+            )
+            assert _macos_has_text() is True
+
+    def test_no_text(self):
+        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="«class PNGf»", returncode=0
+            )
+            assert _macos_has_text() is False
+
+    def test_get_text(self):
+        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="pbpaste text", returncode=0)
+            assert _macos_get_text() == "pbpaste text"
+
+    def test_get_text_empty(self):
+        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="", returncode=0)
+            assert _macos_get_text() is None
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Level 7: PowerShell WSL path resolution
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestFindPowershellWsl:
+    def setup_method(self):
+        import hermes_cli.clipboard as cb
+        cb._powershell_path = None  # Reset cache
+
+    def test_finds_on_path(self):
+        with patch("hermes_cli.clipboard.shutil.which", return_value="/usr/bin/powershell.exe"):
+            assert _find_powershell_wsl() == "/usr/bin/powershell.exe"
+
+    def test_fallback_to_system32(self):
+        with patch("hermes_cli.clipboard.shutil.which", return_value=None):
+            with patch("os.path.isfile", side_effect=lambda p: "System32" in p):
+                with patch("os.access", return_value=True):
+                    result = _find_powershell_wsl()
+                    assert "System32" in result
+
+    def test_caches_result(self):
+        import hermes_cli.clipboard as cb
+        with patch("hermes_cli.clipboard.shutil.which", return_value="/usr/bin/powershell.exe") as m:
+            _find_powershell_wsl()
+            _find_powershell_wsl()
+            m.assert_called_once()
+        cb._powershell_path = None  # Clean up
+
+    def test_returns_name_when_nothing_found(self):
+        with patch("hermes_cli.clipboard.shutil.which", return_value=None):
+            with patch("os.path.isfile", return_value=False):
+                assert _find_powershell_wsl() == "powershell.exe"
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Level 8: get_clipboard_text and has_clipboard_text dispatch
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestGetClipboardText:
+    def setup_method(self):
+        import hermes_cli.clipboard as cb
+        cb._wsl_detected = None
+
+    def test_macos_dispatch(self):
+        with patch("hermes_cli.clipboard.sys") as mock_sys:
+            mock_sys.platform = "darwin"
+            with patch("hermes_cli.clipboard._macos_get_text", return_value="mac text") as m:
+                assert get_clipboard_text() == "mac text"
+                m.assert_called_once()
+
+    def test_win32_dispatch(self):
+        with patch("hermes_cli.clipboard.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            with patch("hermes_cli.clipboard._windows_get_text", return_value="win text") as m:
+                assert get_clipboard_text() == "win text"
+                m.assert_called_once()
+
+    def test_wsl_dispatch(self):
+        with patch("hermes_cli.clipboard.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("hermes_cli.clipboard._is_wsl", return_value=True):
+                with patch("hermes_cli.clipboard._wsl_get_text", return_value="wsl text") as m:
+                    assert get_clipboard_text() == "wsl text"
+                    m.assert_called_once()
+
+    def test_wayland_dispatch(self):
+        with patch("hermes_cli.clipboard.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("hermes_cli.clipboard._is_wsl", return_value=False):
+                with patch.dict(os.environ, {"WAYLAND_DISPLAY": "wayland-0"}):
+                    with patch("hermes_cli.clipboard._wayland_get_text", return_value="way text") as m:
+                        assert get_clipboard_text() == "way text"
+                        m.assert_called_once()
+
+    def test_x11_dispatch(self):
+        with patch("hermes_cli.clipboard.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("hermes_cli.clipboard._is_wsl", return_value=False):
+                with patch.dict(os.environ, {}, clear=True):
+                    with patch("hermes_cli.clipboard._xclip_get_text", return_value="x11 text") as m:
+                        assert get_clipboard_text() == "x11 text"
+                        m.assert_called_once()
+
+
+class TestHasClipboardText:
+    def setup_method(self):
+        import hermes_cli.clipboard as cb
+        cb._wsl_detected = None
+
+    def test_macos_dispatch(self):
+        with patch("hermes_cli.clipboard.sys") as mock_sys:
+            mock_sys.platform = "darwin"
+            with patch("hermes_cli.clipboard._macos_has_text", return_value=True) as m:
+                assert has_clipboard_text() is True
+                m.assert_called_once()
+
+    def test_win32_dispatch(self):
+        with patch("hermes_cli.clipboard.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            with patch("hermes_cli.clipboard._windows_has_text", return_value=True) as m:
+                assert has_clipboard_text() is True
+                m.assert_called_once()
+
+
+class TestHasClipboardImageWin32:
+    """has_clipboard_image dispatch for win32."""
+    def test_win32_dispatch(self):
+        with patch("hermes_cli.clipboard.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            with patch("hermes_cli.clipboard._windows_has_image", return_value=True) as m:
+                assert has_clipboard_image() is True
+                m.assert_called_once()

--- a/tests/tools/test_windows_compat.py
+++ b/tests/tools/test_windows_compat.py
@@ -1,12 +1,16 @@
-"""Tests for Windows compatibility of process management code.
+"""Tests for Windows compatibility of process management and platform code.
 
 Verifies that os.setsid and os.killpg are never called unconditionally,
-and that each module uses a platform guard before invoking POSIX-only functions.
+that each module uses a platform guard before invoking POSIX-only functions,
+and that Windows-specific code paths are properly implemented.
 """
 
 import ast
+import os
+import sys
 import pytest
 from pathlib import Path
+from unittest.mock import patch, MagicMock
 
 # Files that must have Windows-safe process management
 GUARDED_FILES = [
@@ -78,3 +82,239 @@ class TestKillpgGuarded:
                 assert "_IS_WINDOWS" in context or "else:" in context, (
                     f"{relpath}:{i + 1} has unguarded os.killpg/os.getpgid call"
                 )
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Unix-only import guards
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestFcntlImportGuarded:
+    """Files that use fcntl must have try/except ImportError guard."""
+
+    FCNTL_FILES = [
+        "tools/memory_tool.py",
+        "hermes_cli/auth.py",
+        "cron/scheduler.py",
+    ]
+
+    @pytest.mark.parametrize("relpath", FCNTL_FILES)
+    def test_fcntl_has_guard(self, relpath):
+        filepath = PROJECT_ROOT / relpath
+        if not filepath.exists():
+            pytest.skip(f"{relpath} not found")
+        source = filepath.read_text(encoding="utf-8")
+        if "import fcntl" not in source:
+            pytest.skip(f"{relpath} does not import fcntl")
+        # Must have try/except around the import
+        assert "except" in source and "fcntl" in source, (
+            f"{relpath} has unguarded fcntl import"
+        )
+        # Must also have msvcrt fallback
+        assert "msvcrt" in source, (
+            f"{relpath} imports fcntl but has no msvcrt fallback"
+        )
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Temp path handling — no hardcoded /tmp
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestNoHardcodedTmpPaths:
+    """Temp paths must use tempfile.gettempdir(), not hardcoded /tmp."""
+
+    TEMP_PATH_FILES = [
+        "tools/environments/local.py",
+        "tools/environments/persistent_shell.py",
+    ]
+
+    @pytest.mark.parametrize("relpath", TEMP_PATH_FILES)
+    def test_no_hardcoded_tmp(self, relpath):
+        filepath = PROJECT_ROOT / relpath
+        if not filepath.exists():
+            pytest.skip(f"{relpath} not found")
+        source = filepath.read_text(encoding="utf-8")
+        lines = source.splitlines()
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            # Skip comments and strings that mention /tmp in docs
+            if stripped.startswith("#") or stripped.startswith('"""') or stripped.startswith("'"):
+                continue
+            # Look for f-string or string concatenation with /tmp/hermes
+            if '"/tmp/hermes' in stripped or "'/tmp/hermes" in stripped:
+                pytest.fail(
+                    f"{relpath}:{i + 1} has hardcoded /tmp path: {stripped[:80]}"
+                )
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# signal.SIGKILL guard
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestSigkillGuarded:
+    """signal.SIGKILL must be guarded on Windows (doesn't exist there)."""
+
+    SIGKILL_FILES = [
+        "hermes_cli/gateway.py",
+        "tools/code_execution_tool.py",
+    ]
+
+    @pytest.mark.parametrize("relpath", SIGKILL_FILES)
+    def test_sigkill_is_guarded(self, relpath):
+        filepath = PROJECT_ROOT / relpath
+        if not filepath.exists():
+            pytest.skip(f"{relpath} not found")
+        source = filepath.read_text(encoding="utf-8")
+        lines = source.splitlines()
+        for i, line in enumerate(lines):
+            if "signal.SIGKILL" in line:
+                # Must be behind a platform check or conditional expression
+                context = "\n".join(lines[max(0, i - 10):i + 1])
+                has_guard = any(g in context for g in [
+                    "_IS_WINDOWS", "win32", "else:", "not is_windows",
+                ])
+                assert has_guard, (
+                    f"{relpath}:{i + 1} has unguarded signal.SIGKILL"
+                )
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# /dev/tty guard
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestDevTtyGuarded:
+    """References to /dev/tty must have Windows alternatives."""
+
+    def test_display_write_tty_has_windows_path(self):
+        filepath = PROJECT_ROOT / "agent" / "display.py"
+        if not filepath.exists():
+            pytest.skip("agent/display.py not found")
+        source = filepath.read_text(encoding="utf-8")
+        assert "CON" in source or "win32" in source, (
+            "agent/display.py: write_tty() has no Windows alternative to /dev/tty"
+        )
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Clipboard — platform dispatch
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestClipboardPlatformCoverage:
+    """Clipboard module must handle all major platforms."""
+
+    def test_has_windows_native_support(self):
+        source = (PROJECT_ROOT / "hermes_cli" / "clipboard.py").read_text(encoding="utf-8")
+        assert "win32" in source, "clipboard.py missing native Windows support"
+        assert "_windows_save" in source, "clipboard.py missing _windows_save"
+        assert "_windows_has_image" in source, "clipboard.py missing _windows_has_image"
+
+    def test_has_text_clipboard_functions(self):
+        source = (PROJECT_ROOT / "hermes_cli" / "clipboard.py").read_text(encoding="utf-8")
+        assert "get_clipboard_text" in source, "clipboard.py missing get_clipboard_text"
+        assert "has_clipboard_text" in source, "clipboard.py missing has_clipboard_text"
+
+    def test_has_wsl_powershell_path_resolution(self):
+        source = (PROJECT_ROOT / "hermes_cli" / "clipboard.py").read_text(encoding="utf-8")
+        assert "_find_powershell_wsl" in source, "clipboard.py missing WSL powershell path finder"
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Config — Windows security functions
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestConfigWindowsSecurity:
+    """Config module must have Windows-aware security."""
+
+    def test_secure_file_has_icacls(self):
+        source = (PROJECT_ROOT / "hermes_cli" / "config.py").read_text(encoding="utf-8")
+        assert "icacls" in source, "config.py: _secure_file missing icacls for Windows"
+
+    def test_has_keyring_integration(self):
+        source = (PROJECT_ROOT / "hermes_cli" / "config.py").read_text(encoding="utf-8")
+        assert "keyring" in source, "config.py: missing keyring integration"
+        assert "_KEYRING_SERVICE" in source, "config.py: missing keyring service name"
+
+    def test_get_env_value_checks_keyring(self):
+        source = (PROJECT_ROOT / "hermes_cli" / "config.py").read_text(encoding="utf-8")
+        assert "_keyring_get" in source, "config.py: get_env_value doesn't check keyring"
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Gateway — Windows Task Scheduler
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestGatewayWindowsSupport:
+    """Gateway must have Windows service management."""
+
+    def test_has_task_scheduler_functions(self):
+        source = (PROJECT_ROOT / "hermes_cli" / "gateway.py").read_text(encoding="utf-8")
+        assert "windows_task_install" in source, "gateway.py: missing windows_task_install"
+        assert "windows_task_uninstall" in source, "gateway.py: missing windows_task_uninstall"
+        assert "windows_task_start" in source, "gateway.py: missing windows_task_start"
+        assert "windows_task_stop" in source, "gateway.py: missing windows_task_stop"
+        assert "schtasks" in source, "gateway.py: Task Scheduler not used"
+
+    def test_command_handler_routes_to_windows(self):
+        source = (PROJECT_ROOT / "hermes_cli" / "gateway.py").read_text(encoding="utf-8")
+        # The install command must check is_windows()
+        assert "is_windows()" in source, "gateway.py: command handler doesn't check is_windows()"
+
+    def test_status_has_windows_branch(self):
+        source = (PROJECT_ROOT / "hermes_cli" / "status.py").read_text(encoding="utf-8")
+        assert "win32" in source, "status.py: missing Windows gateway status branch"
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Shell quoting — cross-platform
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestShellQuote:
+    """Cross-platform shell quoting utility."""
+
+    def test_module_exists(self):
+        filepath = PROJECT_ROOT / "tools" / "shell_quote.py"
+        assert filepath.exists(), "tools/shell_quote.py not found"
+
+    def test_unix_quoting(self):
+        with patch("tools.shell_quote.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            from tools.shell_quote import _win_cmd_quote
+            # On Unix, shell_quote delegates to shlex.quote
+            import shlex
+            assert shlex.quote("hello world") == "'hello world'"
+
+    def test_win_cmd_quote_empty(self):
+        from tools.shell_quote import _win_cmd_quote
+        assert _win_cmd_quote("") == '""'
+
+    def test_win_cmd_quote_no_special_chars(self):
+        from tools.shell_quote import _win_cmd_quote
+        assert _win_cmd_quote("hello") == "hello"
+
+    def test_win_cmd_quote_spaces(self):
+        from tools.shell_quote import _win_cmd_quote
+        result = _win_cmd_quote("hello world")
+        assert result.startswith('"') and result.endswith('"')
+        assert "hello world" in result
+
+    def test_win_cmd_quote_internal_quotes(self):
+        from tools.shell_quote import _win_cmd_quote
+        result = _win_cmd_quote('say "hi"')
+        assert '\\"' in result  # escaped internal quotes
+
+    def test_win_cmd_quote_percent(self):
+        from tools.shell_quote import _win_cmd_quote
+        result = _win_cmd_quote("100%")
+        assert "%%" in result  # escaped percent
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Process killing — Windows taskkill
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestProcessKillingWindows:
+    """Process tree killing must use taskkill on Windows."""
+
+    def test_kill_shell_children_has_taskkill(self):
+        source = (PROJECT_ROOT / "tools" / "environments" / "local.py").read_text(encoding="utf-8")
+        assert "taskkill" in source, "local.py: _kill_shell_children missing taskkill"
+        assert "_IS_WINDOWS" in source, "local.py: missing _IS_WINDOWS guard"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -33,10 +33,27 @@ import uuid
 _IS_WINDOWS = platform.system() == "Windows"
 from typing import Any, Dict, List, Optional
 
-# Availability gate: UDS requires a POSIX OS
+# Availability gate: requires AF_UNIX sockets (POSIX, or Windows 10 1803+)
 logger = logging.getLogger(__name__)
 
-SANDBOX_AVAILABLE = sys.platform != "win32"
+
+def _check_af_unix() -> bool:
+    """Check if AF_UNIX sockets are available on this platform."""
+    if not hasattr(socket, "AF_UNIX"):
+        return False
+    if sys.platform != "win32":
+        return True  # Always available on Unix
+    # Windows: AF_UNIX added in build 17134 (Windows 10 1803)
+    # but may not work in all environments — test it
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.close()
+        return True
+    except (OSError, AttributeError):
+        return False
+
+
+SANDBOX_AVAILABLE = _check_af_unix()
 
 # The 7 tools allowed inside the sandbox. The intersection of this list
 # and the session's enabled tools determines which stubs are generated.
@@ -389,7 +406,11 @@ def execute_code(
     # Use /tmp on macOS to avoid the long /var/folders/... path that pushes
     # Unix domain socket paths past the 104-byte macOS AF_UNIX limit.
     # On Linux, tempfile.gettempdir() already returns /tmp.
-    _sock_tmpdir = "/tmp" if sys.platform == "darwin" else tempfile.gettempdir()
+    # On Windows, use tempfile.gettempdir() which returns %TEMP%.
+    if sys.platform == "darwin":
+        _sock_tmpdir = "/tmp"
+    else:
+        _sock_tmpdir = tempfile.gettempdir()
     sock_path = os.path.join(_sock_tmpdir, f"hermes_rpc_{uuid.uuid4().hex}.sock")
 
     tool_call_log: list = []

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -6,6 +6,7 @@ import platform
 import shutil
 import signal
 import subprocess
+import tempfile
 import threading
 import time
 
@@ -318,7 +319,7 @@ class LocalEnvironment(PersistentShellMixin, BaseEnvironment):
 
     @property
     def _temp_prefix(self) -> str:
-        return f"/tmp/hermes-local-{self._session_id}"
+        return os.path.join(tempfile.gettempdir(), f"hermes-local-{self._session_id}")
 
     def _spawn_shell_process(self) -> subprocess.Popen:
         user_shell = _find_bash()
@@ -347,10 +348,17 @@ class LocalEnvironment(PersistentShellMixin, BaseEnvironment):
         if self._shell_pid is None:
             return
         try:
-            subprocess.run(
-                ["pkill", "-P", str(self._shell_pid)],
-                capture_output=True, timeout=5,
-            )
+            if _IS_WINDOWS:
+                # taskkill /T kills the process tree; /F forces termination
+                subprocess.run(
+                    ["taskkill", "/F", "/T", "/PID", str(self._shell_pid)],
+                    capture_output=True, timeout=5,
+                )
+            else:
+                subprocess.run(
+                    ["pkill", "-P", str(self._shell_pid)],
+                    capture_output=True, timeout=5,
+                )
         except (subprocess.TimeoutExpired, FileNotFoundError):
             pass
 

--- a/tools/environments/persistent_shell.py
+++ b/tools/environments/persistent_shell.py
@@ -1,8 +1,10 @@
 """Persistent shell mixin: file-based IPC protocol for long-lived bash shells."""
 
 import logging
+import os
 import shlex
 import subprocess
+import tempfile
 import threading
 import time
 import uuid
@@ -44,7 +46,7 @@ class PersistentShellMixin:
 
     @property
     def _temp_prefix(self) -> str:
-        return f"/tmp/hermes-persistent-{self._session_id}"
+        return os.path.join(tempfile.gettempdir(), f"hermes-persistent-{self._session_id}")
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,7 +23,14 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
-import fcntl
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
 import json
 import logging
 import os
@@ -134,10 +141,19 @@ class MemoryStore:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         fd = open(lock_path, "w")
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            if fcntl:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+            elif msvcrt:
+                msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
             yield
         finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            if fcntl:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            elif msvcrt:
+                try:
+                    msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
             fd.close()
 
     @staticmethod

--- a/tools/shell_quote.py
+++ b/tools/shell_quote.py
@@ -1,0 +1,42 @@
+"""Cross-platform shell quoting utility.
+
+On Unix: uses shlex.quote() (POSIX sh quoting).
+On Windows: wraps in double quotes with proper escaping for cmd.exe.
+
+Usage:
+    from tools.shell_quote import shell_quote
+    cmd = f"whisper {shell_quote(input_path)} --model {shell_quote(model)}"
+"""
+
+import shlex
+import sys
+
+
+def shell_quote(s: str) -> str:
+    """Quote a string for safe interpolation into a shell command.
+
+    Uses the appropriate quoting strategy for the current platform:
+    - Unix: shlex.quote() (single-quote wrapping)
+    - Windows: double-quote wrapping with cmd.exe metachar escaping
+    """
+    if sys.platform != "win32":
+        return shlex.quote(s)
+    return _win_cmd_quote(s)
+
+
+def _win_cmd_quote(s: str) -> str:
+    """Quote a string for safe use in cmd.exe.
+
+    cmd.exe metacharacters: & | < > ^ " % !
+    Strategy: wrap in double quotes, escape internal double quotes with
+    backslash, and escape % with %% (environment variable expansion).
+    """
+    if not s:
+        return '""'
+    # If the string has no special chars, return as-is
+    _CMD_META = set('&|<>^"% !\t')
+    if not any(c in _CMD_META for c in s):
+        return s
+    # Escape internal double quotes and percent signs
+    escaped = s.replace('"', '\\"').replace("%", "%%")
+    return f'"{escaped}"'

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -29,6 +29,8 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+
+from tools.shell_quote import shell_quote as _shell_quote
 from pathlib import Path
 from typing import Optional, Dict, Any
 
@@ -143,7 +145,7 @@ def _get_local_command_template() -> Optional[str]:
 
     whisper_binary = _find_whisper_binary()
     if whisper_binary:
-        quoted_binary = shlex.quote(whisper_binary)
+        quoted_binary = _shell_quote(whisper_binary)
         return (
             f"{quoted_binary} {{input_path}} --model {{model}} --output_format txt "
             "--output_dir {output_dir} --language {language}"
@@ -226,7 +228,8 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_OPENAI and os.getenv("GROQ_API_KEY"):
         logger.info("No local STT available, using Groq Whisper API")
         return "groq"
-    if _HAS_OPENAI and _resolve_openai_api_key():
+    if _HAS_OPENAI and _resolve_openai_logout
+api_key():
         logger.info("No local STT available, using OpenAI Whisper API")
         return "openai"
     return "none"
@@ -342,10 +345,10 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
                 return {"success": False, "transcript": "", "error": prep_error}
 
             command = command_template.format(
-                input_path=shlex.quote(prepared_input),
-                output_dir=shlex.quote(output_dir),
-                language=shlex.quote(language),
-                model=shlex.quote(normalized_model),
+                input_path=_shell_quote(prepared_input),
+                output_dir=_shell_quote(output_dir),
+                language=_shell_quote(language),
+                model=_shell_quote(normalized_model),
             )
             subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
 
@@ -552,3 +555,4 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }
+

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -785,6 +785,10 @@ def cleanup_temp_recordings(max_age_seconds: int = 3600) -> int:
                 if age > max_age_seconds:
                     os.unlink(entry.path)
                     deleted += 1
+            except PermissionError:
+                # Windows: file may still be open by another process.
+                # Skip it — will be cleaned up on next run.
+                pass
             except OSError:
                 pass
 


### PR DESCRIPTION
Clipboard & Paste (the headline fix):
- Ctrl+PrtScn then Ctrl+V now attaches screenshots on Windows Terminal
- Full rewrite of hermes_cli/clipboard.py with native Windows support
- Added text clipboard functions (get_clipboard_text, has_clipboard_text)
- WSL powershell.exe path resolution with caching and fallback paths
- Increased PowerShell timeouts for WSL cold starts (8s->15s, 15s->25s)
- Paste collapsing threshold raised (5 lines -> 10 lines + 200 chars)
- Visual confirmation on image attach from all paste handlers

Phase 1 - Critical crash fixes:
- tools/memory_tool.py: fcntl/msvcrt cross-platform file locking
- hermes_cli/gateway.py: signal.SIGKILL guarded on Windows (use SIGTERM)
- tools/environments/local.py, persistent_shell.py: tempfile.gettempdir()
- agent/display.py: CON device on Windows instead of /dev/tty

Phase 2 - Security hardening:
- hermes_cli/config.py: icacls for real file protection on Windows
- hermes_cli/config.py: keyring integration for Windows Credential Manager
- cli.py: shell=True replaced with shlex.split on Unix for quick commands
- tools/shell_quote.py: cross-platform shell quoting (cmd.exe escaping)
- gateway/platforms/sms.py: webhook binds 127.0.0.1 by default

Phase 3 - Feature parity:
- hermes_cli/gateway.py: Windows Task Scheduler install/start/stop/uninstall
- hermes_cli/status.py: Windows gateway status display
- gateway/status.py: wmic for process info instead of /proc
- tools/code_execution_tool.py: AF_UNIX runtime detection (not blanket disable)
- tools/environments/local.py: taskkill /F /T for process tree killing

Phase 4 - Polish:
- WINDOWS.md: comprehensive Windows documentation
- .github/workflows/windows-tests.yml: Windows CI pipeline
- tests/tools/test_windows_compat.py: 37 tests (up from 12)
- tests/tools/test_clipboard.py: 124 tests (up from 112)
- README.md: updated from 'not supported' to 'supported'
- Platform-aware path hints in CLI output
- Voice temp cleanup handles Windows file locking
- pyproject.toml: keyring optional dependency for Windows

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

