### PR TITLE
fix(cli): prevent 'Press ENTER to continue...' on exit

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1204,6 +1204,53 @@ _client_cache: Dict[tuple, tuple] = {}
 _client_cache_lock = threading.Lock()
 
 
+def _force_close_async_httpx(client: Any) -> None:
+    """Mark the httpx AsyncClient inside an AsyncOpenAI client as closed.
+
+    This prevents ``AsyncHttpxClientWrapper.__del__`` from scheduling
+    ``aclose()`` on a (potentially closed) event loop, which causes
+    ``RuntimeError: Event loop is closed`` → prompt_toolkit's
+    "Press ENTER to continue..." handler.
+
+    We intentionally do NOT run the full async close path — the
+    connections will be dropped by the OS when the process exits.
+    """
+    try:
+        from httpx._client import ClientState
+        inner = getattr(client, "_client", None)
+        if inner is not None and not getattr(inner, "is_closed", True):
+            inner._state = ClientState.CLOSED
+    except Exception:
+        pass
+
+
+def shutdown_cached_clients() -> None:
+    """Close all cached clients (sync and async) to prevent event-loop errors.
+
+    Call this during CLI shutdown, *before* the event loop is closed, to
+    avoid ``AsyncHttpxClientWrapper.__del__`` raising on a dead loop.
+    """
+    import inspect
+
+    with _client_cache_lock:
+        for key, entry in list(_client_cache.items()):
+            client = entry[0]
+            if client is None:
+                continue
+            # Mark any async httpx transport as closed first (prevents __del__
+            # from scheduling aclose() on a dead event loop).
+            _force_close_async_httpx(client)
+            # Sync clients: close the httpx connection pool cleanly.
+            # Async clients: skip — we already neutered __del__ above.
+            try:
+                close_fn = getattr(client, "close", None)
+                if close_fn and not inspect.iscoroutinefunction(close_fn):
+                    close_fn()
+            except Exception:
+                pass
+        _client_cache.clear()
+
+
 def _get_cached_client(
     provider: str,
     model: str = None,
@@ -1222,6 +1269,7 @@ def _get_cached_client(
                 # "Event loop is closed" when httpx tries to clean up its
                 # transport.  Discard the stale client and create a fresh one.
                 if cached_loop is not None and cached_loop.is_closed():
+                    _force_close_async_httpx(cached_client)
                     del _client_cache[cache_key]
                 else:
                     return cached_client, model or cached_default

--- a/cli.py
+++ b/cli.py
@@ -498,6 +498,14 @@ def _run_cleanup():
         shutdown_mcp_servers()
     except Exception:
         pass
+    # Close cached auxiliary LLM clients (sync + async) so that
+    # AsyncHttpxClientWrapper.__del__ doesn't fire on a closed event loop
+    # and trigger prompt_toolkit's "Press ENTER to continue..." handler.
+    try:
+        from agent.auxiliary_client import shutdown_cached_clients
+        shutdown_cached_clients()
+    except Exception:
+        pass
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

During normal CLI usage (not on exit), users see this interrupting their session:

```
Unhandled exception in event loop:
  File httpx/_client.py in aclose
  ...
  RuntimeError: Event loop is closed

Press ENTER to continue...
```

## Root Cause

The OpenAI SDK wraps httpx's `AsyncClient` in `AsyncHttpxClientWrapper` which has a `__del__`:

```python
class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):
    def __del__(self) -> None:
        if self.is_closed:
            return
        try:
            asyncio.get_running_loop().create_task(self.aclose())
        except Exception:
            pass
```

The mid-session flow that triggers this:
1. **Turn 1**: Agent tool call runs on worker thread → creates `AsyncOpenAI` client bound to thread's event loop → client is cached in `_client_cache`
2. Worker thread finishes → its event loop closes
3. **Turn 2**: New worker thread → `_get_cached_client()` detects stale entry (loop is closed) → evicts it with `del`
4. `del` triggers `__del__` → `asyncio.get_running_loop()` finds prompt_toolkit's running loop → schedules `aclose()`
5. `aclose()` tries to close TCP connections on the dead worker loop → `RuntimeError: Event loop is closed`
6. prompt_toolkit catches the unhandled exception and shows "Press ENTER to continue..."

## Fix

- **`_force_close_async_httpx()`** — sets httpx `AsyncClient._state = ClientState.CLOSED`, so `__del__` checks `is_closed` and returns immediately (no-op)
- **Stale client eviction** (`_get_cached_client`) — now calls `_force_close_async_httpx()` before `del`, preventing the mid-session error
- **`shutdown_cached_clients()`** — called from `_run_cleanup()` on CLI exit to clean up any remaining cached clients
- **CLI cleanup** — `_run_cleanup()` in cli.py calls `shutdown_cached_clients()`

## Files Changed

- `agent/auxiliary_client.py` — new shutdown functions + fix stale eviction
- `cli.py` — call shutdown in cleanup