### PR TITLE
fix(cli): allow custom/local endpoints without API key

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1762,8 +1762,22 @@ class HermesCLI:
         resolved_acp_command = runtime.get("command")
         resolved_acp_args = list(runtime.get("args") or [])
         if not isinstance(api_key, str) or not api_key:
-            self.console.print("[bold red]Provider resolver returned an empty API key.[/]")
-            return False
+            # Custom / local endpoints (llama.cpp, ollama, vLLM, etc.) often
+            # don't require authentication.  When a base_url IS configured but
+            # no API key was found, use a placeholder so the OpenAI SDK
+            # doesn't reject the request and local servers just ignore it.
+            _source = runtime.get("source", "")
+            _has_custom_base = isinstance(base_url, str) and base_url and "openrouter.ai" not in base_url
+            if _has_custom_base:
+                api_key = "no-key-required"
+                logger.debug(
+                    "No API key for custom endpoint %s (source=%s), "
+                    "using placeholder — local servers typically ignore auth",
+                    base_url, _source,
+                )
+            else:
+                self.console.print("[bold red]Provider resolver returned an empty API key.[/]")
+                return False
         if not isinstance(base_url, str) or not base_url:
             self.console.print("[bold red]Provider resolver returned an empty base URL.[/]")
             return False


### PR DESCRIPTION
## Problem

Users running local LLM servers (llama.cpp, ollama, vLLM) get:

```
Provider resolver returned an empty API key.
```

This broke after the runtime provider resolver was tightened to enforce non-empty API keys. Local servers don't need auth.

## Fix

In `_ensure_runtime_credentials()`: when a custom base_url IS configured but no API key was found, use a placeholder (`"no-key-required"`) instead of failing. Local servers ignore the Authorization header.

Only applies when the base URL is NOT an OpenRouter URL (those always need real keys).

Reported by @ThatWolfieGuy — llama.cpp with Qwen 3.5 stopped working after updating to v0.4.0.