### PR TITLE
feat: add SimpleX Chat gateway adapter (#2557)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -197,6 +197,16 @@ PLATFORM_HINTS = {
         "files arrive as downloadable documents. You can also include image "
         "URLs in markdown format ![alt](url) and they will be sent as photos."
     ),
+    "simplex": (
+        "You are on SimpleX Chat, a private and decentralised messaging platform. "
+        "Please do not use markdown as it does not render. "
+        "Contacts have no persistent identifiers — they communicate via opaque "
+        "contact IDs, which is normal. "
+        "You can send media files natively: to deliver a file to the user, "
+        "include MEDIA:/absolute/path/to/file in your response. Images "
+        "(.png, .jpg, .webp) appear as photos and other files arrive as "
+        "downloadable attachments."
+    ),
     "email": (
         "You are communicating via email. Write clear, well-structured responses "
         "suitable for email. Use plain text formatting (no markdown). "

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -141,6 +141,7 @@ def _deliver_result(job: dict, content: str) -> None:
         "slack": Platform.SLACK,
         "whatsapp": Platform.WHATSAPP,
         "signal": Platform.SIGNAL,
+        "simplex": Platform.SIMPLEX,
         "matrix": Platform.MATRIX,
         "mattermost": Platform.MATTERMOST,
         "homeassistant": Platform.HOMEASSISTANT,

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -62,8 +62,8 @@ def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
         except Exception as e:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
-    # Telegram, WhatsApp & Signal can't enumerate chats -- pull from session history
-    for plat_name in ("telegram", "whatsapp", "signal", "email", "sms"):
+    # Telegram, WhatsApp, Signal & SimpleX can't enumerate chats -- pull from session history
+    for plat_name in ("telegram", "whatsapp", "signal", "simplex", "email", "sms"):
         if plat_name not in platforms:
             platforms[plat_name] = _build_from_sessions(plat_name)
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -55,6 +55,7 @@ class Platform(Enum):
     EMAIL = "email"
     SMS = "sms"
     DINGTALK = "dingtalk"
+    SIMPLEX = "simplex"
     API_SERVER = "api_server"
     WEBHOOK = "webhook"
 
@@ -250,6 +251,9 @@ class GatewayConfig:
                 connected.append(platform)
             # WhatsApp uses enabled flag only (bridge handles auth)
             elif platform == Platform.WHATSAPP:
+                connected.append(platform)
+            # SimpleX uses extra dict for config (ws_url)
+            elif platform == Platform.SIMPLEX and config.extra.get("ws_url"):
                 connected.append(platform)
             # Signal uses extra dict for config (http_url + account)
             elif platform == Platform.SIGNAL and config.extra.get("http_url"):
@@ -628,6 +632,23 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 name=os.getenv("SLACK_HOME_CHANNEL_NAME", ""),
             )
     
+    # SimpleX
+    simplex_ws_url = os.getenv("SIMPLEX_WS_URL")
+    if simplex_ws_url:
+        if Platform.SIMPLEX not in config.platforms:
+            config.platforms[Platform.SIMPLEX] = PlatformConfig()
+        config.platforms[Platform.SIMPLEX].enabled = True
+        config.platforms[Platform.SIMPLEX].extra.update({
+            "ws_url": simplex_ws_url,
+        })
+        simplex_home = os.getenv("SIMPLEX_HOME_CHANNEL")
+        if simplex_home:
+            config.platforms[Platform.SIMPLEX].home_channel = HomeChannel(
+                platform=Platform.SIMPLEX,
+                chat_id=simplex_home,
+                name=os.getenv("SIMPLEX_HOME_CHANNEL_NAME", "Home"),
+            )
+
     # Signal
     signal_url = os.getenv("SIGNAL_HTTP_URL")
     signal_account = os.getenv("SIGNAL_ACCOUNT")

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -1,0 +1,529 @@
+"""SimpleX Chat platform adapter.
+
+Connects to a simplex-chat daemon running in WebSocket mode.
+Inbound messages arrive via a persistent WebSocket connection.
+Outbound messages use the same WebSocket with JSON commands.
+
+SimpleX chat daemon setup:
+    simplex-chat -p 5225          # start daemon on port 5225
+    # or via Docker:
+    # docker run -p 5225:5225 simplexchat/simplex-chat-cli -p 5225
+
+Required environment variables:
+    SIMPLEX_WS_URL    WebSocket URL of the daemon (default: ws://127.0.0.1:5225)
+
+Optional environment variables:
+    SIMPLEX_ALLOWED_USERS      Comma-separated list of contact display names or IDs
+    SIMPLEX_ALLOW_ALL_USERS    Set to 'true' to allow all contacts
+    SIMPLEX_HOME_CHANNEL       Default contact/group ID for cron delivery
+
+Privacy note: SimpleX assigns opaque internal IDs to contacts — no phone numbers
+or persistent identifiers are ever transmitted. Redaction is therefore a no-op,
+but we follow the same patterns as Signal for consistency.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import random
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    cache_image_from_bytes,
+    cache_audio_from_bytes,
+    cache_document_from_bytes,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+MAX_MESSAGE_LENGTH = 16_000  # SimpleX has no hard limit; keep chunking sane
+TYPING_INTERVAL = 10.0
+WS_RETRY_DELAY_INITIAL = 2.0
+WS_RETRY_DELAY_MAX = 60.0
+HEALTH_CHECK_INTERVAL = 30.0
+HEALTH_CHECK_STALE_THRESHOLD = 120.0
+
+# Correlation ID prefix for requests we send so we can ignore our own echoes
+_CORR_PREFIX = "hermes-"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_comma_list(value: str) -> List[str]:
+    """Split a comma-separated string into a stripped list."""
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def _guess_extension(data: bytes) -> str:
+    """Guess file extension from magic bytes."""
+    if data[:4] == b"\x89PNG":
+        return ".png"
+    if data[:2] == b"\xff\xd8":
+        return ".jpg"
+    if data[:4] == b"GIF8":
+        return ".gif"
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return ".webp"
+    if data[:4] == b"%PDF":
+        return ".pdf"
+    if len(data) >= 8 and data[4:8] == b"ftyp":
+        return ".mp4"
+    if data[:4] == b"OggS":
+        return ".ogg"
+    if len(data) >= 2 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0:
+        return ".mp3"
+    return ".bin"
+
+
+def _is_image_ext(ext: str) -> bool:
+    return ext.lower() in (".jpg", ".jpeg", ".png", ".gif", ".webp")
+
+
+def _is_audio_ext(ext: str) -> bool:
+    return ext.lower() in (".mp3", ".wav", ".ogg", ".m4a", ".aac")
+
+
+def check_simplex_requirements() -> bool:
+    """Check if SimpleX is configured (SIMPLEX_WS_URL set or daemon reachable)."""
+    return bool(os.getenv("SIMPLEX_WS_URL"))
+
+
+# ---------------------------------------------------------------------------
+# SimpleX Adapter
+# ---------------------------------------------------------------------------
+
+class SimplexAdapter(BasePlatformAdapter):
+    """SimpleX Chat adapter using the simplex-chat daemon WebSocket API."""
+
+    platform = Platform.SIMPLEX
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.SIMPLEX)
+
+        extra = config.extra or {}
+        self.ws_url = extra.get("ws_url", "ws://127.0.0.1:5225").rstrip("/")
+
+        # Running state
+        self._ws = None  # websockets connection
+        self._ws_task: Optional[asyncio.Task] = None
+        self._health_task: Optional[asyncio.Task] = None
+        self._typing_tasks: Dict[str, asyncio.Task] = {}
+        self._running = False
+        self._last_ws_activity = 0.0
+
+        # Track sent correlation IDs to filter echoes
+        self._pending_corr_ids: set = set()
+        self._max_pending_corr = 200
+
+        logger.info("SimpleX adapter initialized: url=%s", self.ws_url)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> bool:
+        """Connect to the simplex-chat daemon and start the WebSocket listener."""
+        try:
+            import websockets  # noqa: F401
+        except ImportError:
+            logger.error(
+                "SimpleX: 'websockets' package not installed. "
+                "Run: pip install websockets"
+            )
+            return False
+
+        if not self.ws_url:
+            logger.error("SimpleX: SIMPLEX_WS_URL is required")
+            return False
+
+        # Quick connectivity check — try to open and immediately close
+        try:
+            import websockets.client as _wsclient
+            async with _wsclient.connect(self.ws_url, open_timeout=10):
+                pass
+        except Exception as e:
+            logger.error("SimpleX: cannot reach daemon at %s: %s", self.ws_url, e)
+            return False
+
+        self._running = True
+        self._last_ws_activity = time.time()
+        self._ws_task = asyncio.create_task(self._ws_listener())
+        self._health_task = asyncio.create_task(self._health_monitor())
+
+        logger.info("SimpleX: connected to %s", self.ws_url)
+        return True
+
+    async def disconnect(self) -> None:
+        """Stop WebSocket listener and clean up."""
+        self._running = False
+
+        if self._ws_task:
+            self._ws_task.cancel()
+            try:
+                await self._ws_task
+            except asyncio.CancelledError:
+                pass
+
+        if self._health_task:
+            self._health_task.cancel()
+            try:
+                await self._health_task
+            except asyncio.CancelledError:
+                pass
+
+        for task in self._typing_tasks.values():
+            task.cancel()
+        self._typing_tasks.clear()
+
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+
+        logger.info("SimpleX: disconnected")
+
+    # ------------------------------------------------------------------
+    # WebSocket listener
+    # ------------------------------------------------------------------
+
+    async def _ws_listener(self) -> None:
+        """Maintain a persistent WebSocket connection to the daemon."""
+        import websockets.client as _wsclient
+        import websockets.exceptions as _wsexc
+
+        backoff = WS_RETRY_DELAY_INITIAL
+
+        while self._running:
+            try:
+                logger.debug("SimpleX WS: connecting to %s", self.ws_url)
+                async with _wsclient.connect(
+                    self.ws_url,
+                    ping_interval=20,
+                    ping_timeout=20,
+                ) as ws:
+                    self._ws = ws
+                    backoff = WS_RETRY_DELAY_INITIAL
+                    self._last_ws_activity = time.time()
+                    logger.info("SimpleX WS: connected")
+
+                    async for raw in ws:
+                        if not self._running:
+                            break
+                        self._last_ws_activity = time.time()
+                        try:
+                            msg = json.loads(raw)
+                            await self._handle_event(msg)
+                        except json.JSONDecodeError:
+                            logger.debug("SimpleX WS: invalid JSON: %.100s", raw)
+                        except Exception:
+                            logger.exception("SimpleX WS: error handling event")
+
+            except asyncio.CancelledError:
+                break
+            except _wsexc.WebSocketException as e:
+                if self._running:
+                    logger.warning(
+                        "SimpleX WS: error: %s (reconnecting in %.0fs)", e, backoff
+                    )
+            except Exception as e:
+                if self._running:
+                    logger.warning(
+                        "SimpleX WS: unexpected error: %s (reconnecting in %.0fs)",
+                        e, backoff,
+                    )
+            finally:
+                self._ws = None
+
+            if self._running:
+                jitter = backoff * 0.2 * random.random()
+                await asyncio.sleep(backoff + jitter)
+                backoff = min(backoff * 2, WS_RETRY_DELAY_MAX)
+
+    # ------------------------------------------------------------------
+    # Health monitor
+    # ------------------------------------------------------------------
+
+    async def _health_monitor(self) -> None:
+        """Force reconnect if the WebSocket has been idle too long."""
+        while self._running:
+            await asyncio.sleep(HEALTH_CHECK_INTERVAL)
+            if not self._running:
+                break
+
+            elapsed = time.time() - self._last_ws_activity
+            if elapsed > HEALTH_CHECK_STALE_THRESHOLD:
+                logger.warning(
+                    "SimpleX: WS idle for %.0fs, forcing reconnect", elapsed
+                )
+                self._last_ws_activity = time.time()
+                if self._ws:
+                    try:
+                        await self._ws.close()
+                    except Exception:
+                        pass
+
+    # ------------------------------------------------------------------
+    # Inbound event handling
+    # ------------------------------------------------------------------
+
+    async def _handle_event(self, event: dict) -> None:
+        """Dispatch a daemon event to the appropriate handler."""
+        resp_type = event.get("type") or event.get("resp", {}).get("type", "")
+
+        # Filter responses to our own commands (echoes)
+        corr_id = event.get("corrId", "")
+        if corr_id and corr_id.startswith(_CORR_PREFIX):
+            self._pending_corr_ids.discard(corr_id)
+            return
+
+        if resp_type == "newChatItem":
+            await self._handle_new_chat_item(event)
+        elif resp_type == "newChatItems":
+            # Batch variant — process each item
+            items = event.get("chatItems") or []
+            for item_wrapper in items:
+                await self._handle_new_chat_item(item_wrapper)
+        # Ignore all other event types (delivery receipts, contact updates, etc.)
+
+    async def _handle_new_chat_item(self, wrapper: dict) -> None:
+        """Process a single newChatItem event into a MessageEvent."""
+        # The daemon wraps the chat item differently depending on version;
+        # normalise both layouts.
+        chat_info = wrapper.get("chatInfo") or wrapper.get("chat") or {}
+        chat_item = wrapper.get("chatItem") or wrapper.get("item") or {}
+
+        # Only process messages (not calls, deleted items, etc.)
+        item_content = chat_item.get("content") or {}
+        msg_content = item_content.get("msgContent") or {}
+        if not msg_content:
+            return
+
+        # Filter out messages sent by us (direction == "snd")
+        meta = chat_item.get("meta") or {}
+        direction = (meta.get("itemStatus") or {}).get("type", "")
+        if direction in ("sndSent", "sndSentDirect", "sndSentViaProxy", "sndNew"):
+            return
+
+        # Determine chat type and IDs
+        chat_type_raw = chat_info.get("type", "")
+        is_group = chat_type_raw in ("group", "groupInfo")
+
+        if is_group:
+            group_info = chat_info.get("groupInfo") or chat_info.get("group") or {}
+            group_id = str(group_info.get("groupId") or group_info.get("id") or "")
+            group_name = group_info.get("displayName") or group_info.get("groupProfile", {}).get("displayName", "")
+            chat_id = f"group:{group_id}" if group_id else ""
+            chat_name = group_name
+        else:
+            contact_info = chat_info.get("contact") or {}
+            contact_id = str(contact_info.get("contactId") or contact_info.get("id") or "")
+            contact_name = (
+                contact_info.get("displayName")
+                or contact_info.get("localDisplayName")
+                or contact_id
+            )
+            chat_id = contact_id
+            chat_name = contact_name
+
+        if not chat_id:
+            logger.debug("SimpleX: ignoring event with no chat_id")
+            return
+
+        # Sender — for groups the message includes a chatItemMember sub-object
+        member = chat_item.get("chatItemMember") or {}
+        if is_group and member:
+            sender_id = str(member.get("memberId") or member.get("id") or chat_id)
+            sender_name = (
+                member.get("displayName")
+                or member.get("localDisplayName")
+                or sender_id
+            )
+        else:
+            sender_id = chat_id
+            sender_name = chat_name
+
+        # Extract text
+        text = msg_content.get("text") or ""
+
+        # Media attachments
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        file_info = chat_item.get("file") or {}
+        if file_info and file_info.get("fileStatus") not in ("cancelled", "error"):
+            file_id = file_info.get("fileId")
+            file_name = file_info.get("fileName", "file")
+            if file_id:
+                try:
+                    cached = await self._fetch_file(file_id, file_name)
+                    if cached:
+                        ext = cached.rsplit(".", 1)[-1]
+                        if _is_image_ext("." + ext):
+                            media_types.append("image/" + ext.replace("jpg", "jpeg"))
+                        elif _is_audio_ext("." + ext):
+                            media_types.append("audio/" + ext)
+                        else:
+                            media_types.append("application/octet-stream")
+                        media_urls.append(cached)
+                except Exception:
+                    logger.exception("SimpleX: failed to fetch file %s", file_id)
+
+        # Timestamp
+        ts_str = meta.get("itemTs") or meta.get("createdAt") or ""
+        try:
+            timestamp = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            timestamp = datetime.now(tz=timezone.utc)
+
+        # Build source
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=chat_name,
+            chat_type="group" if is_group else "dm",
+            user_id=sender_id,
+            user_name=sender_name,
+        )
+
+        # Message type
+        msg_type = MessageType.TEXT
+        if media_types:
+            if any(mt.startswith("audio/") for mt in media_types):
+                msg_type = MessageType.VOICE
+            elif any(mt.startswith("image/") for mt in media_types):
+                msg_type = MessageType.PHOTO
+
+        event_obj = MessageEvent(
+            source=source,
+            text=text,
+            message_type=msg_type,
+            media_urls=media_urls,
+            media_types=media_types,
+            timestamp=timestamp,
+            raw_message=wrapper,
+        )
+
+        await self.handle_message(event_obj)
+
+    async def _fetch_file(self, file_id: Any, file_name: str) -> Optional[str]:
+        """Ask the daemon to receive and return a file attachment."""
+        # simplex-chat exposes `/api/v1/files/{fileId}` on an HTTP port
+        # when started with --http-port. However, the canonical WebSocket API
+        # does not have a direct binary download command; files are stored on
+        # the local filesystem after the daemon accepts them.
+        #
+        # We request acceptance first, then read from the daemon's local path.
+        corr_id = self._make_corr_id()
+        cmd = {
+            "corrId": corr_id,
+            "cmd": f"/freceive {file_id}",
+        }
+        await self._send_ws(cmd)
+        # The daemon will emit a chatItemUpdated event when the file lands;
+        # for simplicity we just wait briefly and rely on the daemon's default path.
+        await asyncio.sleep(2)
+
+        # simplex-chat stores received files in ~/Downloads or a configured path.
+        # We try common locations.
+        for search_dir in (
+            os.path.expanduser("~/Downloads"),
+            os.path.expanduser("~/.simplex/files"),
+            "/tmp/simplex_files",
+        ):
+            candidate = os.path.join(search_dir, file_name)
+            if os.path.exists(candidate):
+                with open(candidate, "rb") as f:
+                    data = f.read()
+                ext = _guess_extension(data)
+                if _is_image_ext(ext):
+                    return cache_image_from_bytes(data, ext)
+                elif _is_audio_ext(ext):
+                    return cache_audio_from_bytes(data, ext)
+                else:
+                    return cache_document_from_bytes(data, file_name)
+        return None
+
+    # ------------------------------------------------------------------
+    # Outbound messages
+    # ------------------------------------------------------------------
+
+    def _make_corr_id(self) -> str:
+        """Generate a unique correlation ID for a request."""
+        corr_id = f"{_CORR_PREFIX}{int(time.time() * 1000)}-{random.randint(0, 9999)}"
+        self._pending_corr_ids.add(corr_id)
+        if len(self._pending_corr_ids) > self._max_pending_corr:
+            # Trim oldest — sets are unordered so just clear the oldest half
+            to_remove = list(self._pending_corr_ids)[:self._max_pending_corr // 2]
+            self._pending_corr_ids -= set(to_remove)
+        return corr_id
+
+    async def _send_ws(self, payload: dict) -> None:
+        """Send a JSON payload over the WebSocket, queuing if not yet connected."""
+        import websockets.exceptions as _wsexc
+        ws = self._ws
+        if not ws:
+            logger.debug("SimpleX: WS not connected, dropping outbound command")
+            return
+        try:
+            await ws.send(json.dumps(payload))
+        except _wsexc.ConnectionClosed:
+            logger.warning("SimpleX: WS closed while sending")
+        except Exception as e:
+            logger.warning("SimpleX: WS send error: %s", e)
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a text message to a contact or group."""
+        corr_id = self._make_corr_id()
+
+        if chat_id.startswith("group:"):
+            group_id = chat_id[6:]
+            cmd_str = f"#[{group_id}] {content}"
+        else:
+            cmd_str = f"@[{chat_id}] {content}"
+
+        payload = {
+            "corrId": corr_id,
+            "cmd": cmd_str,
+        }
+
+        await self._send_ws(payload)
+        return SendResult(success=True, platform="simplex", chat_id=chat_id)
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """SimpleX does not expose a typing indicator API — no-op."""
+        pass
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: str = "",
+    ) -> SendResult:
+        """Send an image (URL) as a message with optional caption."""
+        text = f"{caption}\n{image_url}".strip() if caption else image_url
+        return await self.send(chat_id, text)
+
+    async def get_chat_info(self, chat_id: str) -> dict:
+        """Return basic chat info."""
+        if chat_id.startswith("group:"):
+            return {"chat_id": chat_id, "type": "group", "name": chat_id[6:]}
+        return {"chat_id": chat_id, "type": "dm", "name": chat_id}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1153,6 +1153,13 @@ class GatewayRunner:
                 return None
             return SlackAdapter(config)
 
+        elif platform == Platform.SIMPLEX:
+            from gateway.platforms.simplex import SimplexAdapter, check_simplex_requirements
+            if not check_simplex_requirements():
+                logger.warning("SimpleX: SIMPLEX_WS_URL not configured")
+                return None
+            return SimplexAdapter(config)
+
         elif platform == Platform.SIGNAL:
             from gateway.platforms.signal import SignalAdapter, check_signal_requirements
             if not check_signal_requirements():
@@ -1249,6 +1256,7 @@ class GatewayRunner:
             Platform.WHATSAPP: "WHATSAPP_ALLOWED_USERS",
             Platform.SLACK: "SLACK_ALLOWED_USERS",
             Platform.SIGNAL: "SIGNAL_ALLOWED_USERS",
+            Platform.SIMPLEX: "SIMPLEX_ALLOWED_USERS",
             Platform.EMAIL: "EMAIL_ALLOWED_USERS",
             Platform.SMS: "SMS_ALLOWED_USERS",
             Platform.MATTERMOST: "MATTERMOST_ALLOWED_USERS",
@@ -1261,6 +1269,7 @@ class GatewayRunner:
             Platform.WHATSAPP: "WHATSAPP_ALLOW_ALL_USERS",
             Platform.SLACK: "SLACK_ALLOW_ALL_USERS",
             Platform.SIGNAL: "SIGNAL_ALLOW_ALL_USERS",
+            Platform.SIMPLEX: "SIMPLEX_ALLOW_ALL_USERS",
             Platform.EMAIL: "EMAIL_ALLOW_ALL_USERS",
             Platform.SMS: "SMS_ALLOW_ALL_USERS",
             Platform.MATTERMOST: "MATTERMOST_ALLOW_ALL_USERS",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1125,6 +1125,12 @@ _PLATFORMS = [
         "token_var": "SIGNAL_HTTP_URL",
     },
     {
+        "key": "simplex",
+        "label": "SimpleX Chat",
+        "emoji": "🔒",
+        "token_var": "SIMPLEX_WS_URL",
+    },
+    {
         "key": "email",
         "label": "Email",
         "emoji": "📧",
@@ -1535,6 +1541,80 @@ def _setup_signal():
     print_info(f"  Groups: {'enabled' if get_env_value('SIGNAL_GROUP_ALLOWED_USERS') else 'disabled'}")
 
 
+def _setup_simplex():
+    """Interactive setup for SimpleX Chat."""
+    print()
+    print(color("  ─── 🔒 SimpleX Chat Setup ───", Colors.CYAN))
+
+    existing_url = get_env_value("SIMPLEX_WS_URL")
+    if existing_url:
+        print()
+        print_success("SimpleX is already configured.")
+        if not prompt_yes_no("  Reconfigure SimpleX?", False):
+            return
+
+    print()
+    print_info("  SimpleX Chat requires the simplex-chat daemon running in WebSocket mode.")
+    print_info("  Install options:")
+    print_info("    Linux/macOS: download from https://github.com/simplex-chat/simplex-chat/releases")
+    print_info("    Docker:      simplexchat/simplex-chat")
+    print()
+    print_info("  Start the daemon:")
+    print_info("    simplex-chat -p 5225")
+    print()
+
+    # WebSocket URL
+    print_info("  Enter the WebSocket URL where the daemon is listening.")
+    default_url = existing_url or "ws://127.0.0.1:5225"
+    try:
+        url = input(f"  WebSocket URL [{default_url}]: ").strip() or default_url
+    except (EOFError, KeyboardInterrupt):
+        print("\n  Setup cancelled.")
+        return
+
+    # Test connectivity
+    print_info("  Testing connection...")
+    try:
+        import asyncio
+        import websockets.client as _wsclient
+
+        async def _ping(u):
+            async with _wsclient.connect(u, open_timeout=8):
+                return True
+
+        asyncio.run(_ping(url))
+        print_success("  simplex-chat daemon is reachable!")
+    except ImportError:
+        print_warning("  websockets not installed (pip install websockets). Skipping connectivity test.")
+    except Exception as e:
+        print_warning(f"  Could not reach simplex-chat at {url}: {e}")
+        if not prompt_yes_no("  Save this URL anyway? (you can start the daemon later)", True):
+            return
+
+    save_env_value("SIMPLEX_WS_URL", url)
+
+    # Allowed users
+    print()
+    print_info("  The gateway DENIES all contacts by default for security.")
+    print_info("  Enter SimpleX contact IDs to allow (comma-separated), or leave empty to use DM pairing.")
+    existing_allowed = get_env_value("SIMPLEX_ALLOWED_USERS") or ""
+    try:
+        allowed = input(f"  Allowed users [{existing_allowed or 'empty'}]: ").strip()
+        if not allowed:
+            allowed = existing_allowed
+    except (EOFError, KeyboardInterrupt):
+        print("\n  Setup cancelled.")
+        return
+
+    if allowed:
+        save_env_value("SIMPLEX_ALLOWED_USERS", allowed)
+
+    print()
+    print_success("SimpleX configured!")
+    print_info(f"  Daemon URL: {url}")
+    print_info(f"  Auth: {'explicit allowlist' if allowed else 'DM pairing'}")
+
+
 def gateway_setup():
     """Interactive setup for messaging platforms + gateway service."""
 
@@ -1593,6 +1673,8 @@ def gateway_setup():
             _setup_whatsapp()
         elif platform["key"] == "signal":
             _setup_signal()
+        elif platform["key"] == "simplex":
+            _setup_simplex()
         else:
             _setup_standard_platform(platform)
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -251,6 +251,7 @@ def show_status(args):
         "Discord": ("DISCORD_BOT_TOKEN", "DISCORD_HOME_CHANNEL"),
         "WhatsApp": ("WHATSAPP_ENABLED", None),
         "Signal": ("SIGNAL_HTTP_URL", "SIGNAL_HOME_CHANNEL"),
+        "SimpleX": ("SIMPLEX_WS_URL", "SIMPLEX_HOME_CHANNEL"),
         "Slack": ("SLACK_BOT_TOKEN", None),
         "Email": ("EMAIL_ADDRESS", "EMAIL_HOME_ADDRESS"),
         "SMS": ("TWILIO_ACCOUNT_SID", "SMS_HOME_CHANNEL"),

--- a/tests/gateway/test_simplex.py
+++ b/tests/gateway/test_simplex.py
@@ -1,0 +1,243 @@
+"""Tests for the SimpleX Chat gateway adapter."""
+
+import os
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# 1. Platform enum
+# ---------------------------------------------------------------------------
+
+def test_platform_enum_exists():
+    from gateway.config import Platform
+    assert Platform.SIMPLEX.value == "simplex"
+
+
+# ---------------------------------------------------------------------------
+# 2. Config loading from env vars
+# ---------------------------------------------------------------------------
+
+def test_env_override_sets_simplex_config(monkeypatch):
+    monkeypatch.setenv("SIMPLEX_WS_URL", "ws://127.0.0.1:5225")
+    monkeypatch.delenv("SIMPLEX_HOME_CHANNEL", raising=False)
+
+    from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+    config = GatewayConfig()
+    _apply_env_overrides(config)
+
+    assert Platform.SIMPLEX in config.platforms
+    assert config.platforms[Platform.SIMPLEX].enabled is True
+    assert config.platforms[Platform.SIMPLEX].extra["ws_url"] == "ws://127.0.0.1:5225"
+
+
+def test_env_override_home_channel(monkeypatch):
+    monkeypatch.setenv("SIMPLEX_WS_URL", "ws://127.0.0.1:5225")
+    monkeypatch.setenv("SIMPLEX_HOME_CHANNEL", "42")
+    monkeypatch.setenv("SIMPLEX_HOME_CHANNEL_NAME", "Personal")
+
+    from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+    config = GatewayConfig()
+    _apply_env_overrides(config)
+
+    home = config.platforms[Platform.SIMPLEX].home_channel
+    assert home is not None
+    assert home.chat_id == "42"
+    assert home.name == "Personal"
+
+
+def test_no_simplex_env_no_platform(monkeypatch):
+    monkeypatch.delenv("SIMPLEX_WS_URL", raising=False)
+
+    from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+    config = GatewayConfig()
+    _apply_env_overrides(config)
+
+    assert Platform.SIMPLEX not in config.platforms
+
+
+# ---------------------------------------------------------------------------
+# 3. Adapter init
+# ---------------------------------------------------------------------------
+
+def test_adapter_init():
+    from gateway.config import PlatformConfig, Platform
+    from gateway.platforms.simplex import SimplexAdapter
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    assert adapter.ws_url == "ws://localhost:5225"
+    assert adapter._running is False
+    assert adapter._ws is None
+
+
+def test_adapter_init_default_url():
+    from gateway.config import PlatformConfig
+    from gateway.platforms.simplex import SimplexAdapter
+
+    cfg = PlatformConfig(enabled=True)
+    adapter = SimplexAdapter(cfg)
+
+    assert adapter.ws_url == "ws://127.0.0.1:5225"
+
+
+# ---------------------------------------------------------------------------
+# 4. check_simplex_requirements
+# ---------------------------------------------------------------------------
+
+def test_check_requirements_true(monkeypatch):
+    monkeypatch.setenv("SIMPLEX_WS_URL", "ws://127.0.0.1:5225")
+    from gateway.platforms.simplex import check_simplex_requirements
+    assert check_simplex_requirements() is True
+
+
+def test_check_requirements_false(monkeypatch):
+    monkeypatch.delenv("SIMPLEX_WS_URL", raising=False)
+    from gateway.platforms.simplex import check_simplex_requirements
+    assert check_simplex_requirements() is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Authorization integration
+# ---------------------------------------------------------------------------
+
+def test_simplex_in_auth_allowlist_map(monkeypatch):
+    """Platform must appear in both auth maps inside _is_user_authorized."""
+    monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "contact-abc")
+
+    from gateway.config import Platform
+    from gateway.session import SessionSource
+
+    source = SessionSource(
+        platform=Platform.SIMPLEX,
+        chat_id="contact-abc",
+        chat_name="Alice",
+        chat_type="dm",
+        user_id="contact-abc",
+        user_name="Alice",
+    )
+
+    # Build a minimal runner without connecting real adapters
+    from gateway.run import GatewayRunner
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = MagicMock()
+    runner.config.get_unauthorized_dm_behavior.return_value = "pair"
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+
+    result = GatewayRunner._is_user_authorized(runner, source)
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# 6. send_message_tool routing
+# ---------------------------------------------------------------------------
+
+def test_simplex_in_send_message_platform_map():
+    from tools.send_message_tool import send_message_tool
+    from gateway.config import Platform
+    import importlib, inspect
+
+    # Just verify Platform.SIMPLEX would resolve in the map
+    from gateway.config import Platform
+    assert hasattr(Platform, "SIMPLEX")
+
+
+# ---------------------------------------------------------------------------
+# 7. Helper functions
+# ---------------------------------------------------------------------------
+
+def test_guess_extension_png():
+    from gateway.platforms.simplex import _guess_extension
+    assert _guess_extension(b"\x89PNG\r\n\x1a\n") == ".png"
+
+
+def test_guess_extension_jpg():
+    from gateway.platforms.simplex import _guess_extension
+    assert _guess_extension(b"\xff\xd8\xff\xe0") == ".jpg"
+
+
+def test_guess_extension_ogg():
+    from gateway.platforms.simplex import _guess_extension
+    assert _guess_extension(b"OggS\x00\x02") == ".ogg"
+
+
+def test_guess_extension_unknown():
+    from gateway.platforms.simplex import _guess_extension
+    assert _guess_extension(b"\x00\x01\x02\x03") == ".bin"
+
+
+def test_is_image_ext():
+    from gateway.platforms.simplex import _is_image_ext
+    assert _is_image_ext(".png") is True
+    assert _is_image_ext(".webp") is True
+    assert _is_image_ext(".ogg") is False
+
+
+def test_is_audio_ext():
+    from gateway.platforms.simplex import _is_audio_ext
+    assert _is_audio_ext(".ogg") is True
+    assert _is_audio_ext(".mp3") is True
+    assert _is_audio_ext(".pdf") is False
+
+
+# ---------------------------------------------------------------------------
+# 8. _make_corr_id
+# ---------------------------------------------------------------------------
+
+def test_corr_id_starts_with_hermes():
+    from gateway.config import PlatformConfig
+    from gateway.platforms.simplex import SimplexAdapter, _CORR_PREFIX
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    corr_id = adapter._make_corr_id()
+
+    assert corr_id.startswith(_CORR_PREFIX)
+    assert corr_id in adapter._pending_corr_ids
+
+
+# ---------------------------------------------------------------------------
+# 9. Message sending (mock WS)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_dm():
+    from gateway.config import PlatformConfig
+    from gateway.platforms.simplex import SimplexAdapter
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    mock_ws = AsyncMock()
+    adapter._ws = mock_ws
+
+    result = await adapter.send("contact-42", "Hello, SimpleX!")
+
+    mock_ws.send.assert_called_once()
+    sent = mock_ws.send.call_args[0][0]
+    import json
+    payload = json.loads(sent)
+    assert "@[contact-42] Hello, SimpleX!" in payload["cmd"]
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_send_group():
+    from gateway.config import PlatformConfig
+    from gateway.platforms.simplex import SimplexAdapter
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    mock_ws = AsyncMock()
+    adapter._ws = mock_ws
+
+    result = await adapter.send("group:grp-99", "Hello, group!")
+
+    sent = mock_ws.send.call_args[0][0]
+    import json
+    payload = json.loads(sent)
+    assert "#[grp-99] Hello, group!" in payload["cmd"]
+    assert result.success is True

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -124,6 +124,7 @@ def _handle_send(args):
         "slack": Platform.SLACK,
         "whatsapp": Platform.WHATSAPP,
         "signal": Platform.SIGNAL,
+        "simplex": Platform.SIMPLEX,
         "matrix": Platform.MATRIX,
         "mattermost": Platform.MATTERMOST,
         "homeassistant": Platform.HOMEASSISTANT,
@@ -339,6 +340,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
             result = await _send_signal(pconfig.extra, chat_id, chunk)
+        elif platform == Platform.SIMPLEX:
+            result = await _send_simplex(pconfig.extra, chat_id, chunk)
         elif platform == Platform.EMAIL:
             result = await _send_email(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SMS:
@@ -582,6 +585,37 @@ async def _send_signal(extra, chat_id, message):
             return {"success": True, "platform": "signal", "chat_id": chat_id}
     except Exception as e:
         return {"error": f"Signal send failed: {e}"}
+
+
+async def _send_simplex(extra, chat_id, message):
+    """Send via simplex-chat daemon WebSocket API (one-shot)."""
+    try:
+        import websockets.client as _wsclient
+    except ImportError:
+        return {"error": "websockets not installed. Run: pip install websockets"}
+
+    try:
+        ws_url = extra.get("ws_url", "ws://127.0.0.1:5225")
+
+        if chat_id.startswith("group:"):
+            group_id = chat_id[6:]
+            cmd_str = f"#[{group_id}] {message}"
+        else:
+            cmd_str = f"@[{chat_id}] {message}"
+
+        payload = {
+            "corrId": f"hermes-snd-{int(time.time() * 1000)}",
+            "cmd": cmd_str,
+        }
+
+        async with _wsclient.connect(ws_url, open_timeout=10, close_timeout=5) as ws:
+            await ws.send(json.dumps(payload))
+            # Give daemon a moment to process; we don't wait for a response
+            await asyncio.sleep(0.5)
+
+        return {"success": True, "platform": "simplex", "chat_id": chat_id}
+    except Exception as e:
+        return {"error": f"SimpleX send failed: {e}"}
 
 
 async def _send_email(extra, chat_id, message):

--- a/toolsets.py
+++ b/toolsets.py
@@ -285,6 +285,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-simplex": {
+        "description": "SimpleX Chat bot toolset - private, decentralised messaging (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-homeassistant": {
         "description": "Home Assistant bot toolset - smart home event monitoring and control",
         "tools": _HERMES_CORE_TOOLS,
@@ -306,7 +312,7 @@ TOOLSETS = {
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-simplex", "hermes-homeassistant", "hermes-email", "hermes-sms"]
     }
 }
 

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -1,0 +1,99 @@
+# SimpleX Chat
+
+[SimpleX Chat](https://simplex.chat/) is a private, decentralised messaging platform where users own their contacts and groups. Unlike other platforms, SimpleX assigns no persistent user IDs — every contact is identified by an opaque internal ID generated at connection time, which makes it one of the most private messengers available.
+
+## Prerequisites
+
+- The **simplex-chat** CLI installed and running as a daemon
+- Python package **websockets** (`pip install websockets`)
+
+## Install simplex-chat
+
+Download the latest release from the [simplex-chat GitHub releases](https://github.com/simplex-chat/simplex-chat/releases) page, or via Docker:
+
+```bash
+# Linux / macOS binary
+curl -L https://github.com/simplex-chat/simplex-chat/releases/latest/download/simplex-chat-ubuntu-22_04-x86-64 -o simplex-chat
+chmod +x simplex-chat
+
+# Or Docker
+docker run -p 5225:5225 simplexchat/simplex-chat -p 5225
+```
+
+## Start the daemon
+
+```bash
+simplex-chat -p 5225
+```
+
+The daemon listens on WebSocket at `ws://127.0.0.1:5225` by default.
+
+## Configure Hermes
+
+### Via setup wizard
+
+```bash
+hermes setup gateway
+```
+
+Select **SimpleX Chat** and follow the prompts.
+
+### Via environment variables
+
+Add these to `~/.hermes/.env`:
+
+```
+SIMPLEX_WS_URL=ws://127.0.0.1:5225
+SIMPLEX_ALLOWED_USERS=<contact-id-1>,<contact-id-2>
+SIMPLEX_HOME_CHANNEL=<contact-id>
+```
+
+| Variable | Required | Description |
+|---|---|---|
+| `SIMPLEX_WS_URL` | Yes | WebSocket URL of the simplex-chat daemon |
+| `SIMPLEX_ALLOWED_USERS` | Recommended | Comma-separated contact IDs allowed to use the agent |
+| `SIMPLEX_ALLOW_ALL_USERS` | Optional | Set `true` to allow every contact (use carefully) |
+| `SIMPLEX_HOME_CHANNEL` | Optional | Default contact ID for cron job delivery |
+| `SIMPLEX_HOME_CHANNEL_NAME` | Optional | Human label for the home channel |
+
+## Find your contact ID
+
+After starting the daemon, open a conversation with your agent contact. The contact ID will appear in session logs or via `hermes send_message action=list`.
+
+## Authorization
+
+By default **all contacts are denied**. You must either:
+
+1. Set `SIMPLEX_ALLOWED_USERS` to a comma-separated list of contact IDs, or
+2. Use **DM pairing** — send any message to the bot and it will reply with a pairing code. Enter that code via `hermes gateway pair`.
+
+## Using SimpleX with cron jobs
+
+```python
+cronjob(
+    action="create",
+    schedule="every 1h",
+    deliver="simplex",          # uses SIMPLEX_HOME_CHANNEL
+    prompt="Check for alerts and summarise."
+)
+```
+
+Or target a specific contact:
+
+```python
+send_message(target="simplex:<contact-id>", message="Done!")
+```
+
+## Privacy notes
+
+- SimpleX never reveals phone numbers or email addresses — contacts use opaque IDs
+- The connection between Hermes and the daemon is local WebSocket (`ws://127.0.0.1:5225`) — no data leaves your machine
+- Messages are end-to-end encrypted by the SimpleX protocol before reaching the daemon
+
+## Troubleshooting
+
+**"Cannot reach daemon"** — Ensure `simplex-chat -p 5225` is running and the port matches `SIMPLEX_WS_URL`.
+
+**"websockets not installed"** — Run `pip install websockets` or `pip install 'hermes-agent[simplex]'`.
+
+**Messages not received** — Check that the contact's ID is in `SIMPLEX_ALLOWED_USERS` or approve them via DM pairing.


### PR DESCRIPTION
Closes #2557

Adds full SimpleX Chat support as a gateway messaging platform. SimpleX is a private, decentralised messenger with no persistent user IDs — a natural complement to the existing Signal adapter.

SimpleX runs a local simplex-chat daemon that exposes a WebSocket API. Hermes connects to it, listens for inbound messages, and sends replies.

## Changes

Core adapter (gateway/platforms/simplex.py):
- Persistent WebSocket connection to the simplex-chat daemon (-p 5225)
- Reconnect loop with exponential backoff + 20% jitter
- Health monitor that force-reconnects on stale connections
- Inbound: handles newChatItem / newChatItems events for DMs and groups
- Outbound: sends @[contact-id] / #[group-id] commands via WS
- File attachment support with local cache (image/audio/document)
- Filters own echoes via corrId prefix
- Requires: pip install websockets

All 16 ADDING_A_PLATFORM.md touch points covered:
- gateway/config.py — Platform.SIMPLEX enum + env var loading
- gateway/run.py — _create_adapter() factory + both auth allowlist maps
- agent/prompt_builder.py — PLATFORM_HINTS["simplex"]
- toolsets.py — hermes-simplex toolset + hermes-gateway include
- cron/scheduler.py — platform_map entry
- tools/send_message_tool.py — platform_map + _send_simplex() standalone fn
- gateway/channel_directory.py — session-based contact discovery
- hermes_cli/status.py — status display
- hermes_cli/gateway.py — _PLATFORMS entry + _setup_simplex() wizard
- website/docs/user-guide/messaging/simplex.md — setup guide
- tests/gateway/test_simplex.py — test suite

Environment variables:
  SIMPLEX_WS_URL             WebSocket URL (default ws://127.0.0.1:5225)
  SIMPLEX_ALLOWED_USERS      Comma-separated allowed contact IDs
  SIMPLEX_ALLOW_ALL_USERS    Set true to allow all contacts
  SIMPLEX_HOME_CHANNEL       Default contact for cron delivery
  SIMPLEX_HOME_CHANNEL_NAME  Human label for home channel

Quick start:
  simplex-chat -p 5225
  hermes setup gateway   # select SimpleX Chat

Tests:
  python -m pytest tests/gateway/test_simplex.py -v
