### PR TITLE
Fix Codex think-only responses being treated as empty final answers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3064,6 +3064,7 @@ class AIAgent:
             out_text = getattr(response, "output_text", "")
             if isinstance(out_text, str):
                 final_text = out_text.strip()
+        visible_final_text = self._strip_think_blocks(final_text).strip() if final_text else ""
 
         assistant_message = SimpleNamespace(
             content=final_text,
@@ -3078,13 +3079,19 @@ class AIAgent:
             finish_reason = "tool_calls"
         elif has_incomplete_items or (saw_commentary_phase and not saw_final_answer_phase):
             finish_reason = "incomplete"
-        elif reasoning_items_raw and not final_text:
+        elif reasoning_items_raw and not visible_final_text:
             # Response contains only reasoning (encrypted thinking state) with
             # no visible content or tool calls.  The model is still thinking and
             # needs another turn to produce the actual answer.  Marking this as
             # "stop" would send it into the empty-content retry loop which burns
             # 3 retries then fails — treat it as incomplete instead so the Codex
             # continuation path handles it correctly.
+            finish_reason = "incomplete"
+        elif final_text and not visible_final_text:
+            # Some Codex responses arrive as a completed message whose visible
+            # text is empty after stripping hidden <think>/<reasoning> blocks.
+            # Treat these like reasoning-only continuations instead of sending
+            # them into the empty-content retry loop.
             finish_reason = "incomplete"
         else:
             finish_reason = "stop"

--- a/tests/test_run_agent_codex_responses.py
+++ b/tests/test_run_agent_codex_responses.py
@@ -921,6 +921,62 @@ def test_run_conversation_codex_continues_after_reasoning_only_response(monkeypa
     )
 
 
+def test_normalize_codex_response_think_only_message_is_incomplete(monkeypatch):
+    """A completed Codex message containing only hidden think-block text should
+    continue instead of hitting the empty-content retry loop."""
+    agent = _build_agent(monkeypatch)
+    response = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text="<think>Internal reasoning only</think>")],
+                status="completed",
+            ),
+        ],
+        usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+        status="completed",
+        model="gpt-5-codex",
+    )
+
+    assistant_message, finish_reason = agent._normalize_codex_response(response)
+
+    assert finish_reason == "incomplete"
+    assert assistant_message.content == "<think>Internal reasoning only</think>"
+
+
+def test_run_conversation_codex_continues_after_think_only_message(monkeypatch):
+    """End-to-end: a think-only Codex message should continue to the final answer."""
+    agent = _build_agent(monkeypatch)
+    think_only = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text="<think>Inspecting...</think>")],
+                status="completed",
+            ),
+        ],
+        usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+        status="completed",
+        model="gpt-5-codex",
+    )
+    responses = [
+        think_only,
+        _codex_message_response("hi"),
+    ]
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
+
+    result = agent.run_conversation("Reply with exactly: hi")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "hi"
+    assert any(
+        msg.get("role") == "assistant"
+        and msg.get("finish_reason") == "incomplete"
+        and "Inspecting" in (msg.get("content") or "")
+        for msg in result["messages"]
+    )
+
+
 def test_run_conversation_codex_preserves_encrypted_reasoning_in_interim(monkeypatch):
     """Encrypted codex_reasoning_items must be preserved in interim messages
     even when there is no visible reasoning text or content."""


### PR DESCRIPTION
## Summary

Fixes a Codex Responses parsing edge case where Hermes could treat a completed message item as a final answer even though its visible text became empty after stripping hidden `<think>` / reasoning blocks.

That caused empty-content retry loops instead of continuing the Codex conversation to get the actual user-visible answer.

## How To Test

- Run `./venv/bin/pytest tests/test_run_agent_codex_responses.py -q`
- Verify these regressions are covered:
  - think-only completed Codex messages normalize to `finish_reason == "incomplete"`
  - a think-only Codex turn continues to a later visible final answer
- Optional broader validation:
  - Run `./venv/bin/pytest tests/ -v`

## Validation

- `./venv/bin/pytest tests/test_run_agent_codex_responses.py -q` ✅
- `./venv/bin/pytest tests/ -v` ❌
  - unrelated existing failure: `tests/test_anthropic_error_handling.py::test_429_rate_limit_is_retried_and_recovers`

## Platforms Tested

- Linux

## Notes

Hermes already handled reasoning-only Codex responses as incomplete, but could still misclassify completed message items whose content was only hidden reasoning text.
