### PR TITLE
fix(approval): honor bare YAML approvals.mode: off

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -4,6 +4,7 @@ from unittest.mock import patch as mock_patch
 
 import tools.approval as approval_module
 from tools.approval import (
+    _get_approval_mode,
     approve_session,
     clear_session,
     detect_dangerous_command,
@@ -14,6 +15,16 @@ from tools.approval import (
     prompt_dangerous_approval,
     submit_pending,
 )
+
+
+class TestApprovalModeParsing:
+    def test_unquoted_yaml_off_boolean_false_maps_to_off(self):
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"mode": False}}):
+            assert _get_approval_mode() == "off"
+
+    def test_string_off_still_maps_to_off(self):
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"mode": "off"}}):
+            assert _get_approval_mode() == "off"
 
 
 class TestDetectDangerousRm:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -277,12 +277,28 @@ def prompt_dangerous_approval(command: str, description: str,
         sys.stdout.flush()
 
 
+def _normalize_approval_mode(mode) -> str:
+    """Normalize approval mode values loaded from YAML/config.
+
+    YAML 1.1 treats bare words like `off` as booleans, so a config entry like
+    `approvals:\n  mode: off` is parsed as False unless quoted. Treat that as the
+    intended string mode instead of falling back to manual approvals.
+    """
+    if isinstance(mode, bool):
+        return "off" if mode is False else "manual"
+    if isinstance(mode, str):
+        normalized = mode.strip().lower()
+        return normalized or "manual"
+    return "manual"
+
+
 def _get_approval_mode() -> str:
     """Read the approval mode from config. Returns 'manual', 'smart', or 'off'."""
     try:
         from hermes_cli.config import load_config
         config = load_config()
-        return config.get("approvals", {}).get("mode", "manual")
+        mode = config.get("approvals", {}).get("mode", "manual")
+        return _normalize_approval_mode(mode)
     except Exception:
         return "manual"
 


### PR DESCRIPTION
Summary

Follow-up bugfix for #1543.

This fixes approval mode parsing so `approvals.mode: off` in `config.yaml` works even when YAML parses bare `off` as boolean `False`.

Problem

The approval system documents these config values:

- `manual`
- `smart`
- `off`

However, in YAML, an unquoted value like:

```yaml
approvals:
  mode: off
```

may be loaded as boolean `False` instead of the string `"off"`.

Before this patch, `_get_approval_mode()` returned the raw config value, so `False` would not behave like `"off"` and Hermes would continue prompting:

`⚠️ Dangerous command requires approval:`

What this PR changes

- adds `_normalize_approval_mode()`
- maps boolean `False` to `"off"`
- maps boolean `True` to `"manual"` as a safe fallback
- normalizes string values with `strip().lower()`
- adds regression tests for:
  - YAML-style `False` value
  - normal string `"off"`

Why this is intentionally small

This PR only fixes `approvals.mode` parsing in `tools/approval.py` and adds a focused regression test.
It does not bundle other config-normalization cleanup, even though similar YAML pitfalls may exist elsewhere.

Test Plan

Ran:

```bash
python -m pytest tests/tools/test_approval.py -q
```

Result:

```text
70 passed
```
