### PR TITLE
fix(auth): preserve 'custom' provider name instead of silently remapping to 'openrouter'

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -690,8 +690,10 @@ def resolve_provider(
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 
-    if normalized in {"openrouter", "custom"}:
+    if normalized == "openrouter":
         return "openrouter"
+    if normalized == "custom":
+        return "custom"
     if normalized in PROVIDER_REGISTRY:
         return normalized
     if normalized != "auto":

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -420,6 +420,12 @@ def resolve_runtime_provider(
         explicit_base_url=explicit_base_url,
     )
     runtime["requested_provider"] = requested_provider
+    # Preserve the user-facing provider name when "custom" was explicitly
+    # requested.  The OpenRouter runtime path handles custom base_urls
+    # correctly, but the display name should reflect what the user set in
+    # config.yaml instead of silently showing "openrouter".  (Fixes #2562)
+    if provider == "custom":
+        runtime["provider"] = "custom"
     return runtime
 
 

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -1,4 +1,5 @@
 from hermes_cli import runtime_provider as rp
+from hermes_cli.auth import resolve_provider
 
 
 def test_resolve_runtime_provider_codex(monkeypatch):
@@ -579,3 +580,84 @@ def test_named_custom_provider_anthropic_api_mode(monkeypatch):
 
     assert resolved["api_mode"] == "anthropic_messages"
     assert resolved["base_url"] == "https://proxy.example.com/anthropic"
+
+
+# ── Custom provider preservation (Fixes #2562) ────────────────────────────
+
+
+def test_custom_provider_not_remapped_to_openrouter(monkeypatch):
+    """provider: custom in config.yaml should stay 'custom', not become 'openrouter'.
+
+    Regression test for #2562: resolve_provider() silently converted 'custom'
+    to 'openrouter', causing /model to display the wrong provider name and
+    overwriting the user's config.
+    """
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "http://localhost:11434/v1",
+        },
+    )
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "http://localhost:11434/v1"
+    assert resolved["requested_provider"] == "custom"
+
+
+def test_custom_provider_uses_config_base_url(monkeypatch):
+    """Custom provider should use base_url from config.yaml."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "http://192.168.1.100:8080/v1",
+            "api_key": "local-key",
+        },
+    )
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "http://192.168.1.100:8080/v1"
+    assert resolved["api_key"] == "local-key"
+
+
+def test_openrouter_provider_still_returns_openrouter(monkeypatch):
+    """Explicit 'openrouter' should still resolve to 'openrouter' (not affected by fix)."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["provider"] == "openrouter"
+
+
+def test_resolve_provider_custom_returns_custom():
+    """resolve_provider('custom') must return 'custom', not 'openrouter'.
+
+    Regression test for #2562.
+    """
+    assert resolve_provider("custom") == "custom"
+
+
+def test_resolve_provider_openrouter_unchanged():
+    """resolve_provider('openrouter') must still return 'openrouter'."""
+    assert resolve_provider("openrouter") == "openrouter"


### PR DESCRIPTION
## Summary

When a user sets `provider: custom` in `config.yaml`, `resolve_provider()` silently converts it to `"openrouter"` (line 666 in `auth.py`). This causes:

- `/model` shows "via openrouter" instead of "via custom"  
- The provider name gets overwritten in the user's mental model and potentially in config
- No notice is given to the user about the remapping

**Root cause**: `resolve_provider()` treated `"custom"` and `"openrouter"` identically:
```python
if normalized in {"openrouter", "custom"}:
    return "openrouter"
```

**Fix**:
- Return `"custom"` from `resolve_provider()` when explicitly requested
- Preserve `"custom"` in the runtime provider dict returned by `resolve_runtime_provider()`
- The OpenRouter runtime code path still handles the actual HTTP calls — it already had full custom `base_url` support (line 235 in `runtime_provider.py`)

Closes #2562

## Changes
```
 hermes_cli/auth.py                        |  4 +-   (split the set check)
 hermes_cli/runtime_provider.py            |  6 +++  (preserve provider name)
 tests/test_runtime_provider_resolution.py | 82 +++ (5 new tests)
```

## Test plan
- [x] Verified bug exists on current main: `resolve_provider("custom")` returns `"openrouter"`
- [x] Verified no existing PRs address #2562
- [x] After fix: `resolve_provider("custom")` returns `"custom"`
- [x] After fix: `resolve_runtime_provider(requested="custom")` returns `provider: "custom"` with correct `base_url`
- [x] `resolve_provider("openrouter")` still returns `"openrouter"` (no regression)
- [x] 5 new tests: 2 for `resolve_provider()`, 3 for `resolve_runtime_provider()` custom flow
- [x] All 34 tests in `test_runtime_provider_resolution.py` pass
- [ ] Run full test suite: `pytest tests/ -x -q`