### PR TITLE
fix(auth): preserve 'custom' provider instead of silently remapping to 'openrouter'

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -690,8 +690,10 @@ def resolve_provider(
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 
-    if normalized in {"openrouter", "custom"}:
+    if normalized == "openrouter":
         return "openrouter"
+    if normalized == "custom":
+        return "custom"
     if normalized in PROVIDER_REGISTRY:
         return normalized
     if normalized != "auto":

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -420,6 +420,11 @@ def resolve_runtime_provider(
         explicit_base_url=explicit_base_url,
     )
     runtime["requested_provider"] = requested_provider
+    # Preserve the user-facing provider name when "custom" was explicitly
+    # requested.  The OpenRouter runtime path handles custom base_urls
+    # correctly, but the display name should reflect what the user set.
+    if provider == "custom":
+        runtime["provider"] = "custom"
     return runtime
 
 

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -579,3 +579,54 @@ def test_named_custom_provider_anthropic_api_mode(monkeypatch):
 
     assert resolved["api_mode"] == "anthropic_messages"
     assert resolved["base_url"] == "https://proxy.example.com/anthropic"
+
+
+# ------------------------------------------------------------------
+# fix #2562 — resolve_provider("custom") must not remap to "openrouter"
+# ------------------------------------------------------------------
+
+def test_resolve_provider_custom_returns_custom():
+    """resolve_provider('custom') must return 'custom', not 'openrouter'."""
+    from hermes_cli.auth import resolve_provider
+    assert resolve_provider("custom") == "custom"
+
+
+def test_resolve_provider_openrouter_unchanged():
+    """resolve_provider('openrouter') must still return 'openrouter'."""
+    from hermes_cli.auth import resolve_provider
+    assert resolve_provider("openrouter") == "openrouter"
+
+
+def test_resolve_runtime_provider_custom_preserves_provider_name(monkeypatch):
+    """resolve_runtime_provider(requested='custom') must return provider='custom'."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {
+        "provider": "custom",
+        "base_url": "https://my-llm.example.com/v1",
+    })
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    resolved = rp.resolve_runtime_provider(requested="custom")
+    assert resolved["provider"] == "custom", (
+        f"Expected provider='custom', got provider='{resolved['provider']}'"
+    )
+
+
+def test_resolve_runtime_provider_custom_base_url_preserved(monkeypatch):
+    """Custom base_url from config must be passed through unchanged."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {
+        "provider": "custom",
+        "base_url": "https://my-llm.example.com/v1",
+    })
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    resolved = rp.resolve_runtime_provider(requested="custom")
+    assert resolved["base_url"] == "https://my-llm.example.com/v1"
+
+
+def test_resolve_runtime_provider_openrouter_not_affected(monkeypatch):
+    """Fixing custom must not change openrouter behavior."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-or-key")
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+    assert resolved["provider"] == "openrouter"


### PR DESCRIPTION
## Problem

`resolve_provider('custom')` silently returned `'openrouter'` due to a combined set check:

```python
if normalized in {"openrouter", "custom"}:
    return "openrouter"
```

This caused:
- `/model` showing "via openrouter" when user set `provider: custom`
- `/status` showing the wrong provider
- No notice given to the user about the remapping

## Fix

Split the set check so each provider returns its own name:

```python
if normalized == "openrouter":
    return "openrouter"
if normalized == "custom":
    return "custom"
```

Also preserve `provider: custom` in the runtime dict returned by `resolve_runtime_provider()` so all display layers receive the correct name.

## What is not changed

- The OpenRouter code path continues to handle `custom` base_url requests correctly — `_resolve_openrouter_runtime()` is still called for `custom`, only the `provider` key in the returned dict changes
- Local model support via `custom` + `base_url` in config.yaml is unaffected
- `resolve_provider('openrouter')` behavior is unchanged

## Tests

5 new tests in `tests/test_runtime_provider_resolution.py`:
- `test_resolve_provider_custom_returns_custom` — verifies the core fix against the actual `resolve_provider()` function
- `test_resolve_provider_openrouter_unchanged` — regression guard
- `test_resolve_runtime_provider_custom_preserves_provider_name` — runtime dict has `provider: custom`
- `test_resolve_runtime_provider_custom_base_url_preserved` — base_url passes through correctly
- `test_resolve_runtime_provider_openrouter_not_affected` — openrouter regression guard

Fixes #2562