### PR TITLE
fix(discord): ignore system messages in on_message handler

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -531,6 +531,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 if message.author == self._client.user:
                     return
                 
+                # Ignore Discord system messages (thread renames, pins, member joins, etc.)
+                if message.type != discord.MessageType.default:
+                    return
+                
                 # Bot message filtering (DISCORD_ALLOW_BOTS):
                 #   "none"     — ignore all other bots (default)
                 #   "mentions" — accept bot messages only when they @mention us

--- a/tests/gateway/test_discord_system_messages.py
+++ b/tests/gateway/test_discord_system_messages.py
@@ -1,0 +1,100 @@
+"""Tests for Discord system message filtering (thread renames, pins, etc.)."""
+
+import unittest
+from unittest.mock import MagicMock
+
+
+def _make_author(*, bot: bool = False, is_self: bool = False):
+    """Create a mock Discord author."""
+    author = MagicMock()
+    author.bot = bot
+    author.id = 99999 if is_self else 12345
+    author.name = "TestBot" if bot else "TestUser"
+    author.display_name = author.name
+    return author
+
+
+def _make_message(*, author=None, content="hello", msg_type=None):
+    """Create a mock Discord message with a specific type."""
+    import discord
+    msg = MagicMock()
+    msg.author = author or _make_author()
+    msg.content = content
+    msg.attachments = []
+    msg.mentions = []
+    msg.type = msg_type if msg_type is not None else discord.MessageType.default
+    msg.channel = MagicMock()
+    msg.channel.id = 222
+    msg.channel.name = "test-channel"
+    msg.channel.guild = MagicMock()
+    msg.channel.guild.name = "TestServer"
+    return msg
+
+
+class TestDiscordSystemMessageFilter(unittest.TestCase):
+    """Test that Discord system messages (thread renames, pins, etc.) are ignored."""
+
+    def _run_filter(self, message, client_user=None):
+        """Simulate the on_message filter logic and return whether message was accepted.
+
+        Replicates the guard added to discord.py:
+            if message.type != discord.MessageType.default:
+                return  # ignored
+        """
+        import discord
+        # Own messages always ignored
+        if message.author == client_user:
+            return False
+
+        # System message filter (the fix being tested)
+        if message.type != discord.MessageType.default:
+            return False
+
+        return True  # message accepted
+
+    def test_default_messages_accepted(self):
+        """Regular user messages (type=default) should be accepted."""
+        import discord
+        msg = _make_message(msg_type=discord.MessageType.default)
+        self.assertTrue(self._run_filter(msg))
+
+    def test_thread_rename_ignored(self):
+        """Thread rename system messages should be ignored."""
+        import discord
+        msg = _make_message(msg_type=discord.MessageType.channel_name_change)
+        self.assertFalse(self._run_filter(msg))
+
+    def test_pins_add_ignored(self):
+        """Pin notifications should be ignored."""
+        import discord
+        msg = _make_message(msg_type=discord.MessageType.pins_add)
+        self.assertFalse(self._run_filter(msg))
+
+    def test_new_member_ignored(self):
+        """New member join messages should be ignored."""
+        import discord
+        msg = _make_message(msg_type=discord.MessageType.new_member)
+        self.assertFalse(self._run_filter(msg))
+
+    def test_premium_guild_subscription_ignored(self):
+        """Boost messages should be ignored."""
+        import discord
+        msg = _make_message(msg_type=discord.MessageType.premium_guild_subscription)
+        self.assertFalse(self._run_filter(msg))
+
+    def test_recipient_add_ignored(self):
+        """Group DM recipient add messages should be ignored."""
+        import discord
+        msg = _make_message(msg_type=discord.MessageType.recipient_add)
+        self.assertFalse(self._run_filter(msg))
+
+    def test_own_default_messages_still_ignored(self):
+        """Bot's own messages should still be ignored even if type is default."""
+        import discord
+        bot_user = _make_author(is_self=True)
+        msg = _make_message(author=bot_user, msg_type=discord.MessageType.default)
+        self.assertFalse(self._run_filter(msg, client_user=bot_user))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Fixes the Discord gateway responding to thread rename events, pin notifications, member joins, boost messages, and other Discord system messages as if they were regular user messages.

When a user renames a Discord thread, Discord fires an `on_message` event with `message.type = channel_name_change` instead of `default`. The bot's `on_message` handler had no type check, so it treated the rename text as a user message and generated a response.

## Related Issue

N/A — straightforward bug fix discovered in production.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/discord.py`: Added early return in `on_message` when `message.type != discord.MessageType.default` — filters out all Discord system messages (thread renames, pins, member joins, boosts, etc.)
- `tests/gateway/test_discord_system_messages.py`: Added test suite covering system message filtering for multiple Discord message types

## How to Test

1. Deploy the gateway with the fix
2. Create or enter a Discord thread where the bot is active
3. Rename the thread
4. Observe that the bot does NOT respond to the rename event
5. Send a normal message — bot responds as expected

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (production Discord gateway)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Tested live on a production Discord server. Thread renames no longer trigger bot responses. Regular messages continue working normally.