### PR TITLE
fix: platform default toolsets silently override tool deselection in `hermes tools`

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -437,15 +437,21 @@ def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[
     plugin_keys = _get_plugin_toolset_keys()
     configurable_keys |= plugin_keys
 
+    # Also exclude platform default toolsets (hermes-cli, hermes-telegram, etc.)
+    # These are "super" toolsets that resolve to ALL tools, so preserving them
+    # would silently override the user's unchecked selections on the next read.
+    platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}
+
     # Get existing toolsets for this platform
     existing_toolsets = config.get("platform_toolsets", {}).get(platform, [])
     if not isinstance(existing_toolsets, list):
         existing_toolsets = []
 
-    # Preserve any entries that are NOT configurable toolsets (i.e. MCP server names)
+    # Preserve any entries that are NOT configurable toolsets and NOT platform
+    # defaults (i.e. only MCP server names should be preserved)
     preserved_entries = {
         entry for entry in existing_toolsets
-        if entry not in configurable_keys
+        if entry not in configurable_keys and entry not in platform_default_keys
     }
 
     # Merge preserved entries with new enabled toolsets

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -100,3 +100,107 @@ def test_save_platform_tools_handles_invalid_existing_config():
 
     saved_toolsets = config["platform_toolsets"]["cli"]
     assert "web" in saved_toolsets
+
+
+def test_save_platform_tools_does_not_preserve_platform_default_toolsets():
+    """Platform default toolsets (hermes-cli, hermes-telegram, etc.) must NOT
+    be preserved across saves.
+
+    These "super" toolsets resolve to ALL tools, so if they survive in the
+    config, they silently override any tools the user unchecked. Previously,
+    the preserve filter only excluded configurable toolset keys (web, browser,
+    terminal, etc.) and treated platform defaults as unknown custom entries
+    (like MCP server names), causing them to be kept unconditionally.
+
+    Regression test: user unchecks image_gen and homeassistant via
+    ``hermes tools``, but hermes-cli stays in the config and re-enables
+    everything on the next read.
+    """
+    config = {
+        "platform_toolsets": {
+            "cli": [
+                "browser", "clarify", "code_execution", "cronjob",
+                "delegation", "file", "hermes-cli",  # <-- the culprit
+                "memory", "session_search", "skills", "terminal",
+                "todo", "tts", "vision", "web",
+            ]
+        }
+    }
+
+    # User unchecks image_gen, homeassistant, moa — keeps the rest
+    new_selection = {
+        "browser", "clarify", "code_execution", "cronjob",
+        "delegation", "file", "memory", "session_search",
+        "skills", "terminal", "todo", "tts", "vision", "web",
+    }
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", new_selection)
+
+    saved = config["platform_toolsets"]["cli"]
+
+    # hermes-cli must NOT survive — it's a platform default, not an MCP server
+    assert "hermes-cli" not in saved
+
+    # The individual toolset keys the user selected must be present
+    assert "web" in saved
+    assert "terminal" in saved
+    assert "browser" in saved
+
+    # Tools the user unchecked must NOT be present
+    assert "image_gen" not in saved
+    assert "homeassistant" not in saved
+    assert "moa" not in saved
+
+
+def test_save_platform_tools_does_not_preserve_hermes_telegram():
+    """Same bug for Telegram — hermes-telegram must not be preserved."""
+    config = {
+        "platform_toolsets": {
+            "telegram": [
+                "browser", "file", "hermes-telegram", "terminal", "web",
+            ]
+        }
+    }
+
+    new_selection = {"browser", "file", "terminal", "web"}
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "telegram", new_selection)
+
+    saved = config["platform_toolsets"]["telegram"]
+    assert "hermes-telegram" not in saved
+    assert "web" in saved
+
+
+def test_save_platform_tools_still_preserves_mcp_with_platform_default_present():
+    """MCP server names must still be preserved even when platform defaults
+    are being stripped out."""
+    config = {
+        "platform_toolsets": {
+            "cli": [
+                "web", "terminal", "hermes-cli", "my-mcp-server", "github-tools",
+            ]
+        }
+    }
+
+    new_selection = {"web", "browser"}
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", new_selection)
+
+    saved = config["platform_toolsets"]["cli"]
+
+    # MCP servers preserved
+    assert "my-mcp-server" in saved
+    assert "github-tools" in saved
+
+    # Platform default stripped
+    assert "hermes-cli" not in saved
+
+    # User selections present
+    assert "web" in saved
+    assert "browser" in saved
+
+    # Deselected configurable toolset removed
+    assert "terminal" not in saved


### PR DESCRIPTION
## Bug

When users uncheck tools via `hermes tools` (e.g. disabling Home Assistant, Image Generation, or Mixture of Agents), the changes **do not persist**. The unchecked tools reappear as enabled on the next read/session.

## Root Cause

`_save_platform_tools()` in `hermes_cli/tools_config.py` preserves config entries that are not in the configurable toolset keys set — this is designed to keep MCP server names intact across saves.

However, **platform default toolsets** like `hermes-cli` and `hermes-telegram` are not in the configurable keys set either. So they get preserved as if they were custom MCP entries. Since these are "super" toolsets that resolve to `_HERMES_CORE_TOOLS` (which contains **every** tool), they silently re-enable everything the user unchecked.

### Reproduction

1. Run `hermes tools`
2. Select CLI platform
3. Uncheck "Home Assistant", "Image Generation", or "Mixture of Agents"
4. Press Enter to confirm
5. Run `hermes tools` again — the unchecked tools are back

### Config before fix
```yaml
platform_toolsets:
  cli:
  - browser
  - clarify
  - file
  - hermes-cli    # ← this resolves to ALL tools, overriding deselections
  - terminal
  - web
```

## Fix

Exclude platform default toolset names (collected from `PLATFORMS[*]["default_toolset"]`) from the preserved entries filter, so only genuine MCP server names survive across saves.

**2 files changed, 112 insertions, 2 deletions:**
- `hermes_cli/tools_config.py` — 8-line fix in `_save_platform_tools()`
- `tests/hermes_cli/test_tools_config.py` — 3 regression tests

## Tests

All 10 tests pass (7 existing + 3 new):

```
tests/hermes_cli/test_tools_config.py::test_save_platform_tools_does_not_preserve_platform_default_toolsets PASSED
tests/hermes_cli/test_tools_config.py::test_save_platform_tools_does_not_preserve_hermes_telegram PASSED
tests/hermes_cli/test_tools_config.py::test_save_platform_tools_still_preserves_mcp_with_platform_default_present PASSED
```

### Note for existing users
Users who already have `hermes-cli` / `hermes-telegram` in their `config.yaml` will need to either:
- Re-run `hermes tools` and re-save (the fix prevents it from being re-added), or
- Manually remove the `hermes-cli` / `hermes-telegram` entries from `platform_toolsets` in `~/.hermes/config.yaml`