### PR TITLE
fix(gateway): auto-include plugin toolsets when platform_toolsets is configured

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3547,6 +3547,22 @@ class GatewayRunner:
             else:
                 default_toolset = default_toolset_map.get(source.platform, "hermes-telegram")
                 enabled_toolsets = [default_toolset]
+            # Auto-include plugin toolsets that are new (not yet known for this
+            # platform). Mirrors the logic in _get_platform_tools() so gateway
+            # platforms behave consistently with the CLI.
+            try:
+                from hermes_cli.tools_config import _get_plugin_toolset_keys
+                from hermes_cli.config import load_config as _load_cfg
+                _plugin_ts = _get_plugin_toolset_keys()
+                if _plugin_ts:
+                    _cfg = _load_cfg()
+                    _known = set(_cfg.get('known_plugin_toolsets', {}).get(platform_config_key, []))
+                    _to_add = [pts for pts in _plugin_ts
+                               if pts not in enabled_toolsets and pts not in _known]
+                    if _to_add:
+                        enabled_toolsets = list(enabled_toolsets) + _to_add
+            except Exception:
+                pass
 
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
 
@@ -4711,6 +4727,22 @@ class GatewayRunner:
         else:
             default_toolset = default_toolset_map.get(source.platform, "hermes-telegram")
             enabled_toolsets = [default_toolset]
+        # Auto-include plugin toolsets that are new (not yet known for this
+        # platform). Mirrors the logic in _get_platform_tools() so gateway
+        # platforms behave consistently with the CLI.
+        try:
+            from hermes_cli.tools_config import _get_plugin_toolset_keys
+            from hermes_cli.config import load_config as _load_cfg
+            _plugin_ts = _get_plugin_toolset_keys()
+            if _plugin_ts:
+                _cfg = _load_cfg()
+                _known = set(_cfg.get('known_plugin_toolsets', {}).get(platform_config_key, []))
+                _to_add = [pts for pts in _plugin_ts
+                           if pts not in enabled_toolsets and pts not in _known]
+                if _to_add:
+                    enabled_toolsets = list(enabled_toolsets) + _to_add
+        except Exception:
+            pass
         
         # Tool progress mode from config.yaml: "all", "new", "verbose", "off"
         # Falls back to env vars for backward compatibility

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -371,3 +371,135 @@ class TestPluginManagerList:
 # in PluginContext (hermes_cli/plugins.py).  The tests referenced _plugin_commands,
 # commands_registered, get_plugin_command_handler, and GATEWAY_KNOWN_COMMANDS
 # integration — all of which are unimplemented features.
+
+
+class TestPluginToolsetGatewayAutoInclude:
+    """Gateway must auto-include plugin toolsets not yet known for a platform."""
+
+    def test_new_plugin_toolset_added_to_enabled_toolsets(self, monkeypatch):
+        """Simulate the gateway logic: new plugin toolset gets appended."""
+        import yaml
+        from hermes_cli.tools_config import _get_plugin_toolset_keys
+
+        # Simulate: enabled_toolsets from config (no plugin toolset listed)
+        enabled_toolsets = ["browser", "terminal"]
+        platform_config_key = "telegram"
+
+        # Mock _get_plugin_toolset_keys to return a plugin toolset
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_plugin_toolset_keys",
+            lambda: {"acp"},
+        )
+
+        # Simulate the gateway logic we added
+        from hermes_cli.tools_config import _get_plugin_toolset_keys as _gptk
+        _plugin_ts = _gptk()
+        _known = set()  # not yet known for this platform
+        _to_add = [pts for pts in _plugin_ts
+                   if pts not in enabled_toolsets and pts not in _known]
+        if _to_add:
+            enabled_toolsets = list(enabled_toolsets) + _to_add
+
+        assert "acp" in enabled_toolsets
+        assert "browser" in enabled_toolsets
+        assert "terminal" in enabled_toolsets
+
+    def test_known_disabled_plugin_toolset_not_added(self, monkeypatch):
+        """Plugin toolset known-but-absent for a platform must stay disabled."""
+        enabled_toolsets = ["browser", "terminal"]
+        platform_config_key = "telegram"
+
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_plugin_toolset_keys",
+            lambda: {"acp"},
+        )
+
+        from hermes_cli.tools_config import _get_plugin_toolset_keys as _gptk
+        _plugin_ts = _gptk()
+        _known = {"acp"}  # user previously disabled it via hermes tools
+        _to_add = [pts for pts in _plugin_ts
+                   if pts not in enabled_toolsets and pts not in _known]
+        if _to_add:
+            enabled_toolsets = list(enabled_toolsets) + _to_add
+
+        assert "acp" not in enabled_toolsets
+
+    def test_explicitly_listed_plugin_toolset_not_duplicated(self, monkeypatch):
+        """Plugin toolset already in enabled_toolsets must not be duplicated."""
+        enabled_toolsets = ["browser", "acp"]
+        platform_config_key = "telegram"
+
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_plugin_toolset_keys",
+            lambda: {"acp"},
+        )
+
+        from hermes_cli.tools_config import _get_plugin_toolset_keys as _gptk
+        _plugin_ts = _gptk()
+        _known = set()
+        _to_add = [pts for pts in _plugin_ts
+                   if pts not in enabled_toolsets and pts not in _known]
+        if _to_add:
+            enabled_toolsets = list(enabled_toolsets) + _to_add
+
+        assert enabled_toolsets.count("acp") == 1
+
+
+class TestPluginToolsetGatewayAutoInclude:
+    """_get_platform_tools() must auto-include new plugin toolsets.
+
+    Mirrors the gateway fix: when platform_toolsets is configured,
+    plugin toolsets not yet known for a platform are appended automatically.
+    """
+
+    def _make_plugin(self, tmp_path, monkeypatch):
+        import yaml
+        import hermes_cli.plugins as plugins_mod
+        from hermes_cli.plugins import PluginManager
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "auto_ts_plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({"name": "auto_ts_plugin"}))
+        init_code = (
+            "def register(ctx):\n"
+            "    ctx.register_tool(\n"
+            "        name=\"auto_ts_tool\",\n"
+            "        toolset=\"test_plugin_ts\",\n"
+            "        schema={\"name\": \"auto_ts_tool\", \"description\": \"Test\","
+            " \"parameters\": {\"type\": \"object\", \"properties\": {}}},\n"
+            "        handler=lambda args, **kw: \"ok\",\n"
+            "    )\n"
+        )
+        (plugin_dir / "__init__.py").write_text(init_code)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+        mgr = PluginManager()
+        mgr.discover_and_load()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+
+    def test_new_plugin_toolset_auto_included_for_cli(self, tmp_path, monkeypatch):
+        """New plugin toolset is auto-included when not yet known for CLI."""
+        self._make_plugin(tmp_path, monkeypatch)
+        from hermes_cli.tools_config import _get_platform_tools
+        config = {"platform_toolsets": {"cli": ["terminal"]}}
+        result = _get_platform_tools(config, "cli")
+        assert "test_plugin_ts" in result
+        assert "terminal" in result
+
+    def test_known_disabled_plugin_toolset_not_included(self, tmp_path, monkeypatch):
+        """Plugin toolset known-but-absent for platform stays disabled."""
+        self._make_plugin(tmp_path, monkeypatch)
+        from hermes_cli.tools_config import _get_platform_tools
+        config = {
+            "platform_toolsets": {"cli": ["terminal"]},
+            "known_plugin_toolsets": {"cli": ["test_plugin_ts"]},
+        }
+        result = _get_platform_tools(config, "cli")
+        assert "test_plugin_ts" not in result
+
+    def test_explicitly_listed_plugin_toolset_not_duplicated(self, tmp_path, monkeypatch):
+        """Plugin toolset already in platform_toolsets is not duplicated."""
+        self._make_plugin(tmp_path, monkeypatch)
+        from hermes_cli.tools_config import _get_platform_tools
+        config = {"platform_toolsets": {"cli": ["terminal", "test_plugin_ts"]}}
+        result = _get_platform_tools(config, "cli")
+        assert list(result).count("test_plugin_ts") == 1


### PR DESCRIPTION
## Problem

When `platform_toolsets` is configured in `config.yaml`, `enabled_toolsets` acts as a strict whitelist. Plugin toolsets registered under a new name (e.g. `acp`) were never included unless the user manually added them to `platform_toolsets` for each platform — defeating the 'no source code changes required' promise of the plugin architecture (originally designed in PR #1555).

## Root Cause

The CLI correctly handles this via `_get_platform_tools()` in `tools_config.py`, which auto-includes new plugin toolsets not yet known for a platform. The gateway was resolving `platform_toolsets` directly without this logic, causing an inconsistency between CLI and gateway behavior.

## Fix

After resolving `enabled_toolsets` in both gateway agent execution paths, append any plugin toolsets that are new (not yet tracked in `known_plugin_toolsets` for that platform). Plugin toolsets that the user has previously seen and disabled via `hermes tools` are respected — the fix only applies to toolsets not yet known for a platform.

This mirrors the existing `_get_platform_tools()` logic exactly, bringing gateway behavior in line with the CLI.

## What is not changed

- No changes to `model_tools.py` or the toolset filter logic
- Plugin toolsets explicitly disabled by the user (tracked via `known_plugin_toolsets`) remain disabled
- All existing toolset behavior is unchanged

## Tests

3 new tests in `tests/test_plugins.py` using the actual `_get_platform_tools()` function:
- `test_new_plugin_toolset_auto_included_for_cli` — new plugin toolset is auto-included
- `test_known_disabled_plugin_toolset_not_included` — user-disabled plugin stays disabled
- `test_explicitly_listed_plugin_toolset_not_duplicated` — no duplication when already listed

Fixes #2574