### PR TITLE
fix: preserve runtime credentials in background review fork

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1386,6 +1386,11 @@ class AIAgent:
                         quiet_mode=True,
                         platform=self.platform,
                         provider=self.provider,
+                        api_key=self.api_key,
+                        base_url=self.base_url,
+                        api_mode=self.api_mode,
+                        acp_command=self.acp_command,
+                        acp_args=list(self.acp_args or []),
                     )
                     review_agent._memory_store = self._memory_store
                     review_agent._memory_enabled = self._memory_enabled

--- a/tests/test_background_review_runtime.py
+++ b/tests/test_background_review_runtime.py
@@ -1,0 +1,60 @@
+"""Regression tests for background review agent runtime inheritance."""
+
+import threading
+
+from run_agent import AIAgent
+
+
+class _ImmediateThread:
+    def __init__(self, target=None, daemon=None, name=None):
+        self._target = target
+
+    def start(self):
+        if self._target is not None:
+            self._target()
+
+
+def test_background_review_inherits_runtime(monkeypatch):
+    captured = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured["init"] = kwargs
+            self._memory_store = None
+            self._memory_enabled = False
+            self._user_profile_enabled = False
+            self._memory_nudge_interval = 99
+            self._skill_nudge_interval = 99
+
+        def run_conversation(self, user_message, conversation_history):
+            captured["run"] = {
+                "user_message": user_message,
+                "conversation_history": conversation_history,
+            }
+
+    monkeypatch.setattr("run_agent.AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = "qwen3.5-9b-local"
+    agent.platform = "cli"
+    agent.provider = "openrouter"
+    agent.api_key = "sk-doodles"
+    agent.base_url = "https://litellm.ferret-beta.ts.net/v1"
+    agent.api_mode = "chat_completions"
+    agent.acp_command = None
+    agent.acp_args = []
+    agent._memory_store = object()
+    agent._memory_enabled = True
+    agent._user_profile_enabled = True
+
+    messages = [{"role": "user", "content": "hello"}]
+    agent._spawn_background_review(messages_snapshot=messages, review_memory=True, review_skills=False)
+
+    assert captured["init"]["model"] == "qwen3.5-9b-local"
+    assert captured["init"]["provider"] == "openrouter"
+    assert captured["init"]["api_key"] == "sk-doodles"
+    assert captured["init"]["base_url"] == "https://litellm.ferret-beta.ts.net/v1"
+    assert captured["init"]["api_mode"] == "chat_completions"
+    assert captured["run"]["conversation_history"] == messages
+    assert "memory" in captured["run"]["user_message"].lower()


### PR DESCRIPTION
## Summary
- pass the active runtime credentials into the background memory/skill review agent
- keep the review fork on the same endpoint and auth as the main agent
- add a regression test covering custom OpenAI-compatible endpoints

## Root cause
The background review fork only inherited `model` and `provider`. For custom OpenAI-compatible routes like Local Qwen, Hermes stores the transport provider as `openrouter`, so the fork would fall back to `https://openrouter.ai/api/v1` with no API key.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=/home/mark/.hermes/hermes-agent-bg-review /home/mark/.hermes/hermes-agent/venv/bin/pytest -c /dev/null /home/mark/.hermes/hermes-agent-bg-review/tests/test_background_review_runtime.py -q`
- `python -m py_compile /home/mark/.hermes/hermes-agent-bg-review/run_agent.py`