### PR TITLE
fix: media delivery fails for file paths containing spaces

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -721,7 +721,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:\s+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -765,7 +765,7 @@ class BasePlatformAdapter(ABC):
         #             and relative paths (./foo.png)
         # (?:~/|/)    anchors to absolute or home-relative paths
         path_re = re.compile(
-            r'(?<![/:\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:' + ext_part + r')\b',
+            r'(?<![/:\w.])(?:~/|/)(?:[\w.\- ]+/)*[\w.\- ]+\.(?:' + ext_part + r')\b',
             re.IGNORECASE,
         )
 


### PR DESCRIPTION
## Summary
- **`extract_media`**: The `MEDIA:<path>` regex used `\S+` as the unquoted-path fallback, which truncated paths at the first space (e.g. `MEDIA:/mnt/c/Users/Desktop/hello world.jpg` matched only up to `hello`). Added a new alternative that matches absolute paths containing spaces, anchored to a known media file extension, before falling back to `\S+`.
- **`extract_local_files`**: The bare-path regex used `[\w.\-]+` for path segments, excluding spaces. Changed to `[\w.\- ]+` so paths like `/mnt/c/Users/Desktop/hello world.jpg` are matched in full and validated by `os.path.isfile()`.

## Reproduction
1. Have a file with spaces in its name (e.g. `hello world.jpg`)
2. Model responds with `MEDIA:/path/to/hello world.jpg`
3. Gateway truncates path to `/path/to/hello` → "File not found"

## Test plan
- [x] `MEDIA:/path/no-spaces.jpg` still works (no regression)
- [x] `MEDIA:/path/with spaces/file.jpg` now matches full path
- [x] Quoted paths (`MEDIA:"/path/with spaces/file.jpg"`) still work
- [x] `extract_local_files` matches bare paths with spaces
- [x] URLs like `https://example.com/img.png` are NOT matched by `extract_local_files`
- [x] Tested end-to-end: Telegram gateway successfully delivered files with spaces in name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
