### PR TITLE
fix(fallback): pass base_url and api_key_env to resolve_provider_client

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2430,6 +2430,8 @@ class GatewayRunner:
                 try:
                     if _err_body is not None:
                         _err_json = _err_body.json().get("error", {})
+                        if not isinstance(_err_json, dict):
+                            _err_json = {}
                 except Exception:
                     pass
                 if _err_json.get("type") == "usage_limit_reached":

--- a/run_agent.py
+++ b/run_agent.py
@@ -3791,8 +3791,12 @@ class AIAgent:
         # access for Codex providers.
         try:
             from agent.auxiliary_client import resolve_provider_client
+            fb_base = fb.get("base_url", "").strip() or None
+            fb_key_env = fb.get("api_key_env", "").strip()
+            fb_key = os.getenv(fb_key_env, "").strip() if fb_key_env else None
             fb_client, _ = resolve_provider_client(
-                fb_provider, model=fb_model, raw_codex=True)
+                fb_provider, model=fb_model, raw_codex=True,
+                explicit_base_url=fb_base, explicit_api_key=fb_key)
             if fb_client is None:
                 logging.warning(
                     "Fallback to %s failed: provider not configured",


### PR DESCRIPTION
## Summary

- **Fallback routing fix**: `_try_activate_fallback()` ignored `base_url` and `api_key_env` from the `fallback_model` config block. The `resolve_provider_client` call always fell back to `OPENAI_BASE_URL`/`OPENAI_API_KEY`, so custom fallback endpoints (e.g. Venice AI) were never actually reached — the fallback would hit the same primary endpoint that was already failing.
- **Error handling fix**: `gateway/run.py` crashed with `AttributeError: str object has no attribute get` when the API returned error as a string (e.g. `{"error": "Too Many Requests"}`) instead of the expected dict format (`{"error": {"type": ...}}`).

## Changes

- `run_agent.py`: Extract `base_url` and `api_key_env` from the fallback config dict and pass them as `explicit_base_url`/`explicit_api_key` to `resolve_provider_client()`, which already supports these parameters.
- `gateway/run.py`: Add `isinstance` check before calling `.get()` on the parsed error body.

## Test plan

- [ ] Configure `fallback_model` with a custom `base_url` and `api_key_env` pointing to a different provider than the primary
- [ ] Trigger a 429 on the primary model and verify the fallback routes to the configured custom endpoint (not the primary)
- [ ] Send a request that returns a string error body and verify no `AttributeError` crash

## Related issues

- Related to #2384 (fallback endpoint leaking)
- Related to #2281 / #2283 (config.yaml provider/base_url ignored)
