### PR TITLE
fix: restore plugin tool bypass for platform_toolsets whitelist

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -292,11 +292,20 @@ def get_tool_definitions(
         for ts_name in get_all_toolsets():
             tools_to_include.update(resolve_toolset(ts_name))
 
-    # Plugin-registered tools are now resolved through the normal toolset
-    # path — validate_toolset() / resolve_toolset() / get_all_toolsets()
-    # all check the tool registry for plugin-provided toolsets.  No bypass
-    # needed; plugins respect enabled_toolsets / disabled_toolsets like any
-    # other toolset.
+    # Always include plugin-registered tools — they bypass the toolset filter
+    # because their toolsets are dynamic (created at plugin load time, not in
+    # config).  When platform_toolsets is configured (a strict whitelist),
+    # plugin toolsets wouldn't be included otherwise.  This was the original
+    # design per PR #1555.  Fixes #2574.
+    try:
+        from hermes_cli.plugins import get_plugin_tool_names
+        plugin_tools = get_plugin_tool_names()
+        if plugin_tools:
+            tools_to_include.update(plugin_tools)
+            if not quiet_mode and plugin_tools:
+                print(f"✅ Plugin tools (bypass toolset filter): {', '.join(sorted(plugin_tools))}")
+    except Exception:
+        pass
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -310,10 +310,13 @@ class TestPluginToolVisibility:
         tool_names = [t["function"]["name"] for t in tools]
         assert "vis_tool" in tool_names
 
-        # Plugin tools are excluded when only other toolsets are enabled
+        # Plugin tools bypass the toolset filter — they are included even when
+        # only other toolsets are in enabled_toolsets (#2574).  This is the
+        # original design from PR #1555: plugins shouldn't require manual
+        # config updates to platform_toolsets.
         tools2 = get_tool_definitions(enabled_toolsets=["terminal"], quiet_mode=True)
         tool_names2 = [t["function"]["name"] for t in tools2]
-        assert "vis_tool" not in tool_names2
+        assert "vis_tool" in tool_names2  # included via plugin bypass
 
         # Plugin tools are included when no toolset filter is active (all enabled)
         tools3 = get_tool_definitions(quiet_mode=True)


### PR DESCRIPTION
## Summary

Restores the plugin tool bypass that was removed in commit 34be3f8b, fixing #2574.

## Problem

When `platform_toolsets` is configured (acting as a strict whitelist), plugin toolsets are not included because their toolset names are dynamic (created at plugin load time, not in config.yaml). Users must manually add the plugin's toolset name to `platform_toolsets` for each platform, which defeats the "no source code changes required" promise of the plugin architecture.

## Root Cause

Commit `34be3f8b` removed the plugin tool bypass in `model_tools.py` with a comment claiming plugins respect `enabled_toolsets` like any other toolset. However, when `platform_toolsets` is configured (which it is for most users), `enabled_toolsets` acts as a strict whitelist. Plugin toolsets that register under a new name (e.g. `"acp"`) are never included unless the user manually adds them.

The original plugin architecture (PR #1555) explicitly designed plugins to bypass the toolset filter — the commit message states: *"Plugin tools bypass toolset filter via get_plugin_tool_names()"*.

## Solution

Restore the `get_plugin_tool_names()` bypass in `get_tool_definitions()`:
- Plugin tools are always included regardless of toolset filtering
- This matches the original design from PR #1555
- Users can install plugins without editing their config

## Test Plan

- Updated `tests/test_plugins.py::TestPluginToolVisibility` to verify plugin tools bypass the whitelist
- CI should run the full test suite

## Checklist

- [x] Code follows project style
- [x] Added/updated tests
- [x] Commit message follows conventional commit format