### PR TITLE
fix(cli): add interactive /resume handler

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2007,6 +2007,20 @@ class HermesCLI:
         
         self.console.print()
 
+    def _reopen_session_record(self) -> None:
+        """Mark the current CLI session record active again in SQLite."""
+        if not self._session_db:
+            return
+        try:
+            self._session_db._conn.execute(
+                "UPDATE sessions SET ended_at = NULL, end_reason = NULL "
+                "WHERE id = ?",
+                (self.session_id,),
+            )
+            self._session_db._conn.commit()
+        except Exception:
+            pass
+
     def _preload_resumed_session(self) -> bool:
         """Load a resumed session's history from the DB early (before first chat).
 
@@ -2021,12 +2035,14 @@ class HermesCLI:
         if not self._resumed or not self._session_db:
             return False
 
+        printer = ChatConsole() if self._app else self.console
+
         session_meta = self._session_db.get_session(self.session_id)
         if not session_meta:
-            self.console.print(
+            printer.print(
                 f"[bold red]Session not found: {self.session_id}[/]"
             )
-            self.console.print(
+            printer.print(
                 "[dim]Use a session ID from a previous CLI run "
                 "(hermes sessions list).[/]"
             )
@@ -2039,31 +2055,22 @@ class HermesCLI:
             title_part = ""
             if session_meta.get("title"):
                 title_part = f' "{session_meta["title"]}"'
-            self.console.print(
+            printer.print(
                 f"[#DAA520]↻ Resumed session [bold]{self.session_id}[/bold]"
                 f"{title_part} "
                 f"({msg_count} user message{'s' if msg_count != 1 else ''}, "
                 f"{len(restored)} total messages)[/]"
             )
-        else:
-            self.console.print(
-                f"[#DAA520]Session {self.session_id} found but has no "
-                f"messages. Starting fresh.[/]"
-            )
-            return False
+            self._reopen_session_record()
+            return True
 
-        # Re-open the session (clear ended_at so it's active again)
-        try:
-            self._session_db._conn.execute(
-                "UPDATE sessions SET ended_at = NULL, end_reason = NULL "
-                "WHERE id = ?",
-                (self.session_id,),
-            )
-            self._session_db._conn.commit()
-        except Exception:
-            pass
-
-        return True
+        printer.print(
+            f"[#DAA520]Session {self.session_id} found but has no "
+            f"messages. Starting fresh.[/]"
+        )
+        self._reopen_session_record()
+        self._resumed = False
+        return False
 
     def _display_resumed_history(self):
         """Render a compact recap of previous conversation messages.
@@ -2779,6 +2786,93 @@ class HermesCLI:
         flush_tool_summary()
         print()
     
+    def resume_session(self, name_or_id: str = ""):
+        """Resume a previously named or directly-addressed session in-place."""
+        if not self._session_db:
+            _cprint("  Session database not available.")
+            return
+
+        target = (name_or_id or "").strip()
+        if not target:
+            try:
+                sessions = self._session_db.list_sessions_rich(source="cli", limit=10)
+                titled = [s for s in sessions if s.get("title")]
+            except Exception as e:
+                _cprint(f"  Could not list sessions: {e}")
+                return
+
+            if not titled:
+                _cprint("  No named sessions found.")
+                _cprint("  Use /title My Session to name the current session, then /resume My Session to return to it later.")
+                return
+
+            _cprint("  Named sessions:")
+            for session in titled[:10]:
+                title = session.get("title") or "(untitled)"
+                preview = (session.get("preview") or "").strip()
+                preview_part = f" — {preview[:40]}" if preview else ""
+                _cprint(f"    • {title}{preview_part}")
+            _cprint("  Usage: /resume <session name>")
+            return
+
+        target_id = None
+        try:
+            session = self._session_db.get_session(target)
+            if session:
+                target_id = session["id"]
+            else:
+                target_id = self._session_db.resolve_session_by_title(target)
+        except Exception:
+            target_id = None
+
+        if not target_id:
+            _cprint(f"  No session found matching '{target}'.")
+            _cprint("  Use /resume with no arguments to list named sessions.")
+            return
+
+        if target_id == self.session_id:
+            current_title = self._session_db.get_session_title(target_id) or target
+            _cprint(f"  Already on session: {current_title}")
+            return
+
+        if self.agent and self.conversation_history:
+            try:
+                self.agent.flush_memories(self.conversation_history)
+            except Exception:
+                pass
+
+        old_session_id = self.session_id
+        if old_session_id:
+            try:
+                self._session_db.end_session(old_session_id, "resume_session")
+            except Exception:
+                pass
+
+        self.session_id = target_id
+        self.session_start = datetime.now()
+        self.conversation_history = []
+        self._pending_title = None
+        self._resumed = True
+
+        loaded = self._preload_resumed_session()
+        if self.agent:
+            self.agent.session_id = self.session_id
+            self.agent.session_start = self.session_start
+            self.agent.reset_session_state()
+            if hasattr(self.agent, "_last_flushed_db_idx"):
+                self.agent._last_flushed_db_idx = len(self.conversation_history)
+            if hasattr(self.agent, "_todo_store"):
+                try:
+                    from tools.todo_tool import TodoStore
+                    self.agent._todo_store = TodoStore()
+                except Exception:
+                    pass
+            if hasattr(self.agent, "_invalidate_system_prompt"):
+                self.agent._invalidate_system_prompt()
+
+        if loaded:
+            self._display_resumed_history()
+
     def new_session(self, silent=False):
         """Start a fresh session with a new session ID and cleared agent state."""
         if self.agent and self.conversation_history:
@@ -3560,6 +3654,10 @@ class HermesCLI:
                     _cprint("  Session database not available.")
         elif canonical == "new":
             self.new_session()
+        elif canonical == "resume":
+            parts = cmd_original.split(maxsplit=1)
+            target = parts[1].strip() if len(parts) > 1 else ""
+            self.resume_session(target)
         elif canonical == "model":
             # Use original case so model names like "Anthropic/Claude-Opus-4" are preserved
             parts = cmd_original.split(maxsplit=1)

--- a/tests/test_cli_new_session.py
+++ b/tests/test_cli_new_session.py
@@ -220,3 +220,85 @@ def test_new_session_resets_token_counters(tmp_path):
     assert comp.last_total_tokens == 0
     assert comp.compression_count == 0
     assert comp._context_probed is False
+
+
+def test_resume_command_restores_named_session_and_resets_agent_state(tmp_path):
+    cli = _prepare_cli_with_active_session(tmp_path)
+    old_session_id = cli.session_id
+
+    target_id = "20260323_000000_resume"
+    cli._session_db.create_session(session_id=target_id, source="cli", model=cli.model)
+    cli._session_db.set_session_title(target_id, "forkwerk")
+    cli._session_db.append_message(target_id, role="user", content="pick up where we left off")
+    cli._session_db.append_message(target_id, role="assistant", content="ready")
+    cli._session_db.end_session(target_id, "idle")
+
+    cli.process_command("/resume forkwerk")
+
+    assert cli.session_id == target_id
+    assert cli._resumed is True
+    assert cli._session_db.get_session(old_session_id)["end_reason"] == "resume_session"
+    assert cli._session_db.get_session(target_id)["ended_at"] is None
+
+    assert cli.conversation_history == [
+        {"role": "user", "content": "pick up where we left off"},
+        {"role": "assistant", "content": "ready"},
+    ]
+
+    assert cli.agent.session_id == target_id
+    assert cli.agent.session_start == cli.session_start
+    assert cli.agent._last_flushed_db_idx == len(cli.conversation_history)
+    assert cli.agent._todo_store.read() == []
+    cli.agent.flush_memories.assert_called_once_with([{"role": "user", "content": "hello"}])
+    cli.agent._invalidate_system_prompt.assert_called_once()
+
+
+def test_resume_command_without_args_lists_named_cli_sessions(tmp_path):
+    cli = _prepare_cli_with_active_session(tmp_path)
+    old_session_id = cli.session_id
+
+    target_id = "20260323_000000_named"
+    cli._session_db.create_session(session_id=target_id, source="cli", model=cli.model)
+    cli._session_db.set_session_title(target_id, "forkwerk")
+    cli._session_db.append_message(target_id, role="user", content="pick up where we left off")
+
+    printed_lines = []
+
+    def _record_print(text):
+        printed_lines.append(text)
+
+    with patch.dict(cli.resume_session.__globals__, {"_cprint": _record_print}):
+        cli.process_command("/resume")
+
+    printed = "\n".join(printed_lines)
+    assert "Named sessions:" in printed
+    assert "forkwerk" in printed
+    assert "Usage: /resume <session name>" in printed
+
+    assert cli.session_id == old_session_id
+    assert cli._resumed is False
+    cli.agent.flush_memories.assert_not_called()
+
+
+def test_resume_command_to_empty_named_session_reopens_without_pending_resume_state(tmp_path):
+    cli = _prepare_cli_with_active_session(tmp_path)
+    old_session_id = cli.session_id
+
+    target_id = "20260323_000000_empty"
+    cli._session_db.create_session(session_id=target_id, source="cli", model=cli.model)
+    cli._session_db.set_session_title(target_id, "forkwerk")
+    cli._session_db.end_session(target_id, "idle")
+
+    cli.process_command("/resume forkwerk")
+
+    assert cli.session_id == target_id
+    assert cli.conversation_history == []
+    assert cli._resumed is False
+    assert cli._session_db.get_session(old_session_id)["end_reason"] == "resume_session"
+    assert cli._session_db.get_session(target_id)["ended_at"] is None
+
+    assert cli.agent.session_id == target_id
+    assert cli.agent.session_start == cli.session_start
+    assert cli.agent._last_flushed_db_idx == 0
+    cli.agent.flush_memories.assert_called_once_with([{"role": "user", "content": "hello"}])
+    cli.agent._invalidate_system_prompt.assert_called_once()

--- a/tests/test_resume_display.py
+++ b/tests/test_resume_display.py
@@ -364,6 +364,8 @@ class TestPreloadResumedSession:
         mock_db = MagicMock()
         mock_db.get_session.return_value = {"id": "empty_session", "title": None}
         mock_db.get_messages_as_conversation.return_value = []
+        mock_conn = MagicMock()
+        mock_db._conn = mock_conn
         cli._session_db = mock_db
 
         buf = StringIO()
@@ -371,8 +373,11 @@ class TestPreloadResumedSession:
         result = cli._preload_resumed_session()
 
         assert result is False
+        assert cli._resumed is False
         output = buf.getvalue()
         assert "no messages" in output
+        mock_conn.execute.assert_called_once()
+        mock_conn.commit.assert_called_once()
 
     def test_loads_session_successfully(self):
         cli = _make_cli(resume="good_session")


### PR DESCRIPTION
## Summary

Fix the interactive CLI `/resume` gap so the shared command catalog and the CLI dispatcher stay in sync.

`/resume` was already:

- registered in `hermes_cli/commands.py`
- implemented on the gateway side in `gateway/run.py`

But the interactive CLI was missing both the handler and the command-dispatch branch, so titled sessions could not be restored from the CLI even though the command was advertised.

## Root cause

The shared command registry and `HermesCLI.process_command()` drifted apart for `/resume`:

- the command registry exposed it to CLI surfaces
- the CLI dispatcher never handled it
- the gateway implementation existed already, which made the omission easy to miss

A follow-up manual smoke uncovered an additional empty-session edge case: resuming a titled session with no persisted messages could emit a malformed/duplicated status notice before the first real turn. This patch folds that fix in too.

## Changes

- add `HermesCLI.resume_session()` in `cli.py`
- wire `canonical == "resume"` into `HermesCLI.process_command()`
- support no-arg `/resume` listing for titled CLI sessions
- support restore-by-title or direct session id resolution
- preserve existing resume preload/display behavior and reset agent session state after the switch
- route preload status output through the prompt-toolkit-safe printer while inside the TUI
- reopen empty resumed sessions cleanly and clear pending resume state so the notice is not repeated on the first user turn
- add focused CLI regression coverage for:
  - restore-by-title
  - no-arg named-session listing
  - empty-session resume behavior

## Verification

```bash
/home/alan/projects/hermes-agent/.venv/bin/python -m pytest -q tests/test_cli_new_session.py tests/test_resume_display.py tests/gateway/test_resume_command.py
```

Result:

- `43 passed`

## Scope

This PR is intentionally narrow:

- changes only `cli.py`, `tests/test_cli_new_session.py`, and `tests/test_resume_display.py`
- leaves unrelated local work and unrelated command-surface cleanup out of scope

Fixes #2591
