### PR TITLE
feat(gateway): add react_emoji config for incoming telegram messages

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1064,6 +1064,14 @@ class TelegramAdapter(BasePlatformAdapter):
         if not update.message or not update.message.text:
             return
 
+        # Optional: React to incoming messages
+        react_emoji = self.config.extra.get("react_emoji")
+        if react_emoji and isinstance(react_emoji, str):
+            try:
+                await update.message.set_reaction(reaction=react_emoji)
+            except Exception as e:
+                logger.debug("[%s] Failed to set reaction: %s", self.name, e)
+
         event = self._build_message_event(update.message, MessageType.TEXT)
         self._enqueue_text_event(event)
     


### PR DESCRIPTION
## Summary
This PR adds a `react_emoji` configuration option to the Telegram gateway. When configured, the agent will automatically react to incoming text messages with the specified emoji. This provides immediate visual feedback to the user that the agent has received and is processing their message.

*Note: This is a popular UX feature already present in OpenClaw and Nanobot. Since Hermes supports migrating from OpenClaw, adding this ensures feature parity for users moving over.*

## Changes
- Added `react_emoji` check in `_handle_text_message` in `gateway/platforms/telegram.py`.
- Uses `update.message.set_reaction(reaction=react_emoji)` to set the reaction.
- Fails gracefully (logs to debug) if the reaction fails (e.g., if the emoji is invalid or the chat doesn't allow reactions).

## How to test
1. Add `react_emoji: "👀"` to your Telegram platform config under `extra`.
2. Send a message to the bot.
3. The bot should immediately react with 👀 before processing the message.

Tested on Windows and Linux.