### PR TITLE
feat(gateway): add silent_tool_hints config to disable notifications for tool hints

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -469,6 +469,11 @@ class TelegramAdapter(BasePlatformAdapter):
             message_ids = []
             thread_id = metadata.get("thread_id") if metadata else None
             
+            # Optional: Send tool hints silently
+            silent_tool_hints = self.config.extra.get("silent_tool_hints", False)
+            is_tool_hint = metadata.get("is_tool_hint", False) if metadata else False
+            disable_notification = silent_tool_hints and is_tool_hint
+
             try:
                 from telegram.error import NetworkError as _NetErr
             except ImportError:
@@ -486,6 +491,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=int(reply_to) if reply_to and i == 0 else None,
                                 message_thread_id=int(thread_id) if thread_id else None,
+                                disable_notification=disable_notification,
                             )
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
@@ -498,6 +504,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     parse_mode=None,
                                     reply_to_message_id=int(reply_to) if reply_to and i == 0 else None,
                                     message_thread_id=int(thread_id) if thread_id else None,
+                                    disable_notification=disable_notification,
                                 )
                             else:
                                 raise


### PR DESCRIPTION
## Summary
This PR adds a `silent_tool_hints` configuration option to the Telegram gateway. When enabled, intermediate messages generated by tools (where `metadata.get("is_tool_hint")` is true) will be sent with `disable_notification=True`.

This prevents the user's phone from buzzing repeatedly when the agent is executing a long chain of tools, while still allowing the final response to trigger a notification.

## Changes
- Added `silent_tool_hints` check in `send` method in `gateway/platforms/telegram.py`.
- Passed `disable_notification=disable_notification` to `_bot.send_message` (both for MarkdownV2 and plain text fallback).

## How to test
1. Add `silent_tool_hints: true` to your Telegram platform config under `extra`.
2. Ask the agent to perform a task that requires multiple tool calls (e.g., searching the web and reading multiple pages).
3. The intermediate tool hint messages will appear in the chat silently, without triggering a push notification sound. The final answer will trigger a sound as usual.