### PR TITLE
fix(agent): handle GLM context overflow and compaction correctly

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
@@ -895,3 +896,92 @@ def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     """Rough token estimate for a message list (pre-flight only)."""
     total_chars = sum(len(str(msg)) for msg in messages)
     return total_chars // 4
+
+
+def estimate_request_tokens_rough(
+    messages: List[Dict[str, Any]],
+    *,
+    system_prompt: str = "",
+    tools: Optional[List[Dict[str, Any]]] = None,
+    prefill_messages: Optional[List[Dict[str, Any]]] = None,
+) -> int:
+    """Rough token estimate for a full chat-completions request.
+
+    Includes the same major payload buckets Hermes sends to providers:
+    system prompt, optional prefill messages, conversation messages, and tool
+    schemas. This is intentionally rough, but it is more faithful than counting
+    only the message list when tools are large.
+    """
+    total_chars = 0
+    if system_prompt:
+        total_chars += len(str({"role": "system", "content": system_prompt}))
+    if prefill_messages:
+        total_chars += sum(len(str(msg)) for msg in prefill_messages)
+    if messages:
+        total_chars += sum(len(str(msg)) for msg in messages)
+    if tools:
+        total_chars += len(str(tools))
+    return total_chars // 4
+
+
+@dataclass(frozen=True)
+class RequestBudget:
+    context_length: int
+    threshold_percent: float
+    threshold_tokens: int
+    warn_tokens: int
+
+
+def estimate_effective_request_tokens_rough(
+    messages: List[Dict[str, Any]],
+    *,
+    system_prompt: str = "",
+    ephemeral_system_prompt: str = "",
+    tools: Optional[List[Dict[str, Any]]] = None,
+    prefill_messages: Optional[List[Dict[str, Any]]] = None,
+) -> int:
+    """Rough token estimate for the effective request Hermes will send.
+
+    This mirrors the request envelope shape Hermes builds at API-call time:
+    stable system prompt + ephemeral system additions + prefill messages +
+    conversation messages + tool schemas.
+    """
+    effective_system = system_prompt or ""
+    if ephemeral_system_prompt:
+        effective_system = (
+            f"{effective_system}\n\n{ephemeral_system_prompt}".strip()
+            if effective_system
+            else ephemeral_system_prompt
+        )
+
+    return estimate_request_tokens_rough(
+        messages,
+        system_prompt=effective_system,
+        tools=tools,
+        prefill_messages=prefill_messages,
+    )
+
+
+def resolve_request_budget(
+    *,
+    model: str,
+    threshold_percent: float,
+    base_url: str = "",
+    api_key: str = "",
+    config_context_length: int | None = None,
+    provider: str = "",
+) -> RequestBudget:
+    """Resolve a model's usable context budget and derived thresholds."""
+    context_length = get_model_context_length(
+        model,
+        base_url=base_url,
+        api_key=api_key,
+        config_context_length=config_context_length,
+        provider=provider,
+    )
+    return RequestBudget(
+        context_length=context_length,
+        threshold_percent=threshold_percent,
+        threshold_tokens=int(context_length * threshold_percent),
+        warn_tokens=int(context_length * 0.95),
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1499,6 +1499,353 @@ class GatewayRunner:
         if config and hasattr(config, "get_unauthorized_dm_behavior"):
             return config.get_unauthorized_dm_behavior(platform)
         return "pair"
+
+    def _resolve_enabled_toolsets_for_source(self, source: SessionSource) -> tuple[str, list]:
+        """Resolve the platform key and enabled toolsets for a source."""
+        default_toolset_map = {
+            Platform.LOCAL: "hermes-cli",
+            Platform.TELEGRAM: "hermes-telegram",
+            Platform.DISCORD: "hermes-discord",
+            Platform.WHATSAPP: "hermes-whatsapp",
+            Platform.SLACK: "hermes-slack",
+            Platform.SIGNAL: "hermes-signal",
+            Platform.HOMEASSISTANT: "hermes-homeassistant",
+            Platform.EMAIL: "hermes-email",
+            Platform.DINGTALK: "hermes-dingtalk",
+        }
+
+        platform_toolsets_config = {}
+        try:
+            config_path = _hermes_home / "config.yaml"
+            if config_path.exists():
+                import yaml
+                with open(config_path, "r", encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+                platform_toolsets_config = user_config.get("platform_toolsets", {})
+        except Exception as e:
+            logger.debug("Could not load platform_toolsets config: %s", e)
+
+        platform_key = {
+            Platform.LOCAL: "cli",
+            Platform.TELEGRAM: "telegram",
+            Platform.DISCORD: "discord",
+            Platform.WHATSAPP: "whatsapp",
+            Platform.SLACK: "slack",
+            Platform.SIGNAL: "signal",
+            Platform.HOMEASSISTANT: "homeassistant",
+            Platform.EMAIL: "email",
+            Platform.DINGTALK: "dingtalk",
+        }.get(source.platform, "telegram")
+
+        config_toolsets = platform_toolsets_config.get(platform_key)
+        if config_toolsets and isinstance(config_toolsets, list):
+            enabled_toolsets = config_toolsets
+        else:
+            default_toolset = default_toolset_map.get(source.platform, "hermes-telegram")
+            enabled_toolsets = [default_toolset]
+
+        return platform_key, enabled_toolsets
+
+    def _normalize_history_for_agent(self, history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Normalize stored transcript entries into the message shape the agent uses."""
+        agent_history: List[Dict[str, Any]] = []
+        for msg in history:
+            role = msg.get("role")
+            if not role or role == "system":
+                continue
+            if role in ("session_meta",):
+                continue
+
+            has_tool_calls = "tool_calls" in msg
+            has_tool_call_id = "tool_call_id" in msg
+            is_tool_message = role == "tool"
+
+            if has_tool_calls or has_tool_call_id or is_tool_message:
+                clean_msg = {k: v for k, v in msg.items() if k != "timestamp"}
+                agent_history.append(clean_msg)
+            else:
+                content = msg.get("content")
+                if content:
+                    if msg.get("mirror"):
+                        mirror_src = msg.get("mirror_source", "another session")
+                        content = f"[Delivered from {mirror_src}] {content}"
+                    entry = {"role": role, "content": content}
+                    if role == "assistant":
+                        for reasoning_key in ("reasoning", "reasoning_details", "codex_reasoning_items"):
+                            reasoning_value = msg.get(reasoning_key)
+                            if reasoning_value:
+                                entry[reasoning_key] = reasoning_value
+                    agent_history.append(entry)
+
+        return agent_history
+
+    @staticmethod
+    def _resolve_agent_system_prompt(agent: Any, conversation_history: List[Dict[str, Any]]) -> str:
+        """Get the effective stable system prompt for an agent, with test-friendly fallback."""
+        builder = getattr(agent, "_get_or_build_active_system_prompt", None)
+        if callable(builder):
+            return builder("", conversation_history=conversation_history) or ""
+        return getattr(agent, "_cached_system_prompt", "") or ""
+
+    def _resolve_turn_agent_setup(
+        self,
+        *,
+        message: str,
+        source: SessionSource,
+        context_prompt: str,
+        session_key: str,
+    ) -> dict:
+        """Resolve the effective agent configuration for a single turn."""
+        platform_key, enabled_toolsets = self._resolve_enabled_toolsets_for_source(source)
+
+        combined_ephemeral = context_prompt or ""
+        gateway_ephemeral = getattr(self, "_ephemeral_system_prompt", "") or ""
+        if gateway_ephemeral:
+            combined_ephemeral = (
+                f"{combined_ephemeral}\n\n{gateway_ephemeral}".strip()
+                if combined_ephemeral
+                else gateway_ephemeral
+            )
+
+        try:
+            load_dotenv(_env_path, override=True, encoding="utf-8")
+        except UnicodeDecodeError:
+            load_dotenv(_env_path, override=True, encoding="latin-1")
+        except Exception:
+            pass
+
+        model = _resolve_gateway_model()
+        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+        honcho_manager, honcho_config = self._get_or_create_gateway_honcho(session_key)
+        reasoning_config = self._load_reasoning_config()
+
+        return {
+            "platform_key": platform_key,
+            "enabled_toolsets": enabled_toolsets,
+            "combined_ephemeral": combined_ephemeral,
+            "turn_route": turn_route,
+            "honcho_manager": honcho_manager,
+            "honcho_config": honcho_config,
+            "reasoning_config": reasoning_config,
+        }
+
+    async def _maybe_hygiene_compress(
+        self,
+        *,
+        event: MessageEvent,
+        source: SessionSource,
+        session_entry,
+        session_key: str,
+        history: List[Dict[str, Any]],
+        context_prompt: str,
+        message_text: str,
+    ) -> List[Dict[str, Any]]:
+        """Auto-compress a large session using the final request shape for this turn."""
+        if not history or len(history) < 4:
+            return history
+
+        _hyg_compression_enabled = True
+        try:
+            _hyg_cfg_path = _hermes_home / "config.yaml"
+            if _hyg_cfg_path.exists():
+                import yaml as _hyg_yaml
+                with open(_hyg_cfg_path, encoding="utf-8") as _hyg_f:
+                    _hyg_data = _hyg_yaml.safe_load(_hyg_f) or {}
+                _comp_cfg = _hyg_data.get("compression", {})
+                if isinstance(_comp_cfg, dict):
+                    _hyg_compression_enabled = str(
+                        _comp_cfg.get("enabled", True)
+                    ).lower() in ("true", "1", "yes")
+        except Exception:
+            pass
+
+        if not _hyg_compression_enabled:
+            return history
+
+        from agent.model_metadata import estimate_effective_request_tokens_rough
+        from run_agent import AIAgent
+
+        _msg_count = len(history)
+        _hyg_adapter = self.adapters.get(source.platform)
+        _hyg_meta = {"thread_id": source.thread_id} if source.thread_id else None
+
+        try:
+            _turn_setup = self._resolve_turn_agent_setup(
+                message=message_text or "",
+                source=source,
+                context_prompt=context_prompt,
+                session_key=session_key,
+            )
+            self._reasoning_config = _turn_setup["reasoning_config"]
+
+            pr = getattr(self, "_provider_routing", {}) or {}
+            _hyg_agent = AIAgent(
+                model=_turn_setup["turn_route"]["model"],
+                **_turn_setup["turn_route"]["runtime"],
+                max_iterations=4,
+                quiet_mode=True,
+                verbose_logging=False,
+                enabled_toolsets=_turn_setup["enabled_toolsets"],
+                ephemeral_system_prompt=_turn_setup["combined_ephemeral"] or None,
+                prefill_messages=getattr(self, "_prefill_messages", None) or None,
+                reasoning_config=_turn_setup["reasoning_config"],
+                providers_allowed=pr.get("only"),
+                providers_ignored=pr.get("ignore"),
+                providers_order=pr.get("order"),
+                provider_sort=pr.get("sort"),
+                provider_require_parameters=pr.get("require_parameters", False),
+                provider_data_collection=pr.get("data_collection"),
+                session_id=session_entry.session_id,
+                platform=_turn_setup["platform_key"],
+                honcho_session_key=session_key,
+                honcho_manager=_turn_setup["honcho_manager"],
+                honcho_config=_turn_setup["honcho_config"],
+                session_db=getattr(self, "_session_db", None),
+                fallback_model=getattr(self, "_fallback_model", None),
+            )
+
+            _hyg_history = self._normalize_history_for_agent(history)
+            if len(_hyg_history) < 4:
+                return history
+
+            _active_system_prompt = self._resolve_agent_system_prompt(
+                _hyg_agent,
+                _hyg_history,
+            )
+            _pending_messages = list(_hyg_history)
+            if message_text:
+                _pending_messages.append({"role": "user", "content": message_text})
+
+            _approx_tokens = estimate_effective_request_tokens_rough(
+                _pending_messages,
+                system_prompt=_active_system_prompt or "",
+                ephemeral_system_prompt=getattr(
+                    _hyg_agent, "ephemeral_system_prompt", ""
+                ) or "",
+                tools=getattr(_hyg_agent, "tools", None),
+                prefill_messages=getattr(_hyg_agent, "prefill_messages", None),
+            )
+            _token_source = "effective-request-estimate"
+            _hyg_context_length = _hyg_agent.context_compressor.context_length
+            _compress_token_threshold = _hyg_agent.context_compressor.threshold_tokens
+            _warn_token_threshold = int(_hyg_context_length * 0.95)
+
+            if _approx_tokens < _compress_token_threshold:
+                return history
+
+            logger.info(
+                "Session hygiene: %s messages, ~%s tokens (%s) — auto-compressing "
+                "(threshold: %s%% of %s = %s tokens)",
+                _msg_count, f"{_approx_tokens:,}", _token_source,
+                int(_hyg_agent.context_compressor.threshold_percent * 100),
+                f"{_hyg_context_length:,}",
+                f"{_compress_token_threshold:,}",
+            )
+
+            if _hyg_adapter:
+                try:
+                    await _hyg_adapter.send(
+                        source.chat_id,
+                        f"🗜️ Session is large ({_msg_count} messages, "
+                        f"~{_approx_tokens:,} tokens). Auto-compressing...",
+                        metadata=_hyg_meta,
+                    )
+                except Exception:
+                    pass
+
+            loop = asyncio.get_event_loop()
+            _compressed, _ = await loop.run_in_executor(
+                None,
+                lambda: _hyg_agent._compress_context(
+                    _hyg_history, "",
+                    approx_tokens=_approx_tokens,
+                ),
+            )
+
+            self.session_store.rewrite_transcript(
+                session_entry.session_id, _compressed
+            )
+            session_entry.last_prompt_tokens = 0
+            history = _compressed
+            _new_count = len(_compressed)
+            _compressed_system_prompt = self._resolve_agent_system_prompt(
+                _hyg_agent,
+                _compressed,
+            )
+            _post_compress_messages = list(_compressed)
+            if message_text:
+                _post_compress_messages.append({"role": "user", "content": message_text})
+            _new_tokens = estimate_effective_request_tokens_rough(
+                _post_compress_messages,
+                system_prompt=_compressed_system_prompt or "",
+                ephemeral_system_prompt=getattr(
+                    _hyg_agent, "ephemeral_system_prompt", ""
+                ) or "",
+                tools=getattr(_hyg_agent, "tools", None),
+                prefill_messages=getattr(_hyg_agent, "prefill_messages", None),
+            )
+
+            logger.info(
+                "Session hygiene: compressed %s → %s msgs, "
+                "~%s → ~%s tokens",
+                _msg_count, _new_count,
+                f"{_approx_tokens:,}", f"{_new_tokens:,}",
+            )
+
+            if _hyg_adapter:
+                try:
+                    await _hyg_adapter.send(
+                        source.chat_id,
+                        f"🗜️ Compressed: {_msg_count} → "
+                        f"{_new_count} messages, "
+                        f"~{_approx_tokens:,} → "
+                        f"~{_new_tokens:,} tokens "
+                        f"(full request estimate)",
+                        metadata=_hyg_meta,
+                    )
+                except Exception:
+                    pass
+
+            if _new_tokens >= _warn_token_threshold and _hyg_adapter:
+                logger.warning(
+                    "Session hygiene: still ~%s tokens after "
+                    "compression — suggesting /reset",
+                    f"{_new_tokens:,}",
+                )
+                try:
+                    await _hyg_adapter.send(
+                        source.chat_id,
+                        "⚠️ Session is still very large "
+                        "after compression "
+                        f"(~{_new_tokens:,} tokens). "
+                        "Consider using /reset to start "
+                        "fresh if you experience issues.",
+                        metadata=_hyg_meta,
+                    )
+                except Exception:
+                    pass
+
+            return history
+
+        except Exception as e:
+            logger.warning("Session hygiene auto-compress failed: %s", e)
+            if "_approx_tokens" in locals() and "_warn_token_threshold" in locals():
+                if _approx_tokens >= _warn_token_threshold and _hyg_adapter:
+                    try:
+                        await _hyg_adapter.send(
+                            source.chat_id,
+                            f"⚠️ Session is very large "
+                            f"({_msg_count} messages, "
+                            f"~{_approx_tokens:,} tokens) and "
+                            "auto-compression failed. Consider "
+                            "using /compress or /reset to avoid "
+                            "issues.",
+                            metadata=_hyg_meta,
+                        )
+                    except Exception:
+                        pass
+            return history
     
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
@@ -1940,251 +2287,6 @@ class GatewayRunner:
         # Load conversation history from transcript
         history = self.session_store.load_transcript(session_entry.session_id)
         
-        # -----------------------------------------------------------------
-        # Session hygiene: auto-compress pathologically large transcripts
-        #
-        # Long-lived gateway sessions can accumulate enough history that
-        # every new message rehydrates an oversized transcript, causing
-        # repeated truncation/context failures.  Detect this early and
-        # compress proactively — before the agent even starts.  (#628)
-        #
-        # Token source priority:
-        # 1. Actual API-reported prompt_tokens from the last turn
-        #    (stored in session_entry.last_prompt_tokens)
-        # 2. Rough char-based estimate (str(msg)//4). Overestimates
-        #    by 30-50% on code/JSON-heavy sessions, but that just
-        #    means hygiene fires a bit early — safe and harmless.
-        # -----------------------------------------------------------------
-        if history and len(history) >= 4:
-            from agent.model_metadata import (
-                estimate_messages_tokens_rough,
-                get_model_context_length,
-            )
-
-            # Read model + compression config from config.yaml.
-            # NOTE: hygiene threshold is intentionally HIGHER than the agent's
-            # own compressor (0.85 vs 0.50).  Hygiene is a safety net for
-            # sessions that grew too large between turns — it fires pre-agent
-            # to prevent API failures.  The agent's own compressor handles
-            # normal context management during its tool loop with accurate
-            # real token counts.  Having hygiene at 0.50 caused premature
-            # compression on every turn in long gateway sessions.
-            _hyg_model = "anthropic/claude-sonnet-4.6"
-            _hyg_threshold_pct = 0.85
-            _hyg_compression_enabled = True
-            _hyg_config_context_length = None
-            _hyg_provider = None
-            _hyg_base_url = None
-            _hyg_api_key = None
-            try:
-                _hyg_cfg_path = _hermes_home / "config.yaml"
-                if _hyg_cfg_path.exists():
-                    import yaml as _hyg_yaml
-                    with open(_hyg_cfg_path, encoding="utf-8") as _hyg_f:
-                        _hyg_data = _hyg_yaml.safe_load(_hyg_f) or {}
-
-                    # Resolve model name (same logic as run_sync)
-                    _model_cfg = _hyg_data.get("model", {})
-                    if isinstance(_model_cfg, str):
-                        _hyg_model = _model_cfg
-                    elif isinstance(_model_cfg, dict):
-                        _hyg_model = _model_cfg.get("default", _hyg_model)
-                        # Read explicit context_length override from model config
-                        # (same as run_agent.py lines 995-1005)
-                        _raw_ctx = _model_cfg.get("context_length")
-                        if _raw_ctx is not None:
-                            try:
-                                _hyg_config_context_length = int(_raw_ctx)
-                            except (TypeError, ValueError):
-                                pass
-                        # Read provider for accurate context detection
-                        _hyg_provider = _model_cfg.get("provider") or None
-                        _hyg_base_url = _model_cfg.get("base_url") or None
-
-                    # Read compression settings — only use enabled flag.
-                    # The threshold is intentionally separate from the agent's
-                    # compression.threshold (hygiene runs higher).
-                    _comp_cfg = _hyg_data.get("compression", {})
-                    if isinstance(_comp_cfg, dict):
-                        _hyg_compression_enabled = str(
-                            _comp_cfg.get("enabled", True)
-                        ).lower() in ("true", "1", "yes")
-
-                # Resolve provider/base_url from runtime if not in config
-                if not _hyg_provider or not _hyg_base_url:
-                    try:
-                        _hyg_runtime = _resolve_runtime_agent_kwargs()
-                        _hyg_provider = _hyg_provider or _hyg_runtime.get("provider")
-                        _hyg_base_url = _hyg_base_url or _hyg_runtime.get("base_url")
-                        _hyg_api_key = _hyg_runtime.get("api_key")
-                    except Exception:
-                        pass
-            except Exception:
-                pass
-
-            if _hyg_compression_enabled:
-                _hyg_context_length = get_model_context_length(
-                    _hyg_model,
-                    base_url=_hyg_base_url or "",
-                    api_key=_hyg_api_key or "",
-                    config_context_length=_hyg_config_context_length,
-                    provider=_hyg_provider or "",
-                )
-                _compress_token_threshold = int(
-                    _hyg_context_length * _hyg_threshold_pct
-                )
-                _warn_token_threshold = int(_hyg_context_length * 0.95)
-
-                _msg_count = len(history)
-
-                # Prefer actual API-reported tokens from the last turn
-                # (stored in session entry) over the rough char-based estimate.
-                _stored_tokens = session_entry.last_prompt_tokens
-                if _stored_tokens > 0:
-                    _approx_tokens = _stored_tokens
-                    _token_source = "actual"
-                else:
-                    _approx_tokens = estimate_messages_tokens_rough(history)
-                    _token_source = "estimated"
-                    # Note: rough estimates overestimate by 30-50% for code/JSON-heavy
-                    # sessions, but that just means hygiene fires a bit early — which
-                    # is safe and harmless.  The 85% threshold already provides ample
-                    # headroom (agent's own compressor runs at 50%).  A previous 1.4x
-                    # multiplier tried to compensate by inflating the threshold, but
-                    # 85% * 1.4 = 119% of context — which exceeds the model's limit
-                    # and prevented hygiene from ever firing for ~200K models (GLM-5).
-
-                _needs_compress = _approx_tokens >= _compress_token_threshold
-
-                if _needs_compress:
-                    logger.info(
-                        "Session hygiene: %s messages, ~%s tokens (%s) — auto-compressing "
-                        "(threshold: %s%% of %s = %s tokens)",
-                        _msg_count, f"{_approx_tokens:,}", _token_source,
-                        int(_hyg_threshold_pct * 100),
-                        f"{_hyg_context_length:,}",
-                        f"{_compress_token_threshold:,}",
-                    )
-
-                    _hyg_adapter = self.adapters.get(source.platform)
-                    _hyg_meta = {"thread_id": source.thread_id} if source.thread_id else None
-                    if _hyg_adapter:
-                        try:
-                            await _hyg_adapter.send(
-                                source.chat_id,
-                                f"🗜️ Session is large ({_msg_count} messages, "
-                                f"~{_approx_tokens:,} tokens). Auto-compressing...",
-                                metadata=_hyg_meta,
-                            )
-                        except Exception:
-                            pass
-
-                    try:
-                        from run_agent import AIAgent
-
-                        _hyg_runtime = _resolve_runtime_agent_kwargs()
-                        if _hyg_runtime.get("api_key"):
-                            _hyg_msgs = [
-                                {"role": m.get("role"), "content": m.get("content")}
-                                for m in history
-                                if m.get("role") in ("user", "assistant")
-                                and m.get("content")
-                            ]
-
-                            if len(_hyg_msgs) >= 4:
-                                _hyg_agent = AIAgent(
-                                    **_hyg_runtime,
-                                    model=_hyg_model,
-                                    max_iterations=4,
-                                    quiet_mode=True,
-                                    enabled_toolsets=["memory"],
-                                    session_id=session_entry.session_id,
-                                )
-
-                                loop = asyncio.get_event_loop()
-                                _compressed, _ = await loop.run_in_executor(
-                                    None,
-                                    lambda: _hyg_agent._compress_context(
-                                        _hyg_msgs, "",
-                                        approx_tokens=_approx_tokens,
-                                    ),
-                                )
-
-                                self.session_store.rewrite_transcript(
-                                    session_entry.session_id, _compressed
-                                )
-                                # Reset stored token count — transcript was rewritten
-                                session_entry.last_prompt_tokens = 0
-                                history = _compressed
-                                _new_count = len(_compressed)
-                                _new_tokens = estimate_messages_tokens_rough(
-                                    _compressed
-                                )
-
-                                logger.info(
-                                    "Session hygiene: compressed %s → %s msgs, "
-                                    "~%s → ~%s tokens",
-                                    _msg_count, _new_count,
-                                    f"{_approx_tokens:,}", f"{_new_tokens:,}",
-                                )
-
-                                if _hyg_adapter:
-                                    try:
-                                        await _hyg_adapter.send(
-                                            source.chat_id,
-                                            f"🗜️ Compressed: {_msg_count} → "
-                                            f"{_new_count} messages, "
-                                            f"~{_approx_tokens:,} → "
-                                            f"~{_new_tokens:,} tokens",
-                                            metadata=_hyg_meta,
-                                        )
-                                    except Exception:
-                                        pass
-
-                                # Still too large after compression — warn user
-                                if _new_tokens >= _warn_token_threshold:
-                                    logger.warning(
-                                        "Session hygiene: still ~%s tokens after "
-                                        "compression — suggesting /reset",
-                                        f"{_new_tokens:,}",
-                                    )
-                                    if _hyg_adapter:
-                                        try:
-                                            await _hyg_adapter.send(
-                                                source.chat_id,
-                                                "⚠️ Session is still very large "
-                                                "after compression "
-                                                f"(~{_new_tokens:,} tokens). "
-                                                "Consider using /reset to start "
-                                                "fresh if you experience issues.",
-                                                metadata=_hyg_meta,
-                                            )
-                                        except Exception:
-                                            pass
-
-                    except Exception as e:
-                        logger.warning(
-                            "Session hygiene auto-compress failed: %s", e
-                        )
-                        # Compression failed and session is dangerously large
-                        if _approx_tokens >= _warn_token_threshold:
-                            _hyg_adapter = self.adapters.get(source.platform)
-                            _hyg_meta = {"thread_id": source.thread_id} if source.thread_id else None
-                            if _hyg_adapter:
-                                try:
-                                    await _hyg_adapter.send(
-                                        source.chat_id,
-                                        f"⚠️ Session is very large "
-                                        f"({_msg_count} messages, "
-                                        f"~{_approx_tokens:,} tokens) and "
-                                        "auto-compression failed. Consider "
-                                        "using /compress or /reset to avoid "
-                                        "issues.",
-                                        metadata=_hyg_meta,
-                                    )
-                                except Exception:
-                                    pass
-
         # First-message onboarding -- only on the very first interaction ever
         if not history and not self.session_store.has_any_sessions():
             context_prompt += (
@@ -2382,6 +2484,16 @@ class GatewayRunner:
                         message_text = _ctx_result.message
                 except Exception as exc:
                     logger.debug("@ context reference expansion failed: %s", exc)
+
+            history = await self._maybe_hygiene_compress(
+                event=event,
+                source=source,
+                session_entry=session_entry,
+                session_key=session_key,
+                history=history,
+                context_prompt=context_prompt,
+                message_text=message_text,
+            )
 
             # Run the agent
             agent_result = await self._run_agent(
@@ -3934,30 +4046,66 @@ class GatewayRunner:
 
         try:
             from run_agent import AIAgent
-            from agent.model_metadata import estimate_messages_tokens_rough
+            from agent.model_metadata import estimate_effective_request_tokens_rough
 
-            runtime_kwargs = _resolve_runtime_agent_kwargs()
-            if not runtime_kwargs.get("api_key"):
-                return "No provider configured -- cannot compress."
+            _redact_pii = False
+            try:
+                import yaml as _pii_yaml
+                with open(_config_path, encoding="utf-8") as _pf:
+                    _pcfg = _pii_yaml.safe_load(_pf) or {}
+                _redact_pii = bool((_pcfg.get("privacy") or {}).get("redact_pii", False))
+            except Exception:
+                pass
 
-            # Resolve model from config (same reason as memory flush above).
-            model = _resolve_gateway_model()
+            context = build_session_context(source, self.config, session_entry)
+            context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
 
-            msgs = [
-                {"role": m.get("role"), "content": m.get("content")}
-                for m in history
-                if m.get("role") in ("user", "assistant") and m.get("content")
-            ]
+            turn_setup = self._resolve_turn_agent_setup(
+                message="",
+                source=source,
+                context_prompt=context_prompt,
+                session_key=session_entry.session_key,
+            )
+            self._reasoning_config = turn_setup["reasoning_config"]
+
+            pr = self._provider_routing
+            msgs = self._normalize_history_for_agent(history)
             original_count = len(msgs)
-            approx_tokens = estimate_messages_tokens_rough(msgs)
 
             tmp_agent = AIAgent(
-                **runtime_kwargs,
-                model=model,
+                model=turn_setup["turn_route"]["model"],
+                **turn_setup["turn_route"]["runtime"],
                 max_iterations=4,
                 quiet_mode=True,
-                enabled_toolsets=["memory"],
+                verbose_logging=False,
+                enabled_toolsets=turn_setup["enabled_toolsets"],
+                ephemeral_system_prompt=turn_setup["combined_ephemeral"] or None,
+                prefill_messages=self._prefill_messages or None,
+                reasoning_config=turn_setup["reasoning_config"],
+                providers_allowed=pr.get("only"),
+                providers_ignored=pr.get("ignore"),
+                providers_order=pr.get("order"),
+                provider_sort=pr.get("sort"),
+                provider_require_parameters=pr.get("require_parameters", False),
+                provider_data_collection=pr.get("data_collection"),
                 session_id=session_entry.session_id,
+                platform=turn_setup["platform_key"],
+                honcho_session_key=session_entry.session_key,
+                honcho_manager=turn_setup["honcho_manager"],
+                honcho_config=turn_setup["honcho_config"],
+                session_db=self._session_db,
+                fallback_model=self._fallback_model,
+            )
+            active_system_prompt = self._resolve_agent_system_prompt(
+                tmp_agent,
+                msgs,
+            )
+            approx_tokens = estimate_effective_request_tokens_rough(
+                msgs,
+                system_prompt=active_system_prompt or "",
+                ephemeral_system_prompt=getattr(tmp_agent, "ephemeral_system_prompt", "") or "",
+                tools=getattr(tmp_agent, "tools", None),
+                prefill_messages=getattr(tmp_agent, "prefill_messages", None),
             )
 
             loop = asyncio.get_event_loop()
@@ -3972,11 +4120,21 @@ class GatewayRunner:
                 session_entry.session_key, last_prompt_tokens=0,
             )
             new_count = len(compressed)
-            new_tokens = estimate_messages_tokens_rough(compressed)
+            compressed_system_prompt = self._resolve_agent_system_prompt(
+                tmp_agent,
+                compressed,
+            )
+            new_tokens = estimate_effective_request_tokens_rough(
+                compressed,
+                system_prompt=compressed_system_prompt or "",
+                ephemeral_system_prompt=getattr(tmp_agent, "ephemeral_system_prompt", "") or "",
+                tools=getattr(tmp_agent, "tools", None),
+                prefill_messages=getattr(tmp_agent, "prefill_messages", None),
+            )
 
             return (
                 f"🗜️ Compressed: {original_count} → {new_count} messages\n"
-                f"~{approx_tokens:,} → ~{new_tokens:,} tokens"
+                f"~{approx_tokens:,} → ~{new_tokens:,} tokens (full request estimate)"
             )
         except Exception as e:
             logger.warning("Manual compress failed: %s", e)
@@ -5120,29 +5278,14 @@ class GatewayRunner:
 
             # Read from env var or use default (same as CLI)
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
-            
-            # Map platform enum to the platform hint key the agent understands.
-            # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
-            platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
-            
-            # Combine platform context with user-configured ephemeral system prompt
-            combined_ephemeral = context_prompt or ""
-            if self._ephemeral_system_prompt:
-                combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
-
-            # Re-read .env and config for fresh credentials (gateway is long-lived,
-            # keys may change without restart).
-            try:
-                load_dotenv(_env_path, override=True, encoding="utf-8")
-            except UnicodeDecodeError:
-                load_dotenv(_env_path, override=True, encoding="latin-1")
-            except Exception:
-                pass
-
-            model = _resolve_gateway_model()
 
             try:
-                runtime_kwargs = _resolve_runtime_agent_kwargs()
+                turn_setup = self._resolve_turn_agent_setup(
+                    message=message,
+                    source=source,
+                    context_prompt=context_prompt,
+                    session_key=session_key,
+                )
             except Exception as exc:
                 return {
                     "final_response": f"⚠️ Provider authentication failed: {exc}",
@@ -5152,8 +5295,13 @@ class GatewayRunner:
                 }
 
             pr = self._provider_routing
-            honcho_manager, honcho_config = self._get_or_create_gateway_honcho(session_key)
-            reasoning_config = self._load_reasoning_config()
+            platform_key = turn_setup["platform_key"]
+            enabled_toolsets = turn_setup["enabled_toolsets"]
+            combined_ephemeral = turn_setup["combined_ephemeral"]
+            reasoning_config = turn_setup["reasoning_config"]
+            honcho_manager = turn_setup["honcho_manager"]
+            honcho_config = turn_setup["honcho_config"]
+            turn_route = turn_setup["turn_route"]
             self._reasoning_config = reasoning_config
             # Set up streaming consumer if enabled
             _stream_consumer = None
@@ -5183,8 +5331,6 @@ class GatewayRunner:
                         stream_consumer_holder[0] = _stream_consumer
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
-
-            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -5249,58 +5395,7 @@ class GatewayRunner:
             # Capture the full tool definitions for transcript logging
             tools_holder[0] = agent.tools if hasattr(agent, 'tools') else None
             
-            # Convert history to agent format.
-            # Two cases:
-            #   1. Normal path (from transcript): simple {role, content, timestamp} dicts
-            #      - Strip timestamps, keep role+content
-            #   2. Interrupt path (from agent result["messages"]): full agent messages
-            #      that may include tool_calls, tool_call_id, reasoning, etc.
-            #      - These must be passed through intact so the API sees valid
-            #        assistant→tool sequences (dropping tool_calls causes 500 errors)
-            agent_history = []
-            for msg in history:
-                role = msg.get("role")
-                if not role:
-                    continue
-                
-                # Skip metadata entries (tool definitions, session info)
-                # -- these are for transcript logging, not for the LLM
-                if role in ("session_meta",):
-                    continue
-                
-                # Skip system messages -- the agent rebuilds its own system prompt
-                if role == "system":
-                    continue
-                
-                # Rich agent messages (tool_calls, tool results) must be passed
-                # through intact so the API sees valid assistant→tool sequences
-                has_tool_calls = "tool_calls" in msg
-                has_tool_call_id = "tool_call_id" in msg
-                is_tool_message = role == "tool"
-                
-                if has_tool_calls or has_tool_call_id or is_tool_message:
-                    clean_msg = {k: v for k, v in msg.items() if k != "timestamp"}
-                    agent_history.append(clean_msg)
-                else:
-                    # Simple text message - just need role and content
-                    content = msg.get("content")
-                    if content:
-                        # Tag cross-platform mirror messages so the agent knows their origin
-                        if msg.get("mirror"):
-                            mirror_src = msg.get("mirror_source", "another session")
-                            content = f"[Delivered from {mirror_src}] {content}"
-                        entry = {"role": role, "content": content}
-                        # Preserve reasoning fields on assistant messages so
-                        # multi-turn reasoning context survives session reload.
-                        # The agent's _build_api_kwargs converts these to the
-                        # provider-specific format (reasoning_content, etc.).
-                        if role == "assistant":
-                            for _rkey in ("reasoning", "reasoning_details",
-                                          "codex_reasoning_items"):
-                                _rval = msg.get(_rkey)
-                                if _rval:
-                                    entry[_rkey] = _rval
-                        agent_history.append(entry)
+            agent_history = self._normalize_history_for_agent(history)
             
             # Collect MEDIA paths already in history so we can exclude them
             # from the current turn's extraction. This is compression-safe:

--- a/run_agent.py
+++ b/run_agent.py
@@ -78,6 +78,7 @@ from agent.prompt_builder import (
 from agent.model_metadata import (
     fetch_model_metadata,
     estimate_tokens_rough, estimate_messages_tokens_rough,
+    estimate_request_tokens_rough, estimate_effective_request_tokens_rough,
     get_next_probe_tier, parse_context_limit_from_error,
     save_context_length,
 )
@@ -1129,6 +1130,7 @@ class AIAgent:
             self.context_compressor.last_total_tokens = 0
             self.context_compressor.compression_count = 0
             self.context_compressor._context_probed = False
+            self.context_compressor._context_probe_persistable = False
     
     def _safe_print(self, *args, **kwargs):
         """Print that silently handles broken pipes / closed stdout.
@@ -2428,6 +2430,40 @@ class AIAgent:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
 
         return "\n\n".join(prompt_parts)
+
+    def _get_or_build_active_system_prompt(
+        self,
+        system_message: str = None,
+        conversation_history: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
+        """Return the stable system prompt snapshot for the current session."""
+        if self._cached_system_prompt is None:
+            stored_prompt = None
+            if conversation_history and self._session_db:
+                try:
+                    session_row = self._session_db.get_session(self.session_id)
+                    if session_row:
+                        stored_prompt = session_row.get("system_prompt") or None
+                except Exception:
+                    pass
+
+            if stored_prompt:
+                self._cached_system_prompt = stored_prompt
+            else:
+                self._cached_system_prompt = self._build_system_prompt(system_message)
+                if self._honcho_context:
+                    self._cached_system_prompt = (
+                        self._cached_system_prompt + "\n\n" + self._honcho_context
+                    ).strip()
+                if self._session_db:
+                    try:
+                        self._session_db.update_system_prompt(
+                            self.session_id, self._cached_system_prompt
+                        )
+                    except Exception as e:
+                        logger.debug("Session DB update_system_prompt failed: %s", e)
+
+        return self._cached_system_prompt
 
     # =========================================================================
     # Pre/post-call guardrails (inspired by PR #1321 — @alireza78a)
@@ -5640,37 +5676,10 @@ class AIAgent:
         # from disk that the model already knows about (it wrote them!),
         # producing a different system prompt and breaking the Anthropic
         # prefix cache.
-        if self._cached_system_prompt is None:
-            stored_prompt = None
-            if conversation_history and self._session_db:
-                try:
-                    session_row = self._session_db.get_session(self.session_id)
-                    if session_row:
-                        stored_prompt = session_row.get("system_prompt") or None
-                except Exception:
-                    pass  # Fall through to build fresh
-
-            if stored_prompt:
-                # Continuing session — reuse the exact system prompt from
-                # the previous turn so the Anthropic cache prefix matches.
-                self._cached_system_prompt = stored_prompt
-            else:
-                # First turn of a new session — build from scratch.
-                self._cached_system_prompt = self._build_system_prompt(system_message)
-                # Bake Honcho context into the prompt so it's stable for
-                # the entire session (not re-fetched per turn).
-                if self._honcho_context:
-                    self._cached_system_prompt = (
-                        self._cached_system_prompt + "\n\n" + self._honcho_context
-                    ).strip()
-                # Store the system prompt snapshot in SQLite
-                if self._session_db:
-                    try:
-                        self._session_db.update_system_prompt(self.session_id, self._cached_system_prompt)
-                    except Exception as e:
-                        logger.debug("Session DB update_system_prompt failed: %s", e)
-
-        active_system_prompt = self._cached_system_prompt
+        active_system_prompt = self._get_or_build_active_system_prompt(
+            system_message,
+            conversation_history=conversation_history,
+        )
 
         # ── Preflight context compression ──
         # Before entering the main loop, check if the loaded conversation
@@ -5684,9 +5693,13 @@ class AIAgent:
             and len(messages) > self.context_compressor.protect_first_n
                                 + self.context_compressor.protect_last_n + 1
         ):
-            _sys_tok_est = estimate_tokens_rough(active_system_prompt or "")
-            _msg_tok_est = estimate_messages_tokens_rough(messages)
-            _preflight_tokens = _sys_tok_est + _msg_tok_est
+            _preflight_tokens = estimate_effective_request_tokens_rough(
+                messages,
+                system_prompt=active_system_prompt or "",
+                ephemeral_system_prompt=self.ephemeral_system_prompt or "",
+                tools=self.tools or None,
+                prefill_messages=self.prefill_messages or None,
+            )
 
             if _preflight_tokens >= self.context_compressor.threshold_tokens:
                 logger.info(
@@ -5712,9 +5725,13 @@ class AIAgent:
                     if len(messages) >= _orig_len:
                         break  # Cannot compress further
                     # Re-estimate after compression
-                    _sys_tok_est = estimate_tokens_rough(active_system_prompt or "")
-                    _msg_tok_est = estimate_messages_tokens_rough(messages)
-                    _preflight_tokens = _sys_tok_est + _msg_tok_est
+                    _preflight_tokens = estimate_effective_request_tokens_rough(
+                        messages,
+                        system_prompt=active_system_prompt or "",
+                        ephemeral_system_prompt=self.ephemeral_system_prompt or "",
+                        tools=self.tools or None,
+                        prefill_messages=self.prefill_messages or None,
+                    )
                     if _preflight_tokens < self.context_compressor.threshold_tokens:
                         break  # Under threshold
 
@@ -5839,8 +5856,11 @@ class AIAgent:
             api_messages = self._sanitize_api_messages(api_messages)
 
             # Calculate approximate request size for logging
-            total_chars = sum(len(str(msg)) for msg in api_messages)
-            approx_tokens = total_chars // 4  # Rough estimate: 4 chars per token
+            approx_tokens = estimate_request_tokens_rough(
+                api_messages,
+                tools=self.tools if self.tools else None,
+            )
+            total_chars = approx_tokens * 4
             
             # Thinking spinner for quiet mode (animated during API call)
             thinking_spinner = None
@@ -6158,9 +6178,15 @@ class AIAgent:
                         # Cache discovered context length after successful call
                         if self.context_compressor._context_probed:
                             ctx = self.context_compressor.context_length
-                            save_context_length(self.model, self.base_url, ctx)
-                            self._safe_print(f"{self.log_prefix}💾 Cached context length: {ctx:,} tokens for {self.model}")
+                            if (
+                                getattr(self.context_compressor, "_context_probe_persistable", False)
+                                and self.model
+                                and self.base_url
+                            ):
+                                save_context_length(self.model, self.base_url, ctx)
+                                self._safe_print(f"{self.log_prefix}💾 Cached context length: {ctx:,} tokens for {self.model}")
                             self.context_compressor._context_probed = False
+                            self.context_compressor._context_probe_persistable = False
 
                         self.session_prompt_tokens += prompt_tokens
                         self.session_completion_tokens += completion_tokens
@@ -6413,7 +6439,7 @@ class AIAgent:
                         'exceeds the limit', 'context window',
                         'request entity too large',  # OpenRouter/Nous 413 safety net
                         'prompt is too long',  # Anthropic: "prompt is too long: N tokens > M maximum"
-                        'prompt exceeds max length',  # Z.AI / GLM: generic 400 overflow wording
+                        'prompt exceeds max length',  # Z.AI GLM coding endpoint
                     ])
 
                     # Fallback heuristic: Anthropic sometimes returns a generic
@@ -6454,6 +6480,9 @@ class AIAgent:
                             compressor.context_length = new_ctx
                             compressor.threshold_tokens = int(new_ctx * compressor.threshold_percent)
                             compressor._context_probed = True
+                            compressor._context_probe_persistable = bool(
+                                parsed_limit and parsed_limit == new_ctx
+                            )
                             self._vprint(f"{self.log_prefix}⚠️  Context length exceeded — stepping down: {old_ctx:,} → {new_ctx:,} tokens", force=True)
                         else:
                             self._vprint(f"{self.log_prefix}⚠️  Context length exceeded at minimum tier — attempting compression...", force=True)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -23,6 +23,9 @@ from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
     _strip_provider_prefix,
+    estimate_request_tokens_rough,
+    estimate_effective_request_tokens_rough,
+    resolve_request_budget,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
     get_model_context_length,
@@ -99,6 +102,62 @@ class TestEstimateMessagesTokensRough:
         ]}
         result = estimate_messages_tokens_rough([msg])
         assert result == len(str(msg)) // 4
+
+
+class TestEstimateEffectiveRequestTokensRough:
+    def test_matches_built_api_request_shape(self):
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        prefill = [{"role": "assistant", "content": "prefill"}]
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "memory",
+                    "description": "x" * 40,
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+        result = estimate_effective_request_tokens_rough(
+            messages,
+            system_prompt="base system",
+            ephemeral_system_prompt="gateway context",
+            prefill_messages=prefill,
+            tools=tools,
+        )
+
+        expected = estimate_request_tokens_rough(
+            [
+                {"role": "system", "content": "base system\n\ngateway context"},
+                {"role": "assistant", "content": "prefill"},
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ],
+            tools=tools,
+        )
+        assert result == expected
+
+
+class TestResolveRequestBudget:
+    @patch("agent.model_metadata.get_model_context_length")
+    def test_uses_configured_threshold_and_context_length(self, mock_ctx):
+        mock_ctx.return_value = 200_000
+
+        budget = resolve_request_budget(
+            model="glm-5-turbo",
+            threshold_percent=0.5,
+            provider="zai",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        )
+
+        assert budget.context_length == 200_000
+        assert budget.threshold_percent == 0.5
+        assert budget.threshold_tokens == 100_000
+        assert budget.warn_tokens == 190_000
 
 
 # =========================================================================

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -17,7 +17,11 @@ from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
 
-from agent.model_metadata import estimate_messages_tokens_rough
+from agent.model_metadata import (
+    estimate_messages_tokens_rough,
+    estimate_request_tokens_rough,
+    estimate_effective_request_tokens_rough,
+)
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
 from gateway.session import SessionEntry, SessionSource
@@ -304,6 +308,11 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
     class FakeCompressAgent:
         def __init__(self, **kwargs):
             self.model = kwargs.get("model")
+            self.context_compressor = SimpleNamespace(
+                context_length=500,
+                threshold_percent=0.5,
+                threshold_tokens=250,
+            )
 
         def _compress_context(self, messages, *_args, **_kwargs):
             return ([{"role": "assistant", "content": "compressed"}], None)
@@ -340,6 +349,11 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
     runner._pending_messages = {}
     runner._pending_approvals = {}
     runner._session_db = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._prefill_messages = None
+    runner._load_reasoning_config = lambda: None
+    runner._get_or_create_gateway_honcho = lambda _session_key: (None, None)
     runner._is_user_authorized = lambda _source: True
     runner._set_session_env = lambda _context: None
     runner._run_agent = AsyncMock(
@@ -381,3 +395,553 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
     assert adapter.sent[1]["chat_id"] == "-1001"
     assert "Compressed:" in adapter.sent[1]["content"]
     assert adapter.sent[1]["metadata"] == {"thread_id": "17585"}
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_reports_full_request_estimate_after_compress(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeCompressAgent:
+        def __init__(self, **kwargs):
+            self.model = kwargs.get("model")
+            self.tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "memory",
+                        "description": "x" * 120,
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+            self.prefill_messages = None
+            self._cached_system_prompt = "system prompt " + ("y" * 120)
+            self.context_compressor = SimpleNamespace(
+                context_length=500,
+                threshold_percent=0.5,
+                threshold_tokens=250,
+            )
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:17585",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._prefill_messages = None
+    runner._load_reasoning_config = lambda: None
+    runner._get_or_create_gateway_honcho = lambda _session_key: (None, None)
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="17585",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    compressed_notice = adapter.sent[1]["content"]
+    assert "Compressed:" in compressed_notice
+    assert "full request estimate" in compressed_notice
+
+    compressed_messages = [
+        {"role": "assistant", "content": "compressed"},
+        {"role": "user", "content": "hello"},
+    ]
+    expected_tokens = estimate_effective_request_tokens_rough(
+        compressed_messages,
+        system_prompt="system prompt " + ("y" * 120),
+        tools=FakeCompressAgent().tools,
+    )
+    assert f"~{expected_tokens:,} tokens" in compressed_notice
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_uses_agent_threshold_and_full_request_shape(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    (tmp_path / "config.yaml").write_text(
+        """
+model:
+  default: glm-5-turbo
+  provider: zai
+  base_url: https://api.z.ai/api/coding/paas/v4
+compression:
+  threshold: 0.5
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    class FakeCompressAgent:
+        def __init__(self, **kwargs):
+            self.model = kwargs.get("model")
+            self.ephemeral_system_prompt = kwargs.get("ephemeral_system_prompt")
+            self.prefill_messages = None
+            self.tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "description": "x" * 120,
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+            self.context_compressor = SimpleNamespace(
+                context_length=400,
+                threshold_percent=0.5,
+                threshold_tokens=200,
+            )
+
+        def _get_or_build_active_system_prompt(self, *_args, **_kwargs):
+            return "base system"
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:17585",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=20)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._prefill_messages = None
+    runner._load_reasoning_config = lambda: None
+    runner._get_or_create_gateway_honcho = lambda _session_key: (None, None)
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+    runner._ephemeral_system_prompt = "gateway note"
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="17585",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert len(adapter.sent) == 2
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_accounts_for_reply_context_injected_message(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    (tmp_path / "config.yaml").write_text(
+        """
+model:
+  default: glm-5-turbo
+  provider: zai
+  base_url: https://api.z.ai/api/coding/paas/v4
+compression:
+  threshold: 0.5
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    class FakeCompressAgent:
+        def __init__(self, **kwargs):
+            self.model = kwargs.get("model")
+            self.ephemeral_system_prompt = kwargs.get("ephemeral_system_prompt")
+            self.prefill_messages = None
+            self.tools = []
+            self.context_compressor = SimpleNamespace(
+                context_length=500,
+                threshold_percent=0.5,
+                threshold_tokens=250,
+            )
+
+        def _get_or_build_active_system_prompt(self, *_args, **_kwargs):
+            return "base system"
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:17585",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=5)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._prefill_messages = None
+    runner._load_reasoning_config = lambda: None
+    runner._get_or_create_gateway_honcho = lambda _session_key: (None, None)
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+    runner._ephemeral_system_prompt = ""
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="17585",
+        ),
+        message_id="1",
+        reply_to_message_id="prev-1",
+        reply_to_text="r" * 1000,
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert len(adapter.sent) == 2
+    assert "Auto-compressing" in adapter.sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_accounts_for_at_expansion(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    (tmp_path / "config.yaml").write_text(
+        """
+model:
+  default: glm-5-turbo
+  provider: zai
+  base_url: https://api.z.ai/api/coding/paas/v4
+compression:
+  threshold: 0.5
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    class FakeCompressAgent:
+        def __init__(self, **kwargs):
+            self.model = kwargs.get("model")
+            self.ephemeral_system_prompt = kwargs.get("ephemeral_system_prompt")
+            self.prefill_messages = None
+            self.tools = []
+            self.context_compressor = SimpleNamespace(
+                context_length=500,
+                threshold_percent=0.5,
+                threshold_tokens=250,
+            )
+
+        def _get_or_build_active_system_prompt(self, *_args, **_kwargs):
+            return "base system"
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    async def _fake_expand(message_text, **_kwargs):
+        return SimpleNamespace(
+            blocked=False,
+            expanded=True,
+            message="[expanded]\n" + ("x" * 1000),
+            warnings=[],
+        )
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:17585",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=5)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._prefill_messages = None
+    runner._load_reasoning_config = lambda: None
+    runner._get_or_create_gateway_honcho = lambda _session_key: (None, None)
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+    runner._ephemeral_system_prompt = ""
+    runner._model = "glm-5-turbo"
+    runner._base_url = "https://api.z.ai/api/coding/paas/v4"
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr(
+        "agent.context_references.preprocess_context_references_async",
+        _fake_expand,
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 500,
+    )
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="@file:test.txt",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="17585",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert len(adapter.sent) == 2
+    assert "Auto-compressing" in adapter.sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_manual_compact_reports_full_request_estimate(monkeypatch):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeCompressAgent:
+        def __init__(self, **kwargs):
+            self.model = kwargs.get("model")
+            self.ephemeral_system_prompt = kwargs.get("ephemeral_system_prompt")
+            self.prefill_messages = None
+            self.tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "memory",
+                        "description": "x" * 120,
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+
+        def _get_or_build_active_system_prompt(self, *_args, **_kwargs):
+            return "base system"
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:17585",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=100)
+    runner.session_store.update_session = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner._session_db = None
+    runner._ephemeral_system_prompt = "gateway note"
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._prefill_messages = None
+    runner._load_reasoning_config = lambda: None
+    runner._get_or_create_gateway_honcho = lambda _session_key: (None, None)
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+
+    event = MessageEvent(
+        text="/compact",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="17585",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_compress_command(event)
+
+    assert "full request estimate" in result
+    assert "tokens" in result

--- a/tests/test_1630_context_overflow_loop.py
+++ b/tests/test_1630_context_overflow_loop.py
@@ -126,6 +126,243 @@ class TestGeneric400Heuristic:
         ])
         assert is_context_length_error
 
+    def test_zai_prompt_exceeds_max_length_needs_phrase_match(self):
+        """Z.AI returns 'Prompt exceeds max length' for context overflow."""
+        error_msg = (
+            "Error code: 400 - {'error': {'code': '1261', "
+            "'message': 'Prompt exceeds max length'}}"
+        )
+        is_context_length_error = any(phrase in error_msg.lower() for phrase in [
+            'context length', 'context size', 'maximum context',
+            'token limit', 'too many tokens', 'reduce the length',
+            'exceeds the limit', 'context window',
+            'request entity too large',
+            'prompt is too long',
+            'prompt exceeds max length',
+        ])
+        assert is_context_length_error
+
+    def test_zai_prompt_exceeds_max_length_triggers_compression_without_persisting_guess(self):
+        """Provider-specific GLM overflow should compress but not persist guessed tiers."""
+        error = Exception(
+            "Error code: 400 - {'error': {'code': '1261', "
+            "'message': 'Prompt exceeds max length'}}"
+        )
+        error.status_code = 400
+
+        agent = self._make_agent()
+        agent.model = "glm-5-turbo"
+        agent.provider = "zai"
+        agent.base_url = "https://api.z.ai/api/coding/paas/v4"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 170_000
+        ok_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="Recovered", tool_calls=None, reasoning_content=None, reasoning=None), finish_reason="stop")],
+            model="glm-5-turbo",
+            usage=SimpleNamespace(prompt_tokens=12, completion_tokens=1, total_tokens=13),
+        )
+        agent.client.chat.completions.create.side_effect = [error, ok_resp]
+
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context", return_value=(
+                [{"role": "user", "content": "compressed summary"}],
+                "compressed prompt",
+            )) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.save_context_length") as mock_save_context,
+        ):
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        mock_save_context.assert_not_called()
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered"
+
+    def test_parsed_context_limit_is_persisted(self):
+        """A provider-reported numeric limit should still be cached."""
+        error = Exception(
+            "Error code: 400 - prompt is too long: 250000 tokens > 200000 maximum"
+        )
+        error.status_code = 400
+
+        agent = self._make_agent()
+        agent.model = "glm-5-turbo"
+        agent.provider = "zai"
+        agent.base_url = "https://api.z.ai/api/coding/paas/v4"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.context_compressor.context_length = 250_000
+        agent.context_compressor.threshold_tokens = 212_500
+        ok_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="Recovered", tool_calls=None, reasoning_content=None, reasoning=None), finish_reason="stop")],
+            model="glm-5-turbo",
+            usage=SimpleNamespace(prompt_tokens=12, completion_tokens=1, total_tokens=13),
+        )
+        agent.client.chat.completions.create.side_effect = [error, ok_resp]
+
+        with (
+            patch.object(agent, "_compress_context", return_value=(
+                [{"role": "user", "content": "compressed summary"}],
+                "compressed prompt",
+            )),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.save_context_length") as mock_save_context,
+        ):
+            result = agent.run_conversation("hello", conversation_history=[
+                {"role": "user", "content": "previous question"},
+                {"role": "assistant", "content": "previous answer"},
+            ])
+
+        mock_save_context.assert_called_once_with(
+            "glm-5-turbo",
+            "https://api.z.ai/api/coding/paas/v4",
+            200_000,
+        )
+        assert result["completed"] is True
+
+    def test_success_path_does_not_cache_guessed_fallback_after_retry(self):
+        """A guessed 128k retry tier must stay in-memory only after recovery."""
+        error = Exception(
+            "Error code: 400 - {'error': {'code': '1261', "
+            "'message': 'Prompt exceeds max length'}}"
+        )
+        error.status_code = 400
+
+        agent = self._make_agent()
+        agent.model = "glm-5-turbo"
+        agent.provider = "zai"
+        agent.base_url = "https://api.z.ai/api/coding/paas/v4"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 170_000
+        ok_resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="Recovered", tool_calls=None, reasoning_content=None, reasoning=None), finish_reason="stop")],
+            model="glm-5-turbo",
+            usage=SimpleNamespace(prompt_tokens=12, completion_tokens=1, total_tokens=13),
+        )
+        agent.client.chat.completions.create.side_effect = [error, ok_resp]
+
+        with (
+            patch.object(agent, "_compress_context", return_value=(
+                [{"role": "user", "content": "compressed summary"}],
+                "compressed prompt",
+            )),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.save_context_length") as mock_save_context,
+        ):
+            result = agent.run_conversation("hello", conversation_history=[
+                {"role": "user", "content": "previous question"},
+                {"role": "assistant", "content": "previous answer"},
+            ])
+
+        assert result["completed"] is True
+        assert agent.context_compressor.context_length == 128_000
+        assert agent.context_compressor._context_probed is False
+        mock_save_context.assert_not_called()
+
+    def test_preflight_counts_tool_schemas(self):
+        """Tool schemas should count toward preflight compression pressure."""
+        huge_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "huge_tool",
+                    "description": "d" * 400,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "payload": {
+                                "type": "string",
+                                "description": "p" * 400,
+                            }
+                        },
+                    },
+                },
+            }
+        ]
+        with (
+            patch("run_agent.get_tool_definitions", return_value=huge_tools),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-12345",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent.client = MagicMock()
+        agent._cached_system_prompt = "s" * 160
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 240
+        agent.context_compressor.threshold_tokens = 200
+        agent.context_compressor.protect_first_n = 1
+        agent.context_compressor.protect_last_n = 1
+        agent.client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None, reasoning_content=None, reasoning=None), finish_reason="stop")],
+            model="test-model",
+            usage=None,
+        )
+
+        history = [
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a"},
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a"},
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a"},
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context", return_value=(
+                [{"role": "user", "content": "compressed summary"}],
+                "compressed prompt",
+            )) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=history)
+
+        from agent.model_metadata import estimate_request_tokens_rough
+
+        assert mock_compress.call_count >= 1
+        first_call = mock_compress.call_args_list[0]
+        first_approx = first_call.kwargs["approx_tokens"]
+        request_messages = history + [{"role": "user", "content": "hello"}]
+        expected_with_tools = estimate_request_tokens_rough(
+            request_messages,
+            system_prompt="s" * 160,
+            tools=huge_tools,
+        )
+        expected_without_tools = estimate_request_tokens_rough(
+            request_messages,
+            system_prompt="s" * 160,
+        )
+
+        assert expected_without_tools < agent.context_compressor.threshold_tokens
+        assert expected_with_tools > agent.context_compressor.threshold_tokens
+        assert first_approx == expected_with_tools
+        assert result["completed"] is True
+
 
 # ---------------------------------------------------------------------------
 # Test 2: Gateway skips persistence on failed agent results


### PR DESCRIPTION
## What does this PR do?

  Fixes GLM context-overflow handling in long, tool-heavy gateway sessions.

  This PR fixes three related problems:

  1. Hermes could undercount the real request size before sending a turn because compaction decisions were not consistently based on the full request payload.
  2. Z.AI `Prompt exceeds max length` overflows could step Hermes down to a lower fallback tier and then incorrectly persist that guessed limit.
  3. Gateway hygiene was still reasoning about the session too early, before later turn enrichment like reply-context injection or `@` expansion had been applied.

  This change fixes that by:
  - estimating the effective request shape for compaction decisions, including system prompt, ephemeral/gateway prompt additions, prefill messages, conversation messages, and tool schemas
  - treating Z.AI `Prompt exceeds max length` as a context-overflow signal
  - persisting only provider-confirmed numeric context limits, while keeping guessed fallback tiers in-memory only
  - moving gateway hygiene compaction to the final pre-agent stage so it sees the same enriched turn payload the agent will actually send
  - making gateway auto-compaction and `/compact` report a full-request estimate after compression instead of a transcript-only estimate

  This approach keeps the change focused while making the gateway and agent reason about the same request surface.

  ## Related Issue

  Fixes #2599 

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Added full/effective request estimators in `agent/model_metadata.py`
  - Updated `run_agent.py` preflight/request-size estimation to use the effective request shape
  - Added Z.AI `Prompt exceeds max length` handling in `run_agent.py`
  - Stopped persisting guessed fallback probe tiers in `run_agent.py`; only parsed numeric limits are cached
  - Moved gateway hygiene compaction in `gateway/run.py` to run after final turn enrichment
  - Updated gateway post-compaction and `/compact` reporting to use full-request estimates
  - Added regression coverage in `tests/test_1630_context_overflow_loop.py`
  - Added request-estimation coverage in `tests/agent/test_model_metadata.py`
  - Added gateway hygiene coverage in `tests/gateway/test_session_hygiene.py`, including enriched-turn cases

  ## How to Test

  1. Run the focused regression slice:

     ```bash
     PYTHONPATH=/path/to/hermes-agent /path/to/venv/bin/python -m pytest \
       tests/agent/test_model_metadata.py \
       tests/gateway/test_session_hygiene.py \
       tests/test_1630_context_overflow_loop.py \
       tests/test_413_compression.py \
       tests/test_context_pressure.py -q

  2. Verify the focused result is:
      - 143 passed, 12 skipped
  3. Run the full suite:

     PYTHONPATH=/path/to/hermes-agent /path/to/venv/bin/python -m pytest tests/ -q
  4. Verify the branch does not introduce new full-suite failures relative to main.

     Current result on this branch:
      - 5 failed, 5966 passed, 166 skipped

     The same 5 failures are also present on main.

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
  - [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Ubuntu Linux

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  Focused verification:

  - 143 passed, 12 skipped

  Full suite:

  - 5 failed, 5966 passed, 166 skipped
  - failure set matches main

  Example provider-side overflow this PR handles correctly:

  Error code: 400 - {'error': {'code': '1261', 'message': 'Prompt exceeds max length'}}