### PR TITLE
fix(browser): fail readiness check when local Chromium is missing

### DIFF
--- a/tests/tools/test_browser_requirements.py
+++ b/tests/tools/test_browser_requirements.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+def test_playwright_registry_dir_uses_default_linux_cache(monkeypatch):
+    from tools.browser_tool import _playwright_registry_dir
+
+    monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", "/tmp/pw-cache")
+
+    with patch("tools.browser_tool.sys.platform", "linux"):
+        assert _playwright_registry_dir() == Path("/tmp/pw-cache/ms-playwright")
+
+
+def test_playwright_registry_dir_resolves_relative_env_path(monkeypatch):
+    from tools.browser_tool import _playwright_registry_dir
+
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "relative-browsers")
+    monkeypatch.setenv("INIT_CWD", "/tmp/project-root")
+
+    assert _playwright_registry_dir() == Path("/tmp/project-root/relative-browsers")
+
+
+def test_check_browser_requirements_requires_local_playwright_runtime():
+    from tools.browser_tool import check_browser_requirements
+
+    with (
+        patch("tools.browser_tool._find_agent_browser"),
+        patch("tools.browser_tool._get_cloud_provider", return_value=None),
+        patch("tools.browser_tool._has_local_playwright_browser", return_value=False),
+    ):
+        assert check_browser_requirements() is False
+
+    with (
+        patch("tools.browser_tool._find_agent_browser"),
+        patch("tools.browser_tool._get_cloud_provider", return_value=None),
+        patch("tools.browser_tool._has_local_playwright_browser", return_value=True),
+    ):
+        assert check_browser_requirements() is True
+
+
+def test_check_browser_requirements_uses_cloud_provider_config_when_selected():
+    from tools.browser_tool import check_browser_requirements
+
+    provider = Mock()
+    provider.is_configured.side_effect = [False, True]
+
+    with (
+        patch("tools.browser_tool._find_agent_browser"),
+        patch("tools.browser_tool._get_cloud_provider", return_value=provider),
+        patch("tools.browser_tool._has_local_playwright_browser") as mock_local_check,
+    ):
+        assert check_browser_requirements() is False
+        assert check_browser_requirements() is True
+
+    mock_local_check.assert_not_called()

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2247,15 +2247,61 @@ def cleanup_all_browsers() -> None:
 # Requirements Check
 # ============================================================================
 
+def _playwright_registry_dir() -> Path:
+    """Return Playwright's browser cache directory.
+
+    Mirrors Playwright's registryDirectory resolution well enough for our local
+    availability checks without importing Playwright internals at runtime.
+    """
+    env_defined = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "").strip()
+    if env_defined == "0":
+        return Path(__file__).parent.parent / "node_modules" / "playwright-core" / ".local-browsers"
+    if env_defined:
+        path = Path(env_defined).expanduser()
+        return path if path.is_absolute() else (Path(os.environ.get("INIT_CWD", os.getcwd())) / path).resolve()
+
+    if sys.platform == "linux":
+        cache_root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    elif sys.platform == "darwin":
+        cache_root = Path.home() / "Library" / "Caches"
+    elif sys.platform == "win32":
+        cache_root = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    else:
+        cache_root = Path.home() / ".cache"
+    return cache_root / "ms-playwright"
+
+
+
+def _has_local_playwright_browser() -> bool:
+    """Return True when the local Playwright browser payload exists.
+
+    Local browser mode needs an installed Chromium runtime, not just the
+    ``agent-browser`` wrapper script. Newer Playwright builds may use either
+    ``chromium-*`` or ``chromium_headless_shell-*`` directories depending on
+    how the launcher is configured, so accept either family.
+    """
+    registry_dir = _playwright_registry_dir()
+    if not registry_dir.exists():
+        return False
+
+    patterns = ("chromium-*", "chromium_headless_shell-*")
+    for pattern in patterns:
+        if any(registry_dir.glob(pattern)):
+            return True
+    return False
+
+
+
 def check_browser_requirements() -> bool:
     """
     Check if browser tool requirements are met.
 
-    In **local mode** (no cloud provider configured): only the
-    ``agent-browser`` CLI must be findable.
+    In **local mode** (no cloud provider configured): both the
+    ``agent-browser`` CLI and a local Playwright Chromium runtime must be
+    available.
 
-    In **cloud mode** (Browserbase, Browser Use, or Firecrawl): the CLI
-    *and* the provider's required credentials must be present.
+    In **cloud mode** (Browserbase, Browser Use, or Firecrawl): the CLI must be
+    findable and the selected provider must be configured.
 
     Returns:
         True if all requirements are met, False otherwise
@@ -2279,10 +2325,10 @@ def check_browser_requirements() -> bool:
 
     # In cloud mode, also require provider credentials
     provider = _get_cloud_provider()
-    if provider is not None and not provider.is_configured():
-        return False
+    if provider is not None:
+        return provider.is_configured()
 
-    return True
+    return _has_local_playwright_browser()
 
 
 # ============================================================================


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive browser readiness check in **local browser mode**.

Today `tools.browser_tool.check_browser_requirements()` returns `True` as soon as the `agent-browser` CLI is present. On current `main`, it does **not** also verify that a local Chromium runtime has actually been installed. That means Hermes can advertise the browser toolset as available, then fail later on first launch because the underlying Playwright browser payload is missing.

This PR makes the local-mode readiness check stricter:

- keep requiring the `agent-browser` CLI
- additionally require an installed local Chromium payload before reporting browser tools as available
- leave cloud-provider readiness logic unchanged

## Why this matters

This is a real bug, not just nicer diagnostics.

Without this change, users can land in a bad state where:

1. `agent-browser` exists
2. browser tools are treated as available
3. local Chromium has never been downloaded
4. the first real browser action fails at runtime

That is exactly the kind of paper-cut maintainers usually want gone: incorrect readiness reporting followed by delayed failure.

## Changes made

- add a helper to resolve Playwright's local browser cache directory across supported platforms
- detect whether a local Chromium payload exists (`chromium-*` or `chromium_headless_shell-*`)
- require that payload in local mode before `check_browser_requirements()` returns `True`
- keep cloud-provider behavior unchanged when Browserbase / Browser Use / Firecrawl is selected
- add focused regression tests for cache-path resolution and readiness gating

## Scope / non-goals

- no changes to cloud-browser provider behavior
- no changes to CDP override handling
- no new install flow; this only makes the readiness check honest

## How to test

### Targeted tests
- `./venv/bin/pytest -q tests/tools/test_browser_requirements.py tests/tools/test_browser_cdp_override.py tests/tools/test_browser_console.py`

### Manual reproduction
1. Ensure `agent-browser` is installed.
2. Use local browser mode with no cloud provider configured.
3. Remove or avoid installing the local Playwright Chromium payload.
4. Confirm browser requirements now fail early instead of reporting the toolset as available and crashing later on launch.

## Platform notes

The cache-directory helper handles the common Playwright locations for Linux, macOS, and Windows, plus `PLAYWRIGHT_BROWSERS_PATH` overrides.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes incorrect behavior)
- [x] ✅ Tests (adding regression coverage)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor
