### PR TITLE
fix(setup): use explicit key mapping for returning-user menu dispatch instead of positional index

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3235,12 +3235,17 @@ def run_setup_wizard(args):
             print_info("Exiting. Run 'hermes setup' again when ready.")
             return
         elif 3 <= choice <= 7:
-            # Individual section
-            section_idx = choice - 3
-            _, label, func = SETUP_SECTIONS[section_idx]
-            func(config)
-            save_config(config)
-            _print_setup_summary(config, hermes_home)
+            # Individual section — map by key, not by position.
+            # SETUP_SECTIONS includes TTS but the returning-user menu skips it,
+            # so positional indexing (choice - 3) would dispatch the wrong section.
+            _RETURNING_USER_SECTION_KEYS = ["model", "terminal", "gateway", "tools", "agent"]
+            section_key = _RETURNING_USER_SECTION_KEYS[choice - 3]
+            section = next((s for s in SETUP_SECTIONS if s[0] == section_key), None)
+            if section:
+                _, label, func = section
+                func(config)
+                save_config(config)
+                _print_setup_summary(config, hermes_home)
             return
     else:
         # ── First-Time Setup ──


### PR DESCRIPTION
Fixes #2609

## Root Cause
The returning-user menu in `hermes setup` dispatched sections using `SETUP_SECTIONS[choice - 3]`. But `SETUP_SECTIONS` includes TTS (index 1) while the returning-user menu skips it, causing an off-by-one shift:

| Choice | Expected | Actual (broken) |
|--------|----------|-----------------|
| 3 | Model | Model ✅ |
| 4 | Terminal | TTS ❌ |
| 5 | Gateway | Terminal ❌ |
| 6 | Tools | Gateway ❌ |
| 7 | Agent | Tools ❌ |

## Fix
Replace positional indexing with an explicit key list `_RETURNING_USER_SECTION_KEYS = ["model", "terminal", "gateway", "tools", "agent"]` and look up sections by key. This is resilient to future additions to `SETUP_SECTIONS`.
