### PR TITLE
fix(cron): normalize repeat=-1 (LLM 'forever' convention) to None to prevent auto-deletion

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -415,7 +415,7 @@ def create_job(
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),
         "repeat": {
-            "times": repeat,  # None = forever
+            "times": None if (repeat is None or repeat <= 0) else repeat,  # None = forever; normalize -1 (LLM convention) to None
             "completed": 0
         },
         "enabled": True,
@@ -571,7 +571,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None):
                 # Check if we've hit the repeat limit
                 times = job["repeat"].get("times")
                 completed = job["repeat"]["completed"]
-                if times is not None and completed >= times:
+                if times is not None and times > 0 and completed >= times:  # times <= 0 means forever (handles LLM passing -1)
                     # Remove the job (limit reached)
                     jobs.pop(i)
                     save_jobs(jobs)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -267,7 +267,8 @@ def cronjob(
                 updates["base_url"] = _normalize_optional_job_value(base_url, strip_trailing_slash=True)
             if repeat is not None:
                 repeat_state = dict(job.get("repeat") or {})
-                repeat_state["times"] = repeat
+                # Normalize repeat <= 0 to None (LLMs often pass -1 to mean "forever")
+                repeat_state["times"] = None if repeat <= 0 else repeat
                 updates["repeat"] = repeat_state
             if schedule is not None:
                 parsed_schedule = parse_schedule(schedule)


### PR DESCRIPTION
Fixes #2611

## Root Cause
LLMs naturally pass `repeat=-1` to mean "forever" (common convention in many APIs). But `mark_job_run()` checked `completed >= times`, which evaluates `1 >= -1` → True, deleting the job after the first run.

## Fix (3 places)

1. **`cron/jobs.py` mark_job_run()**: Added `times > 0` guard — `times <= 0` now means forever
2. **`cron/jobs.py` create_job()**: Normalize `repeat <= 0` to `None` before storing
3. **`tools/cronjob_tools.py` update path**: Same normalization on job updates

## Result
- `repeat=None` → forever ✅ (unchanged)
- `repeat=-1` → forever ✅ (fixed)
- `repeat=0` → forever ✅ (fixed)
- `repeat=1` → once ✅ (unchanged)
- `repeat=3` → 3 times ✅ (unchanged)
