### PR TITLE
fix: prevent agents from starting gateway outside systemd management

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -464,3 +464,40 @@ class TestForkBombDetection:
         dangerous, key, desc = detect_dangerous_command("echo hello:world")
         assert dangerous is False
 
+
+class TestGatewayProtection:
+    """Prevent agents from starting the gateway outside systemd management."""
+
+    def test_gateway_run_with_disown_detected(self):
+        cmd = "kill 1605 && cd ~/.hermes/hermes-agent && source venv/bin/activate && python -m hermes_cli.main gateway run --replace &disown; echo done"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "systemctl" in desc
+
+    def test_gateway_run_with_ampersand_detected(self):
+        cmd = "python -m hermes_cli.main gateway run --replace &"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_gateway_run_with_nohup_detected(self):
+        cmd = "nohup python -m hermes_cli.main gateway run --replace"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_gateway_run_with_setsid_detected(self):
+        cmd = "hermes_cli.main gateway run --replace &disown"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_gateway_run_foreground_not_flagged(self):
+        """Normal foreground gateway run (as in systemd ExecStart) is fine."""
+        cmd = "python -m hermes_cli.main gateway run --replace"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_systemctl_restart_not_flagged(self):
+        """Using systemctl to manage the gateway is the correct approach."""
+        cmd = "systemctl --user restart hermes-gateway"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -49,6 +49,9 @@ DANGEROUS_PATTERNS = [
     (r'\bxargs\s+.*\brm\b', "xargs with rm"),
     (r'\bfind\b.*-exec\s+(/\S*/)?rm\b', "find -exec rm"),
     (r'\bfind\b.*-delete\b', "find -delete"),
+    # Gateway protection: never start gateway outside systemd management
+    (r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b)', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
+    (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
 ]
 
 


### PR DESCRIPTION
## Problem

An agent session on Telegram was asked to restart the gateway for DNS recovery. It ran:
```
kill 1605 && cd ~/.hermes/hermes-agent && source venv/bin/activate && python -m hermes_cli.main gateway run --replace &disown
```

This killed the systemd-managed gateway process and started a replacement with `&disown`, completely outside systemd's management. The systemd service saw a clean exit (code 0) and with `Restart=on-failure`, didn't restart. The orphaned gateway ran for ~7 hours until it received SIGTERM, at which point nothing restarted it.

## Root Causes

1. **`Restart=on-failure` in systemd service** — clean SIGTERM shutdown exits with code 0, which isn't a 'failure', so systemd never restarts
2. **Agent started gateway with `&disown`** — took it out of systemd management entirely

## Fixes

### Code changes (this PR)
- Add dangerous command patterns to `tools/approval.py` detecting:
  - `gateway run` with `&`, `disown`, or `setsid` (backgrounding)
  - `nohup ... gateway run` (detaching from terminal)
- When detected, the approval message tells the agent to use `systemctl --user restart hermes-gateway` instead
- 6 new tests covering all variants

### Already applied directly (not in this PR)
- Fixed systemd service: `Restart=on-failure` → `Restart=always`, `RestartSec=10`
- Applied the approval.py patterns to main repo immediately
- Restarted gateway via systemd — Telegram, WhatsApp, API server all reconnected

## Test plan
- `python -m pytest tests/tools/test_approval.py -n0 -q` — 74 passed
- Full suite: 5948 passed, 0 failures