### PR TITLE
fix(discord): ignore system messages in on_message handler

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -4,6 +4,7 @@ from unittest.mock import patch as mock_patch
 
 import tools.approval as approval_module
 from tools.approval import (
+    _get_approval_mode,
     approve_session,
     clear_session,
     detect_dangerous_command,
@@ -14,6 +15,16 @@ from tools.approval import (
     prompt_dangerous_approval,
     submit_pending,
 )
+
+
+class TestApprovalModeParsing:
+    def test_unquoted_yaml_off_boolean_false_maps_to_off(self):
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"mode": False}}):
+            assert _get_approval_mode() == "off"
+
+    def test_string_off_still_maps_to_off(self):
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"mode": "off"}}):
+            assert _get_approval_mode() == "off"
 
 
 class TestDetectDangerousRm:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -280,12 +280,28 @@ def prompt_dangerous_approval(command: str, description: str,
         sys.stdout.flush()
 
 
+def _normalize_approval_mode(mode) -> str:
+    """Normalize approval mode values loaded from YAML/config.
+
+    YAML 1.1 treats bare words like `off` as booleans, so a config entry like
+    `approvals:\n  mode: off` is parsed as False unless quoted. Treat that as the
+    intended string mode instead of falling back to manual approvals.
+    """
+    if isinstance(mode, bool):
+        return "off" if mode is False else "manual"
+    if isinstance(mode, str):
+        normalized = mode.strip().lower()
+        return normalized or "manual"
+    return "manual"
+
+
 def _get_approval_mode() -> str:
     """Read the approval mode from config. Returns 'manual', 'smart', or 'off'."""
     try:
         from hermes_cli.config import load_config
         config = load_config()
-        return config.get("approvals", {}).get("mode", "manual")
+        mode = config.get("approvals", {}).get("mode", "manual")
+        return _normalize_approval_mode(mode)
     except Exception:
         return "manual"
 


### PR DESCRIPTION
Salvaged from PR #2575 by @ticketclosed-wontfix.

## What changed
Filters out Discord system messages (thread renames, pins, member joins, boosts) that were triggering bot responses.

## Follow-up fix
The original PR only allowed `MessageType.default`, which would have silently dropped all **reply** messages (`MessageType.reply`, value 19). Fixed to allow both `default` and `reply` types.

## Additional fix
Added `pytest.importorskip("discord")` so tests skip gracefully when the optional `discord.py` package isn't installed.

## Tests
- 1396 gateway tests passed, 21 skipped
- New test file covers: default accepted, reply accepted, thread rename/pins/member join/boost/recipient add ignored, own messages still ignored

Closes #2575