### PR TITLE
fix: media delivery fails for file paths containing spaces

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -721,7 +721,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
Salvaged from PR #2583 by @Glucksberg.

## Problem
`MEDIA:/path/with spaces/file.jpg` was truncated at the first space because the regex used `\S+` as the fallback pattern.

## Fix
Added a space-aware regex alternative anchored to known media file extensions, placed before the `\S+` fallback. Also updated `extract_local_files` to allow spaces in path segments.

## Follow-up fix
Changed `\s` to `[^\S\n]` in the space-matching group so the regex doesn't match across newlines (which broke multi-line `MEDIA:` tags — caught by existing tests).

## Tests
80 media extraction tests pass, including regression checks for multi-line tags.

Closes #2583