### PR TITLE
fix(cli): handle EOFError in sessions delete/prune confirmation prompts

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3906,7 +3906,10 @@ For more help on a command:
                 print(f"Session '{args.session_id}' not found.")
                 return
             if not args.yes:
-                confirm = input(f"Delete session '{resolved_session_id}' and all its messages? [y/N] ")
+                try:
+                    confirm = input(f"Delete session '{resolved_session_id}' and all its messages? [y/N] ")
+                except (EOFError, KeyboardInterrupt):
+                    confirm = "n"
                 if confirm.lower() not in ("y", "yes"):
                     print("Cancelled.")
                     return
@@ -3919,7 +3922,10 @@ For more help on a command:
             days = args.older_than
             source_msg = f" from '{args.source}'" if args.source else ""
             if not args.yes:
-                confirm = input(f"Delete all ended sessions older than {days} days{source_msg}? [y/N] ")
+                try:
+                    confirm = input(f"Delete all ended sessions older than {days} days{source_msg}? [y/N] ")
+                except (EOFError, KeyboardInterrupt):
+                    confirm = "n"
                 if confirm.lower() not in ("y", "yes"):
                     print("Cancelled.")
                     return

--- a/tests/hermes_cli/test_sessions_delete.py
+++ b/tests/hermes_cli/test_sessions_delete.py
@@ -62,3 +62,56 @@ def test_sessions_delete_reports_not_found_when_prefix_is_unknown(monkeypatch, c
 
     output = capsys.readouterr().out
     assert "Session 'missing-prefix' not found." in output
+
+
+def test_sessions_delete_handles_eoferror_on_confirm(monkeypatch, capsys):
+    """sessions delete should not crash when stdin is closed (non-TTY)."""
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    class FakeDB:
+        def resolve_session_id(self, session_id):
+            return "20260315_092437_c9a6ff"
+
+        def delete_session(self, session_id):
+            raise AssertionError("delete_session should not be called when cancelled")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys, "argv",
+        ["hermes", "sessions", "delete", "20260315_092437_c9a6"],
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt="": (_ for _ in ()).throw(EOFError))
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert "Cancelled" in output
+
+
+def test_sessions_prune_handles_eoferror_on_confirm(monkeypatch, capsys):
+    """sessions prune should not crash when stdin is closed (non-TTY)."""
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    class FakeDB:
+        def prune_sessions(self, **kwargs):
+            raise AssertionError("prune_sessions should not be called when cancelled")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys, "argv",
+        ["hermes", "sessions", "prune"],
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt="": (_ for _ in ()).throw(EOFError))
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert "Cancelled" in output


### PR DESCRIPTION
## Summary
- `hermes sessions delete` and `hermes sessions prune` crash with unhandled `EOFError` when stdin is not a TTY (piped input, CI/CD, cron scripts)
- The `input()` calls for confirmation aren't wrapped in `try/except`, unlike other prompts in the same file (e.g. line 491, 623)
- Fix wraps both in `try/except (EOFError, KeyboardInterrupt)` defaulting to cancel

## How to reproduce
```bash
hermes sessions delete any_session_id < /dev/null
# → EOFError traceback instead of graceful cancel
```

## How to test
- 2 new tests in `test_sessions_delete.py` that mock `input()` to raise `EOFError`
- Both verify the operation is cancelled (not crashed) and "Cancelled" is printed
- All 4 tests pass

## Platform tested
- Linux