### PR TITLE
fix(cron): skip unnecessary save_jobs when job_id not found in mark_job_run

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -593,8 +593,6 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None):
 
             save_jobs(jobs)
             return
-    
-    save_jobs(jobs)
 
 
 def get_due_jobs() -> List[Dict[str, Any]]:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -339,6 +339,21 @@ class TestMarkJobRun:
         assert updated["last_error"] == "timeout"
 
 
+    def test_unknown_job_id_does_not_save(self, tmp_cron_dir):
+        """mark_job_run with an unknown job_id should not write the file."""
+        job = create_job(prompt="Real", schedule="every 1h")
+        jobs_file = tmp_cron_dir / "cron" / "jobs.json"
+        import os, time
+        mtime_before = os.path.getmtime(jobs_file)
+
+        time.sleep(0.05)  # ensure mtime would differ if written
+
+        mark_job_run("nonexistent-id", success=True)
+
+        mtime_after = os.path.getmtime(jobs_file)
+        assert mtime_before == mtime_after, "jobs file was written despite unknown job_id"
+
+
 class TestGetDueJobs:
     def test_past_due_within_window_returned(self, tmp_cron_dir):
         """Jobs within the dynamic grace window are still considered due (not stale).


### PR DESCRIPTION
## Summary
- `mark_job_run()` writes the unmodified jobs list back to disk when the job_id doesn't match any job in the list
- This is a no-op write that happens on every cron tick for removed/missing jobs
- Fix: remove the trailing `save_jobs(jobs)` that runs after the for-loop exits without a match

## How to reproduce
- Call `mark_job_run("nonexistent-id", success=True)` — the jobs file gets rewritten with identical content

## How to test
- New test `test_unknown_job_id_does_not_save` verifies the file mtime doesn't change for unknown job_ids
- All 6 mark_job_run tests pass

## Platform tested
- Linux