### PR TITLE
fix(tests): resolve pre-existing test suite failures from missing mocks and env pollution

### DIFF
--- a/tests/integration/test_ha_integration.py
+++ b/tests/integration/test_ha_integration.py
@@ -71,7 +71,7 @@ class TestGatewayWebSocket:
     async def test_event_received_and_forwarded(self):
         """Server pushes event -> adapter calls handle_message with correct MessageEvent."""
         async with FakeHAServer() as server:
-            adapter = _adapter_for(server)
+            adapter = _adapter_for(server, watch_all=True)
             adapter.handle_message = AsyncMock()
 
             await adapter.connect()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -593,7 +593,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             "model": "qwen2.5-coder",
             "base_url": "http://localhost:1234/v1",
         }
-        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "env-openrouter-key"}, clear=False):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "env-openrouter-key", "OPENAI_API_KEY": ""}, clear=False):
             with self.assertRaises(ValueError) as ctx:
                 _resolve_delegation_credentials(cfg, parent)
         self.assertIn("OPENAI_API_KEY", str(ctx.exception))

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -5,6 +5,7 @@ dispatch.  All external dependencies (faster_whisper, openai) are mocked.
 """
 
 import json
+import sys
 import os
 import tempfile
 from pathlib import Path
@@ -37,6 +38,7 @@ class TestGetProvider:
 
     def test_local_nothing_available(self, monkeypatch):
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
              patch("tools.transcription_tools._HAS_OPENAI", False):
             from tools.transcription_tools import _get_provider
@@ -51,8 +53,11 @@ class TestGetProvider:
     def test_explicit_openai_no_key_returns_none(self, monkeypatch):
         """Explicit openai without key returns none — no cross-provider fallback."""
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("tools.transcription_tools._HAS_OPENAI", True):
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._resolve_openai_api_key", return_value=""):
             from tools.transcription_tools import _get_provider
             assert _get_provider({"provider": "openai"}) == "none"
 
@@ -118,7 +123,11 @@ class TestValidateAudioFile:
 class TestTranscribeLocal:
 
     def test_successful_transcription(self, tmp_path):
-        audio_file = tmp_path / "test.ogg"
+        import sys
+        fake_fw = MagicMock()
+        fake_fw.__spec__ = MagicMock()
+        sys.modules['faster_whisper'] = fake_fw
+        audio_file = tmp_path / 'test.ogg'
         audio_file.write_bytes(b"fake audio")
 
         mock_segment = MagicMock()
@@ -138,6 +147,7 @@ class TestTranscribeLocal:
 
         assert result["success"] is True
         assert result["transcript"] == "Hello world"
+        sys.modules.pop('faster_whisper', None)
 
     def test_not_installed(self):
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False):
@@ -156,6 +166,7 @@ class TestTranscribeOpenAI:
 
     def test_no_key(self, monkeypatch):
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from tools.transcription_tools import _transcribe_openai
         result = _transcribe_openai("/tmp/test.ogg", "whisper-1")
         assert result["success"] is False

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -5,6 +5,7 @@ model auto-correction, config loading, validation edge cases, and
 end-to-end dispatch.  All external dependencies are mocked.
 """
 
+import sys
 import os
 import struct
 import subprocess
@@ -405,6 +406,17 @@ class TestTranscribeLocalCommand:
 # ============================================================================
 
 class TestTranscribeLocalExtended:
+    def setup_method(self):
+        import sys
+        from unittest.mock import MagicMock
+        self._fw_mock = MagicMock()
+        self._fw_mock.__spec__ = MagicMock()
+        sys.modules.setdefault('faster_whisper', self._fw_mock)
+
+    def teardown_method(self):
+        import sys
+        sys.modules.pop('faster_whisper', None)
+
     def test_model_reuse_on_second_call(self, tmp_path):
         """Second call with same model should NOT reload the model."""
         audio = tmp_path / "test.ogg"

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -9,6 +9,7 @@ Coverage:
 """
 
 import os
+import sys
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -245,11 +246,18 @@ class TestParallelClientConfig:
     def setup_method(self):
         import tools.web_tools
         tools.web_tools._parallel_client = None
+        self._parallel_mock = MagicMock()
+        class FakeParallel:
+            def __init__(self, api_key=None): pass
+        self._parallel_mock.Parallel = FakeParallel
+        self._parallel_mock.Parallel.return_value = FakeParallel()
+        sys.modules['parallel'] = self._parallel_mock
         os.environ.pop("PARALLEL_API_KEY", None)
 
     def teardown_method(self):
         import tools.web_tools
         tools.web_tools._parallel_client = None
+        sys.modules.pop('parallel', None)
         os.environ.pop("PARALLEL_API_KEY", None)
 
     def test_creates_client_with_key(self):


### PR DESCRIPTION
## Problem

Five test classes were failing on every CI run. None of these failures were caused by the tests themselves being wrong — they were infrastructure issues: missing optional dependency mocks and test environment state pollution from earlier tests.

## Root causes and fixes

**`TestParallelClientConfig`** (`tests/tools/test_web_tools_config.py`): The `parallel` package is an optional dependency not installed in the test environment. `from parallel import Parallel` raised `ModuleNotFoundError`. Fixed by injecting a `sys.modules` mock with a `FakeParallel` class so `isinstance()` checks pass correctly.

**`TestTranscribeLocal` / `TestTranscribeLocalExtended`** (`tests/tools/test_transcription.py`, `tests/tools/test_transcription_tools.py`): `faster_whisper` is not installed in the test environment. Fixed by injecting a `sys.modules` mock in `setup_method` with cleanup in `teardown_method` to prevent state leakage between tests.

**`TestGatewayWebSocket.test_event_received_and_forwarded`** (`tests/integration/test_ha_integration.py`): The adapter was created without `watch_all=True`, so all `state_changed` events were silently dropped by the domain filter. Fixed by passing `watch_all=True` to `_adapter_for()`.

**`TestGetProvider.test_explicit_openai_no_key_returns_none`** (`tests/tools/test_transcription.py`): Test environment pollution — earlier tests left `OPENAI_API_KEY` set in the process environment. `monkeypatch.delenv` only removed `VOICE_TOOLS_OPENAI_KEY` but `_resolve_openai_api_key()` also checks `OPENAI_API_KEY`. Fixed by patching `_resolve_openai_api_key` directly so the test is not sensitive to process-level env state.

**`TestDelegationCredentialResolution.test_direct_endpoint`** (`tests/tools/test_delegate.py`): Same env pollution pattern — `OPENAI_API_KEY` was set by an earlier test. Fixed by including `OPENAI_API_KEY: ""` in the `patch.dict` scope so the test controls its own environment.

## Verification

All 5 previously-failing test classes now pass. Full test suite: 5808 passed, 0 failed (excluding pre-existing ignores).