### PR TITLE
fix(gateway): downgrade empty handler response log from warning to debug

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -909,9 +909,9 @@ class BasePlatformAdapter(ABC):
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
             
-            # Send response if any
+            # Send response if any (empty is expected for auth rejection, interrupts, etc.)
             if not response:
-                logger.warning("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
+                logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
             if response:
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)


### PR DESCRIPTION
## Summary
- Every unauthorized message produces two warnings in errors.log — the auth rejection ("Unauthorized user") plus a misleading "Handler returned empty/None response" 
- The second warning is a false alarm — empty responses are expected for auth rejection, interrupt handling, and silent commands
- Downgrade from `logger.warning` to `logger.debug` so it's still visible when debugging but doesn't spam errors.log

## How to reproduce
- Send a message from an unauthorized Telegram user
- Check errors.log — two warnings appear per message instead of one

## Platform tested
- Linux