### PR TITLE
fix(gateway): add all missing platform allowlist env vars to startup warning check

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -904,7 +904,9 @@ class GatewayRunner:
             os.getenv(v)
             for v in ("TELEGRAM_ALLOWED_USERS", "DISCORD_ALLOWED_USERS",
                        "WHATSAPP_ALLOWED_USERS", "SLACK_ALLOWED_USERS",
-                       "SMS_ALLOWED_USERS", "MATRIX_ALLOWED_USERS",
+                       "SIGNAL_ALLOWED_USERS", "EMAIL_ALLOWED_USERS",
+                       "SMS_ALLOWED_USERS", "MATTERMOST_ALLOWED_USERS",
+                       "MATRIX_ALLOWED_USERS", "DINGTALK_ALLOWED_USERS",
                        "GATEWAY_ALLOWED_USERS")
         )
         _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -904,7 +904,7 @@ class GatewayRunner:
             os.getenv(v)
             for v in ("TELEGRAM_ALLOWED_USERS", "DISCORD_ALLOWED_USERS",
                        "WHATSAPP_ALLOWED_USERS", "SLACK_ALLOWED_USERS",
-                       "SMS_ALLOWED_USERS",
+                       "SMS_ALLOWED_USERS", "MATRIX_ALLOWED_USERS",
                        "GATEWAY_ALLOWED_USERS")
         )
         _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")


### PR DESCRIPTION
## Summary

Salvage of #2615 by @SteelPh0enix (cherry-picked with authorship preserved), extended to fix the same issue for all affected platforms.

The gateway startup warning ("No user allowlists configured") only checked TELEGRAM, DISCORD, WHATSAPP, SLACK, and SMS env vars. Users of Signal, Email, Mattermost, Matrix, or DingTalk who had their platform-specific allowlist configured would still see a spurious warning telling them no allowlists exist.

## Changes

- Cherry-picked SteelPh0enix's fix adding `MATRIX_ALLOWED_USERS` to the check
- Extended to also add `SIGNAL_ALLOWED_USERS`, `EMAIL_ALLOWED_USERS`, `MATTERMOST_ALLOWED_USERS`, and `DINGTALK_ALLOWED_USERS`
- The startup check now matches the canonical `platform_env_map` in `_is_user_authorized()` exactly

## Test plan

- 5962 tests pass
- Verified the env var list matches the canonical mapping at line ~1404 in gateway/run.py

Closes #2615