### PR TITLE
fix(cli): warn when sessions export output path looks like a session ID

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3881,6 +3881,20 @@ For more help on a command:
                     print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
 
         elif action == "export":
+            # Warn if the output path looks like a session ID — the user
+            # probably meant `--session-id` instead of a filename.
+            import re as _re
+            if _re.match(r"^\d{8}_\d{6}_[0-9a-f]+$", args.output):
+                print(f"Hint: '{args.output}' looks like a session ID.")
+                print(f"  To export one session: hermes sessions export output.jsonl --session-id {args.output}")
+                print(f"  To export all sessions to a file named '{args.output}': continue as-is")
+                try:
+                    reply = input("Continue exporting ALL sessions to this filename? [y/N] ")
+                except (EOFError, KeyboardInterrupt):
+                    reply = "n"
+                if reply.lower() not in ("y", "yes"):
+                    return
+
             if args.session_id:
                 resolved_session_id = db.resolve_session_id(args.session_id)
                 if not resolved_session_id:


### PR DESCRIPTION
## Summary
- `hermes sessions export 20260323_191619_cacab7` looks like it exports one session, but it actually creates a file with that name containing ALL sessions
- The correct syntax is `hermes sessions export output.jsonl --session-id 20260323_191619_cacab7` which isn't obvious
- Fix: detect when the output path matches the `YYYYMMDD_HHMMSS_hex` session ID format and show a hint with the correct syntax, asking for confirmation before proceeding

## How to reproduce
```bash
hermes sessions export 20260323_191619_cacab7
# Creates a file named "20260323_191619_cacab7" with ALL sessions
# User expected: export just that one session
```

## How to test
- Pass a session-ID-looking string as the output path → hint appears
- Pass a normal filename like `output.jsonl` → no hint, works as before
- EOFError on the confirmation prompt → cancels gracefully

## Platform tested
- Linux