### PR TITLE
fix: Matrix cron delivery — add sender and origin fallback

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -22,6 +22,7 @@ from hermes_time import now as _hermes_now
 
 try:
     from croniter import croniter
+
     HAS_CRONITER = True
 except ImportError:
     HAS_CRONITER = False
@@ -37,7 +38,9 @@ OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
 
-def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
+def _normalize_skill_list(
+    skill: Optional[str] = None, skills: Optional[Any] = None
+) -> List[str]:
     """Normalize legacy/single-skill and multi-skill inputs into a unique ordered list."""
     if skills is None:
         raw_items = [skill] if skill else []
@@ -92,37 +95,42 @@ def ensure_dirs():
 # Schedule Parsing
 # =============================================================================
 
+
 def parse_duration(s: str) -> int:
     """
     Parse duration string into minutes.
-    
+
     Examples:
         "30m" → 30
         "2h" → 120
         "1d" → 1440
     """
     s = s.strip().lower()
-    match = re.match(r'^(\d+)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$', s)
+    match = re.match(
+        r"^(\d+)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$", s
+    )
     if not match:
-        raise ValueError(f"Invalid duration: '{s}'. Use format like '30m', '2h', or '1d'")
-    
+        raise ValueError(
+            f"Invalid duration: '{s}'. Use format like '30m', '2h', or '1d'"
+        )
+
     value = int(match.group(1))
     unit = match.group(2)[0]  # First char: m, h, or d
-    
-    multipliers = {'m': 1, 'h': 60, 'd': 1440}
+
+    multipliers = {"m": 1, "h": 60, "d": 1440}
     return value * multipliers[unit]
 
 
 def parse_schedule(schedule: str) -> Dict[str, Any]:
     """
     Parse schedule string into structured format.
-    
+
     Returns dict with:
         - kind: "once" | "interval" | "cron"
         - For "once": "run_at" (ISO timestamp)
         - For "interval": "minutes" (int)
         - For "cron": "expr" (cron expression)
-    
+
     Examples:
         "30m"              → once in 30 minutes
         "2h"               → once in 2 hours
@@ -134,41 +142,33 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     schedule = schedule.strip()
     original = schedule
     schedule_lower = schedule.lower()
-    
+
     # "every X" pattern → recurring interval
     if schedule_lower.startswith("every "):
         duration_str = schedule[6:].strip()
         minutes = parse_duration(duration_str)
-        return {
-            "kind": "interval",
-            "minutes": minutes,
-            "display": f"every {minutes}m"
-        }
-    
+        return {"kind": "interval", "minutes": minutes, "display": f"every {minutes}m"}
+
     # Check for cron expression (5 or 6 space-separated fields)
     # Cron fields: minute hour day month weekday [year]
     parts = schedule.split()
-    if len(parts) >= 5 and all(
-        re.match(r'^[\d\*\-,/]+$', p) for p in parts[:5]
-    ):
+    if len(parts) >= 5 and all(re.match(r"^[\d\*\-,/]+$", p) for p in parts[:5]):
         if not HAS_CRONITER:
-            raise ValueError("Cron expressions require 'croniter' package. Install with: pip install croniter")
+            raise ValueError(
+                "Cron expressions require 'croniter' package. Install with: pip install croniter"
+            )
         # Validate cron expression
         try:
             croniter(schedule)
         except Exception as e:
             raise ValueError(f"Invalid cron expression '{schedule}': {e}")
-        return {
-            "kind": "cron",
-            "expr": schedule,
-            "display": schedule
-        }
-    
+        return {"kind": "cron", "expr": schedule, "display": schedule}
+
     # ISO timestamp (contains T or looks like date)
-    if 'T' in schedule or re.match(r'^\d{4}-\d{2}-\d{2}', schedule):
+    if "T" in schedule or re.match(r"^\d{4}-\d{2}-\d{2}", schedule):
         try:
             # Parse and validate
-            dt = datetime.fromisoformat(schedule.replace('Z', '+00:00'))
+            dt = datetime.fromisoformat(schedule.replace("Z", "+00:00"))
             # Make naive timestamps timezone-aware at parse time so the stored
             # value doesn't depend on the system timezone matching at check time.
             if dt.tzinfo is None:
@@ -176,11 +176,11 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
             return {
                 "kind": "once",
                 "run_at": dt.isoformat(),
-                "display": f"once at {dt.strftime('%Y-%m-%d %H:%M')}"
+                "display": f"once at {dt.strftime('%Y-%m-%d %H:%M')}",
             }
         except ValueError as e:
             raise ValueError(f"Invalid timestamp '{schedule}': {e}")
-    
+
     # Duration like "30m", "2h", "1d" → one-shot from now
     try:
         minutes = parse_duration(schedule)
@@ -188,11 +188,11 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         return {
             "kind": "once",
             "run_at": run_at.isoformat(),
-            "display": f"once in {original}"
+            "display": f"once in {original}",
         }
     except ValueError:
         pass
-    
+
     raise ValueError(
         f"Invalid schedule '{original}'. Use:\n"
         f"  - Duration: '30m', '2h', '1d' (one-shot)\n"
@@ -248,7 +248,9 @@ def _recoverable_oneshot_run_at(
     return None
 
 
-def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None) -> Optional[str]:
+def compute_next_run(
+    schedule: Dict[str, Any], last_run_at: Optional[str] = None
+) -> Optional[str]:
     """
     Compute the next run time for a schedule.
 
@@ -284,14 +286,15 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
 # Job CRUD Operations
 # =============================================================================
 
+
 def load_jobs() -> List[Dict[str, Any]]:
     """Load all jobs from storage."""
     ensure_dirs()
     if not JOBS_FILE.exists():
         return []
-    
+
     try:
-        with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+        with open(JOBS_FILE, "r", encoding="utf-8") as f:
             data = json.load(f)
             return data.get("jobs", [])
     except (json.JSONDecodeError, IOError):
@@ -301,10 +304,14 @@ def load_jobs() -> List[Dict[str, Any]]:
 def save_jobs(jobs: List[Dict[str, Any]]):
     """Save all jobs to storage."""
     ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(JOBS_FILE.parent), suffix=".tmp", prefix=".jobs_"
+    )
     try:
-        with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(
+                {"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2
+            )
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp_path, JOBS_FILE)
@@ -365,12 +372,16 @@ def create_job(
     normalized_skills = _normalize_skill_list(skill, skills)
     normalized_model = str(model).strip() if isinstance(model, str) else None
     normalized_provider = str(provider).strip() if isinstance(provider, str) else None
-    normalized_base_url = str(base_url).strip().rstrip("/") if isinstance(base_url, str) else None
+    normalized_base_url = (
+        str(base_url).strip().rstrip("/") if isinstance(base_url, str) else None
+    )
     normalized_model = normalized_model or None
     normalized_provider = normalized_provider or None
     normalized_base_url = normalized_base_url or None
 
-    label_source = (prompt or (normalized_skills[0] if normalized_skills else None)) or "cron job"
+    label_source = (
+        prompt or (normalized_skills[0] if normalized_skills else None)
+    ) or "cron job"
     job = {
         "id": job_id,
         "name": name or label_source[:50].strip(),
@@ -384,7 +395,7 @@ def create_job(
         "schedule_display": parsed_schedule.get("display", schedule),
         "repeat": {
             "times": repeat,  # None = forever
-            "completed": 0
+            "completed": 0,
         },
         "enabled": True,
         "state": "scheduled",
@@ -408,10 +419,14 @@ def create_job(
 
 
 def get_job(job_id: str) -> Optional[Dict[str, Any]]:
-    """Get a job by ID."""
+    """Get a job by ID or name."""
     jobs = load_jobs()
     for job in jobs:
         if job["id"] == job_id:
+            return _apply_skill_fields(job)
+    # Fallback: match by name (case-insensitive)
+    for job in jobs:
+        if job.get("name", "").lower() == job_id.lower():
             return _apply_skill_fields(job)
     return None
 
@@ -435,7 +450,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
         schedule_changed = "schedule" in updates
 
         if "skills" in updates or "skill" in updates:
-            normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
+            normalized_skills = _normalize_skill_list(
+                updated.get("skill"), updated.get("skills")
+            )
             updated["skills"] = normalized_skills
             updated["skill"] = normalized_skills[0] if normalized_skills else None
 
@@ -448,7 +465,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             if updated.get("state") != "paused":
                 updated["next_run_at"] = compute_next_run(updated_schedule)
 
-        if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
+        if (
+            updated.get("enabled", True)
+            and updated.get("state") != "paused"
+            and not updated.get("next_run_at")
+        ):
             updated["next_run_at"] = compute_next_run(updated["schedule"])
 
         jobs[i] = updated
@@ -459,8 +480,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
 def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """Pause a job without deleting it."""
+    job = get_job(job_id)
+    if not job:
+        return None
     return update_job(
-        job_id,
+        job["id"],
         {
             "enabled": False,
             "state": "paused",
@@ -478,7 +502,7 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
 
     next_run_at = compute_next_run(job["schedule"])
     return update_job(
-        job_id,
+        job["id"],
         {
             "enabled": True,
             "state": "scheduled",
@@ -495,7 +519,7 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
     if not job:
         return None
     return update_job(
-        job_id,
+        job["id"],
         {
             "enabled": True,
             "state": "scheduled",
@@ -507,10 +531,14 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
 
 
 def remove_job(job_id: str) -> bool:
-    """Remove a job by ID."""
+    """Remove a job by ID or name."""
+    job = get_job(job_id)
+    if not job:
+        return False
+    canonical_id = job["id"]
     jobs = load_jobs()
     original_len = len(jobs)
-    jobs = [j for j in jobs if j["id"] != job_id]
+    jobs = [j for j in jobs if j["id"] != canonical_id]
     if len(jobs) < original_len:
         save_jobs(jobs)
         return True
@@ -520,7 +548,7 @@ def remove_job(job_id: str) -> bool:
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None):
     """
     Mark a job as having been run.
-    
+
     Updates last_run_at, last_status, increments completed count,
     computes next_run_at, and auto-deletes if repeat limit reached.
     """
@@ -531,11 +559,11 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None):
             job["last_run_at"] = now
             job["last_status"] = "ok" if success else "error"
             job["last_error"] = error if not success else None
-            
+
             # Increment completed count
             if job.get("repeat"):
                 job["repeat"]["completed"] = job["repeat"].get("completed", 0) + 1
-                
+
                 # Check if we've hit the repeat limit
                 times = job["repeat"].get("times")
                 completed = job["repeat"]["completed"]
@@ -544,7 +572,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None):
                     jobs.pop(i)
                     save_jobs(jobs)
                     return
-            
+
             # Compute next run
             job["next_run_at"] = compute_next_run(job["schedule"], now)
 
@@ -557,7 +585,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None):
 
             save_jobs(jobs)
             return
-    
+
     save_jobs(jobs)
 
 
@@ -610,7 +638,10 @@ def get_due_jobs() -> List[Dict[str, Any]]:
             # For recurring jobs, check if the scheduled time is stale
             # (gateway was down and missed the window). Fast-forward to
             # the next future occurrence instead of firing a stale run.
-            if kind in ("cron", "interval") and (now - next_run_dt).total_seconds() > 120:
+            if (
+                kind in ("cron", "interval")
+                and (now - next_run_dt).total_seconds() > 120
+            ):
                 # More than 2 minutes late — this is a missed run, not a current one.
                 # Recompute next_run_at to the next future occurrence.
                 new_next = compute_next_run(schedule, now.isoformat())
@@ -644,13 +675,15 @@ def save_job_output(job_id: str, output: str):
     job_output_dir = OUTPUT_DIR / job_id
     job_output_dir.mkdir(parents=True, exist_ok=True)
     _secure_dir(job_output_dir)
-    
+
     timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S")
     output_file = job_output_dir / f"{timestamp}.md"
-    
-    fd, tmp_path = tempfile.mkstemp(dir=str(job_output_dir), suffix='.tmp', prefix='.output_')
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(job_output_dir), suffix=".tmp", prefix=".output_"
+    )
     try:
-        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(output)
             f.flush()
             os.fsync(f.fileno())
@@ -662,5 +695,5 @@ def save_job_output(job_id: str, output: str):
         except OSError:
             pass
         raise
-    
+
     return output_file

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -71,13 +71,29 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
         return None
 
     if deliver == "origin":
-        if not origin:
-            return None
-        return {
-            "platform": origin["platform"],
-            "chat_id": str(origin["chat_id"]),
-            "thread_id": origin.get("thread_id"),
-        }
+        if origin:
+            return {
+                "platform": origin["platform"],
+                "chat_id": str(origin["chat_id"]),
+                "thread_id": origin.get("thread_id"),
+            }
+        # Origin missing (e.g. job created via API/setup script) — try each
+        # platform's home channel as a fallback instead of silently dropping.
+        for platform_name in ("matrix", "telegram", "discord", "slack"):
+            chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
+            if chat_id:
+                logger.info(
+                    "Job '%s' has deliver=origin but no origin; "
+                    "falling back to %s home channel",
+                    job.get("name", job.get("id", "?")),
+                    platform_name,
+                )
+                return {
+                    "platform": platform_name,
+                    "chat_id": chat_id,
+                    "thread_id": None,
+                }
+        return None
 
     if ":" in deliver:
         platform_name, chat_id = deliver.split(":", 1)
@@ -136,37 +152,58 @@ def _deliver_result(job: dict, content: str) -> None:
         "slack": Platform.SLACK,
         "whatsapp": Platform.WHATSAPP,
         "signal": Platform.SIGNAL,
+        "matrix": Platform.MATRIX,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
     }
     platform = platform_map.get(platform_name.lower())
     if not platform:
-        logger.warning("Job '%s': unknown platform '%s' for delivery", job["id"], platform_name)
+        logger.warning(
+            "Job '%s': unknown platform '%s' for delivery", job["id"], platform_name
+        )
         return
 
     try:
         config = load_gateway_config()
     except Exception as e:
-        logger.error("Job '%s': failed to load gateway config for delivery: %s", job["id"], e)
+        logger.error(
+            "Job '%s': failed to load gateway config for delivery: %s", job["id"], e
+        )
         return
 
     pconfig = config.platforms.get(platform)
     if not pconfig or not pconfig.enabled:
-        logger.warning("Job '%s': platform '%s' not configured/enabled", job["id"], platform_name)
+        logger.warning(
+            "Job '%s': platform '%s' not configured/enabled", job["id"], platform_name
+        )
         return
 
     # Run the async send in a fresh event loop (safe from any thread)
     try:
-        result = asyncio.run(_send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id))
+        result = asyncio.run(
+            _send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id)
+        )
     except RuntimeError:
         # asyncio.run() fails if there's already a running loop in this thread;
         # spin up a new thread to avoid that.
         import concurrent.futures
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id))
+            future = pool.submit(
+                asyncio.run,
+                _send_to_platform(
+                    platform, pconfig, chat_id, content, thread_id=thread_id
+                ),
+            )
             result = future.result(timeout=30)
     except Exception as e:
-        logger.error("Job '%s': delivery to %s:%s failed: %s", job["id"], platform_name, chat_id, e)
+        logger.error(
+            "Job '%s': delivery to %s:%s failed: %s",
+            job["id"],
+            platform_name,
+            chat_id,
+            e,
+        )
         return
 
     if result and result.get("error"):
@@ -176,7 +213,14 @@ def _deliver_result(job: dict, content: str) -> None:
         # Mirror the delivered content into the target's gateway session
         try:
             from gateway.mirror import mirror_to_session
-            mirror_to_session(platform_name, chat_id, content, source_label="cron", thread_id=thread_id)
+
+            mirror_to_session(
+                platform_name,
+                chat_id,
+                content,
+                source_label="cron",
+                thread_id=thread_id,
+            )
         except Exception as e:
             logger.warning("Job '%s': mirror_to_session failed: %s", job["id"], e)
 
@@ -190,7 +234,7 @@ def _build_job_prompt(job: dict) -> str:
     # delivery when it has nothing new or noteworthy to report.
     silent_hint = (
         "[SYSTEM: If you have nothing new or noteworthy to report, respond "
-        "with exactly \"[SILENT]\" (optionally followed by a brief internal "
+        'with exactly "[SILENT]" (optionally followed by a brief internal '
         "note). This suppresses delivery to the user while still saving "
         "output locally. Only use [SILENT] when there are genuinely no "
         "changes worth reporting.]\n\n"
@@ -212,7 +256,11 @@ def _build_job_prompt(job: dict) -> str:
         loaded = json.loads(skill_view(skill_name))
         if not loaded.get("success"):
             error = loaded.get("error") or f"Failed to load skill '{skill_name}'"
-            logger.warning("Cron job '%s': skill not found, skipping — %s", job.get("name", job.get("id")), error)
+            logger.warning(
+                "Cron job '%s': skill not found, skipping — %s",
+                job.get("name", job.get("id")),
+                error,
+            )
             skipped.append(skill_name)
             continue
 
@@ -237,28 +285,36 @@ def _build_job_prompt(job: dict) -> str:
         parts.insert(0, notice)
 
     if prompt:
-        parts.extend(["", f"The user has provided the following instruction alongside the skill invocation: {prompt}"])
+        parts.extend(
+            [
+                "",
+                f"The user has provided the following instruction alongside the skill invocation: {prompt}",
+            ]
+        )
     return "\n".join(parts)
 
 
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
-    
+
     Returns:
         Tuple of (success, full_output_doc, final_response, error_message)
     """
     from run_agent import AIAgent
-    
+
     # Initialize SQLite session store so cron job messages are persisted
     # and discoverable via session_search (same pattern as gateway/run.py).
     _session_db = None
     try:
         from hermes_state import SessionDB
+
         _session_db = SessionDB()
     except Exception as e:
-        logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
-    
+        logger.debug(
+            "Job '%s': SQLite session store not available: %s", job.get("id", "?"), e
+        )
+
     job_id = job["id"]
     job_name = job["name"]
     prompt = _build_job_prompt(job)
@@ -278,6 +334,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Re-read .env and config.yaml fresh every run so provider/key
         # changes take effect without a gateway restart.
         from dotenv import load_dotenv
+
         try:
             load_dotenv(str(_hermes_home / ".env"), override=True, encoding="utf-8")
         except UnicodeDecodeError:
@@ -285,17 +342,26 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
-            os.environ["HERMES_CRON_AUTO_DELIVER_PLATFORM"] = delivery_target["platform"]
-            os.environ["HERMES_CRON_AUTO_DELIVER_CHAT_ID"] = str(delivery_target["chat_id"])
+            os.environ["HERMES_CRON_AUTO_DELIVER_PLATFORM"] = delivery_target[
+                "platform"
+            ]
+            os.environ["HERMES_CRON_AUTO_DELIVER_CHAT_ID"] = str(
+                delivery_target["chat_id"]
+            )
             if delivery_target.get("thread_id") is not None:
-                os.environ["HERMES_CRON_AUTO_DELIVER_THREAD_ID"] = str(delivery_target["thread_id"])
+                os.environ["HERMES_CRON_AUTO_DELIVER_THREAD_ID"] = str(
+                    delivery_target["thread_id"]
+                )
 
-        model = job.get("model") or os.getenv("HERMES_MODEL") or "anthropic/claude-opus-4.6"
+        model = (
+            job.get("model") or os.getenv("HERMES_MODEL") or "anthropic/claude-opus-4.6"
+        )
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
         _cfg = {}
         try:
             import yaml
+
             _cfg_path = str(_hermes_home / "config.yaml")
             if os.path.exists(_cfg_path):
                 with open(_cfg_path) as _f:
@@ -307,7 +373,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     elif isinstance(_model_cfg, dict):
                         model = _model_cfg.get("default", model)
         except Exception as e:
-            logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
+            logger.warning(
+                "Job '%s': failed to load config.yaml, using defaults: %s", job_id, e
+            )
 
         # Reasoning config from env or config.yaml
         reasoning_config = None
@@ -323,9 +391,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
         # Prefill messages from env or config.yaml
         prefill_messages = None
-        prefill_file = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "") or _cfg.get("prefill_messages_file", "")
+        prefill_file = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "") or _cfg.get(
+            "prefill_messages_file", ""
+        )
         if prefill_file:
             import json as _json
+
             pfpath = Path(prefill_file).expanduser()
             if not pfpath.is_absolute():
                 pfpath = _hermes_home / pfpath
@@ -336,11 +407,21 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     if not isinstance(prefill_messages, list):
                         prefill_messages = None
                 except Exception as e:
-                    logger.warning("Job '%s': failed to parse prefill messages file '%s': %s", job_id, pfpath, e)
+                    logger.warning(
+                        "Job '%s': failed to parse prefill messages file '%s': %s",
+                        job_id,
+                        pfpath,
+                        e,
+                    )
                     prefill_messages = None
 
-        # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 90
+        # Max iterations (per-job override > global config > default 90)
+        max_iterations = (
+            job.get("max_iterations")
+            or _cfg.get("agent", {}).get("max_turns")
+            or _cfg.get("max_turns")
+            or 90
+        )
 
         # Provider routing
         pr = _cfg.get("provider_routing", {})
@@ -350,9 +431,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             resolve_runtime_provider,
             format_runtime_provider_error,
         )
+
         try:
             runtime_kwargs = {
-                "requested": job.get("provider") or os.getenv("HERMES_INFERENCE_PROVIDER"),
+                "requested": job.get("provider")
+                or os.getenv("HERMES_INFERENCE_PROVIDER"),
             }
             if job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")
@@ -362,6 +445,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             raise RuntimeError(message) from exc
 
         from agent.smart_model_routing import resolve_turn_route
+
         turn_route = resolve_turn_route(
             prompt,
             smart_routing,
@@ -397,18 +481,18 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             session_id=f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}",
             session_db=_session_db,
         )
-        
+
         result = agent.run_conversation(prompt)
-        
+
         final_response = result.get("final_response", "")
         if not final_response:
             final_response = "(No response generated)"
-        
+
         output = f"""# Cron Job: {job_name}
 
 **Job ID:** {job_id}
-**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
-**Schedule:** {job.get('schedule_display', 'N/A')}
+**Run Time:** {_hermes_now().strftime("%Y-%m-%d %H:%M:%S")}
+**Schedule:** {job.get("schedule_display", "N/A")}
 
 ## Prompt
 
@@ -418,19 +502,19 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
 {final_response}
 """
-        
+
         logger.info("Job '%s' completed successfully", job_name)
         return True, output, final_response, None
-        
+
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.error("Job '%s' failed: %s", job_name, error_msg)
-        
+
         output = f"""# Cron Job: {job_name} (FAILED)
 
 **Job ID:** {job_id}
-**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
-**Schedule:** {job.get('schedule_display', 'N/A')}
+**Run Time:** {_hermes_now().strftime("%Y-%m-%d %H:%M:%S")}
+**Schedule:** {job.get("schedule_display", "N/A")}
 
 ## Prompt
 
@@ -461,19 +545,21 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             try:
                 _session_db.close()
             except Exception as e:
-                logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
+                logger.debug(
+                    "Job '%s': failed to close SQLite session store: %s", job_id, e
+                )
 
 
 def tick(verbose: bool = True) -> int:
     """
     Check and run all due jobs.
-    
+
     Uses a file lock so only one tick runs at a time, even if the gateway's
     in-process ticker and a standalone daemon or manual tick overlap.
-    
+
     Args:
         verbose: Whether to print status messages
-    
+
     Returns:
         Number of jobs executed (0 if another tick is already running)
     """
@@ -497,11 +583,13 @@ def tick(verbose: bool = True) -> int:
         due_jobs = get_due_jobs()
 
         if verbose and not due_jobs:
-            logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
+            logger.info("%s - No jobs due", _hermes_now().strftime("%H:%M:%S"))
             return 0
 
         if verbose:
-            logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
+            logger.info(
+                "%s - %s job(s) due", _hermes_now().strftime("%H:%M:%S"), len(due_jobs)
+            )
 
         executed = 0
         for job in due_jobs:
@@ -515,10 +603,22 @@ def tick(verbose: bool = True) -> int:
                 # Deliver the final response to the origin/target chat.
                 # If the agent responded with [SILENT], skip delivery (but
                 # output is already saved above).  Failed jobs always deliver.
-                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+                deliver_content = (
+                    final_response
+                    if success
+                    else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+                )
                 should_deliver = bool(deliver_content)
-                if should_deliver and success and deliver_content.strip().upper().startswith(SILENT_MARKER):
-                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                if (
+                    should_deliver
+                    and success
+                    and deliver_content.strip().upper().startswith(SILENT_MARKER)
+                ):
+                    logger.info(
+                        "Job '%s': agent returned %s — skipping delivery",
+                        job["id"],
+                        SILENT_MARKER,
+                    )
                     should_deliver = False
 
                 if should_deliver:
@@ -531,7 +631,7 @@ def tick(verbose: bool = True) -> int:
                 executed += 1
 
             except Exception as e:
-                logger.error("Error processing job %s: %s", job['id'], e)
+                logger.error("Error processing job %s: %s", job["id"], e)
                 mark_job_run(job["id"], False, str(e))
 
         return executed

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,7 +7,14 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import (
+    _resolve_origin,
+    _resolve_delivery_target,
+    _deliver_result,
+    run_job,
+    SILENT_MARKER,
+    _build_job_prompt,
+)
 
 
 class TestResolveOrigin:
@@ -94,6 +101,34 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
+    def test_origin_no_origin_falls_back_to_home_channel(self, monkeypatch):
+        """deliver='origin' with no origin should fall back to platform home channel."""
+        monkeypatch.setenv("MATRIX_HOME_CHANNEL", "!abc:server")
+        job = {"deliver": "origin", "origin": None}
+        assert _resolve_delivery_target(job) == {
+            "platform": "matrix",
+            "chat_id": "!abc:server",
+            "thread_id": None,
+        }
+
+    def test_origin_no_origin_no_home_channel_returns_none(self, monkeypatch):
+        """deliver='origin' with no origin and no home channel should return None."""
+        monkeypatch.delenv("MATRIX_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("SLACK_HOME_CHANNEL", raising=False)
+        job = {"deliver": "origin", "origin": None}
+        assert _resolve_delivery_target(job) is None
+
+    def test_origin_no_origin_prefers_first_configured_platform(self, monkeypatch):
+        """Fallback order: matrix, telegram, discord, slack."""
+        monkeypatch.delenv("MATRIX_HOME_CHANNEL", raising=False)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-999")
+        job = {"deliver": "origin"}
+        result = _resolve_delivery_target(job)
+        assert result["platform"] == "telegram"
+        assert result["chat_id"] == "-999"
+
 
 class TestDeliverResultMirrorLogging:
     """Verify that mirror_to_session failures are logged, not silently swallowed."""
@@ -107,9 +142,17 @@ class TestDeliverResultMirrorLogging:
         mock_cfg = MagicMock()
         mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
 
-        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
-             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
-             patch("gateway.mirror.mirror_to_session", side_effect=ConnectionError("network down")):
+        with (
+            patch("gateway.config.load_gateway_config", return_value=mock_cfg),
+            patch(
+                "tools.send_message_tool._send_to_platform",
+                new=AsyncMock(return_value={"success": True}),
+            ),
+            patch(
+                "gateway.mirror.mirror_to_session",
+                side_effect=ConnectionError("network down"),
+            ),
+        ):
             job = {
                 "id": "test-job",
                 "deliver": "origin",
@@ -118,8 +161,9 @@ class TestDeliverResultMirrorLogging:
             with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
                 _deliver_result(job, "Hello!")
 
-        assert any("mirror_to_session failed" in r.message for r in caplog.records), \
+        assert any("mirror_to_session failed" in r.message for r in caplog.records), (
             f"Expected 'mirror_to_session failed' warning in logs, got: {[r.message for r in caplog.records]}"
+        )
 
     def test_origin_delivery_preserves_thread_id(self):
         """Origin delivery should forward thread_id to send/mirror helpers."""
@@ -140,9 +184,14 @@ class TestDeliverResultMirrorLogging:
             },
         }
 
-        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
-             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
-             patch("gateway.mirror.mirror_to_session") as mirror_mock:
+        with (
+            patch("gateway.config.load_gateway_config", return_value=mock_cfg),
+            patch(
+                "tools.send_message_tool._send_to_platform",
+                new=AsyncMock(return_value={"success": True}),
+            ) as send_mock,
+            patch("gateway.mirror.mirror_to_session") as mirror_mock,
+        ):
             _deliver_result(job, "hello")
 
         send_mock.assert_called_once()
@@ -165,20 +214,22 @@ class TestRunJobSessionPersistence:
         }
         fake_db = MagicMock()
 
-        with patch("cron.scheduler._hermes_home", tmp_path), \
-             patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
-             patch("hermes_state.SessionDB", return_value=fake_db), \
-             patch(
-                 "hermes_cli.runtime_provider.resolve_runtime_provider",
-                 return_value={
-                     "api_key": "test-key",
-                     "base_url": "https://example.invalid/v1",
-                     "provider": "openrouter",
-                     "api_mode": "chat_completions",
-                 },
-             ), \
-             patch("run_agent.AIAgent") as mock_agent_cls:
+        with (
+            patch("cron.scheduler._hermes_home", tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("dotenv.load_dotenv"),
+            patch("hermes_state.SessionDB", return_value=fake_db),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "test-key",
+                    "base_url": "https://example.invalid/v1",
+                    "provider": "openrouter",
+                    "api_mode": "chat_completions",
+                },
+            ),
+            patch("run_agent.AIAgent") as mock_agent_cls,
+        ):
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
@@ -196,7 +247,9 @@ class TestRunJobSessionPersistence:
         assert kwargs["session_id"].startswith("cron_test-job_")
         fake_db.close.assert_called_once()
 
-    def test_run_job_sets_auto_delivery_env_from_dotenv_home_channel(self, tmp_path, monkeypatch):
+    def test_run_job_sets_auto_delivery_env_from_dotenv_home_channel(
+        self, tmp_path, monkeypatch
+    ):
         job = {
             "id": "test-job",
             "name": "test",
@@ -222,18 +275,20 @@ class TestRunJobSessionPersistence:
                 seen["thread_id"] = os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID")
                 return {"final_response": "ok"}
 
-        with patch("cron.scheduler._hermes_home", tmp_path), \
-             patch("hermes_state.SessionDB", return_value=fake_db), \
-             patch(
-                 "hermes_cli.runtime_provider.resolve_runtime_provider",
-                 return_value={
-                     "api_key": "***",
-                     "base_url": "https://example.invalid/v1",
-                     "provider": "openrouter",
-                     "api_mode": "chat_completions",
-                 },
-             ), \
-             patch("run_agent.AIAgent", FakeAgent):
+        with (
+            patch("cron.scheduler._hermes_home", tmp_path),
+            patch("hermes_state.SessionDB", return_value=fake_db),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "***",
+                    "base_url": "https://example.invalid/v1",
+                    "provider": "openrouter",
+                    "api_mode": "chat_completions",
+                },
+            ),
+            patch("run_agent.AIAgent", FakeAgent),
+        ):
             success, output, final_response, error = run_job(job)
 
         assert success is True
@@ -265,10 +320,12 @@ class TestRunJobConfigLogging:
             "prompt": "hello",
         }
 
-        with patch("cron.scheduler._hermes_home", tmp_path), \
-             patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
-             patch("run_agent.AIAgent") as mock_agent_cls:
+        with (
+            patch("cron.scheduler._hermes_home", tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("dotenv.load_dotenv"),
+            patch("run_agent.AIAgent") as mock_agent_cls,
+        ):
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
@@ -276,8 +333,9 @@ class TestRunJobConfigLogging:
             with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
                 run_job(job)
 
-        assert any("failed to load config.yaml" in r.message for r in caplog.records), \
+        assert any("failed to load config.yaml" in r.message for r in caplog.records), (
             f"Expected 'failed to load config.yaml' warning in logs, got: {[r.message for r in caplog.records]}"
+        )
 
     def test_bad_prefill_messages_is_logged(self, caplog, tmp_path):
         """When the prefill messages file contains invalid JSON, a warning should be logged."""
@@ -294,10 +352,12 @@ class TestRunJobConfigLogging:
             "prompt": "hello",
         }
 
-        with patch("cron.scheduler._hermes_home", tmp_path), \
-             patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
-             patch("run_agent.AIAgent") as mock_agent_cls:
+        with (
+            patch("cron.scheduler._hermes_home", tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("dotenv.load_dotenv"),
+            patch("run_agent.AIAgent") as mock_agent_cls,
+        ):
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
@@ -305,8 +365,11 @@ class TestRunJobConfigLogging:
             with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
                 run_job(job)
 
-        assert any("failed to parse prefill messages" in r.message for r in caplog.records), \
+        assert any(
+            "failed to parse prefill messages" in r.message for r in caplog.records
+        ), (
             f"Expected 'failed to parse prefill messages' warning in logs, got: {[r.message for r in caplog.records]}"
+        )
 
 
 class TestRunJobPerJobOverrides:
@@ -336,12 +399,17 @@ class TestRunJobPerJobOverrides:
             "api_key": "***",
         }
 
-        with patch("cron.scheduler._hermes_home", tmp_path), \
-             patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
-             patch("hermes_state.SessionDB", return_value=fake_db), \
-             patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=fake_runtime) as runtime_mock, \
-             patch("run_agent.AIAgent") as mock_agent_cls:
+        with (
+            patch("cron.scheduler._hermes_home", tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("dotenv.load_dotenv"),
+            patch("hermes_state.SessionDB", return_value=fake_db),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value=fake_runtime,
+            ) as runtime_mock,
+            patch("run_agent.AIAgent") as mock_agent_cls,
+        ):
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
@@ -371,21 +439,28 @@ class TestRunJobSkillBacked:
 
         fake_db = MagicMock()
 
-        with patch("cron.scheduler._hermes_home", tmp_path), \
-             patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
-             patch("hermes_state.SessionDB", return_value=fake_db), \
-             patch(
-                 "hermes_cli.runtime_provider.resolve_runtime_provider",
-                 return_value={
-                     "api_key": "***",
-                     "base_url": "https://example.invalid/v1",
-                     "provider": "openrouter",
-                     "api_mode": "chat_completions",
-                 },
-             ), \
-             patch("tools.skills_tool.skill_view", return_value=json.dumps({"success": True, "content": "# Blogwatcher\nFollow this skill."})), \
-             patch("run_agent.AIAgent") as mock_agent_cls:
+        with (
+            patch("cron.scheduler._hermes_home", tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("dotenv.load_dotenv"),
+            patch("hermes_state.SessionDB", return_value=fake_db),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "***",
+                    "base_url": "https://example.invalid/v1",
+                    "provider": "openrouter",
+                    "api_mode": "chat_completions",
+                },
+            ),
+            patch(
+                "tools.skills_tool.skill_view",
+                return_value=json.dumps(
+                    {"success": True, "content": "# Blogwatcher\nFollow this skill."}
+                ),
+            ),
+            patch("run_agent.AIAgent") as mock_agent_cls,
+        ):
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
@@ -415,23 +490,29 @@ class TestRunJobSkillBacked:
         fake_db = MagicMock()
 
         def _skill_view(name):
-            return json.dumps({"success": True, "content": f"# {name}\nInstructions for {name}."})
+            return json.dumps(
+                {"success": True, "content": f"# {name}\nInstructions for {name}."}
+            )
 
-        with patch("cron.scheduler._hermes_home", tmp_path), \
-             patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
-             patch("hermes_state.SessionDB", return_value=fake_db), \
-             patch(
-                 "hermes_cli.runtime_provider.resolve_runtime_provider",
-                 return_value={
-                     "api_key": "***",
-                     "base_url": "https://example.invalid/v1",
-                     "provider": "openrouter",
-                     "api_mode": "chat_completions",
-                 },
-             ), \
-             patch("tools.skills_tool.skill_view", side_effect=_skill_view) as skill_view_mock, \
-             patch("run_agent.AIAgent") as mock_agent_cls:
+        with (
+            patch("cron.scheduler._hermes_home", tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("dotenv.load_dotenv"),
+            patch("hermes_state.SessionDB", return_value=fake_db),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "***",
+                    "base_url": "https://example.invalid/v1",
+                    "provider": "openrouter",
+                    "api_mode": "chat_completions",
+                },
+            ),
+            patch(
+                "tools.skills_tool.skill_view", side_effect=_skill_view
+            ) as skill_view_mock,
+            patch("run_agent.AIAgent") as mock_agent_cls,
+        ):
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
@@ -442,7 +523,10 @@ class TestRunJobSkillBacked:
         assert error is None
         assert final_response == "ok"
         assert skill_view_mock.call_count == 2
-        assert [call.args[0] for call in skill_view_mock.call_args_list] == ["blogwatcher", "find-nearby"]
+        assert [call.args[0] for call in skill_view_mock.call_args_list] == [
+            "blogwatcher",
+            "find-nearby",
+        ]
 
         prompt_arg = mock_agent.run_conversation.call_args.args[0]
         assert prompt_arg.index("blogwatcher") < prompt_arg.index("find-nearby")
@@ -463,66 +547,102 @@ class TestSilentDelivery:
         }
 
     def test_normal_response_delivers(self):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "Results here", None)), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
+        with (
+            patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]),
+            patch(
+                "cron.scheduler.run_job",
+                return_value=(True, "# output", "Results here", None),
+            ),
+            patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"),
+            patch("cron.scheduler._deliver_result") as deliver_mock,
+            patch("cron.scheduler.mark_job_run"),
+        ):
             from cron.scheduler import tick
+
             tick(verbose=False)
         deliver_mock.assert_called_once()
 
     def test_silent_response_suppresses_delivery(self, caplog):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT]", None)), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
+        with (
+            patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]),
+            patch(
+                "cron.scheduler.run_job",
+                return_value=(True, "# output", "[SILENT]", None),
+            ),
+            patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"),
+            patch("cron.scheduler._deliver_result") as deliver_mock,
+            patch("cron.scheduler.mark_job_run"),
+        ):
             from cron.scheduler import tick
+
             with caplog.at_level(logging.INFO, logger="cron.scheduler"):
                 tick(verbose=False)
         deliver_mock.assert_not_called()
         assert any(SILENT_MARKER in r.message for r in caplog.records)
 
     def test_silent_with_note_suppresses_delivery(self):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None)), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
+        with (
+            patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]),
+            patch(
+                "cron.scheduler.run_job",
+                return_value=(True, "# output", "[SILENT] No changes detected", None),
+            ),
+            patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"),
+            patch("cron.scheduler._deliver_result") as deliver_mock,
+            patch("cron.scheduler.mark_job_run"),
+        ):
             from cron.scheduler import tick
+
             tick(verbose=False)
         deliver_mock.assert_not_called()
 
     def test_silent_is_case_insensitive(self):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
+        with (
+            patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]),
+            patch(
+                "cron.scheduler.run_job",
+                return_value=(True, "# output", "[silent] nothing new", None),
+            ),
+            patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"),
+            patch("cron.scheduler._deliver_result") as deliver_mock,
+            patch("cron.scheduler.mark_job_run"),
+        ):
             from cron.scheduler import tick
+
             tick(verbose=False)
         deliver_mock.assert_not_called()
 
     def test_failed_job_always_delivers(self):
         """Failed jobs deliver regardless of [SILENT] in output."""
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(False, "# output", "", "some error")), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
+        with (
+            patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]),
+            patch(
+                "cron.scheduler.run_job",
+                return_value=(False, "# output", "", "some error"),
+            ),
+            patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"),
+            patch("cron.scheduler._deliver_result") as deliver_mock,
+            patch("cron.scheduler.mark_job_run"),
+        ):
             from cron.scheduler import tick
+
             tick(verbose=False)
         deliver_mock.assert_called_once()
 
     def test_output_saved_even_when_delivery_suppressed(self):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# full output", "[SILENT]", None)), \
-             patch("cron.scheduler.save_job_output") as save_mock, \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
+        with (
+            patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]),
+            patch(
+                "cron.scheduler.run_job",
+                return_value=(True, "# full output", "[SILENT]", None),
+            ),
+            patch("cron.scheduler.save_job_output") as save_mock,
+            patch("cron.scheduler._deliver_result") as deliver_mock,
+            patch("cron.scheduler.mark_job_run"),
+        ):
             save_mock.return_value = "/tmp/out.md"
             from cron.scheduler import tick
+
             tick(verbose=False)
         save_mock.assert_called_once_with("monitor-job", "# full output")
         deliver_mock.assert_not_called()
@@ -551,23 +671,39 @@ class TestBuildJobPromptMissingSkill:
 
     def test_missing_skill_does_not_raise(self):
         """Job should run even when a referenced skill is not installed."""
-        with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
-            result = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+        with patch(
+            "tools.skills_tool.skill_view", side_effect=self._missing_skill_view
+        ):
+            result = _build_job_prompt(
+                {"skills": ["ghost-skill"], "prompt": "do something"}
+            )
         # prompt is preserved even though skill was skipped
         assert "do something" in result
 
     def test_missing_skill_injects_user_notice_into_prompt(self):
         """A system notice about the missing skill is injected into the prompt."""
-        with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
-            result = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+        with patch(
+            "tools.skills_tool.skill_view", side_effect=self._missing_skill_view
+        ):
+            result = _build_job_prompt(
+                {"skills": ["ghost-skill"], "prompt": "do something"}
+            )
         assert "ghost-skill" in result
         assert "not found" in result.lower() or "skipped" in result.lower()
 
     def test_missing_skill_logs_warning(self, caplog):
         """A warning is logged when a skill cannot be found."""
         with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
-            with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
-                _build_job_prompt({"name": "My Job", "skills": ["ghost-skill"], "prompt": "do something"})
+            with patch(
+                "tools.skills_tool.skill_view", side_effect=self._missing_skill_view
+            ):
+                _build_job_prompt(
+                    {
+                        "name": "My Job",
+                        "skills": ["ghost-skill"],
+                        "prompt": "do something",
+                    }
+                )
         assert any("ghost-skill" in record.message for record in caplog.records)
 
     def test_valid_skill_loaded_alongside_missing(self):
@@ -579,6 +715,8 @@ class TestBuildJobPromptMissingSkill:
             return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
 
         with patch("tools.skills_tool.skill_view", side_effect=_mixed_skill_view):
-            result = _build_job_prompt({"skills": ["ghost-skill", "real-skill"], "prompt": "go"})
+            result = _build_job_prompt(
+                {"skills": ["ghost-skill", "real-skill"], "prompt": "go"}
+            )
         assert "Real skill content." in result
         assert "go" in result

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -34,21 +34,35 @@ from cron.jobs import (
 # ---------------------------------------------------------------------------
 
 _CRON_THREAT_PATTERNS = [
-    (r'ignore\s+(?:\w+\s+)*(?:previous|all|above|prior)\s+(?:\w+\s+)*instructions', "prompt_injection"),
-    (r'do\s+not\s+tell\s+the\s+user', "deception_hide"),
-    (r'system\s+prompt\s+override', "sys_prompt_override"),
-    (r'disregard\s+(your|all|any)\s+(instructions|rules|guidelines)', "disregard_rules"),
-    (r'curl\s+[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)', "exfil_curl"),
-    (r'wget\s+[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)', "exfil_wget"),
-    (r'cat\s+[^\n]*(\.env|credentials|\.netrc|\.pgpass)', "read_secrets"),
-    (r'authorized_keys', "ssh_backdoor"),
-    (r'/etc/sudoers|visudo', "sudoers_mod"),
-    (r'rm\s+-rf\s+/', "destructive_root_rm"),
+    (
+        r"ignore\s+(?:\w+\s+)*(?:previous|all|above|prior)\s+(?:\w+\s+)*instructions",
+        "prompt_injection",
+    ),
+    (r"do\s+not\s+tell\s+the\s+user", "deception_hide"),
+    (r"system\s+prompt\s+override", "sys_prompt_override"),
+    (
+        r"disregard\s+(your|all|any)\s+(instructions|rules|guidelines)",
+        "disregard_rules",
+    ),
+    (r"curl\s+[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)", "exfil_curl"),
+    (r"wget\s+[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)", "exfil_wget"),
+    (r"cat\s+[^\n]*(\.env|credentials|\.netrc|\.pgpass)", "read_secrets"),
+    (r"authorized_keys", "ssh_backdoor"),
+    (r"/etc/sudoers|visudo", "sudoers_mod"),
+    (r"rm\s+-rf\s+/", "destructive_root_rm"),
 ]
 
 _CRON_INVISIBLE_CHARS = {
-    '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff',
-    '\u202a', '\u202b', '\u202c', '\u202d', '\u202e',
+    "\u200b",
+    "\u200c",
+    "\u200d",
+    "\u2060",
+    "\ufeff",
+    "\u202a",
+    "\u202b",
+    "\u202c",
+    "\u202d",
+    "\u202e",
 }
 
 
@@ -86,7 +100,9 @@ def _repeat_display(job: Dict[str, Any]) -> str:
     return f"{completed}/{times}" if completed else f"{times} times"
 
 
-def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
+def _canonical_skills(
+    skill: Optional[str] = None, skills: Optional[Any] = None
+) -> List[str]:
     if skills is None:
         raw_items = [skill] if skill else []
     elif isinstance(skills, str):
@@ -102,15 +118,15 @@ def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None)
     return normalized
 
 
-
-def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash: bool = False) -> Optional[str]:
+def _normalize_optional_job_value(
+    value: Optional[Any], *, strip_trailing_slash: bool = False
+) -> Optional[str]:
     if value is None:
         return None
     text = str(value).strip()
     if strip_trailing_slash:
         text = text.rstrip("/")
     return text or None
-
 
 
 def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
@@ -132,7 +148,9 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "last_run_at": job.get("last_run_at"),
         "last_status": job.get("last_status"),
         "enabled": job.get("enabled", True),
-        "state": job.get("state", "scheduled" if job.get("enabled", True) else "paused"),
+        "state": job.get(
+            "state", "scheduled" if job.get("enabled", True) else "paused"
+        ),
         "paused_at": job.get("paused_at"),
         "paused_reason": job.get("paused_reason"),
     }
@@ -163,10 +181,19 @@ def cronjob(
 
         if normalized == "create":
             if not schedule:
-                return json.dumps({"success": False, "error": "schedule is required for create"}, indent=2)
+                return json.dumps(
+                    {"success": False, "error": "schedule is required for create"},
+                    indent=2,
+                )
             canonical_skills = _canonical_skills(skill, skills)
             if not prompt and not canonical_skills:
-                return json.dumps({"success": False, "error": "create requires either prompt or at least one skill"}, indent=2)
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": "create requires either prompt or at least one skill",
+                    },
+                    indent=2,
+                )
             if prompt:
                 scan_error = _scan_cron_prompt(prompt)
                 if scan_error:
@@ -182,7 +209,9 @@ def cronjob(
                 skills=canonical_skills,
                 model=_normalize_optional_job_value(model),
                 provider=_normalize_optional_job_value(provider),
-                base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
+                base_url=_normalize_optional_job_value(
+                    base_url, strip_trailing_slash=True
+                ),
             )
             return json.dumps(
                 {
@@ -202,23 +231,41 @@ def cronjob(
             )
 
         if normalized == "list":
-            jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
-            return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
+            jobs = [
+                _format_job(job) for job in list_jobs(include_disabled=include_disabled)
+            ]
+            return json.dumps(
+                {"success": True, "count": len(jobs), "jobs": jobs}, indent=2
+            )
 
         if not job_id:
-            return json.dumps({"success": False, "error": f"job_id is required for action '{normalized}'"}, indent=2)
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"job_id is required for action '{normalized}'",
+                },
+                indent=2,
+            )
 
         job = get_job(job_id)
         if not job:
             return json.dumps(
-                {"success": False, "error": f"Job with ID '{job_id}' not found. Use cronjob(action='list') to inspect jobs."},
+                {
+                    "success": False,
+                    "error": f"Job with ID or name '{job_id}' not found. Use cronjob(action='list') to inspect jobs.",
+                },
                 indent=2,
             )
+        # Resolve to canonical ID (supports name-based lookup)
+        job_id = job["id"]
 
         if normalized == "remove":
             removed = remove_job(job_id)
             if not removed:
-                return json.dumps({"success": False, "error": f"Failed to remove job '{job_id}'"}, indent=2)
+                return json.dumps(
+                    {"success": False, "error": f"Failed to remove job '{job_id}'"},
+                    indent=2,
+                )
             return json.dumps(
                 {
                     "success": True,
@@ -264,7 +311,9 @@ def cronjob(
             if provider is not None:
                 updates["provider"] = _normalize_optional_job_value(provider)
             if base_url is not None:
-                updates["base_url"] = _normalize_optional_job_value(base_url, strip_trailing_slash=True)
+                updates["base_url"] = _normalize_optional_job_value(
+                    base_url, strip_trailing_slash=True
+                )
             if repeat is not None:
                 repeat_state = dict(job.get("repeat") or {})
                 repeat_state["times"] = repeat
@@ -277,11 +326,15 @@ def cronjob(
                     updates["state"] = "scheduled"
                     updates["enabled"] = True
             if not updates:
-                return json.dumps({"success": False, "error": "No updates provided."}, indent=2)
+                return json.dumps(
+                    {"success": False, "error": "No updates provided."}, indent=2
+                )
             updated = update_job(job_id, updates)
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
-        return json.dumps({"success": False, "error": f"Unknown cron action '{action}'"}, indent=2)
+        return json.dumps(
+            {"success": False, "error": f"Unknown cron action '{action}'"}, indent=2
+        )
 
     except Exception as e:
         return json.dumps({"success": False, "error": str(e)}, indent=2)
@@ -290,6 +343,7 @@ def cronjob(
 # ---------------------------------------------------------------------------
 # Compatibility wrappers
 # ---------------------------------------------------------------------------
+
 
 def schedule_cronjob(
     prompt: str,
@@ -346,64 +400,58 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
         "properties": {
             "action": {
                 "type": "string",
-                "description": "One of: create, list, update, pause, resume, remove, run"
+                "description": "One of: create, list, update, pause, resume, remove, run",
             },
             "job_id": {
                 "type": "string",
-                "description": "Required for update/pause/resume/remove/run"
+                "description": "Required for update/pause/resume/remove/run",
             },
             "prompt": {
                 "type": "string",
-                "description": "For create: the full self-contained prompt. If skill or skills are also provided, this becomes the task instruction paired with those skills."
+                "description": "For create: the full self-contained prompt. If skill or skills are also provided, this becomes the task instruction paired with those skills.",
             },
             "schedule": {
                 "type": "string",
-                "description": "For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp"
+                "description": "For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp",
             },
-            "name": {
-                "type": "string",
-                "description": "Optional human-friendly name"
-            },
+            "name": {"type": "string", "description": "Optional human-friendly name"},
             "repeat": {
                 "type": "integer",
-                "description": "Optional repeat count. Omit for defaults (once for one-shot, forever for recurring)."
+                "description": "Optional repeat count. Omit for defaults (once for one-shot, forever for recurring).",
             },
             "deliver": {
                 "type": "string",
-                "description": "Delivery target: origin, local, telegram, discord, signal, sms, or platform:chat_id"
+                "description": "Delivery target: origin, local, telegram, discord, signal, sms, or platform:chat_id",
             },
             "model": {
                 "type": "string",
-                "description": "Optional per-job model override used when the cron job runs"
+                "description": "Optional per-job model override used when the cron job runs",
             },
             "provider": {
                 "type": "string",
-                "description": "Optional per-job provider override used when resolving runtime credentials"
+                "description": "Optional per-job provider override used when resolving runtime credentials",
             },
             "base_url": {
                 "type": "string",
-                "description": "Optional per-job base URL override paired with provider/model routing"
+                "description": "Optional per-job base URL override paired with provider/model routing",
             },
             "include_disabled": {
                 "type": "boolean",
-                "description": "For list: include paused/completed jobs"
+                "description": "For list: include paused/completed jobs",
             },
             "skill": {
                 "type": "string",
-                "description": "Optional single skill name to load before executing the cron prompt"
+                "description": "Optional single skill name to load before executing the cron prompt",
             },
             "skills": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Optional ordered list of skills to load before executing the cron prompt. On update, pass an empty array to clear attached skills."
+                "description": "Optional ordered list of skills to load before executing the cron prompt. On update, pass an empty array to clear attached skills.",
             },
-            "reason": {
-                "type": "string",
-                "description": "Optional pause reason"
-            }
+            "reason": {"type": "string", "description": "Optional pause reason"},
         },
-        "required": ["action"]
-    }
+        "required": ["action"],
+    },
 }
 
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -37,19 +37,16 @@ SEND_MESSAGE_SCHEMA = {
             "action": {
                 "type": "string",
                 "enum": ["send", "list"],
-                "description": "Action to perform. 'send' (default) sends a message. 'list' returns all available channels/contacts across connected platforms."
+                "description": "Action to perform. 'send' (default) sends a message. 'list' returns all available channels/contacts across connected platforms.",
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or Telegram topic 'telegram:chat_id:thread_id'. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:#bot-home', 'slack:#engineering', 'signal:+15551234567'"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or Telegram topic 'telegram:chat_id:thread_id'. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:#bot-home', 'slack:#engineering', 'signal:+15551234567'",
             },
-            "message": {
-                "type": "string",
-                "description": "The message text to send"
-            }
+            "message": {"type": "string", "description": "The message text to send"},
         },
-        "required": []
-    }
+        "required": [],
+    },
 }
 
 
@@ -67,6 +64,7 @@ def _handle_list():
     """Return formatted list of available messaging targets."""
     try:
         from gateway.channel_directory import format_directory_for_display
+
         return json.dumps({"targets": format_directory_for_display()})
     except Exception as e:
         return json.dumps({"error": f"Failed to load channel directory: {e}"})
@@ -77,7 +75,9 @@ def _handle_send(args):
     target = args.get("target", "")
     message = args.get("message", "")
     if not target or not message:
-        return json.dumps({"error": "Both 'target' and 'message' are required when action='send'"})
+        return json.dumps(
+            {"error": "Both 'target' and 'message' are required when action='send'"}
+        )
 
     parts = target.split(":", 1)
     platform_name = parts[0].strip().lower()
@@ -94,26 +94,33 @@ def _handle_send(args):
     if target_ref and not is_explicit:
         try:
             from gateway.channel_directory import resolve_channel_name
+
             resolved = resolve_channel_name(platform_name, target_ref)
             if resolved:
                 chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
             else:
-                return json.dumps({
-                    "error": f"Could not resolve '{target_ref}' on {platform_name}. "
-                    f"Use send_message(action='list') to see available targets."
-                })
+                return json.dumps(
+                    {
+                        "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                        f"Use send_message(action='list') to see available targets."
+                    }
+                )
         except Exception:
-            return json.dumps({
-                "error": f"Could not resolve '{target_ref}' on {platform_name}. "
-                f"Try using a numeric channel ID instead."
-            })
+            return json.dumps(
+                {
+                    "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                    f"Try using a numeric channel ID instead."
+                }
+            )
 
     from tools.interrupt import is_interrupted
+
     if is_interrupted():
         return json.dumps({"error": "Interrupted"})
 
     try:
         from gateway.config import load_gateway_config, Platform
+
         config = load_gateway_config()
     except Exception as e:
         return json.dumps({"error": f"Failed to load gateway config: {e}"})
@@ -126,15 +133,22 @@ def _handle_send(args):
         "signal": Platform.SIGNAL,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
+        "matrix": Platform.MATRIX,
     }
     platform = platform_map.get(platform_name)
     if not platform:
         avail = ", ".join(platform_map.keys())
-        return json.dumps({"error": f"Unknown platform: {platform_name}. Available: {avail}"})
+        return json.dumps(
+            {"error": f"Unknown platform: {platform_name}. Available: {avail}"}
+        )
 
     pconfig = config.platforms.get(platform)
     if not pconfig or not pconfig.enabled:
-        return json.dumps({"error": f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables."})
+        return json.dumps(
+            {
+                "error": f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables."
+            }
+        )
 
     from gateway.platforms.base import BasePlatformAdapter
 
@@ -148,11 +162,13 @@ def _handle_send(args):
             chat_id = home.chat_id
             used_home_channel = True
         else:
-            return json.dumps({
-                "error": f"No home channel set for {platform_name} to determine where to send the message. "
-                f"Either specify a channel directly with '{platform_name}:CHANNEL_NAME', "
-                f"or set a home channel via: hermes config set {platform_name.upper()}_HOME_CHANNEL <channel_id>"
-            })
+            return json.dumps(
+                {
+                    "error": f"No home channel set for {platform_name} to determine where to send the message. "
+                    f"Either specify a channel directly with '{platform_name}:CHANNEL_NAME', "
+                    f"or set a home channel via: hermes config set {platform_name.upper()}_HOME_CHANNEL <channel_id>"
+                }
+            )
 
     duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
     if duplicate_skip:
@@ -160,6 +176,7 @@ def _handle_send(args):
 
     try:
         from model_tools import _run_async
+
         result = _run_async(
             _send_to_platform(
                 platform,
@@ -171,14 +188,23 @@ def _handle_send(args):
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
-            result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
+            result["note"] = (
+                f"Sent to {platform_name} home channel (chat_id: {chat_id})"
+            )
 
         # Mirror the sent message into the target's gateway session
         if isinstance(result, dict) and result.get("success") and mirror_text:
             try:
                 from gateway.mirror import mirror_to_session
+
                 source_label = os.getenv("HERMES_SESSION_PLATFORM", "cli")
-                if mirror_to_session(platform_name, chat_id, mirror_text, source_label=source_label, thread_id=thread_id):
+                if mirror_to_session(
+                    platform_name,
+                    chat_id,
+                    mirror_text,
+                    source_label=source_label,
+                    thread_id=thread_id,
+                ):
                     result["mirrored"] = True
             except Exception:
                 pass
@@ -232,7 +258,9 @@ def _get_cron_auto_delivery_target():
     }
 
 
-def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id: str | None):
+def _maybe_skip_cron_duplicate_send(
+    platform_name: str, chat_id: str, thread_id: str | None
+):
     """Skip redundant cron send_message calls when the scheduler will auto-deliver there."""
     auto_target = _get_cron_auto_delivery_target()
     if not auto_target:
@@ -263,7 +291,9 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None):
+async def _send_to_platform(
+    platform, pconfig, chat_id, message, thread_id=None, media_files=None
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -297,7 +327,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if platform == Platform.TELEGRAM:
         last_result = None
         for i, chunk in enumerate(chunks):
-            is_last = (i == len(chunks) - 1)
+            is_last = i == len(chunks) - 1
             result = await _send_telegram(
                 pconfig.token,
                 chat_id,
@@ -339,8 +369,14 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_email(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SMS:
             result = await _send_sms(pconfig.api_key, chat_id, chunk)
+        elif platform == Platform.MATRIX:
+            result = await _send_matrix(
+                pconfig.token, pconfig.extra.get("homeserver", ""), chat_id, chunk
+            )
         else:
-            result = {"error": f"Direct sending not yet implemented for {platform.value}"}
+            result = {
+                "error": f"Direct sending not yet implemented for {platform.value}"
+            }
 
         if isinstance(result, dict) and result.get("error"):
             return result
@@ -367,7 +403,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 
         # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
         # Inspired by github.com/ashaney — PR #1568.
-        _has_html = bool(re.search(r'<[a-zA-Z/][^>]*>', message))
+        _has_html = bool(re.search(r"<[a-zA-Z/][^>]*>", message))
 
         if _has_html:
             formatted = message
@@ -375,7 +411,12 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         else:
             # Reuse the gateway adapter's format_message for markdown→MarkdownV2
             try:
-                from gateway.platforms.telegram import TelegramAdapter, _escape_mdv2, _strip_mdv2
+                from gateway.platforms.telegram import (
+                    TelegramAdapter,
+                    _escape_mdv2,
+                    _strip_mdv2,
+                )
+
                 _adapter = TelegramAdapter.__new__(TelegramAdapter)
                 formatted = _adapter.format_message(message)
             except Exception:
@@ -396,24 +437,37 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         if formatted.strip():
             try:
                 last_msg = await bot.send_message(
-                    chat_id=int_chat_id, text=formatted,
-                    parse_mode=send_parse_mode, **thread_kwargs
+                    chat_id=int_chat_id,
+                    text=formatted,
+                    parse_mode=send_parse_mode,
+                    **thread_kwargs,
                 )
             except Exception as md_error:
                 # Parse failed, fall back to plain text
-                if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower() or "html" in str(md_error).lower():
-                    logger.warning("Parse mode %s failed in _send_telegram, falling back to plain text: %s", send_parse_mode, md_error)
+                if (
+                    "parse" in str(md_error).lower()
+                    or "markdown" in str(md_error).lower()
+                    or "html" in str(md_error).lower()
+                ):
+                    logger.warning(
+                        "Parse mode %s failed in _send_telegram, falling back to plain text: %s",
+                        send_parse_mode,
+                        md_error,
+                    )
                     if not _has_html:
                         try:
                             from gateway.platforms.telegram import _strip_mdv2
+
                             plain = _strip_mdv2(formatted)
                         except Exception:
                             plain = message
                     else:
                         plain = message
                     last_msg = await bot.send_message(
-                        chat_id=int_chat_id, text=plain,
-                        parse_mode=None, **thread_kwargs
+                        chat_id=int_chat_id,
+                        text=plain,
+                        parse_mode=None,
+                        **thread_kwargs,
                     )
                 else:
                     raise
@@ -469,7 +523,9 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             result["warnings"] = warnings
         return result
     except ImportError:
-        return {"error": "python-telegram-bot not installed. Run: pip install python-telegram-bot"}
+        return {
+            "error": "python-telegram-bot not installed. Run: pip install python-telegram-bot"
+        }
     except Exception as e:
         return {"error": f"Telegram send failed: {e}"}
 
@@ -487,12 +543,19 @@ async def _send_discord(token, chat_id, message):
         url = f"https://discord.com/api/v10/channels/{chat_id}/messages"
         headers = {"Authorization": f"Bot {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, json={"content": message}) as resp:
+            async with session.post(
+                url, headers=headers, json={"content": message}
+            ) as resp:
                 if resp.status not in (200, 201):
                     body = await resp.text()
                     return {"error": f"Discord API error ({resp.status}): {body}"}
                 data = await resp.json()
-        return {"success": True, "platform": "discord", "chat_id": chat_id, "message_id": data.get("id")}
+        return {
+            "success": True,
+            "platform": "discord",
+            "chat_id": chat_id,
+            "message_id": data.get("id"),
+        }
     except Exception as e:
         return {"error": f"Discord send failed: {e}"}
 
@@ -505,12 +568,22 @@ async def _send_slack(token, chat_id, message):
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         url = "https://slack.com/api/chat.postMessage"
-        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
         async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, json={"channel": chat_id, "text": message}) as resp:
+            async with session.post(
+                url, headers=headers, json={"channel": chat_id, "text": message}
+            ) as resp:
                 data = await resp.json()
                 if data.get("ok"):
-                    return {"success": True, "platform": "slack", "chat_id": chat_id, "message_id": data.get("ts")}
+                    return {
+                        "success": True,
+                        "platform": "slack",
+                        "chat_id": chat_id,
+                        "message_id": data.get("ts"),
+                    }
                 return {"error": f"Slack API error: {data.get('error', 'unknown')}"}
     except Exception as e:
         return {"error": f"Slack send failed: {e}"}
@@ -591,7 +664,9 @@ async def _send_email(extra, chat_id, message):
     smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
 
     if not all([address, password, smtp_host]):
-        return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
+        return {
+            "error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"
+        }
 
     try:
         msg = MIMEText(message, "plain", "utf-8")
@@ -625,7 +700,9 @@ async def _send_sms(auth_token, chat_id, message):
     account_sid = os.getenv("TWILIO_ACCOUNT_SID", "")
     from_number = os.getenv("TWILIO_PHONE_NUMBER", "")
     if not account_sid or not auth_token or not from_number:
-        return {"error": "SMS not configured (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER required)"}
+        return {
+            "error": "SMS not configured (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER required)"
+        }
 
     # Strip markdown — SMS renders it as literal characters
     message = re.sub(r"\*\*(.+?)\*\*", r"\1", message, flags=re.DOTALL)
@@ -657,9 +734,73 @@ async def _send_sms(auth_token, chat_id, message):
                     error_msg = body.get("message", str(body))
                     return {"error": f"Twilio API error ({resp.status}): {error_msg}"}
                 msg_sid = body.get("sid", "")
-                return {"success": True, "platform": "sms", "chat_id": chat_id, "message_id": msg_sid}
+                return {
+                    "success": True,
+                    "platform": "sms",
+                    "chat_id": chat_id,
+                    "message_id": msg_sid,
+                }
     except Exception as e:
         return {"error": f"SMS send failed: {e}"}
+
+
+async def _send_matrix(token, homeserver, chat_id, message):
+    """Send via Matrix client-server API (one-shot HTTP PUT, no E2EE).
+
+    Uses a simple PUT to the /send endpoint with an access token.
+    Converts basic markdown to HTML for rich rendering in Matrix clients.
+    """
+    try:
+        import aiohttp
+    except ImportError:
+        return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+
+    if not token or not homeserver:
+        return {
+            "error": "Matrix not configured (MATRIX_ACCESS_TOKEN and MATRIX_HOMESERVER required)"
+        }
+
+    import os
+    import time
+    import urllib.parse
+
+    txn_id = f"hermes_{int(time.time() * 1000)}_{os.urandom(4).hex()}"
+    encoded_room = urllib.parse.quote(chat_id)
+    url = f"{homeserver}/_matrix/client/v3/rooms/{encoded_room}/send/m.room.message/{txn_id}"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+    # Basic markdown to HTML for Matrix formatted_body
+    html_body = message
+    html_body = re.sub(
+        r"\*\*(.+?)\*\*", r"<strong>\1</strong>", html_body, flags=re.DOTALL
+    )
+    html_body = re.sub(r"\*(.+?)\*", r"<em>\1</em>", html_body, flags=re.DOTALL)
+    html_body = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r'<a href="\2">\1</a>', html_body)
+    html_body = html_body.replace("\n", "<br>")
+
+    body = {
+        "msgtype": "m.text",
+        "body": message,
+        "format": "org.matrix.custom.html",
+        "formatted_body": html_body,
+    }
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.put(url, json=body, headers=headers, ssl=False) as resp:
+                if resp.status == 200:
+                    data = await resp.json()
+                    return {
+                        "success": True,
+                        "platform": "matrix",
+                        "chat_id": chat_id,
+                        "event_id": data.get("event_id"),
+                    }
+                else:
+                    text = await resp.text()
+                    return {"error": f"Matrix send failed ({resp.status}): {text}"}
+    except Exception as e:
+        return {"error": f"Matrix send failed: {e}"}
 
 
 def _check_send_message():
@@ -669,6 +810,7 @@ def _check_send_message():
         return True
     try:
         from gateway.status import is_gateway_running
+
         return is_gateway_running()
     except Exception:
         return False


### PR DESCRIPTION
## Summary

- **Add `_send_matrix()` sender** to `send_message_tool.py` — sends via Matrix CS API (PUT with access token), matching the pattern of `_send_telegram`/`_send_discord`/`_send_slack`. Without this, Matrix cron delivery silently fails with "Direct sending not yet implemented".
- **Add Matrix to `platform_map`** in both `_handle_send()` and `_deliver_result()`, and remove a pre-existing duplicate entry in the scheduler's map.
- **Fix `deliver="origin"` with null origin** in `_resolve_delivery_target()` — instead of silently returning `None`, falls back to checking each platform's `HOME_CHANNEL` env var (set by `/sethome`). Logs the fallback for observability.
- **Transaction ID uniqueness** — added random suffix to prevent Matrix event deduplication on rapid sends.

## Context

Cron jobs created via setup scripts or the Python API (rather than interactively via a chat message) have `origin=null`. Combined with `deliver="origin"` (the default), `_resolve_delivery_target()` returned `None`, silently dropping all cron output. Even after fixing the delivery target to `matrix:!room_id`, the missing `_send_matrix()` function meant delivery still failed at the `else` branch in `_send_to_platform()`.

## Test plan

- [x] 3 new unit tests for origin fallback behavior (with home channel, without, platform priority order)
- [x] All 32 existing scheduler tests pass
- [x] All 19 existing send_message_tool tests pass
- [x] Manual verification: `_send_matrix()` delivered a test message to a Matrix room (HTTP 200, event_id returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)