### PR TITLE
fix(cli): support -q/--query at top level with --resume and --continue

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3083,7 +3083,13 @@ For more help on a command:
         default=False,
         help="Include the session ID in the agent's system prompt"
     )
-    
+    parser.add_argument(
+        "-q", "--query",
+        dest="top_query",
+        default=None,
+        help="Single query to run (exits after response). Use with --resume/-c."
+    )
+
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
     
     # =========================================================================
@@ -4155,7 +4161,7 @@ For more help on a command:
     # Handle top-level --resume / --continue as shortcut to chat
     if (args.resume or args.continue_last) and args.command is None:
         args.command = "chat"
-        args.query = None
+        args.query = getattr(args, "top_query", None)
         args.model = None
         args.provider = None
         args.toolsets = None


### PR DESCRIPTION
## Summary
- `hermes --resume SESSION -q "hello"` fails with "unrecognized arguments" because `-q` is only defined on the `chat` subparser
- Users expect this to work since `--resume` is a top-level flag
- Fix: add `-q`/`--query` to the top-level parser (as `top_query`) and pass it through when routing `--resume`/`--continue` to the chat command

## How to reproduce
```bash
hermes --resume 20260323_191530_c6cf7d -q "hello"
# error: unrecognized arguments: -q hello
```

## How to test
- `hermes --resume SESSION -q "query"` now routes correctly to chat with the query
- `hermes chat --resume SESSION -q "query"` still works as before (uses chat's own -q)
- 215 existing CLI tests pass (1 pre-existing failure in systemd unit test, unrelated)

## Platform tested
- Linux