### PR TITLE
fix: Matrix cron delivery — add sender and origin fallback

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -71,13 +71,28 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
         return None
 
     if deliver == "origin":
-        if not origin:
-            return None
-        return {
-            "platform": origin["platform"],
-            "chat_id": str(origin["chat_id"]),
-            "thread_id": origin.get("thread_id"),
-        }
+        if origin:
+            return {
+                "platform": origin["platform"],
+                "chat_id": str(origin["chat_id"]),
+                "thread_id": origin.get("thread_id"),
+            }
+        # Origin missing (e.g. job created via API/setup script) — try each
+        # platform's home channel as a fallback instead of silently dropping.
+        for platform_name in ("matrix", "telegram", "discord", "slack"):
+            chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
+            if chat_id:
+                logger.info(
+                    "Job '%s' has deliver=origin but no origin; falling back to %s home channel",
+                    job.get("name", job.get("id", "?")),
+                    platform_name,
+                )
+                return {
+                    "platform": platform_name,
+                    "chat_id": chat_id,
+                    "thread_id": None,
+                }
+        return None
 
     if ":" in deliver:
         platform_name, chat_id = deliver.split(":", 1)
@@ -136,6 +151,7 @@ def _deliver_result(job: dict, content: str) -> None:
         "slack": Platform.SLACK,
         "whatsapp": Platform.WHATSAPP,
         "signal": Platform.SIGNAL,
+        "matrix": Platform.MATRIX,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
     }

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -94,6 +94,34 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
+    def test_origin_no_origin_falls_back_to_home_channel(self, monkeypatch):
+        """deliver='origin' with no origin should fall back to platform home channel."""
+        monkeypatch.setenv("MATRIX_HOME_CHANNEL", "!abc:server")
+        job = {"deliver": "origin", "origin": None}
+        assert _resolve_delivery_target(job) == {
+            "platform": "matrix",
+            "chat_id": "!abc:server",
+            "thread_id": None,
+        }
+
+    def test_origin_no_origin_no_home_channel_returns_none(self, monkeypatch):
+        """deliver='origin' with no origin and no home channel should return None."""
+        monkeypatch.delenv("MATRIX_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("SLACK_HOME_CHANNEL", raising=False)
+        job = {"deliver": "origin", "origin": None}
+        assert _resolve_delivery_target(job) is None
+
+    def test_origin_no_origin_prefers_first_configured_platform(self, monkeypatch):
+        """Fallback order: matrix, telegram, discord, slack."""
+        monkeypatch.delenv("MATRIX_HOME_CHANNEL", raising=False)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-999")
+        job = {"deliver": "origin"}
+        result = _resolve_delivery_target(job)
+        assert result["platform"] == "telegram"
+        assert result["chat_id"] == "-999"
+
 
 class TestDeliverResultMirrorLogging:
     """Verify that mirror_to_session failures are logged, not silently swallowed."""

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -124,6 +124,7 @@ def _handle_send(args):
         "slack": Platform.SLACK,
         "whatsapp": Platform.WHATSAPP,
         "signal": Platform.SIGNAL,
+        "matrix": Platform.MATRIX,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
     }
@@ -339,6 +340,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_email(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SMS:
             result = await _send_sms(pconfig.api_key, chat_id, chunk)
+        elif platform == Platform.MATRIX:
+            result = await _send_matrix(pconfig.token, pconfig.extra.get("homeserver", ""), chat_id, chunk)
         else:
             result = {"error": f"Direct sending not yet implemented for {platform.value}"}
 
@@ -660,6 +663,55 @@ async def _send_sms(auth_token, chat_id, message):
                 return {"success": True, "platform": "sms", "chat_id": chat_id, "message_id": msg_sid}
     except Exception as e:
         return {"error": f"SMS send failed: {e}"}
+
+
+async def _send_matrix(token, homeserver, chat_id, message):
+    """Send via Matrix client-server API (one-shot HTTP PUT, no E2EE).
+
+    Uses a simple PUT to the /send endpoint with an access token.
+    Converts basic markdown to HTML for rich rendering in Matrix clients.
+    """
+    try:
+        import aiohttp
+    except ImportError:
+        return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+
+    if not token or not homeserver:
+        return {"error": "Matrix not configured (MATRIX_ACCESS_TOKEN and MATRIX_HOMESERVER required)"}
+
+    import time
+    import urllib.parse
+
+    txn_id = f"hermes_{int(time.time() * 1000)}_{os.urandom(4).hex()}"
+    encoded_room = urllib.parse.quote(chat_id)
+    url = f"{homeserver}/_matrix/client/v3/rooms/{encoded_room}/send/m.room.message/{txn_id}"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+    # Basic markdown to HTML for Matrix formatted_body
+    html_body = message
+    html_body = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", html_body, flags=re.DOTALL)
+    html_body = re.sub(r"\*(.+?)\*", r"<em>\1</em>", html_body, flags=re.DOTALL)
+    html_body = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r'<a href="\2">\1</a>', html_body)
+    html_body = html_body.replace("\n", "<br>")
+
+    body = {
+        "msgtype": "m.text",
+        "body": message,
+        "format": "org.matrix.custom.html",
+        "formatted_body": html_body,
+    }
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.put(url, json=body, headers=headers, ssl=False) as resp:
+                if resp.status == 200:
+                    data = await resp.json()
+                    return {"success": True, "platform": "matrix", "chat_id": chat_id, "event_id": data.get("event_id")}
+                else:
+                    text = await resp.text()
+                    return {"error": f"Matrix send failed ({resp.status}): {text}"}
+    except Exception as e:
+        return {"error": f"Matrix send failed: {e}"}
 
 
 def _check_send_message():


### PR DESCRIPTION
## Summary

- **Add `_send_matrix()` sender** to `send_message_tool.py` — sends via Matrix CS API (PUT with access token), matching the pattern of `_send_telegram`/`_send_discord`/`_send_slack`. Without this, Matrix cron delivery silently fails with "Direct sending not yet implemented".
- **Add Matrix to `platform_map`** in both `_handle_send()` and `_deliver_result()`.
- **Fix `deliver="origin"` with null origin** in `_resolve_delivery_target()` — instead of silently returning `None`, falls back to checking each platform's `HOME_CHANNEL` env var (set by `/sethome`). Logs the fallback for observability.

## Context

Cron jobs created via setup scripts or the Python API (rather than interactively via a chat message) have `origin=null`. Combined with `deliver="origin"` (the default), `_resolve_delivery_target()` returned `None`, silently dropping all cron output. Even after fixing the delivery target to `matrix:!room_id`, the missing `_send_matrix()` function meant delivery still failed at the `else` branch in `_send_to_platform()`.

## Test plan

- [x] 3 new unit tests for origin fallback behavior (with home channel, without, platform priority order)
- [x] All 32 existing scheduler tests pass
- [x] All 19 existing send_message_tool tests pass
- [x] Manual verification: `_send_matrix()` delivered a test message to a Matrix room (HTTP 200, event_id returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)