### PR TITLE
fix(honcho): support local baseUrl-only configuration

### DIFF
--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -48,11 +48,12 @@ def _resolve_api_key(cfg: dict) -> str:
 def _resolve_base_url(cfg: dict) -> str:
     """Resolve base URL with host -> root -> env fallback.
 
-    Accept snake_case, camelCase, and baseURL as a compatibility alias.
+    Prefer canonical camelCase `baseUrl`, while accepting `base_url`
+    and `baseURL` as compatibility aliases.
     """
     host_cfg = ((cfg.get("hosts") or {}).get(HOST) or {})
     for source in (host_cfg, cfg):
-        for key in ("base_url", "baseUrl", "baseURL"):
+        for key in ("baseUrl", "base_url", "baseURL"):
             value = source.get(key)
             if isinstance(value, str):
                 stripped = value.strip()
@@ -132,7 +133,7 @@ def cmd_setup(args) -> None:
     hosts = cfg.setdefault("hosts", {})
     hermes_host = hosts.setdefault(HOST, {})
 
-    # Connection settings — API key for hosted Honcho, base_url for local/self-hosted.
+    # Connection settings — API key for hosted Honcho, baseUrl for local/self-hosted.
     current_key = cfg.get("apiKey", "")
     masked = f"...{current_key[-8:]}" if len(current_key) > 8 else ("set" if current_key else "not set")
     print(f"  Current API key: {masked}")
@@ -144,7 +145,8 @@ def cmd_setup(args) -> None:
     print(f"  Current base URL: {current_base_url or 'not set'}")
     new_base_url = _prompt("Honcho base URL (optional for local/self-hosted)", default=current_base_url or None)
     if new_base_url:
-        hermes_host["base_url"] = new_base_url
+        hermes_host["baseUrl"] = new_base_url
+        hermes_host.pop("base_url", None)
 
     effective_key = _resolve_api_key(cfg)
     effective_base_url = _resolve_base_url(cfg)

--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -147,6 +147,7 @@ def cmd_setup(args) -> None:
     if new_base_url:
         hermes_host["baseUrl"] = new_base_url
         hermes_host.pop("base_url", None)
+        hermes_host.pop("baseURL", None)
 
     effective_key = _resolve_api_key(cfg)
     effective_base_url = _resolve_base_url(cfg)
@@ -600,8 +601,15 @@ def cmd_migrate(args) -> None:
     print("Step 1  Create a Honcho account")
     print()
     if has_key:
-        masked = f"...{cfg['apiKey'][-8:]}" if len(cfg["apiKey"]) > 8 else "set"
-        print(f"  Honcho API key already configured: {masked}")
+        api_key = _resolve_api_key(cfg)
+        base_url = _resolve_base_url(cfg)
+        if api_key:
+            masked = f"...{api_key[-8:]}" if len(api_key) > 8 else "set"
+            print(f"  Honcho API key already configured: {masked}")
+        else:
+            print("  Honcho API key: (none)")
+        if base_url:
+            print(f"  Honcho base URL: {base_url}")
         print("  Skip to Step 2.")
     else:
         print("  Honcho is a cloud memory service that gives Hermes persistent memory")
@@ -615,7 +623,7 @@ def cmd_migrate(args) -> None:
         if answer.lower() in ("y", "yes"):
             cmd_setup(args)
             cfg = _read_config()
-            has_key = bool(cfg.get("apiKey", ""))
+            has_key = _has_honcho_credentials(cfg)
         else:
             print()
             print("  Run 'hermes honcho setup' when ready, then re-run this walkthrough.")

--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -45,6 +45,26 @@ def _resolve_api_key(cfg: dict) -> str:
     return host_key or cfg.get("apiKey", "") or os.environ.get("HONCHO_API_KEY", "")
 
 
+def _resolve_base_url(cfg: dict) -> str:
+    """Resolve base URL with host -> root -> env fallback.
+
+    Accept snake_case, camelCase, and baseURL as a compatibility alias.
+    """
+    host_cfg = ((cfg.get("hosts") or {}).get(HOST) or {})
+    for source in (host_cfg, cfg):
+        for key in ("base_url", "baseUrl", "baseURL"):
+            value = source.get(key)
+            if isinstance(value, str):
+                stripped = value.strip()
+                if stripped:
+                    return stripped
+    return os.environ.get("HONCHO_BASE_URL", "").strip()
+
+
+def _has_honcho_credentials(cfg: dict) -> bool:
+    return bool(_resolve_api_key(cfg) or _resolve_base_url(cfg))
+
+
 def _prompt(label: str, default: str | None = None, secret: bool = False) -> str:
     suffix = f" [{default}]" if default else ""
     sys.stdout.write(f"  {label}{suffix}: ")
@@ -112,7 +132,7 @@ def cmd_setup(args) -> None:
     hosts = cfg.setdefault("hosts", {})
     hermes_host = hosts.setdefault(HOST, {})
 
-    # API key — shared credential, lives at root so all hosts can read it
+    # Connection settings — API key for hosted Honcho, base_url for local/self-hosted.
     current_key = cfg.get("apiKey", "")
     masked = f"...{current_key[-8:]}" if len(current_key) > 8 else ("set" if current_key else "not set")
     print(f"  Current API key: {masked}")
@@ -120,10 +140,18 @@ def cmd_setup(args) -> None:
     if new_key:
         cfg["apiKey"] = new_key
 
-    effective_key = cfg.get("apiKey", "")
-    if not effective_key:
-        print("\n  No API key configured. Get your API key at https://app.honcho.dev")
-        print("  Run 'hermes honcho setup' again once you have a key.\n")
+    current_base_url = _resolve_base_url(cfg)
+    print(f"  Current base URL: {current_base_url or 'not set'}")
+    new_base_url = _prompt("Honcho base URL (optional for local/self-hosted)", default=current_base_url or None)
+    if new_base_url:
+        hermes_host["base_url"] = new_base_url
+
+    effective_key = _resolve_api_key(cfg)
+    effective_base_url = _resolve_base_url(cfg)
+    if not (effective_key or effective_base_url):
+        print("\n  No Honcho API key or base URL configured.")
+        print("  Hosted Honcho: get an API key at https://app.honcho.dev")
+        print("  Local/self-hosted Honcho: set a base URL like http://localhost:8000\n")
         return
 
     # Peer name
@@ -250,12 +278,14 @@ def cmd_status(args) -> None:
         print(f"  Config error: {e}\n")
         return
 
-    api_key = hcfg.api_key or ""
+    api_key = _resolve_api_key(cfg) or ""
+    base_url = _resolve_base_url(cfg) or hcfg.base_url or ""
     masked = f"...{api_key[-8:]}" if len(api_key) > 8 else ("set" if api_key else "not set")
 
     print("\nHoncho status\n" + "─" * 40)
     print(f"  Enabled:        {hcfg.enabled}")
     print(f"  API key:        {masked}")
+    print(f"  Base URL:       {base_url or 'not set'}")
     print(f"  Workspace:      {hcfg.workspace_id}")
     print(f"  Host:           {hcfg.host}")
     print(f"  Config path:    {active_path}")
@@ -455,8 +485,8 @@ def cmd_tokens(args) -> None:
 def cmd_identity(args) -> None:
     """Seed AI peer identity or show both peer representations."""
     cfg = _read_config()
-    if not _resolve_api_key(cfg):
-        print("  No API key configured. Run 'hermes honcho setup' first.\n")
+    if not _has_honcho_credentials(cfg):
+        print("  No Honcho API key or base URL configured. Run 'hermes honcho setup' first.\n")
         return
 
     file_path = getattr(args, "file", None)
@@ -553,7 +583,7 @@ def cmd_migrate(args) -> None:
                 agent_files.append(p)
 
     cfg = _read_config()
-    has_key = bool(_resolve_api_key(cfg))
+    has_key = _has_honcho_credentials(cfg)
 
     print("\nHoncho migration: OpenClaw native memory → Hermes\n" + "─" * 50)
     print()

--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -46,7 +46,7 @@ def resolve_config_path() -> Path:
 
 _RECALL_MODE_ALIASES = {"auto": "hybrid"}
 _VALID_RECALL_MODES = {"hybrid", "context", "tools"}
-_BASE_URL_KEYS = ("base_url", "baseUrl", "baseURL")
+_BASE_URL_KEYS = ("baseUrl", "base_url", "baseURL")
 
 
 def _normalize_recall_mode(val: str) -> str:
@@ -83,7 +83,8 @@ def _resolve_base_url(*sources: dict[str, Any] | None) -> str | None:
     """Resolve base_url from one or more config dicts plus env fallback.
 
     Resolution order follows the given source order, then HONCHO_BASE_URL.
-    Accepts snake_case, camelCase, and baseURL as a compatibility alias.
+    Prefers canonical camelCase `baseUrl`, while accepting `base_url`
+    and `baseURL` as compatibility aliases.
     """
     for source in sources:
         if not isinstance(source, dict):

--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -46,6 +46,7 @@ def resolve_config_path() -> Path:
 
 _RECALL_MODE_ALIASES = {"auto": "hybrid"}
 _VALID_RECALL_MODES = {"hybrid", "context", "tools"}
+_BASE_URL_KEYS = ("base_url", "baseUrl", "baseURL")
 
 
 def _normalize_recall_mode(val: str) -> str:
@@ -76,6 +77,25 @@ def _resolve_memory_mode(
         overrides = {}
 
     return {"memory_mode": default, "peer_memory_modes": overrides}
+
+
+def _resolve_base_url(*sources: dict[str, Any] | None) -> str | None:
+    """Resolve base_url from one or more config dicts plus env fallback.
+
+    Resolution order follows the given source order, then HONCHO_BASE_URL.
+    Accepts snake_case, camelCase, and baseURL as a compatibility alias.
+    """
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        for key in _BASE_URL_KEYS:
+            value = source.get(key)
+            if isinstance(value, str):
+                stripped = value.strip()
+                if stripped:
+                    return stripped
+    env_value = os.environ.get("HONCHO_BASE_URL", "").strip()
+    return env_value or None
 
 
 @dataclass
@@ -197,11 +217,7 @@ class HonchoClientConfig:
             or raw.get("environment", "production")
         )
 
-        base_url = (
-            raw.get("baseUrl")
-            or os.environ.get("HONCHO_BASE_URL", "").strip()
-            or None
-        )
+        base_url = _resolve_base_url(host_block, raw)
 
         # Auto-enable when API key or base_url is present (unless explicitly disabled)
         # Host-level enabled wins, then root-level, then auto-enable if key/url exists.
@@ -408,7 +424,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
             hermes_cfg = load_config()
             honcho_cfg = hermes_cfg.get("honcho", {})
             if isinstance(honcho_cfg, dict):
-                resolved_base_url = honcho_cfg.get("base_url", "").strip() or None
+                resolved_base_url = _resolve_base_url(honcho_cfg)
         except Exception:
             pass
 

--- a/tests/honcho_integration/test_cli.py
+++ b/tests/honcho_integration/test_cli.py
@@ -47,6 +47,13 @@ class TestResolveBaseUrl:
         }
         assert _resolve_base_url(cfg) == "http://host:8000"
 
+    def test_prefers_canonical_baseUrl_within_same_scope(self):
+        cfg = {
+            "base_url": "http://root-snake:8000",
+            "baseUrl": "http://root-camel:8000",
+        }
+        assert _resolve_base_url(cfg) == "http://root-camel:8000"
+
     def test_accepts_root_level_aliases(self):
         assert _resolve_base_url({"baseURL": "http://root:8001"}) == "http://root:8001"
 

--- a/tests/honcho_integration/test_cli.py
+++ b/tests/honcho_integration/test_cli.py
@@ -1,6 +1,17 @@
 """Tests for Honcho CLI helpers."""
 
-from honcho_integration.cli import _resolve_api_key
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from honcho_integration.cli import (
+    _resolve_api_key,
+    _resolve_base_url,
+    _has_honcho_credentials,
+    cmd_identity,
+    cmd_setup,
+    cmd_status,
+)
+from honcho_integration.client import HonchoClientConfig
 
 
 class TestResolveApiKey:
@@ -26,4 +37,91 @@ class TestResolveApiKey:
         monkeypatch.setenv("HONCHO_API_KEY", "env-key")
         assert _resolve_api_key({}) == "env-key"
         monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+
+
+class TestResolveBaseUrl:
+    def test_prefers_host_scoped_snake_case_value(self):
+        cfg = {
+            "baseUrl": "http://root:8000",
+            "hosts": {"hermes": {"base_url": "http://host:8000"}},
+        }
+        assert _resolve_base_url(cfg) == "http://host:8000"
+
+    def test_accepts_root_level_aliases(self):
+        assert _resolve_base_url({"baseURL": "http://root:8001"}) == "http://root:8001"
+
+    def test_falls_back_to_env(self, monkeypatch):
+        monkeypatch.setenv("HONCHO_BASE_URL", "http://env:8000")
+        assert _resolve_base_url({}) == "http://env:8000"
+        monkeypatch.delenv("HONCHO_BASE_URL", raising=False)
+
+
+class TestHasHonchoCredentials:
+    def test_true_with_api_key(self):
+        assert _has_honcho_credentials({"apiKey": "secret"}) is True
+
+    def test_true_with_base_url_only(self):
+        assert _has_honcho_credentials({"base_url": "http://local:8000"}) is True
+
+    def test_false_without_key_or_base_url(self):
+        assert _has_honcho_credentials({}) is False
+
+
+class TestHonchoCliCommands:
+    def test_identity_allows_base_url_only_config(self, monkeypatch, capsys):
+        cfg = {"hosts": {"hermes": {"base_url": "http://localhost:8000"}}}
+        manager = MagicMock()
+        manager.get_or_create.return_value = object()
+
+        monkeypatch.setattr("honcho_integration.cli._read_config", lambda: cfg)
+        monkeypatch.setattr(
+            "honcho_integration.client.HonchoClientConfig.from_global_config",
+            lambda: HonchoClientConfig(base_url="http://localhost:8000", enabled=True),
+        )
+        monkeypatch.setattr("honcho_integration.client.get_honcho_client", lambda hcfg: MagicMock())
+        monkeypatch.setattr("honcho_integration.session.HonchoSessionManager", lambda honcho, config: manager)
+
+        cmd_identity(SimpleNamespace(file=None, show=False))
+        out = capsys.readouterr().out
+
+        assert "No API key configured" not in out
+        manager.get_or_create.assert_called_once()
+
+    def test_setup_allows_existing_base_url_without_api_key(self, monkeypatch, capsys):
+        cfg = {"hosts": {"hermes": {"base_url": "http://localhost:8000"}}}
+        prompts = iter(["", "http://localhost:8000", "eri", "hermes", "hybrid", "async", "hybrid", "per-session"])
+
+        monkeypatch.setattr("honcho_integration.cli._read_config", lambda: cfg)
+        monkeypatch.setattr("honcho_integration.cli._write_config", lambda updated: None)
+        monkeypatch.setattr("honcho_integration.cli._ensure_sdk_installed", lambda: True)
+        monkeypatch.setattr("honcho_integration.cli._prompt", lambda *args, **kwargs: next(prompts))
+        monkeypatch.setattr("honcho_integration.client.reset_honcho_client", lambda: None)
+        monkeypatch.setattr(
+            "honcho_integration.client.HonchoClientConfig.from_global_config",
+            lambda: HonchoClientConfig(base_url="http://localhost:8000", enabled=True, peer_name="eri"),
+        )
+        monkeypatch.setattr("honcho_integration.client.get_honcho_client", lambda hcfg: MagicMock())
+
+        cmd_setup(SimpleNamespace())
+        out = capsys.readouterr().out
+
+        assert "No API key configured" not in out
+        assert "Honcho is ready" in out
+
+    def test_status_treats_base_url_only_as_connectable(self, monkeypatch, capsys):
+        cfg = {"hosts": {"hermes": {"base_url": "http://localhost:8000", "enabled": True}}}
+        hcfg = HonchoClientConfig(base_url="http://localhost:8000", enabled=True)
+        get_client = MagicMock(return_value=MagicMock())
+
+        monkeypatch.setattr("honcho_integration.cli._read_config", lambda: cfg)
+        monkeypatch.setattr("honcho_integration.client.HonchoClientConfig.from_global_config", lambda: hcfg)
+        monkeypatch.setattr("honcho_integration.client.get_honcho_client", get_client)
+        monkeypatch.setitem(__import__("sys").modules, "honcho", MagicMock())
+
+        cmd_status(SimpleNamespace())
+        out = capsys.readouterr().out
+
+        assert "Base URL:" in out
+        assert "Connection... OK" in out
+        get_client.assert_called_once_with(hcfg)
 

--- a/tests/honcho_integration/test_cli.py
+++ b/tests/honcho_integration/test_cli.py
@@ -70,7 +70,9 @@ class TestHasHonchoCredentials:
     def test_true_with_base_url_only(self):
         assert _has_honcho_credentials({"base_url": "http://local:8000"}) is True
 
-    def test_false_without_key_or_base_url(self):
+    def test_false_without_key_or_base_url(self, monkeypatch):
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+        monkeypatch.delenv("HONCHO_BASE_URL", raising=False)
         assert _has_honcho_credentials({}) is False
 
 

--- a/tests/honcho_integration/test_client.py
+++ b/tests/honcho_integration/test_client.py
@@ -214,7 +214,7 @@ class TestFromGlobalConfig:
         assert config.base_url == "http://localhost:8000"
         assert config.enabled is True
 
-    def test_base_url_from_config_root(self, tmp_path):
+    def test_base_url_from_config_root_camel_case(self, tmp_path):
         """baseUrl in config root is read and takes precedence over env var."""
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps({"baseUrl": "http://config-host:9000"}))
@@ -223,16 +223,74 @@ class TestFromGlobalConfig:
             config = HonchoClientConfig.from_global_config(config_path=config_file)
         assert config.base_url == "http://config-host:9000"
 
-    def test_base_url_not_read_from_host_block(self, tmp_path):
-        """baseUrl is a root-level connection setting, not overridable per-host (consistent with apiKey)."""
+    def test_base_url_from_config_root_snake_case(self, tmp_path):
+        """base_url in config root is also accepted for local/self-hosted instances."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"base_url": "http://config-host:9001"}))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://config-host:9001"
+
+    def test_base_url_from_config_root_upper_url_alias(self, tmp_path):
+        """baseURL is accepted as a compatibility alias when reading config."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"baseURL": "http://config-host:9002"}))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://config-host:9002"
+
+    def test_base_url_host_block_overrides_root(self, tmp_path):
+        """Host-level base_url/baseUrl should override root-level values."""
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps({
             "baseUrl": "http://root:9000",
-            "hosts": {"hermes": {"baseUrl": "http://host-block:9001"}},
+            "hosts": {"hermes": {"base_url": "http://host-block:9001"}},
         }))
 
         config = HonchoClientConfig.from_global_config(config_path=config_file)
-        assert config.base_url == "http://root:9000"
+        assert config.base_url == "http://host-block:9001"
+
+    def test_base_url_host_block_accepts_camel_case_aliases(self, tmp_path):
+        """Host-level baseUrl/baseURL aliases are accepted too."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "hosts": {"hermes": {"baseURL": "http://host-block:9002"}},
+        }))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://host-block:9002"
+
+    def test_base_url_host_block_wins_over_env(self, tmp_path):
+        """Host-level config should beat HONCHO_BASE_URL env fallback."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "hosts": {"hermes": {"baseUrl": "http://host-block:9003"}},
+        }))
+
+        with patch.dict(os.environ, {"HONCHO_BASE_URL": "http://localhost:8000"}, clear=False):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://host-block:9003"
+
+    def test_root_base_url_wins_over_env_when_host_missing(self, tmp_path):
+        """Root config should still beat env fallback when no host override exists."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"base_url": "http://root:9004"}))
+
+        with patch.dict(os.environ, {"HONCHO_BASE_URL": "http://localhost:8000"}, clear=False):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://root:9004"
+
+    def test_base_url_only_config_auto_enables_when_host_scoped(self, tmp_path):
+        """Host-scoped base_url alone should auto-enable local/self-hosted Honcho."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "hosts": {"hermes": {"base_url": "http://host-block:9005"}},
+        }))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.api_key is None
+        assert config.base_url == "http://host-block:9005"
+        assert config.enabled is True
 
 
 class TestResolveSessionName:

--- a/tests/honcho_integration/test_client.py
+++ b/tests/honcho_integration/test_client.py
@@ -223,6 +223,18 @@ class TestFromGlobalConfig:
             config = HonchoClientConfig.from_global_config(config_path=config_file)
         assert config.base_url == "http://config-host:9000"
 
+    def test_base_url_prefers_canonical_root_camel_case_when_multiple_aliases_exist(self, tmp_path):
+        """baseUrl should win over compatibility aliases within the same config scope."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "base_url": "http://config-host:9001",
+            "baseUrl": "http://config-host:9002",
+            "baseURL": "http://config-host:9003",
+        }))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://config-host:9002"
+
     def test_base_url_from_config_root_snake_case(self, tmp_path):
         """base_url in config root is also accepted for local/self-hosted instances."""
         config_file = tmp_path / "config.json"

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -32,9 +32,9 @@ Hermes supports both hosted Honcho and local/self-hosted Honcho.
 | Mode | What Hermes needs | Preferred config |
 |------|-------------------|------------------|
 | Hosted Honcho | `apiKey` | `~/.honcho/config.json` root `apiKey` |
-| Local/self-hosted Honcho | `base_url` | `~/.honcho/config.json` root or `hosts.hermes.base_url` |
+| Local/self-hosted Honcho | `baseUrl` | `~/.honcho/config.json` root or `hosts.hermes.baseUrl` |
 
-For local/self-hosted Honcho, `base_url` is enough — no API key required.
+For local/self-hosted Honcho, `baseUrl` is enough — no API key required.
 
 Minimal local example:
 
@@ -42,7 +42,7 @@ Minimal local example:
 {
   "hosts": {
     "hermes": {
-      "base_url": "http://localhost:8000",
+      "baseUrl": "http://localhost:8000",
       "enabled": true
     }
   }
@@ -62,7 +62,7 @@ Minimal hosted example:
 }
 ```
 
-Hermes auto-enables Honcho when either `apiKey` or `base_url` is present.
+Hermes auto-enables Honcho when either `apiKey` or `baseUrl` is present.
 
 For local/self-hosted deployment details, see the [Honcho self-hosting docs](https://docs.honcho.dev).
 
@@ -88,7 +88,7 @@ pip install 'honcho-ai>=2.0.1'
 
 For hosted Honcho, get an API key from [app.honcho.dev](https://app.honcho.dev) > Settings > API Keys.
 
-For local/self-hosted Honcho, configure a base URL instead of an API key.
+For local/self-hosted Honcho, configure `baseUrl` instead of an API key.
 
 #### 3. Configure
 
@@ -120,7 +120,7 @@ Local/self-hosted example:
 {
   "hosts": {
     "hermes": {
-      "base_url": "http://localhost:8000",
+      "baseUrl": "http://localhost:8000",
       "workspace": "hermes",
       "peerName": "your-name",
       "aiPeer": "hermes",
@@ -134,7 +134,7 @@ Local/self-hosted example:
 }
 ```
 
-`apiKey` lives at the root because it is a shared credential across all Honcho-enabled tools. `base_url` can be configured at the root or under `hosts.hermes`; host-level values win. For compatibility, Hermes also accepts `baseUrl` and `baseURL` when reading config, but `base_url` is the preferred spelling in docs and examples.
+`apiKey` lives at the root because it is a shared credential across all Honcho-enabled tools. `baseUrl` can be configured at the root or under `hosts.hermes`; host-level values win. For compatibility, Hermes also accepts `base_url` and `baseURL` when reading config, but `baseUrl` is the preferred spelling in docs and examples.
 
 You can also use environment variables:
 
@@ -160,14 +160,14 @@ Settings are scoped to `hosts.hermes` and fall back to root-level globals when t
 | Field | Default | Description |
 |-------|---------|-------------|
 | `apiKey` | — | Honcho API key for hosted Honcho (shared across all hosts) |
-| `base_url` | — | Base URL for local/self-hosted Honcho. Also accepts `baseUrl` and `baseURL` when reading config. |
+| `baseUrl` | — | Base URL for local/self-hosted Honcho. Also accepts `base_url` and `baseURL` when reading config. |
 | `sessions` | `{}` | Manual session name overrides per directory (shared) |
 
 **Host-level (`hosts.hermes`)**
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `base_url` | — | Host-specific base URL override for local/self-hosted Honcho. Also accepts `baseUrl` and `baseURL` when reading config. |
+| `baseUrl` | — | Host-specific base URL override for local/self-hosted Honcho. Also accepts `base_url` and `baseURL` when reading config. |
 | `workspace` | `"hermes"` | Workspace identifier |
 | `peerName` | *(derived)* | Your identity name for user modeling |
 | `aiPeer` | `"hermes"` | AI assistant identity name |
@@ -195,16 +195,16 @@ Hermes resolves connection settings in a predictable order.
 2. root `apiKey`
 3. `HONCHO_API_KEY`
 
-`base_url` resolution:
-1. `hosts.hermes.base_url`
-2. `hosts.hermes.baseUrl`
+`baseUrl` resolution:
+1. `hosts.hermes.baseUrl`
+2. `hosts.hermes.base_url`
 3. `hosts.hermes.baseURL`
-4. root `base_url`
-5. root `baseUrl`
+4. root `baseUrl`
+5. root `base_url`
 6. root `baseURL`
 7. `HONCHO_BASE_URL`
 
-For docs and examples, prefer `base_url`. `baseUrl` and `baseURL` are compatibility aliases accepted when reading existing config.
+For docs and examples, prefer `baseUrl`. `base_url` and `baseURL` are compatibility aliases accepted when reading existing config.
 
 ### Memory Modes
 
@@ -362,7 +362,7 @@ This means:
 
 ### Local/self-hosted instance is configured but Hermes still says no API key
 
-Make sure you configured `base_url` rather than only expecting an API key-based flow. For local/self-hosted Honcho, `base_url` is enough.
+Make sure you configured `baseUrl` rather than only expecting an API key-based flow. For local/self-hosted Honcho, `baseUrl` is enough.
 
 Check with:
 
@@ -385,8 +385,8 @@ Check these first:
 
 - `~/.honcho/config.json` is valid JSON
 - there are no trailing commas in the JSON file
-- `base_url` is spelled correctly in the example you copied
-- if you used an alias like `baseUrl` or `baseURL`, remember `base_url` is the canonical documented spelling
+- `baseUrl` is spelled correctly in the example you copied
+- if you used an alias like `base_url` or `baseURL`, remember `baseUrl` is the canonical documented spelling
 - `enabled` is not explicitly set to `false`
 
 ### Local/self-hosted Honcho is unreachable

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -25,17 +25,18 @@ Hermes has two memory systems that can work together or be configured separately
 Set `memoryMode` to `honcho` to use Honcho exclusively. See [Memory Modes](#memory-modes) for per-peer configuration.
 
 
-## Self-hosted / Docker
+## Quick Start
 
-Hermes supports a local Honcho instance (e.g. via Docker) in addition to the hosted API. Point it at your instance using `HONCHO_BASE_URL` — no API key required.
+Hermes supports both hosted Honcho and local/self-hosted Honcho.
 
-**Via `hermes config`:**
+| Mode | What Hermes needs | Preferred config |
+|------|-------------------|------------------|
+| Hosted Honcho | `apiKey` | `~/.honcho/config.json` root `apiKey` |
+| Local/self-hosted Honcho | `base_url` | `~/.honcho/config.json` root or `hosts.hermes.base_url` |
 
-```bash
-hermes config set HONCHO_BASE_URL http://localhost:8000
-```
+For local/self-hosted Honcho, `base_url` is enough — no API key required.
 
-**Via `~/.honcho/config.json`:**
+Minimal local example:
 
 ```json
 {
@@ -48,9 +49,22 @@ hermes config set HONCHO_BASE_URL http://localhost:8000
 }
 ```
 
-Hermes auto-enables Honcho when either `apiKey` or `base_url` is present, so no further configuration is needed for a local instance.
+Minimal hosted example:
 
-To run Honcho locally, refer to the [Honcho self-hosting docs](https://docs.honcho.dev).
+```json
+{
+  "apiKey": "***",
+  "hosts": {
+    "hermes": {
+      "enabled": true
+    }
+  }
+}
+```
+
+Hermes auto-enables Honcho when either `apiKey` or `base_url` is present.
+
+For local/self-hosted deployment details, see the [Honcho self-hosting docs](https://docs.honcho.dev).
 
 ## Setup
 
@@ -60,7 +74,7 @@ To run Honcho locally, refer to the [Honcho self-hosting docs](https://docs.honc
 hermes honcho setup
 ```
 
-The setup wizard walks through API key, peer names, workspace, memory mode, write frequency, recall mode, and session strategy. It offers to install `honcho-ai` if missing.
+The setup wizard walks through hosted vs. local/self-hosted connection settings, peer names, workspace, memory mode, write frequency, recall mode, and session strategy. It offers to install `honcho-ai` if missing.
 
 ### Manual Setup
 
@@ -70,17 +84,21 @@ The setup wizard walks through API key, peer names, workspace, memory mode, writ
 pip install 'honcho-ai>=2.0.1'
 ```
 
-#### 2. Get an API Key
+#### 2. Choose Hosted or Local/Self-Hosted Honcho
 
-Go to [app.honcho.dev](https://app.honcho.dev) > Settings > API Keys.
+For hosted Honcho, get an API key from [app.honcho.dev](https://app.honcho.dev) > Settings > API Keys.
+
+For local/self-hosted Honcho, configure a base URL instead of an API key.
 
 #### 3. Configure
 
-Honcho reads from `~/.honcho/config.json` (shared across all Honcho-enabled applications):
+Honcho reads from `~/.honcho/config.json` (shared across all Honcho-enabled applications).
+
+Hosted example:
 
 ```json
 {
-  "apiKey": "your-honcho-api-key",
+  "apiKey": "your-h...-key",
   "hosts": {
     "hermes": {
       "workspace": "hermes",
@@ -96,16 +114,39 @@ Honcho reads from `~/.honcho/config.json` (shared across all Honcho-enabled appl
 }
 ```
 
-`apiKey` lives at the root because it is a shared credential across all Honcho-enabled tools. All other settings are scoped under `hosts.hermes`. The `hermes honcho setup` wizard writes this structure automatically.
+Local/self-hosted example:
 
-Or set the API key as an environment variable:
-
-```bash
-hermes config set HONCHO_API_KEY your-key
+```json
+{
+  "hosts": {
+    "hermes": {
+      "base_url": "http://localhost:8000",
+      "workspace": "hermes",
+      "peerName": "your-name",
+      "aiPeer": "hermes",
+      "memoryMode": "honcho",
+      "writeFrequency": "async",
+      "recallMode": "hybrid",
+      "sessionStrategy": "per-directory",
+      "enabled": true
+    }
+  }
+}
 ```
 
+`apiKey` lives at the root because it is a shared credential across all Honcho-enabled tools. `base_url` can be configured at the root or under `hosts.hermes`; host-level values win. For compatibility, Hermes also accepts `baseUrl` and `baseURL` when reading config, but `base_url` is the preferred spelling in docs and examples.
+
+You can also use environment variables:
+
+```bash
+export HONCHO_API_KEY=your-key
+export HONCHO_BASE_URL=http://localhost:8000
+```
+
+Only one of these is required. Use `HONCHO_API_KEY` for hosted Honcho or `HONCHO_BASE_URL` for local/self-hosted Honcho.
+
 :::info
-When an API key is present (either in `~/.honcho/config.json` or as `HONCHO_API_KEY`), Honcho auto-enables unless explicitly set to `"enabled": false`.
+When an API key or base URL is present (either in `~/.honcho/config.json` or via environment variables), Honcho auto-enables unless explicitly set to `"enabled": false`.
 :::
 
 ## Configuration
@@ -118,18 +159,20 @@ Settings are scoped to `hosts.hermes` and fall back to root-level globals when t
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `apiKey` | — | Honcho API key (required, shared across all hosts) |
+| `apiKey` | — | Honcho API key for hosted Honcho (shared across all hosts) |
+| `base_url` | — | Base URL for local/self-hosted Honcho. Also accepts `baseUrl` and `baseURL` when reading config. |
 | `sessions` | `{}` | Manual session name overrides per directory (shared) |
 
 **Host-level (`hosts.hermes`)**
 
 | Field | Default | Description |
 |-------|---------|-------------|
+| `base_url` | — | Host-specific base URL override for local/self-hosted Honcho. Also accepts `baseUrl` and `baseURL` when reading config. |
 | `workspace` | `"hermes"` | Workspace identifier |
 | `peerName` | *(derived)* | Your identity name for user modeling |
 | `aiPeer` | `"hermes"` | AI assistant identity name |
 | `environment` | `"production"` | Honcho environment |
-| `enabled` | *(auto)* | Auto-enables when API key is present |
+| `enabled` | *(auto)* | Auto-enables when API key or base URL is present |
 | `saveMessages` | `true` | Whether to sync messages to Honcho |
 | `memoryMode` | `"hybrid"` | Memory mode: `hybrid` or `honcho` |
 | `writeFrequency` | `"async"` | When to write: `async`, `turn`, `session`, or integer N |
@@ -142,6 +185,26 @@ Settings are scoped to `hosts.hermes` and fall back to root-level globals when t
 | `linkedHosts` | `[]` | Other host keys whose workspaces to cross-reference |
 
 All host-level fields fall back to the equivalent root-level key if not set under `hosts.hermes`. Existing configs with settings at root level continue to work.
+
+### Connection Setting Resolution
+
+Hermes resolves connection settings in a predictable order.
+
+`apiKey` resolution:
+1. `hosts.hermes.apiKey`
+2. root `apiKey`
+3. `HONCHO_API_KEY`
+
+`base_url` resolution:
+1. `hosts.hermes.base_url`
+2. `hosts.hermes.baseUrl`
+3. `hosts.hermes.baseURL`
+4. root `base_url`
+5. root `baseUrl`
+6. root `baseURL`
+7. `HONCHO_BASE_URL`
+
+For docs and examples, prefer `base_url`. `baseUrl` and `baseURL` are compatibility aliases accepted when reading existing config.
 
 ### Memory Modes
 
@@ -161,7 +224,7 @@ Memory mode can be set globally or per-peer (user, agent1, agent2, etc):
 }
 ```
 
-To disable Honcho entirely, set `enabled: false` or remove the API key.
+To disable Honcho entirely, set `enabled: false` or remove the API key / base URL.
 
 ### Recall Modes
 
@@ -222,11 +285,13 @@ Resolution: `hosts.<tool>` field > root-level field > default. In this example, 
 
 ### Hermes Config (`~/.hermes/config.yaml`)
 
-Intentionally minimal — most configuration comes from `~/.honcho/config.json`:
+Intentionally minimal — most Honcho configuration should live in `~/.honcho/config.json`:
 
 ```yaml
 honcho: {}
 ```
+
+Use `~/.hermes/config.yaml` only for Hermes-specific overrides. For normal hosted or local/self-hosted setup, prefer `~/.honcho/config.json` so the configuration stays shared across Honcho-enabled tools.
 
 ## How It Works
 
@@ -292,6 +357,46 @@ This means:
 | `/resume` | Current session is flushed, then the resumed session's Honcho context loads |
 | Session expiry | Automatic flush + shutdown after the configured idle timeout |
 | Gateway stop | All active Honcho managers are flushed and shut down gracefully |
+
+## Troubleshooting
+
+### Local/self-hosted instance is configured but Hermes still says no API key
+
+Make sure you configured `base_url` rather than only expecting an API key-based flow. For local/self-hosted Honcho, `base_url` is enough.
+
+Check with:
+
+```bash
+hermes honcho status
+```
+
+A healthy local setup usually looks like:
+
+```text
+Enabled:        True
+API key:        not set
+Base URL:       http://localhost:8000
+Connection...   OK
+```
+
+### Config exists but Hermes is not picking it up
+
+Check these first:
+
+- `~/.honcho/config.json` is valid JSON
+- there are no trailing commas in the JSON file
+- `base_url` is spelled correctly in the example you copied
+- if you used an alias like `baseUrl` or `baseURL`, remember `base_url` is the canonical documented spelling
+- `enabled` is not explicitly set to `false`
+
+### Local/self-hosted Honcho is unreachable
+
+If `hermes honcho status` shows a base URL but connection still fails, verify that your Honcho instance is actually reachable at that URL and that Docker or your local server is running.
+
+### Need more help?
+
+- [Honcho self-hosting docs](https://docs.honcho.dev)
+- [Honcho Discord](https://discord.gg/honcho)
 
 ## Tools
 


### PR DESCRIPTION
## Summary

Fixes Hermes' local/self-hosted Honcho flow so `baseUrl` works without requiring a dummy API key.

### Changes

- resolve Honcho `baseUrl` from host-level and root-level config
- accept `baseUrl`, `base_url`, and `baseURL` when reading existing config
- prefer canonical `baseUrl` when multiple aliases are present in the same config scope
- allow `hermes honcho setup` to work with `baseUrl`-only local/self-hosted setups
- allow `hermes honcho identity` to work without an API key when `baseUrl` is configured
- make `hermes honcho status` reflect local/self-hosted setups correctly
- have `hermes honcho setup` write `hosts.hermes.baseUrl` for new config
- clarify docs around hosted vs local/self-hosted setup
- document config precedence and add troubleshooting guidance
- add support links including the Honcho Discord

## Why

Hermes already intended to support local/self-hosted Honcho via a base URL, but the implementation and docs had drifted apart.

In practice:
- some valid config shapes were not being resolved
- some CLI commands still hard-required an API key
- the docs did not clearly separate hosted and local/self-hosted setup paths
- the documented/canonical key shape in `~/.honcho/config.json` needed to align with the rest of the file's camelCase style

This made valid local setups appear broken.

## Behavior after this change

Hosted Honcho:
- configure `apiKey`

Local/self-hosted Honcho:
- configure `baseUrl`
- no API key required

`baseUrl` is now the canonical documented spelling in `~/.honcho/config.json`. `base_url` and `baseURL` remain accepted as compatibility aliases when reading existing config. Environment variable support remains `HONCHO_BASE_URL`.

## Test Plan

```bash
pytest tests/honcho_integration/test_client.py \
       tests/honcho_integration/test_cli.py \
       tests/test_honcho_client_config.py \
       tests/tools/test_honcho_tools.py \
       tests/gateway/test_honcho_lifecycle.py -q
```

Result:
- 69 passed

## Related

- Closes #2613
- Follows up the meta tracking in #2210
- Related earlier PR in the same area: #2619
EOF; __hermes_rc=$?; printf '__HERMES_FENCE_a9f7b3__'; exit $__hermes_rc
