### PR TITLE
fix(logging): show HTTP status code and provider error body in API error output

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6164,10 +6164,16 @@ class AIAgent:
                     _provider = getattr(self, "provider", "unknown")
                     _base = getattr(self, "base_url", "unknown")
                     _model = getattr(self, "model", "unknown")
-                    self._vprint(f"{self.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}", force=True)
+                    _status_code_str = f" [HTTP {status_code}]" if status_code else ""
+                    self._vprint(f"{self.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}{_status_code_str}", force=True)
                     self._vprint(f"{self.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                     self._vprint(f"{self.log_prefix}   🌐 Endpoint: {_base}", force=True)
                     self._vprint(f"{self.log_prefix}   📝 Error: {str(api_error)[:200]}", force=True)
+                    if status_code == 400:
+                        _err_body = getattr(api_error, "body", None)
+                        _err_body_str = str(_err_body)[:300] if _err_body else None
+                        if _err_body_str:
+                            self._vprint(f"{self.log_prefix}   📋 Details: {_err_body_str}", force=True)
                     self._vprint(f"{self.log_prefix}   ⏱️  Elapsed: {elapsed_time:.2f}s  Context: {len(api_messages)} msgs, ~{approx_tokens:,} tokens")
                     
                     # Check for interrupt before deciding to retry


### PR DESCRIPTION
## Summary

Resolves #2644.

When an API call fails, the terminal output now includes:
1. **HTTP status code** in the header line (e.g. `[HTTP 400]`, `[HTTP 429]`)
2. **Provider error body** (truncated to 300 chars) when the status is 400, which typically contains the actual reason from the provider (e.g. unknown model name, malformed request)

## Before

```
⚠️  API call failed (attempt 1/3): APIError
   🔌 Provider: openrouter  Model: anthropic/claude-opus-4.6
   🌐 Endpoint: https://openrouter.ai/api/v1
   📝 Error: Network connection lost.
```

## After

When status code is available:
```
⚠️  API call failed (attempt 1/3): APIError [HTTP 400]
   🔌 Provider: openrouter  Model: anthropic/claude-opus-4.6
   🌐 Endpoint: https://openrouter.ai/api/v1
   📝 Error: Error code: 400 - ...
   📋 Details: {'error': {'message': 'Unknown model: anthropic/claude-opus-4.6', 'code': 400}}
```

## Root cause analysis from the issue

Looking at the error log shared by the reporter, the underlying error was actually `Error code: 400` throughout — this was logged in `errors.log` but the terminal UI was showing a generic `Network connection lost` without the HTTP code. The 400s were caused by an invalid model identifier (`anthropic/claude-opus-4.6` is not a valid OpenRouter model name), not a network issue.

## Changes

- `run_agent.py`: +6 lines in the API error logging block, no logic changes