### PR TITLE
feat(render): render AI responses as Rich Markdown instead of raw text

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1625,6 +1625,17 @@ class HermesCLI:
                 self._stream_prefilt = self._stream_prefilt[-max_tag_len:]
             return
 
+    @staticmethod
+    def _visual_line_count(text: str, columns: int) -> int:
+        """Return the number of visual terminal rows a printed line occupies."""
+        from wcwidth import wcswidth
+        from tools.ansi_strip import strip_ansi
+        clean = strip_ansi(text) if text else ""
+        w = wcswidth(clean)
+        if w <= 0 or w <= columns:
+            return 1
+        return -(-w // columns)  # ceil division
+
     def _emit_stream_text(self, text: str) -> None:
         """Emit filtered text to the streaming display."""
         if not text:
@@ -1670,7 +1681,7 @@ class HermesCLI:
         while "\n" in self._stream_buf:
             line, self._stream_buf = self._stream_buf.split("\n", 1)
             _cprint(f"{_tc}{line}{_RST}" if _tc else line)
-            self._stream_line_count += 1
+            self._stream_line_count += self._visual_line_count(line, shutil.get_terminal_size().columns)
 
     def _flush_stream(self) -> None:
         """Emit any remaining partial line from the stream buffer and close the box."""
@@ -1680,8 +1691,8 @@ class HermesCLI:
         if self._stream_buf:
             _tc = getattr(self, "_stream_text_ansi", "")
             _cprint(f"{_tc}{self._stream_buf}{_RST}" if _tc else self._stream_buf)
+            self._stream_line_count += self._visual_line_count(self._stream_buf, shutil.get_terminal_size().columns)
             self._stream_buf = ""
-            self._stream_line_count += 1  # partial line flushed
 
         # Close the response box
         if self._stream_box_opened:

--- a/cli.py
+++ b/cli.py
@@ -49,7 +49,7 @@ from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.widgets import TextArea
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit import print_formatted_text as _pt_print
-from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
+from prompt_toolkit.formatted_text import ANSI as _PT_ANSI, FormattedText as _PT_FormattedText
 try:
     from prompt_toolkit.cursor_shapes import CursorShape
     _STEADY_CURSOR = CursorShape.BLOCK  # Non-blinking block cursor
@@ -5673,8 +5673,9 @@ class HermesCLI:
                     _sl_count = self._stream_line_count
                     if _sl_count > 0 and response:
                         # Move cursor up over all streamed lines and erase them
-                        sys.stdout.write(f"\033[{_sl_count}A\033[J")
-                        sys.stdout.flush()
+                        _pt_print(_PT_FormattedText([
+                            ('[ZeroWidthEscape]', f'\033[{_sl_count}A\033[J'),
+                        ]))
                         _chat_console = ChatConsole()
                         _chat_console.print(Panel(
                             Markdown(response),

--- a/cli.py
+++ b/cli.py
@@ -5485,9 +5485,6 @@ class HermesCLI:
         # Add user message to history
         self.conversation_history.append({"role": "user", "content": message})
 
-        ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
-        print(flush=True)
-        
         try:
             # Run the conversation with interrupt monitoring
             result = None
@@ -5742,6 +5739,7 @@ class HermesCLI:
                         padding=(1, 2),
                     ))
 
+            _cprint("")
 
             # Play terminal bell when agent finishes (if enabled).
             # Works over SSH — the bell propagates to the user's terminal.
@@ -7097,40 +7095,32 @@ class HermesCLI:
                     paste_match = _re.match(r'\[Pasted text #\d+: \d+ lines → (.+)\]', user_input) if isinstance(user_input, str) else None
                     if paste_match:
                         paste_path = Path(paste_match.group(1))
-                        _user_bar = f"[{_accent_hex()}]{'─' * 40}[/]"
                         if paste_path.exists():
                             full_text = paste_path.read_text(encoding="utf-8")
                             line_count = full_text.count('\n') + 1
-                            print()
-                            ChatConsole().print(_user_bar)
                             ChatConsole().print(
                                 f"[bold {_accent_hex()}]●[/] [bold]{_escape(f'[Pasted text: {line_count} lines]')}[/]"
                             )
                             user_input = full_text
                         else:
-                            print()
-                            ChatConsole().print(_user_bar)
                             ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]")
                     else:
-                        _user_bar = f"[{_accent_hex()}]{'─' * 40}[/]"
                         if '\n' in user_input:
                             first_line = user_input.split('\n')[0]
                             line_count = user_input.count('\n') + 1
-                            print()
-                            ChatConsole().print(_user_bar)
                             ChatConsole().print(
                                 f"[bold {_accent_hex()}]●[/] [bold]{_escape(first_line)}[/] "
                                 f"[dim](+{line_count - 1} lines)[/]"
                             )
                         else:
-                            print()
-                            ChatConsole().print(_user_bar)
                             ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]")
                     
                     # Show image attachment count
                     if submit_images:
                         n = len(submit_images)
                         _cprint(f"  {_DIM}📎 {n} image{'s' if n > 1 else ''} attached{_RST}")
+
+                    _cprint("")
 
                     # Regular chat - run agent
                     self._agent_running = True

--- a/cli.py
+++ b/cli.py
@@ -1545,6 +1545,7 @@ class HermesCLI:
         """
         if text is None:
             self._flush_stream()
+            self._rerender_streamed_segment()
             self._reset_stream_state()
             return
         if not text:
@@ -1699,6 +1700,51 @@ class HermesCLI:
             w = shutil.get_terminal_size().columns
             _cprint(f"{_GOLD}╰{'─' * (w - 2)}╯{_RST}")
             self._stream_line_count += 1  # bottom border
+
+    def _rerender_streamed_segment(self, text: str | None = None) -> None:
+        """Erase the raw-streamed terminal output and re-render it as a Rich Markdown Panel.
+
+        Called either at intermediate turn boundaries (before tool execution) or
+        after the final agent response.  At intermediate boundaries ``text`` is
+        ``None`` and we fall back to ``self._stream_full_text`` which holds the
+        accumulated raw tokens for the current segment.
+
+        Does nothing when no streaming box was opened (nothing to erase).
+        """
+        if not (self._stream_started and self._stream_box_opened):
+            return
+        _sl_count = self._stream_line_count
+        _text = text if text is not None else self._stream_full_text
+        if _sl_count <= 0 or not _text:
+            return
+
+        try:
+            from hermes_cli.skin_engine import get_active_skin
+            _skin = get_active_skin()
+            label = _skin.get_branding("response_label", "⚕ Hermes")
+            _resp_color = _skin.get_color("response_border", "#CD7F32")
+            _resp_text = _skin.get_color("banner_text", "#FFF8DC")
+        except Exception:
+            label = "⚕ Hermes"
+            _resp_color = "#CD7F32"
+            _resp_text = "#FFF8DC"
+
+        # Move cursor up over all streamed lines and erase them, then re-render
+        # via prompt_toolkit's ZeroWidthEscape so the escape sequence bypasses
+        # StdoutProxy's sanitisation (which would replace \x1b with '?').
+        _pt_print(_PT_FormattedText([
+            ('[ZeroWidthEscape]', f'\033[{_sl_count}A\033[J'),
+        ]))
+        _chat_console = ChatConsole()
+        _chat_console.print(Panel(
+            Markdown(_text),
+            title=f"[{_resp_color} bold]{label}[/]",
+            title_align="left",
+            border_style=_resp_color,
+            style=_resp_text,
+            box=rich_box.HORIZONTALS,
+            padding=(1, 2),
+        ))
 
     def _reset_stream_state(self) -> None:
         """Reset streaming state before each agent invocation."""
@@ -5681,22 +5727,9 @@ class HermesCLI:
                     # Clear raw streamed output and re-render with Rich Markdown.
                     # The streaming path printed raw text token-by-token; now we
                     # replace it with a properly formatted Markdown Panel.
-                    _sl_count = self._stream_line_count
-                    if _sl_count > 0 and response:
-                        # Move cursor up over all streamed lines and erase them
-                        _pt_print(_PT_FormattedText([
-                            ('[ZeroWidthEscape]', f'\033[{_sl_count}A\033[J'),
-                        ]))
-                        _chat_console = ChatConsole()
-                        _chat_console.print(Panel(
-                            Markdown(response),
-                            title=f"[{_resp_color} bold]{label}[/]",
-                            title_align="left",
-                            border_style=_resp_color,
-                            style=_resp_text,
-                            box=rich_box.HORIZONTALS,
-                            padding=(1, 2),
-                        ))
+                    # Uses ZeroWidthEscape internally so ANSI cursor-movement
+                    # sequences bypass prompt_toolkit StdoutProxy's sanitisation.
+                    self._rerender_streamed_segment(text=response)
                 else:
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(

--- a/cli.py
+++ b/cli.py
@@ -446,6 +446,7 @@ except Exception:
 
 from rich import box as rich_box
 from rich.console import Console
+from rich.markdown import Markdown
 from rich.markup import escape as _escape
 from rich.panel import Panel
 from rich.text import Text as _RichText
@@ -1053,6 +1054,8 @@ class HermesCLI:
         self._stream_buf = ""        # Partial line buffer for line-buffered rendering
         self._stream_started = False  # True once first delta arrives
         self._stream_box_opened = False  # True once the response box header is printed
+        self._stream_line_count = 0   # Lines printed during streaming (for MD re-render)
+        self._stream_full_text = ""   # Accumulated raw text for Markdown re-render
         
         # Configuration - priority: CLI args > env vars > config file
         # Model comes from: CLI arg or config.yaml (single source of truth).
@@ -1657,14 +1660,17 @@ class HermesCLI:
             w = shutil.get_terminal_size().columns
             fill = w - 2 - len(label)
             _cprint(f"\n{_GOLD}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
+            self._stream_line_count += 2  # blank line + top border
 
         self._stream_buf += text
+        self._stream_full_text += text
 
         # Emit complete lines, keep partial remainder in buffer
         _tc = getattr(self, "_stream_text_ansi", "")
         while "\n" in self._stream_buf:
             line, self._stream_buf = self._stream_buf.split("\n", 1)
             _cprint(f"{_tc}{line}{_RST}" if _tc else line)
+            self._stream_line_count += 1
 
     def _flush_stream(self) -> None:
         """Emit any remaining partial line from the stream buffer and close the box."""
@@ -1675,11 +1681,13 @@ class HermesCLI:
             _tc = getattr(self, "_stream_text_ansi", "")
             _cprint(f"{_tc}{self._stream_buf}{_RST}" if _tc else self._stream_buf)
             self._stream_buf = ""
+            self._stream_line_count += 1  # partial line flushed
 
         # Close the response box
         if self._stream_box_opened:
             w = shutil.get_terminal_size().columns
             _cprint(f"{_GOLD}╰{'─' * (w - 2)}╯{_RST}")
+            self._stream_line_count += 1  # bottom border
 
     def _reset_stream_state(self) -> None:
         """Reset streaming state before each agent invocation."""
@@ -1688,6 +1696,8 @@ class HermesCLI:
         self._stream_box_opened = False
         self._stream_text_ansi = ""
         self._stream_prefilt = ""
+        self._stream_line_count = 0
+        self._stream_full_text = ""
         self._in_reasoning_block = False
         self._reasoning_box_opened = False
         self._reasoning_buf = ""
@@ -5657,13 +5667,28 @@ class HermesCLI:
                     w = shutil.get_terminal_size().columns
                     _cprint(f"\n{_GOLD}╰{'─' * (w - 2)}╯{_RST}")
                 elif already_streamed:
-                    # Response was already streamed token-by-token with box framing;
-                    # _flush_stream() already closed the box. Skip Rich Panel.
-                    pass
+                    # Clear raw streamed output and re-render with Rich Markdown.
+                    # The streaming path printed raw text token-by-token; now we
+                    # replace it with a properly formatted Markdown Panel.
+                    _sl_count = self._stream_line_count
+                    if _sl_count > 0 and response:
+                        # Move cursor up over all streamed lines and erase them
+                        sys.stdout.write(f"\033[{_sl_count}A\033[J")
+                        sys.stdout.flush()
+                        _chat_console = ChatConsole()
+                        _chat_console.print(Panel(
+                            Markdown(response),
+                            title=f"[{_resp_color} bold]{label}[/]",
+                            title_align="left",
+                            border_style=_resp_color,
+                            style=_resp_text,
+                            box=rich_box.HORIZONTALS,
+                            padding=(1, 2),
+                        ))
                 else:
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(
-                        _rich_text_from_ansi(response),
+                        Markdown(response),
                         title=f"[{_resp_color} bold]{label}[/]",
                         title_align="left",
                         border_style=_resp_color,

--- a/tests/test_markdown_rendering.py
+++ b/tests/test_markdown_rendering.py
@@ -64,3 +64,58 @@ class TestStreamingReRender:
         match = re.search(r'elif already_streamed:\s*\n\s*(pass|# Token)', source)
         assert match is None or "pass" not in match.group(1), \
             "already_streamed branch still just does 'pass' — no markdown re-render"
+
+
+class TestStreamingEraseUsesZeroWidthEscape:
+    """The already_streamed erase sequence must not go through sys.stdout.write.
+
+    Inside prompt_toolkit's patch_stdout() context, sys.stdout is replaced by
+    StdoutProxy which mangles ANSI escape bytes (replaces \\x1b with '?').
+    Cursor-movement sequences such as \\033[NA\\033[J must be sent via
+    ZeroWidthEscape or write_raw so they bypass StdoutProxy's sanitisation.
+    """
+
+    @staticmethod
+    def _already_streamed_branch(source: str) -> str:
+        """Extract the text of the elif already_streamed: block from cli.py source."""
+        import re
+        # Grab from the 'elif already_streamed:' line to the next 'else:' or 'elif '
+        # at the same indentation level.  We take a generous slice so the checks
+        # are reliable regardless of minor refactors.
+        match = re.search(
+            r'(elif already_streamed:.*?)(?=\n\s{16}(?:elif |else:))',
+            source,
+            re.DOTALL,
+        )
+        assert match is not None, \
+            "Could not locate 'elif already_streamed:' block in cli.py"
+        return match.group(1)
+
+    def test_no_raw_stdout_write_in_already_streamed_branch(self):
+        """The already_streamed branch must NOT call sys.stdout.write.
+
+        StdoutProxy.write() replaces \\x1b with '?', so any raw ANSI sequence
+        written via sys.stdout.write() inside a patch_stdout() context will be
+        silently corrupted.  This test will FAIL until the fix is applied.
+        """
+        source = _CLI_PY.read_text()
+        branch = self._already_streamed_branch(source)
+        assert "sys.stdout.write" not in branch, (
+            "already_streamed branch still uses sys.stdout.write — "
+            "ANSI escape sequences will be mangled by prompt_toolkit StdoutProxy"
+        )
+
+    def test_uses_zero_width_escape_or_write_raw(self):
+        """The already_streamed branch must use ZeroWidthEscape or write_raw.
+
+        These are the two prompt_toolkit-safe ways to emit raw ANSI sequences
+        without going through StdoutProxy's byte sanitisation.
+        This test will FAIL until the fix is applied.
+        """
+        source = _CLI_PY.read_text()
+        branch = self._already_streamed_branch(source)
+        uses_safe_api = "ZeroWidthEscape" in branch or "write_raw" in branch
+        assert uses_safe_api, (
+            "already_streamed branch neither uses ZeroWidthEscape nor write_raw — "
+            "cursor-movement ANSI sequences will be corrupted by StdoutProxy"
+        )

--- a/tests/test_markdown_rendering.py
+++ b/tests/test_markdown_rendering.py
@@ -1,14 +1,8 @@
 """Tests for markdown rendering in AI responses (fixes raw **bold** display)."""
 import pytest
-import sys
-import types
+from pathlib import Path
 
-
-# Stub heavy dependencies that aren't installed in test env
-for mod_name in ["fire", "firecrawl", "fal_client", "litellm", "anthropic",
-                 "elevenlabs", "faster_whisper", "edge_tts"]:
-    if mod_name not in sys.modules:
-        sys.modules[mod_name] = types.ModuleType(mod_name)
+_CLI_PY = Path(__file__).parent.parent / "cli.py"
 
 
 class TestMarkdownImport:
@@ -16,8 +10,7 @@ class TestMarkdownImport:
 
     def test_markdown_imported_in_cli(self):
         """cli.py must import Markdown from rich.markdown."""
-        import importlib
-        source = open("/home/peppi/Dev/hermes-agent/cli.py").read()
+        source = _CLI_PY.read_text()
         assert "from rich.markdown import Markdown" in source, \
             "cli.py does not import rich.markdown.Markdown"
 
@@ -39,7 +32,7 @@ class TestNonStreamingUsesMarkdown:
 
     def test_panel_path_uses_markdown_not_raw_text(self):
         """In the non-streaming response branch, Panel content must be Markdown."""
-        source = open("/home/peppi/Dev/hermes-agent/cli.py").read()
+        source = _CLI_PY.read_text()
         # Find the Panel() call in the non-streaming path
         # It should use Markdown(response), not _rich_text_from_ansi(response)
         import re
@@ -53,19 +46,19 @@ class TestStreamingReRender:
 
     def test_stream_line_counter_exists(self):
         """The streaming path must track line count for re-render clearing."""
-        source = open("/home/peppi/Dev/hermes-agent/cli.py").read()
+        source = _CLI_PY.read_text()
         assert "_stream_line_count" in source, \
             "No _stream_line_count variable — streaming re-render won't work"
 
     def test_stream_full_text_accumulator_exists(self):
         """The streaming path must accumulate full text for markdown re-render."""
-        source = open("/home/peppi/Dev/hermes-agent/cli.py").read()
+        source = _CLI_PY.read_text()
         assert "_stream_full_text" in source, \
             "No _stream_full_text accumulator — streaming re-render won't work"
 
     def test_already_streamed_branch_does_not_just_pass(self):
         """The already_streamed branch must re-render, not just 'pass'."""
-        source = open("/home/peppi/Dev/hermes-agent/cli.py").read()
+        source = _CLI_PY.read_text()
         # Find the already_streamed branch — it should NOT just be 'pass'
         import re
         match = re.search(r'elif already_streamed:\s*\n\s*(pass|# Token)', source)

--- a/tests/test_markdown_rendering.py
+++ b/tests/test_markdown_rendering.py
@@ -1,0 +1,73 @@
+"""Tests for markdown rendering in AI responses (fixes raw **bold** display)."""
+import pytest
+import sys
+import types
+
+
+# Stub heavy dependencies that aren't installed in test env
+for mod_name in ["fire", "firecrawl", "fal_client", "litellm", "anthropic",
+                 "elevenlabs", "faster_whisper", "edge_tts"]:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+
+
+class TestMarkdownImport:
+    """Verify rich.markdown.Markdown is imported and available."""
+
+    def test_markdown_imported_in_cli(self):
+        """cli.py must import Markdown from rich.markdown."""
+        import importlib
+        source = open("/home/peppi/Dev/hermes-agent/cli.py").read()
+        assert "from rich.markdown import Markdown" in source, \
+            "cli.py does not import rich.markdown.Markdown"
+
+    def test_rich_markdown_renders_bold(self):
+        """Rich Markdown must convert **bold** to styled text, not raw asterisks."""
+        from rich.console import Console
+        from rich.markdown import Markdown
+        from io import StringIO
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, color_system="truecolor")
+        console.print(Markdown("This is **bold** text"))
+        output = buf.getvalue()
+        assert "**bold**" not in output, \
+            f"Raw markdown asterisks found in rendered output: {output!r}"
+
+
+class TestNonStreamingUsesMarkdown:
+    """The non-streaming Panel path must use Markdown(), not _rich_text_from_ansi()."""
+
+    def test_panel_path_uses_markdown_not_raw_text(self):
+        """In the non-streaming response branch, Panel content must be Markdown."""
+        source = open("/home/peppi/Dev/hermes-agent/cli.py").read()
+        # Find the Panel() call in the non-streaming path
+        # It should use Markdown(response), not _rich_text_from_ansi(response)
+        import re
+        panel_calls = re.findall(r'Panel\(\s*\n?\s*(\w+)\(response\)', source)
+        assert any("Markdown" in call for call in panel_calls), \
+            f"Panel content uses {panel_calls} instead of Markdown(response)"
+
+
+class TestStreamingReRender:
+    """After streaming completes, raw output should be replaced with rendered markdown."""
+
+    def test_stream_line_counter_exists(self):
+        """The streaming path must track line count for re-render clearing."""
+        source = open("/home/peppi/Dev/hermes-agent/cli.py").read()
+        assert "_stream_line_count" in source, \
+            "No _stream_line_count variable — streaming re-render won't work"
+
+    def test_stream_full_text_accumulator_exists(self):
+        """The streaming path must accumulate full text for markdown re-render."""
+        source = open("/home/peppi/Dev/hermes-agent/cli.py").read()
+        assert "_stream_full_text" in source, \
+            "No _stream_full_text accumulator — streaming re-render won't work"
+
+    def test_already_streamed_branch_does_not_just_pass(self):
+        """The already_streamed branch must re-render, not just 'pass'."""
+        source = open("/home/peppi/Dev/hermes-agent/cli.py").read()
+        # Find the already_streamed branch — it should NOT just be 'pass'
+        import re
+        match = re.search(r'elif already_streamed:\s*\n\s*(pass|# Token)', source)
+        assert match is None or "pass" not in match.group(1), \
+            "already_streamed branch still just does 'pass' — no markdown re-render"


### PR DESCRIPTION
## Summary

Render AI responses as **Rich Markdown** instead of raw text, so `**bold**`, `- lists`, and other markdown syntax display properly in the terminal.

### Changes

**`cli.py`**
- Import `rich.markdown.Markdown` and use it in both non-streaming and streaming response paths
- Non-streaming: `Panel(Markdown(response))` replaces `Panel(_rich_text_from_ansi(response))`
- Streaming: after raw token-by-token display completes, erase the raw output and re-render as a formatted Markdown Panel
- Track `_stream_line_count` and `_stream_full_text` during streaming to enable the re-render
- Use prompt_toolkit's `[ZeroWidthEscape]` for cursor movement (raw `sys.stdout.write` gets mangled by `StdoutProxy` which replaces `\x1b` with `?`)

**`tests/test_markdown_rendering.py`**
- Verify `Markdown` import exists in cli.py
- Verify Rich Markdown renders bold text (no raw asterisks)
- Verify non-streaming path uses `Markdown(response)`, not `_rich_text_from_ansi`
- Verify streaming re-render infrastructure exists (`_stream_line_count`, `_stream_full_text`)
- Verify `already_streamed` branch re-renders instead of just `pass`ing
- Verify cursor erase uses `ZeroWidthEscape`/`write_raw` (not `sys.stdout.write`)

### Bug fixes included

1. **Test paths** — replaced hardcoded `/home/peppi/Dev/hermes-agent/cli.py` with `Path(__file__).parent.parent / "cli.py"` so tests pass in CI
2. **Test isolation** — removed top-level `sys.modules` stubs for `faster_whisper` etc. that poisoned 93 transcription tests with `ValueError: faster_whisper.__spec__ is None`
3. **Streaming re-render** — `sys.stdout.write("\033[...")` inside `patch_stdout()` hits prompt_toolkit's `StdoutProxy.write()` which sanitizes ESC chars. Fixed by using `print_formatted_text(FormattedText([('[ZeroWidthEscape]', ...)]))` which routes through `write_raw()`

## Test plan

- [x] `pytest tests/test_markdown_rendering.py` — 8/8 pass
- [x] `pytest tests/tools/test_transcription.py tests/tools/test_transcription_tools.py` — no more `faster_whisper.__spec__` failures
- [ ] Manual: run hermes with `display.streaming: true`, confirm raw output is erased and replaced with formatted markdown
- [ ] Manual: run hermes with streaming off, confirm non-streaming responses render markdown properly