### PR TITLE
feat(cron): conditional triggers for cron jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -361,6 +361,7 @@ def create_job(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    trigger: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -377,6 +378,14 @@ def create_job(
         model: Optional per-job model override
         provider: Optional per-job provider override
         base_url: Optional per-job base URL override
+        trigger: Optional condition that must be met before the job runs.
+            Dict with "type" key and type-specific config:
+            - {"type": "sql", "query": "SELECT COUNT(*) ...", "threshold": 1}
+              Runs query against state.db; skips if result < threshold (default 1)
+            - {"type": "file_changed", "path": "/path/to/file"}
+              Skips if file mtime hasn't changed since last run
+            - {"type": "command", "command": "test -f /tmp/flag"}
+              Skips if command exits non-zero
 
     Returns:
         The created job dict
@@ -434,6 +443,7 @@ def create_job(
         # Delivery configuration
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
+        "trigger": trigger,
     }
 
     jobs = load_jobs()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -37,6 +37,127 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output
 
+# ---------------------------------------------------------------------------
+# Trigger evaluation — $0 gates that run before the LLM is invoked
+# ---------------------------------------------------------------------------
+
+
+def check_trigger(job: dict) -> tuple[bool, str]:
+    """Evaluate a job's trigger condition.
+
+    Returns (should_run, reason).  When no trigger is configured the job
+    always runs.  Trigger evaluation is intentionally cheap — no LLM calls,
+    just SQL queries, file stats, or shell commands.
+    """
+    trigger = job.get("trigger")
+    if not trigger:
+        return True, "no_trigger"
+
+    trigger_type = trigger.get("type", "")
+
+    if trigger_type == "sql":
+        return _check_sql_trigger(trigger, job)
+    elif trigger_type == "file_changed":
+        return _check_file_trigger(trigger, job)
+    elif trigger_type == "command":
+        return _check_command_trigger(trigger)
+    else:
+        logger.warning("Job '%s': unknown trigger type '%s', running anyway",
+                        job.get("name", job["id"]), trigger_type)
+        return True, f"unknown_trigger_type:{trigger_type}"
+
+
+def _check_sql_trigger(trigger: dict, job: dict) -> tuple[bool, str]:
+    """Run a SQL query against state.db.  Skip if result < threshold."""
+    query = trigger.get("query", "")
+    threshold = trigger.get("threshold", 1)
+
+    if not query:
+        return True, "empty_query"
+
+    # Safety: block mutations
+    q_upper = query.strip().upper()
+    if any(q_upper.startswith(kw) for kw in
+           ("INSERT", "UPDATE", "DELETE", "DROP", "ALTER", "CREATE", "ATTACH")):
+        logger.error("Job '%s': trigger query is not read-only, skipping",
+                      job.get("name", job["id"]))
+        return False, "blocked_mutation"
+
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        cur = db.conn.execute(query)
+        row = cur.fetchone()
+        db.close()
+
+        if row is None:
+            return False, "null_result"
+
+        value = row[0] if isinstance(row, (tuple, list)) else row
+        if isinstance(value, (int, float)):
+            triggered = value >= threshold
+        else:
+            triggered = bool(value)
+
+        reason = f"sql:{value}>={threshold}" if triggered else f"sql:{value}<{threshold}"
+        return triggered, reason
+
+    except Exception as e:
+        logger.error("Job '%s': trigger query failed: %s", job.get("name", job["id"]), e)
+        return False, f"sql_error:{e}"
+
+
+def _check_file_trigger(trigger: dict, job: dict) -> tuple[bool, str]:
+    """Skip if file hasn't been modified since the job's last run."""
+    file_path = trigger.get("path", "")
+    if not file_path:
+        return True, "no_path"
+
+    path = Path(os.path.expanduser(file_path))
+    if not path.exists():
+        return False, f"file_not_found:{file_path}"
+
+    last_run = job.get("last_run_at")
+    if not last_run:
+        return True, "first_run"
+
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime).astimezone()
+        last_run_dt = datetime.fromisoformat(last_run)
+        if last_run_dt.tzinfo is None:
+            last_run_dt = last_run_dt.astimezone()
+
+        if mtime > last_run_dt:
+            return True, f"file_modified:{mtime.isoformat()}"
+        return False, "file_unchanged"
+
+    except Exception as e:
+        logger.error("Job '%s': file trigger failed: %s", job.get("name", job["id"]), e)
+        return False, f"file_error:{e}"
+
+
+def _check_command_trigger(trigger: dict) -> tuple[bool, str]:
+    """Run a shell command.  Skip if exit code is non-zero."""
+    command = trigger.get("command", "")
+    if not command:
+        return True, "no_command"
+
+    try:
+        import subprocess
+        result = subprocess.run(
+            command, shell=True, capture_output=True, timeout=10,
+        )
+        if result.returncode == 0:
+            return True, "command_ok"
+        return False, f"command_exit:{result.returncode}"
+
+    except subprocess.TimeoutExpired:
+        logger.warning("Trigger command timed out (10s): %s", command[:80])
+        return False, "command_timeout"
+    except Exception as e:
+        logger.error("Trigger command failed: %s", e)
+        return False, f"command_error:{e}"
+
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
@@ -524,6 +645,15 @@ def tick(verbose: bool = True) -> int:
         executed = 0
         for job in due_jobs:
             try:
+                # Trigger gate: cheap pre-check before spawning the agent
+                should_run, trigger_reason = check_trigger(job)
+                if not should_run:
+                    logger.info("Job '%s' skipped by trigger: %s",
+                                job.get("name", job["id"]), trigger_reason)
+                    # Advance the schedule so the job is checked again next tick
+                    mark_job_run(job["id"], True, None)
+                    continue
+
                 success, output, final_response, error = run_job(job)
 
                 output_file = save_job_output(job["id"], output)

--- a/tests/cron/test_triggers.py
+++ b/tests/cron/test_triggers.py
@@ -1,0 +1,263 @@
+"""Tests for cron trigger evaluation — the $0 pre-run gate."""
+
+import os
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from cron.scheduler import check_trigger
+
+
+class TestNoTrigger:
+    """Jobs without triggers always run."""
+
+    def test_no_trigger_key(self):
+        job = {"id": "test1", "name": "test"}
+        should_run, reason = check_trigger(job)
+        assert should_run is True
+        assert reason == "no_trigger"
+
+    def test_none_trigger(self):
+        job = {"id": "test2", "name": "test", "trigger": None}
+        should_run, reason = check_trigger(job)
+        assert should_run is True
+        assert reason == "no_trigger"
+
+    def test_unknown_trigger_type(self):
+        job = {"id": "test3", "name": "test", "trigger": {"type": "magic"}}
+        should_run, reason = check_trigger(job)
+        assert should_run is True
+        assert "unknown_trigger_type" in reason
+
+
+class TestSqlTrigger:
+    """SQL triggers query state.db and skip if result < threshold."""
+
+    def test_sql_trigger_passes(self):
+        """Query returning value >= threshold should allow the job to run."""
+        mock_db = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (5,)
+        mock_db.conn.execute.return_value = mock_cursor
+
+        job = {
+            "id": "sql1", "name": "test",
+            "trigger": {"type": "sql", "query": "SELECT 5", "threshold": 1}
+        }
+
+        with patch("hermes_state.SessionDB", return_value=mock_db):
+            should_run, reason = check_trigger(job)
+
+        assert should_run is True
+        assert "sql:5>=1" in reason
+        mock_db.close.assert_called_once()
+
+    def test_sql_trigger_blocks(self):
+        """Query returning value < threshold should skip the job."""
+        mock_db = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (0,)
+        mock_db.conn.execute.return_value = mock_cursor
+
+        job = {
+            "id": "sql2", "name": "test",
+            "trigger": {"type": "sql", "query": "SELECT 0", "threshold": 1}
+        }
+
+        with patch("hermes_state.SessionDB", return_value=mock_db):
+            should_run, reason = check_trigger(job)
+
+        assert should_run is False
+        assert "sql:0<1" in reason
+
+    def test_sql_trigger_null_result(self):
+        """Null result should skip the job."""
+        mock_db = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None
+        mock_db.conn.execute.return_value = mock_cursor
+
+        job = {
+            "id": "sql3", "name": "test",
+            "trigger": {"type": "sql", "query": "SELECT NULL"}
+        }
+
+        with patch("hermes_state.SessionDB", return_value=mock_db):
+            should_run, reason = check_trigger(job)
+
+        assert should_run is False
+        assert reason == "null_result"
+
+    def test_sql_trigger_blocks_mutations(self):
+        """Mutation queries should be blocked."""
+        for keyword in ("INSERT", "UPDATE", "DELETE", "DROP", "ALTER", "CREATE"):
+            job = {
+                "id": "sql_mut", "name": "test",
+                "trigger": {"type": "sql", "query": f"{keyword} INTO foo VALUES(1)"}
+            }
+            should_run, reason = check_trigger(job)
+            assert should_run is False
+            assert reason == "blocked_mutation"
+
+    def test_sql_trigger_default_threshold(self):
+        """Default threshold should be 1."""
+        mock_db = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (1,)
+        mock_db.conn.execute.return_value = mock_cursor
+
+        job = {
+            "id": "sql4", "name": "test",
+            "trigger": {"type": "sql", "query": "SELECT 1"}
+        }
+
+        with patch("hermes_state.SessionDB", return_value=mock_db):
+            should_run, reason = check_trigger(job)
+
+        assert should_run is True
+
+    def test_sql_trigger_empty_query(self):
+        """Empty query should allow the job to run."""
+        job = {
+            "id": "sql5", "name": "test",
+            "trigger": {"type": "sql", "query": ""}
+        }
+        should_run, reason = check_trigger(job)
+        assert should_run is True
+        assert reason == "empty_query"
+
+    def test_sql_trigger_error_skips(self):
+        """SQL errors should skip the job (fail-closed)."""
+        job = {
+            "id": "sql6", "name": "test",
+            "trigger": {"type": "sql", "query": "SELECT * FROM nonexistent"}
+        }
+
+        with patch("hermes_state.SessionDB", side_effect=Exception("no such table")):
+            should_run, reason = check_trigger(job)
+
+        assert should_run is False
+        assert "sql_error" in reason
+
+
+class TestFileTrigger:
+    """File triggers check mtime against last run."""
+
+    def test_file_changed_since_last_run(self):
+        """Modified file should allow the job to run."""
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"test")
+            path = f.name
+
+        try:
+            # Last run was an hour ago, file was just created
+            last_run = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+            job = {
+                "id": "file1", "name": "test",
+                "last_run_at": last_run,
+                "trigger": {"type": "file_changed", "path": path}
+            }
+            should_run, reason = check_trigger(job)
+            assert should_run is True
+            assert "file_modified" in reason
+        finally:
+            os.unlink(path)
+
+    def test_file_unchanged_since_last_run(self):
+        """Unchanged file should skip the job."""
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"test")
+            path = f.name
+
+        try:
+            # Last run is in the future — file hasn't changed since
+            last_run = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+            job = {
+                "id": "file2", "name": "test",
+                "last_run_at": last_run,
+                "trigger": {"type": "file_changed", "path": path}
+            }
+            should_run, reason = check_trigger(job)
+            assert should_run is False
+            assert reason == "file_unchanged"
+        finally:
+            os.unlink(path)
+
+    def test_file_first_run(self):
+        """First run (no last_run_at) should always run."""
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"test")
+            path = f.name
+
+        try:
+            job = {
+                "id": "file3", "name": "test",
+                "trigger": {"type": "file_changed", "path": path}
+            }
+            should_run, reason = check_trigger(job)
+            assert should_run is True
+            assert reason == "first_run"
+        finally:
+            os.unlink(path)
+
+    def test_file_not_found(self):
+        """Missing file should skip the job."""
+        job = {
+            "id": "file4", "name": "test",
+            "trigger": {"type": "file_changed", "path": "/nonexistent/file.txt"}
+        }
+        should_run, reason = check_trigger(job)
+        assert should_run is False
+        assert "file_not_found" in reason
+
+
+class TestCommandTrigger:
+    """Command triggers check exit code."""
+
+    def test_command_success(self):
+        """Exit 0 should allow the job to run."""
+        job = {
+            "id": "cmd1", "name": "test",
+            "trigger": {"type": "command", "command": "true"}
+        }
+        should_run, reason = check_trigger(job)
+        assert should_run is True
+        assert reason == "command_ok"
+
+    def test_command_failure(self):
+        """Non-zero exit should skip the job."""
+        job = {
+            "id": "cmd2", "name": "test",
+            "trigger": {"type": "command", "command": "false"}
+        }
+        should_run, reason = check_trigger(job)
+        assert should_run is False
+        assert "command_exit:1" in reason
+
+    def test_command_timeout(self):
+        """Commands that exceed 10s timeout should skip."""
+        job = {
+            "id": "cmd3", "name": "test",
+            "trigger": {"type": "command", "command": "sleep 20"}
+        }
+
+        import subprocess
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("sleep", 10)):
+            should_run, reason = check_trigger(job)
+
+        assert should_run is False
+        assert reason == "command_timeout"
+
+    def test_empty_command(self):
+        """Empty command should allow the job to run."""
+        job = {
+            "id": "cmd4", "name": "test",
+            "trigger": {"type": "command", "command": ""}
+        }
+        should_run, reason = check_trigger(job)
+        assert should_run is True
+        assert reason == "no_command"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -135,6 +135,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "state": job.get("state", "scheduled" if job.get("enabled", True) else "paused"),
         "paused_at": job.get("paused_at"),
         "paused_reason": job.get("paused_reason"),
+        "trigger": job.get("trigger"),
     }
 
 
@@ -153,6 +154,7 @@ def cronjob(
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
     reason: Optional[str] = None,
+    trigger: Optional[Dict[str, Any]] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -183,6 +185,7 @@ def cronjob(
                 model=_normalize_optional_job_value(model),
                 provider=_normalize_optional_job_value(provider),
                 base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
+                trigger=trigger,
             )
             return json.dumps(
                 {
@@ -278,6 +281,8 @@ def cronjob(
                 if job.get("state") != "paused":
                     updates["state"] = "scheduled"
                     updates["enabled"] = True
+            if trigger is not None:
+                updates["trigger"] = trigger if trigger else None
             if not updates:
                 return json.dumps({"success": False, "error": "No updates provided."}, indent=2)
             updated = update_job(job_id, updates)
@@ -402,6 +407,32 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             "reason": {
                 "type": "string",
                 "description": "Optional pause reason"
+            },
+            "trigger": {
+                "type": "object",
+                "description": "Optional pre-run condition. If the trigger evaluates to false, the job is skipped (no LLM cost). Three types: sql (query state.db, skip if result < threshold), file_changed (skip if file unchanged since last run), command (skip if exit code non-zero). Examples: {\"type\": \"sql\", \"query\": \"SELECT COUNT(*) FROM messages WHERE timestamp > strftime('%s','now','-1 hour')\", \"threshold\": 1}, {\"type\": \"file_changed\", \"path\": \"~/data/feed.json\"}, {\"type\": \"command\", \"command\": \"test -f /tmp/new-data-ready\"}",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Trigger type: sql, file_changed, or command"
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "For sql triggers: read-only SQL query against state.db"
+                    },
+                    "threshold": {
+                        "type": "number",
+                        "description": "For sql triggers: minimum value to proceed (default: 1)"
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "For file_changed triggers: file path to monitor"
+                    },
+                    "command": {
+                        "type": "string",
+                        "description": "For command triggers: shell command (must exit 0 to proceed)"
+                    }
+                }
             }
         },
         "required": ["action"]
@@ -451,6 +482,7 @@ registry.register(
         provider=args.get("provider"),
         base_url=args.get("base_url"),
         reason=args.get("reason"),
+        trigger=args.get("trigger"),
         task_id=kw.get("task_id"),
     ),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## Summary

Adds a lightweight **trigger** system for cron jobs — a $0 pre-run gate that evaluates a condition before spawning an AIAgent. If the trigger returns false, the job is skipped and rescheduled. No LLM call, no tokens burned.

**Problem:** Cron jobs run on fixed schedules regardless of whether there's new data to process. A job scheduled `every 30m` fires 48 times/day even if only 2 of those runs have meaningful work. The other 46 runs waste inference costs.

**Solution:** An optional `trigger` field on cron jobs that supports three evaluation types:

| Type | Gate | Cost |
|------|------|------|
| `sql` | Query state.db, skip if result < threshold | $0 (local SQLite) |
| `file_changed` | Check file mtime vs last run | $0 (stat call) |
| `command` | Shell command, skip if exit ≠ 0 | $0 (subprocess) |

### Examples

```python
# Only summarize when there are new conversations
cronjob(action="create",
  prompt="Summarize new conversations",
  schedule="every 2h",
  trigger={"type": "sql",
           "query": "SELECT COUNT(*) FROM messages WHERE timestamp > strftime('%s','now','-2 hours')",
           "threshold": 1})

# Only process when feed file has been updated
cronjob(action="create",
  prompt="Process updated data feed",
  schedule="every 30m",
  trigger={"type": "file_changed", "path": "~/data/feed.json"})

# Only run when an external flag is set
cronjob(action="create",
  prompt="Run nightly analysis",
  schedule="0 9 * * *",
  trigger={"type": "command", "command": "test -f /tmp/new-data-ready"})
```

### Design decisions

- **Fail-closed:** Trigger errors (SQL exceptions, missing files, timeouts) skip the job rather than running it. You never accidentally burn tokens on a broken trigger.
- **Read-only SQL:** Mutation queries (INSERT/UPDATE/DELETE/DROP/ALTER/CREATE) are blocked.
- **10s timeout:** Command triggers have a hard 10-second timeout to prevent blocking the scheduler.
- **Backward compatible:** Jobs without a `trigger` field run exactly as before. Existing jobs, configs, and the `[SILENT]` mechanism are untouched.
- **Minimal surface:** 3 files changed + 1 test file. The trigger check is entirely contained in the cron subsystem — `AIAgent`, `model_tools`, gateway, and config are untouched.

## Files changed

- `cron/scheduler.py` — `check_trigger()` function + 3 type-specific evaluators, wired into `tick()` before `run_job()`
- `cron/jobs.py` — `trigger` param on `create_job()`, persisted in job dict
- `tools/cronjob_tools.py` — `trigger` param on `cronjob()` tool + schema update
- `tests/cron/test_triggers.py` — 18 tests covering all trigger types, edge cases, and failure modes

## Test plan

- [x] 18 unit tests passing (`pytest tests/cron/test_triggers.py`)
- [ ] Manual test: create a cron job with SQL trigger, verify it skips when query returns 0
- [ ] Manual test: create a cron job with file_changed trigger, verify it skips when file is stale
- [ ] Manual test: verify existing cron jobs without triggers still run normally