### PR TITLE
fix(async): close unscheduled coroutines in threadsafe bridges

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -31,10 +31,16 @@ def _send_update(
     update: Any,
 ) -> None:
     """Fire-and-forget an ACP session update from a worker thread."""
+    coro = conn.session_update(session_id, update)
     try:
-        future = asyncio.run_coroutine_threadsafe(
-            conn.session_update(session_id, update), loop
-        )
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+    except Exception:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        logger.debug("Failed to send ACP update", exc_info=True)
+        return
+
+    try:
         future.result(timeout=5)
     except Exception:
         logger.debug("Failed to send ACP update", exc_info=True)

--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -61,6 +61,13 @@ def make_approval_callback(
 
         try:
             future = asyncio.run_coroutine_threadsafe(coro, loop)
+        except Exception as exc:
+            if asyncio.iscoroutine(coro):
+                coro.close()
+            logger.warning("Permission request timed out or failed: %s", exc)
+            return "deny"
+
+        try:
             response = future.result(timeout=timeout)
         except (FutureTimeout, Exception) as exc:
             logger.warning("Permission request timed out or failed: %s", exc)

--- a/environments/patches.py
+++ b/environments/patches.py
@@ -70,8 +70,15 @@ class _AsyncWorker:
         a running event loop.
         """
         if self._loop is None or self._loop.is_closed():
+            if asyncio.iscoroutine(coro):
+                coro.close()
             raise RuntimeError("AsyncWorker loop is not running")
-        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        except Exception:
+            if asyncio.iscoroutine(coro):
+                coro.close()
+            raise
         return future.result(timeout=timeout)
 
     def stop(self):

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -331,7 +331,15 @@ class _IncomingHandler(ChatbotHandler if DINGTALK_STREAM_AVAILABLE else object):
             logger.error("[DingTalk] Event loop unavailable, cannot dispatch message")
             return dingtalk_stream.AckMessage.STATUS_OK, "OK"
 
-        future = asyncio.run_coroutine_threadsafe(self._adapter._on_message(message), loop)
+        coro = self._adapter._on_message(message)
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro, loop)
+        except Exception:
+            if asyncio.iscoroutine(coro):
+                coro.close()
+            logger.exception("[DingTalk] Error processing incoming message")
+            return dingtalk_stream.AckMessage.STATUS_OK, "OK"
+
         try:
             future.result(timeout=60)
         except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5041,18 +5041,18 @@ class GatewayRunner:
         _hooks_ref = self.hooks
 
         def _step_callback_sync(iteration: int, tool_names: list) -> None:
+            coro = _hooks_ref.emit("agent:step", {
+                "platform": source.platform.value if source.platform else "",
+                "user_id": source.user_id,
+                "session_id": session_id,
+                "iteration": iteration,
+                "tool_names": tool_names,
+            })
             try:
-                asyncio.run_coroutine_threadsafe(
-                    _hooks_ref.emit("agent:step", {
-                        "platform": source.platform.value if source.platform else "",
-                        "user_id": source.user_id,
-                        "session_id": session_id,
-                        "iteration": iteration,
-                        "tool_names": tool_names,
-                    }),
-                    _loop_for_step,
-                )
+                asyncio.run_coroutine_threadsafe(coro, _loop_for_step)
             except Exception as _e:
+                if asyncio.iscoroutine(coro):
+                    coro.close()
                 logger.debug("agent:step hook error: %s", _e)
 
         # Bridge sync status_callback → async adapter.send for context pressure
@@ -5063,16 +5063,16 @@ class GatewayRunner:
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter:
                 return
+            coro = _status_adapter.send(
+                _status_chat_id,
+                message,
+                metadata=_status_thread_metadata,
+            )
             try:
-                asyncio.run_coroutine_threadsafe(
-                    _status_adapter.send(
-                        _status_chat_id,
-                        message,
-                        metadata=_status_thread_metadata,
-                    ),
-                    _loop_for_step,
-                )
+                asyncio.run_coroutine_threadsafe(coro, _loop_for_step)
             except Exception as _e:
+                if asyncio.iscoroutine(coro):
+                    coro.close()
                 logger.debug("status_callback error (%s): %s", event_type, _e)
 
         def run_sync():

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -2,6 +2,8 @@
 
 import asyncio
 from concurrent.futures import Future
+import gc
+import warnings
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,11 +12,26 @@ import acp
 from acp.schema import ToolCallStart, ToolCallProgress, AgentThoughtChunk, AgentMessageChunk
 
 from acp_adapter.events import (
+    _send_update,
     make_message_cb,
     make_step_cb,
     make_thinking_cb,
     make_tool_progress_cb,
 )
+
+
+def _mock_threadsafe_success(mock_rcts):
+    """Patch run_coroutine_threadsafe to close the submitted coroutine in tests."""
+    future = MagicMock(spec=Future)
+    future.result.return_value = None
+
+    def _submit(coro, loop):
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        return future
+
+    mock_rcts.side_effect = _submit
+    return future
 
 
 @pytest.fixture()
@@ -48,9 +65,7 @@ class TestToolProgressCallback:
 
         # Run callback in the event loop context
         with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
-            future = MagicMock(spec=Future)
-            future.result.return_value = None
-            mock_rcts.return_value = future
+            _mock_threadsafe_success(mock_rcts)
 
             cb("terminal", "$ ls -la", {"command": "ls -la"})
 
@@ -71,9 +86,7 @@ class TestToolProgressCallback:
         cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids)
 
         with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
-            future = MagicMock(spec=Future)
-            future.result.return_value = None
-            mock_rcts.return_value = future
+            _mock_threadsafe_success(mock_rcts)
 
             cb("read_file", "Reading /etc/hosts", '{"path": "/etc/hosts"}')
 
@@ -87,9 +100,7 @@ class TestToolProgressCallback:
         cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids)
 
         with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
-            future = MagicMock(spec=Future)
-            future.result.return_value = None
-            mock_rcts.return_value = future
+            _mock_threadsafe_success(mock_rcts)
 
             cb("terminal", "$ echo hi", None)
 
@@ -104,9 +115,7 @@ class TestToolProgressCallback:
         step_cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids)
 
         with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
-            future = MagicMock(spec=Future)
-            future.result.return_value = None
-            mock_rcts.return_value = future
+            _mock_threadsafe_success(mock_rcts)
 
             progress_cb("terminal", "$ ls", {"command": "ls"})
             progress_cb("terminal", "$ pwd", {"command": "pwd"})
@@ -117,6 +126,37 @@ class TestToolProgressCallback:
 
             step_cb(2, [{"name": "terminal", "result": "ok-2"}])
             assert "terminal" not in tool_call_ids
+
+
+class TestSendUpdate:
+    def test_scheduler_failure_closes_update_coroutine(self, event_loop_fixture):
+        created = {"coro": None}
+
+        async def _session_update(session_id, update):
+            return None
+
+        conn = MagicMock()
+
+        def _capture_update(session_id, update):
+            created["coro"] = _session_update(session_id, update)
+            return created["coro"]
+
+        conn.session_update = _capture_update
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe", side_effect=RuntimeError("scheduler down")):
+                _send_update(conn, "session-1", event_loop_fixture, {"type": "noop"})
+            gc.collect()
+
+        assert created["coro"] is not None
+        assert created["coro"].cr_frame is None
+        runtime_warnings = [
+            w for w in caught
+            if issubclass(w.category, RuntimeWarning)
+            and "was never awaited" in str(w.message)
+        ]
+        assert runtime_warnings == []
 
 
 # ---------------------------------------------------------------------------
@@ -132,9 +172,7 @@ class TestThinkingCallback:
         cb = make_thinking_cb(mock_conn, "session-1", loop)
 
         with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
-            future = MagicMock(spec=Future)
-            future.result.return_value = None
-            mock_rcts.return_value = future
+            _mock_threadsafe_success(mock_rcts)
 
             cb("Analyzing the code...")
 
@@ -166,9 +204,7 @@ class TestStepCallback:
         cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids)
 
         with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
-            future = MagicMock(spec=Future)
-            future.result.return_value = None
-            mock_rcts.return_value = future
+            _mock_threadsafe_success(mock_rcts)
 
             cb(1, [{"name": "terminal", "result": "success"}])
 
@@ -196,9 +232,7 @@ class TestStepCallback:
         cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids)
 
         with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
-            future = MagicMock(spec=Future)
-            future.result.return_value = None
-            mock_rcts.return_value = future
+            _mock_threadsafe_success(mock_rcts)
 
             cb(2, ["read_file"])
 
@@ -219,9 +253,7 @@ class TestMessageCallback:
         cb = make_message_cb(mock_conn, "session-1", loop)
 
         with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
-            future = MagicMock(spec=Future)
-            future.result.return_value = None
-            mock_rcts.return_value = future
+            _mock_threadsafe_success(mock_rcts)
 
             cb("Here is your answer.")
 

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -1,7 +1,9 @@
 """Tests for acp_adapter.permissions — ACP approval bridging."""
 
 import asyncio
+import gc
 from concurrent.futures import Future
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -73,3 +75,31 @@ class TestApprovalMapping:
             result = cb("rm -rf /", "dangerous")
 
         assert result == "deny"
+
+    def test_scheduler_failure_closes_permission_coroutine(self):
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        created = {"coro": None}
+
+        async def _response_coro(**kwargs):
+            return _make_response(AllowedOutcome(option_id="allow_once", outcome="selected"))
+
+        def _request_permission(**kwargs):
+            created["coro"] = _response_coro(**kwargs)
+            return created["coro"]
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", side_effect=RuntimeError("scheduler down")):
+                cb = make_approval_callback(_request_permission, loop, session_id="s1", timeout=0.01)
+                result = cb("rm -rf /", "dangerous")
+            gc.collect()
+
+        assert result == "deny"
+        assert created["coro"] is not None
+        assert created["coro"].cr_frame is None
+        runtime_warnings = [
+            w for w in caught
+            if issubclass(w.category, RuntimeWarning)
+            and "was never awaited" in str(w.message)
+        ]
+        assert runtime_warnings == []

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -1,6 +1,8 @@
 """Tests for DingTalk platform adapter."""
 import asyncio
+import gc
 import json
+import warnings
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
@@ -261,6 +263,41 @@ class TestConnect:
         assert len(adapter._session_webhooks) == 0
         assert len(adapter._seen_messages) == 0
         assert adapter._http_client is None
+
+
+class TestIncomingHandler:
+    def test_scheduler_failure_closes_message_coroutine(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter, _IncomingHandler
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        created = {"coro": None}
+
+        async def _on_message(message):
+            return None
+
+        def _capture(message):
+            created["coro"] = _on_message(message)
+            return created["coro"]
+
+        adapter._on_message = _capture
+        loop = MagicMock()
+        loop.is_closed.return_value = False
+        handler = _IncomingHandler(adapter, loop)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch("gateway.platforms.dingtalk.asyncio.run_coroutine_threadsafe", side_effect=RuntimeError("scheduler down")):
+                handler.process(MagicMock())
+            gc.collect()
+
+        assert created["coro"] is not None
+        assert created["coro"].cr_frame is None
+        runtime_warnings = [
+            w for w in caught
+            if issubclass(w.category, RuntimeWarning)
+            and "was never awaited" in str(w.message)
+        ]
+        assert runtime_warnings == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_environment_patches.py
+++ b/tests/test_environment_patches.py
@@ -1,0 +1,49 @@
+"""Tests for coroutine cleanup in environments.patches helpers."""
+
+import gc
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestAsyncWorker:
+    def test_scheduler_failure_closes_coroutine(self):
+        from environments.patches import _AsyncWorker
+
+        worker = _AsyncWorker()
+        worker._loop = MagicMock()
+        worker._loop.is_closed.return_value = False
+
+        async def _sample():
+            return "ok"
+
+        coro = _sample()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch("environments.patches.asyncio.run_coroutine_threadsafe", side_effect=RuntimeError("scheduler down")):
+                with pytest.raises(RuntimeError, match="scheduler down"):
+                    worker.run_coroutine(coro)
+            gc.collect()
+
+        assert coro.cr_frame is None
+        runtime_warnings = [
+            w for w in caught
+            if issubclass(w.category, RuntimeWarning)
+            and "was never awaited" in str(w.message)
+        ]
+        assert runtime_warnings == []
+
+    def test_missing_loop_closes_coroutine(self):
+        from environments.patches import _AsyncWorker
+
+        worker = _AsyncWorker()
+
+        async def _sample():
+            return "ok"
+
+        coro = _sample()
+        with pytest.raises(RuntimeError, match="not running"):
+            worker.run_coroutine(coro)
+        assert coro.cr_frame is None

--- a/tests/tools/test_mcp_probe.py
+++ b/tests/tools/test_mcp_probe.py
@@ -1,6 +1,8 @@
 """Tests for probe_mcp_server_tools() in tools.mcp_tool."""
 
 import asyncio
+import gc
+import warnings
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -23,6 +25,15 @@ def _reset_mcp_state():
 
 class TestProbeMcpServerTools:
     """Tests for the lightweight probe_mcp_server_tools function."""
+
+    @staticmethod
+    def _run_coro(coro_or_factory, timeout=120):
+        coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
 
     def test_returns_empty_when_mcp_not_available(self):
         with patch("tools.mcp_tool._MCP_AVAILABLE", False):
@@ -66,16 +77,7 @@ class TestProbeMcpServerTools:
              patch("tools.mcp_tool._ensure_mcp_loop"), \
              patch("tools.mcp_tool._run_on_mcp_loop") as mock_run, \
              patch("tools.mcp_tool._stop_mcp_loop"):
-
-            # Simulate running the async probe
-            def run_coro(coro, timeout=120):
-                loop = asyncio.new_event_loop()
-                try:
-                    return loop.run_until_complete(coro)
-                finally:
-                    loop.close()
-
-            mock_run.side_effect = run_coro
+            mock_run.side_effect = self._run_coro
 
             from tools.mcp_tool import probe_mcp_server_tools
             result = probe_mcp_server_tools()
@@ -107,15 +109,7 @@ class TestProbeMcpServerTools:
              patch("tools.mcp_tool._ensure_mcp_loop"), \
              patch("tools.mcp_tool._run_on_mcp_loop") as mock_run, \
              patch("tools.mcp_tool._stop_mcp_loop"):
-
-            def run_coro(coro, timeout=120):
-                loop = asyncio.new_event_loop()
-                try:
-                    return loop.run_until_complete(coro)
-                finally:
-                    loop.close()
-
-            mock_run.side_effect = run_coro
+            mock_run.side_effect = self._run_coro
 
             from tools.mcp_tool import probe_mcp_server_tools
             result = probe_mcp_server_tools()
@@ -140,15 +134,7 @@ class TestProbeMcpServerTools:
              patch("tools.mcp_tool._ensure_mcp_loop"), \
              patch("tools.mcp_tool._run_on_mcp_loop") as mock_run, \
              patch("tools.mcp_tool._stop_mcp_loop"):
-
-            def run_coro(coro, timeout=120):
-                loop = asyncio.new_event_loop()
-                try:
-                    return loop.run_until_complete(coro)
-                finally:
-                    loop.close()
-
-            mock_run.side_effect = run_coro
+            mock_run.side_effect = self._run_coro
 
             from tools.mcp_tool import probe_mcp_server_tools
             result = probe_mcp_server_tools()
@@ -169,6 +155,27 @@ class TestProbeMcpServerTools:
 
         assert result == {}
         mock_stop.assert_called_once()
+
+    def test_probe_failure_does_not_leak_unawaited_coroutine(self):
+        config = {"github": {"command": "npx", "connect_timeout": 5}}
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch("tools.mcp_tool._load_mcp_config", return_value=config), \
+                 patch("tools.mcp_tool._ensure_mcp_loop"), \
+                 patch("tools.mcp_tool._run_on_mcp_loop", side_effect=RuntimeError("boom")), \
+                 patch("tools.mcp_tool._stop_mcp_loop"):
+                from tools.mcp_tool import probe_mcp_server_tools
+                result = probe_mcp_server_tools()
+            gc.collect()
+
+        assert result == {}
+        runtime_warnings = [
+            w for w in caught
+            if issubclass(w.category, RuntimeWarning)
+            and "was never awaited" in str(w.message)
+        ]
+        assert runtime_warnings == []
 
     def test_skips_disabled_servers(self):
         """Disabled servers are not probed."""
@@ -192,15 +199,7 @@ class TestProbeMcpServerTools:
              patch("tools.mcp_tool._ensure_mcp_loop"), \
              patch("tools.mcp_tool._run_on_mcp_loop") as mock_run, \
              patch("tools.mcp_tool._stop_mcp_loop"):
-
-            def run_coro(coro, timeout=120):
-                loop = asyncio.new_event_loop()
-                try:
-                    return loop.run_until_complete(coro)
-                finally:
-                    loop.close()
-
-            mock_run.side_effect = run_coro
+            mock_run.side_effect = self._run_coro
 
             from tools.mcp_tool import probe_mcp_server_tools
             result = probe_mcp_server_tools()

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -175,6 +175,44 @@ class TestCheckFunction:
 
 
 # ---------------------------------------------------------------------------
+# MCP loop runner
+# ---------------------------------------------------------------------------
+
+class TestRunOnMcpLoop:
+    def test_scheduler_failure_closes_factory_coroutine(self):
+        import tools.mcp_tool as mcp
+
+        created = {"coro": None}
+
+        async def _sample():
+            return "ok"
+
+        def factory():
+            created["coro"] = _sample()
+            return created["coro"]
+
+        fake_loop = MagicMock()
+        fake_loop.is_running.return_value = True
+
+        with patch.object(mcp, "_mcp_loop", fake_loop):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                with patch("tools.mcp_tool.asyncio.run_coroutine_threadsafe", side_effect=RuntimeError("scheduler down")):
+                    with pytest.raises(RuntimeError, match="scheduler down"):
+                        mcp._run_on_mcp_loop(factory)
+                gc.collect()
+
+        assert created["coro"] is not None
+        assert created["coro"].cr_frame is None
+        runtime_warnings = [
+            w for w in caught
+            if issubclass(w.category, RuntimeWarning)
+            and "was never awaited" in str(w.message)
+        ]
+        assert runtime_warnings == []
+
+
+# ---------------------------------------------------------------------------
 # Tool handler
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4,8 +4,10 @@ All tests use mocks -- no real MCP servers or subprocesses are started.
 """
 
 import asyncio
+import gc
 import json
 import os
+import warnings
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -181,7 +183,8 @@ class TestToolHandler:
 
     def _patch_mcp_loop(self, coro_side_effect=None):
         """Return a patch for _run_on_mcp_loop that runs the coroutine directly."""
-        def fake_run(coro, timeout=30):
+        def fake_run(coro_or_factory, timeout=30):
+            coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
             loop = asyncio.new_event_loop()
             try:
                 return loop.run_until_complete(coro)
@@ -252,6 +255,31 @@ class TestToolHandler:
                 result = json.loads(handler({}))
             assert "error" in result
             assert "connection lost" in result["error"]
+        finally:
+            _servers.pop("test_srv", None)
+
+    def test_scheduler_failure_does_not_leak_unawaited_coroutine(self):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=_make_call_result("ignored"))
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "greet", 120)
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=RuntimeError("loop down")):
+                    result = json.loads(handler({"name": "world"}))
+                gc.collect()
+            assert "error" in result
+            runtime_warnings = [
+                w for w in caught
+                if issubclass(w.category, RuntimeWarning)
+                and "was never awaited" in str(w.message)
+            ]
+            assert runtime_warnings == []
         finally:
             _servers.pop("test_srv", None)
 
@@ -1201,7 +1229,8 @@ class TestUtilityHandlers:
 
     def _patch_mcp_loop(self):
         """Return a patch for _run_on_mcp_loop that runs the coroutine directly."""
-        def fake_run(coro, timeout=30):
+        def fake_run(coro_or_factory, timeout=30):
+            coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
             loop = asyncio.new_event_loop()
             try:
                 return loop.run_until_complete(coro)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -937,7 +937,12 @@ def _run_on_mcp_loop(coro_or_factory, timeout: float = 30):
         raise RuntimeError("MCP event loop is not running")
 
     coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
-    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    try:
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+    except Exception:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        raise
     try:
         return future.result(timeout=timeout)
     except concurrent.futures.TimeoutError:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1833,11 +1833,18 @@ def shutdown_mcp_servers():
     with _lock:
         loop = _mcp_loop
     if loop is not None and loop.is_running():
+        shutdown_coro = _shutdown()
         try:
-            future = asyncio.run_coroutine_threadsafe(_shutdown(), loop)
-            future.result(timeout=15)
+            future = asyncio.run_coroutine_threadsafe(shutdown_coro, loop)
         except Exception as exc:
+            if asyncio.iscoroutine(shutdown_coro):
+                shutdown_coro.close()
             logger.debug("Error during MCP shutdown: %s", exc)
+        else:
+            try:
+                future.result(timeout=15)
+            except Exception as exc:
+                logger.debug("Error during MCP shutdown: %s", exc)
 
     _stop_mcp_loop()
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -70,6 +70,7 @@ Thread safety:
 """
 
 import asyncio
+import concurrent.futures
 import json
 import logging
 import math
@@ -921,14 +922,27 @@ def _ensure_mcp_loop():
         _mcp_thread.start()
 
 
-def _run_on_mcp_loop(coro, timeout: float = 30):
-    """Schedule a coroutine on the MCP event loop and block until done."""
+def _run_on_mcp_loop(coro_or_factory, timeout: float = 30):
+    """Schedule a coroutine on the MCP event loop and block until done.
+
+    Accepts either a coroutine object or a zero-arg callable that returns one.
+    Callers can pass a factory to avoid constructing coroutine objects when the
+    MCP loop is unavailable or a patched scheduler raises before awaiting.
+    """
     with _lock:
         loop = _mcp_loop
     if loop is None or not loop.is_running():
+        if asyncio.iscoroutine(coro_or_factory):
+            coro_or_factory.close()
         raise RuntimeError("MCP event loop is not running")
+
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
     future = asyncio.run_coroutine_threadsafe(coro, loop)
-    return future.result(timeout=timeout)
+    try:
+        return future.result(timeout=timeout)
+    except concurrent.futures.TimeoutError:
+        future.cancel()
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -1039,7 +1053,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             return json.dumps({"result": "\n".join(parts) if parts else ""})
 
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop(_call, timeout=tool_timeout)
         except Exception as exc:
             logger.error(
                 "MCP tool %s/%s call failed: %s",
@@ -1082,7 +1096,7 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
             return json.dumps({"resources": resources})
 
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop(_call, timeout=tool_timeout)
         except Exception as exc:
             logger.error(
                 "MCP %s/list_resources failed: %s", server_name, exc,
@@ -1124,7 +1138,7 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
             return json.dumps({"result": "\n".join(parts) if parts else ""})
 
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop(_call, timeout=tool_timeout)
         except Exception as exc:
             logger.error(
                 "MCP %s/read_resource failed: %s", server_name, exc,
@@ -1171,7 +1185,7 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
             return json.dumps({"prompts": prompts})
 
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop(_call, timeout=tool_timeout)
         except Exception as exc:
             logger.error(
                 "MCP %s/list_prompts failed: %s", server_name, exc,
@@ -1224,7 +1238,7 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
             return json.dumps(resp)
 
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop(_call, timeout=tool_timeout)
         except Exception as exc:
             logger.error(
                 "MCP %s/get_prompt failed: %s", server_name, exc,
@@ -1660,7 +1674,7 @@ def discover_mcp_tools() -> List[str]:
 
     # Per-server timeouts are handled inside _discover_and_register_server.
     # The outer timeout is generous: 120s total for parallel discovery.
-    _run_on_mcp_loop(_discover_all(), timeout=120)
+    _run_on_mcp_loop(_discover_all, timeout=120)
 
     _sync_mcp_toolsets(list(servers.keys()))
 
@@ -1774,7 +1788,7 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
         )
 
     try:
-        _run_on_mcp_loop(_probe_all(), timeout=120)
+        _run_on_mcp_loop(_probe_all, timeout=120)
     except Exception as exc:
         logger.debug("MCP probe failed: %s", exc)
     finally:


### PR DESCRIPTION
## Summary

This fixes the same coroutine-leak pattern anywhere the repo bridges sync code into an async loop with asyncio.run_coroutine_threadsafe(...).

## Changes

- close unscheduled coroutines when threadsafe scheduling fails in MCP, ACP permission/update bridges, DingTalk incoming dispatch, gateway sync-to-async callbacks, the async worker helper, and MCP shutdown
- keep the close-on-failure behavior scoped to scheduler submission failures so work already handed to the loop is left alone
- add regression tests for the ACP bridges, DingTalk incoming dispatch, MCP scheduling, and environments.patches.AsyncWorker
- clean up ACP event tests so mocked scheduler submissions do not leak coroutines themselves

## Test plan

- source venv/bin/activate && pytest tests/acp/test_permissions.py tests/acp/test_events.py tests/gateway/test_dingtalk.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_probe.py tests/test_environment_patches.py -q -W error::RuntimeWarning
- source venv/bin/activate && pytest tests/acp tests/gateway/test_dingtalk.py tests/tools -q -x