### PR TITLE
feat(slack): add reply_in_thread config option

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -252,7 +252,16 @@ class SlackAdapter(BasePlatformAdapter):
 
         Prefers metadata thread_id (the thread parent's ts, set by the
         gateway) over reply_to (which may be a child message's ts).
+
+        When reply_in_thread is disabled (via config.extra), top-level
+        channel messages receive direct channel replies. Messages that
+        originate inside an existing thread are still threaded.
         """
+        if not self.config.extra.get("reply_in_thread", True):
+            if metadata and metadata.get("thread_id"):
+                return metadata["thread_id"]
+            return None
+
         if metadata:
             if metadata.get("thread_id"):
                 return metadata["thread_id"]


### PR DESCRIPTION
## Problem

When a Hermes agent on Slack replies to a channel message, it always creates a thread reply. Many teams prefer direct channel replies — thread replies bury the bot's response and require an extra click to see.

## Solution

Add a `reply_in_thread` option (default `true` for backward compatibility) to the Slack platform config:

```yaml
platforms:
  slack:
    extra:
      reply_in_thread: false
```

When `false`, `_resolve_thread_ts()` returns `None` for top-level channel messages, so replies go directly to the channel. Messages that originate inside an existing thread are still threaded (thread context is preserved).

## Changes

- Added a 4-line guard at the top of `_resolve_thread_ts()` in `gateway/platforms/slack.py`
- Default is `true` — fully backward compatible, no behavior change unless explicitly configured

Closes #2662