### PR TITLE
feat(cli): add permissions mode label to banner and status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1349,6 +1349,8 @@ class HermesCLI:
 
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
             parts.append(duration_label)
+            if os.getenv("HERMES_YOLO_MODE"):
+                parts.append("⚠ FULL ACCESS")
             return " │ ".join(parts)
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
@@ -1404,6 +1406,11 @@ class HermesCLI:
                 ("class:status-bar-dim", " "),
                 (bar_style, percent_label),
             ]
+            if os.getenv("HERMES_YOLO_MODE"):
+                frags.extend([
+                    ("class:status-bar-dim", " │ "),
+                    ("class:status-bar-yolo", "⚠ FULL ACCESS"),
+                ])
             frags.extend([
                 ("class:status-bar-dim", " │ "),
                 ("class:status-bar-dim", duration_label),
@@ -6921,6 +6928,7 @@ class HermesCLI:
             'status-bar-warn': 'bg:#1a1a2e #FFD700 bold',
             'status-bar-bad': 'bg:#1a1a2e #FF8C00 bold',
             'status-bar-critical': 'bg:#1a1a2e #FF6B6B bold',
+            'status-bar-yolo': 'bg:#1a1a2e #FF4444 bold',
             # Bronze horizontal rules around the input area
             'input-rule': '#CD7F32',
             # Clipboard image attachment badges

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -295,6 +295,12 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         model_short = model_short[:25] + "..."
     ctx_str = f" [dim {dim}]·[/] [dim {dim}]{_format_context_length(context_length)} context[/]" if context_length else ""
     left_lines.append(f"[{accent}]{model_short}[/]{ctx_str} [dim {dim}]·[/] [dim {dim}]Nous Research[/]")
+
+    import os as _os
+    if _os.getenv("HERMES_YOLO_MODE"):
+        left_lines.append(f"[bold red]⚠ FULL ACCESS[/] [dim {dim}]— all approvals bypassed[/]")
+    else:
+        left_lines.append(f"[bold green]✓ RESTRICTED ACCESS[/] [dim {dim}]— dangerous commands require approval[/]")
     left_lines.append(f"[dim {dim}]{cwd}[/]")
     if session_id:
         left_lines.append(f"[dim {session_color}]Session: {session_id}[/]")


### PR DESCRIPTION
## Problem

When running with `--yolo`, there is no visible indication that all approval prompts are bypassed. Users may forget they launched in FULL ACCESS mode.

## Solution

Show a permanent permissions label in two places:

**Welcome banner** (below the model name):
- `⚠ FULL ACCESS` in red when `--yolo` is active
- `✓ RESTRICTED ACCESS` in green otherwise (positive confirmation)

**Status bar** (bottom of the terminal, appended after duration):
- `⚠ FULL ACCESS` in red (`#FF4444 bold`) only when `--yolo` is active — no noise in the default case

## Files changed

- `hermes_cli/banner.py` — permissions line in the welcome banner
- `cli.py` — `⚠ FULL ACCESS` fragment in `_get_status_bar_fragments()` and `_build_status_bar_text()` fallback; new `status-bar-yolo` style

## Notes

- No behavior change — purely informational display
- RESTRICTED ACCESS label shown by default gives users positive confirmation they are protected
- Label is visible from first launch and persists in the status bar throughout the session

Closes #2663