### PR TITLE
fix(config): log warning instead of silently swallowing config.yaml errors

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -515,8 +515,13 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(
+            "Failed to process config.yaml — falling back to .env / gateway.json values. "
+            "Check %s for syntax errors. Error: %s",
+            _home / "config.yaml",
+            e,
+        )
 
     config = GatewayConfig.from_dict(gw_data)
 


### PR DESCRIPTION
## What does this PR do?
Fixes a silent failure in `gateway/config.py` where the entire config.yaml processing block (lines 411-517) is wrapped in `except Exception: pass`. Any YAML syntax error, file permission issue, or unexpected data shape is silently swallowed — users see no error and have no idea why their config changes have no effect.

## Type of Change
- 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `gateway/config.py`: Replaced bare `except Exception: pass` with `except Exception as e: logger.warning(...)` that logs:
  - That config.yaml processing failed
  - The config file path to check for syntax errors
  - The actual error message
  - That the gateway is falling back to .env / gateway.json values

No new imports needed — `logger = logging.getLogger(__name__)` was already defined at the top of the file.

## How to Test
1. Introduce a syntax error in `~/.hermes/config.yaml` (e.g. add a stray `:` or unbalanced quotes)
2. Start the gateway: `hermes gateway`
3. Check logs - you should now see a warning with the file path and error details
4. Run tests: `python3 -m pytest tests/ -q`

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs
N/A — logging change, no UI impact.