### PR TITLE
fix(file_tools): pass docker_mount_cwd_to_workspace to container_config

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -114,6 +114,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "container_disk": config.get("container_disk", 51200),
                     "container_persistent": config.get("container_persistent", True),
                     "docker_volumes": config.get("docker_volumes", []),
+                    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                    "docker_forward_env": config.get("docker_forward_env", []),
                 }
 
             ssh_config = None


### PR DESCRIPTION
## Summary

Closes #2672

## Problem

`file_tools._get_file_ops()` builds a `container_config` dict when the terminal backend is Docker/Singularity/Modal/Daytona, but it was missing two keys that `terminal_tool.py` already forwarded correctly:

- `docker_mount_cwd_to_workspace` — host cwd not bind-mounted to `/workspace` in file tools (the original reported bug)
- `docker_forward_env` — host env vars not forwarded into the container for file tools

Both keys are present in `_get_env_config()` (imported from `terminal_tool`), and `_create_environment()` reads them via `cc.get()`. The gap was only in the dict construction in `file_tools`.

## Change

```python
# tools/file_tools.py
"docker_volumes": config.get("docker_volumes", []),
+"docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+"docker_forward_env": config.get("docker_forward_env", []),
```

Two lines, matching the existing pattern in `terminal_tool.py` line 960–968.