### PR TITLE
fix: Prevent memory overwrite by flush agent (add-only constraint)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -554,6 +554,11 @@ class GatewayRunner:
                 "2. If you discovered a reusable workflow or solved a non-trivial "
                 "problem, consider saving it as a skill.\n"
                 "3. If nothing is worth saving, that's fine — just skip.\n\n"
+                "IMPORTANT: Only use the 'add' action for memory. Do NOT use "
+                "'replace' or 'remove' — other sessions or cron jobs may have "
+                "updated memory since this conversation ended, and you do not have "
+                "visibility into those changes. Overwriting existing entries risks "
+                "discarding newer information.\n\n"
                 "Do NOT respond to the user. Just use the memory and skill_manage "
                 "tools if needed, then stop.]"
             )


### PR DESCRIPTION
   Fixes #2670 

   ## Summary                                                                    
                                                                                
  - Flush agent was calling `replace`/`remove` on memory entries based on stale conversation history, silently overwriting changes made by the live agent, other sessions, or cron jobs after the session ended                      
  - Restrict flush agent to `add`-only action so existing entries are never modified with stale context                                              
  - Fixes memory revert issue observed after gateway restarts and session timeouts                                                               
          
   ## Test plan
              
  - Start a session, write specific memory entries via the memory tool
  - Confirm entries persist to `~/.hermes/memories/MEMORY.md`                   
  - Restart the gateway
  - Verify entries written by the live agent are preserved after restart        

   ## Type of Change

    Bug fix (non-breaking change that fixes an issue)

   ## Changes Made

  - `gateway/run.py`: Added `add`-only constraint to the flush agent prompt in `_flush_memories_for_session()`, preventing `replace`/`remove` actions on memory entries that may have been updated since the conversation ended        
   
   ## How to Test
                                                              
  1. Start a gateway session and write specific memory entries via the memory tool - confirm they persist to `~/.hermes/memories/MEMORY.md`              
  2. Restart the gateway (`systemctl --user restart hermes-gateway`)            
  3. Check `MEMORY.md` - entries written by the live agent should be preserved, not reverted                                                                  
                                                                                