### PR TITLE
fix(vision): use sync call_llm to avoid AsyncOpenAI deadlock in gateway mode

### DIFF
--- a/tests/test_model_tools_async_bridge.py
+++ b/tests/test_model_tools_async_bridge.py
@@ -224,8 +224,7 @@ class TestVisionDispatchLoopSafety:
 
         with (
             patch(
-                "tools.vision_tools.async_call_llm",
-                new_callable=AsyncMock,
+                "tools.vision_tools.call_llm",
                 return_value=fake_response,
             ),
             patch(
@@ -268,8 +267,7 @@ class TestVisionDispatchLoopSafety:
 
         with (
             patch(
-                "tools.vision_tools.async_call_llm",
-                new_callable=AsyncMock,
+                "tools.vision_tools.call_llm",
                 return_value=fake_response,
             ),
             patch(

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -311,14 +311,14 @@ class TestErrorLoggingExcInfo:
             ),
             caplog.at_level(logging.WARNING, logger="tools.vision_tools"),
         ):
-            # Mock the async_call_llm function to return a mock response
+            # Mock the call_llm function to return a mock response
             mock_response = MagicMock()
             mock_choice = MagicMock()
             mock_choice.message.content = "A test image description"
             mock_response.choices = [mock_choice]
 
             with (
-                patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_response),
+                patch("tools.vision_tools.call_llm", return_value=mock_response),
             ):
                 # Make unlink fail to trigger cleanup warning
                 original_unlink = Path.unlink
@@ -408,8 +408,7 @@ class TestTildeExpansion:
                 return_value="data:image/png;base64,abc",
             ),
             patch(
-                "tools.vision_tools.async_call_llm",
-                new_callable=AsyncMock,
+                "tools.vision_tools.call_llm",
                 return_value=mock_response,
             ),
         ):

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -38,7 +38,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
 from urllib.parse import urlparse
 import httpx
-from agent.auxiliary_client import async_call_llm
+from agent.auxiliary_client import call_llm
 from tools.debug_helpers import DebugSession
 
 logger = logging.getLogger(__name__)
@@ -318,7 +318,7 @@ async def vision_analyze_tool(
         }
         if model:
             call_kwargs["model"] = model
-        response = await async_call_llm(**call_kwargs)
+        response = call_llm(**call_kwargs)
         
         # Extract the analysis
         analysis = response.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary

Closes #2681

## Root Cause

In gateway mode, tool handlers run in a `ThreadPoolExecutor` thread. `_run_async()` detects the running gateway event loop and spawns a fresh thread with `asyncio.run()`, creating a new event loop. `AsyncOpenAI`'s internal `httpx.AsyncClient` is cached and bound to the *previous* loop — when called from this new loop it deadlocks silently. The request never completes (timeout at 91.5s).

`_download_image()` is unaffected: it creates a fresh `httpx.AsyncClient` as a context manager each call. Only the long-lived `AsyncOpenAI` client was the problem.

## Fix

Replace `async_call_llm()` with the sync `call_llm()` for the actual LLM vision call. `vision_analyze_tool()` stays `async` for the `await _download_image()`, but the LLM call no longer touches `AsyncOpenAI` across loop boundaries.

```diff
-from agent.auxiliary_client import async_call_llm
+from agent.auxiliary_client import call_llm
 ...
-        response = await async_call_llm(**call_kwargs)
+        response = call_llm(**call_kwargs)
```

## Tests

Updated two test patches from `AsyncMock(async_call_llm)` to `MagicMock(call_llm)`. All 45 vision_tools tests pass.