### PR TITLE
fix(config): log warning instead of silently swallowing config.yaml errors

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -523,8 +523,13 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(
+            "Failed to process config.yaml — falling back to .env / gateway.json values. "
+            "Check %s for syntax errors. Error: %s",
+            _home / "config.yaml",
+            e,
+        )
 
     config = GatewayConfig.from_dict(gw_data)
 


### PR DESCRIPTION
Salvage of #2673 by @sprmn24 — cherry-picked onto current main.

Replaces bare `except Exception: pass` in `gateway/config.py` with a `logger.warning()` that logs the config file path, the error, and that the gateway is falling back to .env / gateway.json values. No new imports needed (`logger` already existed).

Original PR: #2673