### PR TITLE
fix(security): prevent shell injection in _expand_path via ~user path suffix

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -433,9 +433,13 @@ class ShellFileOperations(FileOperations):
                 slash_idx = rest.find('/')
                 username = rest[:slash_idx] if slash_idx >= 0 else rest
                 if username and re.fullmatch(r'[a-zA-Z0-9._-]+', username):
-                    expand_result = self._exec(f"echo {path}")
+                    # Only expand ~username (not the full path) to avoid shell
+                    # injection via path suffixes like "~user/$(malicious)".
+                    expand_result = self._exec(f"echo ~{username}")
                     if expand_result.exit_code == 0 and expand_result.stdout.strip():
-                        return expand_result.stdout.strip()
+                        user_home = expand_result.stdout.strip()
+                        suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
+                        return user_home + suffix
         
         return path
     


### PR DESCRIPTION
Salvage of PR #2047 by @Gutslabs — cherry-picked with authorship preserved.

## What

`_expand_path()` passed the full unquoted path to `echo` via shell when handling `~username/...` paths. The username was validated with regex, but the **path suffix** was not — allowing command substitution in the suffix.

**Before:** `echo ~root/$(id)` → shell executes `$(id)`
**After:** `echo ~root` → get home dir, then append `/$(id)` as plain string in Python

All `~` expansion still works identically for legitimate paths:
- `~` → $HOME
- `~/foo` → $HOME/foo
- `~root/foo` → /root/foo (expanded safely)

## Test plan
- 6044 tests pass, 0 failures