### PR TITLE
feat(skills): add html5-canvas-game-dev skill

### DIFF
--- a/skills/gaming/html5-canvas-game-dev/SKILL.md
+++ b/skills/gaming/html5-canvas-game-dev/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: html5-canvas-game-dev
+description: >
+  Build single-file HTML5 canvas games. Covers survivor shooters,
+  artillery/Worms games, shop and perk systems, Web Audio sound,
+  mathematical progression, and roguelite design. Patterns from
+  real community-built games using Hermes Agent.
+version: 2.0.0
+license: MIT
+tags: [gamedev, html5, canvas, javascript, game-design, web-audio, worms, artillery]
+metadata:
+  hermes:
+    category: gaming
+    triggers:
+      - html game
+      - canvas game
+      - browser game
+      - shoot em up
+      - brotato
+      - worms game
+      - artillery game
+      - turn based game
+      - game balance
+      - web audio sounds
+---
+
+# HTML5 Canvas Game Development
+
+Patterns for building single-file HTML5 canvas games. No build tools,
+no dependencies — everything in one .html file.
+
+For detailed code snippets, see [references/code-patterns.md](references/code-patterns.md).
+
+---
+
+## 1. Architecture
+
+Single HTML file with: `<style>` (overlays), `<canvas>`, `<script>` (everything).
+
+Game state machine (survivor):
+```
+breedSelect → playing → shop → playing → ... → boss → victory → newRun
+                ↓                                                  ↓
+             gameOver → restart → breedSelect              breedSelect
+```
+
+Game state machine (artillery/turn-based):
+```
+lobby → teamSelect → myTurn ↔ theirTurn → gameOver
+```
+
+Key principle: Use delta time (`dt`) for ALL movement and timers.
+`entity.x += speed * dt` — never assume a fixed frame rate.
+
+---
+
+## 2. Projectile Systems
+
+Every projectile is an object in a `projectiles[]` array.
+
+Base properties: x, y, vx, vy, damage, range, distance, radius,
+pierce, bounce, knockback, slow, weaponType, explosive, expSize.
+
+Special behaviors (checked each frame):
+
+| Mechanic | Summary |
+|----------|---------|
+| Pierce | `p.pierce--` on hit; remove at `< 0` |
+| Bounce | Flip velocity on wall; `p.bounce--` |
+| Homing | Steer toward nearest enemy |
+| Gravity | `p.vy += gravity * dt` (arcs, cannons) |
+| Boomerang | Decelerate, reverse, catch on return |
+| Ricochet | Redirect toward next enemy after hit |
+| Fire Zone | Create persistent AoE on impact |
+| Spin-up | Ramp fire rate from 30%→100% over time |
+| KB Cap | Only strongest knockback per enemy per frame |
+| Wind | `p.vx += wind * strength * dt` (artillery) |
+| Charge | Hold to charge power, release to fire |
+
+See code-patterns.md for full implementations.
+
+---
+
+## 3. Enemy AI Patterns
+
+Common types:
+- **Melee**: Walk toward player, attack on timer at melee range
+- **Ranged**: Approach to preferred distance, shoot, retreat if too close
+- **Rush**: Wobble movement with sin() offset, speed burst when close
+- **Splitter**: On death spawn N smaller enemies (use pendingSpawns array)
+- **Tank**: Slow, high HP, knockback resistant
+- **Explosive**: Approach → windup telegraph → dodgeable dash
+
+Dodge system: Check at EVERY damage source. Show "DODGE!" text feedback.
+Players won't know the stat works without visible confirmation.
+
+Collision fix: Push enemies out when overlapping player body.
+
+---
+
+## 4. Mathematical Progression
+
+Five systems for organic, non-linear game feel:
+
+| System | Purpose | Formula |
+|--------|---------|---------|
+| Golden Ratio (φ) | Economy scaling | `cost = base * φ^count` |
+| Sinusoidal Waves | Spawn rhythm | `\|sin(N*π*t)\|^3` = N surge humps |
+| Logistic Map | Chaos at high diff | `x = r*x*(1-x)`, r > 3.57 = chaos |
+| Prime Factorization | Mutation combos | Each prime = mutation type |
+| Harmonic Series | Diminishing returns | `value = base / (1 + count)` |
+
+Golden ratio drives costs UP, harmonic drives value DOWN. Together
+they create a natural soft cap — buying more is always possible but
+increasingly inefficient.
+
+Wave spawning: Use TIME-based progress (waveTimer/waveDuration), not
+enemy count. This makes rhythm predictable regardless of kill speed.
+
+---
+
+## 5. Sound Design (Web Audio API)
+
+No audio files needed. Oscillator + gain envelope = full sound library.
+
+Rules of thumb:
+- Positive events: ASCENDING frequency (coins, kills, victory)
+- Negative events: DESCENDING frequency (hurt, death)
+- Impact events: Start LOUD, decay fast
+- Frequent sounds: 0.03-0.1s. Rare sounds: 0.3-1s
+- Throttle rapid sounds to prevent audio overload
+
+Pitch-scaling pickups: Rapid coin collection raises pitch (+30hz per
+pickup, cap at +400hz, reset after 0.4s gap). Sells the "vacuum" feel.
+
+Catch sounds: When a boomerang returns, play a short ascending click
+(800→1100hz, 0.07s). Validates the mechanic — players feel the catch.
+
+Easter eggs: Buffer keystrokes during specific states. Trigger on
+secret word match. Show brief visual confirmation.
+
+---
+
+## 6. Shop / Perk Systems
+
+Shop flow: Wave ends → open shop → buy/sell/refresh/lock → next wave.
+
+Perk gating: Higher ranks unlock at later waves.
+Duplicate protection: `ownedPerkKeys` Set.
+Pity system: Force high-rank after N low shops.
+
+### Perk Taxonomy (complete survivor game needs ALL of these)
+
+| Category | Examples |
+|----------|---------|
+| Offense | damage, crit chance, crit damage, fire rate |
+| Defense | max HP, regen, dodge, armor (flat reduction) |
+| Sustain | lifesteal (heal % of damage dealt) |
+| Shield | triggered shield at low HP with cooldown |
+| Thorns | reflect damage on melee hit |
+| Utility | speed, luck, magnet, projectile bounce |
+| Economy | passive coin gen, shop discount |
+| Risk/Reward | trade HP for coins, conditional damage bonus |
+| Legendary | build-defining uniques (1 per run) |
+
+### Key Design Patterns
+
+**Immediate-effect perks**: Not all perks are passive. Some trigger on
+purchase (e.g., lose 10% max HP, gain 50 coins NOW). Show both the
+gain and loss as floating damage text — player must see the tradeoff.
+
+**Conditional damage (Leverage)**: +60% damage above 80% HP, -20% below
+40%. Creates synergy trees: leverage + lifesteal = stay topped off.
+
+**Repeatable perks**: When all uniques exhausted, offer stackable perks
+with golden ratio costs and harmonic diminishing returns.
+
+### Perk Display: Sticker Collage
+
+Render perks as colored badge stickers. Under 8 perks: clean stack.
+8+ perks: "collage mode" with deterministic random rotations and
+overlapping like a poster board. Higher rank = slightly bigger + higher
+z-index. Rank 5 gets a glow animation.
+
+---
+
+## 7. Roguelite Progression
+
+**Victory carryover** (beating the boss):
+- Save 10% of coins (rounded up)
+- Carry weakest weapon (reset to level 1)
+- Carry all perks
+- Increment difficulty
+
+**Death** = lose everything, reset to difficulty 1.
+
+**Weapon graduation**: After difficulty N, remove starter weapon from
+shop. Player has outgrown it. Keeps shop interesting.
+
+---
+
+## 8. Worms / Artillery Games (Turn-Based)
+
+Turn system: 40-second timer + move budget (800 units per turn).
+End turn on timer expiry, manual button, or after projectile lands.
+
+Core mechanics:
+- **Aim**: Arrow keys rotate aim angle (clamp to upward arc)
+- **Charge-to-fire**: Hold Space to charge power (0-100%), release to fire
+- **Wind**: Random per turn, affects horizontal velocity
+- **Trajectory**: Gravity pulls down, wind pushes sideways
+- **Destructible terrain**: Heightmap array, lower values in blast radius
+- **Limited ammo**: Infinite fallback weapon + limited special weapons
+
+Multiplayer: WebSocket or Supabase realtime for turn sync. Support
+guest login + social auth. Private game links via UUID room codes.
+Global leaderboard with win/loss tracking.
+
+---
+
+## 9. Balance
+
+DPS = damage × fireRate. Account for pierce, pellets, splash.
+Per upgrade level: damage × 1.25, fireRate × 1.12.
+
+Red flags:
+- Any weapon > 2x DPS of same tier = nerf it
+- Zero downsides + top DPS = broken
+- "Fun but weak" beats "boring but strong"
+
+Difficulty scaling (use multiple levers):
+- HP: linear (main lever)
+- Speed: logarithmic `speed * (1 + log(diff) * 0.08)`
+- Damage: logarithmic `damage * (1 + log(diff) * 0.12)`
+
+---
+
+## 10. Community Showcase
+
+Games built with Hermes Agent and these patterns:
+
+**HODL OR DIE (BrotherDoge)** — @123mikeyd
+Brotato-style survival shooter. Dogecoin themed. Wave-based with
+shop system, 11 weapons, 40+ perks, boss battles, roguelite
+carryover, sticker perk collage, degen easter egg.
+https://github.com/123mikeyd/Brother_Doge_VideoGame
+
+**WAR_V3_FINALE** — @javierblez
+Worms-style 2D artillery. Built in 2.5 hours with Hermes Agent.
+Turn-based with wind, destructible terrain, 4 weapons, multiplayer
+matchmaking, leaderboards, and private game links.
+https://warv3finale.com

--- a/skills/gaming/html5-canvas-game-dev/references/code-patterns.md
+++ b/skills/gaming/html5-canvas-game-dev/references/code-patterns.md
@@ -1,0 +1,242 @@
+# Code Patterns Reference
+
+Detailed code snippets for HTML5 canvas game systems.
+Load this when implementing specific mechanics.
+
+## Projectile Specials
+
+### Knockback Cap (prevents shotgun pellet teleport)
+```javascript
+enemy._frameKB = 0; // reset each frame
+if (kbStrength > enemy._frameKB) {
+    if (enemy._frameKB) { enemy.x -= enemy._frameKBx; enemy.y -= enemy._frameKBy; }
+    enemy.x += kbX; enemy.y += kbY;
+    enemy._frameKB = kbStrength;
+    enemy._frameKBx = kbX; enemy._frameKBy = kbY;
+}
+```
+
+### Boomerang
+```javascript
+if (!p.returning && p.distance > p.range * 0.5) p.returning = true;
+if (p.returning) {
+    const dx = player.x - p.x, dy = player.y - p.y;
+    const d = Math.sqrt(dx*dx + dy*dy);
+    if (d < 25) { p.pierce = -1; playSound('boomerangCatch'); }
+    else {
+        p.vx = (dx/d) * returnSpeed;
+        p.vy = (dy/d) * returnSpeed;
+        p.distance -= returnSpeed * dt;
+    }
+} else { p.vx *= 0.97; p.vy *= 0.97; }
+```
+
+### Ricochet
+```javascript
+if (player.ricochet && p.pierce >= 0) {
+    let nearest = null, bestDist = 200;
+    enemies.forEach(e => {
+        if (e === hitEnemy) return;
+        const d = dist(e, p);
+        if (d < bestDist) { bestDist = d; nearest = e; }
+    });
+    if (nearest) {
+        const a = Math.atan2(nearest.y - p.y, nearest.x - p.x);
+        const spd = Math.sqrt(p.vx*p.vx + p.vy*p.vy);
+        p.vx = Math.cos(a) * spd; p.vy = Math.sin(a) * spd;
+    }
+}
+```
+
+## Math Systems
+
+### Golden Ratio Cost Scaling
+```javascript
+const PHI = 1.618033988749895;
+function goldenCost(baseCost, count) {
+    return Math.round(baseCost * Math.pow(PHI, count));
+}
+```
+
+### Sinusoidal Wave Spawn Curve (Wave N = N surges)
+```javascript
+function waveSpawnCurve(t, waveNum) {
+    const n = Math.max(1, waveNum);
+    const raw = Math.pow(Math.abs(Math.sin(n * Math.PI * t)), 3);
+    const floor = 0.05;
+    return floor + raw * (1 - floor);
+}
+// Use time-based progress: waveTimer / waveDuration
+```
+
+### Logistic Map (chaos at high difficulty)
+```javascript
+function logisticMap(x, r) { return r * x * (1 - x); }
+const chaosR = Math.min(3.95, 2.5 + difficulty * 0.18);
+chaosX = logisticMap(chaosX, chaosR);
+```
+
+### Prime Factorization (mutation fingerprints)
+```javascript
+function primeFactorize(n) {
+    const factors = {};
+    for (let d = 2; d * d <= n; d++) {
+        while (n % d === 0) { factors[d] = (factors[d] || 0) + 1; n /= d; }
+    }
+    if (n > 1) factors[n] = 1;
+    return factors;
+}
+// 2=Swarm, 3=Armored, 5=Volatile, 7=PackHunter, 11=Regen, 13=Phasing
+```
+
+### Harmonic Diminishing Returns
+```javascript
+function harmonicValue(baseValue, count) {
+    return baseValue / (1 + count);
+}
+```
+
+## Perk Implementation Patterns
+
+### Fire Rate Bonus
+```javascript
+if (player.fireRateBonus > 0) fireRate *= (1 + player.fireRateBonus);
+```
+
+### Lifesteal
+```javascript
+if (player.lifesteal > 0) {
+    player.health = Math.min(player.maxHealth, player.health + damage * player.lifesteal);
+}
+```
+
+### Armor + Thorns (in damage-receiving code)
+```javascript
+if (player.armor > 0) damage = Math.max(1, damage - player.armor);
+player.health -= damage;
+if (player.thorns > 0) { enemy.health -= player.thorns; }
+```
+
+### Leverage (conditional damage at projectile hit)
+```javascript
+if (player.leverage) {
+    const ratio = player.health / player.maxHealth;
+    if (ratio > 0.8) damage *= 1.6;
+    else if (ratio < 0.4) damage *= 0.8;
+}
+```
+
+### Triggered Shield (FOMO Shield)
+```javascript
+// In update loop:
+if (player.fomoShield && player.fomoShieldHP <= 0 && player.fomoShieldCooldown <= 0) {
+    if (player.health < player.maxHealth * 0.25) {
+        player.fomoShieldHP = 50; player.fomoShieldCooldown = 60;
+    }
+}
+// In damage code: absorb from shield HP before player HP
+```
+
+### Immediate Trade Perk (HP for coins)
+```javascript
+const hpLoss = Math.floor(player.maxHealth * 0.1);
+player.maxHealth -= hpLoss;
+if (player.health > player.maxHealth) player.health = player.maxHealth;
+coins += 50;
+spawnDamageText(player.x, player.y - 30, '+50🪙', '#ffd700', false);
+spawnDamageText(player.x, player.y - 10, `-${hpLoss}❤️`, '#ff4444', false);
+```
+
+### Shop Discount
+```javascript
+const discount = 1 - (player.shopDiscount || 0);
+return Math.round(basePrice * discount);
+```
+
+### Passive Coin Generation
+```javascript
+if (player.coinGen > 0) {
+    player.coinGenTimer += dt;
+    if (player.coinGenTimer >= 3) { player.coinGenTimer -= 3; coins += player.coinGen; }
+}
+```
+
+## Sticker/Badge Perk Display (collage mode at 8+ perks)
+```javascript
+const isCollage = player.perks.length >= 8;
+hud.className = isCollage ? 'collage' : 'clean';
+entries.forEach(([label, data], i) => {
+    let style = '';
+    if (isCollage) {
+        const seed = (i * 7 + data.rank * 13) % 30;
+        const rotation = (seed - 15) * 1.2;
+        const scale = 0.9 + (data.rank / 5) * 0.2;
+        const zIndex = data.rank * 10 + (entries.length - i);
+        style = `transform:rotate(${rotation}deg) scale(${scale}); z-index:${zIndex};`;
+    }
+    html += `<div class="perk-sticker rank-${data.rank}" style="${style}">${label}</div>`;
+});
+```
+
+## Roguelite Carryover (victory only, death = lose all)
+```javascript
+// In victory():
+pendingCarryCoins = Math.ceil(coins * 0.1);
+pendingCarryWeapon = findWeakestWeapon(); // lowest tier, then lowest level, reset to lvl 1
+// In selectBreed():
+if (pendingCarryWeapon) player.weapons = [pendingCarryWeapon]; else defaultWeapon;
+if (pendingCarryCoins > 0) coins = pendingCarryCoins;
+// In restartGame() (death): clear both + reset difficulty
+```
+
+## Worms Artillery Patterns
+
+### Trajectory with Wind
+```javascript
+p.vx += wind * windStrength * dt;
+p.vy += gravity * dt;
+p.x += p.vx * dt;
+p.y += p.vy * dt;
+```
+
+### Charge-to-Fire
+```javascript
+// Space down: startCharge = Date.now()
+// Space up:
+const power = Math.min(1, (Date.now() - startCharge) / 3000);
+const speed = 200 + power * 800;
+// Launch at aimAngle with speed
+```
+
+### Destructible Terrain (heightmap)
+```javascript
+function destroyTerrain(cx, cy, radius) {
+    for (let x = cx - radius; x <= cx + radius; x++) {
+        const dist = Math.abs(x - cx);
+        const depth = Math.sqrt(radius * radius - dist * dist);
+        terrain[x] = Math.max(terrain[x], cy + depth);
+    }
+}
+```
+
+## Sound Design
+
+### Pitch-Scaling Coin Pickups
+```javascript
+let coinStreakCount = 0, coinStreakTimer = 0;
+// On coin pickup:
+coinStreakCount++;
+coinStreakTimer = 0.4;
+const pitchBoost = Math.min(400, coinStreakCount * 30);
+osc.frequency.setValueAtTime(1200 + pitchBoost, t);
+// In update: if (coinStreakTimer <= 0) coinStreakCount = 0;
+```
+
+### Easter Egg Key Buffer
+```javascript
+let secretBuffer = '';
+// In keydown during specific gameState:
+secretBuffer += e.key.toLowerCase();
+if (secretBuffer.length > 10) secretBuffer = secretBuffer.slice(-10);
+if (secretBuffer.endsWith('secretword')) { /* activate */ }
+```


### PR DESCRIPTION
## New Skill: html5-canvas-game-dev

Community-built skill for single-file HTML5 canvas games. Developed over multiple sessions while building actual games with Hermes Agent.

### What it covers
- Single-file architecture (no build tools, no dependencies)
- Survivor shooters (Brotato-style wave-based)
- Worms-style artillery (turn-based, wind, destructible terrain)
- Projectile systems (12 mechanics: pierce, bounce, homing, boomerang, ricochet, etc.)
- Mathematical progression (golden ratio, sinusoidal waves, logistic map, prime factorization)
- Web Audio synth sound design (no audio files needed)
- Shop, perk, and upgrade systems with full perk taxonomy
- Roguelite progression (carryover, weapon graduation)
- Balance methodology

### Structure
```
skills/gaming/html5-canvas-game-dev/
├── SKILL.md                      (252 lines — overview + patterns)
└── references/
    └── code-patterns.md          (242 lines — implementation details)
```

Follows the agentskills.io spec: under 500 lines in SKILL.md, code moved to references for progressive disclosure, proper frontmatter with triggers.

### Community showcase
Includes examples of games built with Hermes Agent using these patterns:
- **HODL OR DIE** by @123mikeyd — Brotato-style survivor shooter (github.com/123mikeyd/Brother_Doge_VideoGame)
- **WAR_V3_FINALE** by @javierblez — Worms-style artillery game built in 2.5 hours (warv3finale.com)

### Why add this
Gamedev is one of the most popular use cases for vibe coding with AI agents. This skill gives Hermes the context to help users build browser games without hallucinating patterns — every technique here was tested in a real shipped game.