### PR TITLE
fix(security): image format validation with magic bytes, size limits, and SVG blocking

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -57,13 +57,35 @@ def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
     """
     Save raw image bytes to the cache and return the absolute file path.
 
+    Validates that the data is a real image (magic-byte check) and enforces
+    a size limit before writing to disk.
+
     Args:
         data: Raw image bytes.
         ext:  File extension including the dot (e.g. ".jpg", ".png").
 
     Returns:
         Absolute path to the cached image file as a string.
+
+    Raises:
+        ValueError: If the data is not a recognized image or exceeds size limit.
     """
+    from tools.image_safety import MAX_IMAGE_SIZE_BYTES, _ALLOWED_IMAGE_MIMES
+
+    if len(data) > MAX_IMAGE_SIZE_BYTES:
+        raise ValueError(f"Image too large ({len(data) / 1024 / 1024:.1f} MB)")
+
+    # Validate magic bytes before writing to disk
+    try:
+        import filetype
+        kind = filetype.match(data)
+        if kind is None or kind.mime not in _ALLOWED_IMAGE_MIMES:
+            detected = kind.mime if kind else "unknown"
+            logger.warning("Rejected non-image from cache: detected %s", detected)
+            raise ValueError(f"Not a valid image (detected: {detected})")
+    except ImportError:
+        pass  # filetype not available — write as-is
+
     cache_dir = get_image_cache_dir()
     filename = f"img_{uuid.uuid4().hex[:12]}{ext}"
     filepath = cache_dir / filename
@@ -75,7 +97,8 @@ async def cache_image_from_url(url: str, ext: str = ".jpg") -> str:
     """
     Download an image from a URL and save it to the local cache.
 
-    Uses httpx for async download with a reasonable timeout.
+    Validates the URL against SSRF, checks size, and verifies the
+    downloaded content is a real image before caching.
 
     Args:
         url: The HTTP/HTTPS URL to download from.
@@ -83,8 +106,15 @@ async def cache_image_from_url(url: str, ext: str = ".jpg") -> str:
 
     Returns:
         Absolute path to the cached image file as a string.
+
+    Raises:
+        ValueError: If the URL is blocked (SSRF) or content is not a valid image.
     """
     import httpx
+    from tools.url_safety import is_safe_url
+
+    if not is_safe_url(url):
+        raise ValueError(f"Blocked: URL targets a private or internal address")
 
     async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
         response = await client.get(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
   "firecrawl-py",
   "parallel-web>=0.4.2",
   "fal-client",
+  # Image format validation (magic-byte detection, pure Python)
+  "filetype>=1.2.0",
   # Text-to-speech (Edge TTS is free, no API key needed)
   "edge-tts",
   "faster-whisper>=1.0.0",

--- a/tests/tools/test_image_safety.py
+++ b/tests/tools/test_image_safety.py
@@ -1,0 +1,180 @@
+"""Tests for tools/image_safety.py — image format validation and size limits."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tools.image_safety import (
+    MAX_IMAGE_SIZE_BYTES,
+    validate_image_file,
+    check_content_length,
+    get_real_mime_type,
+)
+
+
+@pytest.fixture
+def tmp_dir(tmp_path):
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Magic bytes validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateImageFile:
+    def test_real_jpeg(self, tmp_dir):
+        f = tmp_dir / "real.jpg"
+        f.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+        ok, err, mime = validate_image_file(f)
+        assert ok is True
+        assert mime == "image/jpeg"
+
+    def test_real_png(self, tmp_dir):
+        f = tmp_dir / "real.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+        ok, err, mime = validate_image_file(f)
+        assert ok is True
+        assert mime == "image/png"
+
+    def test_real_gif(self, tmp_dir):
+        f = tmp_dir / "real.gif"
+        f.write_bytes(b"GIF89a" + b"\x00" * 100)
+        ok, err, mime = validate_image_file(f)
+        assert ok is True
+        assert mime == "image/gif"
+
+    def test_real_webp(self, tmp_dir):
+        f = tmp_dir / "real.webp"
+        # WebP needs proper RIFF container with VP8 chunk
+        f.write_bytes(b"RIFF\x24\x00\x00\x00WEBPVP8 \x18\x00\x00\x00" + b"\x00" * 100)
+        ok, err, mime = validate_image_file(f)
+        assert ok is True
+        assert mime == "image/webp"
+
+    def test_fake_jpeg_html(self, tmp_dir):
+        """A .jpg file that is actually HTML should be rejected."""
+        f = tmp_dir / "fake.jpg"
+        f.write_bytes(b"<html><script>alert(1)</script></html>")
+        ok, err, mime = validate_image_file(f)
+        assert ok is False
+        assert "not a recognized image" in err.lower() or "not an image" in err.lower()
+
+    def test_fake_jpeg_executable(self, tmp_dir):
+        """A .jpg file that is actually an ELF binary should be rejected."""
+        f = tmp_dir / "fake.jpg"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        ok, err, mime = validate_image_file(f)
+        assert ok is False
+
+    def test_fake_png_pdf(self, tmp_dir):
+        """A .png file that is actually a PDF should be rejected."""
+        f = tmp_dir / "fake.png"
+        f.write_bytes(b"%PDF-1.4" + b"\x00" * 100)
+        ok, err, mime = validate_image_file(f)
+        assert ok is False
+        assert "not an image" in err.lower()
+
+    def test_svg_blocked(self, tmp_dir):
+        """SVG files should be blocked (can contain scripts)."""
+        f = tmp_dir / "test.svg"
+        f.write_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>')
+        ok, err, mime = validate_image_file(f)
+        assert ok is False
+        assert "svg" in err.lower()
+
+    def test_svgz_blocked(self, tmp_dir):
+        """Compressed SVG should also be blocked."""
+        f = tmp_dir / "test.svgz"
+        f.write_bytes(b"\x1f\x8b" + b"\x00" * 50)  # gzip header
+        ok, err, mime = validate_image_file(f)
+        assert ok is False
+        assert "svg" in err.lower()
+
+    def test_empty_file(self, tmp_dir):
+        f = tmp_dir / "empty.jpg"
+        f.write_bytes(b"")
+        ok, err, mime = validate_image_file(f)
+        assert ok is False
+        assert "empty" in err.lower()
+
+    def test_missing_file(self, tmp_dir):
+        f = tmp_dir / "nonexistent.jpg"
+        ok, err, mime = validate_image_file(f)
+        assert ok is False
+        assert "not found" in err.lower()
+
+    def test_oversized_file(self, tmp_dir):
+        """Files exceeding MAX_IMAGE_SIZE_BYTES should be rejected."""
+        f = tmp_dir / "huge.jpg"
+        # Write just enough to exceed limit (header check only, not full 20MB)
+        f.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+        # Fake the size by checking the constant
+        assert MAX_IMAGE_SIZE_BYTES == 20 * 1024 * 1024
+
+    def test_random_bytes(self, tmp_dir):
+        """Random bytes that don't match any format should be rejected."""
+        f = tmp_dir / "random.jpg"
+        f.write_bytes(bytes(range(256)) * 4)
+        ok, err, mime = validate_image_file(f)
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Content-Length pre-flight check
+# ---------------------------------------------------------------------------
+
+
+class TestCheckContentLength:
+    def test_small_file(self):
+        ok, err = check_content_length(1024)
+        assert ok is True
+
+    def test_at_limit(self):
+        ok, err = check_content_length(MAX_IMAGE_SIZE_BYTES)
+        assert ok is True
+
+    def test_over_limit(self):
+        ok, err = check_content_length(MAX_IMAGE_SIZE_BYTES + 1)
+        assert ok is False
+        assert "too large" in err.lower()
+
+    def test_none_allows(self):
+        """Unknown Content-Length should be allowed (checked after download)."""
+        ok, err = check_content_length(None)
+        assert ok is True
+
+    def test_zero(self):
+        ok, err = check_content_length(0)
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# MIME type detection
+# ---------------------------------------------------------------------------
+
+
+class TestGetRealMimeType:
+    def test_jpeg(self, tmp_dir):
+        f = tmp_dir / "test.jpg"
+        f.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+        assert get_real_mime_type(f) == "image/jpeg"
+
+    def test_png(self, tmp_dir):
+        f = tmp_dir / "test.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+        assert get_real_mime_type(f) == "image/png"
+
+    def test_wrong_extension(self, tmp_dir):
+        """A .png file with JPEG magic bytes should return image/jpeg."""
+        f = tmp_dir / "misleading.png"
+        f.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+        assert get_real_mime_type(f) == "image/jpeg"
+
+    def test_fallback_on_unknown(self, tmp_dir):
+        """Unknown content falls back to extension-based detection."""
+        f = tmp_dir / "unknown.webp"
+        f.write_bytes(b"not real webp content but has extension")
+        mime = get_real_mime_type(f)
+        assert mime == "image/webp"  # extension fallback

--- a/tests/tools/test_image_safety.py
+++ b/tests/tools/test_image_safety.py
@@ -107,11 +107,14 @@ class TestValidateImageFile:
 
     def test_oversized_file(self, tmp_dir):
         """Files exceeding MAX_IMAGE_SIZE_BYTES should be rejected."""
+        from unittest.mock import patch
         f = tmp_dir / "huge.jpg"
-        # Write just enough to exceed limit (header check only, not full 20MB)
         f.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
-        # Fake the size by checking the constant
-        assert MAX_IMAGE_SIZE_BYTES == 20 * 1024 * 1024
+        # Temporarily lower the limit to test rejection without writing 20MB
+        with patch("tools.image_safety.MAX_IMAGE_SIZE_BYTES", 50):
+            ok, err, mime = validate_image_file(f)
+            assert ok is False
+            assert "too large" in err.lower()
 
     def test_random_bytes(self, tmp_dir):
         """Random bytes that don't match any format should be rejected."""

--- a/tools/image_safety.py
+++ b/tools/image_safety.py
@@ -1,0 +1,128 @@
+"""Image safety checks — validates file format and enforces size limits.
+
+Prevents:
+  - Fake images: files with image extensions but non-image content (HTML, scripts, executables)
+  - Oversized files: large downloads that could exhaust memory or disk
+  - SVG with embedded scripts: SVG can contain <script>, <iframe>, event handlers
+
+Uses the `filetype` library for magic-byte detection (pure Python, no system deps).
+Falls back to extension-based detection if filetype is unavailable.
+"""
+
+import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Maximum image file size (20 MB)
+MAX_IMAGE_SIZE_BYTES = 20 * 1024 * 1024
+
+# Allowed image MIME types (magic-byte verified)
+_ALLOWED_IMAGE_MIMES = frozenset({
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+    "image/bmp",
+    "image/tiff",
+})
+
+# SVG is text-based and can contain scripts — blocked by default
+_SVG_EXTENSIONS = frozenset({".svg", ".svgz"})
+
+
+def validate_image_file(path: Path) -> Tuple[bool, str, Optional[str]]:
+    """Validate that a file is a real image with an allowed format.
+
+    Args:
+        path: Path to the downloaded image file.
+
+    Returns:
+        (is_valid, error_message, detected_mime)
+        - is_valid: True if the file is a safe image
+        - error_message: empty string if valid, description of problem if not
+        - detected_mime: the real MIME type detected from content, or None
+    """
+    if not path.is_file():
+        return False, "File not found", None
+
+    # Check file size
+    size = path.stat().st_size
+    if size == 0:
+        return False, "File is empty (0 bytes)", None
+    if size > MAX_IMAGE_SIZE_BYTES:
+        size_mb = size / (1024 * 1024)
+        limit_mb = MAX_IMAGE_SIZE_BYTES / (1024 * 1024)
+        return False, f"File too large ({size_mb:.1f} MB, limit {limit_mb:.0f} MB)", None
+
+    # Block SVG by extension (SVG is text-based, filetype can't detect it via magic bytes)
+    if path.suffix.lower() in _SVG_EXTENSIONS:
+        return False, "SVG files are not supported (may contain embedded scripts)", None
+
+    # Detect real file type from magic bytes
+    try:
+        import filetype
+        kind = filetype.guess(str(path))
+        if kind is None:
+            return False, "Unable to detect file type — not a recognized image format", None
+        if kind.mime not in _ALLOWED_IMAGE_MIMES:
+            return False, f"Not an image file (detected: {kind.mime})", kind.mime
+        return True, "", kind.mime
+    except ImportError:
+        # filetype not installed — fall back to extension check with warning
+        logger.warning("filetype library not available — using extension-based image validation only")
+        return _fallback_extension_check(path)
+    except Exception as e:
+        logger.warning("Image validation error: %s", e)
+        return False, f"Image validation failed: {e}", None
+
+
+def check_content_length(content_length: Optional[int]) -> Tuple[bool, str]:
+    """Pre-flight check on Content-Length header before downloading.
+
+    Args:
+        content_length: Value from the Content-Length HTTP header, or None.
+
+    Returns:
+        (is_ok, error_message)
+    """
+    if content_length is None:
+        return True, ""  # Unknown size — proceed and check after download
+    if content_length > MAX_IMAGE_SIZE_BYTES:
+        size_mb = content_length / (1024 * 1024)
+        limit_mb = MAX_IMAGE_SIZE_BYTES / (1024 * 1024)
+        return False, f"Image too large ({size_mb:.1f} MB, limit {limit_mb:.0f} MB)"
+    return True, ""
+
+
+def get_real_mime_type(path: Path) -> str:
+    """Detect the real MIME type from file content, not extension.
+
+    Falls back to extension-based detection if filetype is unavailable.
+    """
+    try:
+        import filetype
+        kind = filetype.guess(str(path))
+        if kind and kind.mime.startswith("image/"):
+            return kind.mime
+    except (ImportError, Exception):
+        pass
+
+    # Fallback: extension-based
+    ext_map = {
+        ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+        ".png": "image/png", ".gif": "image/gif",
+        ".webp": "image/webp", ".bmp": "image/bmp",
+        ".tiff": "image/tiff", ".tif": "image/tiff",
+    }
+    return ext_map.get(path.suffix.lower(), "image/jpeg")
+
+
+def _fallback_extension_check(path: Path) -> Tuple[bool, str, Optional[str]]:
+    """Extension-only validation when filetype library is not available."""
+    allowed_extensions = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff", ".tif"}
+    ext = path.suffix.lower()
+    if ext not in allowed_extensions:
+        return False, f"Unsupported image extension: {ext}", None
+    return True, "", None

--- a/tools/image_safety.py
+++ b/tools/image_safety.py
@@ -26,6 +26,9 @@ _ALLOWED_IMAGE_MIMES = frozenset({
     "image/webp",
     "image/bmp",
     "image/tiff",
+    "image/heic",       # iPhone default camera format
+    "image/heif",       # HEIF container (related to HEIC)
+    "image/avif",       # Next-gen format (Chrome, Firefox)
 })
 
 # SVG is text-based and can contain scripts — blocked by default
@@ -114,6 +117,8 @@ def get_real_mime_type(path: Path) -> str:
         ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
         ".png": "image/png", ".gif": "image/gif",
         ".webp": "image/webp", ".bmp": "image/bmp",
+        ".heic": "image/heic", ".heif": "image/heif",
+        ".avif": "image/avif",
         ".tiff": "image/tiff", ".tif": "image/tiff",
     }
     return ext_map.get(path.suffix.lower(), "image/jpeg")
@@ -121,7 +126,7 @@ def get_real_mime_type(path: Path) -> str:
 
 def _fallback_extension_check(path: Path) -> Tuple[bool, str, Optional[str]]:
     """Extension-only validation when filetype library is not available."""
-    allowed_extensions = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff", ".tif"}
+    allowed_extensions = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff", ".tif", ".heic", ".heif", ".avif"}
     ext = path.suffix.lower()
     if ext not in allowed_extensions:
         return False, f"Unsupported image extension: {ext}", None

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -281,7 +281,11 @@ async def vision_analyze_tool(
         # Determine if this is a local file path or a remote URL
         local_path = Path(os.path.expanduser(image_url))
         if local_path.is_file():
-            # Local file path (e.g. from platform image cache) -- skip download
+            # Local file path (e.g. from platform image cache) -- validate format
+            from tools.image_safety import validate_image_file
+            is_valid, err_msg, _ = validate_image_file(local_path)
+            if not is_valid:
+                raise ValueError(f"Image validation failed: {err_msg}")
             logger.info("Using local image file: %s", image_url)
             temp_image_path = local_path
             should_cleanup = False  # Don't delete cached/local files

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -74,6 +74,11 @@ def _validate_image_url(url: str) -> bool:
     if not is_safe_url(url):
         return False
 
+    # Block SVG URLs (can contain embedded scripts)
+    path_lower = parsed.path.lower()
+    if path_lower.endswith(".svg") or path_lower.endswith(".svgz"):
+        return False
+
     return True
 
 
@@ -132,10 +137,24 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
                     },
                 )
                 response.raise_for_status()
-                
+
+                # Check Content-Length before reading body into memory
+                from tools.image_safety import check_content_length, validate_image_file
+                content_length = response.headers.get("content-length")
+                cl_int = int(content_length) if content_length else None
+                cl_ok, cl_err = check_content_length(cl_int)
+                if not cl_ok:
+                    raise ValueError(cl_err)
+
                 # Save the image content
                 destination.write_bytes(response.content)
-            
+
+                # Validate the downloaded file is a real image
+                is_valid, err_msg, detected_mime = validate_image_file(destination)
+                if not is_valid:
+                    destination.unlink(missing_ok=True)
+                    raise ValueError(f"Image validation failed: {err_msg}")
+
             return destination
         except Exception as e:
             last_error = e
@@ -157,25 +176,17 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
 
 def _determine_mime_type(image_path: Path) -> str:
     """
-    Determine the MIME type of an image based on its file extension.
-    
+    Determine the MIME type of an image from its content (magic bytes).
+    Falls back to extension-based detection if filetype is unavailable.
+
     Args:
         image_path (Path): Path to the image file
-        
+
     Returns:
         str: The MIME type (defaults to image/jpeg if unknown)
     """
-    extension = image_path.suffix.lower()
-    mime_types = {
-        '.jpg': 'image/jpeg',
-        '.jpeg': 'image/jpeg',
-        '.png': 'image/png',
-        '.gif': 'image/gif',
-        '.bmp': 'image/bmp',
-        '.webp': 'image/webp',
-        '.svg': 'image/svg+xml'
-    }
-    return mime_types.get(extension, 'image/jpeg')
+    from tools.image_safety import get_real_mime_type
+    return get_real_mime_type(image_path)
 
 
 def _image_to_base64_data_url(image_path: Path, mime_type: Optional[str] = None) -> str:


### PR DESCRIPTION
## Summary

Vision tools and platform image cache accepted any file as an image based on URL extension alone. A `.jpg` URL serving HTML, scripts, or executables was downloaded, cached, and sent to the LLM without content validation.

### What was wrong

- **No format validation:** MIME type determined from file extension, not content. A `.jpg` file containing `<script>alert(1)</script>` was accepted as `image/jpeg`.
- **No size limit:** Arbitrarily large files downloaded into memory and disk.
- **SVG allowed:** SVG can contain `<script>`, `<iframe>`, event handlers.
- **Platform cache unprotected:** `cache_image_from_bytes()` / `cache_image_from_url()` in base.py had zero validation — images from Telegram, Discord, Signal, WhatsApp, Matrix, Mattermost, Slack, Email all bypassed any check.
- **No SSRF on cache path:** `cache_image_from_url()` had no `is_safe_url()` check.
- **Local files skipped:** `vision_analyze_tool` skipped validation for local file paths.

### Fix

New module `tools/image_safety.py` with:
- Magic-byte validation via `filetype` library (pure Python, 50KB, no system deps)
- 9 supported formats: JPEG, PNG, GIF, WebP, BMP, TIFF, HEIC, HEIF, AVIF
- SVG blocked (script injection risk)
- 20MB size limit (Content-Length pre-check + post-download file size check)
- Graceful fallback if filetype unavailable (extension-only with warning)

Applied to ALL image entry points:
- `vision_tools._download_image()` — remote URL downloads
- `vision_tools.vision_analyze_tool()` — local file paths
- `base.cache_image_from_bytes()` — all messaging platform image cache
- `base.cache_image_from_url()` — URL-based cache + SSRF protection

### Protected platforms

Telegram, Discord, Signal, WhatsApp, Matrix, Mattermost, Slack, Email, CLI — all use `cache_image_from_bytes` or `cache_image_from_url` which now validate.

## Test plan

- [x] 68 tests pass (46 existing vision + 22 new image_safety)
- [x] Real images accepted: JPEG, PNG, GIF, WebP
- [x] Fake images rejected: HTML-as-jpg, ELF-as-jpg, PDF-as-png
- [x] SVG/SVGZ blocked by extension
- [x] Platform cache rejects non-image bytes
- [x] Platform cache URL SSRF blocked
- [x] Local file paths validated before processing
- [x] Size limit enforced (Content-Length + file size)
- [x] Full end-to-end flow verified with bash (7 scenarios)
- [x] Existing vision tests unaffected