### PR TITLE
feat: add hermes-memory MCP integration (structured persistent memory)

### DIFF
--- a/docs/hermes-memory-integration.md
+++ b/docs/hermes-memory-integration.md
@@ -91,6 +91,51 @@ Both can run simultaneously. The memory tool handles "who is the user" and
 "what's the environment". hermes-memory handles "what did we decide about auth"
 and "what are the project constraints".
 
+## Managing MEMORY.md pressure
+
+MEMORY.md is injected into every turn — keeping it compact directly reduces token
+cost. hermes-memory acts as a relief valve: structured facts that accumulate in
+MEMORY.md can be migrated to the DB and replaced with a single `memory_search()`
+call on-demand.
+
+### Compression guidelines
+
+When MEMORY.md approaches its character limit, apply these rules in order:
+
+1. **Abbreviate first** — most entries can be cut 40-60% with standard shorthands:
+   `pr`=pour, `req`=requis, `chg`=changement, `cfg`=config, `dep`=dépendance,
+   `w/`=avec, `→`=vers/puis, `↑`=upgrade, `0`=zéro, drop articles and filler words.
+
+2. **Migrate structured facts** — any C/D/V entry that isn't needed every turn
+   belongs in hermes-memory, not MEMORY.md:
+   ```
+   # Before (in MEMORY.md, ~120 chars):
+   "Database IDs must always be UUID, never autoincrement. Decided in sprint 3."
+
+   # After (migrated to hermes-memory):
+   memory_write("C[db.id]: UUID mndtry, nvr autoincrement")
+   # MEMORY.md entry removed — retrieved with memory_search("db id") when needed
+   ```
+
+3. **Remove duplicates** — facts already in hermes-memory DB don't need to be in
+   MEMORY.md. Keep only the pointer: `memory_search() pour détails projet`.
+
+### Automated pressure relief
+
+A cron job can automate this at scheduled intervals:
+
+```
+# Example cron prompt (runs 2x/day):
+Check MEMORY.md usage via memory_status(). If MEMORY > 55% or USER > 55%:
+- Abbreviate verbose entries
+- Migrate structured C/D/V facts to memory_write()
+- Remove entries already covered in hermes-memory DB
+Target: both stores below 45%.
+If already below threshold, do nothing.
+```
+
+This keeps injection cost stable even across long-running projects.
+
 ## Links
 
 - PyPI: https://pypi.org/project/hermes-memory/

--- a/docs/hermes-memory-integration.md
+++ b/docs/hermes-memory-integration.md
@@ -1,0 +1,97 @@
+# hermes-memory: Structured Memory via MCP
+
+Persistent, structured memory for Hermes sessions that survives context compression.
+
+## The problem
+
+During long sessions, context compression removes older messages. Constraints decided
+at turn 5 vanish by turn 50. The agent forgets what was agreed, re-asks questions,
+and contradicts earlier decisions.
+
+The existing `memory` tool (MEMORY.md / USER.md) stores free-text entries injected
+at session start. It works well for user preferences and environment facts, but has
+no structure, no search, no scope lifecycle, and no automatic pressure management.
+
+## What hermes-memory adds
+
+A structured fact store with typed notation, FTS5 search, scoped lifecycle,
+and automatic gauge-based memory management:
+
+- **7 MCP tools**: write, search, tick, status, reflect, export, purge
+- **Typed facts**: C[target] (constraints), D[target] (decisions), V[target] (values)
+- **Scope lifecycle**: auto-cooling after 6 turns of silence, topic shift detection
+- **Gauge pressure**: automatic dedup at 70%, archival at 85%, synthesis at 95%
+- **Zero infra**: SQLite + FTS5, no cloud, no embedding model, no API keys
+
+## Installation
+
+```bash
+pip install hermes-memory
+```
+
+## Configuration
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  hermes-memory:
+    command: "hermes-memory"
+    env:
+      HERMES_MEMORY_DB: "~/.hermes/memory.db"
+```
+
+That's it. Hermes discovers the 7 tools at startup.
+
+## How the agent uses it
+
+At session start, `memory_status` injects a compact block (~180 tokens):
+
+```
+[MEMORY_SPEC v1.0]
+
+NOTATION
+C[t]: constraint  D[t]: decision  V[t]: value
+?[t]: unknown     ✓[t]: done      ~[t]: obsolete
+
+ABBREVS
+cfg impl msg req usr resp prod feat dev deps auth err db btn ...
+
+RULES
+- call memory_write() for any C/D/V/? detected
+- call memory_search() before answering on known topics
+- call memory_tick(turn, message) on every user message
+- call memory_reflect(topic) when user asks about history
+
+[MEMORY 42% (4.2k/10k)]
+
+C[db.id]: UUID mndtry, nvr autoincrement
+D[auth]: JWT 7j refresh 6j
+V[srv.prod]: api.example.com:3005
+```
+
+The agent then calls `memory_write` whenever it detects a constraint, decision,
+or value in the conversation. The notation achieves 65-78% token savings vs raw
+messages.
+
+## Relationship to existing memory tool
+
+hermes-memory is **complementary**, not a replacement:
+
+| | memory tool (MEMORY.md) | hermes-memory |
+|---|---|---|
+| Storage | flat text file | SQLite + FTS5 |
+| Search | substring match | full-text search |
+| Structure | free-form entries | typed notation (C/D/V/?/✓/~) |
+| Scoping | none | auto-scoped lifecycle |
+| Pressure | manual char limit | automatic gauge (merge/archive/synthesis) |
+| Use case | user prefs, env facts | project constraints, decisions, values |
+
+Both can run simultaneously. The memory tool handles "who is the user" and
+"what's the environment". hermes-memory handles "what did we decide about auth"
+and "what are the project constraints".
+
+## Links
+
+- PyPI: https://pypi.org/project/hermes-memory/
+- Spec: `MEMORY_SPEC.md` in the hermes-memory repository

--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -395,9 +395,33 @@ enabled: false
 
 That keeps the config around but prevents connection and registration.
 
+## Built-in MCP servers
+
+### hermes-memory: structured agent memory
+
+hermes-memory gives the agent persistent, searchable memory that survives context
+compression. Facts are stored as typed notation (constraints, decisions, values)
+with automatic lifecycle management.
+
+```bash
+pip install hermes-memory
+```
+
+```yaml
+mcp_servers:
+  hermes-memory:
+    command: "hermes-memory"
+```
+
+Once configured, the agent gets 7 new tools: `memory_write`, `memory_search`,
+`memory_tick`, `memory_status`, `memory_reflect`, `memory_export`, `memory_purge`.
+
+See [hermes-memory integration guide](/docs/hermes-memory-integration) for details.
+
 ## Recommended first MCP setups
 
 Good first servers for most users:
+- **hermes-memory** — structured persistent memory (recommended for all users)
 - filesystem
 - git
 - GitHub


### PR DESCRIPTION
## The problem, and why existing solutions miss it

Every LLM agent forgets. After ~30 turns, context compression kicks in and silently removes older messages. A constraint decided at turn 5 ("always use UUID, never autoincrement") vanishes by turn 50. The agent contradicts itself, re-asks questions, and the user has to repeat things.

The current memory tool (MEMORY.md) helps for user preferences, but it is unstructured free-text with no search, no lifecycle, and no pressure management. It cannot answer "what did we decide about auth?" without injecting everything.

Existing external solutions (Mem0, Zep, MemGPT) add cloud infra, embedding models, and vector stores. They treat memory as a retrieval problem. But the real problem is **what to remember, when to forget, and how to keep the context small**.

## Why MCP, and why not a core integration

The short answer: MCP is the right boundary for this feature. But if the team prefers a native integration, the code is ready for it.

**Why MCP makes sense here:**

hermes-memory touches three concerns that are hard to integrate cleanly into a monolith: persistent storage, session lifecycle, and pressure-based memory management. As an MCP server it:

- ships independently, versioned separately
- works with any MCP-compatible agent, not just Hermes
- can be replaced or extended without touching the agent core
- keeps the agent codebase clean

## What hermes-memory provides

A structured fact store with 8 MCP tools, typed notation, FTS5 search, scoped lifecycle, and automatic gauge-based pressure management:

- **Typed facts**: `C[target]` (constraints), `D[target]` (decisions), `V[target]` (values), `?[target]` (unknowns), `✓[target]` (resolved), `~[target]` (obsolete)
- **Scope lifecycle**: auto-cooling after 6 turns of silence, topic shift detection
- **Gauge pressure**: automatic dedup at 70%, archival at 85%, synthesis at 95%
- **Zero infra**: SQLite + FTS5, no cloud, no embedding model, no API keys

## The 8 MCP tools

| Tool | Description |
|---|---|
| `memory_write` | Store a typed fact in MEMORY_SPEC notation |
| `memory_search` | FTS5 search across hot + cold facts |
| `memory_tick` | Advance turn counter, trigger scope cooling |
| `memory_status` | Session injection payload (gauge + hot facts) |
| `memory_reflect` | On-demand synthesis grouped by fact type |
| `memory_export` | Dump all facts as plain notation |
| `memory_purge` | Hard-delete superseded / archived facts |
| `memory_optimize` | **[v0.3.0]** Compress MEMORY.md/USER.md + migrate facts to DB |

## memory_optimize — automatic MEMORY.md pressure relief (v0.3.0)

MEMORY.md is injected into every turn — every byte costs tokens on every call. `memory_optimize` acts as a relief valve:

1. Reads `MEMORY.md` and `USER.md` from `~/.hermes/memories/`
2. Scans for `C[...]` / `D[...]` / `V[...]` lines → migrates them to the hermes-memory DB, removes them from the flat file
3. Applies abbreviation compression on remaining entries (~40-60% reduction)
4. **No-op if both files are below threshold** (default 55%) — safe to call on a schedule

```
# output when action taken:
optimized:
  MEMORY: 85.0% → 38.2%  (3 facts migrated)
  USER:   62.0% → 41.5%
  3 fact(s) moved to hermes-memory DB

# output when healthy:
no action needed
MEMORY: 36.0%  USER: 37.0%
(both below 55% threshold)
```

## Relationship to existing memory tool

Complementary, not a replacement.

| | memory tool (MEMORY.md) | hermes-memory |
|---|---|---|
| Storage | flat text file | SQLite + FTS5 |
| Search | substring match | full-text search with prefix matching |
| Structure | free-form entries | typed notation (C/D/V/?/✓/~) |
| Scoping | none | auto-scoped lifecycle with 3 closing triggers |
| Pressure | manual char limit | automatic gauge (merge → archive → synthesis) |
| Overflow relief | none | `memory_optimize` migrates + compresses automatically |
| Best for | user prefs, env facts | project constraints, decisions, values |

Both run simultaneously. The memory tool handles "who is the user". hermes-memory handles "what did we decide".

## Changes in this PR

- `docs/hermes-memory-integration.md`: full integration guide including MEMORY.md pressure management strategy and cron automation pattern
- Updated MCP usage guide with hermes-memory section and config example

## Installation

```bash
pip install hermes-memory  # v0.3.0
```

```yaml
mcp_servers:
  hermes-memory:
    command: "hermes-memory"
```

Set `HERMES_MEMORY_DB` to override default storage path (`~/.hermes/memory.db`).

## Technical details

- 52 tests, all passing
- Full code review by Claude Code (18 findings, 11 fixed, 7 accepted for v0.1)
- PyPI: https://pypi.org/project/hermes-memory/0.3.0/
- Repo: https://github.com/Mibayy/hermes-memory
- Related: #2662
