### PR TITLE
fix(security): block path traversal in V4A patch parser

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from tools.patch_parser import (
     OperationType,
+    _validate_patch_path,
     apply_v4a_operations,
     parse_v4a_patch,
 )
@@ -185,3 +186,52 @@ class TestApplyUpdate:
             '    result = 1\n'
             '    return result + 1'
         )
+
+
+class TestPathValidation:
+    """Verify patch parser rejects paths that escape the working directory."""
+
+    def test_relative_path_allowed(self):
+        assert _validate_patch_path("src/main.py") is None
+
+    def test_nested_relative_allowed(self):
+        assert _validate_patch_path("a/b/c/file.txt") is None
+
+    def test_absolute_path_blocked(self):
+        assert _validate_patch_path("/etc/passwd") is not None
+
+    def test_absolute_home_blocked(self):
+        assert _validate_patch_path("/root/.ssh/authorized_keys") is not None
+
+    def test_parent_traversal_blocked(self):
+        assert _validate_patch_path("../../../etc/shadow") is not None
+
+    def test_hidden_traversal_blocked(self):
+        assert _validate_patch_path("src/../../etc/passwd") is not None
+
+    def test_empty_path_blocked(self):
+        assert _validate_patch_path("") is not None
+
+    def test_apply_rejects_absolute_path_in_patch(self):
+        """A crafted patch targeting /etc/passwd should be rejected."""
+        patch = """\
+*** Begin Patch
+*** Update File: /etc/passwd
+@@ root @@
+ root:x:0:0:root:/root:/bin/bash
+-root:x:0:0:root:/root:/bin/bash
++root:x:0:0:root:/root:/bin/sh
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert len(ops) == 1
+
+        from types import SimpleNamespace
+        file_ops = SimpleNamespace(
+            read_file=lambda *a, **kw: None,
+            write_file=lambda *a, **kw: None,
+        )
+        result = apply_v4a_operations(ops, file_ops)
+        # Should have error, not success
+        assert result.error is not None
+        assert "absolute" in result.error.lower() or "rejected" in result.error.lower()

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -28,6 +28,7 @@ Usage:
         result = apply_v4a_operations(operations, file_ops)
 """
 
+import os
 import re
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple, Any
@@ -206,28 +207,58 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
     return operations, None
 
 
-def apply_v4a_operations(operations: List[PatchOperation], 
+def _validate_patch_path(path: str) -> Optional[str]:
+    """Reject paths that escape the working directory.
+
+    Returns an error message if the path is unsafe, or None if OK.
+    Blocks absolute paths and ``../`` traversal so a crafted patch
+    cannot target system files like ``/etc/passwd`` or ``~/.ssh/``.
+    """
+    if not path or not path.strip():
+        return "empty file path"
+    cleaned = path.strip()
+    # Block absolute paths
+    if os.path.isabs(cleaned):
+        return f"absolute paths not allowed in patches: {cleaned}"
+    # Block parent directory traversal
+    normalized = os.path.normpath(cleaned)
+    if normalized.startswith(".."):
+        return f"path traversal not allowed in patches: {cleaned}"
+    return None
+
+
+def apply_v4a_operations(operations: List[PatchOperation],
                           file_ops: Any) -> 'PatchResult':
     """
     Apply V4A patch operations using a file operations interface.
-    
+
     Args:
         operations: List of PatchOperation from parse_v4a_patch
         file_ops: Object with read_file, write_file methods
-    
+
     Returns:
         PatchResult with results of all operations
     """
     # Import here to avoid circular imports
     from tools.file_operations import PatchResult
-    
+
     files_modified = []
     files_created = []
     files_deleted = []
     all_diffs = []
     errors = []
-    
+
     for op in operations:
+        # Validate all file paths before applying any operation
+        path_error = _validate_patch_path(op.file_path)
+        if path_error:
+            errors.append(f"Rejected {op.operation.value} on {op.file_path}: {path_error}")
+            continue
+        if op.new_path:
+            path_error = _validate_patch_path(op.new_path)
+            if path_error:
+                errors.append(f"Rejected move target {op.new_path}: {path_error}")
+                continue
         try:
             if op.operation == OperationType.ADD:
                 result = _apply_add(op, file_ops)


### PR DESCRIPTION
## Summary
- V4A patch parser extracts file paths from patch content via regex and passes them directly to file operations (read_file, write_file, rm, mv) with no validation
- A crafted patch embedded in a skill or prompt injection could target arbitrary system files
- Fix: add `_validate_patch_path()` that rejects absolute paths and `../` traversal before any file operation

## Security Impact
- A malicious skill or prompt-injected patch content could target: `/etc/passwd`, `~/.ssh/authorized_keys`, `~/.hermes/.env`, etc.
- Affects all users — the patch parser is used by the main file operations tool
- Severity: HIGH

## How to reproduce
```
*** Begin Patch
*** Update File: /etc/passwd
*** Delete File: ../../../root/.ssh/authorized_keys
```
These paths are accepted and executed without validation.

## How to test
- 8 new tests: relative paths (allowed), absolute paths (blocked), traversal (blocked), hidden traversal (blocked), empty paths (blocked), full integration test with crafted patch
- All 17 tests pass

## Platform tested
- Linux