### PR TITLE
fix(telegram): always inject reply context; use partial quote text

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1517,7 +1517,11 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_to_text = None
         if message.reply_to_message:
             reply_to_id = str(message.reply_to_message.message_id)
-            reply_to_text = message.reply_to_message.text or message.reply_to_message.caption or None
+            # Prefer the partial quote (selected text) when user quoted specific text
+            if getattr(message, 'quote', None) and message.quote.text:
+                reply_to_text = message.quote.text
+            else:
+                reply_to_text = message.reply_to_message.text or message.reply_to_message.caption or None
 
         return MessageEvent(
             text=message.text or "",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2345,13 +2345,7 @@ class GatewayRunner:
         # -----------------------------------------------------------------
         if getattr(event, 'reply_to_text', None) and event.reply_to_message_id:
             reply_snippet = event.reply_to_text[:500]
-            found_in_history = any(
-                reply_snippet[:200] in (msg.get("content") or "")
-                for msg in history
-                if msg.get("role") in ("assistant", "user", "tool")
-            )
-            if not found_in_history:
-                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+            message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         try:
             # Emit agent:start hook


### PR DESCRIPTION
## Problem

When a user replies to a message in the current session, the agent had no way to know which specific message was being referenced from a flat conversation history. The `found_in_history` check was silently dropping the `[Replying to: "..."]` prefix in this exact case, making replies ambiguous. Also ignoring Telegram's partial-quote feature (selected text), always using the full message instead.

## Changes

**gateway/run.py** — removed `found_in_history` suppression. Reply context is now always injected.

**gateway/platforms/telegram.py** — use `message.quote.text` when available instead of full message text.

## Testing

Verified on a live Telegram bot.