### PR TITLE
fix: pass docker_mount_cwd_to_workspace to container_config in file_tools

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -114,6 +114,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "container_disk": config.get("container_disk", 51200),
                     "container_persistent": config.get("container_persistent", True),
                     "docker_volumes": config.get("docker_volumes", []),
+                    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                 }
 
             ssh_config = None


### PR DESCRIPTION
## Summary

Fixes #2672

## Problem

When using `docker` as terminal backend with `docker_mount_cwd_to_workspace: true` in config.yaml, file operations (find, read, write, etc.) ignored this setting and used sandbox directories instead of the host cwd bind mount.

The issue was that `file_tools.py`'s `_get_file_ops()` function did not include `docker_mount_cwd_to_workspace` in its `container_config` dictionary.

## Root Cause

`terminal_tool.py` correctly includes `docker_mount_cwd_to_workspace` in `container_config` (line 970), but `file_tools.py` was missing this field (line 109-116).

## Solution

Added `docker_mount_cwd_to_workspace` to the `container_config` dict in `file_tools.py`:

```python
container_config = {
    ...
    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
}
```

## Testing

With `docker_mount_cwd_to_workspace: true`:
- Before: File tools use sandbox directory
- After: File tools correctly bind mount host cwd to /workspace