### PR TITLE
fix(tools): warn on duplicate tool registration instead of silent overwrite

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -282,3 +282,28 @@ class TestSecretCaptureResultContract:
             "validated": False,
         }
         assert "secret" not in json.dumps(result).lower()
+
+
+class TestDuplicateRegistration:
+    def test_duplicate_tool_warns(self, caplog):
+        """Re-registering a tool should log a warning, not silently overwrite."""
+        import logging
+        reg = ToolRegistry()
+        reg.register(name="dup", toolset="first", schema=_make_schema("dup"), handler=_dummy_handler)
+
+        with caplog.at_level(logging.WARNING, logger="tools.registry"):
+            reg.register(name="dup", toolset="second", schema=_make_schema("dup"), handler=_dummy_handler)
+
+        assert any("registered twice" in r.message for r in caplog.records)
+
+    def test_duplicate_tool_keeps_latest(self):
+        """The latest registration should win (backwards compatible)."""
+        reg = ToolRegistry()
+        reg.register(name="dup", toolset="first", schema=_make_schema("dup"), handler=_dummy_handler)
+
+        def _handler2(args, **kw):
+            return json.dumps({"version": 2})
+
+        reg.register(name="dup", toolset="second", schema=_make_schema("dup"), handler=_handler2)
+        result = json.loads(reg.dispatch("dup", {}))
+        assert result == {"version": 2}

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -66,6 +66,12 @@ class ToolRegistry:
         emoji: str = "",
     ):
         """Register a tool.  Called at module-import time by each tool file."""
+        if name in self._tools:
+            logger.warning(
+                "Tool '%s' registered twice (toolset '%s' overwriting '%s'). "
+                "Check for duplicate plugin loads.",
+                name, toolset, self._tools[name].toolset,
+            )
         self._tools[name] = ToolEntry(
             name=name,
             toolset=toolset,


### PR DESCRIPTION
## Summary
- `registry.register()` silently overwrites existing tool entries with the same name
- If a plugin loads twice or two plugins register the same tool name, the first handler is lost without any indication
- Fix: log a warning with both toolset names when a duplicate registration is detected

## How to reproduce
- Register a tool "my_tool" from plugin A, then register "my_tool" from plugin B
- Plugin A's handler is silently lost — no warning in logs

## How to test
- 2 new tests: `test_duplicate_tool_warns` (checks warning is logged) and `test_duplicate_tool_keeps_latest` (verifies backwards-compatible overwrite behavior)
- All 22 registry tests pass

## Platform tested
- Linux