### PR TITLE
Fix Codex context routing and explicit model switching

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -387,9 +387,14 @@ class HermesACPAgent(acp.Agent):
 
         # Auto-detect provider for the requested model
         try:
-            from hermes_cli.models import parse_model_input, detect_provider_for_model
+            from hermes_cli.models import _KNOWN_PROVIDER_NAMES, parse_model_input, detect_provider_for_model
+            colon = new_model.find(":")
+            explicit_provider_syntax = (
+                colon > 0
+                and new_model[:colon].strip().lower() in _KNOWN_PROVIDER_NAMES
+            )
             target_provider, new_model = parse_model_input(new_model, current_provider)
-            if target_provider == current_provider:
+            if not explicit_provider_syntax and target_provider == current_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:
                     target_provider, new_model = detected

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -146,6 +146,10 @@ def _is_openrouter_base_url(base_url: str) -> bool:
     return "openrouter.ai" in _normalize_base_url(base_url).lower()
 
 
+def _is_codex_base_url(base_url: str) -> bool:
+    return "chatgpt.com/backend-api/codex" in _normalize_base_url(base_url).lower()
+
+
 def _is_custom_endpoint(base_url: str) -> bool:
     normalized = _normalize_base_url(base_url)
     return bool(normalized) and not _is_openrouter_base_url(normalized)
@@ -429,15 +433,29 @@ def fetch_endpoint_model_metadata(
 
     for candidate in candidates:
         url = candidate.rstrip("/") + "/models"
+        urls_to_try = [url]
+        if _is_codex_base_url(candidate):
+            urls_to_try.insert(0, url + "?client_version=1.0.0")
+        for url_to_fetch in urls_to_try:
+            try:
+                response = requests.get(url_to_fetch, headers=headers, timeout=10)
+                response.raise_for_status()
+                payload = response.json()
+                break
+            except Exception as exc:
+                last_error = exc
+                payload = None
+        if payload is None:
+            continue
         try:
-            response = requests.get(url, headers=headers, timeout=10)
-            response.raise_for_status()
-            payload = response.json()
             cache: Dict[str, Dict[str, Any]] = {}
-            for model in payload.get("data", []):
+            model_entries = payload.get("data")
+            if not isinstance(model_entries, list):
+                model_entries = payload.get("models", [])
+            for model in model_entries:
                 if not isinstance(model, dict):
                     continue
-                model_id = model.get("id")
+                model_id = model.get("id") or model.get("slug")
                 if not model_id:
                     continue
                 entry: Dict[str, Any] = {"name": model.get("name", model_id)}
@@ -791,11 +809,16 @@ def get_model_context_length(
             return cached
 
     # 2. Active endpoint metadata for truly custom/unknown endpoints.
-    # Known providers (Copilot, OpenAI, Anthropic, etc.) skip this — their
-    # /models endpoint may report a provider-imposed limit (e.g. Copilot
-    # returns 128k) instead of the model's full context (400k).  models.dev
-    # has the correct per-provider values and is checked at step 5+.
-    if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url):
+    # Most known providers skip this because their /models endpoint may report
+    # a provider-imposed limit rather than the raw model max. OpenAI Codex is
+    # the exception: its official /models payload exposes the effective working
+    # context_window we want Hermes to compact against.
+    use_endpoint_metadata = _is_custom_endpoint(base_url) and (
+        not _is_known_provider_base_url(base_url)
+        or provider == "openai-codex"
+        or _is_codex_base_url(base_url)
+    )
+    if use_endpoint_metadata:
         endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
         matched = endpoint_metadata.get(model)
         if not matched:

--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -43,6 +43,25 @@ _COMPLEX_KEYWORDS = {
     "kubernetes",
 }
 
+_RUNTIME_QUERY_TERMS = {
+    "model",
+    "provider",
+    "context",
+    "window",
+    "token",
+    "tokens",
+    "pricing",
+    "price",
+    "cost",
+}
+
+_SELF_REFERENTIAL_TERMS = {
+    "you",
+    "your",
+    "using",
+    "use",
+}
+
 _URL_RE = re.compile(r"https?://|www\.", re.IGNORECASE)
 
 
@@ -101,6 +120,8 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
 
     lowered = text.lower()
     words = {token.strip(".,:;!?()[]{}\"'`") for token in lowered.split()}
+    if (words & _RUNTIME_QUERY_TERMS) and ((words & _SELF_REFERENTIAL_TERMS) or "are you" in lowered):
+        return None
     if words & _COMPLEX_KEYWORDS:
         return None
 

--- a/cli.py
+++ b/cli.py
@@ -1278,7 +1278,8 @@ class HermesCLI:
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
 
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
-        model_name = self.model or "unknown"
+        agent = getattr(self, "agent", None)
+        model_name = getattr(agent, "model", None) or self.model or "unknown"
         model_short = model_name.split("/")[-1] if "/" in model_name else model_name
         if model_short.endswith(".gguf"):
             model_short = model_short[:-5]
@@ -1304,7 +1305,6 @@ class HermesCLI:
             "compressions": 0,
         }
 
-        agent = getattr(self, "agent", None)
         if not agent:
             return snapshot
 
@@ -1938,7 +1938,6 @@ class HermesCLI:
                 pass_session_id=self.pass_session_id,
                 tool_progress_callback=self._on_tool_progress,
                 stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
-                tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
             )
             # Route agent status output through prompt_toolkit so ANSI escape
             # sequences aren't garbled by patch_stdout's StdoutProxy (#2262).
@@ -3564,12 +3563,18 @@ class HermesCLI:
             if len(parts) > 1:
                 from hermes_cli.auth import resolve_provider
                 from hermes_cli.models import (
+                    _KNOWN_PROVIDER_NAMES,
                     parse_model_input,
                     validate_requested_model,
                     _PROVIDER_LABELS,
                 )
 
                 raw_input = parts[1].strip()
+                colon = raw_input.find(":")
+                explicit_provider_syntax = (
+                    colon > 0
+                    and raw_input[:colon].strip().lower() in _KNOWN_PROVIDER_NAMES
+                )
 
                 # Parse provider:model syntax (e.g. "openrouter:anthropic/claude-sonnet-4.5")
                 current_provider = self.provider or self.requested_provider or "openrouter"
@@ -3584,7 +3589,7 @@ class HermesCLI:
                 is_custom = current_provider == "custom" or (
                     "localhost" in _base or "127.0.0.1" in _base
                 )
-                if target_provider == current_provider and not is_custom:
+                if not explicit_provider_syntax and target_provider == current_provider and not is_custom:
                     from hermes_cli.models import detect_provider_for_model
                     detected = detect_provider_for_model(new_model, current_provider)
                     if detected:
@@ -4633,24 +4638,6 @@ class HermesCLI:
 
         except Exception as e:
             print(f"  ❌ MCP reload failed: {e}")
-
-    # ====================================================================
-    # Tool-call generation indicator (shown during streaming)
-    # ====================================================================
-
-    def _on_tool_gen_start(self, tool_name: str) -> None:
-        """Called when the model begins generating tool-call arguments.
-
-        Closes any open streaming boxes (reasoning / response) and prints a
-        short status line so the user sees activity instead of a frozen
-        screen while a large payload (e.g. a 45 KB write_file) streams in.
-        """
-        self._flush_stream()
-        self._close_reasoning_box()
-
-        from agent.display import get_tool_emoji
-        emoji = get_tool_emoji(tool_name, default="⚡")
-        _cprint(f"  ┊ {emoji} preparing {tool_name}…")
 
     # ====================================================================
     # Tool progress callback (audio cues for voice mode)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2851,6 +2851,15 @@ class GatewayRunner:
             lines.append("Switch provider: `/model provider-name` or `/model provider:model-name`")
             return "\n".join(lines)
 
+        from hermes_cli.models import _KNOWN_PROVIDER_NAMES
+
+        raw_args = (args or "").strip()
+        colon = raw_args.find(":")
+        explicit_provider_syntax = (
+            colon > 0
+            and raw_args[:colon].strip().lower() in _KNOWN_PROVIDER_NAMES
+        )
+
         # Parse provider:model syntax
         target_provider, new_model = parse_model_input(args, current_provider)
 
@@ -2868,7 +2877,7 @@ class GatewayRunner:
         )
 
         # Auto-detect provider when no explicit provider:model syntax was used
-        if target_provider == current_provider and not is_custom:
+        if not explicit_provider_syntax and target_provider == current_provider and not is_custom:
             from hermes_cli.models import detect_provider_for_model
             detected = detect_provider_for_model(new_model, current_provider)
             if detected:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -335,6 +335,9 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     The colon is only treated as a provider delimiter if the left side is a
     recognized provider name or alias.  This avoids misinterpreting model names
     that happen to contain colons (e.g. ``anthropic/claude-3.5-sonnet:beta``).
+    If the provider prefix is recognized but the model part is empty, the empty
+    model string is returned so the caller can surface a clean validation error
+    instead of treating the whole input as a literal model id.
 
     Returns ``(provider, model)`` where *provider* is either the explicit
     provider from the input or *current_provider* if none was specified.
@@ -344,7 +347,7 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     if colon > 0:
         provider_part = stripped[:colon].strip().lower()
         model_part = stripped[colon + 1:].strip()
-        if provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES:
+        if provider_part and provider_part in _KNOWN_PROVIDER_NAMES:
             return (normalize_provider(provider_part), model_part)
     return (current_provider, stripped)
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -260,6 +260,48 @@ class TestGetModelContextLength:
         assert result == 131072
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_openai_codex_prefers_provider_models_metadata(self, mock_endpoint_fetch, mock_fetch):
+        """Codex should trust its own /models context_window over OpenRouter."""
+        mock_fetch.return_value = {
+            "gpt-5.4": {"context_length": 1050000}
+        }
+        mock_endpoint_fetch.return_value = {
+            "gpt-5.4": {"context_length": 272000}
+        }
+
+        result = get_model_context_length(
+            "gpt-5.4",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="codex-token",
+            provider="openai-codex",
+        )
+
+        assert result == 272000
+        mock_endpoint_fetch.assert_called_once_with(
+            "https://chatgpt.com/backend-api/codex",
+            api_key="codex-token",
+        )
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_openai_codex_falls_back_when_provider_models_missing(self, mock_endpoint_fetch, mock_fetch):
+        """If Codex /models misses, keep the existing downstream fallbacks."""
+        mock_fetch.return_value = {
+            "gpt-5.4": {"context_length": 1050000}
+        }
+        mock_endpoint_fetch.return_value = {}
+
+        result = get_model_context_length(
+            "gpt-5.4",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="codex-token",
+            provider="openai-codex",
+        )
+
+        assert result == 1050000
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     def test_config_context_length_overrides_all(self, mock_fetch):
         """Explicit config_context_length takes priority over everything."""
         mock_fetch.return_value = {
@@ -368,6 +410,33 @@ class TestFetchModelMetadata:
         result2 = fetch_model_metadata()
         assert "test/model" in result2
         assert mock_get.call_count == 1  # cached
+
+    @patch("agent.model_metadata.requests.get")
+    def test_endpoint_metadata_supports_codex_models_shape(self, mock_get):
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "models": [
+                {
+                    "slug": "gpt-5.4",
+                    "context_window": 272000,
+                    "name": "gpt-5.4",
+                }
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        result = fetch_endpoint_model_metadata(
+            "https://chatgpt.com/backend-api/codex",
+            api_key="codex-token",
+            force_refresh=True,
+        )
+
+        assert result["gpt-5.4"]["context_length"] == 272000
+        called_url = mock_get.call_args.args[0]
+        assert called_url.endswith("/models?client_version=1.0.0")
 
     @patch("agent.model_metadata.requests.get")
     def test_api_failure_returns_empty_on_cold_cache(self, mock_get):

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -38,6 +38,11 @@ def test_skips_tool_heavy_prompt_keywords():
     assert choose_cheap_model_route(prompt, _BASE_CONFIG) is None
 
 
+def test_skips_runtime_introspection_prompt():
+    prompt = "hey wich model are you?"
+    assert choose_cheap_model_route(prompt, _BASE_CONFIG) is None
+
+
 def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_resolved(monkeypatch):
     from agent.smart_model_routing import resolve_turn_route
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -71,10 +71,10 @@ class TestParseModelInput:
         assert provider == "nous"
         assert model == "hermes-3"
 
-    def test_empty_model_after_colon_keeps_current(self):
+    def test_empty_model_after_colon_preserves_provider_and_empty_model(self):
         provider, model = parse_model_input("openrouter:", "nous")
-        assert provider == "nous"
-        assert model == "openrouter:"
+        assert provider == "openrouter"
+        assert model == ""
 
     def test_colon_at_start_keeps_current(self):
         provider, model = parse_model_input(":something", "openrouter")

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -213,6 +213,30 @@ def test_cli_turn_routing_uses_cheap_model_when_simple(monkeypatch):
     assert result["label"] is not None
 
 
+def test_model_command_keeps_explicit_provider_prefix(monkeypatch):
+    cli = _import_cli()
+
+    monkeypatch.setattr(
+        "hermes_cli.models.detect_provider_for_model",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not auto-detect explicit provider:model input")),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *args, **kwargs: {"accepted": True, "persist": False, "recognized": True, "message": None},
+    )
+
+    shell = cli.HermesCLI(model="gpt-5.4", compact=True, max_turns=1)
+    shell.provider = "openai-codex"
+    shell.requested_provider = "openai-codex"
+    shell.base_url = "https://chatgpt.com/backend-api/codex"
+    shell.api_key = "codex-key"
+
+    assert shell.process_command("/model openai-codex:gpt-5.4") is True
+    assert shell.model == "gpt-5.4"
+    assert shell.provider == "openai-codex"
+    assert shell.requested_provider == "openai-codex"
+
+
 def test_cli_prefers_config_provider_over_stale_env_override(monkeypatch):
     cli = _import_cli()
 

--- a/tests/test_cli_status_bar.py
+++ b/tests/test_cli_status_bar.py
@@ -118,6 +118,33 @@ class TestCLIStatusBar:
         assert "⚕" in text
         assert "claude-sonnet-4-20250514" in text
 
+    def test_status_bar_uses_active_agent_model_when_smart_routed(self):
+        cli_obj = _make_cli(model="gpt-5.4")
+        cli_obj.agent = SimpleNamespace(
+            model="gpt-5.4-mini",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            session_input_tokens=38_600,
+            session_output_tokens=0,
+            session_cache_read_tokens=0,
+            session_cache_write_tokens=0,
+            session_prompt_tokens=38_600,
+            session_completion_tokens=0,
+            session_total_tokens=38_600,
+            session_api_calls=1,
+            context_compressor=SimpleNamespace(
+                last_prompt_tokens=38_600,
+                context_length=128_000,
+                compression_count=0,
+            ),
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "gpt-5.4-mini" in text
+        assert "gpt-5.4 │" not in text
+        assert "38.6K/128K" in text
+
 
 class TestCLIUsageReport:
     def test_show_usage_includes_estimated_cost(self, capsys):

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -421,7 +421,7 @@ Hermes uses a multi-source resolution chain to detect the correct context window
 1. **Config override** — `model.context_length` in config.yaml (highest priority)
 2. **Custom provider per-model** — `custom_providers[].models.<id>.context_length`
 3. **Persistent cache** — previously discovered values (survives restarts)
-4. **Endpoint `/models`** — queries your server's API (local/custom endpoints)
+4. **Endpoint `/models`** — queries your server's API (local/custom endpoints, plus OpenAI Codex provider metadata)
 5. **Anthropic `/v1/models`** — queries Anthropic's API for `max_input_tokens` (API-key users only)
 6. **OpenRouter API** — live model metadata from OpenRouter
 7. **Nous Portal** — suffix-matches Nous model IDs against OpenRouter metadata
@@ -429,6 +429,8 @@ Hermes uses a multi-source resolution chain to detect the correct context window
 9. **Fallback defaults** — broad model family patterns (128K default)
 
 For most setups this works out of the box. The system is provider-aware — the same model can have different context limits depending on who serves it (e.g., `claude-opus-4.6` is 1M on Anthropic direct but 128K on GitHub Copilot).
+
+OpenAI Codex is a notable provider-specific case: Hermes reads the provider-reported `context_window` from `https://chatgpt.com/backend-api/codex/models` when available, so compaction follows the Codex working window for that provider instead of borrowing a generic max context from another catalog.
 
 To set the context length explicitly, add `context_length` to your model config:
 


### PR DESCRIPTION
## Summary
- use Codex provider metadata for GPT-5.4 context detection and document the compaction behavior
- fix `/model` explicit `provider:model` handling so provider selection stays stable
- keep runtime-introspection prompts on the primary model so status/model reporting stays coherent

## Testing
- `/home/juan/.hermes/hermes-agent/venv/bin/pytest -q tests/agent/test_model_metadata.py tests/hermes_cli/test_model_validation.py tests/agent/test_smart_model_routing.py tests/test_cli_provider_resolution.py tests/test_cli_status_bar.py`