### PR TITLE
fix(fallback): pass explicit credentials from fallback config to provider router

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3789,10 +3789,15 @@ class AIAgent:
         # Use centralized router for client construction.
         # raw_codex=True because the main agent needs direct responses.stream()
         # access for Codex providers.
+        # Pass explicit base_url/api_key from fallback config so custom
+        # providers don't fall back to env-var resolution (which may point
+        # at the primary/exhausted endpoint).
         try:
             from agent.auxiliary_client import resolve_provider_client
             fb_client, _ = resolve_provider_client(
-                fb_provider, model=fb_model, raw_codex=True)
+                fb_provider, model=fb_model, raw_codex=True,
+                explicit_base_url=fb.get("base_url"),
+                explicit_api_key=fb.get("api_key"))
             if fb_client is None:
                 logging.warning(
                     "Fallback to %s failed: provider not configured",


### PR DESCRIPTION
## Summary

- **`_try_activate_fallback()` was ignoring `base_url` and `api_key` from the `fallback_model` config** when calling `resolve_provider_client()`. For custom providers, this caused the router to fall through to environment variable resolution (`OPENAI_BASE_URL` / `OPENAI_API_KEY`), which typically still point at the primary (exhausted) endpoint — silently defeating the entire fallback mechanism.
- Now forwards `fb.get("base_url")` and `fb.get("api_key")` as `explicit_base_url` and `explicit_api_key`, parameters that `resolve_provider_client()` already supports but were never used from this call site.

## Reproduction

Configure a custom fallback provider in `config.yaml`:

```yaml
model:
  default: gpt-5.4
  provider: openai-codex

fallback_model:
  provider: custom
  model: qwen3.5-27b
  base_url: http://localhost:1234/v1
  api_key: sk-local-key
```

Exhaust the primary model's quota. Before this fix, fallback activation would fail because the provider router never received the custom endpoint credentials — it tried env vars instead, which either pointed at the primary or weren't set.

## Test plan

- [ ] Exhaust primary model quota and verify fallback activates with the correct custom endpoint
- [ ] Verify fallback still works for non-custom providers (openrouter, anthropic, etc.) where `base_url`/`api_key` are `None` in config
- [ ] Run existing `tests/test_fallback_model.py` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)