### PR TITLE
feat(telegram): edit-as-branch, rewind transcript when user edits a message

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -369,6 +369,7 @@ class BasePlatformAdapter(ABC):
         # Maps user platform_message_id -> list of bot response platform_message_ids
         # Used by edit-as-branch to delete old bot responses from chat
         self._response_message_ids: Dict[str, List[str]] = {}
+        self._response_ids_callback: Optional[Callable] = None
 
     @property
     def has_fatal_error(self) -> bool:
@@ -452,6 +453,10 @@ class BasePlatformAdapter(ABC):
         an optional response string.
         """
         self._message_handler = handler
+
+    def set_response_ids_callback(self, callback: Callable) -> None:
+        """Set callback for persisting bot response IDs after sending."""
+        self._response_ids_callback = callback
     
     @abstractmethod
     async def connect(self) -> bool:
@@ -1104,6 +1109,12 @@ class BasePlatformAdapter(ABC):
             # Store mapping of user message -> bot response IDs (for edit-as-branch)
             if event.message_id and _sent_message_ids:
                 self._response_message_ids[event.message_id] = _sent_message_ids
+                # Persist to transcript so IDs survive gateway restarts
+                if self._response_ids_callback:
+                    try:
+                        self._response_ids_callback(event, _sent_message_ids)
+                    except Exception as e:
+                        logger.warning("[%s] Failed to persist response IDs: %s", self.name, e)
 
             # Check if there's a pending message that was queued during our processing
             if session_key in self._pending_messages:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -299,6 +299,9 @@ class MessageEvent:
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     
+    # Edit flag (set when this event is from an edited message)
+    is_edit: bool = False
+    
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
         return self.text.startswith("/")
@@ -363,6 +366,9 @@ class BasePlatformAdapter(ABC):
         self._background_tasks: set[asyncio.Task] = set()
         # Chats where auto-TTS on voice input is disabled (set by /voice off)
         self._auto_tts_disabled_chats: set = set()
+        # Maps user platform_message_id -> list of bot response platform_message_ids
+        # Used by edit-as-branch to delete old bot responses from chat
+        self._response_message_ids: Dict[str, List[str]] = {}
 
     @property
     def has_fatal_error(self) -> bool:
@@ -495,6 +501,14 @@ class BasePlatformAdapter(ABC):
         sending a new message.
         """
         return SendResult(success=False, error="Not supported")
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a previously sent message. Returns True on success.
+
+        Override in subclasses. Default returns False (not supported).
+        Used by edit-as-branch to remove old bot responses from chat.
+        """
+        return False
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """
@@ -904,6 +918,7 @@ class BasePlatformAdapter(ABC):
             # Send response if any
             if not response:
                 logger.warning("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
+            _sent_message_ids = []  # Collect bot response IDs for edit-as-branch
             if response:
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)
@@ -967,6 +982,13 @@ class BasePlatformAdapter(ABC):
                         reply_to=event.message_id,
                         metadata=_thread_metadata,
                     )
+                    if result.success and result.message_id:
+                        _sent_message_ids.append(result.message_id)
+                    # Also collect all message_ids from raw_response (multi-message sends)
+                    if result.success and result.raw_response and isinstance(result.raw_response, dict):
+                        for _rid in result.raw_response.get("message_ids", []):
+                            if _rid not in _sent_message_ids:
+                                _sent_message_ids.append(_rid)
 
                     # Log send failures (don't raise - user already saw tool progress)
                     if not result.success:
@@ -1078,6 +1100,10 @@ class BasePlatformAdapter(ABC):
                             )
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
+
+            # Store mapping of user message -> bot response IDs (for edit-as-branch)
+            if event.message_id and _sent_message_ids:
+                self._response_message_ids[event.message_id] = _sent_message_ids
 
             # Check if there's a pending message that was queued during our processing
             if session_key in self._pending_messages:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -235,6 +235,15 @@ class TelegramAdapter(BasePlatformAdapter):
             self._bot = self._app.bot
             
             # Register handlers
+            
+            # Handle edited messages FIRST (edit-as-branch).
+            # Must be before other handlers because MessageFilter.check_update
+            # matches edited_message updates too — without this ordering,
+            # the TEXT handler below would swallow edits as new messages.
+            self._app.add_handler(TelegramMessageHandler(
+                filters.UpdateType.EDITED_MESSAGE & (filters.TEXT | filters.CAPTION) & ~filters.COMMAND,
+                self._handle_edited_message
+            ))
             self._app.add_handler(TelegramMessageHandler(
                 filters.TEXT & ~filters.COMMAND,
                 self._handle_text_message
@@ -522,6 +531,22 @@ class TelegramAdapter(BasePlatformAdapter):
                 exc_info=True,
             )
             return SendResult(success=False, error=str(e))
+
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a message from a Telegram chat. Returns True on success."""
+        if not self._bot:
+            return False
+        try:
+            await self._bot.delete_message(
+                chat_id=int(chat_id),
+                message_id=int(message_id),
+            )
+            return True
+        except Exception as e:
+            logger.warning("[%s] Failed to delete message %s: %s", self.name, message_id, e)
+            return False
+
 
     async def send_voice(
         self,
@@ -1411,6 +1436,22 @@ class TelegramAdapter(BasePlatformAdapter):
                 f"a sticker with emoji {emoji}" if emoji else "a sticker",
                 emoji, set_name,
             )
+
+    async def _handle_edited_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle an edited text message -- triggers edit-as-branch.
+        
+        When a user edits a message, we treat it as a branch rewrite:
+        truncate the transcript from that point and re-run the agent
+        with the new text.
+        """
+        edited = update.edited_message
+        if not edited or not edited.text:
+            return
+        
+        event = self._build_message_event(edited, MessageType.TEXT)
+        event.is_edit = True
+        
+        await self.handle_message(event)
 
     def _build_message_event(self, message: Message, msg_type: MessageType) -> MessageEvent:
         """Build a MessageEvent from a Telegram message."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1445,6 +1445,10 @@ class GatewayRunner:
                 self._pending_messages[_quick_key] = event.text
             return None
 
+        # Edit-as-branch: if this is an edited message, do transcript surgery and re-run
+        if getattr(event, 'is_edit', False) and event.message_id:
+            return await self._handle_edit_as_branch(event)
+
         # Check for commands
         command = event.get_command()
         
@@ -2262,9 +2266,11 @@ class GatewayRunner:
                 
                 # If no new messages found (edge case), fall back to simple user/assistant
                 if not new_messages:
+                    _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
+                    if event.message_id:
+                        _user_entry["platform_message_id"] = event.message_id
                     self.session_store.append_to_transcript(
-                        session_entry.session_id,
-                        {"role": "user", "content": message_text, "timestamp": ts}
+                        session_entry.session_id, _user_entry
                     )
                     if response:
                         self.session_store.append_to_transcript(
@@ -2277,6 +2283,13 @@ class GatewayRunner:
                     # to prevent the duplicate-write bug (#860).  We still write
                     # to JSONL for backward compatibility and as a backup.
                     agent_persisted = self._session_db is not None
+                    # Tag the first user message with its platform message ID
+                    # (for edit-as-branch: matching edited messages to transcript entries)
+                    if event.message_id:
+                        for msg in new_messages:
+                            if msg.get("role") == "user":
+                                msg["platform_message_id"] = event.message_id
+                                break
                     for msg in new_messages:
                         # Skip system messages (they're rebuilt each run)
                         if msg.get("role") == "system":
@@ -2286,6 +2299,12 @@ class GatewayRunner:
                         self.session_store.append_to_transcript(
                             session_entry.session_id, entry,
                             skip_db=agent_persisted,
+                        )
+                    # Backfill platform_message_id in SQLite for the user message
+                    # (the agent already wrote it to DB without this field)
+                    if agent_persisted and event.message_id:
+                        self.session_store.backfill_platform_message_id(
+                            session_entry.session_id, "user", message_text, event.message_id,
                         )
             
             # Update session with actual prompt token count and model from the agent
@@ -2804,6 +2823,81 @@ class GatewayRunner:
         available = "`none`, " + ", ".join(f"`{n}`" for n in personalities.keys())
         return f"Unknown personality: `{args}`\n\nAvailable: {available}"
     
+    async def _handle_edit_as_branch(self, event: MessageEvent) -> Optional[str]:
+        """Handle an edited message by truncating transcript and re-running.
+
+        Like git reset: finds the original message in the transcript by
+        platform_message_id, removes it and everything after it, then
+        re-processes the edited text as a new message.
+        """
+        source = event.source
+        session_entry = self.session_store.get_or_create_session(source)
+        history = self.session_store.load_transcript(session_entry.session_id)
+
+        # Find the original message by platform_message_id
+        target_idx = None
+        for i, msg in enumerate(history):
+            if msg.get("platform_message_id") == event.message_id:
+                target_idx = i
+                break
+
+        if target_idx is None:
+            # Message not found in transcript -- treat as a normal new message.
+            # This happens if: session was reset, message predates platform_message_id
+            # tracking, or the message was already undone.
+            logger.info(
+                "[edit-as-branch] message_id %s not found in transcript, treating as new message",
+                event.message_id,
+            )
+            event.is_edit = False
+            return await self._handle_message(event)
+
+        removed_count = len(history) - target_idx
+        logger.info(
+            "[edit-as-branch] Truncating transcript at index %d (removing %d messages), re-running with edited text",
+            target_idx, removed_count,
+        )
+
+        # Truncate: remove the matched message and everything after it
+        truncated = history[:target_idx]
+        self.session_store.rewrite_transcript(session_entry.session_id, truncated)
+        session_entry.last_prompt_tokens = 0  # Reset token count (same as /retry)
+
+        # Delete ALL orphaned messages from the Telegram chat (from edit point onward).
+        # In DMs and admin groups, bot can delete both its own and user messages.
+        # In non-admin groups, user message deletions will fail gracefully.
+        adapter = self.adapters.get(source.platform)
+        if adapter:
+            removed_messages = history[target_idx:]
+            ids_to_delete = set()
+
+            # 1. Collect platform_message_ids from removed transcript entries
+            for msg in removed_messages:
+                pmid = msg.get("platform_message_id")
+                if pmid:
+                    ids_to_delete.add(pmid)
+
+            # 2. Collect bot response IDs from in-memory tracking
+            if hasattr(adapter, '_response_message_ids'):
+                for msg in removed_messages:
+                    pmid = msg.get("platform_message_id")
+                    if pmid and pmid in adapter._response_message_ids:
+                        for resp_id in adapter._response_message_ids[pmid]:
+                            ids_to_delete.add(resp_id)
+                        del adapter._response_message_ids[pmid]
+
+            # 3. Don't delete the edited message itself -- the user's edit
+            #    should stay visible in the chat. Only delete what came after.
+            ids_to_delete.discard(event.message_id)
+
+            # 4. Delete all collected messages
+            for msg_id in ids_to_delete:
+                await adapter.delete_message(str(source.chat_id), msg_id)
+
+        # Re-run with the new (edited) text as a normal message
+        event.is_edit = False
+        return await self._handle_message(event)
+
     async def _handle_retry_command(self, event: MessageEvent) -> str:
         """Handle /retry command - re-send the last user message."""
         source = event.source

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -918,6 +918,7 @@ class GatewayRunner:
             
             # Set up message + fatal error handlers
             adapter.set_message_handler(self._handle_message)
+            adapter.set_response_ids_callback(self._persist_response_ids)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             
             # Try to connect
@@ -2823,6 +2824,17 @@ class GatewayRunner:
         available = "`none`, " + ", ".join(f"`{n}`" for n in personalities.keys())
         return f"Unknown personality: `{args}`\n\nAvailable: {available}"
     
+    def _persist_response_ids(self, event, sent_message_ids: list) -> None:
+        """Persist bot response message IDs to transcript (survives restart)."""
+        if not event.message_id or not sent_message_ids:
+            return
+        source = event.source
+        session_entry = self.session_store.get_or_create_session(source)
+        self.session_store.tag_response_message_ids(
+            session_entry.session_id, event.message_id, sent_message_ids
+        )
+
+
     async def _handle_edit_as_branch(self, event: MessageEvent) -> Optional[str]:
         """Handle an edited message by truncating transcript and re-running.
 
@@ -2877,7 +2889,18 @@ class GatewayRunner:
                 if pmid:
                     ids_to_delete.add(pmid)
 
-            # 2. Collect bot response IDs from in-memory tracking
+            # 2. Collect bot response IDs from transcript (persisted)
+            import json as _json
+            for msg in removed_messages:
+                resp_ids_raw = msg.get("response_message_ids")
+                if resp_ids_raw:
+                    try:
+                        for resp_id in _json.loads(resp_ids_raw):
+                            ids_to_delete.add(resp_id)
+                    except (ValueError, TypeError):
+                        pass
+
+            # 3. Also check in-memory tracking (for messages sent since last restart)
             if hasattr(adapter, '_response_message_ids'):
                 for msg in removed_messages:
                     pmid = msg.get("platform_message_id")
@@ -2886,11 +2909,11 @@ class GatewayRunner:
                             ids_to_delete.add(resp_id)
                         del adapter._response_message_ids[pmid]
 
-            # 3. Don't delete the edited message itself -- the user's edit
+            # 4. Don't delete the edited message itself -- the user's edit
             #    should stay visible in the chat. Only delete what came after.
             ids_to_delete.discard(event.message_id)
 
-            # 4. Delete all collected messages
+            # 5. Delete all collected messages
             for msg_id in ids_to_delete:
                 await adapter.delete_message(str(source.chat_id), msg_id)
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -885,6 +885,7 @@ class SessionStore:
                     tool_name=message.get("tool_name"),
                     tool_calls=message.get("tool_calls"),
                     tool_call_id=message.get("tool_call_id"),
+                    platform_message_id=message.get("platform_message_id"),
                 )
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
@@ -912,6 +913,7 @@ class SessionStore:
                         tool_name=msg.get("tool_name"),
                         tool_calls=msg.get("tool_calls"),
                         tool_call_id=msg.get("tool_call_id"),
+                        platform_message_id=msg.get("platform_message_id"),
                     )
             except Exception as e:
                 logger.debug("Failed to rewrite transcript in DB: %s", e)
@@ -921,6 +923,15 @@ class SessionStore:
         with open(transcript_path, "w", encoding="utf-8") as f:
             for msg in messages:
                 f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+
+    def backfill_platform_message_id(self, session_id: str, role: str, content: str, platform_message_id: str) -> bool:
+        """Backfill platform_message_id on a message the agent already persisted to SQLite."""
+        if self._db:
+            try:
+                return self._db.set_platform_message_id(session_id, role, content, platform_message_id)
+            except Exception as e:
+                logger.debug("Failed to backfill platform_message_id: %s", e)
+        return False
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript."""

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -933,6 +933,14 @@ class SessionStore:
                 logger.debug("Failed to backfill platform_message_id: %s", e)
         return False
 
+    def tag_response_message_ids(self, session_id: str, platform_message_id: str, response_ids: list) -> None:
+        """Persist bot response message IDs on the user's transcript entry."""
+        import json
+        if self._db:
+            self._db.set_response_message_ids(
+                session_id, platform_message_id, json.dumps(response_ids)
+            )
+
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript."""
         # Try SQLite first

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -26,7 +26,7 @@ from typing import Dict, Any, List, Optional
 
 DEFAULT_DB_PATH = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -189,6 +189,13 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass
                 cursor.execute("UPDATE schema_version SET version = 5")
+            if current_version < 6:
+                # v6: add platform_message_id to messages (for edit-as-branch)
+                try:
+                    cursor.execute('ALTER TABLE messages ADD COLUMN platform_message_id TEXT')
+                except sqlite3.OperationalError:
+                    pass  # Column already exists
+                cursor.execute('UPDATE schema_version SET version = 6')
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -587,6 +594,7 @@ class SessionDB:
         tool_call_id: str = None,
         token_count: int = None,
         finish_reason: str = None,
+        platform_message_id: str = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -597,8 +605,9 @@ class SessionDB:
         with self._lock:
             cursor = self._conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
-                   tool_calls, tool_name, timestamp, token_count, finish_reason)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   tool_calls, tool_name, timestamp, token_count, finish_reason,
+                   platform_message_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -609,6 +618,7 @@ class SessionDB:
                     time.time(),
                     token_count,
                     finish_reason,
+                    platform_message_id,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -660,7 +670,7 @@ class SessionDB:
         """
         with self._lock:
             cursor = self._conn.execute(
-                "SELECT role, content, tool_call_id, tool_calls, tool_name "
+                "SELECT role, content, tool_call_id, tool_calls, tool_name, platform_message_id "
                 "FROM messages WHERE session_id = ? ORDER BY timestamp, id",
                 (session_id,),
             )
@@ -677,6 +687,8 @@ class SessionDB:
                     msg["tool_calls"] = json.loads(row["tool_calls"])
                 except (json.JSONDecodeError, TypeError):
                     pass
+            if row["platform_message_id"]:
+                msg["platform_message_id"] = row["platform_message_id"]
             messages.append(msg)
         return messages
 
@@ -896,6 +908,31 @@ class SessionDB:
             messages = self.get_messages(session["id"])
             results.append({**session, "messages": messages})
         return results
+
+    def set_platform_message_id(self, session_id: str, role: str, content: str, platform_message_id: str) -> bool:
+        """Backfill platform_message_id on an existing message (matched by session, role, content).
+
+        Used when the agent persists messages to SQLite before platform metadata
+        is available, and the gateway needs to tag them after the fact.
+        Updates the LAST matching message (most recent) to avoid tagging old duplicates.
+        """
+        with self._lock:
+            # Find the row id of the last matching message
+            cursor = self._conn.execute(
+                """SELECT id FROM messages
+                   WHERE session_id = ? AND role = ? AND content = ? AND platform_message_id IS NULL
+                   ORDER BY timestamp DESC, id DESC LIMIT 1""",
+                (session_id, role, content),
+            )
+            row = cursor.fetchone()
+            if not row:
+                return False
+            self._conn.execute(
+                "UPDATE messages SET platform_message_id = ? WHERE id = ?",
+                (platform_message_id, row[0] if isinstance(row, tuple) else row["id"]),
+            )
+            self._conn.commit()
+        return True
 
     def clear_messages(self, session_id: str) -> None:
         """Delete all messages for a session and reset its counters."""

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -201,6 +201,16 @@ class SessionDB:
                     pass  # Column already exists
                 cursor.execute('UPDATE schema_version SET version = 6')
 
+        # Safety net: ensure v6 columns exist even if migration was partial
+        # (e.g. version was bumped but ALTER TABLE failed silently)
+        existing_cols = {row[1] for row in cursor.execute('PRAGMA table_info(messages)').fetchall()}
+        for col in ['platform_message_id', 'response_message_ids']:
+            if col not in existing_cols:
+                try:
+                    cursor.execute(f'ALTER TABLE messages ADD COLUMN {col} TEXT')
+                except sqlite3.OperationalError:
+                    pass
+
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
         try:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -190,9 +190,13 @@ class SessionDB:
                         pass
                 cursor.execute("UPDATE schema_version SET version = 5")
             if current_version < 6:
-                # v6: add platform_message_id to messages (for edit-as-branch)
+                # v6: add platform_message_id and response_message_ids to messages (for edit-as-branch)
                 try:
                     cursor.execute('ALTER TABLE messages ADD COLUMN platform_message_id TEXT')
+                except sqlite3.OperationalError:
+                    pass  # Column already exists
+                try:
+                    cursor.execute('ALTER TABLE messages ADD COLUMN response_message_ids TEXT')
                 except sqlite3.OperationalError:
                     pass  # Column already exists
                 cursor.execute('UPDATE schema_version SET version = 6')
@@ -689,6 +693,8 @@ class SessionDB:
                     pass
             if row["platform_message_id"]:
                 msg["platform_message_id"] = row["platform_message_id"]
+            if row["response_message_ids"]:
+                msg["response_message_ids"] = row["response_message_ids"]
             messages.append(msg)
         return messages
 
@@ -933,6 +939,17 @@ class SessionDB:
             )
             self._conn.commit()
         return True
+
+    def set_response_message_ids(self, session_id: str, platform_message_id: str, response_ids_json: str) -> None:
+        """Tag a user message with its bot response message IDs (JSON list)."""
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute(
+                """UPDATE messages SET response_message_ids = ?
+                   WHERE session_id = ? AND platform_message_id = ?""",
+                (response_ids_json, session_id, platform_message_id),
+            )
+            self._conn.commit()
 
     def clear_messages(self, session_id: str) -> None:
         """Delete all messages for a session and reset its counters."""


### PR DESCRIPTION
## Problem

When a user edits a message in Telegram, the bot ignores it completely. User has no way to correct a message and get a fresh response other than /undo + retype.

## Changes

hermes_state.py - schema migration v6, adds platform_message_id column to messages table.

gateway/session.py - passes platform_message_id through both append_to_transcript() and rewrite_transcript().

gateway/run.py - new _handle_edit_as_branch() method. Finds the edited message in the transcript, truncates everything from that point, deletes orphaned messages from the chat, re-runs the agent with the edited text. Also tags user messages with platform_message_id and backfills it in SQLite.

gateway/platforms/base.py - adds is_edit flag to MessageEvent, delete_message() base method, and in-memory response ID tracking.

gateway/platforms/telegram.py - registers edited_message handler (before the text handler to avoid filter conflicts), implements delete_message().

## Testing

Verified on a live Telegram bot.