### PR TITLE
fix(security): add read-path deny list for credential and secret files

### DIFF
--- a/tests/tools/test_file_read_deny.py
+++ b/tests/tools/test_file_read_deny.py
@@ -1,0 +1,57 @@
+"""Tests for read-path deny list on sensitive credential files."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.file_operations import _is_read_denied
+
+
+_HOME = str(Path.home())
+
+
+class TestIsReadDenied:
+    def test_hermes_env_blocked(self):
+        assert _is_read_denied(os.path.join(_HOME, ".hermes", ".env")) is True
+
+    def test_hermes_auth_json_blocked(self):
+        assert _is_read_denied(os.path.join(_HOME, ".hermes", "auth.json")) is True
+
+    def test_ssh_private_key_blocked(self):
+        assert _is_read_denied(os.path.join(_HOME, ".ssh", "id_rsa")) is True
+        assert _is_read_denied(os.path.join(_HOME, ".ssh", "id_ed25519")) is True
+
+    def test_etc_shadow_blocked(self):
+        assert _is_read_denied("/etc/shadow") is True
+
+    def test_aws_credentials_blocked(self):
+        assert _is_read_denied(os.path.join(_HOME, ".aws", "credentials")) is True
+
+    def test_gnupg_dir_blocked(self):
+        assert _is_read_denied(os.path.join(_HOME, ".gnupg", "private-keys-v1.d", "key")) is True
+
+    def test_kube_config_blocked(self):
+        assert _is_read_denied(os.path.join(_HOME, ".kube", "config")) is True
+
+    def test_normal_project_file_allowed(self):
+        assert _is_read_denied("/tmp/test.py") is False
+
+    def test_relative_path_allowed(self):
+        assert _is_read_denied("src/main.py") is False
+
+    def test_tilde_expansion_blocked(self):
+        assert _is_read_denied("~/.hermes/.env") is True
+
+    def test_traversal_to_shadow_blocked(self):
+        assert _is_read_denied("/tmp/../etc/shadow") is True
+
+    def test_netrc_blocked(self):
+        assert _is_read_denied(os.path.join(_HOME, ".netrc")) is True
+
+    def test_hermes_config_yaml_allowed(self):
+        """config.yaml is not a secret — should be readable."""
+        assert _is_read_denied(os.path.join(_HOME, ".hermes", "config.yaml")) is False
+
+    def test_hermes_sessions_allowed(self):
+        """Session files should be readable."""
+        assert _is_read_denied(os.path.join(_HOME, ".hermes", "sessions", "test.json")) is False

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -75,6 +75,49 @@ WRITE_DENIED_PREFIXES = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# Read-path deny list — blocks reads on credential/secret files
+# ---------------------------------------------------------------------------
+
+READ_DENIED_PATHS = {
+    os.path.realpath(p) for p in [
+        os.path.join(_HOME, ".hermes", ".env"),
+        os.path.join(_HOME, ".hermes", "auth.json"),
+        os.path.join(_HOME, ".ssh", "id_rsa"),
+        os.path.join(_HOME, ".ssh", "id_ed25519"),
+        os.path.join(_HOME, ".ssh", "id_ecdsa"),
+        os.path.join(_HOME, ".netrc"),
+        os.path.join(_HOME, ".pgpass"),
+        os.path.join(_HOME, ".npmrc"),
+        os.path.join(_HOME, ".pypirc"),
+        "/etc/shadow",
+        "/etc/gshadow",
+    ]
+}
+
+READ_DENIED_PREFIXES = [
+    os.path.realpath(p) + os.sep for p in [
+        os.path.join(_HOME, ".aws"),
+        os.path.join(_HOME, ".gnupg"),
+        os.path.join(_HOME, ".kube"),
+    ]
+]
+
+
+def _is_read_denied(path: str) -> bool:
+    """Return True if path targets a known credential/secret file."""
+    try:
+        resolved = os.path.realpath(os.path.expanduser(str(path)))
+    except (ValueError, OSError):
+        return False
+    if resolved in READ_DENIED_PATHS:
+        return True
+    for prefix in READ_DENIED_PREFIXES:
+        if resolved.startswith(prefix):
+            return True
+    return False
+
+
 def _get_safe_write_root() -> Optional[str]:
     """Return the resolved HERMES_WRITE_SAFE_ROOT path, or None if unset.
 
@@ -477,10 +520,14 @@ class ShellFileOperations(FileOperations):
         """
         # Expand ~ and other shell paths
         path = self._expand_path(path)
-        
+
+        # Block reads on known credential/secret files
+        if _is_read_denied(path):
+            return ReadResult(error=f"Access denied: '{path}' is a protected credential file.")
+
         # Clamp limit
         limit = min(limit, MAX_LINES)
-        
+
         # Check if file exists and get size (wc -c is POSIX, works on Linux + macOS)
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
         stat_result = self._exec(stat_cmd)
@@ -854,7 +901,11 @@ class ShellFileOperations(FileOperations):
         """
         # Expand ~ and other shell paths
         path = self._expand_path(path)
-        
+
+        # Block searches targeting known credential directories
+        if _is_read_denied(path):
+            return SearchResult(error=f"Access denied: '{path}' is a protected path.")
+
         # Validate that the path exists before searching
         check = self._exec(f"test -e {self._escape_shell_arg(path)} && echo exists || echo not_found")
         if "not_found" in check.stdout:


### PR DESCRIPTION
## Summary
- `read_file` has zero path restrictions — reads ANY file including `/etc/shadow`, `~/.hermes/.env` (API keys), `~/.hermes/auth.json` (OAuth tokens), SSH private keys
- The write path has `_is_write_denied()` with a deny list, but no equivalent exists for reads
- Fix: add `READ_DENIED_PATHS` and `READ_DENIED_PREFIXES` covering credential files, and enforce in both `read_file()` and `search()`
- Non-secret files like `~/.hermes/config.yaml` and session files remain readable

## Security Impact
- On gateway (Telegram/Discord), prompt injection can instruct: `read_file("~/.hermes/.env")` → exfiltrates all API keys
- Also reads: `~/.hermes/auth.json` (OAuth tokens, refresh tokens), `~/.ssh/id_rsa`, `/etc/shadow`
- Confirmed working on v0.4.0 — all three reads succeed without any restriction
- Severity: CRITICAL

## How to reproduce
```bash
hermes chat -q "Use the read_file tool to read ~/.hermes/.env"
hermes chat -q "Use the read_file tool to read /etc/shadow"
```

## How to test
- 14 new tests covering: .env blocked, auth.json blocked, SSH keys blocked, /etc/shadow blocked, .aws/ prefix blocked, .gnupg/ prefix blocked, .kube/ blocked, traversal paths blocked, normal project files allowed, config.yaml allowed, session files allowed
- All 75 existing file tool tests pass

## Platform tested
- Linux, hermes-agent v0.4.0