### PR TITLE
fix(cli): use venv pip in update command instead of system pip

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2759,8 +2759,18 @@ def cmd_update(args):
                     cwd=PROJECT_ROOT, check=True, env=uv_env,
                 )
         else:
-            venv_pip = PROJECT_ROOT / "venv" / ("Scripts" if sys.platform == "win32" else "bin") / "pip"
-            pip_cmd = [str(venv_pip)] if venv_pip.exists() else ["pip"]
+            venv_bin = PROJECT_ROOT / "venv" / ("Scripts" if sys.platform == "win32" else "bin")
+            venv_pip = venv_bin / "pip"
+            venv_python = venv_bin / ("python.exe" if sys.platform == "win32" else "python")
+            if venv_pip.exists():
+                pip_cmd = [str(venv_pip)]
+            elif venv_python.exists():
+                pip_cmd = [str(venv_python), "-m", "pip"]
+            else:
+                print("  ✗ No virtual environment found at: venv/")
+                print("  Re-run the install script to set up the venv:")
+                print("    curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash")
+                sys.exit(1)
             try:
                 subprocess.run(pip_cmd + ["install", "-e", ".[all]", "--quiet"], cwd=PROJECT_ROOT, check=True)
             except subprocess.CalledProcessError:


### PR DESCRIPTION
## Summary

On Debian/Ubuntu with PEP 668, `hermes update` fails with `externally-managed-environment` because the fallback `pip` command resolves to the system pip.

Fixes #2648.

## Root Cause

When `uv` is not available and `venv/bin/pip` does not exist, the update command falls back to bare `["pip"]`:

```python
pip_cmd = [str(venv_pip)] if venv_pip.exists() else ["pip"]
```

On modern Debian/Ubuntu, the system pip refuses to install packages outside a venv (PEP 668).

## Fix

Replace the `["pip"]` fallback with a proper chain:

1. `venv/bin/pip` — existing behavior, works when pip binary exists in venv
2. `venv/bin/python -m pip` — new fallback for venvs created without the pip binary (e.g. `python -m venv --without-pip` + `ensurepip`)
3. Error with re-install instructions — instead of silently using system pip

## Changes

`hermes_cli/main.py`: 1 block, +12/-2 lines

## Testing

- Verified on Ubuntu (the reported platform)
- Windows path handling preserved (`Scripts/python.exe` vs `bin/python`)
- The uv code path (lines 2748-2760) is unaffected