### PR TITLE
fix(mcp): pre-compile env-var regex and unify interpolation across mcp_tool and mcp_config

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -12,10 +12,11 @@ import asyncio
 import getpass
 import logging
 import os
-import re
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
+
+from tools.mcp_tool import _ENV_VAR_PATTERN
 
 from hermes_cli.config import (
     load_config,
@@ -470,7 +471,7 @@ def cmd_mcp_test(args):
         for k, v in headers.items():
             if isinstance(v, str) and ("key" in k.lower() or "auth" in k.lower()):
                 # Mask the value
-                resolved = _interpolate_value(v)
+                resolved = _ENV_VAR_PATTERN.sub(lambda m: os.getenv(m.group(1), ""), v)
                 if len(resolved) > 8:
                     masked = resolved[:4] + "***" + resolved[-4:]
                 else:
@@ -498,13 +499,6 @@ def cmd_mcp_test(args):
             short = desc[:55] + "..." if len(desc) > 55 else desc
             print(f"    {color(tool_name, Colors.GREEN):36s} {short}")
     print()
-
-
-def _interpolate_value(value: str) -> str:
-    """Resolve ``${ENV_VAR}`` references in a string."""
-    def _replace(m):
-        return os.getenv(m.group(1), "")
-    return re.sub(r"\$\{(\w+)\}", _replace, value)
 
 
 # ─── hermes mcp configure ────────────────────────────────────────────────────

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -144,6 +144,11 @@ _CREDENTIAL_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# Pre-compiled pattern for ${VAR_NAME} style env-var interpolation.
+# Supports any non-} characters in the variable name (hyphens, dots, etc.)
+# so providers like MY-VAR or my.var work correctly.
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
 
 # ---------------------------------------------------------------------------
 # Security helpers
@@ -938,10 +943,9 @@ def _run_on_mcp_loop(coro, timeout: float = 30):
 def _interpolate_env_vars(value):
     """Recursively resolve ``${VAR}`` placeholders from ``os.environ``."""
     if isinstance(value, str):
-        import re
         def _replace(m):
             return os.environ.get(m.group(1), m.group(0))
-        return re.sub(r"\$\{([^}]+)\}", _replace, value)
+        return _ENV_VAR_PATTERN.sub(_replace, value)
     if isinstance(value, dict):
         return {k: _interpolate_env_vars(v) for k, v in value.items()}
     if isinstance(value, list):


### PR DESCRIPTION
## Summary

Fixes two related code quality issues in MCP env-var interpolation:

## Changes

**`tools/mcp_tool.py`**
- Add module-level `_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")` after `_CREDENTIAL_PATTERN`
- Remove redundant inner `import re` inside `_interpolate_env_vars()` (module-level import already exists)
- Use pre-compiled pattern instead of re-compiling on every call

**`hermes_cli/mcp_config.py`**
- Remove `_interpolate_value()` which used `\w+` and would silently fail on env vars with hyphens or dots (e.g. `MY-VAR`, `my.var`)
- Replace its single call site with the shared `_ENV_VAR_PATTERN` from `mcp_tool.py`
- Remove now-unused `import re`

## Impact

Pure code hygiene — no behavior change for standard `[a-zA-Z0-9_]` env var names. Fixes a subtle inconsistency where `hermes mcp test` could show unresolved auth headers for env vars with hyphens/dots that work correctly at runtime.

Closes #2711
Closes #2712