### PR TITLE
fix(gateway): use configured context_length and base_url for local/Ollama models

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2023,6 +2023,10 @@ class GatewayRunner:
                         _hyg_api_key = _hyg_runtime.get("api_key")
                     except Exception:
                         pass
+                # Final fallback: OPENAI_BASE_URL covers local/Ollama setups
+                # where base_url is set in the environment rather than config.
+                if not _hyg_base_url:
+                    _hyg_base_url = os.environ.get("OPENAI_BASE_URL") or None
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary

Gateway hygiene compression never triggered for local/Ollama models because `get_model_context_length()` was called without `base_url`, causing cache misses and falling back to the 2M default. This set the threshold at 1.7M tokens — effectively unreachable.

## Changes

- Read `model.context_length` from the already-loaded config as the primary source (most reliable for local models)
- Pass `OPENAI_BASE_URL` from environment to `get_model_context_length()` as fallback, so the persistent cache is keyed correctly
- Wraps config read in try/except for safety

## Impact

Users running local models (Ollama, llama.cpp, vLLM) with custom model tags will now get proper context-window-aware compression. No change for cloud providers.

Closes #2708