### PR TITLE
feat(cli): show FULL ACCESS / RESTRICTED ACCESS label in welcome banner

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1989,6 +1989,12 @@ class HermesCLI:
             if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
                 ctx_len = self.agent.context_compressor.context_length
             
+            # Detect full-access (yolo) mode from env var or config
+            _yolo = bool(
+                os.environ.get("HERMES_YOLO_MODE")
+                or self.config.get("approvals", {}).get("mode") == "off"
+            )
+
             # Build and display the banner
             build_welcome_banner(
                 console=self.console,
@@ -1998,6 +2004,7 @@ class HermesCLI:
                 enabled_toolsets=self.enabled_toolsets,
                 session_id=self.session_id,
                 context_length=ctx_len,
+                yolo_mode=_yolo,
             )
         
         # Show tool availability warnings if any tools are disabled

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -244,7 +244,8 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
                          enabled_toolsets: List[str] = None,
                          session_id: str = None,
                          get_toolset_for_tool=None,
-                         context_length: int = None):
+                         context_length: int = None,
+                         yolo_mode: bool = False):
     """Build and print a welcome banner with caduceus on left and info on right.
 
     Args:
@@ -256,6 +257,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         session_id: Session identifier.
         get_toolset_for_tool: Callable to map tool name -> toolset name.
         context_length: Model's context window size in tokens.
+        yolo_mode: If True, show FULL ACCESS warning (all approvals bypassed).
     """
     from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
     if get_toolset_for_tool is None:
@@ -298,6 +300,10 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     left_lines.append(f"[dim {dim}]{cwd}[/]")
     if session_id:
         left_lines.append(f"[dim {session_color}]Session: {session_id}[/]")
+    if yolo_mode:
+        left_lines.append(f"[bold red]⚠  FULL ACCESS[/] [dim {dim}]— tool approvals bypassed[/]")
+    else:
+        left_lines.append(f"[bold green]✓  RESTRICTED ACCESS[/] [dim {dim}]— tool approvals enabled[/]")
     left_content = "\n".join(left_lines)
 
     right_lines = [f"[bold {accent}]Available Tools[/]"]


### PR DESCRIPTION
## Summary

Adds a permissions mode indicator to the welcome banner so users immediately know whether tool approvals are active when Hermes starts.

## Changes

**`hermes_cli/banner.py`**
- Add `yolo_mode: bool = False` parameter to `build_welcome_banner()`
- When `yolo_mode=True`: show `⚠  FULL ACCESS — tool approvals bypassed` in red
- Otherwise: show `✓  RESTRICTED ACCESS — tool approvals enabled` in green

**`cli.py`**
- Detect yolo mode from `HERMES_YOLO_MODE` env var or `approvals.mode == "off"` config key
- Pass `yolo_mode` to `build_welcome_banner()`

## Impact

Small cosmetic addition to the banner. No behavioral changes. Helps users running with `--yolo` or `approvals.mode: off` immediately see their permission state without checking config.

Closes #2663