### PR TITLE
fix(agent): reset turn counter and compression summary on /clear or /new

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1118,6 +1118,9 @@ class AIAgent:
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
         
+        # Turn counter — reset so flush_min_turns guard works correctly in new session
+        self._user_turn_count = 0
+
         # Context compressor internal counters (if present)
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.last_prompt_tokens = 0
@@ -1125,6 +1128,9 @@ class AIAgent:
             self.context_compressor.last_total_tokens = 0
             self.context_compressor.compression_count = 0
             self.context_compressor._context_probed = False
+            # Clear the previous summary so it doesn't seed the next session's
+            # iterative compression with context from a prior conversation.
+            self.context_compressor._previous_summary = None
     
     def _safe_print(self, *args, **kwargs):
         """Print that silently handles broken pipes / closed stdout.


### PR DESCRIPTION
## Summary

`/clear` and `/new` call `new_session()` → `reset_session_state()`, but two pieces of state survived and polluted the new session.

## Root Cause

`reset_session_state()` in `run_agent.py` reset token counters and compressor stats but missed:

1. **`context_compressor._previous_summary`** — if compression ran in the prior session, the old summary seeded the next session's iterative compression, causing cross-session context pollution (the new conversation's summary would reference prior-session content).

2. **`_user_turn_count`** — never reset, so the `flush_min_turns` guard in the new session saw an inflated count from the previous conversation.

## Changes

`run_agent.py` — add two lines to `reset_session_state()`:
```python
self._user_turn_count = 0
# ...
self.context_compressor._previous_summary = None
```

## Impact

Minimal — pure bug fix, no behavior change for normal sessions. `/clear` and `/new` now produce a fully clean slate for compression.

Closes #2635