### PR TITLE
fix(api): honour Retry-After header on HTTP 429 Too Many Requests

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6449,7 +6449,27 @@ class AIAgent:
                         logging.error(f"{self.log_prefix}Request details - Messages: {len(api_messages)}, Approx tokens: {approx_tokens:,}")
                         raise api_error
 
-                    wait_time = min(2 ** retry_count, 60)  # Exponential backoff: 2s, 4s, 8s, 16s, 32s, 60s, 60s
+                    # Honour the Retry-After header for 429 rate-limit responses.
+                    # Providers may return Retry-After: <seconds> to tell the
+                    # client exactly how long to wait before the next request.
+                    _retry_after_secs = None
+                    if status_code == 429:
+                        _resp = getattr(api_error, "response", None)
+                        if _resp is not None:
+                            _ra_header = (
+                                _resp.headers.get("Retry-After")
+                                or _resp.headers.get("retry-after")
+                            )
+                            if _ra_header:
+                                try:
+                                    _retry_after_secs = max(1.0, float(_ra_header))
+                                    self._vprint(
+                                        f"{self.log_prefix}   ⏳ Retry-After: {_retry_after_secs:.0f}s (from server header)",
+                                        force=True,
+                                    )
+                                except (ValueError, TypeError):
+                                    pass
+                    wait_time = _retry_after_secs if _retry_after_secs is not None else min(2 ** retry_count, 60)  # Exponential backoff: 2s, 4s, 8s, 16s, 32s, 60s, 60s
                     logger.warning(
                         "Retrying API call in %ss (attempt %s/%s) %s error=%s",
                         wait_time,


### PR DESCRIPTION
## Summary

When a provider returns a 429 with a `Retry-After` header, the agent was ignoring it and retrying after the generic exponential-backoff delay (2s, 4s, 8s…). This wasted rate-limit quota on providers that enforce a specific cooldown window (e.g. `Retry-After: 3600`).

## Changes

`run_agent.py` — in the retry error handler, after detecting `status_code == 429`:
- Read `Retry-After` / `retry-after` header from `api_error.response.headers`
- Use it as `wait_time` if present and parseable (clamped to ≥ 1s)
- Log a visible `⏳ Retry-After: Xs (from server header)` line
- Fall back to the existing exponential backoff if the header is absent or unparseable

## Impact

No behavioral change for providers that don't send `Retry-After`. For providers that do (custom endpoints, OpenRouter, Blablador, etc.), the agent now waits the server-specified duration instead of retrying too early.

Closes #2642