### PR TITLE
fix(auth): preserve 'custom' provider instead of silently mapping to openrouter

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -690,8 +690,10 @@ def resolve_provider(
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 
-    if normalized in {"openrouter", "custom"}:
+    if normalized == "openrouter":
         return "openrouter"
+    if normalized == "custom":
+        return "custom"
     if normalized in PROVIDER_REGISTRY:
         return normalized
     if normalized != "auto":


### PR DESCRIPTION
## Summary

`normalize_provider()` in `auth.py` grouped `'custom'` and `'openrouter'` in a single set check and returned `'openrouter'` for both. Users who set `provider: custom` in `config.yaml` would silently have their provider switched to `openrouter` mid-session with no warning, error message, or any indication that the switch happened.

## Root Cause

`hermes_cli/auth.py` line 693:
```python
# Before
if normalized in {"openrouter", "custom"}:
    return "openrouter"
```

## Fix

Split the single set check into two explicit returns:
```python
if normalized == "openrouter":
    return "openrouter"
if normalized == "custom":
    return "custom"
```

## Impact

One-line surgical fix. Users who set `provider: custom` (local LLMs, custom OpenAI-compatible endpoints) will no longer have their provider silently overridden.

Closes #2562