### PR TITLE
feat(slack): add reply_in_thread config option

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -252,7 +252,18 @@ class SlackAdapter(BasePlatformAdapter):
 
         Prefers metadata thread_id (the thread parent's ts, set by the
         gateway) over reply_to (which may be a child message's ts).
+
+        When ``reply_in_thread`` is ``false`` in the platform extra config,
+        top-level channel messages receive direct channel replies instead of
+        thread replies.  Messages that originate inside an existing thread are
+        always replied to in-thread to preserve conversation context.
         """
+        # When reply_in_thread is disabled (default: True for backward compat),
+        # only thread messages that are already part of an existing thread.
+        if not self.config.extra.get("reply_in_thread", True):
+            existing_thread = (metadata or {}).get("thread_id") or (metadata or {}).get("thread_ts")
+            return existing_thread or None
+
         if metadata:
             if metadata.get("thread_id"):
                 return metadata["thread_id"]


### PR DESCRIPTION
## Summary

Hermes always threads replies to Slack channel messages. Teams that prefer direct channel replies had no way to opt out.

## Changes

Add `reply_in_thread` to the Slack platform `extra` config (default `true` for full backward compatibility):

```yaml
platforms:
  slack:
    extra:
      reply_in_thread: false
```

When `false`, `_resolve_thread_ts()` returns `None` for top-level channel messages → replies go directly to the channel. Messages already inside an existing thread are always replied in-thread to preserve conversation context.

## Implementation

Minimal change to `gateway/platforms/slack.py` — 11 lines added to `_resolve_thread_ts()`.

Closes #2662