### PR TITLE
refactor(mcp): unify env-var interpolation and pre-compile regex

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -12,7 +12,6 @@ import asyncio
 import getpass
 import logging
 import os
-import re
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -501,10 +500,9 @@ def cmd_mcp_test(args):
 
 
 def _interpolate_value(value: str) -> str:
-    """Resolve ``${ENV_VAR}`` references in a string."""
-    def _replace(m):
-        return os.getenv(m.group(1), "")
-    return re.sub(r"\$\{(\w+)\}", _replace, value)
+    """Resolve ``${ENV_VAR}`` references in a string for display."""
+    from tools.mcp_tool import _ENV_VAR_PATTERN
+    return _ENV_VAR_PATTERN.sub(lambda m: os.getenv(m.group(1), ""), value)
 
 
 # ─── hermes mcp configure ────────────────────────────────────────────────────

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -935,13 +935,15 @@ def _run_on_mcp_loop(coro, timeout: float = 30):
 # Config loading
 # ---------------------------------------------------------------------------
 
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
 def _interpolate_env_vars(value):
     """Recursively resolve ``${VAR}`` placeholders from ``os.environ``."""
     if isinstance(value, str):
-        import re
         def _replace(m):
             return os.environ.get(m.group(1), m.group(0))
-        return re.sub(r"\$\{([^}]+)\}", _replace, value)
+        return _ENV_VAR_PATTERN.sub(_replace, value)
     if isinstance(value, dict):
         return {k: _interpolate_env_vars(v) for k, v in value.items()}
     if isinstance(value, list):


### PR DESCRIPTION
## Summary

Two separate env-var interpolation functions existed with inconsistent regex patterns, causing `hermes mcp test` to potentially show different results than runtime.

Fixes #2711 and #2712.

## Root Cause

| File | Regex | Behavior |
|---|---|---|
| `tools/mcp_tool.py` | `\$\{([^}]+)\}` | Matches any chars inside `${...}` ✅ |
| `hermes_cli/mcp_config.py` | `\$\{(\w+)\}` | Word chars only — silently fails on `-` or `.` ❌ |

## Changes

**`tools/mcp_tool.py`** (+3/-2):
- Pre-compile regex as `_ENV_VAR_PATTERN` at module level
- Remove redundant inner `import re` in `_interpolate_env_vars()`

**`hermes_cli/mcp_config.py`** (+2/-4):
- Rewrite `_interpolate_value()` to reuse `_ENV_VAR_PATTERN` from `mcp_tool`
- Remove now-unused `import re`

## Testing

- No behavioral change for common env var names (`[a-zA-Z0-9_]`)
- Fixes resolution for env vars with dots or hyphens (edge case)
- Pre-compiled regex eliminates per-call compilation overhead