### PR TITLE
fix(file_tools): pass docker_mount_cwd_to_workspace to container_config

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -114,6 +114,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "container_disk": config.get("container_disk", 51200),
                     "container_persistent": config.get("container_persistent", True),
                     "docker_volumes": config.get("docker_volumes", []),
+                    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                 }
 
             ssh_config = None


### PR DESCRIPTION
## Summary

`docker_mount_cwd_to_workspace: true` in `config.yaml` had no effect on file tool operations (find, read, write, etc.) because the `container_config` dict built in `file_tools.py` was missing this key.

## Root Cause

`_create_environment()` in `terminal_tool.py` reads `cc.get('docker_mount_cwd_to_workspace', False)` from `container_config` and passes it as `auto_mount_cwd` to `DockerEnvironment`. The terminal tool correctly included this key (line 966), but `file_tools.py` omitted it from its `container_config` dict, so the value was always `False` regardless of user configuration.

## Fix

One-line addition to `file_tools.py` to include `docker_mount_cwd_to_workspace` alongside the other existing container config keys.

Closes #2672