### PR TITLE
fix(auth): show actionable error when API key is a placeholder value

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1779,6 +1779,16 @@ class HermesCLI:
                     "using placeholder — local servers typically ignore auth",
                     base_url, _source,
                 )
+            elif runtime.get("_placeholder_rejected"):
+                self.console.print(
+                    "[bold red]Your configured API key is a placeholder value "
+                    "('none', 'null', 'dummy', etc.) which Hermes does not accept.[/] "
+                    "If you are running a [bold]local model[/] that does not require "
+                    "authentication, set [bold]base_url[/] to your server's address "
+                    "and leave the API key blank — Hermes will supply a no-op placeholder "
+                    "automatically. For cloud providers, please set a real API key."
+                )
+                return False
             else:
                 self.console.print("[bold red]Provider resolver returned an empty API key.[/]")
                 return False

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -196,8 +196,11 @@ def _resolve_named_custom_runtime(
         os.getenv("OPENROUTER_API_KEY", "").strip(),
     ]
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
+    placeholder_rejected = not api_key and any(
+        c and not has_usable_secret(c) for c in api_key_candidates
+    )
 
-    return {
+    result = {
         "provider": "openrouter",
         "api_mode": custom_provider.get("api_mode")
         or _detect_api_mode_for_url(base_url)
@@ -206,6 +209,9 @@ def _resolve_named_custom_runtime(
         "api_key": api_key,
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
     }
+    if placeholder_rejected:
+        result["_placeholder_rejected"] = True
+    return result
 
 
 def _resolve_openrouter_runtime(
@@ -276,10 +282,13 @@ def _resolve_openrouter_runtime(
         (str(candidate or "").strip() for candidate in api_key_candidates if has_usable_secret(candidate)),
         "",
     )
+    placeholder_rejected = not api_key and any(
+        str(c or "").strip() and not has_usable_secret(c) for c in api_key_candidates
+    )
 
     source = "explicit" if (explicit_api_key or explicit_base_url) else "env/config"
 
-    return {
+    result = {
         "provider": "openrouter",
         "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
         or _detect_api_mode_for_url(base_url)
@@ -288,6 +297,9 @@ def _resolve_openrouter_runtime(
         "api_key": api_key,
         "source": source,
     }
+    if placeholder_rejected:
+        result["_placeholder_rejected"] = True
+    return result
 
 
 def resolve_runtime_provider(


### PR DESCRIPTION
## Summary

When a user sets their API key to a placeholder value like `none`, `null`, or `dummy`, `has_usable_secret()` silently rejects it and the CLI displays the opaque message **"Provider resolver returned an empty API key"** — no hint about why or how to fix it.

## Changes

- **`runtime_provider.py`**: Both `_resolve_named_custom_runtime()` and `_resolve_openrouter_runtime()` now set `_placeholder_rejected: True` in their return dict when key resolution failed because all candidates were non-empty but failed the placeholder check.
- **`cli.py`**: When `_placeholder_rejected` is set, display a targeted, human-readable message:
  > _Your configured API key is a placeholder value ('none', 'null', 'dummy', etc.) which Hermes does not accept. If you are running a local model that does not require authentication, set `base_url` to your server's address and leave the API key blank — Hermes will supply a no-op placeholder automatically. For cloud providers, please set a real API key._

Closes #2565