### PR TITLE
fix(stt): map cloud-only model names to default local model for faster-whisper

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -522,7 +522,18 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
 
     if provider == "local":
         local_cfg = stt_config.get("local", {})
-        model_name = model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+        raw_model = model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+        # Cloud-only model names (e.g. "whisper-1") are invalid for faster-whisper.
+        # Normalise them to the default local model size ("base") so a config
+        # written by the setup wizard (which inserts stt.model: "whisper-1")
+        # doesn't crash on the first voice message.
+        model_name = _normalize_local_command_model(raw_model)
+        if model_name != raw_model:
+            logger.warning(
+                "stt.model '%s' is a cloud-only name and cannot be used with the "
+                "local faster-whisper provider; falling back to '%s'.",
+                raw_model, model_name,
+            )
         return _transcribe_local(file_path, model_name)
 
     if provider == "local_command":


### PR DESCRIPTION
## Summary

The setup wizard writes `stt.model: "whisper-1"` to `config.yaml` (the OpenAI API model identifier). When the **local** faster-whisper provider is active, this value was passed directly to `WhisperModel()` which rejects it with:

```
Invalid model size 'whisper-1', expected one of: tiny, base, small, medium, large...
```

The crash was swallowed by the caller, so voice messages were silently ignored.

## Fix

In `transcribe_audio()`, the local provider path now calls `_normalize_local_command_model()` on the raw model name before passing it to `_transcribe_local()`. This function already existed and is already used by the `local_command` path — it maps any cloud-only model name (`whisper-1`, `gpt-4o-transcribe`, `whisper-large-v3`, …) to `DEFAULT_LOCAL_MODEL` (`"base"`).

A `WARNING` log is emitted when the substitution occurs so users can see why their configured model name is being ignored.

Closes #2544