### PR TITLE
feat(cron): log execution results to memories/cron_log.md

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -258,6 +258,60 @@ def _build_job_prompt(job: dict) -> str:
     return "\n".join(parts)
 
 
+# ---------------------------------------------------------------------------
+# Cron execution log — write a one-liner to memories/ so the conversational
+# agent is aware of past scheduled task runs.
+# ---------------------------------------------------------------------------
+
+_CRON_LOG_MAX_LINES = 100  # Keep the log compact; prune oldest entries
+
+
+def _log_cron_execution(job: dict, success: bool, error: Optional[str] = None) -> None:
+    """Append a one-line execution record to ``memories/cron_log.md``.
+
+    The conversational agent can reference this file to answer questions
+    like "did you run the briefing today?" without needing full cron
+    context loaded during the job itself.
+    """
+    try:
+        memories_dir = _hermes_home / "memories"
+        memories_dir.mkdir(parents=True, exist_ok=True)
+        log_path = memories_dir / "cron_log.md"
+
+        timestamp = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+        job_name = job.get("name", job.get("id", "unknown"))
+        status = "✅" if success else "❌"
+        line = f"- [{timestamp}] {status} **{job_name}**"
+        if error:
+            # Truncate long errors to keep the log readable
+            short_error = error[:120].replace("\n", " ")
+            line += f" — {short_error}"
+
+        # Append to log, creating header if needed
+        if log_path.exists():
+            existing = log_path.read_text(encoding="utf-8")
+        else:
+            existing = "# Cron Execution Log\n\nRecent scheduled task runs (auto-generated, newest last):\n"
+
+        lines = existing.rstrip().split("\n")
+        lines.append(line)
+
+        # Prune oldest entries (keep header + last N entries)
+        header_end = 0
+        for i, l in enumerate(lines):
+            if l.startswith("- ["):
+                header_end = i
+                break
+        entry_lines = [l for l in lines[header_end:] if l.startswith("- [")]
+        if len(entry_lines) > _CRON_LOG_MAX_LINES:
+            entry_lines = entry_lines[-_CRON_LOG_MAX_LINES:]
+        pruned = lines[:header_end] + entry_lines
+
+        log_path.write_text("\n".join(pruned) + "\n", encoding="utf-8")
+    except Exception as e:
+        logger.debug("Failed to write cron execution log: %s", e)
+
+
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -546,6 +600,7 @@ def tick(verbose: bool = True) -> int:
                         logger.error("Delivery failed for job %s: %s", job["id"], de)
 
                 mark_job_run(job["id"], success, error)
+                _log_cron_execution(job, success, error)
                 executed += 1
 
             except Exception as e:

--- a/tests/cron/test_cron_log.py
+++ b/tests/cron/test_cron_log.py
@@ -1,0 +1,133 @@
+"""Tests for cron execution log (memories/cron_log.md).
+
+Verifies that:
+1. Successful job runs are logged with ✅
+2. Failed job runs are logged with ❌ and truncated error
+3. Log file is created with header if it doesn't exist
+4. Old entries are pruned when exceeding max lines
+5. Logging failures are non-fatal (never crash the scheduler)
+"""
+
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+
+@pytest.fixture
+def temp_hermes_home(tmp_path):
+    """Set up a temporary HERMES_HOME for testing."""
+    with patch("cron.scheduler._hermes_home", tmp_path):
+        yield tmp_path
+
+
+def _make_job(name="test-job", job_id="test-123"):
+    return {"name": name, "id": job_id}
+
+
+class TestCronExecutionLog:
+
+    def test_successful_job_logged(self, temp_hermes_home):
+        from cron.scheduler import _log_cron_execution
+
+        _log_cron_execution(_make_job("Daily Briefing"), success=True)
+
+        log_path = temp_hermes_home / "memories" / "cron_log.md"
+        assert log_path.exists()
+        content = log_path.read_text()
+        assert "# Cron Execution Log" in content
+        assert "✅" in content
+        assert "**Daily Briefing**" in content
+
+    def test_failed_job_logged_with_error(self, temp_hermes_home):
+        from cron.scheduler import _log_cron_execution
+
+        _log_cron_execution(
+            _make_job("Backup"),
+            success=False,
+            error="ConnectionError: database unreachable",
+        )
+
+        log_path = temp_hermes_home / "memories" / "cron_log.md"
+        content = log_path.read_text()
+        assert "❌" in content
+        assert "**Backup**" in content
+        assert "ConnectionError" in content
+
+    def test_error_truncated(self, temp_hermes_home):
+        from cron.scheduler import _log_cron_execution
+
+        long_error = "x" * 200
+        _log_cron_execution(_make_job(), success=False, error=long_error)
+
+        log_path = temp_hermes_home / "memories" / "cron_log.md"
+        content = log_path.read_text()
+        # Error should be truncated to 120 chars
+        lines = [l for l in content.split("\n") if l.startswith("- [")]
+        assert len(lines) == 1
+        # The error portion should not contain the full 200-char string
+        assert "x" * 200 not in lines[0]
+        assert "x" * 120 in lines[0]
+
+    def test_creates_memories_dir(self, temp_hermes_home):
+        from cron.scheduler import _log_cron_execution
+
+        memories_dir = temp_hermes_home / "memories"
+        assert not memories_dir.exists()
+
+        _log_cron_execution(_make_job(), success=True)
+        assert memories_dir.exists()
+        assert (memories_dir / "cron_log.md").exists()
+
+    def test_appends_multiple_entries(self, temp_hermes_home):
+        from cron.scheduler import _log_cron_execution
+
+        _log_cron_execution(_make_job("Job A"), success=True)
+        _log_cron_execution(_make_job("Job B"), success=True)
+        _log_cron_execution(_make_job("Job C"), success=False, error="timeout")
+
+        log_path = temp_hermes_home / "memories" / "cron_log.md"
+        content = log_path.read_text()
+        entries = [l for l in content.split("\n") if l.startswith("- [")]
+        assert len(entries) == 3
+        assert "Job A" in entries[0]
+        assert "Job B" in entries[1]
+        assert "Job C" in entries[2]
+
+    def test_prunes_old_entries(self, temp_hermes_home):
+        from cron.scheduler import _log_cron_execution, _CRON_LOG_MAX_LINES
+
+        # Write more than max entries
+        for i in range(_CRON_LOG_MAX_LINES + 20):
+            _log_cron_execution(_make_job(f"Job-{i}"), success=True)
+
+        log_path = temp_hermes_home / "memories" / "cron_log.md"
+        content = log_path.read_text()
+        entries = [l for l in content.split("\n") if l.startswith("- [")]
+        assert len(entries) == _CRON_LOG_MAX_LINES
+        # Should keep newest, prune oldest
+        assert f"Job-{_CRON_LOG_MAX_LINES + 19}" in entries[-1]
+        assert "Job-0" not in content
+
+    def test_logging_failure_is_nonfatal(self, temp_hermes_home):
+        from cron.scheduler import _log_cron_execution
+
+        # Make memories dir unwritable
+        memories_dir = temp_hermes_home / "memories"
+        memories_dir.mkdir(parents=True)
+        memories_dir.chmod(0o444)
+
+        # Should not raise — just log debug and continue
+        try:
+            _log_cron_execution(_make_job(), success=True)
+        finally:
+            memories_dir.chmod(0o755)
+
+    def test_job_without_name_uses_id(self, temp_hermes_home):
+        from cron.scheduler import _log_cron_execution
+
+        _log_cron_execution({"id": "abc-456"}, success=True)
+
+        log_path = temp_hermes_home / "memories" / "cron_log.md"
+        content = log_path.read_text()
+        assert "**abc-456**" in content


### PR DESCRIPTION
## Summary

Cron jobs run with `lightContext: true` in isolated sessions. The conversational agent has no awareness of past scheduled task runs, so when a user asks "did you run the briefing today?" the agent incorrectly denies it.

Fixes #2704.

## Solution

After each cron job completes, append a one-line execution record to `memories/cron_log.md`:

```
- [2026-03-24 08:30:00] ✅ **Daily Morning Briefing**
- [2026-03-24 09:00:00] ❌ **Backup** — ConnectionError: database unreachable
```

The agent can reference this file via the memory/file tools when asked about cron history.

## Design Decisions

- **Separate file** (`cron_log.md`) instead of appending to `MEMORY.md` — keeps the user's curated memory clean
- **One-liner per run** — minimal disk usage, easy to scan
- **Auto-prune at 100 entries** — prevents unbounded growth
- **Non-fatal** — logging failures are caught and debug-logged, never crash the scheduler
- **Error truncation** — long errors are capped at 120 chars to keep the log readable

## Changes

- `cron/scheduler.py`: +55 lines — `_log_cron_execution()` function + call after `mark_job_run()`
- `tests/cron/test_cron_log.py`: +133 lines — 8 tests covering success, failure, pruning, edge cases

## Testing

| Test | What it verifies |
|---|---|
| `test_successful_job_logged` | ✅ emoji, job name in log |
| `test_failed_job_logged_with_error` | ❌ emoji, error message |
| `test_error_truncated` | Long errors capped at 120 chars |
| `test_creates_memories_dir` | Auto-creates `memories/` if missing |
| `test_appends_multiple_entries` | Multiple runs accumulate in order |
| `test_prunes_old_entries` | Oldest pruned when exceeding 100 entries |
| `test_logging_failure_is_nonfatal` | Unwritable dir does not crash |
| `test_job_without_name_uses_id` | Falls back to job ID if no name |