### PR TITLE
fix(cli): preserve MCP server aliases in platform toolset config

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -399,9 +399,20 @@ def _get_platform_tools(config: dict, platform: str) -> Set[str]:
     # "hermes-cli" (which include all _HERMES_CORE_TOOLS) cause disabled
     # toolsets to re-appear as enabled.
     has_explicit_config = any(ts in configurable_keys for ts in toolset_names)
+    platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}
 
     if has_explicit_config:
-        enabled_toolsets = {ts for ts in toolset_names if ts in configurable_keys}
+        enabled_toolsets = {
+            ts for ts in toolset_names if ts in configurable_keys
+        }
+        # Preserve any non-configurable toolset entries already stored for the
+        # platform, such as MCP server aliases. These are intentionally not part
+        # of CONFIGURABLE_TOOLSETS, but they still need to reach the agent.
+        enabled_toolsets |= {
+            ts
+            for ts in toolset_names
+            if ts not in configurable_keys and ts not in platform_default_keys
+        }
     else:
         # No explicit config — fall back to resolving composite toolset names
         # (e.g. "hermes-cli") to individual tool names and reverse-mapping.

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -49,6 +49,23 @@ def test_toolset_has_keys_for_vision_accepts_codex_auth(tmp_path, monkeypatch):
     assert _toolset_has_keys("vision") is True
 
 
+def test_get_platform_tools_preserves_mcp_server_aliases():
+    """MCP server aliases must survive _get_platform_tools() round-trip."""
+    config = {
+        "platform_toolsets": {
+            "cli": ["terminal", "web", "file", "my-mcp-server", "another-mcp"]
+        }
+    }
+
+    result = _get_platform_tools(config, "cli")
+
+    assert "my-mcp-server" in result
+    assert "another-mcp" in result
+    assert "terminal" in result
+    assert "web" in result
+    assert "file" in result
+
+
 def test_save_platform_tools_preserves_mcp_server_names():
     """Ensure MCP server names are preserved when saving platform tools.
 


### PR DESCRIPTION
## What does this PR do?

Preserves MCP server aliases in platform toolset configuration. When `_get_platform_tools()` resolves the enabled toolsets, non-configurable entries like the MCP server names registered via `mcp_servers` config were being silently dropped. So after a user would run `hermes tools` to toggle toolsets, the MCP aliases would disappear from the saved config.

This fix preserves any toolset entries that aren't in `CONFIGURABLE_TOOLSETS` (not `web`, `terminal`, `file`, etc.) AND aren't platform default keys (not `hermes-cli`, `hermes-telegram`, etc.)

This allows the MCP-registered toolset to pass through to the agent to be able to use them.

## Related Issue

This issue is related to #2574 , which addresses a similar symptom (that toolsets are dropped from the config) but for MCP server aliases instead of the Python plugin toolsets. And PRs #2577 and #2578 address the plugin case; this PR is solely focused on fixing the MCP alias case.


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`hermes_cli/tools_config.py`: In `_get_platform_tools()`, after collecting configurable toolsets, also preserve non-configurable toolset entries (MCP server aliases) that are stored in the platform config but aren't part of `CONFIGURABLE_TOOLSETS` or platform defaults.

## How to Test

1.  Configure an MCP server in `~/.hermes/config.yaml`:
      ```yaml
      mcp_servers:
        my-server:
          command: ["node", "server.js"]
2. Run hermes tools, and toggle some toolsets on/off, and then exit. 
3. Check ~/.hermes/config.yaml to verify my-server or whatever you set is still present in platform_toolsets.
4. Run hermes chat, and confirm that the MCP tools are available.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 (Ubuntu 24.04.2)

### Documentation & Housekeeping

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


