### PR TITLE
feat(gateway): coalesce rapid inbound messages

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -41,6 +41,16 @@ def _normalize_unauthorized_dm_behavior(value: Any, default: str = "pair") -> st
     return default
 
 
+def _coerce_non_negative_int(value: Any, default: int = 0) -> int:
+    """Coerce a config value to a non-negative integer, falling back safely."""
+    if value is None:
+        return default
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return default
+
+
 class Platform(Enum):
     """Supported messaging platforms."""
     LOCAL = "local"
@@ -201,6 +211,62 @@ class StreamingConfig:
 
 
 @dataclass
+class MessageCoalescingConfig:
+    """Configuration for batching rapid inbound gateway messages into one turn."""
+
+    enabled: bool = True
+    debounce_ms: int = 1500
+    max_wait_ms: int = 5000
+    min_messages: int = 2
+    multi_user_only: bool = True
+    include_hint: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "debounce_ms": self.debounce_ms,
+            "max_wait_ms": self.max_wait_ms,
+            "min_messages": self.min_messages,
+            "multi_user_only": self.multi_user_only,
+            "include_hint": self.include_hint,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Optional[Dict[str, Any]],
+        *,
+        defaults: Optional["MessageCoalescingConfig"] = None,
+    ) -> "MessageCoalescingConfig":
+        base = defaults or cls()
+        if not isinstance(data, dict):
+            return cls(
+                enabled=base.enabled,
+                debounce_ms=base.debounce_ms,
+                max_wait_ms=base.max_wait_ms,
+                min_messages=base.min_messages,
+                multi_user_only=base.multi_user_only,
+                include_hint=base.include_hint,
+            )
+
+        debounce_ms = _coerce_non_negative_int(data.get("debounce_ms"), base.debounce_ms)
+        max_wait_ms = _coerce_non_negative_int(data.get("max_wait_ms"), base.max_wait_ms)
+        min_messages = max(1, _coerce_non_negative_int(data.get("min_messages"), base.min_messages))
+
+        if max_wait_ms < debounce_ms:
+            max_wait_ms = debounce_ms
+
+        return cls(
+            enabled=_coerce_bool(data.get("enabled"), base.enabled),
+            debounce_ms=debounce_ms,
+            max_wait_ms=max_wait_ms,
+            min_messages=min_messages,
+            multi_user_only=_coerce_bool(data.get("multi_user_only"), base.multi_user_only),
+            include_hint=_coerce_bool(data.get("include_hint"), base.include_hint),
+        )
+
+
+@dataclass
 class GatewayConfig:
     """
     Main gateway configuration.
@@ -232,6 +298,9 @@ class GatewayConfig:
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
+
+    # Inbound message coalescing
+    message_coalescing: MessageCoalescingConfig = field(default_factory=MessageCoalescingConfig)
 
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
@@ -313,6 +382,7 @@ class GatewayConfig:
             "always_log_local": self.always_log_local,
             "stt_enabled": self.stt_enabled,
             "group_sessions_per_user": self.group_sessions_per_user,
+            "message_coalescing": self.message_coalescing.to_dict(),
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
         }
@@ -356,6 +426,7 @@ class GatewayConfig:
             stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
 
         group_sessions_per_user = data.get("group_sessions_per_user")
+        message_coalescing = MessageCoalescingConfig.from_dict(data.get("message_coalescing"))
         unauthorized_dm_behavior = _normalize_unauthorized_dm_behavior(
             data.get("unauthorized_dm_behavior"),
             "pair",
@@ -372,8 +443,27 @@ class GatewayConfig:
             always_log_local=data.get("always_log_local", True),
             stt_enabled=_coerce_bool(stt_enabled, True),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
+            message_coalescing=message_coalescing,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+        )
+
+    def get_message_coalescing(self, platform: Optional[Platform] = None) -> MessageCoalescingConfig:
+        """Return the effective coalescing config for a platform."""
+        if not platform:
+            return MessageCoalescingConfig.from_dict(
+                self.message_coalescing.to_dict(),
+                defaults=self.message_coalescing,
+            )
+
+        platform_cfg = self.platforms.get(platform)
+        platform_override = None
+        if platform_cfg and isinstance(platform_cfg.extra, dict):
+            platform_override = platform_cfg.extra.get("message_coalescing")
+
+        return MessageCoalescingConfig.from_dict(
+            platform_override,
+            defaults=self.message_coalescing,
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -446,6 +536,10 @@ def load_gateway_config() -> GatewayConfig:
 
             if "group_sessions_per_user" in yaml_cfg:
                 gw_data["group_sessions_per_user"] = yaml_cfg["group_sessions_per_user"]
+
+            message_coalescing_cfg = yaml_cfg.get("message_coalescing")
+            if isinstance(message_coalescing_cfg, dict):
+                gw_data["message_coalescing"] = message_coalescing_cfg
 
             streaming_cfg = yaml_cfg.get("streaming")
             if isinstance(streaming_cfg, dict):
@@ -797,5 +891,4 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.default_reset_policy.at_hour = int(reset_hour)
         except ValueError:
             pass
-
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -253,9 +253,6 @@ class MessageCoalescingConfig:
         max_wait_ms = _coerce_non_negative_int(data.get("max_wait_ms"), base.max_wait_ms)
         min_messages = max(1, _coerce_non_negative_int(data.get("min_messages"), base.min_messages))
 
-        if max_wait_ms < debounce_ms:
-            max_wait_ms = debounce_ms
-
         return cls(
             enabled=_coerce_bool(data.get("enabled"), base.enabled),
             debounce_ms=debounce_ms,
@@ -891,4 +888,3 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.default_reset_policy.at_hour = int(reset_hour)
         except ValueError:
             pass
-

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -968,7 +968,10 @@ class BasePlatformAdapter(ABC):
 
     def _pop_coalesced_event(self, session_key: str) -> Optional[MessageEvent]:
         """Return the current coalesced event and clear any pending timer."""
-        current_task = asyncio.current_task()
+        try:
+            current_task = asyncio.current_task()
+        except RuntimeError:
+            current_task = None
         task = self._pending_coalescing_tasks.pop(session_key, None)
         if task and task is not current_task and not task.done():
             task.cancel()
@@ -1373,7 +1376,10 @@ class BasePlatformAdapter(ABC):
     
     def get_pending_message(self, session_key: str) -> Optional[MessageEvent]:
         """Get and clear any pending message for a session."""
-        return self._pending_messages.pop(session_key, None)
+        pending_message = self._pending_messages.pop(session_key, None)
+        if pending_message is not None:
+            return pending_message
+        return self._pop_coalesced_event(session_key)
     
     def build_source(
         self,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -23,7 +23,7 @@ import sys
 from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import MessageCoalescingConfig, Platform, PlatformConfig
 from gateway.session import SessionSource, build_session_key
 from hermes_cli.config import get_hermes_home
 
@@ -328,6 +328,15 @@ class SendResult:
     raw_response: Any = None
 
 
+@dataclass
+class PendingCoalescedMessages:
+    """Buffered inbound messages waiting to be coalesced into one turn."""
+
+    events: List[MessageEvent] = field(default_factory=list)
+    first_received_at: float = 0.0
+    last_received_at: float = 0.0
+
+
 # Type for message handlers
 MessageHandler = Callable[[MessageEvent], Awaitable[Optional[str]]]
 
@@ -357,6 +366,8 @@ class BasePlatformAdapter(ABC):
         # Key: session_key (e.g., chat_id), Value: (event, asyncio.Event for interrupt)
         self._active_sessions: Dict[str, asyncio.Event] = {}
         self._pending_messages: Dict[str, MessageEvent] = {}
+        self._pending_coalesced_messages: Dict[str, PendingCoalescedMessages] = {}
+        self._pending_coalescing_tasks: Dict[str, asyncio.Task] = {}
         # Background message-processing tasks spawned by handle_message().
         # Gateway shutdown cancels these so an old gateway instance doesn't keep
         # working on a task after --replace or manual restarts.
@@ -835,8 +846,202 @@ class BasePlatformAdapter(ABC):
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
         )
-        
-        # Check if there's already an active handler for this session
+
+        coalescing = self._get_message_coalescing_config()
+
+        if event.is_command():
+            self._clear_coalesced_message(session_key)
+            await self._handle_message_now(event, session_key)
+            return
+
+        if self._should_coalesce_event(event, coalescing):
+            self._append_coalesced_message(session_key, event)
+            if session_key in self._active_sessions:
+                self._active_sessions[session_key].set()
+                return
+            self._schedule_coalesced_flush(session_key, coalescing)
+            try:
+                thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+                await self.send_typing(event.source.chat_id, metadata=thread_metadata)
+            except Exception:
+                pass
+            return
+
+        if session_key not in self._active_sessions:
+            coalesced_event = self._pop_coalesced_event(session_key)
+            if coalesced_event is not None:
+                await self._handle_message_now(coalesced_event, session_key)
+
+        await self._handle_message_now(event, session_key)
+
+    def _get_message_coalescing_config(self) -> MessageCoalescingConfig:
+        """Resolve adapter-level inbound message coalescing settings."""
+        raw = self.config.extra.get("message_coalescing")
+        if raw is None:
+            return MessageCoalescingConfig(enabled=False)
+        if isinstance(raw, MessageCoalescingConfig):
+            return raw
+        if not isinstance(raw, dict):
+            return MessageCoalescingConfig(enabled=False)
+        return MessageCoalescingConfig.from_dict(raw)
+
+    @staticmethod
+    def _should_coalesce_event(
+        event: MessageEvent,
+        config: MessageCoalescingConfig,
+    ) -> bool:
+        """Return True when an inbound event should wait for a quiet period."""
+        if not config.enabled:
+            return False
+        if event.is_command():
+            return False
+        if event.message_type != MessageType.TEXT:
+            return False
+        if event.media_urls:
+            return False
+        if config.multi_user_only and event.source.chat_type == "dm":
+            return False
+        return bool((event.text or "").strip())
+
+    def _append_coalesced_message(
+        self,
+        session_key: str,
+        event: MessageEvent,
+    ) -> PendingCoalescedMessages:
+        """Append an inbound message to a session's pending coalesced batch."""
+        now = asyncio.get_running_loop().time()
+        batch = self._pending_coalesced_messages.get(session_key)
+        if batch is None:
+            batch = PendingCoalescedMessages(
+                events=[event],
+                first_received_at=now,
+                last_received_at=now,
+            )
+            self._pending_coalesced_messages[session_key] = batch
+            return batch
+
+        batch.events.append(event)
+        batch.last_received_at = now
+        return batch
+
+    def _schedule_coalesced_flush(
+        self,
+        session_key: str,
+        config: MessageCoalescingConfig,
+    ) -> None:
+        """Reset the debounce timer for an idle coalesced batch."""
+        batch = self._pending_coalesced_messages.get(session_key)
+        if batch is None:
+            return
+
+        prior_task = self._pending_coalescing_tasks.pop(session_key, None)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+
+        elapsed_ms = max(
+            0,
+            int((asyncio.get_running_loop().time() - batch.first_received_at) * 1000),
+        )
+        remaining_cap_ms = max(0, config.max_wait_ms - elapsed_ms)
+        delay_ms = config.debounce_ms
+        if len(batch.events) < config.min_messages:
+            delay_ms = min(delay_ms, 350)
+        if config.max_wait_ms > 0:
+            delay_ms = min(delay_ms, remaining_cap_ms)
+
+        self._pending_coalescing_tasks[session_key] = asyncio.create_task(
+            self._flush_coalesced_message_after(session_key, delay_ms / 1000.0)
+        )
+
+    async def _flush_coalesced_message_after(self, session_key: str, delay_seconds: float) -> None:
+        """Wait for the coalescing window, then dispatch the merged event."""
+        current_task = asyncio.current_task()
+        try:
+            await asyncio.sleep(max(0.0, delay_seconds))
+            event = self._pop_coalesced_event(session_key)
+            if event is None:
+                return
+            await self._handle_message_now(event, session_key)
+        finally:
+            if self._pending_coalescing_tasks.get(session_key) is current_task:
+                self._pending_coalescing_tasks.pop(session_key, None)
+
+    def _pop_coalesced_event(self, session_key: str) -> Optional[MessageEvent]:
+        """Return the current coalesced event and clear any pending timer."""
+        current_task = asyncio.current_task()
+        task = self._pending_coalescing_tasks.pop(session_key, None)
+        if task and task is not current_task and not task.done():
+            task.cancel()
+
+        batch = self._pending_coalesced_messages.pop(session_key, None)
+        if batch is None:
+            return None
+        return self._build_coalesced_event(batch)
+
+    def _clear_coalesced_message(self, session_key: str) -> None:
+        """Drop any pending coalesced inbound batch for a session."""
+        self._pending_coalesced_messages.pop(session_key, None)
+        task = self._pending_coalescing_tasks.pop(session_key, None)
+        if task and not task.done():
+            task.cancel()
+
+    def _build_coalesced_event(self, batch: PendingCoalescedMessages) -> MessageEvent:
+        """Format a pending batch into a single MessageEvent."""
+        if len(batch.events) == 1:
+            return batch.events[0]
+
+        latest = batch.events[-1]
+        elapsed_seconds = max(0.0, batch.last_received_at - batch.first_received_at)
+        include_hint = self._get_message_coalescing_config().include_hint
+        unique_senders = {
+            event.source.user_id or event.source.user_name or ""
+            for event in batch.events
+            if event.source
+        }
+        include_sender = latest.source.chat_type != "dm" or len(unique_senders) > 1
+
+        lines: List[str] = []
+        for item in batch.events:
+            text = (item.text or "").strip() or "[empty message]"
+            timestamp = item.timestamp.strftime("%H:%M:%S")
+            if include_sender:
+                sender = item.source.user_name or item.source.user_id or "User"
+                lines.append(f"[{timestamp}] {sender}: {text}")
+            else:
+                lines.append(f"[{timestamp}] {text}")
+
+        parts: List[str] = []
+        if include_hint:
+            summary = (
+                f"{len(batch.events)} rapid messages arrived over {elapsed_seconds:.1f}s. "
+                "Treat them as one turn and respond to the overall request."
+            )
+            if len(unique_senders) > 1:
+                summary += f" {len(unique_senders)} participants are involved."
+            parts.extend([summary, ""])
+        parts.extend(lines)
+
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        for item in batch.events:
+            media_urls.extend(item.media_urls)
+            media_types.extend(item.media_types)
+
+        return MessageEvent(
+            text="\n\n".join(parts).strip(),
+            message_type=latest.message_type,
+            source=latest.source,
+            raw_message=latest.raw_message,
+            message_id=latest.message_id,
+            media_urls=media_urls,
+            media_types=media_types,
+            reply_to_message_id=latest.reply_to_message_id,
+            reply_to_text=latest.reply_to_text,
+            timestamp=latest.timestamp,
+        )
+
+    async def _handle_message_now(self, event: MessageEvent, session_key: str) -> None:
+        """Dispatch an inbound event immediately using interrupt-aware session logic."""
         if session_key in self._active_sessions:
             # Special case: photo bursts/albums frequently arrive as multiple near-
             # simultaneous messages. Queue them without interrupting the active run,
@@ -854,22 +1059,20 @@ class BasePlatformAdapter(ABC):
                             existing.text = f"{existing.text}\n\n{event.text}".strip()
                 else:
                     self._pending_messages[session_key] = event
-                return  # Don't interrupt now - will run after current task completes
+                return
 
-            # Default behavior for non-photo follow-ups: interrupt the running agent
             print(f"[{self.name}] ⚡ New message while session {session_key} is active - triggering interrupt")
             self._pending_messages[session_key] = event
-            # Signal the interrupt (the processing task checks this)
             self._active_sessions[session_key].set()
-            return  # Don't process now - will be handled after current task finishes
-        
-        # Spawn background task to process this message
-        task = asyncio.create_task(self._process_message_background(event, session_key))
+            return
+
+        interrupt_event = asyncio.Event()
+        self._active_sessions[session_key] = interrupt_event
+        task = asyncio.create_task(self._process_message_background(event, session_key, interrupt_event))
         try:
             self._background_tasks.add(task)
         except TypeError:
-            # Some tests stub create_task() with lightweight sentinels that are not
-            # hashable and do not support lifecycle callbacks.
+            self._active_sessions.pop(session_key, None)
             return
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
@@ -895,10 +1098,15 @@ class BasePlatformAdapter(ABC):
             min_ms, max_ms = 800, 2500
         return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
 
-    async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
+    async def _process_message_background(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        interrupt_event: Optional[asyncio.Event] = None,
+    ) -> None:
         """Background task that actually processes the message."""
-        # Create interrupt event for this session
-        interrupt_event = asyncio.Event()
+        if interrupt_event is None:
+            interrupt_event = asyncio.Event()
         self._active_sessions[session_key] = interrupt_event
         
         # Start continuous typing indicator (refreshes every 2 seconds)
@@ -1088,8 +1296,10 @@ class BasePlatformAdapter(ABC):
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
 
             # Check if there's a pending message that was queued during our processing
-            if session_key in self._pending_messages:
-                pending_event = self._pending_messages.pop(session_key)
+            pending_event = self._pending_messages.pop(session_key, None)
+            if pending_event is None:
+                pending_event = self._pop_coalesced_event(session_key)
+            if pending_event is not None:
                 print(f"[{self.name}] 📨 Processing queued message from interrupt")
                 # Clean up current session before processing pending
                 if session_key in self._active_sessions:
@@ -1147,6 +1357,14 @@ class BasePlatformAdapter(ABC):
             await asyncio.gather(*tasks, return_exceptions=True)
         self._background_tasks.clear()
         self._pending_messages.clear()
+        pending_coalescing_tasks = list(self._pending_coalescing_tasks.values())
+        for task in pending_coalescing_tasks:
+            if not task.done():
+                task.cancel()
+        if pending_coalescing_tasks:
+            await asyncio.gather(*pending_coalescing_tasks, return_exceptions=True)
+        self._pending_coalescing_tasks.clear()
+        self._pending_coalesced_messages.clear()
         self._active_sessions.clear()
 
     def has_pending_interrupt(self, session_key: str) -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1282,6 +1282,7 @@ class GatewayRunner:
                 "group_sessions_per_user",
                 self.config.group_sessions_per_user,
             )
+            config.extra["message_coalescing"] = self.config.get_message_coalescing(platform).to_dict()
 
         if platform == Platform.TELEGRAM:
             from gateway.platforms.telegram import TelegramAdapter, check_telegram_requirements

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -333,6 +333,18 @@ DEFAULT_CONFIG = {
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
     },
 
+    # Gateway inbound message batching for rapid-fire chat messages.
+    # Hermes coalesces by session key, so group chats still respect
+    # group_sessions_per_user unless the user disables it separately.
+    "message_coalescing": {
+        "enabled": True,
+        "debounce_ms": 1500,
+        "max_wait_ms": 5000,
+        "min_messages": 2,
+        "multi_user_only": True,
+        "include_hint": True,
+    },
+
     # WhatsApp platform settings (gateway mode)
     "whatsapp": {
         # Reply prefix prepended to every outgoing WhatsApp message.
@@ -373,7 +385,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 10,
+    "_config_version": 11,
 }
 
 # =============================================================================

--- a/tests/gateway/test_message_coalescing.py
+++ b/tests/gateway/test_message_coalescing.py
@@ -143,6 +143,23 @@ class TestMessageCoalescingConfig:
         assert created.extra["message_coalescing"]["debounce_ms"] == 1500
         assert created.extra["message_coalescing"]["max_wait_ms"] == 5000
 
+    def test_preserves_max_wait_below_debounce(self):
+        config = GatewayConfig.from_dict(
+            {
+                "message_coalescing": {
+                    "enabled": True,
+                    "debounce_ms": 1500,
+                    "max_wait_ms": 300,
+                    "min_messages": 2,
+                    "multi_user_only": True,
+                    "include_hint": True,
+                }
+            }
+        )
+
+        assert config.message_coalescing.debounce_ms == 1500
+        assert config.message_coalescing.max_wait_ms == 300
+
 
 class TestAdapterMessageCoalescing:
     @pytest.mark.asyncio
@@ -361,6 +378,34 @@ class TestAdapterMessageCoalescing:
         assert len(seen_texts) == 2
         assert "second" in seen_texts[1]
         assert "third" in seen_texts[1]
+
+    @pytest.mark.asyncio
+    async def test_get_pending_message_returns_coalesced_followup_for_interrupt_handoff(self):
+        adapter = DummyCoalescingAdapter(
+            extra={
+                "message_coalescing": {
+                    "enabled": True,
+                    "debounce_ms": 50,
+                    "max_wait_ms": 200,
+                    "min_messages": 2,
+                    "multi_user_only": True,
+                    "include_hint": True,
+                }
+            }
+        )
+        adapter.set_message_handler(AsyncMock(return_value=None))
+
+        follow_up = _make_event("follow-up", message_id="2")
+        session_key = build_session_key(follow_up.source)
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        await adapter.handle_message(follow_up)
+
+        pending = adapter.get_pending_message(session_key)
+
+        assert pending is not None
+        assert pending.text == "follow-up"
+        assert adapter.get_pending_message(session_key) is None
 
     @pytest.mark.asyncio
     async def test_cancel_background_tasks_clears_pending_coalescing(self):

--- a/tests/gateway/test_message_coalescing.py
+++ b/tests/gateway/test_message_coalescing.py
@@ -1,0 +1,389 @@
+"""Tests for gateway inbound message coalescing."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import (
+    GatewayConfig,
+    MessageCoalescingConfig,
+    Platform,
+    PlatformConfig,
+    load_gateway_config,
+)
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+class DummyCoalescingAdapter(BasePlatformAdapter):
+    """Minimal adapter for platform-agnostic coalescing tests."""
+
+    def __init__(self, *, extra=None):
+        super().__init__(
+            PlatformConfig(enabled=True, token="fake-token", extra=extra or {}),
+            Platform.TELEGRAM,
+        )
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="1")
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+def _make_event(
+    text: str,
+    *,
+    chat_type: str = "group",
+    chat_id: str = "12345",
+    user_id: str = "u-1",
+    user_name: str = "Alice",
+    message_id: str = "1",
+) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=chat_id,
+            chat_type=chat_type,
+            user_id=user_id,
+            user_name=user_name,
+        ),
+        message_id=message_id,
+    )
+
+
+class TestMessageCoalescingConfig:
+    def test_roundtrip_preserves_message_coalescing_settings(self):
+        config = GatewayConfig(
+            message_coalescing=MessageCoalescingConfig(
+                enabled=True,
+                debounce_ms=1500,
+                max_wait_ms=5000,
+                min_messages=2,
+                multi_user_only=True,
+                include_hint=True,
+            )
+        )
+
+        restored = GatewayConfig.from_dict(config.to_dict())
+
+        assert restored.message_coalescing.enabled is True
+        assert restored.message_coalescing.debounce_ms == 1500
+        assert restored.message_coalescing.max_wait_ms == 5000
+        assert restored.message_coalescing.min_messages == 2
+        assert restored.message_coalescing.multi_user_only is True
+        assert restored.message_coalescing.include_hint is True
+
+    def test_bridges_message_coalescing_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "message_coalescing:\n"
+            "  enabled: true\n"
+            "  debounce_ms: 1200\n"
+            "  max_wait_ms: 4200\n"
+            "  min_messages: 3\n"
+            "  multi_user_only: false\n"
+            "  include_hint: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.message_coalescing.enabled is True
+        assert config.message_coalescing.debounce_ms == 1200
+        assert config.message_coalescing.max_wait_ms == 4200
+        assert config.message_coalescing.min_messages == 3
+        assert config.message_coalescing.multi_user_only is False
+        assert config.message_coalescing.include_hint is False
+
+    def test_create_adapter_injects_resolved_message_coalescing(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            message_coalescing=MessageCoalescingConfig(
+                enabled=True,
+                debounce_ms=1500,
+                max_wait_ms=5000,
+                min_messages=2,
+                multi_user_only=True,
+                include_hint=True,
+            ),
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    token="fake-token",
+                    extra={"message_coalescing": {"debounce_ms": "oops"}},
+                )
+            },
+        )
+
+        adapter_config = runner.config.platforms[Platform.TELEGRAM]
+
+        with patch("gateway.platforms.telegram.check_telegram_requirements", return_value=True), patch(
+            "gateway.platforms.telegram.TelegramAdapter", side_effect=lambda cfg: cfg
+        ):
+            created = runner._create_adapter(Platform.TELEGRAM, adapter_config)
+
+        assert created.extra["message_coalescing"]["debounce_ms"] == 1500
+        assert created.extra["message_coalescing"]["max_wait_ms"] == 5000
+
+
+class TestAdapterMessageCoalescing:
+    @pytest.mark.asyncio
+    async def test_group_messages_are_coalesced_into_single_dispatch(self):
+        adapter = DummyCoalescingAdapter(
+            extra={
+                "message_coalescing": {
+                    "enabled": True,
+                    "debounce_ms": 50,
+                    "max_wait_ms": 200,
+                    "min_messages": 2,
+                    "multi_user_only": True,
+                    "include_hint": True,
+                }
+            }
+        )
+        adapter.set_message_handler(AsyncMock(return_value=None))
+        adapter._handle_message_now = AsyncMock()
+
+        await adapter.handle_message(_make_event("part one", message_id="1"))
+        await asyncio.sleep(0.01)
+        await adapter.handle_message(_make_event("part two", message_id="2"))
+        await asyncio.sleep(0.08)
+
+        adapter._handle_message_now.assert_awaited_once()
+        dispatched_event, dispatched_key = adapter._handle_message_now.call_args.args
+        assert "part one" in dispatched_event.text
+        assert "part two" in dispatched_event.text
+        assert "respond to the overall request" in dispatched_event.text.lower()
+        assert dispatched_event.message_id == "2"
+        assert dispatched_key == build_session_key(dispatched_event.source)
+        assert adapter._pending_coalesced_messages == {}
+
+    @pytest.mark.asyncio
+    async def test_dms_bypass_multi_user_only_coalescing(self):
+        adapter = DummyCoalescingAdapter(
+            extra={
+                "message_coalescing": {
+                    "enabled": True,
+                    "debounce_ms": 5000,
+                    "max_wait_ms": 5000,
+                    "min_messages": 2,
+                    "multi_user_only": True,
+                    "include_hint": True,
+                }
+            }
+        )
+        adapter.set_message_handler(AsyncMock(return_value=None))
+        adapter._handle_message_now = AsyncMock()
+
+        event = _make_event("hello", chat_type="dm")
+        await adapter.handle_message(event)
+
+        adapter._handle_message_now.assert_awaited_once_with(
+            event,
+            build_session_key(event.source),
+        )
+        assert adapter._pending_coalesced_messages == {}
+
+    @pytest.mark.asyncio
+    async def test_command_clears_pending_coalesced_batch(self):
+        adapter = DummyCoalescingAdapter(
+            extra={
+                "message_coalescing": {
+                    "enabled": True,
+                    "debounce_ms": 5000,
+                    "max_wait_ms": 5000,
+                    "min_messages": 2,
+                    "multi_user_only": True,
+                    "include_hint": True,
+                }
+            }
+        )
+        adapter.set_message_handler(AsyncMock(return_value=None))
+        adapter._handle_message_now = AsyncMock()
+
+        queued_event = _make_event("queued prompt", message_id="1")
+        session_key = build_session_key(queued_event.source)
+        await adapter.handle_message(queued_event)
+
+        assert session_key in adapter._pending_coalesced_messages
+
+        command = MessageEvent(
+            text="/reset",
+            message_type=MessageType.COMMAND,
+            source=queued_event.source,
+            message_id="cmd-1",
+        )
+        await adapter.handle_message(command)
+
+        assert session_key not in adapter._pending_coalesced_messages
+        assert session_key not in adapter._pending_coalescing_tasks
+        adapter._handle_message_now.assert_awaited_once_with(command, session_key)
+
+    @pytest.mark.asyncio
+    async def test_max_wait_caps_repeated_timer_extensions(self):
+        adapter = DummyCoalescingAdapter(
+            extra={
+                "message_coalescing": {
+                    "enabled": True,
+                    "debounce_ms": 80,
+                    "max_wait_ms": 120,
+                    "min_messages": 2,
+                    "multi_user_only": True,
+                    "include_hint": True,
+                }
+            }
+        )
+        adapter.set_message_handler(AsyncMock(return_value=None))
+        adapter._handle_message_now = AsyncMock()
+
+        await adapter.handle_message(_make_event("one", message_id="1"))
+        await asyncio.sleep(0.05)
+        await adapter.handle_message(_make_event("two", message_id="2"))
+        await asyncio.sleep(0.05)
+        await adapter.handle_message(_make_event("three", message_id="3"))
+        await asyncio.sleep(0.05)
+
+        adapter._handle_message_now.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_batches_below_min_messages_flush_before_full_debounce(self):
+        adapter = DummyCoalescingAdapter(
+            extra={
+                "message_coalescing": {
+                    "enabled": True,
+                    "debounce_ms": 2000,
+                    "max_wait_ms": 5000,
+                    "min_messages": 3,
+                    "multi_user_only": True,
+                    "include_hint": True,
+                }
+            }
+        )
+        adapter.set_message_handler(AsyncMock(return_value=None))
+        adapter._handle_message_now = AsyncMock()
+
+        await adapter.handle_message(_make_event("single message", message_id="1"))
+        await asyncio.sleep(0.45)
+
+        adapter._handle_message_now.assert_awaited_once()
+        flushed_event = adapter._handle_message_now.call_args.args[0]
+        assert flushed_event.text == "single message"
+
+    @pytest.mark.asyncio
+    async def test_non_text_event_flushes_pending_batch_before_dispatch(self):
+        adapter = DummyCoalescingAdapter(
+            extra={
+                "message_coalescing": {
+                    "enabled": True,
+                    "debounce_ms": 5000,
+                    "max_wait_ms": 5000,
+                    "min_messages": 2,
+                    "multi_user_only": True,
+                    "include_hint": True,
+                }
+            }
+        )
+        adapter.set_message_handler(AsyncMock(return_value=None))
+        adapter._handle_message_now = AsyncMock()
+
+        text_event = _make_event("draft text", message_id="1")
+        await adapter.handle_message(text_event)
+
+        photo_event = MessageEvent(
+            text="caption",
+            message_type=MessageType.PHOTO,
+            source=text_event.source,
+            message_id="2",
+            media_urls=["/tmp/photo.jpg"],
+            media_types=["image/jpeg"],
+        )
+        await adapter.handle_message(photo_event)
+
+        assert adapter._handle_message_now.await_count == 2
+        flushed_event = adapter._handle_message_now.await_args_list[0].args[0]
+        dispatched_photo = adapter._handle_message_now.await_args_list[1].args[0]
+        assert "draft text" in flushed_event.text
+        assert dispatched_photo is photo_event
+
+    @pytest.mark.asyncio
+    async def test_active_session_batches_followup_texts_until_current_run_finishes(self):
+        adapter = DummyCoalescingAdapter(
+            extra={
+                "message_coalescing": {
+                    "enabled": True,
+                    "debounce_ms": 50,
+                    "max_wait_ms": 200,
+                    "min_messages": 2,
+                    "multi_user_only": True,
+                    "include_hint": True,
+                }
+            }
+        )
+        release = asyncio.Event()
+        seen_texts = []
+
+        async def handler(event):
+            seen_texts.append(event.text)
+            if len(seen_texts) == 1:
+                await release.wait()
+            return None
+
+        adapter.set_message_handler(handler)
+
+        first_event = _make_event("first", message_id="1")
+        await adapter._handle_message_now(first_event, build_session_key(first_event.source))
+        await asyncio.sleep(0)
+        await adapter.handle_message(_make_event("second", message_id="2"))
+        await adapter.handle_message(_make_event("third", message_id="3"))
+
+        release.set()
+        await asyncio.sleep(0.1)
+
+        assert seen_texts[0] == "first"
+        assert len(seen_texts) == 2
+        assert "second" in seen_texts[1]
+        assert "third" in seen_texts[1]
+
+    @pytest.mark.asyncio
+    async def test_cancel_background_tasks_clears_pending_coalescing(self):
+        adapter = DummyCoalescingAdapter(
+            extra={
+                "message_coalescing": {
+                    "enabled": True,
+                    "debounce_ms": 1000,
+                    "max_wait_ms": 5000,
+                    "min_messages": 2,
+                    "multi_user_only": True,
+                    "include_hint": True,
+                }
+            }
+        )
+        adapter.set_message_handler(AsyncMock(return_value=None))
+        adapter._handle_message_now = AsyncMock()
+
+        await adapter.handle_message(_make_event("hello"))
+        assert adapter._pending_coalesced_messages
+        assert adapter._pending_coalescing_tasks
+
+        await adapter.cancel_background_tasks()
+
+        assert adapter._pending_coalesced_messages == {}
+        assert adapter._pending_coalescing_tasks == {}


### PR DESCRIPTION
Closes #345

## Summary
- add platform-agnostic inbound message coalescing in `BasePlatformAdapter`
- add `message_coalescing` config with `enabled`, `debounce_ms`, `max_wait_ms`, `min_messages`, `multi_user_only`, and `include_hint`
- preserve rapid follow-up fragments both before an agent run starts and while one is already processing
- format coalesced turns with timestamps and attribution, flush pending text before non-text events, and clear queued batches on commands
- add regression tests for config loading, batching, max wait capping, non-text flushes, and active-session follow-ups

## Issue Alignment
This implements the coalescing flow requested in #345, adapted to Hermes's actual gateway architecture. Spacebot assumes one conversation owner per channel; Hermes defaults to `group_sessions_per_user: true`, so this implementation coalesces by Hermes `session_key` instead of raw channel to avoid mixing separate user sessions incorrectly.

## Verification
- All tests passed
