### PR TITLE
fix(auth): migrate Anthropic OAuth endpoints to platform.claude.com

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -201,21 +201,12 @@ def is_claude_code_token_valid(creds: Dict[str, Any]) -> bool:
     return now_ms < (expires_at - 60_000)
 
 
-def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
-    """Attempt to refresh an expired Claude Code OAuth token.
+def _exchange_refresh_token(refresh_token: str) -> Optional[Dict[str, Any]]:
+    """Exchange a refresh token for new credentials via the OAuth token endpoint.
 
-    Uses the same token endpoint and client_id as Claude Code / OpenCode.
-    Only works for credentials that have a refresh token (from claude /login
-    or claude setup-token with OAuth flow).
-
-    Returns the new access token, or None if refresh fails.
+    Returns dict with {access_token, refresh_token, expires_in} on success, None on failure.
     """
     import urllib.request
-
-    refresh_token = creds.get("refreshToken", "")
-    if not refresh_token:
-        logger.debug("No refresh token available — cannot refresh")
-        return None
 
     data = json.dumps({
         "grant_type": "refresh_token",
@@ -235,22 +226,34 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
 
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
-            result = json.loads(resp.read().decode())
-            new_access = result.get("access_token", "")
-            new_refresh = result.get("refresh_token", refresh_token)
-            expires_in = result.get("expires_in", 3600)  # seconds
-
-            if new_access:
-                import time
-                new_expires_ms = int(time.time() * 1000) + (expires_in * 1000)
-                # Write refreshed credentials back to ~/.claude/.credentials.json
-                _write_claude_code_credentials(new_access, new_refresh, new_expires_ms)
-                logger.debug("Successfully refreshed Claude Code OAuth token")
-                return new_access
+            return json.loads(resp.read().decode())
     except Exception as e:
-        logger.debug("Failed to refresh Claude Code token: %s", e)
+        logger.debug("OAuth token refresh failed: %s", e)
+        return None
 
-    return None
+
+def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
+    """Refresh an expired Claude Code OAuth token.
+
+    Returns the new access token, or None if refresh fails.
+    """
+    import time
+
+    refresh_token = creds.get("refreshToken", "")
+    if not refresh_token:
+        logger.debug("No refresh token available — cannot refresh")
+        return None
+
+    result = _exchange_refresh_token(refresh_token)
+    if not result or not result.get("access_token"):
+        return None
+
+    new_access = result["access_token"]
+    new_refresh = result.get("refresh_token", refresh_token)
+    new_expires_ms = int(time.time() * 1000) + (result.get("expires_in", 3600) * 1000)
+    _write_claude_code_credentials(new_access, new_refresh, new_expires_ms)
+    logger.debug("Successfully refreshed Claude Code OAuth token")
+    return new_access
 
 
 def _write_claude_code_credentials(access_token: str, refresh_token: str, expires_at_ms: int) -> None:
@@ -604,47 +607,22 @@ def refresh_hermes_oauth_token() -> Optional[str]:
     Returns the new access token, or None if refresh fails.
     """
     import time
-    import urllib.request
 
     creds = read_hermes_oauth_credentials()
     if not creds or not creds.get("refreshToken"):
         return None
 
-    try:
-        data = json.dumps({
-            "grant_type": "refresh_token",
-            "refresh_token": creds["refreshToken"],
-            "client_id": _OAUTH_CLIENT_ID,
-        }).encode()
+    result = _exchange_refresh_token(creds["refreshToken"])
+    if not result or not result.get("access_token"):
+        return None
 
-        req = urllib.request.Request(
-            _OAUTH_TOKEN_URL,
-            data=data,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_CLAUDE_CODE_VERSION} (external, cli)",
-            },
-            method="POST",
-        )
-
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            result = json.loads(resp.read().decode())
-
-        new_access = result.get("access_token", "")
-        new_refresh = result.get("refresh_token", creds["refreshToken"])
-        expires_in = result.get("expires_in", 3600)
-
-        if new_access:
-            new_expires_ms = int(time.time() * 1000) + (expires_in * 1000)
-            _save_hermes_oauth_credentials(new_access, new_refresh, new_expires_ms)
-            # Also update Claude Code's credential file
-            _write_claude_code_credentials(new_access, new_refresh, new_expires_ms)
-            logger.debug("Successfully refreshed Hermes OAuth token")
-            return new_access
-    except Exception as e:
-        logger.debug("Failed to refresh Hermes OAuth token: %s", e)
-
-    return None
+    new_access = result["access_token"]
+    new_refresh = result.get("refresh_token", creds["refreshToken"])
+    new_expires_ms = int(time.time() * 1000) + (result.get("expires_in", 3600) * 1000)
+    _save_hermes_oauth_credentials(new_access, new_refresh, new_expires_ms)
+    _write_claude_code_credentials(new_access, new_refresh, new_expires_ms)
+    logger.debug("Successfully refreshed Hermes OAuth token")
+    return new_access
 
 
 # ---------------------------------------------------------------------------

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -210,7 +210,6 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
 
     Returns the new access token, or None if refresh fails.
     """
-    import urllib.parse
     import urllib.request
 
     refresh_token = creds.get("refreshToken", "")
@@ -218,20 +217,17 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
         logger.debug("No refresh token available — cannot refresh")
         return None
 
-    # Client ID used by Claude Code's OAuth flow
-    CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-
-    data = urllib.parse.urlencode({
+    data = json.dumps({
         "grant_type": "refresh_token",
         "refresh_token": refresh_token,
-        "client_id": CLIENT_ID,
+        "client_id": _OAUTH_CLIENT_ID,
     }).encode()
 
     req = urllib.request.Request(
-        "https://console.anthropic.com/v1/oauth/token",
+        _OAUTH_TOKEN_URL,
         data=data,
         headers={
-            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Type": "application/json",
             "User-Agent": f"claude-cli/{_CLAUDE_CODE_VERSION} (external, cli)",
         },
         method="POST",
@@ -447,9 +443,9 @@ def run_oauth_setup_token() -> Optional[str]:
 # Stores credentials in ~/.hermes/.anthropic_oauth.json (our own file).
 
 _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
-_OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
-_OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
+_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+_OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
+_OAUTH_SCOPES = "org:create_api_key user:profile user:inference user:file_upload user:mcp_servers user:sessions"
 _HERMES_OAUTH_FILE = Path(os.getenv("HERMES_HOME", str(Path.home() / ".hermes"))) / ".anthropic_oauth.json"
 
 
@@ -491,7 +487,7 @@ def run_hermes_oauth_login() -> Optional[str]:
         "state": verifier,
     }
     from urllib.parse import urlencode
-    auth_url = f"https://claude.ai/oauth/authorize?{urlencode(params)}"
+    auth_url = f"https://platform.claude.com/oauth/authorize?{urlencode(params)}"
 
     print()
     print("Authorize Hermes with your Claude Pro/Max subscription.")


### PR DESCRIPTION
## Summary

Anthropic migrated their OAuth infrastructure from `console.anthropic.com` / `claude.ai` to `platform.claude.com`. Claude Code v2.1.81 already uses the new endpoints, but Hermes was still pointing at the old ones — causing **401 "Invalid bearer token"** errors on every OAuth-authenticated API call.

**How this was discovered:** Extracted API URLs from the Claude Code v2.1.81 binary (`strings` on the Mach-O executable) and compared them against Hermes's hardcoded endpoints. All three OAuth URLs had changed:

| Endpoint | Before (broken) | After (fixed) |
|----------|-----------------|---------------|
| Authorize | `claude.ai/oauth/authorize` | `platform.claude.com/oauth/authorize` |
| Token exchange | `console.anthropic.com/v1/oauth/token` | `platform.claude.com/v1/oauth/token` |
| Redirect URI | `console.anthropic.com/oauth/code/callback` | `platform.claude.com/oauth/code/callback` |

### Additional fixes in the same file

- **Added missing OAuth scopes** to match Claude Code: `user:file_upload`, `user:mcp_servers`, `user:sessions`
- **Deduplicated `CLIENT_ID`** in `_refresh_oauth_token()` — was hardcoding the UUID instead of using the shared `_OAUTH_CLIENT_ID` constant
- **Aligned `_refresh_oauth_token()` Content-Type** from `application/x-www-form-urlencoded` to `application/json`, matching every other token exchange call in the file

### After merging

Users with existing Hermes OAuth credentials will need to re-authenticate since tokens from the old endpoint are no longer valid:

```bash
python -m hermes_cli.main auth login --provider anthropic
```

## Test plan

- [x] `pytest tests/test_anthropic_adapter.py tests/test_anthropic_oauth_flow.py` — 79 passed