### PR TITLE
fix(security): harden subprocess calls against shell injection

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -378,8 +378,13 @@ class TestTranscribeLocalCommand:
             return _TempDir()
 
         def fake_run(cmd, *args, **kwargs):
-            if isinstance(cmd, list):
-                output_path = cmd[-1]
+            # After shell-injection hardening, both ffmpeg prep and the
+            # local STT command arrive as lists (shlex.split).  Distinguish
+            # them by checking whether the binary looks like ffmpeg.
+            cmd_list = cmd if isinstance(cmd, list) else [cmd]
+            is_ffmpeg = "ffmpeg" in cmd_list[0]
+            if is_ffmpeg:
+                output_path = cmd_list[-1]
                 with open(output_path, "wb") as handle:
                     handle.write(b"RIFF....WAVEfmt ")
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -389,7 +389,10 @@ class DockerEnvironment(BaseEnvironment):
             exec_command = f"cd {work_dir} && {exec_command}"
             work_dir = "/"
 
-        assert self._inner.container_id, "Container not started"
+        # FIX: use explicit check instead of assert — assertions are stripped
+        # by python -O, which would silently allow commands on a None container.
+        if not self._inner.container_id:
+            raise RuntimeError("Container not started")
         cmd = [self._inner.config.executable, "exec"]
         if effective_stdin is not None:
             cmd.append("-i")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -347,7 +347,9 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
                 language=shlex.quote(language),
                 model=shlex.quote(normalized_model),
             )
-            subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+            # SECURITY: avoid shell=True — shlex.split preserves quoted args from
+            # shlex.quote() above while eliminating shell injection surface.
+            subprocess.run(shlex.split(command), shell=False, check=True, capture_output=True, text=True)
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))
             if not txt_files:


### PR DESCRIPTION
## Summary
- Replace `shell=True` with `shlex.split()` in `tools/transcription_tools.py`
- Use list-based subprocess in `mini-swe-agent` docker cleanup to prevent injection via container_id
- Replace `assert` with `RuntimeError` in `tools/environments/docker.py` (assertions stripped by `python -O`)

Closes #2743

## Test Plan
- [ ] Verify local STT transcription still works with the `shlex.split()` change
- [ ] Verify docker container cleanup terminates containers correctly
- [ ] Verify `python -O` doesn't bypass the container_id check

## Platforms Tested
- macOS