### PR TITLE
fix: guard str.split() index access against empty results

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -76,7 +76,9 @@ def _detect_claude_code_version() -> str:
             )
             if result.returncode == 0 and result.stdout.strip():
                 # Output is like "2.1.74 (Claude Code)" or just "2.1.74"
-                version = result.stdout.strip().split()[0]
+                # FIX: guard split() — stdout could be empty or whitespace-only
+                parts = result.stdout.strip().split()
+                version = parts[0] if parts else ""
                 if version and version[0].isdigit():
                     return version
         except Exception:

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -794,7 +794,9 @@ class SlackAdapter(BasePlatformAdapter):
         from hermes_cli.commands import slack_subcommand_map
         subcommand_map = slack_subcommand_map()
         subcommand_map["compact"] = "/compress"
-        first_word = text.split()[0] if text else ""
+        # FIX: guard against whitespace-only text that splits to an empty list
+        parts = text.split() if text else []
+        first_word = parts[0] if parts else ""
         if first_word in subcommand_map:
             # Preserve arguments after the subcommand
             rest = text[len(first_word):].strip()

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -811,7 +811,11 @@ class ShellFileOperations(FileOperations):
         # Check if linter command is available
         linter_cmd = LINTERS[ext]
         # Extract the base command (first word)
-        base_cmd = linter_cmd.split()[0]
+        # FIX: guard against empty linter_cmd to prevent IndexError
+        parts = linter_cmd.split()
+        if not parts:
+            return LintResult(skipped=True, message="Empty linter command")
+        base_cmd = parts[0]
         
         if not self._has_command(base_cmd):
             return LintResult(skipped=True, message=f"{base_cmd} not available")


### PR DESCRIPTION
## Summary
- Guard `linter_cmd.split()[0]` in `tools/file_operations.py` against empty commands
- Guard `text.split()[0]` in `gateway/platforms/slack.py` against whitespace-only messages
- Guard `result.stdout.strip().split()[0]` in `agent/anthropic_adapter.py` against empty output

All three cases could raise `IndexError` when `split()` returns an empty list.

Closes #2745

## Test Plan
- [ ] Configure an empty linter command and verify graceful skip instead of crash
- [ ] Send a whitespace-only Slack command and verify it falls through to `/help`
- [ ] Verify Claude Code version detection handles empty stdout gracefully

## Platforms Tested
- macOS