### PR TITLE
fix(tools): wrap browser provider network calls with error handling

### DIFF
--- a/tools/browser_providers/browser_use.py
+++ b/tools/browser_providers/browser_use.py
@@ -40,12 +40,17 @@ class BrowserUseProvider(CloudBrowserProvider):
         }
 
     def create_session(self, task_id: str) -> Dict[str, object]:
-        response = requests.post(
-            f"{_BASE_URL}/browsers",
-            headers=self._headers(),
-            json={},
-            timeout=30,
-        )
+        # FIX: wrap network call to surface connection errors as RuntimeError
+        # instead of letting raw requests exceptions propagate.
+        try:
+            response = requests.post(
+                f"{_BASE_URL}/browsers",
+                headers=self._headers(),
+                json={},
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Browser Use API connection failed: {exc}") from exc
 
         if not response.ok:
             raise RuntimeError(

--- a/tools/browser_providers/browserbase.py
+++ b/tools/browser_providers/browserbase.py
@@ -80,45 +80,53 @@ class BrowserbaseProvider(CloudBrowserProvider):
             "Content-Type": "application/json",
             "X-BB-API-Key": config["api_key"],
         }
-        response = requests.post(
-            "https://api.browserbase.com/v1/sessions",
-            headers=headers,
-            json=session_config,
-            timeout=30,
-        )
-
         proxies_fallback = False
         keepalive_fallback = False
 
-        # Handle 402 — paid features unavailable
-        if response.status_code == 402:
-            if enable_keep_alive:
-                keepalive_fallback = True
-                logger.warning(
-                    "keepAlive may require paid plan (402), retrying without it. "
-                    "Sessions may timeout during long operations."
-                )
-                session_config.pop("keepAlive", None)
-                response = requests.post(
-                    "https://api.browserbase.com/v1/sessions",
-                    headers=headers,
-                    json=session_config,
-                    timeout=30,
-                )
+        # FIX: wrap network calls to handle connection failures gracefully
+        # instead of propagating raw requests exceptions.
+        try:
+            response = requests.post(
+                "https://api.browserbase.com/v1/sessions",
+                headers=headers,
+                json=session_config,
+                timeout=30,
+            )
 
-            if response.status_code == 402 and enable_proxies:
-                proxies_fallback = True
-                logger.warning(
-                    "Proxies unavailable (402), retrying without proxies. "
-                    "Bot detection may be less effective."
-                )
-                session_config.pop("proxies", None)
-                response = requests.post(
-                    "https://api.browserbase.com/v1/sessions",
-                    headers=headers,
-                    json=session_config,
-                    timeout=30,
-                )
+            # Handle 402 — paid features unavailable
+            if response.status_code == 402:
+                if enable_keep_alive:
+                    keepalive_fallback = True
+                    logger.warning(
+                        "keepAlive may require paid plan (402), retrying without it. "
+                        "Sessions may timeout during long operations."
+                    )
+                    session_config.pop("keepAlive", None)
+                    response = requests.post(
+                        "https://api.browserbase.com/v1/sessions",
+                        headers=headers,
+                        json=session_config,
+                        timeout=30,
+                    )
+
+                if response.status_code == 402 and enable_proxies:
+                    proxies_fallback = True
+                    logger.warning(
+                        "Proxies unavailable (402), retrying without proxies. "
+                        "Bot detection may be less effective."
+                    )
+                    session_config.pop("proxies", None)
+                    response = requests.post(
+                        "https://api.browserbase.com/v1/sessions",
+                        headers=headers,
+                        json=session_config,
+                        timeout=30,
+                    )
+
+        except requests.RequestException as exc:
+            raise RuntimeError(
+                f"Browserbase API connection failed: {exc}"
+            ) from exc
 
         if not response.ok:
             raise RuntimeError(


### PR DESCRIPTION
## Summary
- Wrap `requests.post()` in `tools/browser_providers/browser_use.py` with `requests.RequestException` handling
- Wrap all `requests.post()` calls (including 402 retry logic) in `tools/browser_providers/browserbase.py`
- Connection failures now surface as clear `RuntimeError` messages instead of raw stack traces

Closes #2746

## Test Plan
- [ ] Disconnect network and attempt to create a Browser Use session — verify clear error message
- [ ] Disconnect network and attempt to create a Browserbase session — verify clear error message
- [ ] Verify normal browser session creation still works when API is reachable

## Platforms Tested
- macOS