### PR TITLE
fix(cli): log swallowed exception in runtime model auto-detection

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -53,8 +53,13 @@ def _auto_detect_local_model(base_url: str) -> str:
                 model_id = models[0].get("id", "")
                 if model_id:
                     return model_id
-    except Exception:
-        pass
+    except Exception as exc:
+        # FIX: log instead of silently swallowing — aids debugging when
+        # local model auto-detection fails unexpectedly.
+        import logging
+        logging.getLogger(__name__).debug(
+            "Auto-detect model from %s failed: %s", base_url, exc
+        )
     return ""
 
 


### PR DESCRIPTION
## Summary
- Replace bare `except Exception: pass` with debug-level logging in `hermes_cli/runtime_provider.py`
- Failures in local endpoint model discovery are now diagnosable via debug logs instead of silently hidden

Closes #2747

## Test Plan
- [ ] Configure a local endpoint with an unreachable URL and verify debug log message appears
- [ ] Verify successful model auto-detection still works as before
- [ ] Verify the function still returns empty string on failure (no behavior change)

## Platforms Tested
- macOS