### PR TITLE
fix: make batch_runner DEFAULT_TOOL_STATS immutable to prevent race conditions

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -25,6 +25,7 @@ import logging
 import os
 import time
 from pathlib import Path
+from types import MappingProxyType
 from typing import List, Dict, Any, Optional, Tuple
 from datetime import datetime
 from multiprocessing import Pool, Lock
@@ -42,7 +43,9 @@ from toolset_distributions import (
 from model_tools import TOOL_TO_TOOLSET_MAP
 
 
-# Global configuration for worker processes
+# NOTE: _WORKER_CONFIG is set once per worker process in the initializer
+# function (via multiprocessing.Pool(initializer=...)), so each process
+# gets its own copy. Not shared across threads within the same process.
 _WORKER_CONFIG = {}
 
 # All possible tools - auto-derived from the master mapping in model_tools.py.
@@ -51,8 +54,9 @@ _WORKER_CONFIG = {}
 # filtering corrupted entries during trajectory combination.
 ALL_POSSIBLE_TOOLS = set(TOOL_TO_TOOLSET_MAP.keys())
 
-# Default stats for tools that weren't used
-DEFAULT_TOOL_STATS = {'count': 0, 'success': 0, 'failure': 0}
+# FIX: immutable mapping prevents accidental mutation of shared default
+# across parallel worker processes.
+DEFAULT_TOOL_STATS = MappingProxyType({'count': 0, 'success': 0, 'failure': 0})
 
 
 def _normalize_tool_stats(tool_stats: Dict[str, Dict[str, int]]) -> Dict[str, Dict[str, int]]:


### PR DESCRIPTION
## Summary
- Use `types.MappingProxyType` for `DEFAULT_TOOL_STATS` in `batch_runner.py` to prevent accidental mutation
- Add clarifying comment about `_WORKER_CONFIG` per-process initialization semantics
- Any accidental mutation now raises `TypeError` immediately instead of silently corrupting data across workers

Closes #2748

## Test Plan
- [ ] Run batch trajectory generation and verify tool stats are correctly computed
- [ ] Verify `dict(DEFAULT_TOOL_STATS)` still works for creating mutable copies
- [ ] Verify direct mutation attempt raises `TypeError`

## Platforms Tested
- macOS