### PR TITLE
fix(honcho): graceful degradation for bad URL and add disable command

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -34,6 +34,7 @@ Usage:
     hermes honcho identity                 # Show AI peer identity representation
     hermes honcho identity <file>          # Seed AI peer identity from a file (SOUL.md etc.)
     hermes honcho migrate                  # Step-by-step migration guide: OpenClaw native → Hermes + Honcho
+    hermes honcho disable                  # Disable Honcho and warn about leftover environment variables
     hermes version             Show version
     hermes update              Update to latest version
     hermes uninstall           Uninstall Hermes Agent
@@ -3690,6 +3691,10 @@ For more help on a command:
     honcho_subparsers.add_parser(
         "migrate",
         help="Step-by-step migration guide from openclaw-honcho to Hermes Honcho",
+    )
+    honcho_subparsers.add_parser(
+        "disable",
+        help="Disable Honcho integration and warn about leftover environment variables",
     )
 
     def cmd_honcho(args):

--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -754,6 +754,28 @@ def cmd_migrate(args) -> None:
     print()
 
 
+
+def cmd_disable(args) -> None:
+    """Disable Honcho integration by setting enabled: false in config."""
+    cfg = _read_config()
+    cfg.setdefault("hosts", {}).setdefault(HOST, {})["enabled"] = False
+    # Also clear root-level enabled so there is no ambiguity
+    cfg["enabled"] = False
+    _write_config(cfg)
+    print("\n  Honcho integration disabled.\n")
+    # Warn if environment variables could re-enable Honcho at next startup
+    env_key = os.environ.get("HONCHO_API_KEY", "")
+    env_url = os.environ.get("HONCHO_BASE_URL", "")
+    if env_key or env_url:
+        print("  ⚠  The following environment variables are still set and may")
+        print("     re-enable Honcho on next startup:")
+        if env_key:
+            print(f"       HONCHO_API_KEY={env_key[:8]}...")
+        if env_url:
+            print(f"       HONCHO_BASE_URL={env_url}")
+        print("     Unset them to fully disable Honcho.\n")
+
+
 def honcho_command(args) -> None:
     """Route honcho subcommands."""
     sub = getattr(args, "honcho_command", None)
@@ -775,6 +797,8 @@ def honcho_command(args) -> None:
         cmd_identity(args)
     elif sub == "migrate":
         cmd_migrate(args)
+    elif sub == "disable":
+        cmd_disable(args)
     else:
         print(f"  Unknown honcho command: {sub}")
-        print("  Available: setup, status, sessions, map, peer, mode, tokens, identity, migrate\n")
+        print("  Available: setup, status, sessions, map, peer, mode, tokens, identity, migrate, disable\n")

--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -25,6 +25,27 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _sanitize_url(url: str | None) -> str | None:
+    """Return url unchanged, or None if it contains non-printable ASCII characters.
+
+    A stray terminal escape sequence (e.g. \x1b from copy-paste) in a URL
+    causes the Honcho SDK to raise ``Invalid non-printable ASCII character``
+    at client construction time, which previously crashed the entire tool
+    surface.  Catching it here keeps Honcho disabled with a clear warning
+    rather than propagating a confusing error.
+    """
+    if url is None:
+        return None
+    if all(0x20 <= ord(c) < 0x7F for c in url):
+        return url
+    logger.warning(
+        "Honcho base_url contains non-printable characters and will be ignored: %r",
+        url,
+    )
+    return None
+
+
 GLOBAL_CONFIG_PATH = Path.home() / ".honcho" / "config.json"
 HOST = "hermes"
 
@@ -141,7 +162,7 @@ class HonchoClientConfig:
     def from_env(cls, workspace_id: str = "hermes") -> HonchoClientConfig:
         """Create config from environment variables (fallback)."""
         api_key = os.environ.get("HONCHO_API_KEY")
-        base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
+        base_url = _sanitize_url(os.environ.get("HONCHO_BASE_URL", "").strip() or None)
         return cls(
             workspace_id=workspace_id,
             api_key=api_key,
@@ -200,7 +221,7 @@ class HonchoClientConfig:
             or raw.get("environment", "production")
         )
 
-        base_url = (
+        base_url = _sanitize_url(
             raw.get("baseUrl")
             or os.environ.get("HONCHO_BASE_URL", "").strip()
             or None
@@ -411,7 +432,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
             hermes_cfg = load_config()
             honcho_cfg = hermes_cfg.get("honcho", {})
             if isinstance(honcho_cfg, dict):
-                resolved_base_url = honcho_cfg.get("base_url", "").strip() or None
+                resolved_base_url = _sanitize_url(honcho_cfg.get("base_url", "").strip() or None)
         except Exception:
             pass
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -975,7 +975,7 @@ class AIAgent:
                             logger.debug("Honcho enabled but missing API key or disabled in config")
             except Exception as e:
                 logger.warning("Honcho init failed — memory disabled: %s", e)
-                print(f"  Honcho init failed: {e}")
+                print(f"  Honcho init failed: {e!r}")
                 print("  Run 'hermes honcho setup' to reconfigure.")
                 self._honcho = None
 
@@ -2227,7 +2227,7 @@ class AIAgent:
         except Exception as e:
             logger.warning("Honcho sync failed: %s", e)
             if not self.quiet_mode:
-                print(f"  Honcho write failed: {e}")
+                print(f"  Honcho write failed: {e!r}")
 
     def _build_system_prompt(self, system_message: str = None) -> str:
         """

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -103,3 +103,33 @@ class TestHonchoClientConfigAutoEnable:
 
         assert cfg.api_key == "fallback-key"
         assert cfg.enabled is True  # from_env() sets enabled=True
+
+
+class TestSanitizeUrl:
+    """Test that non-printable characters in base_url disable Honcho gracefully."""
+
+    def test_clean_url_passes_through(self, tmp_path):
+        """A well-formed base_url is accepted unchanged."""
+        config_path = tmp_path / "config.json"
+        config_path.write_text('{"baseUrl": "https://honcho.example.com", "apiKey": "key123"}')
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+        assert cfg.base_url == "https://honcho.example.com"
+        assert cfg.enabled is True
+
+    def test_nonprintable_url_is_rejected(self, tmp_path):
+        """A base_url containing a terminal escape sequence is silently dropped."""
+        config_path = tmp_path / "config.json"
+        # Simulate a URL with an accidentally pasted escape character
+        bad_url = "https://honcho.example.com/\x1b[0m/api"
+        import json
+        config_path.write_text(json.dumps({"baseUrl": bad_url, "apiKey": "key123"}))
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+        assert cfg.base_url is None
+
+    def test_nonprintable_env_url_is_rejected(self, monkeypatch):
+        """HONCHO_BASE_URL with non-printable chars is dropped in from_env()."""
+        monkeypatch.setenv("HONCHO_BASE_URL", "https://host.com/\x1b[0m")
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+        cfg = HonchoClientConfig.from_env()
+        assert cfg.base_url is None
+        assert cfg.enabled is False


### PR DESCRIPTION
Fixes #2736 (item 5)

## Problem

A terminal escape sequence accidentally pasted into `honcho.base_url` (e.g. `\x1b` from copy-paste) caused the Honcho SDK to raise `Invalid non-printable ASCII character` at startup. The exception was caught but the raw error string was printed to the terminal, corrupting terminal state and making all tools appear broken. Removing `honcho: {}` from config did not fix it if the bad value was also in an env var.

## Changes

- **`honcho_integration/client.py`**: Add `_sanitize_url()` helper that returns `None` with a warning when `base_url` contains non-printable ASCII characters. Applied in `from_global_config()`, `from_env()`, and `get_honcho_client()`.
- **`honcho_integration/cli.py`** + **`hermes_cli/main.py`**: Add `hermes honcho disable` command that sets `enabled: false` in config and warns the user about leftover `HONCHO_API_KEY` / `HONCHO_BASE_URL` environment variables.
- **`tests/test_honcho_client_config.py`**: Add `TestSanitizeUrl` covering clean URL, config-file bad URL, and env-var bad URL.

## Not implemented

The issue also mentions a full reinstall was required. This PR prevents the broken state from occurring; a recovery path beyond `hermes honcho disable` was not added as it would require broader changes.