### PR TITLE
parse HERMES_YOLO_MODE as explicit truthy flag

### DIFF
--- a/tests/tools/test_terminal_disk_usage.py
+++ b/tests/tools/test_terminal_disk_usage.py
@@ -11,7 +11,7 @@ import pytest
 import sys
 import tools.terminal_tool  # noqa: F401 -- ensure module is loaded
 _tt_mod = sys.modules["tools.terminal_tool"]
-from tools.terminal_tool import get_active_environments_info
+from tools.terminal_tool import get_active_environments_info, _check_disk_usage_warning
 
 # 1 MiB of data so the rounded MB value is clearly distinguishable
 _1MB = b"x" * (1024 * 1024)
@@ -62,3 +62,12 @@ class TestDiskUsageGlob:
         # Should be ~2.0 MB total (1 MB per task).
         # With the bug, each task globs everything -> ~4.0 MB.
         assert info["total_disk_usage_mb"] == pytest.approx(2.0, abs=0.1)
+
+
+class TestDiskUsageWarningHardening:
+    def test_check_disk_usage_warning_logs_debug_on_unexpected_error(self):
+        with patch.object(_tt_mod, "_get_scratch_dir", side_effect=RuntimeError("boom")),              patch.object(_tt_mod.logger, "debug") as debug_mock:
+            result = _check_disk_usage_warning()
+
+        assert result is False
+        debug_mock.assert_called()

--- a/tests/tools/test_yolo_mode.py
+++ b/tests/tools/test_yolo_mode.py
@@ -108,3 +108,17 @@ class TestYoloMode:
         result = check_dangerous_command("rm -rf /", "local",
                                          approval_callback=lambda *a: "deny")
         assert not result["approved"]
+
+    @pytest.mark.parametrize("false_like_value", ["0", "false", "no", "off"])
+    def test_yolo_mode_false_like_values_do_not_bypass(self, monkeypatch, false_like_value):
+        """False-like string values must not enable YOLO bypass."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", false_like_value)
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-session")
+
+        result = check_dangerous_command(
+            "rm -rf /",
+            "local",
+            approval_callback=lambda *a: "deny",
+        )
+        assert not result["approved"]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -287,6 +287,14 @@ def _get_approval_mode() -> str:
         return "manual"
 
 
+def _is_truthy_env(var_name: str) -> bool:
+    """Return True only for explicit truthy env values."""
+    value = os.getenv(var_name)
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _smart_approve(command: str, description: str) -> str:
     """Use the auxiliary LLM to assess risk and decide approval.
 
@@ -358,7 +366,7 @@ def check_dangerous_command(command: str, env_type: str,
         return {"approved": True, "message": None}
 
     # --yolo: bypass all approval prompts
-    if os.getenv("HERMES_YOLO_MODE"):
+    if _is_truthy_env("HERMES_YOLO_MODE"):
         return {"approved": True, "message": None}
 
     is_dangerous, pattern_key, description = detect_dangerous_command(command)
@@ -433,7 +441,7 @@ def check_all_command_guards(command: str, env_type: str,
 
     # --yolo or approvals.mode=off: bypass all approval prompts
     approval_mode = _get_approval_mode()
-    if os.getenv("HERMES_YOLO_MODE") or approval_mode == "off":
+    if _is_truthy_env("HERMES_YOLO_MODE") or approval_mode == "off":
         return {"approved": True, "message": None}
 
     is_cli = os.getenv("HERMES_INTERACTIVE")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -75,9 +75,9 @@ DISK_USAGE_WARNING_THRESHOLD_GB = float(os.getenv("TERMINAL_DISK_WARNING_GB", "5
 
 def _check_disk_usage_warning():
     """Check if total disk usage exceeds warning threshold."""
-    scratch_dir = _get_scratch_dir()
-    
     try:
+        scratch_dir = _get_scratch_dir()
+
         # Get total size of hermes directories
         total_bytes = 0
         import glob

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -98,6 +98,7 @@ def _check_disk_usage_warning():
         
         return False
     except Exception as e:
+        logger.debug("Disk usage warning check failed: %s", e, exc_info=True)
         return False
 
 


### PR DESCRIPTION
This PR hardens command-approval safety by changing YOLO mode parsing in tools/approval.py so HERMES_YOLO_MODE only enables bypass for explicit truthy values (1, true, yes, on) instead of any non-empty string, which prevents accidental bypass when users set false-like values such as 0, false, no, or off; it also adds focused regression coverage in tests/tools/test_yolo_mode.py to verify those false-like values do not disable dangerous-command checks while preserving existing behavior for valid truthy enablement