### PR TITLE
url-safety : restrict URL validation to http/https schemes

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -16,6 +16,14 @@ class TestIsSafeUrl:
         ]):
             assert is_safe_url("https://example.com/image.png") is True
 
+    def test_ftp_scheme_blocked(self):
+        """Only http/https should be allowed for fetch tools."""
+        assert is_safe_url("ftp://example.com/file.txt") is False
+
+    def test_missing_scheme_blocked(self):
+        """Bare host/path should be rejected to avoid ambiguous handling."""
+        assert is_safe_url("example.com/path") is False
+
     def test_localhost_blocked(self):
         with patch("socket.getaddrinfo", return_value=[
             (2, 1, 6, "", ("127.0.0.1", 0)),

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -55,6 +55,10 @@ def is_safe_url(url: str) -> bool:
     """
     try:
         parsed = urlparse(url)
+        scheme = (parsed.scheme or "").strip().lower()
+        if scheme not in {"http", "https"}:
+            logger.warning("Blocked request — unsupported URL scheme: %s", scheme or "<empty>")
+            return False
         hostname = (parsed.hostname or "").strip().lower()
         if not hostname:
             return False


### PR DESCRIPTION
tightens SSRF preflight protection by updating tools/url_safety.py so is_safe_url() explicitly allows only http and https schemes and fails closed for unsupported or missing schemes, reducing ambiguity and preventing non-web protocols from entering fetch paths, and it adds focused regression tests in tests/tools/test_url_safety.py to verify that ftp://... and scheme-less inputs are blocked while existing safe URL behavior remains unchanged.