### PR TITLE
Parse session env flags as explicit truthy values

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -100,6 +100,13 @@ class TestCronjobRequirements:
 
         assert check_cronjob_requirements() is False
 
+    @pytest.mark.parametrize("false_like_value", ["0", "false", "no", "off"])
+    def test_rejects_false_like_interactive_env(self, monkeypatch, false_like_value):
+        monkeypatch.setenv("HERMES_INTERACTIVE", false_like_value)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        assert check_cronjob_requirements() is False
+
 
 # =========================================================================
 # schedule_cronjob

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -409,6 +409,14 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
 }
 
 
+def _is_truthy_env(var_name: str) -> bool:
+    """Return True only for explicit truthy env values."""
+    value = os.getenv(var_name)
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def check_cronjob_requirements() -> bool:
     """
     Check if cronjob tools can be used.
@@ -418,9 +426,9 @@ def check_cronjob_requirements() -> bool:
     so no external crontab executable is required.
     """
     return bool(
-        os.getenv("HERMES_INTERACTIVE")
-        or os.getenv("HERMES_GATEWAY_SESSION")
-        or os.getenv("HERMES_EXEC_ASK")
+        _is_truthy_env("HERMES_INTERACTIVE")
+        or _is_truthy_env("HERMES_GATEWAY_SESSION")
+        or _is_truthy_env("HERMES_EXEC_ASK")
     )
 
 


### PR DESCRIPTION
Hardens cronjob tool availability checks by updating check_cronjob_requirements() in tools/cronjob_tools.py to treat session environment variables (HERMES_INTERACTIVE, HERMES_GATEWAY_SESSION, and HERMES_EXEC_ASK) as enabled only for explicit truthy values (1, true, yes, on) rather than any non-empty string, preventing false-like values such as 0, false, no, or off from accidentally enabling the tool, and it adds focused regression coverage in tests/tools/test_cronjob_tools.py to verify those false-like values correctly keep cronjob requirements disabled