### PR TITLE
fix: status bar shows 26K instead of 260K for token counts with trailing zeros

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -649,7 +649,8 @@ def format_token_count_compact(value: int) -> str:
                 text = f"{scaled:.1f}"
             else:
                 text = f"{scaled:.0f}"
-            text = text.rstrip("0").rstrip(".")
+            if "." in text:
+                text = text.rstrip("0").rstrip(".")
             return f"{sign}{text}{suffix}"
 
     return f"{value:,}"


### PR DESCRIPTION
## Summary
<img width="449" height="31" alt="image" src="https://github.com/user-attachments/assets/bd8e6f79-60d2-4c81-901d-80c88863e5d9" />

- `format_token_count_compact()` used unconditional `rstrip("0")` to clean decimal trailing zeros (e.g. `"1.50"` → `"1.5"`), but this also stripped meaningful trailing zeros from whole numbers (`"260"` → `"26"`, `"100"` → `"1"`, `"500"` → `"5"`)
- Guard the strip behind a `"." in text` check so only decimal zeros are removed
- Affects any token count that's a round multiple of 10 at the K/M/B display threshold (e.g. 260K, 100K, 500K, 200M)

## Test plan
- [ ] Verify `format_token_count_compact(260_000)` returns `"260K"` (not `"26K"`)
- [ ] Verify `format_token_count_compact(100_000)` returns `"100K"` (not `"1K"`)
- [ ] Verify decimal stripping still works: `format_token_count_compact(12_450)` returns `"12.4K"`
- [ ] Run `python -m pytest tests/test_cli_status_bar.py -q` — all pass