### PR TITLE
feat(gateway): auto-respond in Slack threads without @mention

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -523,6 +523,12 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+
+            # Slack settings → env vars (env vars take precedence)
+            slack_cfg = yaml_cfg.get("slack", {})
+            if isinstance(slack_cfg, dict):
+                if "auto_respond_threads" in slack_cfg and not os.getenv("SLACK_AUTO_RESPOND_THREADS"):
+                    os.environ["SLACK_AUTO_RESPOND_THREADS"] = str(slack_cfg["auto_respond_threads"]).lower()
     except Exception as e:
         logger.warning(
             "Failed to process config.yaml — falling back to .env / gateway.json values. "

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -9,6 +9,7 @@ Uses slack-bolt (Python) with Socket Mode for:
 """
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -59,7 +60,7 @@ class SlackAdapter(BasePlatformAdapter):
       - SLACK_APP_TOKEN (xapp-...) for Socket Mode connection
 
     Features:
-      - DMs and channel messages (mention-gated in channels)
+      - DMs and channel messages (mention-gated in channels; auto-responds in threads where bot has participated)
       - Thread support
       - File/image/audio attachments
       - Slash commands (/hermes)
@@ -74,6 +75,11 @@ class SlackAdapter(BasePlatformAdapter):
         self._handler: Optional[AsyncSocketModeHandler] = None
         self._bot_user_id: Optional[str] = None
         self._user_name_cache: Dict[str, str] = {}  # user_id → display name
+        # Track threads where the bot has participated so follow-up messages
+        # in those threads don't require @mention.  Persisted to disk so the
+        # set survives gateway restarts.
+        self._bot_participated_threads: set = self._load_participated_threads()
+        self._MAX_TRACKED_THREADS = 500
 
     async def connect(self) -> bool:
         """Connect to Slack via Socket Mode."""
@@ -623,6 +629,46 @@ class SlackAdapter(BasePlatformAdapter):
             )
             return {"name": chat_id, "type": "unknown"}
 
+    # ----- Thread participation tracking -----
+
+    @staticmethod
+    def _thread_state_path() -> _Path:
+        """Path to the persisted thread participation set."""
+        from hermes_cli.config import get_hermes_home
+        return get_hermes_home() / "slack_threads.json"
+
+    @classmethod
+    def _load_participated_threads(cls) -> set:
+        """Load persisted thread IDs from disk."""
+        path = cls._thread_state_path()
+        try:
+            if path.exists():
+                data = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(data, list):
+                    return set(data)
+        except Exception as e:
+            logger.debug("Could not load slack thread state: %s", e)
+        return set()
+
+    def _save_participated_threads(self) -> None:
+        """Persist the current thread set to disk (best-effort)."""
+        path = self._thread_state_path()
+        try:
+            thread_list = list(self._bot_participated_threads)
+            if len(thread_list) > self._MAX_TRACKED_THREADS:
+                thread_list = thread_list[-self._MAX_TRACKED_THREADS:]
+                self._bot_participated_threads = set(thread_list)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(thread_list), encoding="utf-8")
+        except Exception as e:
+            logger.debug("Could not save slack thread state: %s", e)
+
+    def _track_thread(self, thread_id: str) -> None:
+        """Add a thread to the participation set and persist."""
+        if thread_id not in self._bot_participated_threads:
+            self._bot_participated_threads.add(thread_id)
+            self._save_participated_threads()
+
     # ----- Internal handlers -----
 
     async def _handle_slack_message(self, event: dict) -> None:
@@ -655,11 +701,24 @@ class SlackAdapter(BasePlatformAdapter):
         else:
             thread_ts = event.get("thread_ts") or ts  # ts fallback for channels
 
-        # In channels, only respond if bot is mentioned
+        # In channels, respond if bot is mentioned OR (when enabled) if bot
+        # already participated in this thread (mirroring Discord behaviour).
+        #
+        # Config: slack.auto_respond_threads (default: false)
+        #   env override: SLACK_AUTO_RESPOND_THREADS
         if not is_dm and self._bot_user_id:
-            if f"<@{self._bot_user_id}>" not in text:
+            is_mentioned = f"<@{self._bot_user_id}>" in text
+            auto_respond = os.getenv(
+                "SLACK_AUTO_RESPOND_THREADS", "false"
+            ).lower() in ("true", "1", "yes")
+            in_bot_thread = (
+                auto_respond
+                and event.get("thread_ts") is not None
+                and event["thread_ts"] in self._bot_participated_threads
+            )
+            if not is_mentioned and not in_bot_thread:
                 return
-            # Strip the bot mention from the text
+            # Strip the bot mention from the text (if present)
             text = text.replace(f"<@{self._bot_user_id}>", "").strip()
 
         # Determine message type
@@ -773,6 +832,10 @@ class SlackAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=thread_ts if thread_ts != ts else None,
         )
+
+        # Track thread participation so follow-ups don't require @mention
+        if thread_ts and not is_dm:
+            self._track_thread(thread_ts)
 
         # Add 👀 reaction to acknowledge receipt
         await self._add_reaction(channel_id, ts, "eyes")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -533,6 +533,102 @@ class TestMessageRouting:
 
 
 # ---------------------------------------------------------------------------
+# TestThreadParticipation — auto-respond in threads without @mention
+# ---------------------------------------------------------------------------
+
+
+class TestThreadParticipation:
+    """Verify that the bot auto-responds in threads it has already participated in."""
+
+    @pytest.mark.asyncio
+    async def test_thread_message_without_mention_in_participated_thread(self, adapter, monkeypatch):
+        """Messages in a thread where bot has participated should be processed."""
+        monkeypatch.setenv("SLACK_AUTO_RESPOND_THREADS", "true")
+        adapter._bot_participated_threads.add("1234567890.000001")
+        event = {
+            "text": "follow-up question",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000099",
+            "thread_ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_thread_message_ignored_when_feature_disabled(self, adapter, monkeypatch):
+        """With auto_respond_threads off, thread messages still require @mention."""
+        monkeypatch.delenv("SLACK_AUTO_RESPOND_THREADS", raising=False)
+        adapter._bot_participated_threads.add("1234567890.000001")
+        event = {
+            "text": "follow-up question",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000099",
+            "thread_ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_message_without_mention_in_unknown_thread(self, adapter, monkeypatch):
+        """Messages in a thread the bot hasn't participated in should be ignored."""
+        monkeypatch.setenv("SLACK_AUTO_RESPOND_THREADS", "true")
+        event = {
+            "text": "random thread message",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000099",
+            "thread_ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mention_tracks_thread_participation(self, adapter):
+        """When bot is mentioned in a channel thread, the thread should be tracked."""
+        event = {
+            "text": "<@U_BOT> help me",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000002",
+            "thread_ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        assert "1234567890.000001" in adapter._bot_participated_threads
+
+    @pytest.mark.asyncio
+    async def test_top_level_mention_tracks_thread(self, adapter):
+        """A top-level @mention (no thread_ts) should track ts as the thread."""
+        event = {
+            "text": "<@U_BOT> hello",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        assert "1234567890.000001" in adapter._bot_participated_threads
+
+    @pytest.mark.asyncio
+    async def test_dm_does_not_track_threads(self, adapter):
+        """DM messages should not be tracked in participated threads."""
+        event = {
+            "text": "hello",
+            "user": "U_USER",
+            "channel": "D123",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        assert len(adapter._bot_participated_threads) == 0
+
+
+# ---------------------------------------------------------------------------
 # TestSendTyping — assistant.threads.setStatus
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Port the Discord thread participation tracking pattern to the Slack adapter
- When enabled, the bot responds to follow-up messages in threads where it has already participated — no @mention required
- Thread participation is persisted to `~/.hermes/slack_threads.json` (capped at 500 entries) so it survives restarts
- Feature is **off by default**, enabled via `config.yaml` or env var:

```yaml
slack:
  auto_respond_threads: true
```

Or: `SLACK_AUTO_RESPOND_THREADS=true`

## Changes

- `gateway/platforms/slack.py`: Add thread participation tracking (`_bot_participated_threads`) and gate the mention-skip on the new config flag
- `gateway/config.py`: Bridge `slack.auto_respond_threads` from config.yaml to env var
- `tests/gateway/test_slack.py`: 6 new tests

## Test plan

- [x] Message in participated thread is processed without @mention (when enabled)
- [x] Message in participated thread still requires @mention when feature is disabled
- [x] Message in unknown thread without @mention is ignored
- [x] @mention in a thread tracks participation
- [x] Top-level @mention tracks the message ts as thread
- [x] DM messages don't track thread participation
- [x] All existing tests still pass

## Platforms tested

- macOS (Darwin 25.3.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)