### PR TITLE
fix(agent): count compression restarts toward retry limit to prevent infinite loop

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6482,6 +6482,11 @@ class AIAgent:
             if restart_with_compressed_messages:
                 api_call_count -= 1
                 self.iteration_budget.refund()
+                # Count compression restarts toward the retry limit to prevent
+                # infinite loops when compression reduces messages but not enough
+                # to fit the context window.
+                retry_count += 1
+                restart_with_compressed_messages = False
                 continue
 
             if restart_with_length_continuation:


### PR DESCRIPTION
## Summary
- Context overflow triggers compression and restarts the API call via `continue`, but `retry_count` is never incremented
- If compression reduces messages but not enough to fit the context window, the outer `while retry_count < max_retries` loop runs forever: API call → overflow → compress → retry → overflow → compress → ...
- `compression_attempts` limits inner compression attempts, but the outer retry loop stays at `retry_count=0` indefinitely
- Fix: increment `retry_count` on each compression restart, giving a hard exit after `max_retries` total attempts

## How to reproduce
- Start a long conversation that approaches the context limit
- Trigger a tool that produces large output (e.g., large file read)
- Context overflow → compression removes some messages but not enough → retry → same overflow → loop burns API credits indefinitely

## How to test
- Existing compression test passes
- The fix adds 1 line: `retry_count += 1` and resets the flag to prevent stale state

## Platform tested
- Linux, hermes-agent v0.4.0