### PR TITLE
fix(security): block path traversal in checkpoint restore

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -411,3 +411,22 @@ class TestErrorResilience:
         # Should not raise
         result = mgr.ensure_checkpoint(str(work_dir), "test")
         assert result is False
+
+
+class TestRestorePathTraversal:
+    """Verify /rollback blocks path traversal attempts."""
+
+    def test_traversal_blocked(self, mgr, work_dir):
+        result = mgr.restore(str(work_dir), "abc123", file_path="../../../etc/passwd")
+        assert result["success"] is False
+        assert "traversal" in result["error"].lower()
+
+    def test_absolute_path_outside_blocked(self, mgr, work_dir):
+        result = mgr.restore(str(work_dir), "abc123", file_path="/etc/shadow")
+        assert result["success"] is False
+        assert "traversal" in result["error"].lower()
+
+    def test_relative_inside_allowed(self, mgr, work_dir):
+        # Will fail on missing checkpoint, but NOT on path traversal
+        result = mgr.restore(str(work_dir), "abc123", file_path="src/main.py")
+        assert "traversal" not in result.get("error", "").lower()

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -365,6 +365,13 @@ class CheckpointManager:
         Returns dict with success/error info.
         """
         abs_dir = str(Path(working_dir).resolve())
+
+        # Validate file_path early — block traversal outside working directory
+        if file_path:
+            resolved = os.path.normpath(os.path.join(abs_dir, file_path))
+            if not resolved.startswith(abs_dir + os.sep) and resolved != abs_dir:
+                return {"success": False, "error": f"Path traversal not allowed: {file_path}"}
+
         shadow = _shadow_repo_path(abs_dir)
 
         if not (shadow / "HEAD").exists():


### PR DESCRIPTION
## Summary
- `restore()` in checkpoint_manager.py passes `file_path` directly to `git checkout HASH -- file_path` with no validation
- A prompt injection could use `/rollback 1 ../../../etc/passwd` to restore files outside the working directory

## Security Impact
- Path traversal via the /rollback command — can target files outside the project directory
- Severity: HIGH

## How to reproduce
- `/rollback 1 ../../../etc/important_file` — path passed to git without validation

## How to test
- 3 new tests: traversal blocked, absolute path outside blocked, relative path inside allowed
- All 40 checkpoint manager tests pass

## Platform tested
- Linux, hermes-agent v0.4.0