### PR TITLE
fix(plugins): warn when required env vars are missing or zero tools registered

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -297,6 +297,22 @@ class PluginManager:
 
             loaded.module = module
 
+            # Warn early if required env vars are missing so the user gets a
+            # clear message instead of a silent no-op from the plugin itself.
+            missing_env = [
+                var for var in manifest.requires_env
+                if not os.environ.get(var)
+            ]
+            if missing_env:
+                logger.warning(
+                    "Plugin '%s' is missing required environment variable(s): %s. "
+                    "Tools may not be registered. "
+                    "If running as a systemd service, add these to the service's "
+                    "Environment= directives (they are not loaded from ~/.hermes/.env).",
+                    manifest.name,
+                    ", ".join(missing_env),
+                )
+
             # Call register()
             register_fn = getattr(module, "register", None)
             if register_fn is None:
@@ -326,6 +342,19 @@ class PluginManager:
                     }
                 )
                 loaded.enabled = True
+
+                # Warn when the plugin registered nothing at all — this is the
+                # silent-skip pattern reported in #2765 (e.g. Hindsight plugin
+                # returns early when HINDSIGHT_API_URL is absent without any
+                # log output of its own).
+                if not loaded.tools_registered and not loaded.hooks_registered:
+                    logger.warning(
+                        "Plugin '%s' registered zero tools and zero hooks. "
+                        "If this plugin requires environment variables, ensure "
+                        "they are set in the process that loads it "
+                        "(~/.hermes/.env is NOT loaded by systemd-managed services).",
+                        manifest.name,
+                    )
 
         except Exception as exc:
             loaded.error = str(exc)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -367,6 +367,85 @@ class TestPluginManagerList:
 
 
 
+# ── TestPluginMissingEnvWarnings ───────────────────────────────────────────
+
+
+class TestPluginMissingEnvWarnings:
+    """Warnings emitted when required env vars are absent or tools are not registered."""
+
+    def test_missing_requires_env_logs_warning(self, tmp_path, monkeypatch, caplog):
+        """A warning is logged when required env vars listed in plugin.yaml are absent."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir, "needs_env_plugin",
+            manifest_extra={"requires_env": ["MY_PLUGIN_API_URL"]},
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+        monkeypatch.delenv("MY_PLUGIN_API_URL", raising=False)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        assert any("MY_PLUGIN_API_URL" in r.message for r in caplog.records)
+        assert any("systemd" in r.message for r in caplog.records)
+
+    def test_present_requires_env_no_warning(self, tmp_path, monkeypatch, caplog):
+        """No missing-env warning when all required env vars are present."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir, "has_env_plugin",
+            manifest_extra={"requires_env": ["MY_PLUGIN_API_URL"]},
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+        monkeypatch.setenv("MY_PLUGIN_API_URL", "http://localhost:8888")
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        assert not any("MY_PLUGIN_API_URL" in r.message for r in caplog.records)
+
+    def test_zero_registrations_logs_warning(self, tmp_path, monkeypatch, caplog):
+        """A warning is logged when register() completes but registers nothing."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        # register() does nothing — simulates a plugin that returns early
+        # because a required env var is absent (the Hindsight pattern).
+        _make_plugin_dir(plugins_dir, "silent_plugin", register_body="pass")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        assert any("zero tools" in r.message for r in caplog.records)
+        assert any("~/.hermes/.env" in r.message for r in caplog.records)
+
+    def test_no_zero_warning_when_tool_registered(self, tmp_path, monkeypatch, caplog):
+        """No zero-registration warning when at least one tool is registered."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "active_plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({"name": "active_plugin"}))
+        (plugin_dir / "__init__.py").write_text(
+            'def register(ctx):\n'
+            '    ctx.register_tool(\n'
+            '        name="active_tool",\n'
+            '        toolset="plugin_active_plugin",\n'
+            '        schema={"name": "active_tool", "description": "x", '
+            '"parameters": {"type": "object", "properties": {}}},\n'
+            '        handler=lambda args, **kw: "ok",\n'
+            '    )\n'
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        assert not any("zero tools" in r.message for r in caplog.records)
+
+
 # NOTE: TestPluginCommands removed – register_command() was never implemented
 # in PluginContext (hermes_cli/plugins.py).  The tests referenced _plugin_commands,
 # commands_registered, get_plugin_command_handler, and GATEWAY_KNOWN_COMMANDS


### PR DESCRIPTION
## Summary

Closes #2765

When a plugin's `register()` function silently returns without registering any tools or hooks — typically because a required environment variable (e.g. `HINDSIGHT_API_URL`) is absent — Hermes now emits two targeted `WARNING`-level log messages.

## Changes

**`hermes_cli/plugins.py` — `_load_plugin()`**

1. **Pre-register check**: if `manifest.requires_env` lists vars that are not set in the current process environment, a warning is logged *before* calling `register()`, naming the missing variables and noting that `~/.hermes/.env` is **not** loaded by systemd-managed services (the root cause identified in the report).

2. **Post-register check**: if `register()` completes but neither tools nor hooks were registered, a second warning is logged pointing the user toward the env-var / systemd distinction.

Both messages are visible via `hermes --log-level warning` and in `journalctl` output for the gateway service.

## Tests

Four new tests in `tests/test_plugins.py` (`TestPluginMissingEnvWarnings`):

| Test | Asserts |
|---|---|
| `test_missing_requires_env_logs_warning` | Warning emitted, names the missing var, mentions systemd |
| `test_present_requires_env_no_warning` | No warning when all required vars are set |
| `test_zero_registrations_logs_warning` | Warning emitted when register() is a no-op |
| `test_no_zero_warning_when_tool_registered` | No warning when at least one tool is registered |

All 21 plugin tests pass.