### PR TITLE
fix(gateway): skip session expiry flush when agent is still running

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1146,6 +1146,10 @@ class GatewayRunner:
                         continue  # already flushed this session
                     if not self.session_store._is_session_expired(entry):
                         continue  # session still active
+                    # Skip sessions with an agent still running — tearing down
+                    # Honcho mid-execution causes tool failures and corrupted state.
+                    if key in self._running_agents:
+                        continue
                     # Session has expired — flush memories in the background
                     logger.info(
                         "Session %s expired (key=%s), flushing memories proactively",


### PR DESCRIPTION
## Summary
- `_session_expiry_watcher` flushes and shuts down Honcho for expired sessions without checking if an agent is still running
- Running agents lose Honcho access mid-execution → tool failures, corrupted session state
- Fix: check `key in self._running_agents` before flushing — defer to next watcher cycle

## How to reproduce
- Start a long-running agent task via gateway
- Wait for the session idle timeout to expire while the agent is still processing
- Honcho is torn down → agent's memory tools start failing

## How to test
- The fix is a 2-line guard check — if the session key is in `_running_agents`, skip the flush
- The session will be flushed on the next watcher cycle after the agent finishes

## Platform tested
- Linux, hermes-agent v0.4.0