### PR TITLE
fix(email): handle missing @ in EMAIL_ADDRESS to prevent IndexError

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -438,7 +438,8 @@ class EmailAdapter(BasePlatformAdapter):
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id
 
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
+        _domain = self._address.split("@")[1] if "@" in self._address else "hermes.local"
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{_domain}>"
         msg["Message-ID"] = msg_id
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
@@ -515,7 +516,8 @@ class EmailAdapter(BasePlatformAdapter):
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id
 
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
+        _domain = self._address.split("@")[1] if "@" in self._address else "hermes.local"
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{_domain}>"
         msg["Message-ID"] = msg_id
 
         if body:

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1057,5 +1057,27 @@ class TestSendEmailStandalone(unittest.TestCase):
         self.assertIn("not configured", result["error"])
 
 
+class TestEmailMessageIdDomain(unittest.TestCase):
+    """Verify Message-ID domain extraction handles bad EMAIL_ADDRESS."""
+
+    def test_address_with_at_sign(self):
+        """Normal email address extracts domain correctly."""
+        addr = "user@example.com"
+        domain = addr.split("@")[1] if "@" in addr else "hermes.local"
+        self.assertEqual(domain, "example.com")
+
+    def test_address_without_at_sign(self):
+        """Malformed address falls back to hermes.local."""
+        addr = "not-an-email"
+        domain = addr.split("@")[1] if "@" in addr else "hermes.local"
+        self.assertEqual(domain, "hermes.local")
+
+    def test_empty_address(self):
+        """Empty address falls back to hermes.local."""
+        addr = ""
+        domain = addr.split("@")[1] if "@" in addr else "hermes.local"
+        self.assertEqual(domain, "hermes.local")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Message-ID generation uses `self._address.split('@')[1]` at two locations (lines 441, 518)
- Crashes with `IndexError` when `EMAIL_ADDRESS` env var is empty or malformed (no `@` sign)
- Fix: check for `@` before splitting, fall back to `hermes.local` domain

## How to reproduce
- Set `EMAIL_ADDRESS=""` or `EMAIL_ADDRESS="not-an-email"` in .env
- Send a message via the email gateway → IndexError crash

## How to test
- 3 new tests: normal address, malformed address, empty address
- All 68 email tests pass

## Platform tested
- Linux, hermes-agent v0.4.0