### PR TITLE
fix(signal): evict oldest sent timestamp instead of arbitrary one

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -615,7 +615,7 @@ class SignalAdapter(BasePlatformAdapter):
         if ts:
             self._recent_sent_timestamps.add(ts)
             if len(self._recent_sent_timestamps) > self._max_recent_timestamps:
-                self._recent_sent_timestamps.pop()
+                self._recent_sent_timestamps.discard(min(self._recent_sent_timestamps))
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send a typing indicator."""


### PR DESCRIPTION
## Summary
- `_track_sent_timestamp()` uses `set.pop()` to evict when the echo-back filter exceeds 50 entries
- `set.pop()` removes an **arbitrary** element, not the oldest — could drop a recent timestamp while keeping old ones
- This causes the echo-back filter to miss actual echo-backs in Note to Self / self-chat mode
- Fix: use `min()` to always evict the oldest timestamp

## How to reproduce
- Use Signal Note to Self / self-chat mode
- Send 50+ messages rapidly
- Some echo-backs may slip through the filter because recent timestamps get evicted randomly

## How to test
- All 33 signal tests pass
- The fix is a 1-line change: `set.pop()` → `set.discard(min(set))`

## Platform tested
- Linux, hermes-agent v0.4.0