### PR TITLE
feat(skills): add Zotero research library integration

### DIFF
--- a/optional-skills/research/zotero/SKILL.md
+++ b/optional-skills/research/zotero/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: zotero
+description: Manage a Zotero reference library — add books and papers by DOI, ISBN, arXiv ID, or URL; read PDF content; create and organise reading notes; manage collections and tags; set up a dedicated hermes-agent workspace folder inside the library. Use when the user mentions Zotero, wants to add references, read papers or books, take reading notes, manage a research library, search their bibliography, export citations (APA, MLA, BibTeX), or organise research collections.
+version: 1.0.0
+author: ed
+license: MIT
+required_environment_variables:
+  - name: ZOTERO_API_KEY
+    prompt: Zotero API key
+    help: Get a key at https://www.zotero.org/settings/keys — enable read/write access to your library
+    required_for: all operations
+  - name: ZOTERO_USER_ID
+    prompt: Zotero user ID (numeric)
+    help: Found at https://www.zotero.org/settings/keys alongside your API key
+    required_for: all operations
+metadata:
+  hermes:
+    tags: [Research, Zotero, Papers, Books, PDF, Notes, References, Bibliography, Citations]
+    related_skills: [arxiv, ocr-and-documents]
+    category: research
+---
+
+# Zotero
+
+Manage a Zotero reference library via the Web API v3. Add items, read PDFs, write notes, organise collections.
+
+## Setup
+
+**Required environment variables** (in `~/.hermes/.env` or shell):
+```
+ZOTERO_API_KEY=your_key_here      # from zotero.org/settings/keys (needs write access)
+ZOTERO_USER_ID=1234567            # numeric ID shown on the same page
+```
+
+**One-time workspace bootstrap** (creates the hermes-agent collection tree):
+```bash
+python scripts/zotero_setup.py
+```
+
+This creates inside your Zotero library:
+```
+hermes-agent/
+├── Books/
+├── Papers/
+├── Notes/
+└── Reading List/
+```
+
+Re-running is safe — it is idempotent. Use `--show` to print existing keys without modifying.
+
+**Base URL for all API calls:**
+```
+https://api.zotero.org/users/{ZOTERO_USER_ID}
+```
+
+Always send headers:
+```
+Zotero-API-Version: 3
+Zotero-API-Key: {ZOTERO_API_KEY}
+```
+
+## Adding Items
+
+Use `scripts/zotero_add.py`. It fetches metadata from external sources, then POSTs to Zotero and places the item in the hermes-agent sub-collection.
+
+```bash
+# Add by DOI (fetches from CrossRef)
+python scripts/zotero_add.py --doi 10.1145/3290605.3300786
+
+# Add by ISBN (fetches from Open Library)
+python scripts/zotero_add.py --isbn 978-0-13-468599-1
+
+# Add by arXiv ID (PDF readable on demand via URL — no upload to Zotero needed)
+python scripts/zotero_add.py --arxiv 2301.07041
+
+# Add by URL (creates webpage item)
+python scripts/zotero_add.py --url https://example.com/article
+
+# Add to a specific sub-collection (use key from zotero_setup output)
+python scripts/zotero_add.py --doi 10.1145/xxx --collection BOOKS_KEY
+
+# Bulk import from BibTeX file (batches ≤50 per request)
+python scripts/zotero_add.py --bibtex refs.bib
+```
+
+## Browsing the Library
+
+```bash
+# List hermes-agent sub-collections (with keys)
+python scripts/zotero_search.py --collections
+
+# List all items in a collection
+python scripts/zotero_search.py --collection COLLECTION_KEY
+
+# Get full metadata for one item
+python scripts/zotero_search.py --item ITEM_KEY
+
+# Collection stats: item counts by type and top tags
+python scripts/zotero_search.py --stats --collection COLLECTION_KEY
+```
+
+## Searching
+
+```bash
+# Full-text keyword search
+python scripts/zotero_search.py "transformer attention mechanism"
+
+# Filter by tag
+python scripts/zotero_search.py --tag "machine-learning"
+
+# Filter by item type (book, journalArticle, conferencePaper, webpage…)
+python scripts/zotero_search.py --type book
+
+# Items added after a date
+python scripts/zotero_search.py --since 2025-01-01
+
+# Detect duplicates by DOI/ISBN/title
+python scripts/zotero_search.py --dupes
+
+# Combined filters
+python scripts/zotero_search.py "deep learning" --tag "unread" --type journalArticle
+
+# Export collection to BibTeX
+python scripts/zotero_search.py --export bibtex COLLECTION_KEY > refs.bib
+```
+
+## Reading PDFs
+
+`zotero_read.py` tries methods in order (fastest first):
+
+1. Zotero fulltext index (`GET /items/{key}/fulltext`) — instant if indexed by desktop app
+2. Download from Zotero cloud storage + extract with `pdfplumber`
+3. **Fetch directly from source URL** (arXiv, open-access DOI via Unpaywall) — works even if no PDF is stored in Zotero
+
+This means arXiv papers are always readable even if the PDF was never uploaded.
+
+```bash
+# Read the PDF for an item (auto-finds attachment or fetches from source)
+python scripts/zotero_read.py ITEM_KEY
+
+# Limit to first N pages (good for long papers)
+python scripts/zotero_read.py ITEM_KEY --pages 10
+
+# Save extracted text to a file
+python scripts/zotero_read.py ITEM_KEY --out summary.txt
+
+# Metadata and abstract only — no PDF fetch
+python scripts/zotero_read.py ITEM_KEY --metadata-only
+
+# Get a formatted citation
+python scripts/zotero_read.py ITEM_KEY --cite apa
+python scripts/zotero_read.py ITEM_KEY --cite mla
+python scripts/zotero_read.py ITEM_KEY --cite bibtex
+```
+
+`pdfplumber` must be installed for PDF extraction:
+```bash
+pip install pdfplumber
+```
+
+## Notes
+
+Notes are Zotero items with `itemType: "note"` attached as children of a parent item.
+
+```bash
+# Create a reading note on an item
+python scripts/zotero_note.py create ITEM_KEY --title "Reading notes" --body "Key points..."
+
+# Create note from a file
+python scripts/zotero_note.py create ITEM_KEY --title "Summary" --file notes.md
+
+# Use a template (reading, book, quick)
+python scripts/zotero_note.py create ITEM_KEY --template reading
+
+# List all notes for an item
+python scripts/zotero_note.py list ITEM_KEY
+
+# Show note content
+python scripts/zotero_note.py show NOTE_KEY
+
+# Update an existing note
+python scripts/zotero_note.py update NOTE_KEY --body "Replacement text"
+python scripts/zotero_note.py update NOTE_KEY --append "...additional text"
+
+# Set reading progress tag on an item (replaces previous status)
+python scripts/zotero_note.py status ITEM_KEY unread
+python scripts/zotero_note.py status ITEM_KEY reading
+python scripts/zotero_note.py status ITEM_KEY done
+```
+
+### Structured note template
+
+When creating a reading note, use this structure:
+
+```markdown
+## Summary
+[2-3 sentence overview]
+
+## Key Points
+- Point 1
+- Point 2
+
+## Quotes
+> "Notable quote" (p. X)
+
+## Questions / Gaps
+- Question raised
+
+## Related
+- [Related item or concept]
+```
+
+## Organisation
+
+```bash
+# Add an item to a collection (can be in multiple)
+python scripts/zotero_add.py --move ITEM_KEY --collection COLLECTION_KEY
+
+# Create a new sub-collection under hermes-agent
+python scripts/zotero_setup.py --add-collection "Philosophy"
+
+# Bulk-tag items in a collection
+python scripts/zotero_search.py --collection COLLECTION_KEY --add-tag "reading-sprint-2026"
+```
+
+## Export & Citations
+
+```bash
+# Export full collection to BibTeX
+python scripts/zotero_search.py --export bibtex HERMES_COLLECTION_KEY > library.bib
+
+# Export to RIS format
+python scripts/zotero_search.py --export ris HERMES_COLLECTION_KEY > library.ris
+
+# Single-item citation
+python scripts/zotero_read.py ITEM_KEY --cite apa
+```
+
+Citation styles supported: `apa`, `mla`, `chicago`, `bibtex`.
+
+## Workflow Recipes
+
+### Add a paper and take notes
+```bash
+python scripts/zotero_add.py --doi 10.1234/example --collection PAPERS_KEY
+# Note the ITEM_KEY printed
+python scripts/zotero_read.py ITEM_KEY --pages 5
+python scripts/zotero_note.py create ITEM_KEY --template reading
+python scripts/zotero_note.py status ITEM_KEY reading
+```
+
+### Literature review on a topic
+```bash
+python scripts/zotero_search.py "your topic" --type journalArticle
+python scripts/zotero_search.py --export bibtex COLLECTION_KEY > review.bib
+```
+
+### Reading sprint
+```bash
+python scripts/zotero_search.py --tag "unread" --collection HERMES_KEY
+# For each item:
+python scripts/zotero_read.py ITEM_KEY --pages 10
+python scripts/zotero_note.py create ITEM_KEY --title "Sprint notes" --body "..."
+python scripts/zotero_note.py status ITEM_KEY done
+```
+
+### Add a book
+```bash
+python scripts/zotero_add.py --isbn 978-0-06-112008-4 --collection BOOKS_KEY
+# Zotero will store title, author, publisher, year from Open Library
+```
+
+## Deletions
+
+Deletion is **not available** through these scripts. To delete items, collections, or tags, use the Zotero desktop app. This prevents accidental data loss.
+
+## Notes
+
+- All script output prints the Zotero item key — save it for follow-up operations
+- `zotero_setup.py --show` prints all hermes-agent collection keys without modifying anything
+- Rate limit: Zotero API allows ~15 requests/second with a valid API key
+- Items can belong to multiple collections simultaneously
+- The fulltext index is populated when you open a PDF in the Zotero desktop app; use the download fallback if not yet indexed
+- Date strings like "December 27, 2017" are handled correctly — year is extracted by regex
+
+## API Reference
+
+For full endpoint details, see [api-reference.md](api-reference.md).

--- a/optional-skills/research/zotero/api-reference.md
+++ b/optional-skills/research/zotero/api-reference.md
@@ -1,0 +1,270 @@
+# Zotero API Reference
+
+Base URL: `https://api.zotero.org/users/{userID}`  
+Headers (all requests): `Zotero-API-Version: 3`, `Zotero-API-Key: {key}`
+
+---
+
+## Collections
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/collections` | All collections (flat list) |
+| `GET` | `/collections/top` | Top-level collections only |
+| `GET` | `/collections/{key}` | Single collection metadata |
+| `GET` | `/collections/{key}/collections` | Subcollections |
+| `GET` | `/collections/{key}/items` | All items in collection |
+| `GET` | `/collections/{key}/items/top` | Top-level items (no children) |
+| `POST` | `/collections` | Create collection(s) |
+| `PUT` | `/collections/{key}` | Replace collection |
+| `PATCH` | `/collections/{key}` | Update collection fields |
+| `DELETE` | `/collections/{key}` | Delete collection |
+
+**Create collection:**
+```json
+POST /collections
+[{"name": "Books", "parentCollection": "PARENT_KEY"}]
+```
+Response: `200 OK` with `{"successful": {"0": {"key": "NEWKEY", ...}}}`
+
+**Top-level collections response example:**
+```json
+[
+  {"key": "ABCD1234", "version": 42, "data": {"key": "ABCD1234", "name": "hermes-agent", "parentCollection": false}},
+  {"key": "EFGH5678", "version": 43, "data": {"key": "EFGH5678", "name": "Books", "parentCollection": "ABCD1234"}}
+]
+```
+
+---
+
+## Items
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/items` | All items in library |
+| `GET` | `/items/top` | Top-level items only |
+| `GET` | `/items/{key}` | Single item |
+| `GET` | `/items/{key}/children` | Child items (notes, attachments) |
+| `POST` | `/items` | Create item(s) (up to 50) |
+| `PUT` | `/items/{key}` | Replace item (requires version) |
+| `PATCH` | `/items/{key}` | Partial update |
+| `DELETE` | `/items/{key}` | Delete item |
+| `DELETE` | `/items?itemKey=K1,K2` | Batch delete |
+
+**Item query parameters:**
+
+| Param | Description | Example |
+|-------|-------------|---------|
+| `q` | Keyword search | `q=deep+learning` |
+| `qmode` | Search mode: `titleCreatorYear` or `everything` | `qmode=everything` |
+| `itemType` | Filter by type | `itemType=book` |
+| `tag` | Filter by tag | `tag=unread` |
+| `collection` | Filter by collection key | `collection=ABCD1234` |
+| `since` | Library version (for sync) | `since=42` |
+| `limit` | Results per page (1-100, default 25) | `limit=100` |
+| `start` | Pagination offset | `start=100` |
+| `sort` | Sort field | `sort=dateAdded` |
+| `direction` | `asc` or `desc` | `direction=desc` |
+
+**Pagination:** Check `Total-Results` response header. Use `start` to page through.
+
+**Create journal article:**
+```json
+POST /items
+[{
+  "itemType": "journalArticle",
+  "title": "Attention Is All You Need",
+  "creators": [{"creatorType": "author", "firstName": "Ashish", "lastName": "Vaswani"}],
+  "abstractNote": "...",
+  "publicationTitle": "NeurIPS",
+  "volume": "30",
+  "date": "2017",
+  "DOI": "10.48550/arXiv.1706.03762",
+  "url": "https://arxiv.org/abs/1706.03762",
+  "tags": [{"tag": "unread"}, {"tag": "transformers"}],
+  "collections": ["COLLECTION_KEY"]
+}]
+```
+
+**Create book:**
+```json
+[{
+  "itemType": "book",
+  "title": "The Pragmatic Programmer",
+  "creators": [{"creatorType": "author", "firstName": "David", "lastName": "Thomas"}],
+  "publisher": "Addison-Wesley",
+  "date": "2019",
+  "ISBN": "978-0-13-595705-9",
+  "numPages": "352",
+  "collections": ["BOOKS_COLLECTION_KEY"]
+}]
+```
+
+**Create webpage item:**
+```json
+[{
+  "itemType": "webpage",
+  "title": "Page Title",
+  "url": "https://example.com",
+  "websiteTitle": "Site Name",
+  "accessDate": "2026-03-24",
+  "collections": ["COLLECTION_KEY"]
+}]
+```
+
+**Item types reference:**
+
+| Type | `itemType` value |
+|------|-----------------|
+| Journal Article | `journalArticle` |
+| Book | `book` |
+| Book Section | `bookSection` |
+| Conference Paper | `conferencePaper` |
+| Thesis | `thesis` |
+| Preprint | `preprint` |
+| Webpage | `webpage` |
+| Report | `report` |
+| Magazine Article | `magazineArticle` |
+| Blog Post | `blogPost` |
+
+---
+
+## Notes
+
+Notes are items with `itemType: "note"` and a `parentItem` key.
+
+**Create a child note:**
+```json
+POST /items
+[{
+  "itemType": "note",
+  "parentItem": "PARENT_ITEM_KEY",
+  "note": "<p><strong>Summary</strong></p><p>Key points here...</p>",
+  "tags": [{"tag": "reading-note"}]
+}]
+```
+
+The `note` field is **HTML**. Plain text should be wrapped in `<p>` tags.
+
+**Update a note (PATCH):**
+```
+PATCH /items/{noteKey}
+If-Unmodified-Since-Version: {current_version}
+
+{"note": "<p>Updated content</p>", "version": {current_version}}
+```
+
+---
+
+## Attachments & PDFs
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/items/{key}/children` | Get child items (find attachment key) |
+| `GET` | `/items/{attachmentKey}/file` | Download the file (follows redirect) |
+| `GET` | `/items/{attachmentKey}/fulltext` | Get indexed text content |
+| `PUT` | `/items/{attachmentKey}/fulltext` | Set/update indexed text |
+
+**Fulltext response:**
+```json
+{
+  "content": "Extracted text from the PDF...",
+  "indexedPages": 12,
+  "totalPages": 42
+}
+```
+
+**Download PDF:** The `/file` endpoint returns a redirect to the actual file (Zotero cloud or WebDAV). Follow redirects with `requests.get(..., allow_redirects=True)`.
+
+**Attachment item fields:**
+```json
+{
+  "itemType": "attachment",
+  "linkMode": "imported_file",
+  "title": "paper.pdf",
+  "filename": "paper.pdf",
+  "contentType": "application/pdf",
+  "md5": "abc123...",
+  "mtime": 1700000000000
+}
+```
+
+---
+
+## Tags
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/tags` | All tags in library |
+| `GET` | `/items/{key}/tags` | Tags on one item |
+| `GET` | `/collections/{key}/tags` | Tags in a collection |
+| `DELETE` | `/tags?tag=name` | Delete tag from all items |
+
+Tags are set on items in the `tags` array field:
+```json
+"tags": [{"tag": "unread"}, {"tag": "machine-learning"}]
+```
+
+---
+
+## Versioning & Writes
+
+Every item/collection has a `version` integer. Writes must include:
+- `If-Unmodified-Since-Version: {version}` header (single-item writes)
+- `version` in the JSON body (PATCH)
+
+For new items (`POST`), no version is needed. Response includes `Last-Modified-Version` header with the new library version.
+
+**Write token** (idempotency for `POST`):
+```
+Zotero-Write-Token: {random-32-char-hex}
+```
+
+---
+
+## External Metadata APIs
+
+### CrossRef (DOI lookup)
+```
+GET https://api.crossref.org/works/{DOI}
+```
+Key response fields: `title[0]`, `author[].given/family`, `published.date-parts[0]`, `container-title[0]`, `DOI`, `URL`, `type`
+
+### Open Library (ISBN lookup)
+```
+GET https://openlibrary.org/api/books?bibkeys=ISBN:{isbn}&format=json&jscmd=data
+```
+Key response fields (under `ISBN:{isbn}`): `title`, `authors[].name`, `publishers[].name`, `publish_date`, `number_of_pages`, `identifiers.isbn_13[0]`
+
+### arXiv (arXiv ID lookup)
+```
+GET https://export.arxiv.org/api/query?id_list={arxiv_id}
+```
+Returns Atom XML. Parse namespace `http://www.w3.org/2005/Atom`. Key tags: `title`, `author/name`, `published`, `summary`, `id` (URL containing the ID).
+
+### Google Books (ISBN fallback)
+```
+GET https://www.googleapis.com/books/v1/volumes?q=isbn:{isbn}
+```
+Key fields: `items[0].volumeInfo.{title, authors[], publisher, publishedDate, pageCount, industryIdentifiers[]}`
+
+---
+
+## Error Responses
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Success (reads + some writes) |
+| `204` | Success, no body (deletes) |
+| `400` | Bad request / malformed JSON |
+| `403` | Invalid API key or insufficient permissions |
+| `404` | Item/collection not found |
+| `409` | Version conflict (`If-Unmodified-Since-Version` mismatch) |
+| `412` | Precondition failed |
+| `429` | Rate limit exceeded — back off and retry |
+
+---
+
+## Zotero Item Key Format
+
+Keys are 8-character uppercase alphanumeric strings, e.g. `A3BC4DEF`.

--- a/optional-skills/research/zotero/scripts/zotero_add.py
+++ b/optional-skills/research/zotero/scripts/zotero_add.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""
+zotero_add.py — Add items to your Zotero library.
+
+Fetches metadata from external sources, creates a Zotero item,
+and places it in the hermes-agent collection (or a specified one).
+
+PDF reading is handled by zotero_read.py, which fetches PDFs directly
+from the source URL (arXiv, open-access DOIs) — no upload needed.
+
+Usage:
+  python zotero_add.py --doi 10.1145/3290605.3300786
+  python zotero_add.py --isbn 978-0-13-468599-1
+  python zotero_add.py --arxiv 2301.07041
+  python zotero_add.py --url https://example.com/article
+  python zotero_add.py --bibtex refs.bib
+  python zotero_add.py --doi 10.1234/x --collection ABCD1234
+  python zotero_add.py --move ITEM_KEY --collection COLL_KEY
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+try:
+    import requests
+except ImportError:
+    sys.exit("requests is required: pip install requests")
+
+API_BASE = "https://api.zotero.org"
+CROSSREF_BASE = "https://api.crossref.org/works"
+OPENLIBRARY_BASE = "https://openlibrary.org/api/books"
+GBOOKS_BASE = "https://www.googleapis.com/books/v1/volumes"
+ARXIV_BASE = "https://export.arxiv.org/api/query"
+ATOM_NS = "http://www.w3.org/2005/Atom"
+ARXIV_NS = "http://arxiv.org/schemas/atom"
+
+HEADERS: dict = {}
+USER_ID: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Environment helpers
+# ---------------------------------------------------------------------------
+
+def get_env() -> tuple[str, str]:
+    api_key = os.environ.get("ZOTERO_API_KEY", "")
+    user_id = os.environ.get("ZOTERO_USER_ID", "")
+    if not api_key or not user_id:
+        sys.exit(
+            "Set ZOTERO_API_KEY and ZOTERO_USER_ID environment variables.\n"
+            "  Get them at: https://www.zotero.org/settings/keys"
+        )
+    return api_key, user_id
+
+
+def build_headers(api_key: str) -> dict:
+    return {
+        "Zotero-API-Version": "3",
+        "Zotero-API-Key": api_key,
+        "Content-Type": "application/json",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Metadata fetchers
+# ---------------------------------------------------------------------------
+
+def fetch_doi(doi: str) -> dict:
+    """Fetch metadata from CrossRef for a DOI."""
+    doi_clean = doi.strip().lstrip("https://doi.org/").lstrip("http://dx.doi.org/")
+    print(f"  Fetching DOI metadata from CrossRef: {doi_clean}")
+    resp = requests.get(f"{CROSSREF_BASE}/{doi_clean}",
+                        headers={"User-Agent": "hermes-agent/1.0 (mailto:user@example.com)"})
+    if resp.status_code == 404:
+        sys.exit(f"DOI not found in CrossRef: {doi_clean}")
+    resp.raise_for_status()
+    work = resp.json().get("message", {})
+
+    authors = []
+    for author in work.get("author", []):
+        authors.append({
+            "creatorType": "author",
+            "firstName": author.get("given", ""),
+            "lastName": author.get("family", ""),
+        })
+
+    # Map CrossRef type to Zotero itemType
+    cr_type = work.get("type", "journal-article")
+    type_map = {
+        "journal-article": "journalArticle",
+        "proceedings-article": "conferencePaper",
+        "book": "book",
+        "book-chapter": "bookSection",
+        "monograph": "book",
+        "report": "report",
+        "dissertation": "thesis",
+        "preprint": "preprint",
+        "posted-content": "preprint",
+    }
+    item_type = type_map.get(cr_type, "journalArticle")
+
+    date_parts = work.get("published", work.get("published-print", work.get("issued", {}))).get("date-parts", [[]])
+    year = str(date_parts[0][0]) if date_parts and date_parts[0] else ""
+
+    titles = work.get("title", [""])
+    title = titles[0] if titles else ""
+
+    item: dict = {
+        "itemType": item_type,
+        "title": title,
+        "creators": authors,
+        "DOI": work.get("DOI", doi_clean),
+        "url": work.get("URL", f"https://doi.org/{doi_clean}"),
+        "date": year,
+        "abstractNote": work.get("abstract", ""),
+    }
+
+    if item_type == "journalArticle":
+        containers = work.get("container-title", [])
+        item["publicationTitle"] = containers[0] if containers else ""
+        item["volume"] = work.get("volume", "")
+        item["issue"] = work.get("issue", "")
+        pages = work.get("page", "")
+        item["pages"] = pages
+
+    if item_type == "conferencePaper":
+        containers = work.get("container-title", [])
+        item["proceedingsTitle"] = containers[0] if containers else ""
+
+    return item
+
+
+def fetch_isbn(isbn: str) -> dict:
+    """Fetch book metadata from Open Library (fallback: Google Books)."""
+    isbn_clean = re.sub(r"[-\s]", "", isbn)
+    print(f"  Fetching ISBN metadata from Open Library: {isbn_clean}")
+
+    resp = requests.get(
+        OPENLIBRARY_BASE,
+        params={"bibkeys": f"ISBN:{isbn_clean}", "format": "json", "jscmd": "data"},
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    book = data.get(f"ISBN:{isbn_clean}")
+
+    if not book:
+        print("  Not found in Open Library, trying Google Books...")
+        return fetch_isbn_google(isbn_clean)
+
+    authors = [
+        {"creatorType": "author", "firstName": "", "lastName": a["name"]}
+        for a in book.get("authors", [])
+    ]
+    # Split single "Firstname Lastname" strings
+    split_authors = []
+    for a in authors:
+        parts = a["lastName"].rsplit(" ", 1)
+        if len(parts) == 2:
+            split_authors.append({"creatorType": "author", "firstName": parts[0], "lastName": parts[1]})
+        else:
+            split_authors.append(a)
+
+    publishers = book.get("publishers", [{}])
+    publisher = publishers[0].get("name", "") if publishers else ""
+
+    return {
+        "itemType": "book",
+        "title": book.get("title", ""),
+        "creators": split_authors,
+        "publisher": publisher,
+        "date": book.get("publish_date", ""),
+        "numPages": str(book.get("number_of_pages", "")),
+        "ISBN": isbn_clean,
+        "url": book.get("url", ""),
+        "abstractNote": book.get("description", {}).get("value", "") if isinstance(book.get("description"), dict) else book.get("description", ""),
+    }
+
+
+def fetch_isbn_google(isbn: str) -> dict:
+    """Fallback: Google Books API for ISBN."""
+    resp = requests.get(GBOOKS_BASE, params={"q": f"isbn:{isbn}"})
+    if resp.status_code == 429:
+        sys.exit(f"Google Books rate limit hit. Please wait a minute and retry.")
+    resp.raise_for_status()
+    items = resp.json().get("items", [])
+    if not items:
+        sys.exit(f"ISBN not found in Open Library or Google Books: {isbn}")
+
+    info = items[0].get("volumeInfo", {})
+    raw_authors = info.get("authors", [])
+    authors = []
+    for name in raw_authors:
+        parts = name.rsplit(" ", 1)
+        if len(parts) == 2:
+            authors.append({"creatorType": "author", "firstName": parts[0], "lastName": parts[1]})
+        else:
+            authors.append({"creatorType": "author", "firstName": "", "lastName": name})
+
+    return {
+        "itemType": "book",
+        "title": info.get("title", ""),
+        "creators": authors,
+        "publisher": info.get("publisher", ""),
+        "date": info.get("publishedDate", "")[:4] if info.get("publishedDate") else "",
+        "numPages": str(info.get("pageCount", "")),
+        "ISBN": isbn,
+        "abstractNote": info.get("description", ""),
+    }
+
+
+def fetch_arxiv(arxiv_id: str) -> dict:
+    """Fetch preprint metadata from arXiv Atom API."""
+    arxiv_id_clean = arxiv_id.strip().removeprefix("https://arxiv.org/abs/").removeprefix("arXiv:")
+    print(f"  Fetching arXiv metadata: {arxiv_id_clean}")
+    resp = requests.get(ARXIV_BASE, params={"id_list": arxiv_id_clean})
+    resp.raise_for_status()
+
+    root = ET.fromstring(resp.text)
+    ns = {"a": ATOM_NS, "arxiv": ARXIV_NS}
+    entry = root.find("a:entry", ns)
+    if entry is None:
+        sys.exit(f"arXiv ID not found: {arxiv_id_clean}")
+
+    title = (entry.find("a:title", ns).text or "").strip().replace("\n", " ")
+    summary = (entry.find("a:summary", ns).text or "").strip()
+    published = (entry.find("a:published", ns).text or "")[:4]
+    authors = [
+        {
+            "creatorType": "author",
+            "firstName": " ".join(a.find("a:name", ns).text.split()[:-1]),
+            "lastName": a.find("a:name", ns).text.split()[-1],
+        }
+        for a in entry.findall("a:author", ns)
+        if a.find("a:name", ns) is not None
+    ]
+
+    cat_el = entry.find("arxiv:primary_category", ns)
+    category = cat_el.get("term", "") if cat_el is not None else ""
+
+    return {
+        "itemType": "preprint",
+        "title": title,
+        "creators": authors,
+        "abstractNote": summary,
+        "date": published,
+        "url": f"https://arxiv.org/abs/{arxiv_id_clean}",
+        "archiveID": f"arXiv:{arxiv_id_clean}",
+        "repository": "arXiv",
+        "extra": f"arXiv: {arxiv_id_clean}\nPrimary category: {category}",
+    }
+
+
+def build_url_item(url: str) -> dict:
+    """Build a minimal webpage item from a URL."""
+    from datetime import date
+    return {
+        "itemType": "webpage",
+        "title": url,
+        "url": url,
+        "accessDate": date.today().isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Zotero write helpers
+# ---------------------------------------------------------------------------
+
+def get_hermes_collection_key() -> str | None:
+    """Try to find the hermes-agent collection key."""
+    resp = requests.get(
+        f"{API_BASE}/users/{USER_ID}/collections/top",
+        headers=HEADERS,
+        params={"limit": 100},
+    )
+    resp.raise_for_status()
+    for col in resp.json():
+        if col.get("data", {}).get("name", "").lower() == "hermes-agent":
+            return col["data"]["key"]
+    return None
+
+
+def post_items(items: list[dict]) -> list[str]:
+    """Post items to Zotero (batch ≤50). Returns list of created keys."""
+    created_keys = []
+    for i in range(0, len(items), 50):
+        batch = items[i:i + 50]
+        resp = requests.post(
+            f"{API_BASE}/users/{USER_ID}/items",
+            headers=HEADERS,
+            json=batch,
+        )
+        resp.raise_for_status()
+        result = resp.json()
+        for idx, item in result.get("successful", {}).items():
+            key = item.get("data", {}).get("key") or item.get("key", "")
+            created_keys.append(key)
+        if result.get("failed"):
+            for idx, err in result["failed"].items():
+                print(f"  Warning: item {idx} failed: {err}", file=sys.stderr)
+    return created_keys
+
+
+def add_to_collection(item_key: str, collection_key: str) -> None:
+    """Add an item to a collection."""
+    # Fetch current item to get its collections
+    resp = requests.get(f"{API_BASE}/users/{USER_ID}/items/{item_key}", headers=HEADERS)
+    resp.raise_for_status()
+    item = resp.json()
+    version = item["data"]["version"]
+    collections = item["data"].get("collections", [])
+    if collection_key not in collections:
+        collections.append(collection_key)
+    patch_headers = {**HEADERS, "If-Unmodified-Since-Version": str(version)}
+    resp2 = requests.patch(
+        f"{API_BASE}/users/{USER_ID}/items/{item_key}",
+        headers=patch_headers,
+        json={"collections": collections, "version": version},
+    )
+    resp2.raise_for_status()
+
+
+# ---------------------------------------------------------------------------
+# BibTeX parser
+# ---------------------------------------------------------------------------
+
+def parse_bibtex(path: str) -> list[dict]:
+    """Minimal BibTeX parser → list of Zotero item dicts."""
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    items = []
+    entries = re.findall(r"@(\w+)\s*\{([^,]+),\s*(.*?)\n\}", content, re.DOTALL)
+
+    type_map = {
+        "article": "journalArticle",
+        "book": "book",
+        "inproceedings": "conferencePaper",
+        "proceedings": "conferencePaper",
+        "phdthesis": "thesis",
+        "mastersthesis": "thesis",
+        "misc": "webpage",
+        "techreport": "report",
+        "incollection": "bookSection",
+        "unpublished": "manuscript",
+    }
+
+    for bib_type, citekey, body in entries:
+        item_type = type_map.get(bib_type.lower(), "journalArticle")
+        fields: dict = {}
+        for match in re.finditer(r'(\w+)\s*=\s*[{"](.*?)[}"],?', body, re.DOTALL):
+            fields[match.group(1).lower()] = match.group(2).strip()
+
+        title = fields.get("title", "").replace("{", "").replace("}", "")
+        year = fields.get("year", "")
+        author_str = fields.get("author", "")
+        authors = []
+        for name in author_str.split(" and "):
+            name = name.strip()
+            if not name:
+                continue
+            if "," in name:
+                last, first = name.split(",", 1)
+                authors.append({"creatorType": "author", "firstName": first.strip(), "lastName": last.strip()})
+            else:
+                parts = name.rsplit(" ", 1)
+                if len(parts) == 2:
+                    authors.append({"creatorType": "author", "firstName": parts[0], "lastName": parts[1]})
+                else:
+                    authors.append({"creatorType": "author", "firstName": "", "lastName": name})
+
+        item: dict = {
+            "itemType": item_type,
+            "title": title,
+            "creators": authors,
+            "date": year,
+            "abstractNote": fields.get("abstract", ""),
+            "extra": f"BibTeX key: {citekey}",
+        }
+        if fields.get("doi"):
+            item["DOI"] = fields["doi"]
+        if fields.get("url"):
+            item["url"] = fields["url"]
+        if fields.get("journal"):
+            item["publicationTitle"] = fields["journal"]
+        if fields.get("volume"):
+            item["volume"] = fields["volume"]
+        if fields.get("pages"):
+            item["pages"] = fields["pages"]
+        if fields.get("publisher"):
+            item["publisher"] = fields["publisher"]
+        if fields.get("isbn"):
+            item["ISBN"] = fields["isbn"]
+        if fields.get("booktitle"):
+            item["proceedingsTitle"] = fields["booktitle"]
+
+        items.append(item)
+
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Add items to Zotero library")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--doi", metavar="DOI")
+    source.add_argument("--isbn", metavar="ISBN")
+    source.add_argument("--arxiv", metavar="ARXIV_ID")
+    source.add_argument("--url", metavar="URL")
+    source.add_argument("--bibtex", metavar="FILE")
+    source.add_argument("--move", metavar="ITEM_KEY", help="Move/copy existing item to a collection")
+    parser.add_argument("--collection", metavar="COLLECTION_KEY",
+                        help="Target collection key (default: hermes-agent root)")
+    parser.add_argument("--tag", action="append", default=[], metavar="TAG",
+                        help="Add tag(s) to the item (repeatable)")
+    args = parser.parse_args()
+
+    api_key, user_id = get_env()
+    global HEADERS, USER_ID
+    HEADERS = build_headers(api_key)
+    USER_ID = user_id
+
+    # Resolve target collection
+    collection_key = args.collection
+    if not collection_key and args.move is None:
+        collection_key = get_hermes_collection_key()
+        if collection_key:
+            print(f"  Using hermes-agent collection: {collection_key}")
+        else:
+            print("  Warning: hermes-agent collection not found. Run zotero_setup.py first.")
+            print("  Item will be added to library root.")
+
+    # --move: just add to collection
+    if args.move:
+        if not args.collection:
+            sys.exit("--move requires --collection COLLECTION_KEY")
+        add_to_collection(args.move, args.collection)
+        print(f"Added {args.move} to collection {args.collection}")
+        return
+
+    # Build item metadata
+    if args.doi:
+        item = fetch_doi(args.doi)
+    elif args.isbn:
+        item = fetch_isbn(args.isbn)
+    elif args.arxiv:
+        item = fetch_arxiv(args.arxiv)
+    elif args.url:
+        item = build_url_item(args.url)
+    elif args.bibtex:
+        items = parse_bibtex(args.bibtex)
+        print(f"  Parsed {len(items)} entries from {args.bibtex}")
+        for it in items:
+            if collection_key:
+                it["collections"] = [collection_key]
+            if args.tag:
+                it["tags"] = [{"tag": t} for t in args.tag]
+            it.setdefault("tags", [{"tag": "unread"}])
+        print(f"  Posting {len(items)} items to Zotero...")
+        keys = post_items(items)
+        print(f"\n✓ Created {len(keys)} items")
+        for k in keys:
+            print(f"  {k}")
+        return
+
+    # Apply collection and default tags
+    if collection_key:
+        item["collections"] = [collection_key]
+    tags = [{"tag": t} for t in args.tag] if args.tag else [{"tag": "unread"}]
+    item["tags"] = tags
+
+    print(f"\n  Title: {item.get('title', '(unknown)')}")
+    print(f"  Type:  {item['itemType']}")
+    if item.get("creators"):
+        first_author = item["creators"][0]
+        print(f"  Author: {first_author.get('firstName', '')} {first_author.get('lastName', '')}")
+    print(f"  Date:  {item.get('date', '')}")
+
+    print("\n  Posting to Zotero...")
+    keys = post_items([item])
+    if keys:
+        print(f"\n✓ Created item: {keys[0]}")
+        print(f"  View: https://www.zotero.org/users/{USER_ID}/items/{keys[0]}")
+    else:
+        print("  No items created.")
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/research/zotero/scripts/zotero_note.py
+++ b/optional-skills/research/zotero/scripts/zotero_note.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""
+zotero_note.py — Create, update, list, and tag notes on Zotero items.
+
+Notes in Zotero are items with itemType "note" that are children of a parent item.
+The note body is stored as HTML; this script handles plain text / markdown conversion.
+
+Usage:
+  python zotero_note.py list ITEM_KEY
+  python zotero_note.py show NOTE_KEY
+  python zotero_note.py create ITEM_KEY --title "Reading notes" --body "Key points..."
+  python zotero_note.py create ITEM_KEY --title "Summary" --file notes.md
+  python zotero_note.py create ITEM_KEY --template reading
+  python zotero_note.py update NOTE_KEY --body "Replacement text"
+  python zotero_note.py update NOTE_KEY --append "Additional paragraph"
+  python zotero_note.py status ITEM_KEY unread
+  python zotero_note.py status ITEM_KEY reading
+  python zotero_note.py status ITEM_KEY done
+  python zotero_note.py delete NOTE_KEY
+"""
+
+import argparse
+import html
+import os
+import re
+import sys
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    sys.exit("requests is required: pip install requests")
+
+API_BASE = "https://api.zotero.org"
+HEADERS: dict = {}
+USER_ID: str = ""
+
+PROGRESS_TAGS = {"unread", "reading", "done"}
+
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+
+TEMPLATES = {
+    "reading": """## Summary
+[2-3 sentence overview of the work]
+
+## Key Points
+- 
+- 
+- 
+
+## Notable Quotes
+> "..." (p. X)
+
+## Questions / Gaps
+- 
+
+## Related Work
+- 
+
+## My Assessment
+""",
+    "book": """## Overview
+[What is this book about?]
+
+## Chapter Notes
+### Chapter 1: 
+
+## Key Takeaways
+1. 
+2. 
+3. 
+
+## Favourite Passages
+> "..." (p. X)
+
+## Would Recommend To
+""",
+    "quick": """## Quick Notes
+[Stream-of-consciousness first impressions]
+
+## Follow-up
+- [ ] 
+""",
+}
+
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+
+def get_env() -> tuple[str, str]:
+    api_key = os.environ.get("ZOTERO_API_KEY", "")
+    user_id = os.environ.get("ZOTERO_USER_ID", "")
+    if not api_key or not user_id:
+        sys.exit(
+            "Set ZOTERO_API_KEY and ZOTERO_USER_ID environment variables.\n"
+            "  Get them at: https://www.zotero.org/settings/keys"
+        )
+    return api_key, user_id
+
+
+def build_headers(api_key: str) -> dict:
+    return {
+        "Zotero-API-Version": "3",
+        "Zotero-API-Key": api_key,
+        "Content-Type": "application/json",
+    }
+
+
+# ---------------------------------------------------------------------------
+# HTML / text helpers
+# ---------------------------------------------------------------------------
+
+def text_to_html(text: str) -> str:
+    """Convert plain text / basic markdown to Zotero note HTML."""
+    lines = text.split("\n")
+    html_parts = []
+    in_list = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Headings
+        if stripped.startswith("### "):
+            if in_list:
+                html_parts.append("</ul>")
+                in_list = False
+            html_parts.append(f"<h3>{html.escape(stripped[4:])}</h3>")
+        elif stripped.startswith("## "):
+            if in_list:
+                html_parts.append("</ul>")
+                in_list = False
+            html_parts.append(f"<h2>{html.escape(stripped[3:])}</h2>")
+        elif stripped.startswith("# "):
+            if in_list:
+                html_parts.append("</ul>")
+                in_list = False
+            html_parts.append(f"<h1>{html.escape(stripped[2:])}</h1>")
+        # Blockquote
+        elif stripped.startswith("> "):
+            if in_list:
+                html_parts.append("</ul>")
+                in_list = False
+            html_parts.append(f"<blockquote><p>{html.escape(stripped[2:])}</p></blockquote>")
+        # List items
+        elif stripped.startswith("- ") or stripped.startswith("* "):
+            if not in_list:
+                html_parts.append("<ul>")
+                in_list = True
+            content = stripped[2:]
+            # Handle checkboxes
+            if content.startswith("[ ] "):
+                content = "☐ " + content[4:]
+            elif content.startswith("[x] ") or content.startswith("[X] "):
+                content = "☑ " + content[4:]
+            html_parts.append(f"<li>{html.escape(content)}</li>")
+        # Numbered list
+        elif re.match(r"^\d+\. ", stripped):
+            if in_list:
+                html_parts.append("</ul>")
+                in_list = False
+            content = re.sub(r"^\d+\. ", "", stripped)
+            html_parts.append(f"<p>{html.escape(content)}</p>")
+        # Blank line
+        elif not stripped:
+            if in_list:
+                html_parts.append("</ul>")
+                in_list = False
+            html_parts.append("")
+        # Regular paragraph
+        else:
+            if in_list:
+                html_parts.append("</ul>")
+                in_list = False
+            # Inline bold/italic
+            content = html.escape(stripped)
+            content = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", content)
+            content = re.sub(r"\*(.+?)\*", r"<em>\1</em>", content)
+            content = re.sub(r"`(.+?)`", r"<code>\1</code>", content)
+            html_parts.append(f"<p>{content}</p>")
+
+    if in_list:
+        html_parts.append("</ul>")
+
+    return "\n".join(p for p in html_parts if p != "")
+
+
+def html_to_text(html_str: str) -> str:
+    """Minimal HTML → plain text for display."""
+    if not html_str:
+        return ""
+    text = re.sub(r"<h[1-3][^>]*>(.*?)</h[1-3]>", lambda m: "\n## " + m.group(1) + "\n", html_str, flags=re.DOTALL)
+    text = re.sub(r"<blockquote[^>]*>(.*?)</blockquote>", lambda m: "\n> " + m.group(1).strip() + "\n", text, flags=re.DOTALL)
+    text = re.sub(r"<li[^>]*>(.*?)</li>", lambda m: "  - " + m.group(1).strip(), text, flags=re.DOTALL)
+    text = re.sub(r"<p[^>]*>(.*?)</p>", lambda m: m.group(1).strip() + "\n", text, flags=re.DOTALL)
+    text = re.sub(r"<br\s*/?>", "\n", text)
+    text = re.sub(r"<[^>]+>", "", text)
+    text = html.unescape(text)
+    # Collapse multiple blank lines
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def build_note_html(title: str | None, body: str) -> str:
+    """Wrap body HTML with an optional title heading."""
+    body_html = text_to_html(body)
+    if title:
+        return f"<h1>{html.escape(title)}</h1>\n{body_html}"
+    return body_html
+
+
+# ---------------------------------------------------------------------------
+# API helpers
+# ---------------------------------------------------------------------------
+
+def get_item(item_key: str) -> dict:
+    resp = requests.get(f"{API_BASE}/users/{USER_ID}/items/{item_key}", headers=HEADERS)
+    if resp.status_code == 404:
+        sys.exit(f"Item not found: {item_key}")
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_children(item_key: str) -> list[dict]:
+    resp = requests.get(f"{API_BASE}/users/{USER_ID}/items/{item_key}/children", headers=HEADERS)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def create_note(parent_key: str, note_html: str, tags: list[str] | None = None) -> str:
+    """Create a child note. Returns the new note's key."""
+    payload = [{
+        "itemType": "note",
+        "parentItem": parent_key,
+        "note": note_html,
+        "tags": [{"tag": t} for t in (tags or [])],
+    }]
+    resp = requests.post(
+        f"{API_BASE}/users/{USER_ID}/items",
+        headers=HEADERS,
+        json=payload,
+    )
+    resp.raise_for_status()
+    result = resp.json()
+    created = result.get("successful", {}).get("0", {})
+    return created.get("data", {}).get("key") or created.get("key", "")
+
+
+def update_note(note_key: str, note_html: str) -> None:
+    """Replace a note's content."""
+    item = get_item(note_key)
+    data = item["data"]
+    if data.get("itemType") != "note":
+        sys.exit(f"{note_key} is not a note item (type: {data.get('itemType')})")
+    version = data["version"]
+    patch_headers = {**HEADERS, "If-Unmodified-Since-Version": str(version)}
+    resp = requests.patch(
+        f"{API_BASE}/users/{USER_ID}/items/{note_key}",
+        headers=patch_headers,
+        json={"note": note_html, "version": version},
+    )
+    resp.raise_for_status()
+
+
+def append_to_note(note_key: str, append_html: str) -> None:
+    """Append content to an existing note."""
+    item = get_item(note_key)
+    data = item["data"]
+    if data.get("itemType") != "note":
+        sys.exit(f"{note_key} is not a note item")
+    existing = data.get("note", "")
+    new_html = existing + "\n" + append_html
+    version = data["version"]
+    patch_headers = {**HEADERS, "If-Unmodified-Since-Version": str(version)}
+    resp = requests.patch(
+        f"{API_BASE}/users/{USER_ID}/items/{note_key}",
+        headers=patch_headers,
+        json={"note": new_html, "version": version},
+    )
+    resp.raise_for_status()
+
+
+def set_tags(item_key: str, tags_to_set: list[str], replace_progress: bool = False) -> None:
+    """Set tags on an item. If replace_progress=True, removes existing PROGRESS_TAGS first."""
+    item = get_item(item_key)
+    data = item["data"]
+    version = data["version"]
+    current_tags = data.get("tags", [])
+
+    if replace_progress:
+        current_tags = [t for t in current_tags if t["tag"] not in PROGRESS_TAGS]
+
+    existing_names = {t["tag"] for t in current_tags}
+    for tag in tags_to_set:
+        if tag not in existing_names:
+            current_tags.append({"tag": tag})
+
+    patch_headers = {**HEADERS, "If-Unmodified-Since-Version": str(version)}
+    resp = requests.patch(
+        f"{API_BASE}/users/{USER_ID}/items/{item_key}",
+        headers=patch_headers,
+        json={"tags": current_tags, "version": version},
+    )
+    resp.raise_for_status()
+
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def cmd_list(item_key: str) -> None:
+    children = get_children(item_key)
+    notes = [c for c in children if c["data"].get("itemType") == "note"]
+    if not notes:
+        print(f"No notes on item {item_key}")
+        return
+    print(f"\n{len(notes)} note(s) on {item_key}:\n")
+    for note in notes:
+        data = note["data"]
+        key = data["key"]
+        raw = data.get("note", "")
+        preview = html_to_text(raw)[:100].replace("\n", " ")
+        tags = [t["tag"] for t in data.get("tags", [])]
+        tag_str = f"  [{', '.join(tags)}]" if tags else ""
+        date = data.get("dateModified", "")[:10]
+        print(f"  [{key}] {preview}...{tag_str}  (modified: {date})")
+    print()
+
+
+def cmd_show(note_key: str) -> None:
+    item = get_item(note_key)
+    data = item["data"]
+    if data.get("itemType") != "note":
+        print(f"Warning: {note_key} has type '{data.get('itemType')}', not 'note'")
+    raw = data.get("note", "")
+    text = html_to_text(raw)
+    tags = [t["tag"] for t in data.get("tags", [])]
+    print(f"\n[{note_key}]  modified: {data.get('dateModified', '')[:10]}")
+    if tags:
+        print(f"Tags: {', '.join(tags)}")
+    print(f"{'─' * 60}")
+    print(text)
+    print(f"{'─' * 60}\n")
+
+
+def cmd_create(args: argparse.Namespace) -> None:
+    # Get body text
+    if args.template:
+        body = TEMPLATES.get(args.template, "")
+        if not body:
+            sys.exit(f"Unknown template: {args.template}. Available: {', '.join(TEMPLATES)}")
+        if args.body:
+            body = args.body + "\n\n" + body
+    elif args.file:
+        body = Path(args.file).read_text(encoding="utf-8")
+    elif args.body:
+        body = args.body
+    else:
+        # Read from stdin
+        print("Enter note body (Ctrl+D to finish):")
+        try:
+            body = sys.stdin.read()
+        except KeyboardInterrupt:
+            sys.exit("\nCancelled")
+
+    note_html = build_note_html(args.title, body)
+    tags = args.tag or []
+
+    print(f"Creating note on item {args.item_key}...")
+    key = create_note(args.item_key, note_html, tags=tags)
+    if key:
+        print(f"✓ Created note: {key}")
+    else:
+        print("Note created (key unavailable in response)")
+
+
+def cmd_update(args: argparse.Namespace) -> None:
+    if args.append:
+        append_html = text_to_html(args.append)
+        print(f"Appending to note {args.note_key}...")
+        append_to_note(args.note_key, append_html)
+        print("✓ Note updated")
+    elif args.body:
+        note_html = build_note_html(args.title, args.body)
+        print(f"Updating note {args.note_key}...")
+        update_note(args.note_key, note_html)
+        print("✓ Note updated")
+    elif args.file:
+        body = Path(args.file).read_text(encoding="utf-8")
+        note_html = build_note_html(args.title, body)
+        print(f"Updating note {args.note_key} from file...")
+        update_note(args.note_key, note_html)
+        print("✓ Note updated")
+    else:
+        sys.exit("Provide --body, --append, or --file")
+
+
+def cmd_status(item_key: str, status: str) -> None:
+    if status not in PROGRESS_TAGS:
+        sys.exit(f"Status must be one of: {', '.join(sorted(PROGRESS_TAGS))}")
+    print(f"Setting status '{status}' on {item_key}...")
+    set_tags(item_key, [status], replace_progress=True)
+    print(f"✓ Tagged as '{status}'")
+
+
+def cmd_delete(note_key: str) -> None:
+    print(
+        f"Deletion is disabled in this skill to prevent accidental data loss.\n"
+        f"To delete note {note_key}, open the Zotero desktop app, right-click the item, and choose Delete."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage Zotero notes")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # list
+    p_list = subparsers.add_parser("list", help="List notes on an item")
+    p_list.add_argument("item_key")
+
+    # show
+    p_show = subparsers.add_parser("show", help="Show note content")
+    p_show.add_argument("note_key")
+
+    # create
+    p_create = subparsers.add_parser("create", help="Create a note on an item")
+    p_create.add_argument("item_key")
+    p_create.add_argument("--title", metavar="TITLE", help="Note title (H1 heading)")
+    p_create.add_argument("--body", metavar="TEXT", help="Note body text (markdown)")
+    p_create.add_argument("--file", metavar="FILE", help="Read body from a file")
+    p_create.add_argument("--template", choices=list(TEMPLATES), metavar="TEMPLATE",
+                          help=f"Use a template: {', '.join(TEMPLATES)}")
+    p_create.add_argument("--tag", action="append", default=[], metavar="TAG")
+
+    # update
+    p_update = subparsers.add_parser("update", help="Update an existing note")
+    p_update.add_argument("note_key")
+    p_update.add_argument("--title", metavar="TITLE")
+    p_update.add_argument("--body", metavar="TEXT", help="Replace note body")
+    p_update.add_argument("--append", metavar="TEXT", help="Append to note")
+    p_update.add_argument("--file", metavar="FILE", help="Replace body with file content")
+
+    # status
+    p_status = subparsers.add_parser("status", help="Set reading progress tag")
+    p_status.add_argument("item_key")
+    p_status.add_argument("status", choices=sorted(PROGRESS_TAGS))
+
+    # delete
+    p_delete = subparsers.add_parser("delete", help="Delete a note")
+    p_delete.add_argument("note_key")
+
+    args = parser.parse_args()
+
+    api_key, user_id = get_env()
+    global HEADERS, USER_ID
+    HEADERS = build_headers(api_key)
+    USER_ID = user_id
+
+    if args.command == "list":
+        cmd_list(args.item_key)
+    elif args.command == "show":
+        cmd_show(args.note_key)
+    elif args.command == "create":
+        cmd_create(args)
+    elif args.command == "update":
+        cmd_update(args)
+    elif args.command == "status":
+        cmd_status(args.item_key, args.status)
+    elif args.command == "delete":
+        cmd_delete(args.note_key)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/research/zotero/scripts/zotero_read.py
+++ b/optional-skills/research/zotero/scripts/zotero_read.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""
+zotero_read.py — Read PDF content and metadata from Zotero items.
+
+Tries methods in order (fastest first):
+  1. Zotero fulltext index (GET /items/{key}/fulltext) — instant if indexed
+  2. Download PDF via API + extract with pdfplumber
+  3. Print metadata + abstract if no PDF found
+
+Usage:
+  python zotero_read.py ITEM_KEY
+  python zotero_read.py ITEM_KEY --pages 10
+  python zotero_read.py ITEM_KEY --out summary.txt
+  python zotero_read.py ITEM_KEY --cite apa
+  python zotero_read.py ITEM_KEY --cite mla
+  python zotero_read.py ITEM_KEY --cite bibtex
+  python zotero_read.py ITEM_KEY --metadata-only
+"""
+
+import argparse
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    sys.exit("requests is required: pip install requests")
+
+API_BASE = "https://api.zotero.org"
+HEADERS: dict = {}
+USER_ID: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+
+def get_env() -> tuple[str, str]:
+    api_key = os.environ.get("ZOTERO_API_KEY", "")
+    user_id = os.environ.get("ZOTERO_USER_ID", "")
+    if not api_key or not user_id:
+        sys.exit(
+            "Set ZOTERO_API_KEY and ZOTERO_USER_ID environment variables.\n"
+            "  Get them at: https://www.zotero.org/settings/keys"
+        )
+    return api_key, user_id
+
+
+def build_headers(api_key: str) -> dict:
+    return {
+        "Zotero-API-Version": "3",
+        "Zotero-API-Key": api_key,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Zotero fetch helpers
+# ---------------------------------------------------------------------------
+
+def get_item(item_key: str) -> dict:
+    resp = requests.get(f"{API_BASE}/users/{USER_ID}/items/{item_key}", headers=HEADERS)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_children(item_key: str) -> list[dict]:
+    resp = requests.get(f"{API_BASE}/users/{USER_ID}/items/{item_key}/children", headers=HEADERS)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_fulltext(attachment_key: str) -> dict | None:
+    """Returns fulltext JSON or None if not indexed."""
+    resp = requests.get(f"{API_BASE}/users/{USER_ID}/items/{attachment_key}/fulltext", headers=HEADERS)
+    if resp.status_code == 404:
+        return None
+    if resp.status_code == 200:
+        data = resp.json()
+        if data.get("content"):
+            return data
+    return None
+
+
+def download_pdf(attachment_key: str) -> bytes | None:
+    """Download the PDF file bytes (follows redirect)."""
+    resp = requests.get(
+        f"{API_BASE}/users/{USER_ID}/items/{attachment_key}/file",
+        headers=HEADERS,
+        allow_redirects=True,
+    )
+    if resp.status_code == 200 and resp.content:
+        return resp.content
+    return None
+
+
+# ---------------------------------------------------------------------------
+# PDF extraction
+# ---------------------------------------------------------------------------
+
+def extract_pdf_text(pdf_bytes: bytes, max_pages: int | None = None) -> str:
+    try:
+        import pdfplumber
+    except ImportError:
+        sys.exit(
+            "pdfplumber is needed to extract PDF text: pip install pdfplumber\n"
+            "Alternatively, ensure the item is indexed in Zotero desktop first."
+        )
+
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+        f.write(pdf_bytes)
+        tmp_path = f.name
+
+    try:
+        import pdfplumber
+        texts = []
+        with pdfplumber.open(tmp_path) as pdf:
+            pages = pdf.pages if max_pages is None else pdf.pages[:max_pages]
+            for page in pages:
+                text = page.extract_text()
+                if text:
+                    texts.append(text)
+        return "\n\n".join(texts)
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Citation formatters
+# ---------------------------------------------------------------------------
+
+def _derive_pdf_url(data: dict) -> str | None:
+    """
+    Try to derive a direct PDF URL from item metadata.
+    Works for: arXiv preprints, open-access DOIs that redirect to PDFs.
+    """
+    import re as _re
+    url = data.get("url", "")
+    extra = data.get("extra", "")
+
+    # arXiv abstract URL → PDF URL
+    arxiv_match = _re.search(r"arxiv\.org/abs/([\w./v]+)", url)
+    if arxiv_match:
+        return f"https://arxiv.org/pdf/{arxiv_match.group(1)}"
+
+    # arXiv ID in extra field (added by zotero_add.py)
+    extra_match = _re.search(r"arXiv:\s*([\w./v]+)", extra)
+    if extra_match:
+        return f"https://arxiv.org/pdf/{extra_match.group(1)}"
+
+    # archiveID field (set by fetch_arxiv)
+    archive_id = data.get("archiveID", "")
+    if archive_id.startswith("arXiv:"):
+        return f"https://arxiv.org/pdf/{archive_id[6:]}"
+
+    # DOI → try unpaywall for open-access PDF
+    doi = data.get("DOI", "")
+    if doi:
+        try:
+            unpaywall = requests.get(
+                f"https://api.unpaywall.org/v2/{doi}",
+                params={"email": "hermes-agent@example.com"},
+                timeout=8,
+            )
+            if unpaywall.ok:
+                oa = unpaywall.json().get("best_oa_location") or {}
+                pdf_url = oa.get("url_for_pdf") or oa.get("url")
+                if pdf_url and pdf_url.endswith(".pdf"):
+                    return pdf_url
+        except Exception:
+            pass
+
+    return None
+
+
+def extract_year(date_str: str) -> str:
+    """Extract a 4-digit year from a date string like 'December 27, 2017' or '2017-12-27'."""
+    import re
+    match = re.search(r"\b(1[5-9]\d{2}|20\d{2})\b", date_str or "")
+    return match.group(1) if match else (date_str[:4] if len(date_str) >= 4 else date_str)
+
+
+def fmt_creators_list(creators: list[dict]) -> list[str]:
+    names = []
+    for c in creators:
+        last = c.get("lastName") or c.get("name", "")
+        first = c.get("firstName", "")
+        if first and last:
+            names.append(f"{last}, {first}")
+        elif last:
+            names.append(last)
+    return names
+
+
+def fmt_author_apa(creators: list[dict]) -> str:
+    names = fmt_creators_list(creators)
+    if not names:
+        return ""
+    if len(names) == 1:
+        return names[0]
+    if len(names) <= 20:
+        return ", ".join(names[:-1]) + ", & " + names[-1]
+    return ", ".join(names[:19]) + ", ... " + names[-1]
+
+
+def fmt_author_mla(creators: list[dict]) -> str:
+    names = fmt_creators_list(creators)
+    if not names:
+        return ""
+    if len(names) == 1:
+        return names[0]
+    return names[0] + ", et al."
+
+
+def fmt_author_chicago(creators: list[dict]) -> str:
+    names = fmt_creators_list(creators)
+    if not names:
+        return ""
+    if len(names) <= 3:
+        return ", ".join(names)
+    return names[0] + ", et al."
+
+
+def cite_apa(data: dict) -> str:
+    creators = data.get("creators", [])
+    author = fmt_author_apa(creators)
+    year = extract_year(data.get("date", "")) or "n.d."
+    title = data.get("title", "")
+    itype = data.get("itemType", "")
+    doi = data.get("DOI", "")
+    url = data.get("url", "")
+
+    if itype == "journalArticle":
+        journal = data.get("publicationTitle", "")
+        volume = data.get("volume", "")
+        issue = data.get("issue", "")
+        pages = data.get("pages", "")
+        vol_str = f", *{volume}*" if volume else ""
+        iss_str = f"({issue})" if issue else ""
+        pg_str = f", {pages}" if pages else ""
+        doi_str = f" https://doi.org/{doi}" if doi else (f" {url}" if url else "")
+        return f"{author} ({year}). {title}. *{journal}*{vol_str}{iss_str}{pg_str}.{doi_str}"
+
+    if itype == "book":
+        publisher = data.get("publisher", "")
+        return f"{author} ({year}). *{title}*. {publisher}."
+
+    if itype == "conferencePaper":
+        proc = data.get("proceedingsTitle", "")
+        return f"{author} ({year}). {title}. In *{proc}*." + (f" https://doi.org/{doi}" if doi else "")
+
+    if itype in ("preprint", "manuscript"):
+        repo = data.get("repository", "Preprint")
+        return f"{author} ({year}). *{title}*. {repo}." + (f" https://doi.org/{doi}" if doi else (f" {url}" if url else ""))
+
+    # Generic fallback
+    return f"{author} ({year}). {title}." + (f" https://doi.org/{doi}" if doi else "")
+
+
+def cite_mla(data: dict) -> str:
+    creators = data.get("creators", [])
+    author = fmt_author_mla(creators)
+    title = data.get("title", "")
+    year = extract_year(data.get("date", "")) or "n.d."
+    itype = data.get("itemType", "")
+    doi = data.get("DOI", "")
+    url = data.get("url", "")
+
+    if itype == "journalArticle":
+        journal = data.get("publicationTitle", "")
+        volume = data.get("volume", "")
+        issue = data.get("issue", "")
+        pages = data.get("pages", "")
+        loc = f"vol. {volume}" if volume else ""
+        if issue:
+            loc += f", no. {issue}"
+        loc_str = f", {loc}" if loc else ""
+        pg_str = f", pp. {pages}" if pages else ""
+        doi_str = f", doi:{doi}" if doi else (f", {url}" if url else "")
+        return f'{author}. "{title}." *{journal}*{loc_str}, {year}{pg_str}{doi_str}.'
+
+    if itype == "book":
+        publisher = data.get("publisher", "")
+        return f"{author}. *{title}*. {publisher}, {year}."
+
+    return f'{author}. "{title}." {year}.'
+
+
+def cite_chicago(data: dict) -> str:
+    creators = data.get("creators", [])
+    author = fmt_author_chicago(creators)
+    title = data.get("title", "")
+    year = extract_year(data.get("date", "")) or "n.d."
+    itype = data.get("itemType", "")
+    doi = data.get("DOI", "")
+    url = data.get("url", "")
+
+    if itype == "journalArticle":
+        journal = data.get("publicationTitle", "")
+        volume = data.get("volume", "")
+        issue = data.get("issue", "")
+        pages = data.get("pages", "")
+        vol_str = f" {volume}" if volume else ""
+        iss_str = f", no. {issue}" if issue else ""
+        pg_str = f": {pages}" if pages else ""
+        doi_str = f" https://doi.org/{doi}." if doi else ""
+        return f'{author}. "{title}." *{journal}*{vol_str}{iss_str} ({year}){pg_str}.{doi_str}'
+
+    if itype == "book":
+        publisher = data.get("publisher", "")
+        return f"{author}. *{title}*. {publisher}, {year}."
+
+    return f'{author}. "{title}." {year}.'
+
+
+def cite_bibtex(data: dict) -> str:
+    key = data.get("key", "UNKNOWN")
+    itype = data.get("itemType", "misc")
+    type_map = {
+        "journalArticle": "article",
+        "book": "book",
+        "conferencePaper": "inproceedings",
+        "thesis": "phdthesis",
+        "report": "techreport",
+        "bookSection": "incollection",
+        "preprint": "misc",
+        "webpage": "misc",
+    }
+    bib_type = type_map.get(itype, "misc")
+    creators = data.get("creators", [])
+    author = " and ".join(
+        f"{c.get('lastName', '')}, {c.get('firstName', '')}".strip(", ")
+        for c in creators
+    )
+    title = data.get("title", "")
+    year = extract_year(data.get("date", ""))
+
+    fields = [("author", author), ("title", f"{{{title}}}"), ("year", year)]
+    for f in ("publicationTitle", "volume", "number", "pages", "publisher", "DOI", "url"):
+        val = data.get(f, "")
+        if val:
+            fields.append((f.lower(), val))
+    body = ",\n  ".join(f"{k} = {{{v}}}" for k, v in fields if v)
+    return f"@{bib_type}{{{key},\n  {body}\n}}"
+
+
+CITE_STYLES = {
+    "apa": cite_apa,
+    "mla": cite_mla,
+    "chicago": cite_chicago,
+    "bibtex": cite_bibtex,
+}
+
+
+# ---------------------------------------------------------------------------
+# Print helpers
+# ---------------------------------------------------------------------------
+
+def print_metadata(data: dict) -> None:
+    creators = data.get("creators", [])
+    names = fmt_creators_list(creators)
+    print(f"\n{'─' * 70}")
+    print(f"Title:   {data.get('title', '')}")
+    if names:
+        print(f"Authors: {'; '.join(names[:5])}" + (" et al." if len(names) > 5 else ""))
+    print(f"Type:    {data.get('itemType', '')}")
+    print(f"Date:    {extract_year(data.get('date', ''))}")
+    for field in ("publicationTitle", "publisher", "DOI", "ISBN", "url"):
+        val = data.get(field, "")
+        if val:
+            print(f"{field.capitalize():8s} {val}")
+    tags = [t["tag"] for t in data.get("tags", [])]
+    if tags:
+        print(f"Tags:    {', '.join(tags)}")
+    abstract = data.get("abstractNote", "")
+    if abstract:
+        print(f"\nAbstract:\n{abstract[:600]}{'...' if len(abstract) > 600 else ''}")
+    print(f"{'─' * 70}\n")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Read PDF content from a Zotero item")
+    parser.add_argument("item_key", help="Zotero item key")
+    parser.add_argument("--pages", type=int, metavar="N", help="Limit to first N pages")
+    parser.add_argument("--out", metavar="FILE", help="Save extracted text to a file")
+    parser.add_argument("--cite", choices=list(CITE_STYLES), metavar="STYLE",
+                        help="Print formatted citation: apa, mla, chicago, bibtex")
+    parser.add_argument("--metadata-only", action="store_true",
+                        help="Show only metadata (no PDF extraction)")
+    args = parser.parse_args()
+
+    api_key, user_id = get_env()
+    global HEADERS, USER_ID
+    HEADERS = build_headers(api_key)
+    USER_ID = user_id
+
+    # Fetch item metadata
+    print(f"Fetching item {args.item_key}...")
+    item = get_item(args.item_key)
+    data = item.get("data", {})
+    print_metadata(data)
+
+    # Citation mode
+    if args.cite:
+        cite_fn = CITE_STYLES[args.cite]
+        print(f"Citation ({args.cite.upper()}):\n")
+        print(cite_fn(data))
+        print()
+        return
+
+    if args.metadata_only:
+        return
+
+    # Find PDF attachment
+    print("Looking for PDF attachment...")
+    children = get_children(args.item_key)
+    pdf_attachments = [
+        c for c in children
+        if c["data"].get("itemType") == "attachment"
+        and c["data"].get("contentType", "").startswith("application/pdf")
+    ]
+
+    # Also check if this item itself is an attachment
+    if data.get("itemType") == "attachment" and data.get("contentType", "").startswith("application/pdf"):
+        attachment_key = args.item_key
+    elif pdf_attachments:
+        attachment_key = pdf_attachments[0]["data"]["key"]
+        print(f"Found attachment: {attachment_key}")
+    else:
+        attachment_key = None
+
+    if attachment_key:
+        # Try fulltext index first (fastest — populated by Zotero desktop app)
+        print("Checking Zotero fulltext index...")
+        fulltext = get_fulltext(attachment_key)
+        if fulltext:
+            content = fulltext.get("content", "")
+            indexed = fulltext.get("indexedPages", "?")
+            total = fulltext.get("totalPages", "?")
+            print(f"✓ Fulltext index: {indexed}/{total} pages indexed\n")
+
+            if args.pages:
+                paragraphs = content.split("\n\n")
+                approx_per_page = max(1, len(paragraphs) // max(1, int(indexed or 1)))
+                content = "\n\n".join(paragraphs[:args.pages * approx_per_page])
+                print(f"(Showing approximately first {args.pages} pages)\n")
+
+            if args.out:
+                Path(args.out).write_text(content, encoding="utf-8")
+                print(f"Text saved to: {args.out}")
+            else:
+                print(content)
+            return
+
+        # Fallback: download from Zotero cloud storage
+        print("Fulltext not indexed. Downloading from Zotero cloud...")
+        pdf_bytes = download_pdf(attachment_key)
+        if pdf_bytes:
+            print(f"Downloaded {len(pdf_bytes):,} bytes. Extracting text...")
+            text = extract_pdf_text(pdf_bytes, max_pages=args.pages)
+            if text.strip():
+                if args.out:
+                    Path(args.out).write_text(text, encoding="utf-8")
+                    print(f"Text saved to: {args.out}")
+                else:
+                    print(text)
+                return
+            print("No text extracted from Zotero-stored PDF (may be scanned). Trying source URL...")
+
+    # No attachment, or extraction failed — try fetching directly from the source URL
+    # (covers arXiv papers added via API without PDF upload, open-access DOIs, etc.)
+    source_pdf_url = _derive_pdf_url(data)
+    if source_pdf_url:
+        print(f"Fetching PDF from source: {source_pdf_url}")
+        try:
+            resp = requests.get(source_pdf_url, headers={"User-Agent": "hermes-agent/1.0"},
+                                allow_redirects=True, timeout=60)
+            resp.raise_for_status()
+            pdf_bytes = resp.content
+            print(f"Downloaded {len(pdf_bytes):,} bytes. Extracting text...")
+            text = extract_pdf_text(pdf_bytes, max_pages=args.pages)
+            if text.strip():
+                if args.out:
+                    Path(args.out).write_text(text, encoding="utf-8")
+                    print(f"Text saved to: {args.out}")
+                else:
+                    print(text)
+                return
+            print("No text extracted. The PDF may be scanned/image-based.")
+        except Exception as e:
+            print(f"Could not fetch PDF from source URL: {e}")
+
+    # Nothing worked — show abstract
+    print("\nNo PDF text available. Showing abstract only.")
+    if data.get("abstractNote"):
+        print("\nAbstract (full):")
+        print(data["abstractNote"])
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/research/zotero/scripts/zotero_search.py
+++ b/optional-skills/research/zotero/scripts/zotero_search.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""
+zotero_search.py — Search and browse your Zotero library.
+
+Usage:
+  python zotero_search.py "query"
+  python zotero_search.py "deep learning" --tag unread --type journalArticle
+  python zotero_search.py --collection COLL_KEY
+  python zotero_search.py --collections
+  python zotero_search.py --item ITEM_KEY
+  python zotero_search.py --stats
+  python zotero_search.py --dupes
+  python zotero_search.py --tag unread
+  python zotero_search.py --since 2025-01-01
+  python zotero_search.py --export bibtex COLL_KEY
+  python zotero_search.py --export ris COLL_KEY
+  python zotero_search.py --collection COLL_KEY --add-tag "sprint-2026"
+  python zotero_search.py --remove-tag "old-tag"
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime
+
+
+def extract_year(date_str: str) -> str:
+    """Extract a 4-digit year from strings like 'December 27, 2017' or '2017-12-27'."""
+    match = re.search(r"\b(1[5-9]\d{2}|20\d{2})\b", date_str or "")
+    return match.group(1) if match else (date_str[:4] if len(date_str) >= 4 else date_str)
+
+try:
+    import requests
+except ImportError:
+    sys.exit("requests is required: pip install requests")
+
+API_BASE = "https://api.zotero.org"
+HEADERS: dict = {}
+USER_ID: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+
+def get_env() -> tuple[str, str]:
+    api_key = os.environ.get("ZOTERO_API_KEY", "")
+    user_id = os.environ.get("ZOTERO_USER_ID", "")
+    if not api_key or not user_id:
+        sys.exit(
+            "Set ZOTERO_API_KEY and ZOTERO_USER_ID environment variables.\n"
+            "  Get them at: https://www.zotero.org/settings/keys"
+        )
+    return api_key, user_id
+
+
+def build_headers(api_key: str) -> dict:
+    return {
+        "Zotero-API-Version": "3",
+        "Zotero-API-Key": api_key,
+        "Content-Type": "application/json",
+    }
+
+
+# ---------------------------------------------------------------------------
+# API helpers
+# ---------------------------------------------------------------------------
+
+def paginate(url: str, params: dict | None = None) -> list[dict]:
+    """Fetch all pages of a paginated endpoint."""
+    results = []
+    params = dict(params or {})
+    params.setdefault("limit", 100)
+    start = 0
+    while True:
+        params["start"] = start
+        resp = requests.get(url, headers=HEADERS, params=params)
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+        results.extend(batch)
+        total = int(resp.headers.get("Total-Results", len(batch)))
+        start += len(batch)
+        if start >= total:
+            break
+    return results
+
+
+def get_item(item_key: str) -> dict:
+    resp = requests.get(f"{API_BASE}/users/{USER_ID}/items/{item_key}", headers=HEADERS)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_collections() -> list[dict]:
+    return paginate(f"{API_BASE}/users/{USER_ID}/collections")
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+def fmt_creators(creators: list[dict]) -> str:
+    names = []
+    for c in creators[:3]:
+        last = c.get("lastName") or c.get("name", "")
+        first = c.get("firstName", "")
+        names.append(f"{last}, {first}".strip(", ") if first else last)
+    result = "; ".join(names)
+    if len(creators) > 3:
+        result += f" et al. (+{len(creators) - 3})"
+    return result
+
+
+def fmt_item_line(item: dict, idx: int | None = None) -> str:
+    data = item.get("data", {})
+    key = data.get("key", "")
+    title = data.get("title", "(no title)")[:80]
+    creators = fmt_creators(data.get("creators", []))
+    year = extract_year(data.get("date", "")) if data.get("date") else ""
+    itype = data.get("itemType", "")
+    tags = [t["tag"] for t in data.get("tags", []) if not t["tag"].startswith("_")]
+    tag_str = f"  [{', '.join(tags[:3])}]" if tags else ""
+
+    prefix = f"{idx:3}. " if idx is not None else "  "
+    line = f"{prefix}[{key}] {title}"
+    meta = f"      {creators} ({year}) · {itype}{tag_str}" if creators or year else f"      {itype}{tag_str}"
+    return f"{line}\n{meta}"
+
+
+def print_items(items: list[dict], limit: int = 50) -> None:
+    shown = items[:limit]
+    for i, item in enumerate(shown, 1):
+        print(fmt_item_line(item, i))
+        print()
+    if len(items) > limit:
+        print(f"  ... and {len(items) - limit} more (use --limit N to show more)")
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def cmd_search(query: str, args: argparse.Namespace) -> None:
+    params: dict = {"q": query, "qmode": "everything"}
+    if args.tag:
+        params["tag"] = args.tag
+    if args.type:
+        params["itemType"] = args.type
+    if args.collection:
+        url = f"{API_BASE}/users/{USER_ID}/collections/{args.collection}/items/top"
+    else:
+        url = f"{API_BASE}/users/{USER_ID}/items/top"
+
+    items = paginate(url, params)
+    # Apply --since filter locally (API's `since` is by version, not date)
+    if args.since:
+        cutoff = args.since
+        items = [
+            it for it in items
+            if it["data"].get("dateAdded", "") >= cutoff
+        ]
+
+    print(f"\n{len(items)} result(s) for: '{query}'\n")
+    print_items(items, limit=args.limit)
+
+
+def cmd_list_collection(collection_key: str, args: argparse.Namespace) -> None:
+    params: dict = {}
+    if args.tag:
+        params["tag"] = args.tag
+    if args.type:
+        params["itemType"] = args.type
+    url = f"{API_BASE}/users/{USER_ID}/collections/{collection_key}/items/top"
+    items = paginate(url, params)
+    if args.since:
+        items = [it for it in items if it["data"].get("dateAdded", "") >= args.since]
+
+    # Get collection name
+    resp = requests.get(f"{API_BASE}/users/{USER_ID}/collections/{collection_key}", headers=HEADERS)
+    col_name = resp.json().get("data", {}).get("name", collection_key) if resp.ok else collection_key
+
+    print(f"\n{len(items)} items in '{col_name}':\n")
+    print_items(items, limit=args.limit)
+
+
+def cmd_collections() -> None:
+    cols = get_collections()
+    children: dict[str | bool, list] = defaultdict(list)
+    for c in cols:
+        parent = c["data"].get("parentCollection", False)
+        children[parent].append(c)
+
+    def print_level(parent_key: str | bool, indent: int = 0) -> None:
+        for col in sorted(children[parent_key], key=lambda c: c["data"]["name"]):
+            key = col["data"]["key"]
+            name = col["data"]["name"]
+            prefix = "  " * indent + ("└── " if indent > 0 else "")
+            print(f"{prefix}{name}  [{key}]")
+            print_level(key, indent + 1)
+
+    print(f"\nYour Zotero collections ({len(cols)} total):\n")
+    print_level(False)
+    print()
+
+
+def cmd_item(item_key: str) -> None:
+    item = get_item(item_key)
+    data = item.get("data", {})
+    print(f"\n{'─' * 60}")
+    print(f"Key:     {data.get('key')}")
+    print(f"Type:    {data.get('itemType')}")
+    print(f"Title:   {data.get('title', '')}")
+    print(f"Authors: {fmt_creators(data.get('creators', []))}")
+    print(f"Date:    {data.get('date', '')}")
+
+    for field in ("publicationTitle", "publisher", "DOI", "ISBN", "url", "pages", "volume", "issue"):
+        val = data.get(field, "")
+        if val:
+            print(f"{field.capitalize():8s} {val}")
+
+    tags = [t["tag"] for t in data.get("tags", [])]
+    if tags:
+        print(f"Tags:    {', '.join(tags)}")
+
+    collections = data.get("collections", [])
+    if collections:
+        print(f"Collections: {', '.join(collections)}")
+
+    abstract = data.get("abstractNote", "")
+    if abstract:
+        print(f"\nAbstract:\n  {abstract[:500]}{'...' if len(abstract) > 500 else ''}")
+
+    print(f"{'─' * 60}\n")
+
+    # Show children summary
+    children_resp = requests.get(
+        f"{API_BASE}/users/{USER_ID}/items/{item_key}/children",
+        headers=HEADERS
+    )
+    if children_resp.ok:
+        children = children_resp.json()
+        notes = [c for c in children if c["data"].get("itemType") == "note"]
+        attachments = [c for c in children if c["data"].get("itemType") == "attachment"]
+        if notes:
+            print(f"Notes ({len(notes)}):")
+            for n in notes:
+                print(f"  [{n['data']['key']}] {n['data'].get('note', '')[:80]}")
+            print()
+        if attachments:
+            print(f"Attachments ({len(attachments)}):")
+            for a in attachments:
+                print(f"  [{a['data']['key']}] {a['data'].get('filename', a['data'].get('title', ''))}")
+            print()
+
+
+def cmd_stats(args: argparse.Namespace) -> None:
+    url = f"{API_BASE}/users/{USER_ID}/items/top"
+    if args.collection:
+        url = f"{API_BASE}/users/{USER_ID}/collections/{args.collection}/items/top"
+
+    print("Fetching library stats (this may take a moment)...")
+    items = paginate(url)
+
+    type_counts: Counter = Counter()
+    tag_counts: Counter = Counter()
+    year_counts: Counter = Counter()
+
+    for item in items:
+        data = item.get("data", {})
+        type_counts[data.get("itemType", "unknown")] += 1
+        for t in data.get("tags", []):
+            tag_counts[t["tag"]] += 1
+        year = extract_year(data.get("date", ""))
+        if year and year.isdigit():
+            year_counts[year] += 1
+
+    print(f"\n{'─' * 50}")
+    print(f"Total items: {len(items)}")
+    print(f"\nBy type:")
+    for itype, count in type_counts.most_common():
+        print(f"  {itype:30s} {count:4d}")
+    print(f"\nTop tags:")
+    for tag, count in tag_counts.most_common(15):
+        print(f"  {tag:30s} {count:4d}")
+    if year_counts:
+        print(f"\nBy year (top 10):")
+        for year, count in sorted(year_counts.items(), reverse=True)[:10]:
+            print(f"  {year}  {count:4d}")
+    print(f"{'─' * 50}\n")
+
+
+def cmd_dupes() -> None:
+    print("Scanning for duplicates (fetching all items)...")
+    items = paginate(f"{API_BASE}/users/{USER_ID}/items/top")
+
+    doi_map: dict[str, list] = defaultdict(list)
+    isbn_map: dict[str, list] = defaultdict(list)
+    title_map: dict[str, list] = defaultdict(list)
+
+    for item in items:
+        data = item.get("data", {})
+        doi = data.get("DOI", "").strip().lower()
+        isbn = re.sub(r"[-\s]", "", data.get("ISBN", "").strip())
+        title = data.get("title", "").strip().lower()[:80]
+        key = data.get("key", "")
+
+        if doi:
+            doi_map[doi].append(key)
+        if isbn:
+            isbn_map[isbn].append(key)
+        if title:
+            title_map[title].append(key)
+
+    found = False
+    for doi, keys in doi_map.items():
+        if len(keys) > 1:
+            print(f"\nDuplicate DOI: {doi}")
+            for k in keys:
+                print(f"  {k}")
+            found = True
+
+    for isbn, keys in isbn_map.items():
+        if len(keys) > 1:
+            print(f"\nDuplicate ISBN: {isbn}")
+            for k in keys:
+                print(f"  {k}")
+            found = True
+
+    for title, keys in title_map.items():
+        if len(keys) > 1:
+            print(f"\nDuplicate title: {title[:60]}")
+            for k in keys:
+                print(f"  {k}")
+            found = True
+
+    if not found:
+        print("No duplicates found.")
+    else:
+        print(f"\nTip: delete duplicates with: python zotero_add.py (or use Zotero desktop Duplicate Items pane)")
+
+
+def cmd_add_tag(collection_key: str, tag: str) -> None:
+    items = paginate(f"{API_BASE}/users/{USER_ID}/collections/{collection_key}/items/top")
+    print(f"Adding tag '{tag}' to {len(items)} items...")
+    for item in items:
+        data = item["data"]
+        version = data["version"]
+        tags = data.get("tags", [])
+        if not any(t["tag"] == tag for t in tags):
+            tags.append({"tag": tag})
+            patch_headers = {**HEADERS, "If-Unmodified-Since-Version": str(version)}
+            requests.patch(
+                f"{API_BASE}/users/{USER_ID}/items/{data['key']}",
+                headers=patch_headers,
+                json={"tags": tags, "version": version},
+            )
+    print(f"Done.")
+
+
+def cmd_remove_tag(tag: str) -> None:
+    print(
+        f"Tag deletion is disabled in this skill to prevent accidental data loss.\n"
+        f"To remove tag '{tag}' from all items, open the Zotero desktop app → Tags panel → right-click and delete."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+def item_to_bibtex(item: dict) -> str:
+    data = item.get("data", {})
+    key = data.get("key", "UNKNOWN")
+    itype = data.get("itemType", "misc")
+    type_map = {
+        "journalArticle": "article",
+        "book": "book",
+        "conferencePaper": "inproceedings",
+        "thesis": "phdthesis",
+        "report": "techreport",
+        "bookSection": "incollection",
+        "preprint": "misc",
+        "webpage": "misc",
+    }
+    bib_type = type_map.get(itype, "misc")
+
+    creators = data.get("creators", [])
+    author = " and ".join(
+        f"{c.get('lastName', '')}, {c.get('firstName', '')}".strip(", ")
+        for c in creators
+    )
+    title = data.get("title", "")
+    year = extract_year(data.get("date", ""))
+
+    fields = [
+        ("author", author),
+        ("title", f"{{{title}}}"),
+        ("year", year),
+    ]
+    for field in ("publicationTitle", "journal", "volume", "number", "pages", "publisher", "DOI", "url"):
+        val = data.get(field, "")
+        if val:
+            fields.append((field.lower(), val))
+
+    body = ",\n  ".join(f"{k} = {{{v}}}" for k, v in fields if v)
+    return f"@{bib_type}{{{key},\n  {body}\n}}\n"
+
+
+def item_to_ris(item: dict) -> str:
+    data = item.get("data", {})
+    type_map = {
+        "journalArticle": "JOUR",
+        "book": "BOOK",
+        "conferencePaper": "CONF",
+        "thesis": "THES",
+        "report": "RPRT",
+        "preprint": "JOUR",
+        "webpage": "ELEC",
+    }
+    ris_type = type_map.get(data.get("itemType", ""), "GEN")
+    lines = [f"TY  - {ris_type}"]
+    lines.append(f"TI  - {data.get('title', '')}")
+    for c in data.get("creators", []):
+        lines.append(f"AU  - {c.get('lastName', '')}, {c.get('firstName', '')}")
+    if data.get("date"):
+        lines.append(f"PY  - {extract_year(data['date'])}")
+    if data.get("publicationTitle"):
+        lines.append(f"JO  - {data['publicationTitle']}")
+    if data.get("volume"):
+        lines.append(f"VL  - {data['volume']}")
+    if data.get("pages"):
+        lines.append(f"SP  - {data['pages']}")
+    if data.get("DOI"):
+        lines.append(f"DO  - {data['DOI']}")
+    if data.get("url"):
+        lines.append(f"UR  - {data['url']}")
+    if data.get("abstractNote"):
+        lines.append(f"AB  - {data['abstractNote'][:500]}")
+    lines.append("ER  - ")
+    return "\n".join(lines) + "\n\n"
+
+
+def cmd_export(fmt: str, collection_key: str) -> None:
+    items = paginate(f"{API_BASE}/users/{USER_ID}/collections/{collection_key}/items/top")
+    if fmt == "bibtex":
+        for item in items:
+            print(item_to_bibtex(item))
+    elif fmt == "ris":
+        for item in items:
+            print(item_to_ris(item))
+    else:
+        sys.exit(f"Unknown export format: {fmt}. Use 'bibtex' or 'ris'.")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Search and browse Zotero library")
+    parser.add_argument("query", nargs="?", help="Keyword search query")
+    parser.add_argument("--collection", metavar="KEY", help="Filter/list by collection key")
+    parser.add_argument("--collections", action="store_true", help="List all collections")
+    parser.add_argument("--item", metavar="KEY", help="Show full detail for one item")
+    parser.add_argument("--tag", metavar="TAG", help="Filter by tag")
+    parser.add_argument("--type", metavar="ITEMTYPE", help="Filter by item type")
+    parser.add_argument("--since", metavar="DATE", help="Items added on or after date (YYYY-MM-DD)")
+    parser.add_argument("--stats", action="store_true", help="Show library statistics")
+    parser.add_argument("--dupes", action="store_true", help="Find duplicate items")
+    parser.add_argument("--add-tag", metavar="TAG", help="Add tag to all items in --collection")
+    parser.add_argument("--remove-tag", metavar="TAG", help="Remove tag from all items in library")
+    parser.add_argument("--export", nargs=2, metavar=("FORMAT", "COLL_KEY"),
+                        help="Export collection: bibtex|ris COLLECTION_KEY")
+    parser.add_argument("--limit", type=int, default=50, help="Max items to display (default: 50)")
+    args = parser.parse_args()
+
+    api_key, user_id = get_env()
+    global HEADERS, USER_ID
+    HEADERS = build_headers(api_key)
+    USER_ID = user_id
+
+    if args.export:
+        cmd_export(args.export[0], args.export[1])
+    elif args.collections:
+        cmd_collections()
+    elif args.item:
+        cmd_item(args.item)
+    elif args.stats:
+        cmd_stats(args)
+    elif args.dupes:
+        cmd_dupes()
+    elif args.add_tag:
+        if not args.collection:
+            sys.exit("--add-tag requires --collection KEY")
+        cmd_add_tag(args.collection, args.add_tag)
+    elif args.remove_tag:
+        cmd_remove_tag(args.remove_tag)
+    elif args.query:
+        if args.collection and not args.query:
+            cmd_list_collection(args.collection, args)
+        else:
+            cmd_search(args.query, args)
+    elif args.collection:
+        cmd_list_collection(args.collection, args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/research/zotero/scripts/zotero_setup.py
+++ b/optional-skills/research/zotero/scripts/zotero_setup.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+zotero_setup.py — Bootstrap the hermes-agent workspace inside Zotero.
+
+Creates (idempotently):
+  hermes-agent/
+  ├── Books/
+  ├── Papers/
+  ├── Notes/
+  └── Reading List/
+
+Usage:
+  python zotero_setup.py              # create/verify collection tree
+  python zotero_setup.py --show       # print keys without modifying anything
+  python zotero_setup.py --add-collection "Philosophy"
+  python zotero_setup.py --add-collection "Philosophy" --parent hermes-agent
+"""
+
+import argparse
+import json
+import os
+import sys
+
+try:
+    import requests
+except ImportError:
+    sys.exit("requests is required: pip install requests")
+
+
+API_BASE = "https://api.zotero.org"
+HEADERS = {}
+
+ROOT_NAME = "hermes-agent"
+DEFAULT_CHILDREN = ["Books", "Papers", "Notes", "Reading List"]
+
+
+def get_env() -> tuple[str, str]:
+    api_key = os.environ.get("ZOTERO_API_KEY", "")
+    user_id = os.environ.get("ZOTERO_USER_ID", "")
+    if not api_key or not user_id:
+        sys.exit(
+            "Set ZOTERO_API_KEY and ZOTERO_USER_ID environment variables.\n"
+            "  Get them at: https://www.zotero.org/settings/keys"
+        )
+    return api_key, user_id
+
+
+def build_headers(api_key: str) -> dict:
+    return {
+        "Zotero-API-Version": "3",
+        "Zotero-API-Key": api_key,
+        "Content-Type": "application/json",
+    }
+
+
+def get_all_collections(user_id: str) -> list[dict]:
+    """Fetch all collections, handling pagination."""
+    url = f"{API_BASE}/users/{user_id}/collections"
+    collections = []
+    start = 0
+    while True:
+        resp = requests.get(url, headers=HEADERS, params={"limit": 100, "start": start})
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+        collections.extend(batch)
+        total = int(resp.headers.get("Total-Results", len(batch)))
+        start += len(batch)
+        if start >= total:
+            break
+    return collections
+
+
+def find_collection_by_name(collections: list[dict], name: str, parent_key: str | None = None) -> dict | None:
+    """Find a collection matching name (case-insensitive) and optional parent."""
+    for col in collections:
+        data = col.get("data", {})
+        col_name = data.get("name", "")
+        col_parent = data.get("parentCollection", False)
+        name_match = col_name.lower() == name.lower()
+        parent_match = (
+            (parent_key is None) or
+            (parent_key is False and not col_parent) or
+            (col_parent == parent_key)
+        )
+        if name_match and parent_match:
+            return col
+    return None
+
+
+def create_collection(user_id: str, name: str, parent_key: str | None = None) -> dict:
+    """Create a collection and return the created object."""
+    url = f"{API_BASE}/users/{user_id}/collections"
+    payload = [{"name": name}]
+    if parent_key:
+        payload[0]["parentCollection"] = parent_key
+    resp = requests.post(url, headers=HEADERS, json=payload)
+    resp.raise_for_status()
+    result = resp.json()
+    created = result.get("successful", {}).get("0", {})
+    if not created:
+        sys.exit(f"Failed to create collection '{name}': {resp.text}")
+    return created
+
+
+def ensure_collection(
+    user_id: str,
+    collections: list[dict],
+    name: str,
+    parent_key: str | None = None,
+    dry_run: bool = False,
+) -> tuple[str, bool]:
+    """Return (key, was_created). Creates if missing."""
+    existing = find_collection_by_name(collections, name, parent_key=parent_key or False)
+    if existing:
+        return existing["data"]["key"], False
+
+    if dry_run:
+        return f"[would create '{name}']", False
+
+    print(f"  Creating collection: {name}")
+    created = create_collection(user_id, name, parent_key)
+    key = created.get("data", {}).get("key") or created.get("key", "")
+    # Append to local list so child lookups work in same run
+    collections.append(created)
+    return key, True
+
+
+def print_tree(collections: list[dict], root_key: str, indent: int = 0) -> None:
+    prefix = "  " * indent
+    root = next((c for c in collections if c["data"]["key"] == root_key), None)
+    if not root:
+        return
+    print(f"{prefix}├── {root['data']['name']}  [{root_key}]")
+    children = [
+        c for c in collections
+        if c["data"].get("parentCollection") == root_key
+    ]
+    for child in sorted(children, key=lambda c: c["data"]["name"]):
+        child_key = child["data"]["key"]
+        print(f"{prefix}│   ├── {child['data']['name']}  [{child_key}]")
+
+
+def cmd_show(user_id: str) -> None:
+    collections = get_all_collections(user_id)
+    root = find_collection_by_name(collections, ROOT_NAME, parent_key=False)
+    if not root:
+        print(f"'{ROOT_NAME}' collection not found. Run without --show to create it.")
+        return
+    root_key = root["data"]["key"]
+    print(f"\nhermes-agent collection tree:")
+    print_tree(collections, root_key)
+    print()
+
+    # Print env-style key map
+    print("Collection keys (for use with other scripts):")
+    print(f"  HERMES_KEY={root_key}")
+    children = [
+        c for c in collections
+        if c["data"].get("parentCollection") == root_key
+    ]
+    for child in sorted(children, key=lambda c: c["data"]["name"]):
+        name_env = child["data"]["name"].upper().replace(" ", "_")
+        print(f"  {name_env}_KEY={child['data']['key']}")
+
+
+def cmd_setup(user_id: str) -> None:
+    print("Fetching existing collections...")
+    collections = get_all_collections(user_id)
+
+    print(f"\nEnsuring collection: {ROOT_NAME}")
+    root_key, root_created = ensure_collection(user_id, collections, ROOT_NAME, parent_key=None)
+    if not root_created:
+        print(f"  Already exists  [{root_key}]")
+    else:
+        print(f"  Created  [{root_key}]")
+
+    child_keys: dict[str, str] = {}
+    for child_name in DEFAULT_CHILDREN:
+        key, created = ensure_collection(user_id, collections, child_name, parent_key=root_key)
+        child_keys[child_name] = key
+        if not created:
+            print(f"  {child_name}: already exists  [{key}]")
+        else:
+            print(f"  {child_name}: created  [{key}]")
+
+    print("\n✓ hermes-agent workspace ready\n")
+    print(f"{'hermes-agent':20s}  {root_key}")
+    for name, key in child_keys.items():
+        print(f"  {name:18s}  {key}")
+    print()
+
+
+def cmd_add_collection(user_id: str, name: str, parent_name: str) -> None:
+    collections = get_all_collections(user_id)
+
+    # Resolve parent
+    if parent_name.lower() in ("hermes-agent", "root", "hermes"):
+        parent = find_collection_by_name(collections, ROOT_NAME, parent_key=False)
+        if not parent:
+            sys.exit(f"'{ROOT_NAME}' collection not found. Run setup first.")
+        parent_key = parent["data"]["key"]
+    else:
+        parent = find_collection_by_name(collections, parent_name)
+        if not parent:
+            sys.exit(f"Parent collection '{parent_name}' not found.")
+        parent_key = parent["data"]["key"]
+
+    key, created = ensure_collection(user_id, collections, name, parent_key=parent_key)
+    if created:
+        print(f"Created '{name}' under '{parent_name}'  [{key}]")
+    else:
+        print(f"'{name}' already exists under '{parent_name}'  [{key}]")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Bootstrap hermes-agent Zotero workspace")
+    parser.add_argument("--show", action="store_true", help="Print collection keys without modifying")
+    parser.add_argument("--add-collection", metavar="NAME", help="Add a new sub-collection")
+    parser.add_argument("--parent", default="hermes-agent", metavar="NAME",
+                        help="Parent for --add-collection (default: hermes-agent)")
+    args = parser.parse_args()
+
+    api_key, user_id = get_env()
+    global HEADERS
+    HEADERS = build_headers(api_key)
+
+    if args.show:
+        cmd_show(user_id)
+    elif args.add_collection:
+        cmd_add_collection(user_id, args.add_collection, args.parent)
+    else:
+        cmd_setup(user_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a new optional skill for managing a Zotero reference library directly from Hermes. The skill ships in `optional-skills/research/zotero/` and is not activated by default — users discover and install it via `hermes skills browse`.

- **Collection management** — bootstraps a `hermes-agent` workspace inside Zotero (`Books`, `Papers`, `Notes`, `Reading List` sub-collections); idempotent, safe to re-run
- **Item ingestion** — add references by DOI (CrossRef), ISBN (Open Library / Google Books fallback), arXiv ID, plain URL, or BibTeX file import
- **PDF reading** — tries Zotero fulltext index first, falls back to `pdfplumber` on cloud attachment, then fetches directly from source URL (arXiv → pdf, Unpaywall for open-access DOIs) — no upload required
- **Library search** — full-text query, browse by collection, per-item detail, stats, duplicate detection, BibTeX/RIS export
- **Notes** — create/update notes with markdown→HTML conversion, reading-progress tags (`unread` / `reading` / `done`), reading templates
- **Deletions intentionally blocked** — all delete paths print a message directing the user to the Zotero desktop app; no API delete calls are made by the skill

## Files changed

```
optional-skills/research/zotero/
├── SKILL.md              # Agent instructions, env var setup metadata, usage examples
├── api-reference.md      # Zotero Web API v3 + CrossRef/Open Library/arXiv reference
└── scripts/
    ├── zotero_setup.py   # Collection hierarchy bootstrap
    ├── zotero_add.py     # Item ingestion (DOI, ISBN, arXiv, URL, BibTeX)
    ├── zotero_search.py  # Search, browse, stats, export
    ├── zotero_read.py    # PDF text extraction + citation formatting (APA/MLA/BibTeX)
    └── zotero_note.py    # Note CRUD + reading-progress tagging
```

## Configuration

Two environment variables declared via `required_environment_variables` frontmatter (triggers secure CLI prompt on first load):

| Variable | Purpose |
|---|---|
| `ZOTERO_API_KEY` | Read/write API key from https://www.zotero.org/settings/keys |
| `ZOTERO_USER_ID` | Numeric user ID shown on the same keys page |

## How to test

```bash
# Bootstrap collections
python optional-skills/research/zotero/scripts/zotero_setup.py setup

# Add a paper by arXiv ID
python optional-skills/research/zotero/scripts/zotero_add.py --arxiv 2301.07041

# Add a book by ISBN
python optional-skills/research/zotero/scripts/zotero_add.py --isbn 9780262033848

# Read a paper's PDF
python optional-skills/research/zotero/scripts/zotero_read.py <item-key> --pdf

# Search the library
python optional-skills/research/zotero/scripts/zotero_search.py "attention transformer"

# Full agent loop
hermes chat -q "Add the paper 1706.03762 to my Zotero library and summarise it"
```

## Test results

- `tests/skills/` — 37/37 passed
- skill-related subset of main suite — 438/438 passed

Tested on: Linux (Ubuntu 24.04), Python 3.11

uwu