### PR TITLE
fix(slack): return first chunk's message_id for multi-chunk sends

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -160,6 +160,7 @@ class SlackAdapter(BasePlatformAdapter):
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            first_result = None
             last_result = None
 
             # reply_broadcast: also post thread replies to the main channel.
@@ -178,10 +179,14 @@ class SlackAdapter(BasePlatformAdapter):
                         kwargs["reply_broadcast"] = True
 
                 last_result = await self._app.client.chat_postMessage(**kwargs)
+                if first_result is None:
+                    first_result = last_result
 
+            # Return the FIRST chunk's message_id — that's the primary message
+            # the gateway tracks for streaming edits and reply threading.
             return SendResult(
                 success=True,
-                message_id=last_result.get("ts") if last_result else None,
+                message_id=first_result.get("ts") if first_result else None,
                 raw_response=last_result,
             )
 


### PR DESCRIPTION
## Summary
- When a long message is split into chunks, `send()` returns the last chunk's `ts` as `message_id`
- Streaming edits and reply threading then target the wrong chunk (last instead of first)
- The first chunks become stale and can't be updated
- Fix: track and return the first chunk's `ts`

## How to reproduce
- Send a message longer than 3000 chars via Slack gateway
- The response gets split into multiple chunks
- Streaming edits only update the last chunk

## How to test
- The fix adds `first_result` tracking alongside existing `last_result`
- `raw_response` still returns the last result for backwards compatibility

## Platform tested
- Linux, hermes-agent v0.4.0