### PR TITLE
fix(agent): reject oversized base64 images before decoding to prevent OOM

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3906,6 +3906,11 @@ class AIAgent:
             "image/jpeg": ".jpg",
             "image/jpg": ".jpg",
         }.get(mime, ".jpg")
+        # Reject oversized images before decoding to prevent OOM.
+        # 50 MB base64 ≈ 37.5 MB decoded — reasonable limit for inline images.
+        _MAX_BASE64_LEN = 50 * 1024 * 1024
+        if len(data) > _MAX_BASE64_LEN:
+            raise ValueError(f"Base64 image data too large ({len(data):,} bytes, max {_MAX_BASE64_LEN:,})")
         tmp = tempfile.NamedTemporaryFile(prefix="anthropic_image_", suffix=suffix, delete=False)
         with tmp:
             tmp.write(base64.b64decode(data))


### PR DESCRIPTION
## Summary
- `_save_anthropic_image_to_temp()` calls `base64.b64decode(data)` with no size check
- A large base64 payload decodes fully into memory before writing to disk
- Fix: check base64 string length before decoding, reject if over 50MB (~37.5MB decoded)

## How to reproduce
- Send an inline base64 image > 50MB in a message
- The entire payload is decoded into memory before any write

## How to test
- The check is a simple length comparison before the decode call
- Normal images (< 50MB base64) are unaffected

## Platform tested
- Linux, hermes-agent v0.4.0