### PR TITLE
fix(api-server): add thread lock to ResponseStore SQLite operations

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -22,6 +22,7 @@ import json
 import logging
 import os
 import sqlite3
+import threading
 import time
 import uuid
 from typing import Any, Dict, List, Optional
@@ -66,6 +67,7 @@ class ResponseStore:
 
     def __init__(self, max_size: int = MAX_STORED_RESPONSES, db_path: str = None):
         self._max_size = max_size
+        self._lock = threading.Lock()
         if db_path is None:
             try:
                 from hermes_cli.config import get_hermes_home
@@ -94,58 +96,61 @@ class ResponseStore:
 
     def get(self, response_id: str) -> Optional[Dict[str, Any]]:
         """Retrieve a stored response by ID (updates access time for LRU)."""
-        row = self._conn.execute(
-            "SELECT data FROM responses WHERE response_id = ?", (response_id,)
-        ).fetchone()
-        if row is None:
-            return None
-        import time
-        self._conn.execute(
-            "UPDATE responses SET accessed_at = ? WHERE response_id = ?",
-            (time.time(), response_id),
-        )
-        self._conn.commit()
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT data FROM responses WHERE response_id = ?", (response_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            self._conn.execute(
+                "UPDATE responses SET accessed_at = ? WHERE response_id = ?",
+                (time.time(), response_id),
+            )
+            self._conn.commit()
         return json.loads(row[0])
 
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""
-        import time
-        self._conn.execute(
-            "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
-            (response_id, json.dumps(data, default=str), time.time()),
-        )
-        # Evict oldest entries beyond max_size
-        count = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()[0]
-        if count > self._max_size:
+        with self._lock:
             self._conn.execute(
-                "DELETE FROM responses WHERE response_id IN "
-                "(SELECT response_id FROM responses ORDER BY accessed_at ASC LIMIT ?)",
-                (count - self._max_size,),
+                "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
+                (response_id, json.dumps(data, default=str), time.time()),
             )
-        self._conn.commit()
+            # Evict oldest entries beyond max_size
+            count = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()[0]
+            if count > self._max_size:
+                self._conn.execute(
+                    "DELETE FROM responses WHERE response_id IN "
+                    "(SELECT response_id FROM responses ORDER BY accessed_at ASC LIMIT ?)",
+                    (count - self._max_size,),
+                )
+            self._conn.commit()
 
     def delete(self, response_id: str) -> bool:
         """Remove a response from the store. Returns True if found and deleted."""
-        cursor = self._conn.execute(
-            "DELETE FROM responses WHERE response_id = ?", (response_id,)
-        )
-        self._conn.commit()
-        return cursor.rowcount > 0
+        with self._lock:
+            cursor = self._conn.execute(
+                "DELETE FROM responses WHERE response_id = ?", (response_id,)
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
 
     def get_conversation(self, name: str) -> Optional[str]:
         """Get the latest response_id for a conversation name."""
-        row = self._conn.execute(
-            "SELECT response_id FROM conversations WHERE name = ?", (name,)
-        ).fetchone()
-        return row[0] if row else None
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT response_id FROM conversations WHERE name = ?", (name,)
+            ).fetchone()
+            return row[0] if row else None
 
     def set_conversation(self, name: str, response_id: str) -> None:
         """Map a conversation name to its latest response_id."""
-        self._conn.execute(
-            "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
-            (name, response_id),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
+                (name, response_id),
+            )
+            self._conn.commit()
 
     def close(self) -> None:
         """Close the database connection."""

--- a/tests/gateway/test_response_store_lock.py
+++ b/tests/gateway/test_response_store_lock.py
@@ -1,0 +1,262 @@
+"""
+Tests for ResponseStore thread safety (PR #2780).
+
+Verifies that the threading.Lock added to ResponseStore prevents data
+corruption under concurrent access and that the lock is acquired during
+store, get, and delete operations.
+"""
+
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+from gateway.platforms.api_server import ResponseStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_store(max_size=100):
+    """Return an in-memory ResponseStore."""
+    return ResponseStore(max_size=max_size, db_path=":memory:")
+
+
+# ---------------------------------------------------------------------------
+# Lock presence
+# ---------------------------------------------------------------------------
+
+
+class TestResponseStoreLockExists:
+    def test_has_lock_attribute(self):
+        store = _make_store()
+        assert hasattr(store, "_lock"), "ResponseStore should have a _lock attribute"
+
+    def test_lock_is_threading_lock(self):
+        store = _make_store()
+        # threading.Lock() returns a _thread.lock / threading._RLock-compatible object
+        assert hasattr(store._lock, "acquire") and hasattr(store._lock, "release")
+
+
+# ---------------------------------------------------------------------------
+# Lock is acquired during each operation
+# ---------------------------------------------------------------------------
+
+
+class _TrackingLock:
+    """threading.Lock wrapper that counts context-manager entries."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.enter_count = 0
+
+    def __enter__(self):
+        self._lock.acquire()
+        self.enter_count += 1
+        return self
+
+    def __exit__(self, *args):
+        self._lock.release()
+
+    def acquire(self, *a, **kw):
+        return self._lock.acquire(*a, **kw)
+
+    def release(self):
+        return self._lock.release()
+
+
+class TestResponseStoreLockAcquired:
+    """Replace the store's lock with a _TrackingLock to verify it is entered."""
+
+    def _tracked_store(self):
+        store = _make_store()
+        tracking = _TrackingLock()
+        store._lock = tracking
+        return store, tracking
+
+    def test_put_acquires_lock(self):
+        store, lock = self._tracked_store()
+        store.put("r1", {"x": 1})
+        assert lock.enter_count >= 1
+
+    def test_get_acquires_lock(self):
+        store, lock = self._tracked_store()
+        store.put("r1", {"x": 1})
+        before = lock.enter_count
+        store.get("r1")
+        assert lock.enter_count > before
+
+    def test_get_missing_acquires_lock(self):
+        store, lock = self._tracked_store()
+        store.get("no_such_id")
+        assert lock.enter_count >= 1
+
+    def test_delete_acquires_lock(self):
+        store, lock = self._tracked_store()
+        store.put("r1", {"x": 1})
+        before = lock.enter_count
+        store.delete("r1")
+        assert lock.enter_count > before
+
+    def test_get_conversation_acquires_lock(self):
+        store, lock = self._tracked_store()
+        store.get_conversation("conv1")
+        assert lock.enter_count >= 1
+
+    def test_set_conversation_acquires_lock(self):
+        store, lock = self._tracked_store()
+        store.set_conversation("conv1", "r1")
+        assert lock.enter_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Concurrent access does not crash or corrupt data
+# ---------------------------------------------------------------------------
+
+
+class TestResponseStoreConcurrency:
+    """Hammer the store from multiple threads and verify correctness."""
+
+    def test_concurrent_puts_do_not_crash(self):
+        store = _make_store(max_size=200)
+        errors = []
+
+        def worker(tid):
+            try:
+                for i in range(20):
+                    store.put(f"t{tid}_r{i}", {"tid": tid, "i": i})
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(t,)) for t in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Concurrent puts raised: {errors}"
+
+    def test_concurrent_gets_do_not_crash(self):
+        store = _make_store()
+        for i in range(50):
+            store.put(f"r{i}", {"val": i})
+
+        errors = []
+
+        def reader(tid):
+            try:
+                for i in range(50):
+                    store.get(f"r{i % 50}")
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=reader, args=(t,)) for t in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Concurrent gets raised: {errors}"
+
+    def test_concurrent_mixed_operations_do_not_crash(self):
+        store = _make_store(max_size=50)
+        errors = []
+
+        def writer(tid):
+            try:
+                for i in range(10):
+                    rid = f"t{tid}_r{i}"
+                    store.put(rid, {"tid": tid, "i": i})
+                    store.get(rid)
+                    store.delete(rid)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer, args=(t,)) for t in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Mixed concurrent operations raised: {errors}"
+
+    def test_concurrent_puts_data_integrity(self):
+        """Each thread writes its own keyed entry; all entries must be readable."""
+        store = _make_store(max_size=1000)
+        n_threads = 10
+        items_per_thread = 10
+
+        def writer(tid):
+            for i in range(items_per_thread):
+                store.put(f"t{tid}_r{i}", {"tid": tid, "idx": i})
+
+        threads = [threading.Thread(target=writer, args=(t,)) for t in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Verify a sampling of written entries survived
+        for tid in range(n_threads):
+            for i in range(items_per_thread):
+                result = store.get(f"t{tid}_r{i}")
+                assert result is not None, f"Entry t{tid}_r{i} missing after concurrent write"
+                assert result["tid"] == tid
+                assert result["idx"] == i
+
+    def test_concurrent_conversation_set_get(self):
+        store = _make_store()
+        errors = []
+
+        def worker(tid):
+            try:
+                for i in range(20):
+                    store.set_conversation(f"conv{tid}", f"r{tid}_{i}")
+                    store.get_conversation(f"conv{tid}")
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(t,)) for t in range(6)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Concurrent conversation ops raised: {errors}"
+
+    def test_lock_prevents_interleaved_writes(self):
+        """
+        Simulate interleaving by holding the lock externally and confirm
+        a second thread blocks until the lock is released.
+        """
+        store = _make_store()
+        results = []
+
+        def slow_writer():
+            with store._lock:
+                # Hold the lock for a moment
+                time.sleep(0.05)
+                results.append("slow_start")
+                time.sleep(0.05)
+                results.append("slow_end")
+
+        def fast_writer():
+            # Give slow_writer a moment to grab the lock first
+            time.sleep(0.01)
+            # This should block until slow_writer releases
+            store.put("fast_key", {"v": 1})
+            results.append("fast_done")
+
+        t1 = threading.Thread(target=slow_writer)
+        t2 = threading.Thread(target=fast_writer)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        # slow_writer must complete entirely before fast_writer's put proceeds
+        assert results.index("slow_end") < results.index("fast_done"), (
+            "fast_writer should not complete before slow_writer releases the lock"
+        )


### PR DESCRIPTION
## Summary
- `ResponseStore` uses `check_same_thread=False` for cross-thread SQLite access but has no lock
- Concurrent API handlers (FastAPI runs in a thread pool) can interleave operations, causing `sqlite3.OperationalError` or corrupted reads
- Fix: add `threading.Lock()` around all database methods, matching the pattern already used by `SessionDB` in `hermes_state.py`

## How to reproduce
- Run the API server with multiple concurrent clients
- Simultaneous get/put/delete calls race on the shared connection

## How to test
- All 7 ResponseStore-related tests pass
- The lock uses `with self._lock:` blocks matching the SessionDB pattern

## Platform tested
- Linux, hermes-agent v0.4.0