### PR TITLE
fix(shell): replace fixed 10ms poll interval with exponential backoff to reduce WSL2 resource consumption

### DIFF
--- a/tools/environments/persistent_shell.py
+++ b/tools/environments/persistent_shell.py
@@ -40,7 +40,7 @@ class PersistentShellMixin:
     def _cleanup_temp_files(self): ...
 
     _session_id: str = ""
-    _poll_interval: float = 0.01        # initial poll interval (10ms)
+    _poll_interval_start: float = 0.01  # initial poll interval (10ms)
     _poll_interval_max: float = 0.25    # max poll interval (250ms) — reduces I/O for long commands
 
     @property
@@ -225,7 +225,7 @@ class PersistentShellMixin:
         )
         self._send_to_shell(ipc_script)
         deadline = time.monotonic() + timeout
-        poll_interval = self._poll_interval  # starts at 10ms, backs off to 250ms
+        poll_interval = self._poll_interval_start  # starts at 10ms, backs off to 250ms
 
         while True:
             if is_interrupted():

--- a/tools/environments/persistent_shell.py
+++ b/tools/environments/persistent_shell.py
@@ -40,7 +40,8 @@ class PersistentShellMixin:
     def _cleanup_temp_files(self): ...
 
     _session_id: str = ""
-    _poll_interval: float = 0.01
+    _poll_interval: float = 0.01        # initial poll interval (10ms)
+    _poll_interval_max: float = 0.25    # max poll interval (250ms) — reduces I/O for long commands
 
     @property
     def _temp_prefix(self) -> str:
@@ -224,7 +225,7 @@ class PersistentShellMixin:
         )
         self._send_to_shell(ipc_script)
         deadline = time.monotonic() + timeout
-        poll_interval = self._poll_interval
+        poll_interval = self._poll_interval  # starts at 10ms, backs off to 250ms
 
         while True:
             if is_interrupted():
@@ -256,6 +257,10 @@ class PersistentShellMixin:
                 break
 
             time.sleep(poll_interval)
+            # Exponential backoff: fast start (10ms) for quick commands,
+            # ramps up to 250ms for long-running commands — reduces I/O by 10-25x
+            # on WSL2 where polling keeps the VM hot and memory pressure high.
+            poll_interval = min(poll_interval * 1.5, self._poll_interval_max)
 
         output, exit_code, new_cwd = self._read_persistent_output()
         if new_cwd:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -87,7 +87,7 @@ class SSHEnvironment(PersistentShellMixin, BaseEnvironment):
         except subprocess.TimeoutExpired:
             raise RuntimeError(f"SSH connection to {self.user}@{self.host} timed out")
 
-    _poll_interval: float = 0.15
+    _poll_interval_start: float = 0.15  # SSH: higher initial interval (150ms) for network latency
 
     @property
     def _temp_prefix(self) -> str:


### PR DESCRIPTION
Fixes #2784

## Problem
PersistentShellMixin used a hardcoded 10ms polling interval, causing ~100 file I/O operations per second per running command. On WSL2, this keeps the VM continuously active, prevents Windows from reclaiming memory, and causes vmmemWSL to grow unbounded.

## Fix
- Replace fixed interval with exponential backoff (10ms → 250ms cap, 1.5x multiplier)
- Rename `_poll_interval` → `_poll_interval_start` for clarity
- Update SSHEnvironment to use renamed attribute (150ms initial for network latency)

## Result
- Fast commands (<100ms): same behavior as before
- Long commands (>1s): 10-25x fewer file reads
- WSL2: VM can cool down and release memory between polls
