### PR TITLE
fix(tools):  exponential backoff for PersistentShellMixin poll interval   

### DIFF
--- a/tools/environments/persistent_shell.py
+++ b/tools/environments/persistent_shell.py
@@ -40,7 +40,8 @@ class PersistentShellMixin:
     def _cleanup_temp_files(self): ...
 
     _session_id: str = ""
-    _poll_interval: float = 0.01
+    _poll_interval_start: float = 0.01
+    _poll_interval_max: float = 0.25
 
     @property
     def _temp_prefix(self) -> str:
@@ -224,7 +225,7 @@ class PersistentShellMixin:
         )
         self._send_to_shell(ipc_script)
         deadline = time.monotonic() + timeout
-        poll_interval = self._poll_interval
+        poll_interval = self._poll_interval_start
 
         while True:
             if is_interrupted():
@@ -256,6 +257,7 @@ class PersistentShellMixin:
                 break
 
             time.sleep(poll_interval)
+            poll_interval = min(poll_interval * 1.5, self._poll_interval_max)
 
         output, exit_code, new_cwd = self._read_persistent_output()
         if new_cwd:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -87,7 +87,7 @@ class SSHEnvironment(PersistentShellMixin, BaseEnvironment):
         except subprocess.TimeoutExpired:
             raise RuntimeError(f"SSH connection to {self.user}@{self.host} timed out")
 
-    _poll_interval: float = 0.15
+    _poll_interval_start: float = 0.15
 
     @property
     def _temp_prefix(self) -> str:


### PR DESCRIPTION
Fixes #2784

 ## Summary                                                                    
                                                                              
  - Replaces hardcoded 10ms `_poll_interval` with exponential backoff (10ms → 250ms cap) in `_execute_persistent_locked()`
  - Reduces sustained file I/O from ~100 reads/sec to ~4 reads/sec for long-running commands                                                         
  - Updates `SSHEnvironment` to use renamed `_poll_interval_start` attribute (was `_poll_interval = 0.15`)                                                 
                                                                              
  ## Details

  Fixes #2784. `PersistentShellMixin` was polling the status temp file every 10ms regardless of command duration. On WSL2 this keeps the VM continuously active, causing `vmmemWSL` memory growth and CPU spikes.                      
                                                                              
  The backoff progression (10ms → 15 → 22 → 33 → ... → 250ms) keeps fast commands responsive while reducing I/O pressure for longer-running ones by ~25x.                                                                         
                                                                              
  ## Test plan

  - [ ] Run a short command (<100ms) via persistent shell — completion latency should be unchanged
  - [ ] Run a long-running command - verify CPU/disk activity is reduced compared to before                                                          
  - [ ] Verify SSH environment still works (uses `_poll_interval_start = 0.15`)

