### PR TITLE
fix(cron): warn user when creating cron job if gateway is not running

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -138,7 +138,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _check_cron_ticker_warning() -> "str | None":
+def _check_cron_ticker_warning() -> Optional[str]:
     """Return a warning if the cron ticker is not running (gateway not active).
 
     Cron jobs only fire automatically when the gateway is running.

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -197,6 +197,7 @@ def cronjob(
                     "next_run_at": job["next_run_at"],
                     "job": _format_job(job),
                     "message": f"Cron job '{job['name']}' created.",
+                    "warning": _check_cron_ticker_warning(),
                 },
                 indent=2,
             )

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -138,6 +138,26 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _check_cron_ticker_warning() -> str:
+    """Return a warning if the cron ticker is not running (gateway not active).
+
+    Cron jobs only fire automatically when the gateway is running.
+    In CLI-only mode, users must manually run 'hermes cron tick'.
+    """
+    try:
+        from gateway.status import get_running_pid
+        pid = get_running_pid()
+        if pid is None:
+            return (
+                "⚠️ The gateway is not running — this cron job will NOT fire automatically. "
+                "To enable automatic execution, run: hermes gateway run. "
+                "Or manually trigger: hermes cron tick."
+            )
+    except Exception:
+        pass
+    return None
+
+
 def cronjob(
     action: str,
     job_id: Optional[str] = None,

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -138,7 +138,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _check_cron_ticker_warning() -> str:
+def _check_cron_ticker_warning() -> "str | None":
     """Return a warning if the cron ticker is not running (gateway not active).
 
     Cron jobs only fire automatically when the gateway is running.


### PR DESCRIPTION
Fixes #2788

## Root Cause
Cron jobs only fire automatically when the gateway is running. In CLI-only mode, the cron ticker is never started, so jobs never execute. Users creating cron jobs via CLI had no indication of this.

## Fix
Added `_check_cron_ticker_warning()` that checks if the gateway is running via `get_running_pid()`. When a cron job is created and the gateway is NOT running, the response includes a `warning` field:

⚠️ The gateway is not running — this cron job will NOT fire automatically. To enable automatic execution, run: hermes gateway run. Or manually trigger: hermes cron tick.

The LLM sees this warning and can relay it to the user.
