### PR TITLE
fix: remove litellm dependency (PyPI supply chain compromise)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,6 @@ dependencies = [
   # Text-to-speech (Edge TTS is free, no API key needed)
   "edge-tts",
   "faster-whisper>=1.0.0",
-  # mini-swe-agent deps (terminal tool)
-  "litellm>=1.75.5",
-  "typer",
-  "platformdirs",
   # Skills Hub (GitHub App JWT auth — optional, only needed for bot identity)
   "PyJWT[crypto]",
 ]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -721,8 +721,11 @@ install_deps() {
     # Install submodules
     log_info "Installing mini-swe-agent (terminal tool backend)..."
     if [ -d "mini-swe-agent" ] && [ -f "mini-swe-agent/pyproject.toml" ]; then
-        $UV_CMD pip install -e "./mini-swe-agent" || log_warn "mini-swe-agent install failed (terminal tools may not work)"
-        log_success "mini-swe-agent installed"
+        if $UV_CMD pip install -e "./mini-swe-agent"; then
+            log_success "mini-swe-agent installed"
+        else
+            log_warn "mini-swe-agent install failed (Docker/Modal terminal backends may not work, local terminal is unaffected)"
+        fi
     else
         log_warn "mini-swe-agent not found (run: git submodule update --init)"
     fi

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -130,7 +130,7 @@ echo -e "${CYAN}→${NC} Installing submodules..."
 if [ -d "mini-swe-agent" ] && [ -f "mini-swe-agent/pyproject.toml" ]; then
     $UV_CMD pip install -e "./mini-swe-agent" && \
         echo -e "${GREEN}✓${NC} mini-swe-agent installed" || \
-        echo -e "${YELLOW}⚠${NC} mini-swe-agent install failed (terminal tools may not work)"
+        echo -e "${YELLOW}⚠${NC} mini-swe-agent install failed (Docker/Modal terminal backends may not work, local terminal is unaffected)"
 else
     echo -e "${YELLOW}⚠${NC} mini-swe-agent not found (run: git submodule update --init --recursive)"
 fi


### PR DESCRIPTION
## Summary

litellm 1.82.7/1.82.8 contained a credential stealer (`.pth` auto-exec payload that exfiltrates API keys, SSH keys, cloud credentials, etc. on any Python startup). PyPI has quarantined the entire litellm package, which blocks all fresh hermes-agent installs.

**Ref:** https://github.com/BerriAI/litellm/issues/24512

## Changes

- **Remove `litellm>=1.75.5`, `typer`, `platformdirs`** from hermes-agent's `pyproject.toml` — these are mini-swe-agent deps that are redundantly duplicated here. mini-swe-agent has its own `pyproject.toml` and manages its own dependencies.
- **Fix `install.sh`** — `log_success "mini-swe-agent installed"` was printing unconditionally even on install failure. Now uses proper if/else.
- **Update warning messages** in both `install.sh` and `setup-hermes.sh` — clarifies that only Docker/Modal terminal backends are affected when mini-swe-agent fails to install; local terminal is unaffected.

## Impact

- Unblocks fresh installs immediately
- No hermes-agent functionality is lost (litellm is not imported anywhere in the main codebase)
- mini-swe-agent sub-install will soft-fail with a warning until litellm quarantine lifts
- Local terminal backend (used by ~all users) works without mini-swe-agent

## Test plan

- 6086 tests pass, 0 failures