### PR TITLE
add 402 payment error hint to vision tool error handler

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -375,6 +375,13 @@ async def vision_analyze_tool(
         # so it can inform the user instead of a cryptic API error.
         err_str = str(e).lower()
         if any(hint in err_str for hint in (
+            "402", "insufficient", "payment required", "credits", "billing",
+        )):
+            analysis = (
+                "Insufficient credits or payment required. Please top up your "
+                f"API provider account and try again. Error: {e}"
+            )
+        elif any(hint in err_str for hint in (
             "does not support", "not support image", "invalid_request",
             "content_policy", "image_url", "multimodal",
             "unrecognized request argument", "image input",


### PR DESCRIPTION
 ## Summary
            
  When an API provider returns a 402 (Insufficient Credits / Payment Required)error during vision analysis, the error fell through to the generic "There was a problem with the request" message, giving users no actionable information. 
                                                                                
  This PR adds explicit handling for payment/credit errors so users get a clear message to top up their account.                                              
                                  
  ## Changes                                                                    
                                                                                
  - `tools/vision_tools.py`: Added 402/credit-related hints (`"402"`, `"insufficient"`, `"payment required"`, `"credits"`, `"billing"`) before the  existing vision capability error check.        