### PR TITLE
fix(tools): handle 402 insufficient credits error in vision tool

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -375,6 +375,13 @@ async def vision_analyze_tool(
         # so it can inform the user instead of a cryptic API error.
         err_str = str(e).lower()
         if any(hint in err_str for hint in (
+            "402", "insufficient", "payment required", "credits", "billing",
+        )):
+            analysis = (
+                "Insufficient credits or payment required. Please top up your "
+                f"API provider account and try again. Error: {e}"
+            )
+        elif any(hint in err_str for hint in (
             "does not support", "not support image", "invalid_request",
             "content_policy", "image_url", "multimodal",
             "unrecognized request argument", "image input",


### PR DESCRIPTION
## Summary

Salvaged from PR #2798 by @dlkakbs.

When an API provider returns a 402 (Payment Required / Insufficient Credits) during vision analysis, the error previously fell through to the generic "There was a problem with the request" message. This adds explicit handling for payment/credit errors so users get an actionable message to top up their account.

Adds hint checks for: `402`, `insufficient`, `payment required`, `credits`, `billing` — placed before the existing vision capability check (correct priority: payment errors aren't "model doesn't support vision").

Closes #2798.

## Tests
Full suite: 6096 passed.