### PR TITLE
Feat: Webhook signal cortex

### DIFF
--- a/gateway/cortex.py
+++ b/gateway/cortex.py
@@ -86,14 +86,19 @@ class SessionSignalManager:
             if not queue:
                 return []
             claimed: List[SignalRecord] = []
+            consumed_ids: List[str] = []
             while queue:
                 signal_id = queue.popleft()
                 signal = self._signals.get(signal_id)
                 if not signal or signal.state != "pending":
+                    consumed_ids.append(signal_id)
                     continue
                 signal.state = "delivered"
                 signal.delivered_at = datetime.now()
                 claimed.append(signal)
+                consumed_ids.append(signal_id)
+            for sid in consumed_ids:
+                self._signals.pop(sid, None)
             if not queue:
                 self._queues.pop(session_key, None)
             return claimed

--- a/gateway/cortex.py
+++ b/gateway/cortex.py
@@ -1,0 +1,124 @@
+"""Cortex signal manager for gateway-owned external event delivery."""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Deque, Dict, List, Optional
+
+
+@dataclass
+class SignalRecord:
+    """A user-facing signal emitted by an external producer."""
+
+    signal_id: str
+    target_session_key: str
+    source_type: str
+    source_ref: str
+    title: str
+    summary: str
+    priority: str = "normal"
+    reason: str = "notify"
+    action_items: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=datetime.now)
+    delivered_at: Optional[datetime] = None
+    state: str = "pending"
+
+    def to_prompt_dict(self) -> Dict[str, Any]:
+        return {
+            "signal_id": self.signal_id,
+            "title": self.title,
+            "summary": self.summary,
+            "priority": self.priority,
+            "reason": self.reason,
+            "action_items": list(self.action_items),
+            "metadata": dict(self.metadata),
+            "created_at": self.created_at.isoformat(),
+        }
+
+
+class SessionSignalManager:
+    """Thread-safe in-memory queue of per-session Cortex signals."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._signals: Dict[str, SignalRecord] = {}
+        self._queues: Dict[str, Deque[str]] = defaultdict(deque)
+
+    def create_signal(
+        self,
+        *,
+        target_session_key: str,
+        source_type: str,
+        source_ref: str,
+        title: str,
+        summary: str,
+        priority: str = "normal",
+        reason: str = "notify",
+        action_items: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SignalRecord:
+        signal = SignalRecord(
+            signal_id=f"sig_{uuid.uuid4().hex[:12]}",
+            target_session_key=target_session_key,
+            source_type=source_type,
+            source_ref=source_ref,
+            title=title.strip(),
+            summary=summary.strip(),
+            priority=priority if priority in {"normal", "urgent"} else "normal",
+            reason=reason if reason in {"notify", "approval_required", "input_required"} else "notify",
+            action_items=[str(item).strip() for item in (action_items or []) if str(item).strip()],
+            metadata=dict(metadata or {}),
+        )
+        with self._lock:
+            self._signals[signal.signal_id] = signal
+            self._queues[target_session_key].append(signal.signal_id)
+        return signal
+
+    def claim_pending(self, session_key: str) -> List[SignalRecord]:
+        """Atomically claim and remove all pending signals for a session."""
+        with self._lock:
+            queue = self._queues.get(session_key)
+            if not queue:
+                return []
+            claimed: List[SignalRecord] = []
+            while queue:
+                signal_id = queue.popleft()
+                signal = self._signals.get(signal_id)
+                if not signal or signal.state != "pending":
+                    continue
+                signal.state = "delivered"
+                signal.delivered_at = datetime.now()
+                claimed.append(signal)
+            if not queue:
+                self._queues.pop(session_key, None)
+            return claimed
+
+    def has_pending(self, session_key: str) -> bool:
+        with self._lock:
+            queue = self._queues.get(session_key)
+            if not queue:
+                return False
+            return any(
+                (signal := self._signals.get(signal_id)) and signal.state == "pending"
+                for signal_id in queue
+            )
+
+    def pending_count(self, session_key: str) -> int:
+        with self._lock:
+            queue = self._queues.get(session_key)
+            if not queue:
+                return 0
+            return sum(
+                1
+                for signal_id in queue
+                if (signal := self._signals.get(signal_id)) and signal.state == "pending"
+            )
+
+    def get(self, signal_id: str) -> Optional[SignalRecord]:
+        with self._lock:
+            return self._signals.get(signal_id)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -298,6 +298,9 @@ class MessageEvent:
     
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
+
+    # Ephemeral gateway/runtime metadata (not user-authored message content)
+    metadata: Dict[str, Any] = field(default_factory=dict)
     
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -145,17 +145,25 @@ class WebhookAdapter(BasePlatformAdapter):
         info stored during webhook receipt so it doesn't leak memory.
         """
         delivery = self._delivery_info.pop(chat_id, {})
-        deliver_type = delivery.get("deliver", "log")
+        route_deliver_type = str(delivery.get("deliver_type", "always") or "always").lower()
+        deliver_target = delivery.get("deliver", "log")
 
-        if deliver_type == "log":
+        if route_deliver_type == "signal":
+            logger.info(
+                "[webhook] Suppressed final response delivery for %s (signal mode)",
+                chat_id,
+            )
+            return SendResult(success=True)
+
+        if deliver_target == "log":
             logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
             return SendResult(success=True)
 
-        if deliver_type == "github_comment":
+        if deliver_target == "github_comment":
             return await self._deliver_github_comment(content, delivery)
 
         # Cross-platform delivery (telegram, discord, etc.)
-        if self.gateway_runner and deliver_type in (
+        if self.gateway_runner and deliver_target in (
             "telegram",
             "discord",
             "slack",
@@ -163,12 +171,12 @@ class WebhookAdapter(BasePlatformAdapter):
             "sms",
         ):
             return await self._deliver_cross_platform(
-                deliver_type, content, delivery
+                deliver_target, content, delivery
             )
 
-        logger.warning("[webhook] Unknown deliver type: %s", deliver_type)
+        logger.warning("[webhook] Unknown deliver type: %s", deliver_target)
         return SendResult(
-            success=False, error=f"Unknown deliver type: {deliver_type}"
+            success=False, error=f"Unknown deliver type: {deliver_target}"
         )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
@@ -263,11 +271,17 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "ignored", "event": event_type}
             )
 
+        deliver_type = str(route_config.get("deliver_type", "always") or "always").lower()
+        if deliver_type not in {"always", "signal"}:
+            deliver_type = "always"
+
         # Format prompt from template
         prompt_template = route_config.get("prompt", "")
         prompt = self._render_prompt(
             prompt_template, payload, event_type, route_name
         )
+        if deliver_type == "signal":
+            prompt = self._augment_signal_prompt(prompt)
 
         # Inject skill content if configured.
         # We call build_skill_invocation_message() directly rather than
@@ -330,6 +344,7 @@ class WebhookAdapter(BasePlatformAdapter):
         # Store delivery info for send() — consumed (popped) on delivery
         deliver_config = {
             "deliver": route_config.get("deliver", "log"),
+            "deliver_type": deliver_type,
             "deliver_extra": self._render_delivery_extra(
                 route_config.get("deliver_extra", {}), payload
             ),
@@ -351,6 +366,16 @@ class WebhookAdapter(BasePlatformAdapter):
             source=source,
             raw_message=payload,
             message_id=delivery_id,
+            metadata={
+                "webhook": {
+                    "route_name": route_name,
+                    "delivery_id": delivery_id,
+                    "event_type": event_type,
+                    "deliver": deliver_config["deliver"],
+                    "deliver_type": deliver_type,
+                    "deliver_extra": deliver_config["deliver_extra"],
+                }
+            },
         )
 
         logger.info(
@@ -458,6 +483,18 @@ class WebhookAdapter(BasePlatformAdapter):
             else:
                 rendered[key] = value
         return rendered
+
+    def _augment_signal_prompt(self, prompt: str) -> str:
+        """Wrap a webhook prompt with signal-mode delivery instructions."""
+        instructions = (
+            "[Webhook signal mode instructions:\n"
+            "- Your final assistant response is NOT shown to the user.\n"
+            "- Use the signal_user tool only if the user must be notified, must approve something, or must provide input.\n"
+            "- Include any durable identifiers Hermes will need later in metadata (for example email_id, thread_id, invoice_id, draft_id).\n"
+            "- If no user-facing follow-up is required, do not call signal_user and finish silently.\n"
+            "- If you already completed work (for example drafting a reply), summarize that inside signal_user so Hermes can explain it naturally.]\n\n"
+        )
+        return instructions + (prompt or "")
 
     # ------------------------------------------------------------------
     # Response delivery

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -221,6 +221,7 @@ from gateway.session import (
     build_session_key,
 )
 from gateway.delivery import DeliveryRouter, DeliveryTarget
+from gateway.cortex import SessionSignalManager, SignalRecord
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
 
 logger = logging.getLogger(__name__)
@@ -336,6 +337,7 @@ class GatewayRunner:
             has_active_processes_fn=lambda key: process_registry.has_active_for_session(key),
         )
         self.delivery_router = DeliveryRouter(self.config)
+        self.cortex = SessionSignalManager()
         self._running = False
         self._shutdown_event = asyncio.Event()
         self._exit_cleanly = False
@@ -401,6 +403,7 @@ class GatewayRunner:
 
         # Per-chat voice reply mode: "off" | "voice_only" | "all"
         self._voice_mode: Dict[str, str] = self._load_voice_modes()
+        self._signal_wake_tasks: Dict[str, asyncio.Task] = {}
 
     def _get_or_create_gateway_honcho(self, session_key: str):
         """Return a persistent Honcho manager/config pair for this gateway session."""
@@ -667,6 +670,175 @@ class GatewayRunner:
             source,
             group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
         )
+
+    def _find_existing_source_for_target(
+        self,
+        platform: Platform,
+        chat_id: str,
+        thread_id: Optional[str] = None,
+    ) -> Optional[SessionSource]:
+        """Reuse an existing session origin when resolving a Cortex target."""
+        self.session_store._ensure_loaded()
+        matches = []
+        for entry in self.session_store._entries.values():
+            origin = entry.origin
+            if not origin:
+                continue
+            if origin.platform != platform or origin.chat_id != chat_id:
+                continue
+            if thread_id and origin.thread_id != thread_id:
+                continue
+            matches.append(entry)
+        if not matches:
+            return None
+        matches.sort(key=lambda entry: entry.updated_at, reverse=True)
+        return matches[0].origin
+
+    def _resolve_cortex_target_source(
+        self,
+        deliver: str,
+        deliver_extra: Optional[Dict[str, Any]] = None,
+    ) -> tuple[Optional[SessionSource], Optional[str]]:
+        """Resolve webhook deliver config into the target session source/key."""
+        deliver_extra = dict(deliver_extra or {})
+        target = DeliveryTarget.parse(deliver)
+        if target.platform in {Platform.LOCAL, Platform.WEBHOOK}:
+            return None, "Signals require a messaging platform target, not local/webhook delivery."
+
+        chat_id = deliver_extra.get("chat_id") or target.chat_id
+        if not chat_id:
+            home = self.config.get_home_channel(target.platform)
+            if not home:
+                return None, f"No chat_id or home channel configured for {target.platform.value}."
+            chat_id = home.chat_id
+            chat_name = home.name
+        else:
+            chat_name = None
+
+        thread_id = deliver_extra.get("thread_id") or target.thread_id
+        existing = self._find_existing_source_for_target(target.platform, str(chat_id), thread_id)
+        if existing:
+            return existing, None
+
+        source = SessionSource(
+            platform=target.platform,
+            chat_id=str(chat_id),
+            chat_name=chat_name,
+            chat_type="dm",
+            thread_id=thread_id,
+        )
+        return source, None
+
+    @staticmethod
+    def _signal_recency_bucket(last_activity: Optional[datetime]) -> str:
+        if not last_activity:
+            return "cold"
+        age_seconds = max(0.0, (datetime.now() - last_activity).total_seconds())
+        if age_seconds <= 120:
+            return "hot"
+        if age_seconds <= 900:
+            return "warm"
+        return "cold"
+
+    def _format_signal_prompt_block(self, signals: List[SignalRecord], *, active_turn: bool, recency: str) -> str:
+        signal_lines: List[str] = []
+        for signal in signals:
+            signal_lines.append(
+                f"- {signal.title} | priority={signal.priority} | reason={signal.reason}\n"
+                f"  summary: {signal.summary}"
+            )
+            if signal.action_items:
+                signal_lines.append(f"  action_items: {json.dumps(signal.action_items, ensure_ascii=False)}")
+            if signal.metadata:
+                signal_lines.append(f"  metadata: {json.dumps(signal.metadata, ensure_ascii=False, default=str)}")
+
+        guidance = (
+            "These Cortex signals arrived during the current turn. Weave them in naturally if relevant; "
+            "if they are unrelated, finish the current answer cleanly and then mention them briefly."
+            if active_turn
+            else (
+                f"You are waking the user due to one or more external events. Session recency is {recency}. "
+                "Phrase the message naturally for that recency. Do not mention internal signal or webhook machinery unless it helps."
+            )
+        )
+        return (
+            f"{guidance}\n\n"
+            "Signals:\n"
+            + "\n".join(signal_lines)
+        )
+
+    def _build_signal_persist_marker(self, signals: List[SignalRecord]) -> str:
+        if not signals:
+            return "[System event: Cortex signals received.]"
+        if len(signals) == 1:
+            title = signals[0].title.replace('"', "'")
+            return f'[System event: signal "{title}" received.]'
+        return f"[System event: {len(signals)} signals received.]"
+
+    async def _maybe_schedule_signal_wake(self, session_key: str, *, delay_seconds: float = 0.0) -> None:
+        """Wake an idle session when undelivered Cortex signals exist."""
+        if not self.cortex.has_pending(session_key):
+            return
+        if session_key in self._running_agents:
+            return
+        existing = self._signal_wake_tasks.get(session_key)
+        if existing and not existing.done():
+            return
+
+        async def _runner() -> None:
+            try:
+                if delay_seconds > 0:
+                    await asyncio.sleep(delay_seconds)
+                await self._deliver_pending_signals(session_key)
+            finally:
+                self._signal_wake_tasks.pop(session_key, None)
+
+        self._signal_wake_tasks[session_key] = asyncio.create_task(_runner())
+
+    async def _deliver_pending_signals(self, session_key: str) -> None:
+        """Claim pending signals and deliver them as a synthetic wake turn."""
+        if session_key in self._running_agents:
+            return
+
+        signals = self.cortex.claim_pending(session_key)
+        if not signals:
+            return
+
+        self.session_store._ensure_loaded()
+        entry = self.session_store._entries.get(session_key)
+        source = entry.origin if entry and entry.origin else None
+        if source is None:
+            logger.warning("Cannot deliver Cortex signal for %s: missing session origin", session_key)
+            return
+
+        recency = self._signal_recency_bucket(entry.updated_at if entry else None)
+        event = MessageEvent(
+            text=self._format_signal_prompt_block(signals, active_turn=False, recency=recency),
+            message_type=MessageType.TEXT,
+            source=source,
+            metadata={
+                "persist_user_message": self._build_signal_persist_marker(signals),
+                "synthetic_signal_delivery": True,
+            },
+        )
+
+        synthetic_session_key = self._session_key_for_source(source)
+        if synthetic_session_key in self._running_agents:
+            return
+
+        self._running_agents[synthetic_session_key] = _AGENT_PENDING_SENTINEL
+        try:
+            response = await self._handle_message_with_agent(event, source, synthetic_session_key)
+            if response:
+                adapter = self.adapters.get(source.platform)
+                if adapter:
+                    send_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                    await adapter.send(source.chat_id, response, metadata=send_meta)
+        except Exception:
+            logger.exception("Failed to deliver pending Cortex signals for %s", session_key)
+        finally:
+            if self._running_agents.get(synthetic_session_key) is _AGENT_PENDING_SENTINEL:
+                del self._running_agents[synthetic_session_key]
 
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         from agent.smart_model_routing import resolve_turn_route
@@ -1852,6 +2024,7 @@ class GatewayRunner:
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str):
         """Inner handler that runs under the _running_agents sentinel guard."""
+        event_metadata = getattr(event, "metadata", None) or {}
 
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
@@ -2198,10 +2371,15 @@ class GatewayRunner:
             )
         
         # One-time prompt if no home channel is set for this platform
-        if not history and source.platform and source.platform != Platform.LOCAL:
+        if not history and source.platform and source.platform not in {Platform.LOCAL, Platform.WEBHOOK}:
             platform_name = source.platform.value
             env_key = f"{platform_name.upper()}_HOME_CHANNEL"
-            if not os.getenv(env_key):
+            home_channel = None
+            try:
+                home_channel = self.config.get_home_channel(source.platform)
+            except Exception:
+                home_channel = None
+            if not os.getenv(env_key) and not home_channel:
                 adapter = self.adapters.get(source.platform)
                 if adapter:
                     await adapter.send(
@@ -2394,7 +2572,9 @@ class GatewayRunner:
                 history=history,
                 source=source,
                 session_id=session_entry.session_id,
-                session_key=session_key
+                session_key=session_key,
+                event_metadata=event_metadata,
+                persist_user_message=event_metadata.get("persist_user_message"),
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -2407,6 +2587,9 @@ class GatewayRunner:
 
             response = agent_result.get("final_response") or ""
             agent_messages = agent_result.get("messages", [])
+
+            if agent_result.get("interrupted") and self.cortex.has_pending(session_key):
+                response = ""
 
             # Surface error details when the agent failed silently (final_response=None)
             if not response and agent_result.get("failed"):
@@ -2601,8 +2784,10 @@ class GatewayRunner:
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                         )
+                await self._maybe_schedule_signal_wake(session_key)
                 return None
 
+            await self._maybe_schedule_signal_wake(session_key)
             return response
             
         except Exception as e:
@@ -3158,6 +3343,12 @@ class GatewayRunner:
         platform_name = source.platform.value if source.platform else "unknown"
         chat_id = source.chat_id
         chat_name = source.chat_name or chat_id
+
+        if source.platform in {None, Platform.LOCAL, Platform.WEBHOOK}:
+            return (
+                "This platform does not use a home channel. "
+                "Run /sethome from a real messaging chat like Telegram, Discord, Slack, Signal, Email, or SMS."
+            )
         
         env_key = f"{platform_name.upper()}_HOME_CHANNEL"
         
@@ -3174,6 +3365,14 @@ class GatewayRunner:
                 yaml.dump(user_config, f, default_flow_style=False)
             # Also set in the current environment so it takes effect immediately
             os.environ[env_key] = str(chat_id)
+            from gateway.config import HomeChannel, PlatformConfig
+            platform_cfg = self.config.platforms.setdefault(source.platform, PlatformConfig())
+            platform_cfg.enabled = True
+            platform_cfg.home_channel = HomeChannel(
+                platform=source.platform,
+                chat_id=str(chat_id),
+                name=str(chat_name),
+            )
         except Exception as e:
             return f"Failed to save home channel: {e}"
         
@@ -4847,6 +5046,8 @@ class GatewayRunner:
         session_id: str,
         session_key: str = None,
         _interrupt_depth: int = 0,
+        event_metadata: Optional[Dict[str, Any]] = None,
+        persist_user_message: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -4875,6 +5076,7 @@ class GatewayRunner:
             Platform.HOMEASSISTANT: "hermes-homeassistant",
             Platform.EMAIL: "hermes-email",
             Platform.DINGTALK: "hermes-dingtalk",
+            Platform.WEBHOOK: "hermes-webhook",
         }
 
         # Try to load platform_toolsets from config
@@ -4900,6 +5102,7 @@ class GatewayRunner:
             Platform.HOMEASSISTANT: "homeassistant",
             Platform.EMAIL: "email",
             Platform.DINGTALK: "dingtalk",
+            Platform.WEBHOOK: "webhook",
         }.get(source.platform, "telegram")
         
         # Use config override if present (list of toolsets), otherwise hardcoded default
@@ -4909,6 +5112,11 @@ class GatewayRunner:
         else:
             default_toolset = default_toolset_map.get(source.platform, "hermes-telegram")
             enabled_toolsets = [default_toolset]
+
+        event_metadata = event_metadata or {}
+        webhook_meta = event_metadata.get("webhook", {}) if isinstance(event_metadata.get("webhook"), dict) else {}
+        if source.platform == Platform.WEBHOOK and webhook_meta.get("deliver_type") == "signal":
+            enabled_toolsets = list(dict.fromkeys(list(enabled_toolsets) + ["cortex-signal"]))
         
         # Tool progress mode from config.yaml: "all", "new", "verbose", "off"
         # Falls back to env vars for backward compatibility
@@ -5115,6 +5323,69 @@ class GatewayRunner:
             except Exception as _e:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
 
+        target_signal_source = None
+        target_signal_session_key = None
+        signal_source_ref = None
+        if source.platform == Platform.WEBHOOK and webhook_meta.get("deliver_type") == "signal":
+            target_signal_source, signal_target_error = self._resolve_cortex_target_source(
+                webhook_meta.get("deliver", ""),
+                webhook_meta.get("deliver_extra") or {},
+            )
+            if target_signal_source:
+                target_signal_session_key = self._session_key_for_source(target_signal_source)
+                signal_source_ref = (
+                    f"{webhook_meta.get('route_name', 'webhook')}:"
+                    f"{webhook_meta.get('delivery_id', session_id)}"
+                )
+            else:
+                logger.warning("Webhook signal mode target resolution failed: %s", signal_target_error)
+
+        def _signal_callback_sync(
+            *,
+            title: str,
+            summary: str,
+            reason: str,
+            priority: str = "normal",
+            action_items=None,
+            metadata=None,
+        ) -> str:
+            if not target_signal_source or not target_signal_session_key or not signal_source_ref:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": "No valid signal target is configured for this webhook route.",
+                    }
+                )
+
+            signal = self.cortex.create_signal(
+                target_session_key=target_signal_session_key,
+                source_type="webhook",
+                source_ref=signal_source_ref,
+                title=title,
+                summary=summary,
+                priority=priority or "normal",
+                reason=reason,
+                action_items=action_items or [],
+                metadata=metadata or {},
+            )
+
+            running_agent = self._running_agents.get(target_signal_session_key)
+            if not running_agent:
+                _loop_for_step.call_soon_threadsafe(
+                    lambda: asyncio.create_task(
+                        self._maybe_schedule_signal_wake(target_signal_session_key)
+                    )
+                )
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "signal_id": signal.signal_id,
+                    "target": target_signal_session_key,
+                    "state": signal.state,
+                }
+            )
+
         def run_sync():
             # Pass session_key to process registry via env var so background
             # processes can be mapped back to this gateway session
@@ -5232,6 +5503,8 @@ class GatewayRunner:
                     honcho_config=honcho_config,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    signal_callback=_signal_callback_sync if webhook_meta.get("deliver_type") == "signal" else None,
+                    turn_signal_poll_callback=None,
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
@@ -5245,6 +5518,8 @@ class GatewayRunner:
             agent.stream_delta_callback = _stream_delta_cb
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
+            agent.signal_callback = _signal_callback_sync if webhook_meta.get("deliver_type") == "signal" else None
+            agent.turn_signal_poll_callback = None
             
             # Store agent reference for interrupt support
             agent_holder[0] = agent
@@ -5306,7 +5581,12 @@ class GatewayRunner:
                             if _p:
                                 _history_media_paths.add(_p)
             
-            result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+            result = agent.run_conversation(
+                message,
+                conversation_history=agent_history,
+                task_id=session_id,
+                persist_user_message=persist_user_message,
+            )
             result_holder[0] = result
 
             # Signal the stream consumer that the agent is done
@@ -5571,6 +5851,7 @@ class GatewayRunner:
                     session_id=session_id,
                     session_key=session_key,
                     _interrupt_depth=_interrupt_depth + 1,
+                    event_metadata=event_metadata,
                 )
         finally:
             # Stop progress sender and interrupt monitor
@@ -5593,6 +5874,18 @@ class GatewayRunner:
             tracking_task.cancel()
             if session_key and session_key in self._running_agents:
                 del self._running_agents[session_key]
+            if session_key and self.cortex.has_pending(session_key):
+                try:
+                    await self._maybe_schedule_signal_wake(
+                        session_key,
+                        delay_seconds=0.35,
+                    )
+                except Exception as signal_err:
+                    logger.debug(
+                        "Failed to schedule post-turn signal wake for %s: %s",
+                        session_key,
+                        signal_err,
+                    )
             
             # Wait for cancelled tasks
             for task in [progress_task, interrupt_monitor, tracking_task]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -755,10 +755,12 @@ class GatewayRunner:
         guidance = (
             "These Cortex signals arrived during the current turn. Weave them in naturally if relevant; "
             "if they are unrelated, finish the current answer cleanly and then mention them briefly."
+            "Suggest an action if it is genuinly helpful to the user and relevant to context of each signal. Example, suggest setting a reminder for an upcoming bill or appointment."
             if active_turn
             else (
                 f"You are waking the user due to one or more external events. Session recency is {recency}. "
                 "Phrase the message naturally for that recency. Do not mention internal signal or webhook machinery unless it helps."
+                "Suggest an action if it is genuinly helpful to the user and relevant to context of each signal. Example, suggest setting a reminder for an upcoming bill or appointment."
             )
         )
         return (
@@ -777,7 +779,7 @@ class GatewayRunner:
 
     async def _maybe_schedule_signal_wake(self, session_key: str, *, delay_seconds: float = 0.0) -> None:
         """Wake an idle session when undelivered Cortex signals exist."""
-        if not self.cortex.has_pending(session_key):
+        if not getattr(self, "cortex", None) or not self.cortex.has_pending(session_key):
             return
         if session_key in self._running_agents:
             return
@@ -2588,7 +2590,7 @@ class GatewayRunner:
             response = agent_result.get("final_response") or ""
             agent_messages = agent_result.get("messages", [])
 
-            if agent_result.get("interrupted") and self.cortex.has_pending(session_key):
+            if agent_result.get("interrupted") and getattr(self, "cortex", None) and self.cortex.has_pending(session_key):
                 response = ""
 
             # Surface error details when the agent failed silently (final_response=None)
@@ -5874,7 +5876,7 @@ class GatewayRunner:
             tracking_task.cancel()
             if session_key and session_key in self._running_agents:
                 del self._running_agents[session_key]
-            if session_key and self.cortex.has_pending(session_key):
+            if session_key and getattr(self, "cortex", None) and self.cortex.has_pending(session_key):
                 try:
                     await self._maybe_schedule_signal_wake(
                         session_key,

--- a/model_tools.py
+++ b/model_tools.py
@@ -154,6 +154,7 @@ def _discover_tools():
         "tools.clarify_tool",
         "tools.code_execution_tool",
         "tools.delegate_tool",
+        "tools.signal_user_tool",
         "tools.process_registry",
         "tools.send_message_tool",
         "tools.honcho_tools",
@@ -361,7 +362,7 @@ def get_tool_definitions(
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "signal_user"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 
@@ -373,6 +374,7 @@ def handle_function_call(
     enabled_tools: Optional[List[str]] = None,
     honcho_manager: Optional[Any] = None,
     honcho_session_key: Optional[str] = None,
+    signal_callback: Optional[Any] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -419,6 +421,7 @@ def handle_function_call(
                 enabled_tools=sandbox_enabled,
                 honcho_manager=honcho_manager,
                 honcho_session_key=honcho_session_key,
+                signal_callback=signal_callback,
             )
         else:
             result = registry.dispatch(
@@ -427,6 +430,7 @@ def handle_function_call(
                 user_task=user_task,
                 honcho_manager=honcho_manager,
                 honcho_session_key=honcho_session_key,
+                signal_callback=signal_callback,
             )
 
         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4720,16 +4720,7 @@ class AIAgent:
                 parent_agent=self,
             )
         elif function_name == "signal_user":
-            from tools.signal_user_tool import signal_user_tool as _signal_user_tool
-            return _signal_user_tool(
-                title=function_args.get("title", ""),
-                summary=function_args.get("summary", ""),
-                reason=function_args.get("reason", "notify"),
-                priority=function_args.get("priority", "normal"),
-                action_items=function_args.get("action_items"),
-                metadata=function_args.get("metadata"),
-                callback=self.signal_callback,
-            )
+            return self._dispatch_signal_user(function_args)
         else:
             return handle_function_call(
                 function_name, function_args, effective_task_id,
@@ -4738,6 +4729,18 @@ class AIAgent:
                 honcho_session_key=self._honcho_session_key,
                 signal_callback=self.signal_callback,
             )
+
+    def _dispatch_signal_user(self, function_args: dict) -> str:
+        from tools.signal_user_tool import signal_user_tool as _signal_user_tool
+        return _signal_user_tool(
+            title=function_args.get("title", ""),
+            summary=function_args.get("summary", ""),
+            reason=function_args.get("reason", "notify"),
+            priority=function_args.get("priority", "normal"),
+            action_items=function_args.get("action_items"),
+            metadata=function_args.get("metadata"),
+            callback=self.signal_callback,
+        )
 
     def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute multiple tool calls concurrently using a thread pool.
@@ -5091,16 +5094,7 @@ class AIAgent:
                     elif self.quiet_mode:
                         self._vprint(f"  {cute_msg}")
             elif function_name == "signal_user":
-                from tools.signal_user_tool import signal_user_tool as _signal_user_tool
-                function_result = _signal_user_tool(
-                    title=function_args.get("title", ""),
-                    summary=function_args.get("summary", ""),
-                    reason=function_args.get("reason", "notify"),
-                    priority=function_args.get("priority", "normal"),
-                    action_items=function_args.get("action_items"),
-                    metadata=function_args.get("metadata"),
-                    callback=self.signal_callback,
-                )
+                function_result = self._dispatch_signal_user(function_args)
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
                     self._vprint(f"  {_get_cute_tool_message_impl('signal_user', function_args, tool_duration, result=function_result)}")

--- a/run_agent.py
+++ b/run_agent.py
@@ -354,6 +354,26 @@ def _inject_honcho_turn_context(content, turn_context: str):
     return f"{text}\n\n{note}"
 
 
+def _inject_live_turn_context(content, label: str, turn_context: str):
+    """Append transient gateway/runtime context to the current-turn user message."""
+    if not turn_context:
+        return content
+
+    note = (
+        f"[System note: The following {label} was added during this turn. "
+        "It is transient context for this turn only, not a new user message.]\n\n"
+        f"{turn_context}"
+    )
+
+    if isinstance(content, list):
+        return list(content) + [{"type": "text", "text": note}]
+
+    text = "" if content is None else str(content)
+    if not text.strip():
+        return note
+    return f"{text}\n\n{note}"
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -407,6 +427,8 @@ class AIAgent:
         stream_delta_callback: callable = None,
         tool_gen_callback: callable = None,
         status_callback: callable = None,
+        signal_callback: callable = None,
+        turn_signal_poll_callback: callable = None,
         max_tokens: int = None,
         reasoning_config: Dict[str, Any] = None,
         prefill_messages: List[Dict[str, Any]] = None,
@@ -536,6 +558,8 @@ class AIAgent:
         self.stream_delta_callback = stream_delta_callback
         self.status_callback = status_callback
         self.tool_gen_callback = tool_gen_callback
+        self.signal_callback = signal_callback
+        self.turn_signal_poll_callback = turn_signal_poll_callback
         self._last_reported_tool = None  # Track for "new tool" mode
         
         # Tool execution state — allows _vprint during tool execution
@@ -4695,12 +4719,24 @@ class AIAgent:
                 max_iterations=function_args.get("max_iterations"),
                 parent_agent=self,
             )
+        elif function_name == "signal_user":
+            from tools.signal_user_tool import signal_user_tool as _signal_user_tool
+            return _signal_user_tool(
+                title=function_args.get("title", ""),
+                summary=function_args.get("summary", ""),
+                reason=function_args.get("reason", "notify"),
+                priority=function_args.get("priority", "normal"),
+                action_items=function_args.get("action_items"),
+                metadata=function_args.get("metadata"),
+                callback=self.signal_callback,
+            )
         else:
             return handle_function_call(
                 function_name, function_args, effective_task_id,
                 enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                 honcho_manager=self._honcho,
                 honcho_session_key=self._honcho_session_key,
+                signal_callback=self.signal_callback,
             )
 
     def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
@@ -5054,6 +5090,20 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self.quiet_mode:
                         self._vprint(f"  {cute_msg}")
+            elif function_name == "signal_user":
+                from tools.signal_user_tool import signal_user_tool as _signal_user_tool
+                function_result = _signal_user_tool(
+                    title=function_args.get("title", ""),
+                    summary=function_args.get("summary", ""),
+                    reason=function_args.get("reason", "notify"),
+                    priority=function_args.get("priority", "normal"),
+                    action_items=function_args.get("action_items"),
+                    metadata=function_args.get("metadata"),
+                    callback=self.signal_callback,
+                )
+                tool_duration = time.time() - tool_start_time
+                if self.quiet_mode:
+                    self._vprint(f"  {_get_cute_tool_message_impl('signal_user', function_args, tool_duration, result=function_result)}")
             elif self.quiet_mode:
                 face = random.choice(KawaiiSpinner.KAWAII_WAITING)
                 emoji = _get_tool_emoji(function_name)
@@ -5069,6 +5119,7 @@ class AIAgent:
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                         honcho_manager=self._honcho,
                         honcho_session_key=self._honcho_session_key,
+                        signal_callback=self.signal_callback,
                     )
                     _spinner_result = function_result
                 except Exception as tool_error:
@@ -5085,6 +5136,7 @@ class AIAgent:
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                         honcho_manager=self._honcho,
                         honcho_session_key=self._honcho_session_key,
+                        signal_callback=self.signal_callback,
                     )
                 except Exception as tool_error:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"
@@ -5434,6 +5486,7 @@ class AIAgent:
         self._codex_incomplete_retries = 0
         self._last_content_with_tools = None
         self._mute_post_response = False
+        self._turn_signal_context = ""
         # NOTE: _turns_since_memory and _iters_since_skill are NOT reset here.
         # They are initialized in __init__ and must persist across run_conversation
         # calls so that nudge logic accumulates correctly in CLI mode.
@@ -5613,6 +5666,15 @@ class AIAgent:
                 if not self.quiet_mode:
                     self._safe_print(f"\n⚡ Breaking out of tool loop due to interrupt...")
                 break
+
+            self._turn_signal_context = ""
+            if self.turn_signal_poll_callback:
+                try:
+                    polled_signal_context = self.turn_signal_poll_callback()
+                    if polled_signal_context:
+                        self._turn_signal_context = str(polled_signal_context)
+                except Exception as signal_err:
+                    logger.debug("turn_signal_poll_callback failed: %s", signal_err)
             
             api_call_count += 1
             if not self.iteration_budget.consume():
@@ -5654,6 +5716,12 @@ class AIAgent:
                 if idx == current_turn_user_idx and msg.get("role") == "user" and self._honcho_turn_context:
                     api_msg["content"] = _inject_honcho_turn_context(
                         api_msg.get("content", ""), self._honcho_turn_context
+                    )
+                if idx == current_turn_user_idx and msg.get("role") == "user" and self._turn_signal_context:
+                    api_msg["content"] = _inject_live_turn_context(
+                        api_msg.get("content", ""),
+                        "live Cortex signals",
+                        self._turn_signal_context,
                     )
 
                 # For ALL assistant messages, pass reasoning back to the API

--- a/tests/gateway/test_cortex_signals.py
+++ b/tests/gateway/test_cortex_signals.py
@@ -1,0 +1,347 @@
+"""Gateway Cortex signal tests."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, StreamingConfig
+from gateway.platforms.base import SendResult
+from gateway.session import SessionSource
+
+
+def _make_runner(tmp_path):
+    from gateway.run import GatewayRunner
+
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token"),
+            Platform.WEBHOOK: PlatformConfig(enabled=True, extra={}),
+        },
+        sessions_dir=tmp_path / "sessions",
+        streaming=StreamingConfig(enabled=False),
+        always_log_local=False,
+    )
+    runner = GatewayRunner(config=config)
+    return runner
+
+
+class FakeAIAgent:
+    instances = []
+    emit_signal_payload = None
+
+    def __init__(self, *args, **kwargs):
+        self.__class__.instances.append(self)
+        self.tools = []
+        self.enabled_toolsets = kwargs.get("enabled_toolsets") or []
+        self.signal_callback = kwargs.get("signal_callback")
+        self.turn_signal_poll_callback = kwargs.get("turn_signal_poll_callback")
+        self.model = kwargs.get("model", "fake-model")
+        self.provider = kwargs.get("provider", "openrouter")
+        self.base_url = kwargs.get("base_url", "https://example.test/v1")
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_id = kwargs.get("session_id", "sess_fake")
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+
+    def run_conversation(self, message, conversation_history=None, task_id=None, persist_user_message=None):
+        self.message = message
+        self.persist_user_message = persist_user_message
+        if self.emit_signal_payload and self.signal_callback:
+            self.signal_callback(**self.emit_signal_payload)
+        return {
+            "final_response": "ok",
+            "messages": [
+                {"role": "user", "content": persist_user_message or message},
+                {"role": "assistant", "content": "ok"},
+            ],
+            "api_calls": 1,
+            "model": self.model,
+            "provider": self.provider,
+            "base_url": self.base_url,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "last_prompt_tokens": 0,
+            "estimated_cost_usd": 0.0,
+            "cost_status": "included",
+            "cost_source": "test",
+        }
+
+
+@pytest.mark.asyncio
+async def test_run_agent_adds_cortex_signal_toolset_only_for_signal_webhooks(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = _make_runner(tmp_path)
+    source = SessionSource(
+        platform=Platform.WEBHOOK,
+        chat_id="webhook:email:1",
+        chat_type="webhook",
+        user_id="webhook:email",
+    )
+
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "fake-model")
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: {
+            "api_key": "test-key",
+            "base_url": "https://example.test/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+        },
+    )
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_resolve_turn_agent_config",
+        lambda self, user_message, model, runtime_kwargs: {"model": model, "runtime": runtime_kwargs},
+    )
+    monkeypatch.setattr(GatewayRunner, "_get_or_create_gateway_honcho", lambda self, session_key: (None, None))
+    monkeypatch.setattr("run_agent.AIAgent", FakeAIAgent)
+
+    FakeAIAgent.instances.clear()
+    await runner._run_agent(
+        message="process webhook",
+        context_prompt="ctx",
+        history=[],
+        source=source,
+        session_id="sess_webhook",
+        session_key="agent:main:webhook:webhook:webhook:email:1",
+        event_metadata={
+            "webhook": {
+                "route_name": "email",
+                "delivery_id": "1",
+                "deliver_type": "signal",
+                "deliver": "telegram",
+                "deliver_extra": {"chat_id": "tg-123"},
+            }
+        },
+    )
+    assert FakeAIAgent.instances
+    assert "cortex-signal" in FakeAIAgent.instances[-1].enabled_toolsets
+    assert FakeAIAgent.instances[-1].signal_callback is not None
+    assert FakeAIAgent.instances[-1].turn_signal_poll_callback is None
+
+    FakeAIAgent.instances.clear()
+    await runner._run_agent(
+        message="process webhook",
+        context_prompt="ctx",
+        history=[],
+        source=source,
+        session_id="sess_webhook",
+        session_key="agent:main:webhook:webhook:webhook:email:1",
+        event_metadata={
+            "webhook": {
+                "route_name": "email",
+                "delivery_id": "1",
+                "deliver_type": "always",
+                "deliver": "telegram",
+                "deliver_extra": {"chat_id": "tg-123"},
+            }
+        },
+    )
+    assert FakeAIAgent.instances
+    assert "cortex-signal" not in FakeAIAgent.instances[-1].enabled_toolsets
+    assert FakeAIAgent.instances[-1].signal_callback is None
+    assert FakeAIAgent.instances[-1].turn_signal_poll_callback is None
+
+
+@pytest.mark.asyncio
+async def test_signal_mode_webhook_run_can_enqueue_cortex_signal(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = _make_runner(tmp_path)
+    target_source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="tg-123",
+        chat_type="dm",
+        user_id="user-telegram",
+    )
+    target_entry = runner.session_store.get_or_create_session(target_source)
+
+    source = SessionSource(
+        platform=Platform.WEBHOOK,
+        chat_id="webhook:email:2",
+        chat_type="webhook",
+        user_id="webhook:email",
+    )
+
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "fake-model")
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: {
+            "api_key": "test-key",
+            "base_url": "https://example.test/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+        },
+    )
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_resolve_turn_agent_config",
+        lambda self, user_message, model, runtime_kwargs: {"model": model, "runtime": runtime_kwargs},
+    )
+    monkeypatch.setattr(GatewayRunner, "_get_or_create_gateway_honcho", lambda self, session_key: (None, None))
+    monkeypatch.setattr("run_agent.AIAgent", FakeAIAgent)
+
+    FakeAIAgent.instances.clear()
+    FakeAIAgent.emit_signal_payload = {
+        "title": "Invoice needs review",
+        "summary": "A draft reply was prepared for the invoice email.",
+        "reason": "input_required",
+        "priority": "normal",
+        "action_items": ["Review the draft", "Confirm whether to send it"],
+        "metadata": {"email_id": "email_88", "draft_id": "draft_99"},
+    }
+    runner._running_agents[target_entry.session_key] = object()
+    try:
+        await runner._run_agent(
+            message="process webhook",
+            context_prompt="ctx",
+            history=[],
+            source=source,
+            session_id="sess_webhook",
+            session_key="agent:main:webhook:webhook:webhook:email:2",
+            event_metadata={
+                "webhook": {
+                    "route_name": "email",
+                    "delivery_id": "2",
+                    "deliver_type": "signal",
+                    "deliver": "telegram",
+                    "deliver_extra": {"chat_id": "tg-123"},
+                }
+            },
+        )
+    finally:
+        FakeAIAgent.emit_signal_payload = None
+        runner._running_agents.pop(target_entry.session_key, None)
+
+    assert runner.cortex.has_pending(target_entry.session_key)
+    signals = runner.cortex.claim_pending(target_entry.session_key)
+    assert len(signals) == 1
+    assert signals[0].title == "Invoice needs review"
+    assert signals[0].reason == "input_required"
+    assert signals[0].metadata["email_id"] == "email_88"
+
+
+@pytest.mark.asyncio
+async def test_deliver_pending_signals_wakes_session_naturally(tmp_path, monkeypatch):
+    runner = _make_runner(tmp_path)
+    adapter = AsyncMock()
+    adapter.send = AsyncMock(return_value=SendResult(success=True))
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+        user_name="Ambrose",
+    )
+    entry = runner.session_store.get_or_create_session(source)
+    session_key = entry.session_key
+
+    captured = {}
+
+    async def fake_handle_message_with_agent(event, source_arg, quick_key):
+        captured["event"] = event
+        captured["source"] = source_arg
+        captured["quick_key"] = quick_key
+        return "Here is the follow-up."
+
+    monkeypatch.setattr(runner, "_handle_message_with_agent", fake_handle_message_with_agent)
+
+    runner.cortex.create_signal(
+        target_session_key=session_key,
+        source_type="webhook",
+        source_ref="email:delivery-1",
+        title="Electric bill due",
+        summary="The electricity invoice is due next week and a draft reply was prepared.",
+        reason="notify",
+        action_items=["Review the draft reply", "Confirm whether to pay this week"],
+        metadata={"email_id": "email_123", "draft_id": "draft_456"},
+    )
+
+    await runner._deliver_pending_signals(session_key)
+
+    assert not runner.cortex.has_pending(session_key)
+    assert captured["quick_key"] == session_key
+    assert captured["event"].metadata["persist_user_message"] == '[System event: signal "Electric bill due" received.]'
+    assert "email_123" in captured["event"].text
+    assert "Do not mention internal signal or webhook machinery" in captured["event"].text
+    adapter.send.assert_awaited_once_with("12345", "Here is the follow-up.", metadata=None)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_schedules_post_turn_signal_followup_after_cleanup(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = _make_runner(tmp_path)
+    source = SessionSource(
+        platform=Platform.WEBHOOK,
+        chat_id="webhook:email:postturn",
+        chat_type="webhook",
+        user_id="webhook:email",
+    )
+    session_key = "agent:main:webhook:webhook:webhook:email:postturn"
+
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "fake-model")
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: {
+            "api_key": "test-key",
+            "base_url": "https://example.test/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+        },
+    )
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_resolve_turn_agent_config",
+        lambda self, user_message, model, runtime_kwargs: {"model": model, "runtime": runtime_kwargs},
+    )
+    monkeypatch.setattr(GatewayRunner, "_get_or_create_gateway_honcho", lambda self, session_key: (None, None))
+    monkeypatch.setattr("run_agent.AIAgent", FakeAIAgent)
+
+    runner.cortex.create_signal(
+        target_session_key=session_key,
+        source_type="webhook",
+        source_ref="email:postturn",
+        title="Queued during run",
+        summary="This signal should be delivered after the foreground run ends.",
+    )
+    deliver_mock = AsyncMock()
+    monkeypatch.setattr(runner, "_deliver_pending_signals", deliver_mock)
+
+    await runner._run_agent(
+        message="process webhook",
+        context_prompt="ctx",
+        history=[],
+        source=source,
+        session_id="sess_webhook",
+        session_key=session_key,
+        event_metadata={
+            "webhook": {
+                "route_name": "email",
+                "delivery_id": "postturn",
+                "deliver_type": "signal",
+                "deliver": "telegram",
+                "deliver_extra": {"chat_id": "tg-123"},
+            }
+        },
+    )
+
+    await asyncio.sleep(0.5)
+    deliver_mock.assert_awaited_once_with(session_key)

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -54,7 +54,7 @@ class _CapturingAgent:
         type(self).last_init = dict(kwargs)
         self.tools = []
 
-    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None, **kwargs):
         return {
             "final_response": "ok",
             "messages": [],

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -59,7 +59,7 @@ class FakeAgent:
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
         self.tools = []
 
-    def run_conversation(self, message, conversation_history=None, task_id=None):
+    def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
         self.tool_progress_callback("terminal", "pwd")
         time.sleep(0.35)
         self.tool_progress_callback("browser_navigate", "https://example.com")

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -211,6 +211,14 @@ class TestRenderPrompt:
         assert "my-route" in result
         assert "key" in result
 
+    def test_signal_mode_prompt_instructions_added(self):
+        """Signal-mode routes prepend explicit delivery instructions."""
+        adapter = _make_adapter()
+        result = adapter._augment_signal_prompt("Handle invoice email")
+        assert "final assistant response is NOT shown to the user" in result
+        assert "signal_user" in result
+        assert result.endswith("Handle invoice email")
+
 
 # ===================================================================
 # Delivery extra rendering
@@ -227,6 +235,27 @@ class TestRenderDeliveryExtra:
         assert result["repo"] == "org/repo"
         assert result["pr_number"] == "7"
         assert result["static"] == 42  # non-string left as-is
+
+
+class TestWebhookSendModes:
+    @pytest.mark.asyncio
+    async def test_signal_mode_send_suppresses_final_delivery(self):
+        adapter = _make_adapter()
+        adapter.gateway_runner = MagicMock()
+        adapter.gateway_runner.adapters = {Platform.TELEGRAM: AsyncMock()}
+
+        chat_id = "webhook:alerts:123"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram",
+            "deliver_type": "signal",
+            "deliver_extra": {"chat_id": "999"},
+        }
+
+        result = await adapter.send(chat_id, "This should stay hidden.")
+
+        assert result.success is True
+        adapter.gateway_runner.adapters[Platform.TELEGRAM].send.assert_not_called()
+        assert chat_id not in adapter._delivery_info
 
 
 # ===================================================================
@@ -303,6 +332,43 @@ class TestEventFilter:
                 headers={"X-GitHub-Event": "whatever"},
             )
             assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_signal_mode_sets_event_metadata_and_prompt(self):
+        routes = {
+            "inbox": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "Email subject: {subject}",
+                "deliver": "telegram",
+                "deliver_type": "signal",
+                "deliver_extra": {"chat_id": "12345"},
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        captured_events: list[MessageEvent] = []
+
+        async def _capture(event: MessageEvent):
+            captured_events.append(event)
+
+        adapter.handle_message = _capture
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/inbox",
+                json={"subject": "Power bill due"},
+                headers={"X-GitHub-Delivery": "sig-evt-001"},
+            )
+            assert resp.status == 202
+
+        await asyncio.sleep(0.05)
+
+        assert len(captured_events) == 1
+        event = captured_events[0]
+        assert "signal_user" in event.text
+        assert event.metadata["webhook"]["deliver_type"] == "signal"
+        assert event.metadata["webhook"]["deliver"] == "telegram"
+        assert event.metadata["webhook"]["deliver_extra"]["chat_id"] == "12345"
 
 
 # ===================================================================

--- a/tests/test_anthropic_error_handling.py
+++ b/tests/test_anthropic_error_handling.py
@@ -128,7 +128,7 @@ def _make_agent_cls(error_cls, recover_after=None):
             self._save_trajectory = lambda messages, user_message, completed: None
             self._save_session_log = lambda messages: None
 
-        def run_conversation(self, user_message, conversation_history=None, task_id=None):
+        def run_conversation(self, user_message, conversation_history=None, task_id=None, **kwargs):
             calls = {"n": 0}
 
             def _fake_api_call(api_kwargs):
@@ -263,7 +263,7 @@ def test_401_credential_refresh_recovers(monkeypatch):
             refresh_count["n"] += 1
             return True  # Simulate successful credential refresh
 
-        def run_conversation(self, user_message, conversation_history=None, task_id=None):
+        def run_conversation(self, user_message, conversation_history=None, task_id=None, **kwargs):
             calls = {"n": 0}
 
             def _fake_api_call(api_kwargs):
@@ -341,7 +341,7 @@ def test_401_refresh_fails_is_non_retryable(monkeypatch):
         def _try_refresh_anthropic_client_credentials(self) -> bool:
             return False  # Simulate failed credential refresh
 
-        def run_conversation(self, user_message, conversation_history=None, task_id=None):
+        def run_conversation(self, user_message, conversation_history=None, task_id=None, **kwargs):
             def _fake_api_call(api_kwargs):
                 raise _UnauthorizedError()
 
@@ -423,7 +423,7 @@ def test_prompt_too_long_triggers_compression(monkeypatch):
                 compressed = messages
             return compressed, system_message
 
-        def run_conversation(self, user_message, conversation_history=None, task_id=None):
+        def run_conversation(self, user_message, conversation_history=None, task_id=None, **kwargs):
             calls = {"n": 0}
 
             def _fake_api_call(api_kwargs):

--- a/tests/test_codex_execution_paths.py
+++ b/tests/test_codex_execution_paths.py
@@ -80,7 +80,7 @@ class _Codex401ThenSuccessAgent(run_agent.AIAgent):
         type(self).refresh_attempts += 1
         return True
 
-    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None, **kwargs):
         calls = {"api": 0}
 
         def _fake_api_call(api_kwargs):

--- a/tests/test_context_token_tracking.py
+++ b/tests/test_context_token_tracking.py
@@ -54,7 +54,7 @@ def _make_agent(monkeypatch, api_mode, provider, response_fn):
             self._cleanup_task_resources = self._persist_session = lambda *a, **k: None
             self._save_trajectory = self._save_session_log = lambda *a, **k: None
 
-        def run_conversation(self, msg, conversation_history=None, task_id=None):
+        def run_conversation(self, msg, conversation_history=None, task_id=None, **kwargs):
             self._interruptible_api_call = lambda kw: response_fn()
             return super().run_conversation(msg, conversation_history=conversation_history, task_id=task_id)
 

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1042,6 +1042,7 @@ class TestConcurrentToolExecution:
                 enabled_tools=list(agent.valid_tool_names),
                 honcho_manager=None,
                 honcho_session_key=None,
+                signal_callback=None,
             )
             assert result == "result"
 

--- a/tools/signal_user_tool.py
+++ b/tools/signal_user_tool.py
@@ -1,0 +1,90 @@
+"""Cortex signal emission tool schema."""
+
+import json
+
+from tools.registry import registry
+
+
+def signal_user_tool(
+    title: str,
+    summary: str,
+    reason: str,
+    priority: str = "normal",
+    action_items=None,
+    metadata=None,
+    callback=None,
+):
+    """Gateway-owned tool for surfacing Cortex signals from webhook runs."""
+    if callback is None:
+        return json.dumps(
+            {
+                "success": False,
+                "error": "signal_user is only available in webhook signal runs.",
+            }
+        )
+    return callback(
+        title=title,
+        summary=summary,
+        reason=reason,
+        priority=priority,
+        action_items=action_items,
+        metadata=metadata,
+    )
+
+
+registry.register(
+    name="signal_user",
+    toolset="cortex-signal",
+    schema={
+        "name": "signal_user",
+        "description": (
+            "Notify Hermes about an external event that requires user attention, "
+            "approval, or more input. The final assistant response will not be shown "
+            "to the user in signal-mode webhook runs, so use this tool when the user "
+            "must be notified."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Short headline for the user-facing notification.",
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "Concise factual summary of what happened.",
+                },
+                "reason": {
+                    "type": "string",
+                    "enum": ["notify", "approval_required", "input_required"],
+                    "description": "Why the user should see this signal.",
+                },
+                "priority": {
+                    "type": "string",
+                    "enum": ["normal", "urgent"],
+                    "description": "Urgent may interrupt an active turn.",
+                },
+                "action_items": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Concrete next steps Hermes should present to the user.",
+                },
+                "metadata": {
+                    "type": "object",
+                    "description": "Structured IDs and references Hermes may need later.",
+                },
+            },
+            "required": ["title", "summary", "reason"],
+            "additionalProperties": False,
+        },
+    },
+    handler=lambda args, **kw: signal_user_tool(
+        title=args.get("title", ""),
+        summary=args.get("summary", ""),
+        reason=args.get("reason", "notify"),
+        priority=args.get("priority", "normal"),
+        action_items=args.get("action_items"),
+        metadata=args.get("metadata"),
+        callback=kw.get("signal_callback"),
+    ),
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -196,6 +196,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "cortex-signal": {
+        "description": "Emit Cortex user-facing signals from external event runs",
+        "tools": ["signal_user"],
+        "includes": []
+    },
+
     "honcho": {
         "description": "Honcho AI-native memory for persistent cross-session user modeling",
         "tools": ["honcho_context", "honcho_profile", "honcho_search", "honcho_conclude"],
@@ -293,6 +299,12 @@ TOOLSETS = {
 
     "hermes-email": {
         "description": "Email bot toolset - interact with Hermes via email (IMAP/SMTP)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
+    "hermes-webhook": {
+        "description": "Webhook event toolset - full automation tools without signal emission by default",
         "tools": _HERMES_CORE_TOOLS,
         "includes": []
     },


### PR DESCRIPTION
## What does this PR do?

Adds Cortex signal delivery on top of the existing webhook pipeline.

Webhook routes now support a new `deliver_type` mode:
- `always` keeps the current behavior and delivers the webhook agent’s final response directly to the configured `deliver` target.
- `signal` suppresses the webhook agent’s final response, exposes a new `signal_user` tool to that run, and lets Hermes decide how to surface the event to the user.

This gives Hermes a new Cortex-style signal path for external events. A webhook agent can act silently, or emit a structured signal only when the user actually needs to be notified, asked for input, or asked for approval. Signals are routed using the existing `deliver` / `deliver_extra` target, queued per session, and delivered naturally as a follow-up turn when Hermes is idle or once an active turn finishes.

This PR also fixes an unrelated-but-exposed webhook delivery bug: webhook-originated runs could incorrectly send the `No home channel is set for Webhook` onboarding message into the configured delivery channel (for example Telegram), even when the user had already set a real home channel on their messaging platform. Webhook sessions are now excluded from home-channel onboarding, and `/sethome` rejects unsupported platforms like `webhook` and `local`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `deliver_type: "always" | "signal"` to webhook route handling in [gateway/platforms/webhook.py](/Users/ambrose/hermes-agent/gateway/platforms/webhook.py)
- Added Cortex signal queue/manager and signal record types in [gateway/cortex.py](/Users/ambrose/hermes-agent/gateway/cortex.py)
- Added `signal_user` tool for webhook signal-mode runs in [tools/signal_user_tool.py](/Users/ambrose/hermes-agent/tools/signal_user_tool.py)
- Added webhook-specific toolset wiring so `signal_user` is only available in signal-mode webhook runs in [toolsets.py](/Users/ambrose/hermes-agent/toolsets.py) and [model_tools.py](/Users/ambrose/hermes-agent/model_tools.py)
- Updated gateway runtime in [gateway/run.py](/Users/ambrose/hermes-agent/gateway/run.py) to:
  - resolve signal targets from existing `deliver` / `deliver_extra`
  - suppress final webhook response delivery in signal mode
  - queue signals per session
  - wake idle sessions with a synthetic follow-up turn
  - defer signal delivery until after an active turn completes
  - avoid prompting webhook sessions for a home channel
- Updated [run_agent.py](/Users/ambrose/hermes-agent/run_agent.py) to dispatch `signal_user`
- Added and updated tests in [tests/gateway/test_cortex_signals.py](/Users/ambrose/hermes-agent/tests/gateway/test_cortex_signals.py), [tests/gateway/test_webhook_adapter.py](/Users/ambrose/hermes-agent/tests/gateway/test_webhook_adapter.py), [tests/gateway/test_reasoning_command.py](/Users/ambrose/hermes-agent/tests/gateway/test_reasoning_command.py), [tests/gateway/test_run_progress_topics.py](/Users/ambrose/hermes-agent/tests/gateway/test_run_progress_topics.py), [tests/test_anthropic_error_handling.py](/Users/ambrose/hermes-agent/tests/test_anthropic_error_handling.py), [tests/test_codex_execution_paths.py](/Users/ambrose/hermes-agent/tests/test_codex_execution_paths.py), [tests/test_context_token_tracking.py](/Users/ambrose/hermes-agent/tests/test_context_token_tracking.py), and [tests/test_run_agent.py](/Users/ambrose/hermes-agent/tests/test_run_agent.py)

## How to Test

1. Add this webhook config to `~/.hermes/config.yaml` and start the gateway.

```yaml
webhook:
  enabled: true
  extra:
    port: 8644
    routes:
      invoice-always:
        deliver: telegram
        prompt: |
          Summarize this email event for me.

          Subject: {subject}

          Body: {body}

          Email ID: {email_id}
        secret: INSECURE_NO_AUTH

      invoice-signal:
        deliver: telegram
        deliver_type: signal
        prompt: |
          If this email is a bill, invoice, urgent request, please let me know. Ignore all other emails.

          Your final assistant response is hidden from the user.

          Include durable IDs in metadata.

          Subject: {subject}

          Body: {body}

          Email ID: {email_id}

          Thread ID: {thread_id}
        secret: INSECURE_NO_AUTH
```

2. Verify `always` mode still delivers the webhook agent’s final response directly to the configured Telegram target.

```bash
curl -X POST http://localhost:8644/webhooks/invoice-always \
  -H 'Content-Type: application/json' \
  -d '{
    "subject": "Electric bill due next week",
    "body": "Invoice INV-123 is due next Tuesday.",
    "email_id": "email_123"
  }'
```

3. Verify `signal` mode suppresses the final webhook response and instead sends a natural Hermes follow-up only if the webhook run calls `signal_user`.

```bash
curl -X POST http://localhost:8644/webhooks/invoice-signal \
  -H 'Content-Type: application/json' \
  -d '{
    "subject": "Car insurance bill due next week",
    "body": "Invoice INV002367 $180 is due 27 March. please ensure you pay.",
    "email_id": "email_73734123",
    "thread_id": "thread_111266"
  }'
```

4. While Hermes is idle, confirm the signal wakes the target session and sends a follow-up message in Telegram.
5. While Hermes is already handling a message in that same Telegram session, trigger the `invoice-signal` webhook and confirm Hermes finishes the active turn first, then sends a follow-up message for the queued signal.
6. Confirm that non-urgent/non-relevant emails in signal mode do not produce a user-facing message when the webhook run does not call `signal_user`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused test coverage run:
```bash
source venv/bin/activate && python -m pytest tests/gateway/test_cortex_signals.py tests/gateway/test_webhook_adapter.py::TestWebhookSendModes::test_signal_mode_send_suppresses_final_delivery tests/gateway/test_webhook_adapter.py::TestRenderPrompt::test_signal_mode_prompt_instructions_added tests/gateway/test_reasoning_command.py tests/gateway/test_run_progress_topics.py -q -n0
```

- Additional regression coverage run with isolated `HERMES_HOME`:
```bash
tmpdir=$(mktemp -d /tmp/hermes-review.XXXXXX) && source venv/bin/activate && HERMES_HOME="$tmpdir" python -m pytest tests/test_anthropic_error_handling.py tests/test_codex_execution_paths.py tests/test_context_token_tracking.py tests/test_run_agent.py -q -n0
```