### PR TITLE
feat(delegate): add provider and model overrides

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6278,14 +6278,7 @@ class AIAgent:
             )
         elif function_name == "delegate_task":
             from tools.delegate_tool import delegate_task as _delegate_task
-            return _delegate_task(
-                goal=function_args.get("goal"),
-                context=function_args.get("context"),
-                toolsets=function_args.get("toolsets"),
-                tasks=function_args.get("tasks"),
-                max_iterations=function_args.get("max_iterations"),
-                parent_agent=self,
-            )
+            return _delegate_task(**self._build_delegate_task_kwargs(function_args))
         else:
             return handle_function_call(
                 function_name, function_args, effective_task_id,
@@ -6293,6 +6286,21 @@ class AIAgent:
                 session_id=self.session_id or "",
                 enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
             )
+
+    def _build_delegate_task_kwargs(self, function_args: dict) -> dict:
+        """Normalize delegate_task args shared by sequential and concurrent paths."""
+        return {
+            "goal": function_args.get("goal"),
+            "context": function_args.get("context"),
+            "toolsets": function_args.get("toolsets"),
+            "tasks": function_args.get("tasks"),
+            "provider": function_args.get("provider"),
+            "model": function_args.get("model"),
+            "max_iterations": function_args.get("max_iterations"),
+            "acp_command": function_args.get("acp_command"),
+            "acp_args": function_args.get("acp_args"),
+            "parent_agent": self,
+        }
 
     def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute multiple tool calls concurrently using a thread pool.
@@ -6670,12 +6678,7 @@ class AIAgent:
                 _delegate_result = None
                 try:
                     function_result = _delegate_task(
-                        goal=function_args.get("goal"),
-                        context=function_args.get("context"),
-                        toolsets=function_args.get("toolsets"),
-                        tasks=tasks_arg,
-                        max_iterations=function_args.get("max_iterations"),
-                        parent_agent=self,
+                        **self._build_delegate_task_kwargs(function_args)
                     )
                     _delegate_result = function_result
                 finally:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1381,6 +1381,75 @@ class TestConcurrentToolExecution:
             )
             assert result == "result"
 
+    def test_invoke_tool_forwards_delegate_task_overrides(self, agent):
+        delegate_args = {
+            "goal": "Review the diff",
+            "context": "Check delegate provider overrides",
+            "toolsets": ["terminal", "file"],
+            "tasks": [{"goal": "Task A"}],
+            "provider": "nous",
+            "model": "google/gemini-3-flash-preview",
+            "max_iterations": 12,
+            "acp_command": "copilot",
+            "acp_args": ["--acp", "--stdio"],
+        }
+
+        with patch("tools.delegate_tool.delegate_task", return_value="delegated") as mock_delegate:
+            result = agent._invoke_tool("delegate_task", delegate_args, "task-1")
+
+        mock_delegate.assert_called_once_with(
+            goal="Review the diff",
+            context="Check delegate provider overrides",
+            toolsets=["terminal", "file"],
+            tasks=[{"goal": "Task A"}],
+            provider="nous",
+            model="google/gemini-3-flash-preview",
+            max_iterations=12,
+            acp_command="copilot",
+            acp_args=["--acp", "--stdio"],
+            parent_agent=agent,
+        )
+        assert result == "delegated"
+
+    def test_sequential_delegate_task_forwards_delegate_overrides(self, agent):
+        delegate_args = {
+            "goal": "Review the diff",
+            "provider": "nous",
+            "model": "google/gemini-3-flash-preview",
+            "acp_command": "copilot",
+            "acp_args": ["--acp", "--stdio"],
+        }
+        tool_call = _mock_tool_call(
+            name="delegate_task",
+            arguments=json.dumps(delegate_args),
+            call_id="c1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+
+        with (
+            patch("tools.delegate_tool.delegate_task", return_value='{"results": []}') as mock_delegate,
+            patch.object(agent, "_should_emit_quiet_tool_messages", return_value=False),
+            patch.object(agent, "_should_start_quiet_spinner", return_value=False),
+        ):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        mock_delegate.assert_called_once_with(
+            goal="Review the diff",
+            context=None,
+            toolsets=None,
+            tasks=None,
+            provider="nous",
+            model="google/gemini-3-flash-preview",
+            max_iterations=None,
+            acp_command="copilot",
+            acp_args=["--acp", "--stdio"],
+            parent_agent=agent,
+        )
+        assert len(messages) == 1
+        assert messages[0]["tool_call_id"] == "c1"
+        assert messages[0]["content"] == '{"results": []}'
+
     def test_sequential_tool_callbacks_fire_in_order(self, agent):
         tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -21,6 +21,7 @@ from tools.delegate_tool import (
     DELEGATE_TASK_SCHEMA,
     MAX_CONCURRENT_CHILDREN,
     MAX_DEPTH,
+    _apply_delegation_overrides,
     check_delegate_requirements,
     delegate_task,
     _build_child_agent,
@@ -65,6 +66,8 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("provider", props)
+        self.assertIn("model", props)
         self.assertIn("max_iterations", props)
         self.assertEqual(props["tasks"]["maxItems"], 3)
 
@@ -99,6 +102,27 @@ class TestStripBlockedTools(unittest.TestCase):
     def test_empty_input(self):
         result = _strip_blocked_tools([])
         self.assertEqual(result, [])
+
+
+class TestDelegationOverrides(unittest.TestCase):
+    def test_explicit_model_overrides_config_model(self):
+        cfg = {"model": "anthropic/claude-haiku-3.5", "provider": "openrouter"}
+        result = _apply_delegation_overrides(cfg, model="google/gemini-3-flash-preview")
+        self.assertEqual(result["model"], "google/gemini-3-flash-preview")
+        self.assertEqual(result["provider"], "openrouter")
+
+    def test_explicit_provider_overrides_direct_endpoint_config(self):
+        cfg = {
+            "model": "qwen2.5-coder",
+            "provider": "openrouter",
+            "base_url": "http://localhost:1234/v1",
+            "api_key": "local-key",
+        }
+        result = _apply_delegation_overrides(cfg, provider="nous")
+        self.assertEqual(result["provider"], "nous")
+        self.assertEqual(result["model"], "qwen2.5-coder")
+        self.assertNotIn("base_url", result)
+        self.assertNotIn("api_key", result)
 
 
 class TestDelegateTask(unittest.TestCase):
@@ -929,6 +953,98 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             # But provider/base_url/api_key should inherit from parent
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["base_url"], parent.base_url)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_explicit_provider_and_model_override_config_before_resolution(self, mock_creds, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "anthropic/claude-haiku-3.5",
+            "provider": "openrouter",
+            "base_url": "http://localhost:1234/v1",
+            "api_key": "local-key",
+        }
+        mock_creds.return_value = {
+            "model": "google/gemini-3-flash-preview",
+            "provider": "nous",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "nous-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Done",
+                "api_calls": 1,
+                "duration_seconds": 1.0,
+            }
+
+            delegate_task(
+                goal="Use explicit routing",
+                provider="nous",
+                model="google/gemini-3-flash-preview",
+                parent_agent=parent,
+            )
+
+        mock_creds.assert_called_once_with(
+            {
+                "max_iterations": 45,
+                "model": "google/gemini-3-flash-preview",
+                "provider": "nous",
+            },
+            parent,
+        )
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_explicit_model_override_reaches_all_batch_children(self, mock_creds, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "anthropic/claude-haiku-3.5",
+            "provider": "openrouter",
+        }
+        mock_creds.return_value = {
+            "model": "google/gemini-3-flash-preview",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-batch",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Done",
+                "api_calls": 1,
+                "duration_seconds": 1.0,
+            }
+
+            delegate_task(
+                tasks=[{"goal": "Task A"}, {"goal": "Task B"}],
+                model="google/gemini-3-flash-preview",
+                parent_agent=parent,
+            )
+
+            mock_creds.assert_called_once_with(
+                {
+                    "max_iterations": 45,
+                    "model": "google/gemini-3-flash-preview",
+                    "provider": "openrouter",
+                },
+                parent,
+            )
+            self.assertEqual(mock_build.call_count, 2)
+            for call in mock_build.call_args_list:
+                self.assertEqual(call.kwargs.get("model"), "google/gemini-3-flash-preview")
 
 
 class TestChildCredentialPoolResolution(unittest.TestCase):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1046,6 +1046,47 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             for call in mock_build.call_args_list:
                 self.assertEqual(call.kwargs.get("model"), "google/gemini-3-flash-preview")
 
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_runtime_provider_acp_transport_reaches_child_agent(self, mock_creds, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "claude-sonnet-4.6",
+            "provider": "copilot-acp",
+        }
+        mock_creds.return_value = {
+            "model": "claude-sonnet-4.6",
+            "provider": "copilot-acp",
+            "base_url": "acp://copilot",
+            "api_key": "copilot-acp",
+            "api_mode": "chat_completions",
+            "command": "/usr/bin/copilot",
+            "args": ["--acp", "--stdio"],
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Done",
+                "api_calls": 1,
+                "duration_seconds": 1.0,
+            }
+
+            delegate_task(
+                goal="Use Copilot ACP",
+                provider="copilot-acp",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        self.assertEqual(mock_build.call_args.kwargs.get("override_provider"), "copilot-acp")
+        self.assertEqual(mock_build.call_args.kwargs.get("override_acp_command"), "/usr/bin/copilot")
+        self.assertEqual(mock_build.call_args.kwargs.get("override_acp_args"), ["--acp", "--stdio"])
+
 
 class TestChildCredentialPoolResolution(unittest.TestCase):
     def test_same_provider_shares_parent_pool(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -335,6 +335,39 @@ def _build_child_agent(
 
     return child
 
+
+def _resolve_child_acp_overrides(
+    task: Dict[str, Any],
+    *,
+    top_level_command: Optional[str],
+    top_level_args: Optional[List[str]],
+    runtime_command: Optional[str],
+    runtime_args: Optional[List[str]],
+) -> tuple[Optional[str], Optional[List[str]]]:
+    """Resolve ACP transport overrides for a child task.
+
+    Precedence:
+    1. Per-task override
+    2. Top-level delegate_task override
+    3. Runtime provider-resolved transport
+    4. Parent inheritance inside _build_child_agent()
+    """
+    if "acp_command" in task and task.get("acp_command") is not None:
+        command = task.get("acp_command")
+    elif top_level_command is not None:
+        command = top_level_command
+    else:
+        command = runtime_command
+
+    if "acp_args" in task and task.get("acp_args") is not None:
+        args = task.get("acp_args")
+    elif top_level_args is not None:
+        args = top_level_args
+    else:
+        args = runtime_args
+
+    return command, list(args) if args is not None else None
+
 def _run_single_child(
     task_index: int,
     goal: str,
@@ -592,6 +625,13 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            child_acp_command, child_acp_args = _resolve_child_acp_overrides(
+                t,
+                top_level_command=acp_command,
+                top_level_args=acp_args,
+                runtime_command=creds.get("command"),
+                runtime_args=creds.get("args"),
+            )
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets, model=creds["model"],
@@ -599,8 +639,8 @@ def delegate_task(
                 override_provider=creds["provider"], override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
                 override_api_mode=creds["api_mode"],
-                override_acp_command=t.get("acp_command") or acp_command,
-                override_acp_args=t.get("acp_args") or acp_args,
+                override_acp_command=child_acp_command,
+                override_acp_args=child_acp_args,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -512,6 +512,8 @@ def delegate_task(
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
@@ -543,6 +545,7 @@ def delegate_task(
     cfg = _load_config()
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
+    effective_cfg = _apply_delegation_overrides(cfg, provider=provider, model=model)
 
     # Resolve delegation credentials (provider:model pair).
     # When delegation.provider is configured, this resolves the full credential
@@ -550,7 +553,7 @@ def delegate_task(
     # used by CLI/gateway startup.  When unconfigured, returns None values so
     # children inherit from the parent.
     try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
+        creds = _resolve_delegation_credentials(effective_cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
 
@@ -812,6 +815,30 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     }
 
 
+def _apply_delegation_overrides(
+    cfg: Optional[dict],
+    *,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+) -> dict:
+    """Apply explicit delegate_task provider/model overrides on top of config."""
+    effective_cfg = dict(cfg or {})
+
+    normalized_model = str(model or "").strip() or None
+    normalized_provider = str(provider or "").strip() or None
+
+    if normalized_model:
+        effective_cfg["model"] = normalized_model
+
+    if normalized_provider:
+        effective_cfg["provider"] = normalized_provider
+        # Explicit provider must take precedence over any configured direct endpoint.
+        effective_cfg.pop("base_url", None)
+        effective_cfg.pop("api_key", None)
+
+    return effective_cfg
+
+
 def _load_config() -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
@@ -896,6 +923,24 @@ DELEGATE_TASK_SCHEMA = {
                     "full-stack tasks."
                 ),
             },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Optional provider override for all spawned subagents. "
+                    "Takes priority over delegation.provider in config.yaml. "
+                    "When set, any configured delegation.base_url/api_key direct "
+                    "endpoint is ignored and the named provider is resolved instead."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional model override for all spawned subagents. "
+                    "Takes priority over delegation.model in config.yaml. "
+                    "If unset, delegate_task falls back to delegation.model and "
+                    "then to the parent agent's model."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -969,6 +1014,8 @@ registry.register(
         context=args.get("context"),
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
+        provider=args.get("provider"),
+        model=args.get("model"),
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),


### PR DESCRIPTION
## Summary
- add explicit `provider` and `model` parameters to `delegate_task`
- make explicit tool-call overrides take priority over delegation config values
- ignore configured direct-endpoint delegation settings when an explicit provider is supplied

## Testing
- source venv/bin/activate && python -m pytest tests/tools/test_delegate.py -q
- compared main vs feature-branch failures for the full test suite; no evidence this change introduced new failures