### PR TITLE
fix(plugins): wire-plugin-lifecycle-hooks

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1086,6 +1086,9 @@ class AIAgent:
             else:
                 print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)")
 
+        from hermes_cli.plugins import invoke_hook
+        invoke_hook("on_session_start", session_id=self.session_id, platform=self.platform or "cli")
+
     def reset_session_state(self):
         """Reset all session-scoped token counters to 0 for a fresh session.
         
@@ -3460,6 +3463,8 @@ class AIAgent:
                 if request_client is not None:
                     self._close_request_openai_client(request_client, reason="request_complete")
 
+        from hermes_cli.plugins import invoke_hook
+        invoke_hook("pre_llm_call", messages=api_kwargs.get("messages", []), model=api_kwargs.get("model", ""))
         t = threading.Thread(target=_call, daemon=True)
         t.start()
         while t.is_alive():
@@ -3486,6 +3491,7 @@ class AIAgent:
                 raise InterruptedError("Agent interrupted during API call")
         if result["error"] is not None:
             raise result["error"]
+        invoke_hook("post_llm_call", messages=api_kwargs.get("messages", []), response=result["response"], model=api_kwargs.get("model", ""))
         return result["response"]
 
     # ── Unified streaming API call ─────────────────────────────────────────
@@ -3764,6 +3770,8 @@ class AIAgent:
                 if request_client is not None:
                     self._close_request_openai_client(request_client, reason="stream_request_complete")
 
+        from hermes_cli.plugins import invoke_hook
+        invoke_hook("pre_llm_call", messages=api_kwargs.get("messages", []), model=api_kwargs.get("model", ""))
         t = threading.Thread(target=_call, daemon=True)
         t.start()
         while t.is_alive():
@@ -3787,6 +3795,7 @@ class AIAgent:
                 raise InterruptedError("Agent interrupted during streaming API call")
         if result["error"] is not None:
             raise result["error"]
+        invoke_hook("post_llm_call", messages=api_kwargs.get("messages", []), response=result["response"], model=api_kwargs.get("model", ""))
         return result["response"]
 
     # ── Provider fallback ──────────────────────────────────────────────────
@@ -7094,6 +7103,9 @@ class AIAgent:
 
         # Persist session to both JSON log and SQLite
         self._persist_session(messages, conversation_history)
+
+        from hermes_cli.plugins import invoke_hook
+        invoke_hook("on_session_end", session_id=self.session_id, platform=self.platform or "cli")
 
         # Sync conversation to Honcho for user modeling
         if final_response and not interrupted and sync_honcho:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1086,7 +1086,8 @@ class AIAgent:
             else:
                 print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)")
 
-        from hermes_cli.plugins import invoke_hook
+        from hermes_cli.plugins import discover_plugins, invoke_hook
+        discover_plugins()
         invoke_hook("on_session_start", session_id=self.session_id, platform=self.platform or "cli")
 
     def reset_session_state(self):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -241,6 +241,93 @@ class TestPluginHooks:
 
         assert any("on_banana" in record.message for record in caplog.records)
 
+    def test_pre_llm_call_receives_kwargs(self):
+        """pre_llm_call callback receives messages and model kwargs."""
+        mgr = PluginManager()
+        received = {}
+
+        def cb(**kw):
+            received.update(kw)
+
+        mgr._hooks["pre_llm_call"] = [cb]
+        messages = [{"role": "user", "content": "hi"}]
+        mgr.invoke_hook("pre_llm_call", messages=messages, model="gpt-4o")
+
+        assert received["messages"] is messages
+        assert received["model"] == "gpt-4o"
+
+    def test_post_llm_call_receives_kwargs(self):
+        """post_llm_call callback receives messages, response, and model kwargs."""
+        mgr = PluginManager()
+        received = {}
+
+        def cb(**kw):
+            received.update(kw)
+
+        mgr._hooks["post_llm_call"] = [cb]
+        messages = [{"role": "user", "content": "hi"}]
+        fake_response = object()
+        mgr.invoke_hook("post_llm_call", messages=messages, response=fake_response, model="gpt-4o")
+
+        assert received["messages"] is messages
+        assert received["response"] is fake_response
+        assert received["model"] == "gpt-4o"
+
+    def test_on_session_start_receives_kwargs(self):
+        """on_session_start callback receives session_id and platform kwargs."""
+        mgr = PluginManager()
+        received = {}
+
+        def cb(**kw):
+            received.update(kw)
+
+        mgr._hooks["on_session_start"] = [cb]
+        mgr.invoke_hook("on_session_start", session_id="abc123", platform="cli")
+
+        assert received["session_id"] == "abc123"
+        assert received["platform"] == "cli"
+
+    def test_on_session_end_receives_kwargs(self):
+        """on_session_end callback receives session_id and platform kwargs."""
+        mgr = PluginManager()
+        received = {}
+
+        def cb(**kw):
+            received.update(kw)
+
+        mgr._hooks["on_session_end"] = [cb]
+        mgr.invoke_hook("on_session_end", session_id="abc123", platform="telegram")
+
+        assert received["session_id"] == "abc123"
+        assert received["platform"] == "telegram"
+
+    def test_llm_hooks_exceptions_do_not_propagate(self):
+        """Raising callbacks for LLM hooks do not crash the caller."""
+        mgr = PluginManager()
+        mgr._hooks["pre_llm_call"] = [lambda **kw: 1 / 0]
+        mgr._hooks["post_llm_call"] = [lambda **kw: 1 / 0]
+
+        mgr.invoke_hook("pre_llm_call", messages=[], model="x")
+        mgr.invoke_hook("post_llm_call", messages=[], response=None, model="x")
+
+    def test_session_hooks_exceptions_do_not_propagate(self):
+        """Raising callbacks for session hooks do not crash the caller."""
+        mgr = PluginManager()
+        mgr._hooks["on_session_start"] = [lambda **kw: 1 / 0]
+        mgr._hooks["on_session_end"] = [lambda **kw: 1 / 0]
+
+        mgr.invoke_hook("on_session_start", session_id="s", platform="cli")
+        mgr.invoke_hook("on_session_end", session_id="s", platform="cli")
+
+    def test_all_six_hooks_in_valid_hooks(self):
+        """VALID_HOOKS contains all six documented lifecycle hooks."""
+        expected = {
+            "pre_tool_call", "post_tool_call",
+            "pre_llm_call", "post_llm_call",
+            "on_session_start", "on_session_end",
+        }
+        assert expected == VALID_HOOKS
+
 
 # ── TestPluginContext ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #2817 

 ## Summary

  Four lifecycle hooks (`pre_llm_call`, `post_llm_call`, `on_session_start`, `on_session_end`) were listed in `VALID_HOOKS` and accepted by`register_hook()` but `invoke_hook()` was never called for them - plugin
  callbacks silently never fired.

  - `on_session_start`: fired at end of `AIAgent.__init__` after `session_id` is set
  - `pre_llm_call` / `post_llm_call`: fired in both `_interruptible_api_call` and `_interruptible_streaming_api_call` around the API request thread 
  - `on_session_end`: fired in `run_conversation` after `_persist_session`
  -  discover_plugins() is now called before on_session_start to ensure plugins are loaded at session init - previously hooks fired before any listeners were registered.  

  ## Test plan

  - [x] `pre_llm_call` receives correct `messages` and `model` kwargs
  - [x] `post_llm_call` receives correct `messages`, `response`, and `model`kwargs
  - [x] `on_session_start` / `on_session_end` receive correct `session_id` and`platform` kwargs
  - [x] Exceptions in callbacks do not propagate to the agent loop
  - [x] All six hooks present in `VALID_HOOKS`
  - [ ] Manual: create a plugin registering all four hooks, verify callbacks fire on LLM requests and session start/end
  - [ ] Manual: verify on_session_start fires with registered listeners (not before plugin discovery)  

