### PR TITLE
fix: exclude yc-bench from [all] extra to fix install on Termux/ARM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ all = [
   "hermes-agent[acp]",
   "hermes-agent[voice]",
   "hermes-agent[dingtalk]",
+  # yc-bench is intentionally excluded from [all]: it pulls litellm which has no
+  # prebuilt wheels for constrained environments (Termux, Alpine, older ARM).
+  # Install explicitly with: pip install -e ".[yc-bench]"
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Problem

Installing with `pip install -e ".[all]"` (the default install script behavior) fails on Termux / proot-ubuntu and other constrained ARM environments:

```
ERROR: Could not find a version that satisfies the requirement litellm>=1.75.5 (from hermes-agent)
ERROR: No matching distribution found for litellm>=1.75.5
```

`litellm` has no prebuilt wheel for these platforms. Users have to build it from source, which is impractical in most constrained environments.

## Root Cause

`litellm` is not a direct dependency of hermes-agent — it comes in transitively via the `yc-bench` optional extra, which is included in `[all]`:

```toml
yc-bench = ["yc-bench @ git+https://github.com/collinear-ai/yc-bench.git ; python_version >= '3.12'"]
```

`yc-bench` depends on `litellm`, `streamlit`, `plotly`, and other heavy ML/viz packages that are not needed for standard Hermes usage.

## Fix

Exclude `yc-bench` from the `[all]` meta-extra. It is a niche ML benchmarking tool (not a messaging platform, not a core integration) and does not belong in a catch-all install.

Users who need it can still install explicitly:

```bash
pip install -e '.[yc-bench]'
```

## Affected environments

- Termux (Android) with proot-ubuntu
- Alpine Linux (musl libc)
- Any ARM device without a `litellm` wheel in PyPI

Closes #2821