### PR TITLE
fix(gateway): hygiene compression misses local/aliased models

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2005,6 +2005,16 @@ class GatewayRunner:
                         _hyg_provider = _model_cfg.get("provider") or None
                         _hyg_base_url = _model_cfg.get("base_url") or None
 
+                    # Also check top-level model_context_length — some configs
+                    # place this outside the model: dict (hermes accepts both).
+                    if _hyg_config_context_length is None:
+                        _raw_top = _hyg_data.get("model_context_length")
+                        if _raw_top is not None:
+                            try:
+                                _hyg_config_context_length = int(_raw_top)
+                            except (TypeError, ValueError):
+                                pass
+
                     # Read compression settings — only use enabled flag.
                     # The threshold is intentionally separate from the agent's
                     # compression.threshold (hygiene runs higher).
@@ -2014,15 +2024,16 @@ class GatewayRunner:
                             _comp_cfg.get("enabled", True)
                         ).lower() in ("true", "1", "yes")
 
-                # Resolve provider/base_url from runtime if not in config
-                if not _hyg_provider or not _hyg_base_url:
-                    try:
-                        _hyg_runtime = _resolve_runtime_agent_kwargs()
-                        _hyg_provider = _hyg_provider or _hyg_runtime.get("provider")
-                        _hyg_base_url = _hyg_base_url or _hyg_runtime.get("base_url")
-                        _hyg_api_key = _hyg_runtime.get("api_key")
-                    except Exception:
-                        pass
+                # Resolve provider/base_url/api_key from runtime.
+                # Always run — even if provider/base_url come from config,
+                # we still need api_key for endpoint probing.
+                try:
+                    _hyg_runtime = _resolve_runtime_agent_kwargs()
+                    _hyg_provider = _hyg_provider or _hyg_runtime.get("provider")
+                    _hyg_base_url = _hyg_base_url or _hyg_runtime.get("base_url")
+                    _hyg_api_key = _hyg_api_key or _hyg_runtime.get("api_key")
+                except Exception as _hyg_exc:
+                    logger.debug("Hygiene: runtime resolution failed: %s", _hyg_exc)
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary

Fixes #2708 — gateway hygiene compression never triggers for local/Ollama models because context length detection fails silently.

**Two issues fixed:**

1. **Top-level `model_context_length` ignored** — the hygiene code only read `model.context_length` (nested under `model:`), but many configs (including hermes' own default) place it at the top level as `model_context_length`. Now checks both locations.

2. **Runtime resolution skipped when config has provider+base_url** — `api_key` stayed `None`, breaking endpoint probing. Resolution now always runs. Failures are logged at debug level instead of silently swallowed via bare `except: pass`.

## Root Cause

For a config like:
```yaml
model:
  default: brain
model_context_length: 1000000
```

The hygiene code reads `model.context_length` (None) but misses `model_context_length` (1000000). The model alias `brain` doesn't match any hardcoded defaults, so context falls through to 128K. Compression threshold becomes 85% of 128K = ~109K tokens — effectively unreachable for most sessions.

## Changes

- `gateway/run.py`: Read top-level `model_context_length` as fallback when `model.context_length` is absent
- `gateway/run.py`: Always run runtime provider resolution (not just when provider/base_url missing from config) so `api_key` is available for endpoint probing
- `gateway/run.py`: Log debug message on runtime resolution failure instead of bare `except: pass`

## Test Plan

- [x] All 19 `test_session_hygiene.py` tests pass
- [x] All 75 `test_model_metadata.py` tests pass
- [x] Verified on live Ollama + LiteLLM stack with `model_context_length: 1000000` in config