### PR TITLE
fix(discord): cancel platform-level typing tasks in base.py finally block

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1130,6 +1130,12 @@ class BasePlatformAdapter(ABC):
                 await typing_task
             except asyncio.CancelledError:
                 pass
+            # Also cancel any platform-level persistent typing tasks (e.g. Discord)
+            try:
+                if hasattr(self, "stop_typing"):
+                    await self.stop_typing(event.source.chat_id)
+            except Exception:
+                pass
             # Clean up session tracking
             if session_key in self._active_sessions:
                 del self._active_sessions[session_key]


### PR DESCRIPTION
## Problem

Discord's typing indicator lingers for up to 10 seconds after a response is sent.

Two separate typing loops run concurrently:

1. **`base.py` `_keep_typing`** — pings Discord's typing endpoint every 2s, cancelled in the `finally` block *after* the response is sent
2. **Discord adapter's `_typing_tasks`** — a separate persistent task tracked by `chat_id`

**The race:** `run.py` calls `stop_typing()` (cancelling `_typing_tasks`) *before* the response is sent. But `base.py`'s `_keep_typing` loop immediately calls `send_typing()` again, **recreating** the `_typing_tasks` entry. Then when `base.py`'s `finally` block runs, it cancels `_keep_typing` — but the newly recreated `_typing_tasks` entry is orphaned and never cancelled. Discord's indicator then lingers up to 10 seconds.

## Fix

Add a `stop_typing()` call to `base.py`'s `finally` block, right after cancelling `_keep_typing`:

```python
# Also cancel platform-level persistent typing tasks (e.g. Discord)
try:
    if hasattr(self, "stop_typing"):
        await self.stop_typing(event.source.chat_id)
except Exception:
    pass
```

- `hasattr` guard: only fires on adapters that implement `stop_typing` — no blast radius on other platforms
- Wrapped in `try/except`: cannot break other cleanup
- Idempotent: `stop_typing` when already stopped is a no-op

## Testing

All 1417 gateway tests pass.

Closes #2831

---

*AI-assisted (Claude) | Lightly tested | Reviewed and Understood*