### PR TITLE
feat(runtime): add named Hermes instances with isolated local state and per-instance identity

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -299,6 +299,13 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     left_lines.append(f"[dim {dim}]{cwd}[/]")
     if session_id:
         left_lines.append(f"[dim {session_color}]Session: {session_id}[/]")
+    try:
+        from hermes_cli.instance_runtime import get_active_instance_name
+        _instance_name = get_active_instance_name()
+        if _instance_name != "main":
+            left_lines.append(f"[dim {dim}]Instance: {_instance_name}[/]")
+    except Exception:
+        pass
     left_content = "\n".join(left_lines)
 
     right_lines = [f"[bold {accent}]Available Tools[/]"]

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -38,8 +38,16 @@ def load_hermes_dotenv(
         _load_dotenv_with_fallback(user_env, override=True)
         loaded.append(user_env)
 
+    protected_keys = ("HERMES_BASE_HOME", "HERMES_HOME", "HERMES_INSTANCE", "HERMES_HONCHO_HOST")
+    protected_values = {key: os.environ.get(key) for key in protected_keys}
+
     if project_env_path and project_env_path.exists():
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
+        for key, value in protected_values.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
         loaded.append(project_env_path)
 
     return loaded

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -126,14 +126,14 @@ SERVICE_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
 
 
 def get_service_name() -> str:
-    """Derive a systemd service name scoped to this HERMES_HOME.
-
-    Default ``~/.hermes`` returns ``hermes-gateway`` (backward compatible).
-    Any other HERMES_HOME appends a short hash so multiple installations
-    can each have their own systemd service without conflicting.
-    """
+    """Derive a gateway service name scoped to the active Hermes instance/home."""
     import hashlib
     from pathlib import Path as _Path  # local import to avoid monkeypatch interference
+
+    instance = (os.getenv("HERMES_INSTANCE", "") or "").strip().lower()
+    if instance and instance != "main":
+        return f"{_SERVICE_BASE}-{instance}"
+
     home = get_hermes_home().resolve()
     default = (_Path.home() / ".hermes").resolve()
     if home == default:
@@ -368,8 +368,15 @@ def print_systemd_linger_guidance() -> None:
         print("  If you want the gateway user service to survive logout, run:")
         print("  sudo loginctl enable-linger $USER")
 
+def get_launchd_label() -> str:
+    instance = (os.getenv("HERMES_INSTANCE", "") or "").strip().lower()
+    if instance and instance != "main":
+        return f"ai.hermes.gateway.{instance}"
+    return "ai.hermes.gateway"
+
+
 def get_launchd_plist_path() -> Path:
-    return Path.home() / "Library" / "LaunchAgents" / "ai.hermes.gateway.plist"
+    return Path.home() / "Library" / "LaunchAgents" / f"{get_launchd_label()}.plist"
 
 def _detect_venv_dir() -> Path | None:
     """Detect the active virtualenv directory.
@@ -438,6 +445,9 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     sane_path = ":".join(path_entries)
 
     hermes_home = str(get_hermes_home().resolve())
+    hermes_base_home = str(Path(os.getenv("HERMES_BASE_HOME", hermes_home)).resolve())
+    hermes_instance = (os.getenv("HERMES_INSTANCE", "main") or "main").strip() or "main"
+    hermes_honcho_host = (os.getenv("HERMES_HONCHO_HOST", "hermes") or "hermes").strip() or "hermes"
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
@@ -459,7 +469,10 @@ Environment="USER={username}"
 Environment="LOGNAME={username}"
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
+Environment="HERMES_BASE_HOME={hermes_base_home}"
 Environment="HERMES_HOME={hermes_home}"
+Environment="HERMES_INSTANCE={hermes_instance}"
+Environment="HERMES_HONCHO_HOST={hermes_honcho_host}"
 Restart=on-failure
 RestartSec=30
 KillMode=mixed
@@ -484,7 +497,10 @@ ExecStart={python_path} -m hermes_cli.main gateway run --replace
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
+Environment="HERMES_BASE_HOME={hermes_base_home}"
 Environment="HERMES_HOME={hermes_home}"
+Environment="HERMES_INSTANCE={hermes_instance}"
+Environment="HERMES_HONCHO_HOST={hermes_honcho_host}"
 Restart=on-failure
 RestartSec=30
 KillMode=mixed
@@ -757,13 +773,18 @@ def generate_launchd_plist() -> str:
     working_dir = str(PROJECT_ROOT)
     log_dir = get_hermes_home() / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
-    
+    label = get_launchd_label()
+    hermes_home = str(get_hermes_home().resolve())
+    hermes_base_home = str(Path(os.getenv("HERMES_BASE_HOME", hermes_home)).resolve())
+    hermes_instance = (os.getenv("HERMES_INSTANCE", "main") or "main").strip() or "main"
+    hermes_honcho_host = (os.getenv("HERMES_HONCHO_HOST", "hermes") or "hermes").strip() or "hermes"
+
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>ai.hermes.gateway</string>
+    <string>{label}</string>
     
     <key>ProgramArguments</key>
     <array>
@@ -777,6 +798,18 @@ def generate_launchd_plist() -> str:
     
     <key>WorkingDirectory</key>
     <string>{working_dir}</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_BASE_HOME</key>
+        <string>{hermes_base_home}</string>
+        <key>HERMES_HOME</key>
+        <string>{hermes_home}</string>
+        <key>HERMES_INSTANCE</key>
+        <string>{hermes_instance}</string>
+        <key>HERMES_HONCHO_HOST</key>
+        <string>{hermes_honcho_host}</string>
+    </dict>
     
     <key>RunAtLoad</key>
     <true/>
@@ -865,18 +898,19 @@ def launchd_uninstall():
 def launchd_start():
     refresh_launchd_plist_if_needed()
     plist_path = get_launchd_plist_path()
+    label = get_launchd_label()
     try:
-        subprocess.run(["launchctl", "start", "ai.hermes.gateway"], check=True)
+        subprocess.run(["launchctl", "start", label], check=True)
     except subprocess.CalledProcessError as e:
         if e.returncode != 3 or not plist_path.exists():
             raise
         print("↻ launchd job was unloaded; reloading service definition")
         subprocess.run(["launchctl", "load", str(plist_path)], check=True)
-        subprocess.run(["launchctl", "start", "ai.hermes.gateway"], check=True)
+        subprocess.run(["launchctl", "start", label], check=True)
     print("✓ Service started")
 
 def launchd_stop():
-    subprocess.run(["launchctl", "stop", "ai.hermes.gateway"], check=True)
+    subprocess.run(["launchctl", "stop", get_launchd_label()], check=True)
     print("✓ Service stopped")
 
 def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float = 5.0):
@@ -931,8 +965,9 @@ def launchd_restart():
 
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
+    label = get_launchd_label()
     result = subprocess.run(
-        ["launchctl", "list", "ai.hermes.gateway"],
+        ["launchctl", "list", label],
         capture_output=True,
         text=True
     )
@@ -1437,7 +1472,7 @@ def _is_service_running() -> bool:
         return False
     elif is_macos() and get_launchd_plist_path().exists():
         result = subprocess.run(
-            ["launchctl", "list", "ai.hermes.gateway"],
+            ["launchctl", "list", get_launchd_label()],
             capture_output=True, text=True
         )
         return result.returncode == 0

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -27,7 +27,21 @@ from hermes_cli.colors import Colors, color
 # =============================================================================
 
 def find_gateway_pids() -> list:
-    """Find PIDs of running gateway processes."""
+    """Find PIDs of running gateway processes.
+
+    Checks the HERMES_HOME-scoped PID file first (profile-safe),
+    falling back to global process scan.
+    """
+    # Primary: HERMES_HOME-scoped PID file
+    try:
+        from gateway.status import get_running_pid
+        scoped_pid = get_running_pid()
+        if scoped_pid is not None:
+            return [scoped_pid]
+    except Exception:
+        pass
+
+    # Fallback: global process scan
     pids = []
     patterns = [
         "hermes_cli.main gateway",

--- a/hermes_cli/instance_runtime.py
+++ b/hermes_cli/instance_runtime.py
@@ -1,0 +1,216 @@
+"""Hermes named instance runtime helpers.
+
+Keeps instance resolution independent from the rest of the CLI bootstrap so we can
+set HERMES_HOME before dotenv/config-heavy modules import.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_INSTANCE_NAME = "main"
+_DEFAULT_HOME_NAME = ".hermes"
+_INSTANCE_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_INSTANCE_FLAGS = ("--instance",)
+
+
+@dataclass(frozen=True)
+class InstanceRuntime:
+    instance: str
+    base_home: Path
+    home: Path
+    honcho_host: str
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalize_instance_name(name: str | None) -> str:
+    raw = (name or "").strip().lower()
+    if not raw:
+        return DEFAULT_INSTANCE_NAME
+    if raw in {DEFAULT_INSTANCE_NAME, "default"}:
+        return DEFAULT_INSTANCE_NAME
+    if not _INSTANCE_RE.fullmatch(raw):
+        raise ValueError(
+            "Invalid instance name. Use lowercase letters, numbers, underscores, or hyphens."
+        )
+    return raw
+
+
+def _infer_instance_from_home(home: Path) -> str:
+    if home.parent.name == "instances" and home.name:
+        try:
+            return normalize_instance_name(home.name)
+        except ValueError:
+            return DEFAULT_INSTANCE_NAME
+    return DEFAULT_INSTANCE_NAME
+
+
+def _derive_base_from_home(home: Path) -> Path:
+    if home.parent.name == "instances":
+        return home.parent.parent
+    return home
+
+
+def get_base_hermes_home() -> Path:
+    base = os.getenv("HERMES_BASE_HOME", "").strip()
+    if base:
+        return Path(base).expanduser()
+
+    home_env = os.getenv("HERMES_HOME", "").strip()
+    if home_env:
+        return _derive_base_from_home(Path(home_env).expanduser())
+
+    return Path.home() / _DEFAULT_HOME_NAME
+
+
+def get_active_instance_name() -> str:
+    explicit = os.getenv("HERMES_INSTANCE", "").strip()
+    if explicit:
+        return normalize_instance_name(explicit)
+
+    home_env = os.getenv("HERMES_HOME", "").strip()
+    if home_env:
+        return _infer_instance_from_home(Path(home_env).expanduser())
+
+    return DEFAULT_INSTANCE_NAME
+
+
+def get_instance_home(instance_name: str | None = None, *, base_home: Path | None = None) -> Path:
+    instance = normalize_instance_name(instance_name or get_active_instance_name())
+    root = Path(base_home) if base_home is not None else get_base_hermes_home()
+    if instance == DEFAULT_INSTANCE_NAME:
+        return root
+    return root / "instances" / instance
+
+
+def resolve_honcho_host(instance_name: str | None = None) -> str:
+    instance = normalize_instance_name(instance_name or get_active_instance_name())
+    if instance == DEFAULT_INSTANCE_NAME:
+        return "hermes"
+    return f"hermes.{instance}"
+
+
+def get_active_honcho_host() -> str:
+    explicit = os.getenv("HERMES_HONCHO_HOST", "").strip()
+    if explicit:
+        return explicit
+    return resolve_honcho_host(get_active_instance_name())
+
+
+def get_instance_registry_path(base_home: Path | None = None) -> Path:
+    root = Path(base_home) if base_home is not None else get_base_hermes_home()
+    return root / "instances.json"
+
+
+def build_instance_runtime(instance_name: str | None = None, *, base_home: Path | None = None) -> InstanceRuntime:
+    instance = normalize_instance_name(instance_name or get_active_instance_name())
+    root = Path(base_home) if base_home is not None else get_base_hermes_home()
+    home = get_instance_home(instance, base_home=root)
+    return InstanceRuntime(
+        instance=instance,
+        base_home=root,
+        home=home,
+        honcho_host=resolve_honcho_host(instance),
+    )
+
+
+def register_instance(runtime: InstanceRuntime) -> None:
+    registry_path = get_instance_registry_path(runtime.base_home)
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload: dict = {"instances": {}}
+    if registry_path.exists():
+        try:
+            existing = json.loads(registry_path.read_text(encoding="utf-8"))
+            if isinstance(existing, dict):
+                payload = existing
+        except Exception:
+            pass
+
+    instances = payload.setdefault("instances", {})
+    if not isinstance(instances, dict):
+        instances = {}
+        payload["instances"] = instances
+
+    instances[runtime.instance] = {
+        "home": str(runtime.home),
+        "honcho_host": runtime.honcho_host,
+        "last_used_at": _utc_now_iso(),
+    }
+
+    registry_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _extract_instance_from_argv(argv: Iterable[str]) -> tuple[list[str], str | None]:
+    cleaned: list[str] = []
+    selected: str | None = None
+    items = list(argv)
+    i = 0
+    while i < len(items):
+        arg = items[i]
+        if any(arg.startswith(f"{flag}=") for flag in _INSTANCE_FLAGS):
+            _, _, value = arg.partition("=")
+            if not value.strip():
+                raise ValueError(f"{arg.split('=')[0]} requires a value")
+            selected = value.strip()
+            i += 1
+            continue
+        if arg in _INSTANCE_FLAGS:
+            if i + 1 >= len(items):
+                raise ValueError(f"{arg} requires a value")
+            value = items[i + 1].strip()
+            if not value:
+                raise ValueError(f"{arg} requires a value")
+            selected = value
+            i += 2
+            continue
+        cleaned.append(arg)
+        i += 1
+    return cleaned, selected
+
+
+def bootstrap_instance_env(argv: Iterable[str]) -> list[str]:
+    """Resolve the active Hermes instance and export runtime env vars.
+
+    Returns argv with instance-selection flags removed so argparse does not need to
+    know where `--instance` or `--name` appeared.
+    """
+
+    cleaned, selected = _extract_instance_from_argv(argv)
+
+    existing_base = os.getenv("HERMES_BASE_HOME", "").strip()
+    current_home = os.getenv("HERMES_HOME", "").strip()
+
+    if selected:
+        current_instance = selected
+    elif existing_base:
+        current_instance = os.getenv("HERMES_INSTANCE") or DEFAULT_INSTANCE_NAME
+    elif current_home:
+        current_instance = _infer_instance_from_home(Path(current_home).expanduser())
+    else:
+        current_instance = os.getenv("HERMES_INSTANCE") or DEFAULT_INSTANCE_NAME
+
+    if existing_base:
+        base_home = Path(existing_base).expanduser()
+    elif current_home:
+        base_home = _derive_base_from_home(Path(current_home).expanduser())
+    else:
+        base_home = Path.home() / _DEFAULT_HOME_NAME
+
+    runtime = build_instance_runtime(current_instance, base_home=base_home)
+    os.environ["HERMES_INSTANCE"] = runtime.instance
+    os.environ["HERMES_BASE_HOME"] = str(runtime.base_home)
+    os.environ["HERMES_HOME"] = str(runtime.home)
+    os.environ["HERMES_HONCHO_HOST"] = runtime.honcho_host
+
+    register_instance(runtime)
+    return cleaned

--- a/hermes_cli/instance_runtime.py
+++ b/hermes_cli/instance_runtime.py
@@ -192,17 +192,17 @@ def bootstrap_instance_env(argv: Iterable[str]) -> list[str]:
 
     if selected:
         current_instance = selected
-    elif existing_base:
-        current_instance = os.getenv("HERMES_INSTANCE") or DEFAULT_INSTANCE_NAME
     elif current_home:
         current_instance = _infer_instance_from_home(Path(current_home).expanduser())
+    elif existing_base:
+        current_instance = os.getenv("HERMES_INSTANCE") or DEFAULT_INSTANCE_NAME
     else:
         current_instance = os.getenv("HERMES_INSTANCE") or DEFAULT_INSTANCE_NAME
 
-    if existing_base:
-        base_home = Path(existing_base).expanduser()
-    elif current_home:
+    if current_home:
         base_home = _derive_base_from_home(Path(current_home).expanduser())
+    elif existing_base:
+        base_home = Path(existing_base).expanduser()
     else:
         base_home = Path.home() / _DEFAULT_HOME_NAME
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -54,11 +54,16 @@ from typing import Optional
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
 
-# Load .env from ~/.hermes/.env first, then project root as dev fallback.
+# Resolve named instance selection before any config-heavy imports so HERMES_HOME
+# points at the right instance-local home during module import.
+from hermes_cli.instance_runtime import bootstrap_instance_env
+bootstrap_instance_env(sys.argv[1:])
+
+# Load .env from the resolved Hermes home first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.config import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
-load_hermes_dotenv(project_env=PROJECT_ROOT / '.env')
+load_hermes_dotenv(hermes_home=get_hermes_home(), project_env=PROJECT_ROOT / '.env')
 
 
 import logging
@@ -3053,6 +3058,13 @@ For more help on a command:
         help="Show version and exit"
     )
     parser.add_argument(
+        "--instance",
+        dest="instance_name",
+        metavar="NAME",
+        default=None,
+        help="Run Hermes as a named instance (isolated home, sessions, gateway state, and Honcho host)"
+    )
+    parser.add_argument(
         "--resume", "-r",
         metavar="SESSION",
         default=None,
@@ -4167,7 +4179,7 @@ For more help on a command:
     # Pre-process argv so unquoted multi-word session names after -c / -r
     # are merged into a single token before argparse sees them.
     # e.g. ``hermes -c Pokemon Agent Dev`` → ``hermes -c 'Pokemon Agent Dev'``
-    _processed_argv = _coalesce_session_name_args(sys.argv[1:])
+    _processed_argv = _coalesce_session_name_args(bootstrap_instance_env(sys.argv[1:]))
     args = parser.parse_args(_processed_argv)
     
     # Handle --version flag

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2996,6 +2996,7 @@ def _coalesce_session_name_args(argv: list) -> list:
         "chat", "model", "gateway", "setup", "whatsapp", "login", "logout",
         "status", "cron", "doctor", "config", "pairing", "skills", "tools",
         "mcp", "sessions", "insights", "version", "update", "uninstall",
+        "instance",
     }
     _SESSION_FLAGS = {"-c", "--continue", "-r", "--resume"}
 
@@ -4172,7 +4173,194 @@ For more help on a command:
             sys.exit(1)
 
     acp_parser.set_defaults(func=cmd_acp)
-    
+
+    # =========================================================================
+    # instance command
+    # =========================================================================
+    instance_parser = subparsers.add_parser(
+        "instance",
+        help="Manage Hermes named instances (create, list, show, delete)",
+        description="Create and manage isolated Hermes instances",
+    )
+    instance_subparsers = instance_parser.add_subparsers(dest="instance_action")
+
+    instance_list_parser = instance_subparsers.add_parser("list", help="List all known instances")
+
+    instance_create_parser = instance_subparsers.add_parser("create", help="Create a new instance")
+    instance_create_parser.add_argument("name", help="Instance name (lowercase, letters/numbers/hyphens/underscores)")
+    instance_create_parser.add_argument("--clone", metavar="SOURCE", help="Clone config/.env/SOUL.md from another instance")
+
+    instance_delete_parser = instance_subparsers.add_parser("delete", help="Delete an instance")
+    instance_delete_parser.add_argument("name", help="Instance name to delete")
+    instance_delete_parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation")
+
+    instance_show_parser = instance_subparsers.add_parser("show", help="Show instance details")
+    instance_show_parser.add_argument("name", help="Instance name to inspect")
+
+    def cmd_instance(args):
+        import json as _json
+        import shutil
+        from hermes_cli.instance_runtime import (
+            DEFAULT_INSTANCE_NAME,
+            build_instance_runtime,
+            get_active_instance_name,
+            get_base_hermes_home,
+            get_instance_home,
+            get_instance_registry_path,
+            normalize_instance_name,
+            register_instance,
+        )
+
+        action = getattr(args, "instance_action", None)
+        base_home = get_base_hermes_home()
+
+        if action == "list":
+            # Load registry
+            registry_path = get_instance_registry_path(base_home)
+            registry: dict = {}
+            if registry_path.exists():
+                try:
+                    payload = _json.loads(registry_path.read_text(encoding="utf-8"))
+                    registry = payload.get("instances", {})
+                except Exception:
+                    pass
+
+            # Scan instances/ directory for unregistered ones
+            instances_dir = base_home / "instances"
+            if instances_dir.is_dir():
+                for child in sorted(instances_dir.iterdir()):
+                    if child.is_dir() and child.name not in registry:
+                        registry[child.name] = {
+                            "home": str(child),
+                            "honcho_host": f"hermes.{child.name}",
+                            "last_used_at": "",
+                        }
+
+            # Always include main
+            if DEFAULT_INSTANCE_NAME not in registry:
+                registry[DEFAULT_INSTANCE_NAME] = {
+                    "home": str(base_home),
+                    "honcho_host": "hermes",
+                    "last_used_at": "",
+                }
+
+            active = get_active_instance_name()
+            print(f"{'':2} {'Name':<20} {'Home':<40} {'Honcho Host':<25} {'Last Used'}")
+            print("-" * 110)
+            for name in sorted(registry.keys()):
+                entry = registry[name]
+                marker = "\u25c6" if name == active else " "
+                home = entry.get("home", "")
+                honcho = entry.get("honcho_host", "")
+                last_used = entry.get("last_used_at", "")
+                if last_used:
+                    last_used = last_used[:19]  # trim to readable length
+                print(f"{marker:2} {name:<20} {home:<40} {honcho:<25} {last_used}")
+
+        elif action == "create":
+            try:
+                name = normalize_instance_name(args.name)
+            except ValueError as exc:
+                print(f"Error: {exc}")
+                return
+            if name == DEFAULT_INSTANCE_NAME:
+                print("Error: Cannot create the 'main' instance — it already exists.")
+                return
+            home = get_instance_home(name, base_home=base_home)
+            if home.exists():
+                print(f"Error: Instance directory already exists: {home}")
+                return
+            subdirs = [
+                "memories", "sessions", "skills", "skins", "logs",
+                "plans", "workspace", "audio_cache", "image_cache",
+            ]
+            home.mkdir(parents=True, exist_ok=True)
+            for sd in subdirs:
+                (home / sd).mkdir(exist_ok=True)
+
+            # Clone from source if requested
+            if args.clone:
+                try:
+                    src_name = normalize_instance_name(args.clone)
+                except ValueError as exc:
+                    print(f"Error: Invalid source instance name: {exc}")
+                    shutil.rmtree(home)
+                    return
+                src_home = get_instance_home(src_name, base_home=base_home)
+                if not src_home.exists():
+                    print(f"Error: Source instance home does not exist: {src_home}")
+                    shutil.rmtree(home)
+                    return
+                for fname in ("config.yaml", ".env", "SOUL.md"):
+                    src_file = src_home / fname
+                    if src_file.exists():
+                        shutil.copy2(src_file, home / fname)
+
+            runtime = build_instance_runtime(name, base_home=base_home)
+            register_instance(runtime)
+            print(f"Instance '{name}' created at {home}")
+            print(f"  Honcho host: {runtime.honcho_host}")
+            print(f"\nNext steps:")
+            print(f"  hermes --instance {name} setup     # configure API keys")
+            print(f"  hermes --instance {name}            # start chatting")
+
+        elif action == "delete":
+            try:
+                name = normalize_instance_name(args.name)
+            except ValueError as exc:
+                print(f"Error: {exc}")
+                return
+            if name == DEFAULT_INSTANCE_NAME:
+                print("Error: Cannot delete the 'main' instance.")
+                return
+            home = get_instance_home(name, base_home=base_home)
+            if not args.yes:
+                try:
+                    confirm = input(f"Type '{name}' to confirm deletion: ").strip()
+                except (EOFError, KeyboardInterrupt):
+                    print("\nAborted.")
+                    return
+                if confirm != name:
+                    print("Aborted.")
+                    return
+            if home.exists():
+                shutil.rmtree(home)
+            # Remove from registry
+            registry_path = get_instance_registry_path(base_home)
+            if registry_path.exists():
+                try:
+                    payload = _json.loads(registry_path.read_text(encoding="utf-8"))
+                    instances = payload.get("instances", {})
+                    instances.pop(name, None)
+                    registry_path.write_text(
+                        _json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+                        encoding="utf-8",
+                    )
+                except Exception:
+                    pass
+            print(f"Instance '{name}' deleted.")
+
+        elif action == "show":
+            try:
+                name = normalize_instance_name(args.name)
+            except ValueError as exc:
+                print(f"Error: {exc}")
+                return
+            home = get_instance_home(name, base_home=base_home)
+            print(f"Instance: {name}")
+            print(f"Home:     {home}")
+            if home.exists():
+                print(f"\nContents:")
+                for child in sorted(home.iterdir()):
+                    kind = "dir" if child.is_dir() else "file"
+                    print(f"  {child.name:<30} [{kind}]")
+            else:
+                print("  (directory does not exist)")
+        else:
+            instance_parser.print_help()
+
+    instance_parser.set_defaults(func=cmd_instance)
+
     # =========================================================================
     # Parse and execute
     # =========================================================================

--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -10,9 +10,11 @@ import os
 import sys
 from pathlib import Path
 
-from honcho_integration.client import resolve_config_path, GLOBAL_CONFIG_PATH
+from honcho_integration.client import resolve_active_host, resolve_config_path, GLOBAL_CONFIG_PATH
 
-HOST = "hermes"
+
+def _host_key() -> str:
+    return resolve_active_host()
 
 
 def _config_path() -> Path:
@@ -41,7 +43,7 @@ def _write_config(cfg: dict, path: Path | None = None) -> None:
 
 def _resolve_api_key(cfg: dict) -> str:
     """Resolve API key with host -> root -> env fallback."""
-    host_key = ((cfg.get("hosts") or {}).get(HOST) or {}).get("apiKey")
+    host_key = ((cfg.get("hosts") or {}).get(_host_key()) or {}).get("apiKey")
     return host_key or cfg.get("apiKey", "") or os.environ.get("HONCHO_API_KEY", "")
 
 
@@ -107,10 +109,11 @@ def cmd_setup(args) -> None:
     if not _ensure_sdk_installed():
         return
 
-    # All writes go to hosts.hermes — root keys are managed by the user
-    # or the honcho CLI only.
+    host_key = _host_key()
+    # All writes go to the active Hermes host block — root keys are managed by
+    # the user or the honcho CLI only.
     hosts = cfg.setdefault("hosts", {})
-    hermes_host = hosts.setdefault(HOST, {})
+    hermes_host = hosts.setdefault(host_key, {})
 
     # API key — shared credential, lives at root so all hosts can read it
     current_key = cfg.get("apiKey", "")
@@ -137,7 +140,7 @@ def cmd_setup(args) -> None:
     if new_workspace:
         hermes_host["workspace"] = new_workspace
 
-    hermes_host.setdefault("aiPeer", HOST)
+    hermes_host.setdefault("aiPeer", host_key)
 
     # Memory mode
     current_mode = hermes_host.get("memoryMode") or cfg.get("memoryMode", "hybrid")
@@ -339,10 +342,11 @@ def cmd_peer(args) -> None:
 
     if user_name is None and ai_name is None and reasoning is None:
         # Show current values
+        host_key = _host_key()
         hosts = cfg.get("hosts", {})
-        hermes = hosts.get(HOST, {})
+        hermes = hosts.get(host_key, {})
         user = hermes.get('peerName') or cfg.get('peerName') or '(not set)'
-        ai = hermes.get('aiPeer') or cfg.get('aiPeer') or HOST
+        ai = hermes.get('aiPeer') or cfg.get('aiPeer') or host_key
         lvl = hermes.get("dialecticReasoningLevel") or cfg.get("dialecticReasoningLevel") or "low"
         max_chars = hermes.get("dialecticMaxChars") or cfg.get("dialecticMaxChars") or 600
         print("\nHoncho peers\n" + "─" * 40)
@@ -356,13 +360,15 @@ def cmd_peer(args) -> None:
         print(f"  Dialectic cap:        {max_chars} chars\n")
         return
 
+    host_key = _host_key()
+
     if user_name is not None:
-        cfg.setdefault("hosts", {}).setdefault(HOST, {})["peerName"] = user_name.strip()
+        cfg.setdefault("hosts", {}).setdefault(host_key, {})["peerName"] = user_name.strip()
         changed = True
         print(f"  User peer → {user_name.strip()}")
 
     if ai_name is not None:
-        cfg.setdefault("hosts", {}).setdefault(HOST, {})["aiPeer"] = ai_name.strip()
+        cfg.setdefault("hosts", {}).setdefault(host_key, {})["aiPeer"] = ai_name.strip()
         changed = True
         print(f"  AI peer   → {ai_name.strip()}")
 
@@ -370,7 +376,7 @@ def cmd_peer(args) -> None:
         if reasoning not in REASONING_LEVELS:
             print(f"  Invalid reasoning level '{reasoning}'. Options: {', '.join(REASONING_LEVELS)}")
             return
-        cfg.setdefault("hosts", {}).setdefault(HOST, {})["dialecticReasoningLevel"] = reasoning
+        cfg.setdefault("hosts", {}).setdefault(host_key, {})["dialecticReasoningLevel"] = reasoning
         changed = True
         print(f"  Dialectic reasoning level → {reasoning}")
 
@@ -388,9 +394,11 @@ def cmd_mode(args) -> None:
     cfg = _read_config()
     mode_arg = getattr(args, "mode", None)
 
+    host_key = _host_key()
+
     if mode_arg is None:
         current = (
-            (cfg.get("hosts") or {}).get(HOST, {}).get("memoryMode")
+            (cfg.get("hosts") or {}).get(host_key, {}).get("memoryMode")
             or cfg.get("memoryMode")
             or "hybrid"
         )
@@ -405,7 +413,7 @@ def cmd_mode(args) -> None:
         print(f"  Invalid mode '{mode_arg}'. Options: {', '.join(MODES)}\n")
         return
 
-    cfg.setdefault("hosts", {}).setdefault(HOST, {})["memoryMode"] = mode_arg
+    cfg.setdefault("hosts", {}).setdefault(host_key, {})["memoryMode"] = mode_arg
     _write_config(cfg)
     print(f"  Memory mode → {mode_arg}  ({MODES[mode_arg]})\n")
 
@@ -413,8 +421,9 @@ def cmd_mode(args) -> None:
 def cmd_tokens(args) -> None:
     """Show or set token budget settings."""
     cfg = _read_config()
+    host_key = _host_key()
     hosts = cfg.get("hosts", {})
-    hermes = hosts.get(HOST, {})
+    hermes = hosts.get(host_key, {})
 
     context = getattr(args, "context", None)
     dialectic = getattr(args, "dialectic", None)
@@ -439,11 +448,12 @@ def cmd_tokens(args) -> None:
 
     changed = False
     if context is not None:
-        cfg.setdefault("hosts", {}).setdefault(HOST, {})["contextTokens"] = context
+        cfg.setdefault("hosts", {}).setdefault(host_key, {})["contextTokens"] = context
         print(f"  context tokens → {context}")
         changed = True
+
     if dialectic is not None:
-        cfg.setdefault("hosts", {}).setdefault(HOST, {})["dialecticMaxChars"] = dialectic
+        cfg.setdefault("hosts", {}).setdefault(host_key, {})["dialecticMaxChars"] = dialectic
         print(f"  dialectic cap  → {dialectic} chars")
         changed = True
 

--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -31,6 +31,17 @@ GLOBAL_CONFIG_PATH = Path.home() / ".honcho" / "config.json"
 HOST = "hermes"
 
 
+def resolve_active_host() -> str:
+    explicit = os.environ.get("HERMES_HONCHO_HOST", "").strip()
+    if explicit:
+        return explicit
+
+    instance = (os.environ.get("HERMES_INSTANCE", "") or "").strip().lower()
+    if instance and instance != "main":
+        return f"{HOST}.{instance}"
+    return HOST
+
+
 def resolve_config_path() -> Path:
     """Return the active Honcho config path.
 
@@ -135,40 +146,51 @@ class HonchoClientConfig:
     explicitly_configured: bool = False
 
     @classmethod
-    def from_env(cls, workspace_id: str = "hermes") -> HonchoClientConfig:
+    def from_env(
+        cls,
+        workspace_id: str = "hermes",
+        host: str | None = None,
+    ) -> HonchoClientConfig:
         """Create config from environment variables (fallback)."""
+        resolved_host = host or resolve_active_host()
         api_key = os.environ.get("HONCHO_API_KEY")
         base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
+        effective_workspace = workspace_id
+        if effective_workspace == HOST and resolved_host != HOST:
+            effective_workspace = resolved_host
         return cls(
-            workspace_id=workspace_id,
+            host=resolved_host,
+            workspace_id=effective_workspace,
             api_key=api_key,
             environment=os.environ.get("HONCHO_ENVIRONMENT", "production"),
             base_url=base_url,
+            ai_peer=resolved_host,
             enabled=bool(api_key or base_url),
         )
 
     @classmethod
     def from_global_config(
         cls,
-        host: str = HOST,
+        host: str | None = None,
         config_path: Path | None = None,
     ) -> HonchoClientConfig:
         """Create config from the resolved Honcho config path.
 
         Resolution: $HERMES_HOME/honcho.json -> ~/.honcho/config.json -> env vars.
         """
+        resolved_host = host or resolve_active_host()
         path = config_path or resolve_config_path()
         if not path.exists():
             logger.debug("No global Honcho config at %s, falling back to env", path)
-            return cls.from_env()
+            return cls.from_env(host=resolved_host)
 
         try:
             raw = json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as e:
             logger.warning("Failed to read %s: %s, falling back to env", path, e)
-            return cls.from_env()
+            return cls.from_env(host=resolved_host)
 
-        host_block = (raw.get("hosts") or {}).get(host, {})
+        host_block = (raw.get("hosts") or {}).get(resolved_host, {})
         # A hosts.hermes block or explicit enabled flag means the user
         # intentionally configured Honcho for this host.
         _explicitly_configured = bool(host_block) or raw.get("enabled") is True
@@ -177,12 +199,12 @@ class HonchoClientConfig:
         workspace = (
             host_block.get("workspace")
             or raw.get("workspace")
-            or host
+            or resolved_host
         )
         ai_peer = (
             host_block.get("aiPeer")
             or raw.get("aiPeer")
-            or host
+            or resolved_host
         )
         linked_hosts = host_block.get("linkedHosts", [])
 
@@ -242,7 +264,7 @@ class HonchoClientConfig:
         )
 
         return cls(
-            host=host,
+            host=resolved_host,
             workspace_id=workspace,
             api_key=api_key,
             environment=environment,

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -41,6 +41,7 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
         # Verify binaries exist and are executable
         package-contents = pkgs.runCommand "hermes-package-contents" { } ''
           set -e
+          export HOME=$(mktemp -d)
           echo "=== Checking binaries ==="
           test -x ${hermes-agent}/bin/hermes || (echo "FAIL: hermes binary missing"; exit 1)
           test -x ${hermes-agent}/bin/hermes-agent || (echo "FAIL: hermes-agent binary missing"; exit 1)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -85,6 +85,46 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "TimeoutStopSec=60" in unit
 
+    def test_user_unit_exports_instance_environment(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_INSTANCE", "dreamer")
+        monkeypatch.setenv("HERMES_BASE_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes" / "instances" / "dreamer"))
+        monkeypatch.setenv("HERMES_HONCHO_HOST", "hermes.dreamer")
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert 'Environment="HERMES_INSTANCE=dreamer"' in unit
+        assert f'Environment="HERMES_BASE_HOME={tmp_path / ".hermes"}"' in unit
+        assert f'Environment="HERMES_HOME={tmp_path / ".hermes" / "instances" / "dreamer"}"' in unit
+        assert 'Environment="HERMES_HONCHO_HOST=hermes.dreamer"' in unit
+
+    def test_service_name_uses_named_instance_slug(self, monkeypatch):
+        monkeypatch.setenv("HERMES_INSTANCE", "dreamer")
+        assert gateway_cli.get_service_name() == "hermes-gateway-dreamer"
+
+    def test_launchd_plist_path_scopes_named_instances(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(gateway_cli.Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_INSTANCE", "dreamer")
+
+        assert gateway_cli.get_launchd_plist_path() == tmp_path / "Library" / "LaunchAgents" / "ai.hermes.gateway.dreamer.plist"
+
+    def test_launchd_plist_uses_scoped_label_and_exports_instance_environment(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(gateway_cli.Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_INSTANCE", "dreamer")
+        monkeypatch.setenv("HERMES_BASE_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes" / "instances" / "dreamer"))
+        monkeypatch.setenv("HERMES_HONCHO_HOST", "hermes.dreamer")
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<string>ai.hermes.gateway.dreamer</string>" in plist
+        assert "<key>EnvironmentVariables</key>" in plist
+        assert f"<string>{tmp_path / '.hermes' / 'instances' / 'dreamer'}</string>" in plist
+        assert "<key>HERMES_INSTANCE</key>" in plist
+        assert "<string>dreamer</string>" in plist
+        assert "<key>HERMES_HONCHO_HOST</key>" in plist
+        assert "<string>hermes.dreamer</string>" in plist
+
     def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
         monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/home/test/.nvm/versions/node/v24.14.0/bin/node" if cmd == "node" else None)
 

--- a/tests/hermes_cli/test_instance_isolation.py
+++ b/tests/hermes_cli/test_instance_isolation.py
@@ -1,0 +1,214 @@
+"""Tests for Hermes named-instance isolation across config, env, memory, sessions, and skills."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.instance_runtime import (
+    DEFAULT_INSTANCE_NAME,
+    build_instance_runtime,
+    get_active_instance_name,
+    get_base_hermes_home,
+    get_instance_home,
+    get_instance_registry_path,
+    normalize_instance_name,
+    register_instance,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _setup_base(monkeypatch, tmp_path: Path) -> Path:
+    """Point all Hermes env vars at a fresh tmp_path base home."""
+    base = tmp_path / ".hermes"
+    base.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_BASE_HOME", str(base))
+    monkeypatch.setenv("HERMES_HOME", str(base))
+    monkeypatch.delenv("HERMES_INSTANCE", raising=False)
+    monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+    return base
+
+
+def _create_instance_dirs(base: Path, name: str) -> Path:
+    """Create a minimal instance directory structure."""
+    home = get_instance_home(name, base_home=base)
+    for sub in ("memories", "sessions", "skills", "skins", "logs", "plans",
+                "workspace", "audio_cache", "image_cache"):
+        (home / sub).mkdir(parents=True, exist_ok=True)
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Config isolation
+# ---------------------------------------------------------------------------
+
+class TestConfigIsolation:
+    def test_independent_config_yaml(self, tmp_path, monkeypatch):
+        base = _setup_base(monkeypatch, tmp_path)
+        home_a = _create_instance_dirs(base, "alpha")
+        home_b = _create_instance_dirs(base, "beta")
+
+        (home_a / "config.yaml").write_text("model: gpt-4\n")
+        (home_b / "config.yaml").write_text("model: claude-3\n")
+
+        assert (home_a / "config.yaml").read_text() == "model: gpt-4\n"
+        assert (home_b / "config.yaml").read_text() == "model: claude-3\n"
+
+        # Changing one does not affect the other
+        (home_a / "config.yaml").write_text("model: gpt-4o\n")
+        assert (home_b / "config.yaml").read_text() == "model: claude-3\n"
+
+
+# ---------------------------------------------------------------------------
+# Env isolation
+# ---------------------------------------------------------------------------
+
+class TestEnvIsolation:
+    def test_independent_env_files(self, tmp_path, monkeypatch):
+        base = _setup_base(monkeypatch, tmp_path)
+        home_a = _create_instance_dirs(base, "alpha")
+        home_b = _create_instance_dirs(base, "beta")
+
+        (home_a / ".env").write_text("API_KEY=key_alpha\n")
+        (home_b / ".env").write_text("API_KEY=key_beta\n")
+
+        assert "key_alpha" in (home_a / ".env").read_text()
+        assert "key_beta" in (home_b / ".env").read_text()
+
+        (home_b / ".env").write_text("API_KEY=key_beta_v2\n")
+        assert "key_alpha" in (home_a / ".env").read_text()
+
+
+# ---------------------------------------------------------------------------
+# Memory isolation
+# ---------------------------------------------------------------------------
+
+class TestMemoryIsolation:
+    def test_memory_files_independent(self, tmp_path, monkeypatch):
+        base = _setup_base(monkeypatch, tmp_path)
+        home_a = _create_instance_dirs(base, "alpha")
+        home_b = _create_instance_dirs(base, "beta")
+
+        (home_a / "memories" / "note.md").write_text("alpha memory")
+
+        assert (home_a / "memories" / "note.md").exists()
+        assert not (home_b / "memories" / "note.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Session isolation
+# ---------------------------------------------------------------------------
+
+class TestSessionIsolation:
+    def test_session_files_independent(self, tmp_path, monkeypatch):
+        base = _setup_base(monkeypatch, tmp_path)
+        home_a = _create_instance_dirs(base, "alpha")
+        home_b = _create_instance_dirs(base, "beta")
+
+        (home_a / "sessions" / "sess-001.json").write_text("{}")
+
+        assert (home_a / "sessions" / "sess-001.json").exists()
+        assert not (home_b / "sessions" / "sess-001.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Skills isolation
+# ---------------------------------------------------------------------------
+
+class TestSkillsIsolation:
+    def test_skill_files_independent(self, tmp_path, monkeypatch):
+        base = _setup_base(monkeypatch, tmp_path)
+        home_a = _create_instance_dirs(base, "alpha")
+        home_b = _create_instance_dirs(base, "beta")
+
+        (home_a / "skills" / "greet.py").write_text("def greet(): ...")
+
+        assert (home_a / "skills" / "greet.py").exists()
+        assert not (home_b / "skills" / "greet.py").exists()
+
+
+# ---------------------------------------------------------------------------
+# Instance CRUD
+# ---------------------------------------------------------------------------
+
+class TestInstanceCRUD:
+    def test_create_registers_and_list_shows(self, tmp_path, monkeypatch):
+        base = _setup_base(monkeypatch, tmp_path)
+        name = "dev-test"
+        runtime = build_instance_runtime(name, base_home=base)
+        home = runtime.home
+
+        # Create directory structure
+        for sub in ("memories", "sessions", "skills", "skins", "logs",
+                     "plans", "workspace", "audio_cache", "image_cache"):
+            (home / sub).mkdir(parents=True, exist_ok=True)
+
+        register_instance(runtime)
+
+        # Verify registry contains the instance
+        registry_path = get_instance_registry_path(base)
+        payload = json.loads(registry_path.read_text(encoding="utf-8"))
+        assert name in payload["instances"]
+        assert payload["instances"][name]["home"] == str(home)
+        assert payload["instances"][name]["honcho_host"] == f"hermes.{name}"
+
+    def test_delete_removes_from_registry(self, tmp_path, monkeypatch):
+        base = _setup_base(monkeypatch, tmp_path)
+        name = "ephemeral"
+        runtime = build_instance_runtime(name, base_home=base)
+        home = runtime.home
+        home.mkdir(parents=True, exist_ok=True)
+        register_instance(runtime)
+
+        # Simulate deletion: remove directory and registry entry
+        import shutil
+        shutil.rmtree(home)
+        registry_path = get_instance_registry_path(base)
+        payload = json.loads(registry_path.read_text(encoding="utf-8"))
+        payload["instances"].pop(name, None)
+        registry_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+        assert not home.exists()
+        payload2 = json.loads(registry_path.read_text(encoding="utf-8"))
+        assert name not in payload2["instances"]
+
+    def test_cannot_delete_main(self, tmp_path, monkeypatch):
+        """Verify the guard: DEFAULT_INSTANCE_NAME must not be deletable."""
+        base = _setup_base(monkeypatch, tmp_path)
+        name = normalize_instance_name("main")
+        assert name == DEFAULT_INSTANCE_NAME
+
+        # The CLI guards against this; we verify the invariant holds.
+        assert name == "main", "normalize_instance_name should resolve to 'main'"
+
+    def test_normalize_rejects_invalid_names(self):
+        with pytest.raises(ValueError):
+            normalize_instance_name("has spaces")
+        with pytest.raises(ValueError):
+            normalize_instance_name("@bad!")
+        with pytest.raises(ValueError):
+            normalize_instance_name("-starts-with-dash")
+
+    def test_normalize_maps_default_to_main(self):
+        assert normalize_instance_name("default") == DEFAULT_INSTANCE_NAME
+        assert normalize_instance_name("main") == DEFAULT_INSTANCE_NAME
+        assert normalize_instance_name("") == DEFAULT_INSTANCE_NAME
+        assert normalize_instance_name(None) == DEFAULT_INSTANCE_NAME
+
+    def test_instance_home_paths_are_distinct(self, tmp_path, monkeypatch):
+        base = _setup_base(monkeypatch, tmp_path)
+        home_main = get_instance_home(DEFAULT_INSTANCE_NAME, base_home=base)
+        home_alpha = get_instance_home("alpha", base_home=base)
+        home_beta = get_instance_home("beta", base_home=base)
+
+        assert home_main == base
+        assert home_alpha != home_beta
+        assert home_alpha != home_main
+        assert "instances/alpha" in str(home_alpha)
+        assert "instances/beta" in str(home_beta)

--- a/tests/hermes_cli/test_instance_runtime.py
+++ b/tests/hermes_cli/test_instance_runtime.py
@@ -1,0 +1,122 @@
+"""Tests for Hermes named instance runtime bootstrap and registry."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.instance_runtime import (
+    DEFAULT_INSTANCE_NAME,
+    bootstrap_instance_env,
+    get_active_honcho_host,
+    get_active_instance_name,
+    get_base_hermes_home,
+    get_instance_home,
+    get_instance_registry_path,
+    resolve_honcho_host,
+)
+
+
+def test_get_instance_home_uses_base_home_for_default_instance(tmp_path):
+    assert get_instance_home(DEFAULT_INSTANCE_NAME, base_home=tmp_path) == tmp_path
+
+
+def test_get_instance_home_uses_instances_dir_for_named_instance(tmp_path):
+    assert get_instance_home("dreamer", base_home=tmp_path) == tmp_path / "instances" / "dreamer"
+
+
+def test_resolve_honcho_host_uses_plain_hermes_for_default():
+    assert resolve_honcho_host(DEFAULT_INSTANCE_NAME) == "hermes"
+
+
+def test_resolve_honcho_host_scopes_named_instances():
+    assert resolve_honcho_host("dreamer") == "hermes.dreamer"
+
+
+def test_bootstrap_instance_env_strips_instance_flag_anywhere_and_sets_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("HERMES_BASE_HOME", raising=False)
+    monkeypatch.delenv("HERMES_INSTANCE", raising=False)
+    monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+
+    processed = bootstrap_instance_env(["gateway", "start", "--instance", "dreamer", "--system"])
+
+    expected_base = tmp_path / ".hermes"
+    expected_home = expected_base / "instances" / "dreamer"
+
+    assert processed == ["gateway", "start", "--system"]
+    assert Path(os.environ["HERMES_BASE_HOME"]) == expected_base
+    assert Path(os.environ["HERMES_HOME"]) == expected_home
+    assert os.environ["HERMES_INSTANCE"] == "dreamer"
+    assert os.environ["HERMES_HONCHO_HOST"] == "hermes.dreamer"
+
+
+def test_bootstrap_instance_env_supports_equals_syntax(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("HERMES_BASE_HOME", raising=False)
+    monkeypatch.delenv("HERMES_INSTANCE", raising=False)
+    monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+
+    processed = bootstrap_instance_env(["--instance=treasurer", "chat", "-q", "hi"])
+
+    assert processed == ["chat", "-q", "hi"]
+    assert os.environ["HERMES_INSTANCE"] == "treasurer"
+    assert os.environ["HERMES_HONCHO_HOST"] == "hermes.treasurer"
+
+
+def test_bootstrap_instance_env_keeps_default_instance_when_no_flag(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("HERMES_BASE_HOME", raising=False)
+    monkeypatch.delenv("HERMES_INSTANCE", raising=False)
+    monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+
+    processed = bootstrap_instance_env(["chat"])
+
+    expected_base = tmp_path / ".hermes"
+    assert processed == ["chat"]
+    assert Path(os.environ["HERMES_HOME"]) == expected_base
+    assert Path(os.environ["HERMES_BASE_HOME"]) == expected_base
+    assert os.environ["HERMES_INSTANCE"] == DEFAULT_INSTANCE_NAME
+    assert os.environ["HERMES_HONCHO_HOST"] == "hermes"
+
+
+def test_bootstrap_instance_env_registers_active_instance(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("HERMES_BASE_HOME", raising=False)
+    monkeypatch.delenv("HERMES_INSTANCE", raising=False)
+    monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+
+    bootstrap_instance_env(["--instance", "dreamer", "chat"])
+
+    registry_path = get_instance_registry_path()
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    entry = payload["instances"]["dreamer"]
+
+    assert entry["home"] == str(tmp_path / ".hermes" / "instances" / "dreamer")
+    assert entry["honcho_host"] == "hermes.dreamer"
+
+
+def test_get_base_home_and_active_values_derive_from_env(monkeypatch, tmp_path):
+    base_home = tmp_path / "hermes-root"
+    named_home = base_home / "instances" / "director"
+    monkeypatch.setenv("HERMES_HOME", str(named_home))
+    monkeypatch.setenv("HERMES_INSTANCE", "director")
+    monkeypatch.delenv("HERMES_BASE_HOME", raising=False)
+    monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+
+    assert get_base_hermes_home() == base_home
+    assert get_active_instance_name() == "director"
+    assert get_active_honcho_host() == "hermes.director"
+
+
+def test_bootstrap_rejects_missing_instance_value(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    with pytest.raises(ValueError, match="requires a value"):
+        bootstrap_instance_env(["chat", "--instance"])

--- a/tests/honcho_integration/test_cli.py
+++ b/tests/honcho_integration/test_cli.py
@@ -1,29 +1,37 @@
-"""Tests for Honcho CLI helpers."""
+"""Tests for Honcho CLI commands with named Hermes instances."""
 
-from honcho_integration.cli import _resolve_api_key
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import honcho_integration.cli as honcho_cli
 
 
-class TestResolveApiKey:
-    def test_prefers_host_scoped_key(self):
-        cfg = {
-            "apiKey": "root-key",
-            "hosts": {
-                "hermes": {
-                    "apiKey": "host-key",
-                }
-            },
-        }
-        assert _resolve_api_key(cfg) == "host-key"
+def test_cmd_peer_writes_to_active_instance_host_block(tmp_path, monkeypatch):
+    config_path = tmp_path / "honcho.json"
+    config_path.write_text("{}\n", encoding="utf-8")
 
-    def test_falls_back_to_root_key(self):
-        cfg = {
-            "apiKey": "root-key",
-            "hosts": {"hermes": {}},
-        }
-        assert _resolve_api_key(cfg) == "root-key"
+    monkeypatch.setenv("HERMES_INSTANCE", "dreamer")
+    monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+    monkeypatch.setattr(honcho_cli, "_config_path", lambda: config_path)
 
-    def test_falls_back_to_env_key(self, monkeypatch):
-        monkeypatch.setenv("HONCHO_API_KEY", "env-key")
-        assert _resolve_api_key({}) == "env-key"
-        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+    honcho_cli.cmd_peer(SimpleNamespace(user="eri", ai="dreamer", reasoning=None))
 
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["hosts"]["hermes.dreamer"]["peerName"] == "eri"
+    assert payload["hosts"]["hermes.dreamer"]["aiPeer"] == "dreamer"
+
+
+def test_cmd_mode_writes_memory_mode_to_active_instance_host_block(tmp_path, monkeypatch):
+    config_path = tmp_path / "honcho.json"
+    config_path.write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_INSTANCE", "treasurer")
+    monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+    monkeypatch.setattr(honcho_cli, "_config_path", lambda: config_path)
+
+    honcho_cli.cmd_mode(SimpleNamespace(mode="honcho"))
+
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["hosts"]["hermes.treasurer"]["memoryMode"] == "honcho"

--- a/tests/honcho_integration/test_client.py
+++ b/tests/honcho_integration/test_client.py
@@ -17,6 +17,12 @@ from honcho_integration.client import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_instance_host_env(monkeypatch):
+    monkeypatch.delenv("HERMES_INSTANCE", raising=False)
+    monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+
+
 class TestHonchoClientConfigDefaults:
     def test_default_values(self):
         config = HonchoClientConfig()
@@ -144,7 +150,7 @@ class TestFromGlobalConfig:
     def test_root_fields_used_when_no_host_block(self, tmp_path):
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps({
-            "apiKey": "key",
+            "apiKey": "***",
             "workspace": "root-ws",
             "aiPeer": "root-ai",
         }))
@@ -152,6 +158,45 @@ class TestFromGlobalConfig:
         config = HonchoClientConfig.from_global_config(config_path=config_file)
         assert config.workspace_id == "root-ws"
         assert config.ai_peer == "root-ai"
+
+    def test_uses_instance_scoped_host_by_default(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "***",
+            "workspace": "root-ws",
+            "aiPeer": "root-ai",
+            "hosts": {
+                "hermes.dreamer": {
+                    "workspace": "dreamer-ws",
+                    "aiPeer": "dreamer-ai",
+                }
+            }
+        }))
+
+        monkeypatch.setenv("HERMES_INSTANCE", "dreamer")
+        monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+
+        assert config.host == "hermes.dreamer"
+        assert config.workspace_id == "dreamer-ws"
+        assert config.ai_peer == "dreamer-ai"
+
+    def test_explicit_host_override_still_wins(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "***",
+            "hosts": {
+                "hermes": {"workspace": "main-ws"},
+                "hermes.dreamer": {"workspace": "dreamer-ws"},
+            }
+        }))
+
+        monkeypatch.setenv("HERMES_INSTANCE", "dreamer")
+        monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+        config = HonchoClientConfig.from_global_config(host="hermes", config_path=config_file)
+
+        assert config.host == "hermes"
+        assert config.workspace_id == "main-ws"
 
     def test_session_strategy_default_from_global_config(self, tmp_path):
         """from_global_config with no sessionStrategy should match dataclass default."""


### PR DESCRIPTION
Adds named Hermes instances via early runtime bootstrap. The active instance resolves to an isolated Hermes home, local session store, and gateway service identity, while Hermes-native session state remains authoritative. When Honcho is enabled, its host and peer resolution follow the active instance, enriching each named Hermes instance with identity modeling and continuity scoped to that instance.

## Summary
This introduces named Hermes instances as a native runtime primitive. Each instance gets isolated local state and service identity, while Hermes-native sessions remain the source of truth. When Honcho is enabled, host and peer resolution are derived from the active instance, allowing persistent identity modeling, memory retrieval, and cross-session continuity to accumulate independently for each named Hermes instance.

## What this changes
- adds early runtime bootstrap for `--instance` so the active instance is resolved before config-heavy imports
- scopes Hermes local state per instance via isolated Hermes homes
- introduces a small native instance runtime/registry layer
- scopes gateway service identity per instance across systemd and launchd
- derives Honcho host and peer resolution from the active instance when enabled
- adds regression coverage for bootstrap, env precedence, gateway service scoping, and Honcho host-block behavior

## Architecture
- default instance continues to use `~/.hermes`
- named instances resolve under `~/.hermes/instances/<name>`
- Hermes-native local session state remains authoritative
- gateway service identity is instance-scoped
- when Honcho is enabled, identity modeling, memory retrieval, and continuity are scoped to the active instance

## Implementation notes
- this PR establishes the runtime seam for named instances without introducing cross-instance merged session browsing

## Test plan
- `python -m pytest tests/hermes_cli/test_instance_runtime.py tests/hermes_cli/test_gateway_service.py tests/honcho_integration/test_client.py tests/honcho_integration/test_cli.py -q`
- `python -m pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_linger.py tests/hermes_cli/test_update_gateway_restart.py tests/hermes_cli/test_session_browse.py tests/hermes_cli/test_sessions_delete.py tests/gateway/test_honcho_lifecycle.py tests/tools/test_honcho_tools.py tests/test_honcho_client_config.py tests/hermes_cli/test_gateway_runtime_health.py tests/hermes_cli/test_status.py tests/gateway/test_session.py tests/test_hermes_state.py -q`

## Notes
- full-suite verification in this environment still includes unrelated optional-dependency and pre-existing failures outside this change surface
- verification here focused on the touched runtime, gateway, session, and Honcho-related surfaces
EOF; __hermes_rc=$?; printf '__HERMES_FENCE_a9f7b3__'; exit $__hermes_rc
