### PR TITLE
feat(context): compose context files instead of first-match-wins

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -565,14 +565,19 @@ def _load_cursorrules(cwd_path: Path) -> str:
 def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = False) -> str:
     """Discover and load context files for the system prompt.
 
-    Priority (first found wins — only ONE project context type is loaded):
-      1. .hermes.md / HERMES.md  (walk to git root)
-      2. AGENTS.md / agents.md   (recursive directory walk)
-      3. CLAUDE.md / claude.md   (cwd only)
-      4. .cursorrules / .cursor/rules/*.mdc  (cwd only)
+    Context files are composed rather than first-match-wins:
+
+      .hermes.md / HERMES.md  — per-project user instructions (walk to git root)
+      AGENTS.md / agents.md   — recursive dev guide
+      CLAUDE.md / claude.md   — Claude-specific instructions (cwd only)
+      .cursorrules            — fallback, only if none of the above are present
+
+    Multiple types can coexist. A shared 20,000-char budget is distributed
+    proportionally when the combined content would exceed it.
+    .cursorrules is treated as a pure fallback and skipped when any of the
+    primary sources are present.
 
     SOUL.md from HERMES_HOME is independent and always included when present.
-    Each context source is capped at 20,000 chars.
 
     When *skip_soul* is True, SOUL.md is not included here (it was already
     loaded via ``load_soul_md()`` for the identity slot).
@@ -583,15 +588,30 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
     cwd_path = Path(cwd).resolve()
     sections = []
 
-    # Priority-based project context: first match wins
-    project_context = (
-        _load_hermes_md(cwd_path)
-        or _load_agents_md(cwd_path)
-        or _load_claude_md(cwd_path)
-        or _load_cursorrules(cwd_path)
-    )
-    if project_context:
+    # Compose all present primary context sources
+    hermes = _load_hermes_md(cwd_path)
+    agents = _load_agents_md(cwd_path)
+    claude = _load_claude_md(cwd_path)
+
+    primary_parts = [p for p in (hermes, agents, claude) if p]
+
+    if primary_parts:
+        # Distribute the shared budget proportionally across all present sources
+        total_chars = sum(len(p) for p in primary_parts)
+        if total_chars > CONTEXT_FILE_MAX_CHARS:
+            budget_parts = []
+            for part in primary_parts:
+                share = int(CONTEXT_FILE_MAX_CHARS * len(part) / total_chars)
+                budget_parts.append(part[:share])
+            project_context = "\n\n".join(budget_parts)
+        else:
+            project_context = "\n\n".join(primary_parts)
         sections.append(project_context)
+    else:
+        # No primary sources — fall back to .cursorrules
+        cursorrules = _load_cursorrules(cwd_path)
+        if cursorrules:
+            sections.append(cursorrules)
 
     # SOUL.md from HERMES_HOME only — skip when already loaded as identity
     if not skip_soul:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -526,20 +526,21 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "BLOCKED" in result
 
-    def test_hermes_md_beats_agents_md(self, tmp_path):
-        """When both exist, .hermes.md wins and AGENTS.md is not loaded."""
+    def test_hermes_md_and_agents_md_are_composed(self, tmp_path):
+        """When both exist, both are loaded and composed together."""
         (tmp_path / "AGENTS.md").write_text("Agent guidelines here.")
         (tmp_path / ".hermes.md").write_text("Hermes project rules.")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Hermes project rules" in result
-        assert "Agent guidelines" not in result
+        assert "Agent guidelines" in result
 
-    def test_agents_md_beats_claude_md(self, tmp_path):
+    def test_agents_md_and_claude_md_are_composed(self, tmp_path):
+        """When both exist, both are loaded and composed together."""
         (tmp_path / "AGENTS.md").write_text("Agent guidelines here.")
         (tmp_path / "CLAUDE.md").write_text("Claude guidelines here.")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Agent guidelines" in result
-        assert "Claude guidelines" not in result
+        assert "Claude guidelines" in result
 
     def test_claude_md_beats_cursorrules(self, tmp_path):
         (tmp_path / "CLAUDE.md").write_text("Claude guidelines here.")
@@ -572,17 +573,17 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "BLOCKED" in result
 
-    def test_hermes_md_beats_all_others(self, tmp_path):
-        """When all four types exist, only .hermes.md is loaded."""
+    def test_all_primary_sources_are_composed(self, tmp_path):
+        """When all primary types exist, all are composed. .cursorrules is skipped as fallback."""
         (tmp_path / ".hermes.md").write_text("Hermes wins.")
-        (tmp_path / "AGENTS.md").write_text("Agents lose.")
-        (tmp_path / "CLAUDE.md").write_text("Claude loses.")
-        (tmp_path / ".cursorrules").write_text("Cursor loses.")
+        (tmp_path / "AGENTS.md").write_text("Agents included.")
+        (tmp_path / "CLAUDE.md").write_text("Claude included.")
+        (tmp_path / ".cursorrules").write_text("Cursor skipped.")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Hermes wins" in result
-        assert "Agents lose" not in result
-        assert "Claude loses" not in result
-        assert "Cursor loses" not in result
+        assert "Agents included" in result
+        assert "Claude included" in result
+        assert "Cursor skipped" not in result
 
     def test_cursorrules_loads_when_only_option(self, tmp_path):
         """Cursorrules still loads when no higher-priority files exist."""


### PR DESCRIPTION
Fixes #2835

## Problem

`build_context_files_prompt()` used an `or`-chain that silently dropped every context file after the first match. A project with both `.hermes.md` and `AGENTS.md` would never see the second one.

## Solution

Load all present primary sources and concatenate them. A shared 20,000-char budget is distributed proportionally when the combined content would exceed it.

**New composition order:**

| Source | Role | Behavior |
|---|---|---|
| `.hermes.md` / `HERMES.md` | Per-project user instructions | Always loaded if present |
| `AGENTS.md` / `agents.md` | Recursive dev guide | Always loaded if present |
| `CLAUDE.md` / `claude.md` | Claude-specific instructions | Always loaded if present |
| `.cursorrules` / `.cursor/rules/` | Legacy fallback | Only loaded when none of the above are present |

## Backward compatibility

- Projects with a single context file type: identical behavior
- Cursor-only projects (`.cursorrules`, no `AGENTS.md`): identical behavior
- Only change: projects with multiple primary types now get all of them