### PR TITLE
feat(session-continuity): persist exit summaries and inject recent context

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -51,6 +51,75 @@ _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 _CHARS_PER_TOKEN = 4
 
 
+def serialize_turns_for_summary(
+    turns: List[Dict[str, Any]],
+    max_turns: int = 0,
+    max_content_chars: int = 3000,
+) -> str:
+    """Serialize conversation turns into labeled text for summarization.
+
+    Standalone utility used by both ContextCompressor and exit-summary
+    generation.  Includes tool call arguments and result content so the
+    summarizer can preserve specific details like file paths and commands.
+
+    Args:
+        turns: List of message dicts (role, content, tool_calls, ...).
+        max_turns: If > 0, only serialize the last *max_turns* messages.
+        max_content_chars: Per-message content truncation limit.
+    """
+    if max_turns > 0:
+        turns = turns[-max_turns:]
+
+    parts: List[str] = []
+    for msg in turns:
+        role = msg.get("role", "unknown")
+        content = msg.get("content") or ""
+
+        # Tool results
+        if role == "tool":
+            tool_id = msg.get("tool_call_id", "")
+            if len(content) > max_content_chars:
+                keep = max_content_chars * 2 // 3
+                tail = max_content_chars - keep
+                content = content[:keep] + "\n...[truncated]...\n" + content[-tail:]
+            parts.append(f"[TOOL RESULT {tool_id}]: {content}")
+            continue
+
+        # Assistant messages: include tool call names AND arguments
+        if role == "assistant":
+            if len(content) > max_content_chars:
+                keep = max_content_chars * 2 // 3
+                tail = max_content_chars - keep
+                content = content[:keep] + "\n...[truncated]...\n" + content[-tail:]
+            tool_calls = msg.get("tool_calls", [])
+            if tool_calls:
+                tc_parts = []
+                for tc in tool_calls:
+                    if isinstance(tc, dict):
+                        fn = tc.get("function", {})
+                        name = fn.get("name", "?")
+                        args = fn.get("arguments", "")
+                        if len(args) > 500:
+                            args = args[:400] + "..."
+                        tc_parts.append(f"  {name}({args})")
+                    else:
+                        fn = getattr(tc, "function", None)
+                        name = getattr(fn, "name", "?") if fn else "?"
+                        tc_parts.append(f"  {name}(...)")
+                content += "\n[Tool calls:\n" + "\n".join(tc_parts) + "\n]"
+            parts.append(f"[ASSISTANT]: {content}")
+            continue
+
+        # User and other roles
+        if len(content) > max_content_chars:
+            keep = max_content_chars * 2 // 3
+            tail = max_content_chars - keep
+            content = content[:keep] + "\n...[truncated]...\n" + content[-tail:]
+        parts.append(f"[{role.upper()}]: {content}")
+
+    return "\n\n".join(parts)
+
+
 class ContextCompressor:
     """Compresses conversation context when approaching the model's context limit.
 
@@ -187,53 +256,9 @@ class ContextCompressor:
     def _serialize_for_summary(self, turns: List[Dict[str, Any]]) -> str:
         """Serialize conversation turns into labeled text for the summarizer.
 
-        Includes tool call arguments and result content (up to 3000 chars
-        per message) so the summarizer can preserve specific details like
-        file paths, commands, and outputs.
+        Delegates to the module-level ``serialize_turns_for_summary`` utility.
         """
-        parts = []
-        for msg in turns:
-            role = msg.get("role", "unknown")
-            content = msg.get("content") or ""
-
-            # Tool results: keep more content than before (3000 chars)
-            if role == "tool":
-                tool_id = msg.get("tool_call_id", "")
-                if len(content) > 3000:
-                    content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
-                parts.append(f"[TOOL RESULT {tool_id}]: {content}")
-                continue
-
-            # Assistant messages: include tool call names AND arguments
-            if role == "assistant":
-                if len(content) > 3000:
-                    content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
-                tool_calls = msg.get("tool_calls", [])
-                if tool_calls:
-                    tc_parts = []
-                    for tc in tool_calls:
-                        if isinstance(tc, dict):
-                            fn = tc.get("function", {})
-                            name = fn.get("name", "?")
-                            args = fn.get("arguments", "")
-                            # Truncate long arguments but keep enough for context
-                            if len(args) > 500:
-                                args = args[:400] + "..."
-                            tc_parts.append(f"  {name}({args})")
-                        else:
-                            fn = getattr(tc, "function", None)
-                            name = getattr(fn, "name", "?") if fn else "?"
-                            tc_parts.append(f"  {name}(...)")
-                    content += "\n[Tool calls:\n" + "\n".join(tc_parts) + "\n]"
-                parts.append(f"[ASSISTANT]: {content}")
-                continue
-
-            # User and other roles
-            if len(content) > 3000:
-                content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
-            parts.append(f"[{role.upper()}]: {content}")
-
-        return "\n\n".join(parts)
+        return serialize_turns_for_summary(turns)
 
     def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]]) -> Optional[str]:
         """Generate a structured summary of conversation turns.

--- a/cli.py
+++ b/cli.py
@@ -1016,6 +1016,8 @@ class HermesCLI:
         resume: str = None,
         checkpoints: bool = False,
         pass_session_id: bool = False,
+        last_session_summary: str = None,
+        last_session_time: float = None,
     ):
         """
         Initialize the Hermes CLI.
@@ -1031,6 +1033,8 @@ class HermesCLI:
             compact: Use compact display mode
             resume: Session ID to resume (restores conversation history from SQLite)
             pass_session_id: Include the session ID in the agent's system prompt
+            last_session_summary: Brief summary of previous session for continuity injection
+            last_session_time: Unix timestamp of when the previous session started
         """
         # Initialize Rich console
         self.console = Console()
@@ -1138,6 +1142,8 @@ class HermesCLI:
         self.checkpoints_enabled = checkpoints or cp_cfg.get("enabled", False)
         self.checkpoint_max_snapshots = cp_cfg.get("max_snapshots", 50)
         self.pass_session_id = pass_session_id
+        self._last_session_summary = last_session_summary
+        self._last_session_time = last_session_time
         
         # Ephemeral system prompt: env var takes precedence, then config
         self.system_prompt = (
@@ -1933,6 +1939,12 @@ class HermesCLI:
                 checkpoints_enabled=self.checkpoints_enabled,
                 checkpoint_max_snapshots=self.checkpoint_max_snapshots,
                 pass_session_id=self.pass_session_id,
+                last_session_summary=(
+                    self._last_session_summary if not self._resumed else None
+                ),
+                last_session_time=(
+                    self._last_session_time if not self._resumed else None
+                ),
                 tool_progress_callback=self._on_tool_progress,
                 stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
@@ -2782,7 +2794,16 @@ class HermesCLI:
             except Exception:
                 pass
 
+        # Generate exit summary before ending the old session
         old_session_id = self.session_id
+        if self.conversation_history and len(self.conversation_history) > 4:
+            try:
+                exit_summary = self._generate_exit_summary()
+                if exit_summary and self._session_db and old_session_id:
+                    self._session_db.update_exit_summary(old_session_id, exit_summary)
+            except Exception:
+                pass
+
         if self._session_db and old_session_id:
             try:
                 self._session_db.end_session(old_session_id, "new_session")
@@ -5728,6 +5749,47 @@ class HermesCLI:
             if tts_thread is not None and tts_thread.is_alive():
                 tts_thread.join(timeout=5)
     
+    def _generate_exit_summary(self) -> Optional[str]:
+        """Generate a brief exit summary for session continuity.
+
+        Uses the auxiliary LLM to summarize the conversation in 2-4 sentences.
+        Returns None if the conversation is too short or the LLM call fails.
+        """
+        if len(self.conversation_history) < 5:
+            return None
+        try:
+            from agent.auxiliary_client import call_llm
+            from agent.context_compressor import serialize_turns_for_summary
+
+            serialized = serialize_turns_for_summary(
+                self.conversation_history, max_turns=30, max_content_chars=1500,
+            )
+            if not serialized.strip():
+                return None
+
+            response = call_llm(
+                task="exit_summary",
+                messages=[{
+                    "role": "user",
+                    "content": (
+                        "Summarize this conversation in 2-4 sentences for continuity "
+                        "into the next session. Include: what the user was working on, "
+                        "key outcomes, and any unfinished work. Be specific (file names, "
+                        "error messages, decisions) but extremely concise.\n\n"
+                        f"CONVERSATION:\n{serialized}"
+                    ),
+                }],
+                max_tokens=300,
+                timeout=5.0,
+            )
+            if response and hasattr(response, "choices") and response.choices:
+                content = response.choices[0].message.content
+                if content and content.strip():
+                    return content.strip()
+        except Exception:
+            logger.debug("Exit summary generation failed", exc_info=True)
+        return None
+
     def _print_exit_summary(self):
         """Print session resume info on exit, similar to Claude Code."""
         print()
@@ -7140,6 +7202,14 @@ class HermesCLI:
                     self.agent._honcho.shutdown()
                 except Exception:
                     pass
+            # Generate exit summary for session continuity
+            if self.agent and self.conversation_history and len(self.conversation_history) > 4:
+                try:
+                    exit_summary = self._generate_exit_summary()
+                    if exit_summary and hasattr(self, '_session_db') and self._session_db:
+                        self._session_db.update_exit_summary(self.session_id, exit_summary)
+                except Exception:
+                    pass
             # Close session in SQLite
             if hasattr(self, '_session_db') and self._session_db and self.agent:
                 try:
@@ -7175,10 +7245,12 @@ def main(
     w: bool = False,
     checkpoints: bool = False,
     pass_session_id: bool = False,
+    last_session_summary: str = None,
+    last_session_time: float = None,
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
-    
+
     Args:
         query: Single query to execute (then exit). Alias: -q
         q: Shorthand for --query
@@ -7285,6 +7357,8 @@ def main(
         resume=resume,
         checkpoints=checkpoints,
         pass_session_id=pass_session_id,
+        last_session_summary=last_session_summary,
+        last_session_time=last_session_time,
     )
 
     if parsed_skills:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -618,6 +618,38 @@ class GatewayRunner:
                 sync_honcho=False,
             )
             logger.info("Pre-reset memory flush completed for session %s", old_session_id)
+
+            # Generate exit summary for session continuity
+            if len(msgs) >= 5:
+                try:
+                    from agent.auxiliary_client import call_llm as _aux_call
+                    from agent.context_compressor import serialize_turns_for_summary
+                    _serialized = serialize_turns_for_summary(history, max_turns=30, max_content_chars=1500)
+                    if _serialized.strip():
+                        _resp = _aux_call(
+                            task="exit_summary",
+                            messages=[{
+                                "role": "user",
+                                "content": (
+                                    "Summarize this conversation in 2-4 sentences for continuity "
+                                    "into the next session. Include: what the user was working on, "
+                                    "key outcomes, and any unfinished work. Be specific (file names, "
+                                    "error messages, decisions) but extremely concise.\n\n"
+                                    f"CONVERSATION:\n{_serialized}"
+                                ),
+                            }],
+                            max_tokens=300,
+                            timeout=5.0,
+                        )
+                        if _resp and hasattr(_resp, "choices") and _resp.choices:
+                            _summary = _resp.choices[0].message.content
+                            if _summary and _summary.strip():
+                                self.session_store._db.update_exit_summary(
+                                    old_session_id, _summary.strip(),
+                                )
+                except Exception:
+                    logger.debug("Exit summary generation failed for session %s", old_session_id, exc_info=True)
+
             # Flush any queued Honcho writes before the session is dropped
             if getattr(tmp_agent, '_honcho', None):
                 try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -168,6 +168,14 @@ DEFAULT_CONFIG = {
         "summary_provider": "auto",
         "summary_base_url": None,
     },
+    # Session continuity — auto-generate a summary on exit, inject into next session.
+    "continuity": {
+        "enabled": True,          # Generate exit summaries and offer resume prompt
+        "recency_hours": 4,       # Only show prompt for sessions within this window
+        "min_messages": 5,        # Minimum message count to generate a summary
+        "show_prompt": True,      # Show "Resume?" prompt on startup (TTY only)
+    },
+
     "smart_model_routing": {
         "enabled": False,
         "max_simple_chars": 160,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -468,6 +468,49 @@ def cmd_chat(args):
         # If resolution fails, keep the original value — _init_agent will
         # report "Session not found" with the original input
 
+    # Session continuity: offer to resume last session or silently inject summary
+    if not getattr(args, "resume", None):
+        try:
+            from hermes_state import SessionDB
+            from hermes_cli.config import load_config as _load_cont_cfg
+            _cont_cfg = _load_cont_cfg().get("continuity", {})
+            if _cont_cfg.get("enabled", True):
+                _cont_db = SessionDB()
+                _last = _cont_db.get_last_summarized_session(
+                    source="cli",
+                    max_age_seconds=_cont_cfg.get("recency_hours", 4) * 3600,
+                    min_messages=_cont_cfg.get("min_messages", 5),
+                )
+                _cont_db.close()
+                if _last:
+                    _elapsed = _time.time() - _last["started_at"]
+                    if _elapsed < 3600:
+                        _age_str = f"{int(_elapsed / 60)}m ago"
+                    else:
+                        _age_str = f"{_elapsed / 3600:.1f}h ago"
+                    _title = _last.get("title") or _last["id"][:18]
+                    _msg_count = _last.get("message_count", 0)
+
+                    if _cont_cfg.get("show_prompt", True) and sys.stdin.isatty():
+                        print(f'\n  Last session: "{_title}" ({_age_str}, {_msg_count} messages)')
+                        try:
+                            _reply = input("  Resume? [y] to resume, [Enter] to start fresh: ").strip().lower()
+                        except (EOFError, KeyboardInterrupt):
+                            _reply = ""
+                        if _reply in ("y", "yes"):
+                            args.resume = _last["id"]
+                        else:
+                            # Inject summary silently for continuity
+                            args._last_session_summary = _last.get("exit_summary")
+                            args._last_session_time = _last.get("started_at")
+                        print()
+                    else:
+                        # Non-interactive: just inject summary silently
+                        args._last_session_summary = _last.get("exit_summary")
+                        args._last_session_time = _last.get("started_at")
+        except Exception:
+            pass
+
     # First-run guard: check if any provider is configured before launching
     if not _has_any_provider_configured():
         print()
@@ -529,6 +572,8 @@ def cmd_chat(args):
         "worktree": getattr(args, "worktree", False),
         "checkpoints": getattr(args, "checkpoints", False),
         "pass_session_id": getattr(args, "pass_session_id", False),
+        "last_session_summary": getattr(args, "_last_session_summary", None),
+        "last_session_time": getattr(args, "_last_session_time", None),
     }
     # Filter out None values
     kwargs = {k: v for k, v in kwargs.items() if v is not None}

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -26,7 +26,7 @@ from typing import Dict, Any, List, Optional
 
 DEFAULT_DB_PATH = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -60,6 +60,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     cost_source TEXT,
     pricing_version TEXT,
     title TEXT,
+    exit_summary TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -189,6 +190,13 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass
                 cursor.execute("UPDATE schema_version SET version = 5")
+            if current_version < 6:
+                # v6: add exit_summary column for session continuity
+                try:
+                    cursor.execute("ALTER TABLE sessions ADD COLUMN exit_summary TEXT")
+                except sqlite3.OperationalError:
+                    pass  # Column already exists
+                cursor.execute("UPDATE schema_version SET version = 6")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -257,6 +265,43 @@ class SessionDB:
                 (time.time(), end_reason, session_id),
             )
             self._conn.commit()
+
+    def update_exit_summary(self, session_id: str, summary: str) -> None:
+        """Store a brief exit summary for session continuity."""
+        with self._lock:
+            self._conn.execute(
+                "UPDATE sessions SET exit_summary = ? WHERE id = ?",
+                (summary, session_id),
+            )
+            self._conn.commit()
+
+    def get_last_summarized_session(
+        self,
+        source: str = "cli",
+        max_age_seconds: float = 14400,
+        min_messages: int = 5,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the most recent session with an exit summary.
+
+        Filters by source, recency, and minimum message count.
+        Returns None if no qualifying session exists.
+        """
+        cutoff = time.time() - max_age_seconds
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT id, title, exit_summary, started_at, message_count "
+                "FROM sessions "
+                "WHERE exit_summary IS NOT NULL "
+                "  AND source = ? "
+                "  AND message_count >= ? "
+                "  AND started_at > ? "
+                "ORDER BY started_at DESC LIMIT 1",
+                (source, min_messages, cutoff),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return dict(row)
 
     def update_system_prompt(self, session_id: str, system_prompt: str) -> None:
         """Store the full assembled system prompt snapshot."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -419,6 +419,8 @@ class AIAgent:
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
+        last_session_summary: str = None,
+        last_session_time: float = None,
     ):
         """
         Initialize the AI Agent.
@@ -483,6 +485,8 @@ class AIAgent:
         self._print_fn = None
         self.skip_context_files = skip_context_files
         self.pass_session_id = pass_session_id
+        self.last_session_summary = last_session_summary
+        self.last_session_time = last_session_time
         self.log_prefix_chars = log_prefix_chars
         self.log_prefix = f"{log_prefix} " if log_prefix else ""
         # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
@@ -2348,6 +2352,24 @@ class AIAgent:
                 user_block = self._memory_store.format_for_system_prompt("user")
                 if user_block:
                     prompt_parts.append(user_block)
+
+        # Inject last session summary for continuity (new sessions only)
+        if self.last_session_summary:
+            header = (
+                "# Last Session Context\n"
+                "The following is a brief summary of the user's most recent session. "
+                "Use it for continuity \u2014 if the user wants to pick up where they left off, "
+                "you have context. Do not proactively reference it unless the user's message "
+                "is clearly related.\n"
+            )
+            if self.last_session_time:
+                from datetime import datetime
+                try:
+                    ts = datetime.fromtimestamp(self.last_session_time)
+                    header += f"\nLast session: {ts.strftime('%A, %B %d, %Y at %I:%M %p')}\n"
+                except Exception:
+                    pass
+            prompt_parts.append(header + "\n" + self.last_session_summary)
 
         has_skills_tools = any(name in self.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
         if has_skills_tools:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -737,7 +737,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 5
+        assert version == 6
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -793,12 +793,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v5
+        # Open with SessionDB — should migrate to v6
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 5
+        assert cursor.fetchone()[0] == 6
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -1031,3 +1031,77 @@ class TestResolveSessionByNameOrId:
         db.set_session_title("s1", "my project")
         result = db.resolve_session_by_title("my project")
         assert result == "s1"
+
+
+class TestExitSummary:
+    """Tests for session continuity exit summary storage and retrieval."""
+
+    def test_exit_summary_column_exists(self, db):
+        cursor = db._conn.execute("PRAGMA table_info(sessions)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "exit_summary" in columns
+
+    def test_update_exit_summary(self, db):
+        db.create_session("s1", "cli")
+        db.update_exit_summary("s1", "We worked on the auth module.")
+        session = db.get_session("s1")
+        assert session["exit_summary"] == "We worked on the auth module."
+
+    def test_update_exit_summary_overwrites(self, db):
+        db.create_session("s1", "cli")
+        db.update_exit_summary("s1", "First summary")
+        db.update_exit_summary("s1", "Updated summary")
+        session = db.get_session("s1")
+        assert session["exit_summary"] == "Updated summary"
+
+    def test_get_last_summarized_session_basic(self, db):
+        db.create_session("s1", "cli")
+        # Add enough messages to pass min_messages filter
+        for i in range(6):
+            db.append_message("s1", "user", f"msg {i}")
+        db.update_exit_summary("s1", "Worked on feature X.")
+        result = db.get_last_summarized_session(source="cli", max_age_seconds=9999)
+        assert result is not None
+        assert result["id"] == "s1"
+        assert result["exit_summary"] == "Worked on feature X."
+
+    def test_get_last_summarized_session_filters_source(self, db):
+        db.create_session("s1", "telegram")
+        for i in range(6):
+            db.append_message("s1", "user", f"msg {i}")
+        db.update_exit_summary("s1", "Telegram session summary")
+        # Should not find it when filtering by 'cli'
+        result = db.get_last_summarized_session(source="cli", max_age_seconds=9999)
+        assert result is None
+
+    def test_get_last_summarized_session_filters_min_messages(self, db):
+        db.create_session("s1", "cli")
+        db.append_message("s1", "user", "short convo")
+        db.update_exit_summary("s1", "Too short.")
+        result = db.get_last_summarized_session(source="cli", max_age_seconds=9999, min_messages=5)
+        assert result is None
+
+    def test_get_last_summarized_session_no_summary(self, db):
+        db.create_session("s1", "cli")
+        for i in range(6):
+            db.append_message("s1", "user", f"msg {i}")
+        # No exit_summary set
+        result = db.get_last_summarized_session(source="cli", max_age_seconds=9999)
+        assert result is None
+
+    def test_get_last_summarized_session_returns_most_recent(self, db):
+        import time
+        db.create_session("s1", "cli")
+        for i in range(6):
+            db.append_message("s1", "user", f"msg {i}")
+        db.update_exit_summary("s1", "Older session")
+
+        time.sleep(0.05)  # ensure different started_at
+        db.create_session("s2", "cli")
+        for i in range(6):
+            db.append_message("s2", "user", f"msg {i}")
+        db.update_exit_summary("s2", "Newer session")
+
+        result = db.get_last_summarized_session(source="cli", max_age_seconds=9999)
+        assert result["id"] == "s2"
+        assert result["exit_summary"] == "Newer session"


### PR DESCRIPTION
Title
feat(session-continuity): persist exit summaries and inject recent context into fresh sessions

Summary
This PR adds session continuity for Hermes by storing concise exit summaries at session end and using the latest summary to bootstrap the next fresh session. It improves “pick up where I left off” behavior without forcing explicit resume.

What changed
1) Session DB
- Bump schema version to 6
- Add `sessions.exit_summary` column
- Add `update_exit_summary(session_id, summary)`
- Add `get_last_summarized_session(source, max_age_seconds, min_messages)`

2) Shared summarization utility
- Add `serialize_turns_for_summary(...)` in `agent/context_compressor.py`
- Reuse it in compressor + exit-summary generation path to preserve tool args/results context

3) CLI continuity flow
- On chat startup (when not `--resume`):
  - detect last summarized session within continuity window
  - prompt in TTY to resume vs start fresh
  - if fresh, inject summary into the new agent context
- On session exit / new-session rollover:
  - generate concise 2–4 sentence exit summary via auxiliary model
  - persist summary into SessionDB
- Add continuity config:
  - `continuity.enabled`
  - `continuity.recency_hours`
  - `continuity.min_messages`
  - `continuity.show_prompt`

4) Agent injection
- `AIAgent` accepts `last_session_summary` + `last_session_time`
- New “Last Session Context” block injected into prompt for new sessions only

5) Gateway parity (reset path)
- Generate and store exit summary before session reset, same style as CLI

6) Tests
- Update schema expectation to v6
- Add tests for exit_summary column, update behavior, filtering, and recency/source/min-message logic

Design constraints
- Continuity injection is disabled when explicitly resuming an existing session
- Continuity is best-effort (fail-open): summary generation errors do not block session lifecycle
- Prompt guidance says do not proactively reference old summary unless user intent is related

Risk/impact
- Medium: touches prompt assembly + session lifecycle + DB migration
- Low operational risk if migration succeeds; backward-compatible `ALTER TABLE` guarded by try/except

Validation checklist
- [ ] Fresh install creates schema v6 with `exit_summary`
- [ ] Existing v5 DB migrates cleanly to v6
- [ ] `hermes` startup prompt appears only in TTY and only within recency window
- [ ] `--resume` path does not inject continuity summary
- [ ] New session with continuity has expected prompt block
- [ ] Exit/new-session stores summary when message threshold met
- [ ] Full tests pass in clean contributor env

Manual test plan
1) Create session A, exchange >= 5 messages, exit.
2) Start new `hermes` session:
   - verify resume prompt appears
   - choose Enter (fresh) and verify continuity-aware behavior
3) Start again and choose `y`:
   - verify true resume loads prior conversation history
4) Run `hermes --resume <id>` explicitly:
   - verify no continuity summary injection

Follow-ups (recommended split if needed)
- Optional: move gateway/CLI exit summary generation into one shared helper to reduce duplication
- Optional: explicit unit tests for CLI startup prompt + non-interactive mode behavior
- Optional: add telemetry counters for continuity prompt shown / resume chosen / summary injected
