### PR TITLE
security: least-privilege toolset for SMS platform

### DIFF
--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -9,20 +9,25 @@ Shares credentials with the optional telephony skill — same env vars:
   - TWILIO_PHONE_NUMBER  (E.164 from-number, e.g. +15551234567)
 
 Gateway-specific env vars:
-  - SMS_WEBHOOK_PORT     (default 8080)
-  - SMS_ALLOWED_USERS    (comma-separated E.164 phone numbers)
-  - SMS_ALLOW_ALL_USERS  (true/false)
-  - SMS_HOME_CHANNEL     (phone number for cron delivery)
+  - SMS_WEBHOOK_PORT      (default 8080)
+  - SMS_WEBHOOK_HOST      (default 127.0.0.1)
+  - SMS_PUBLIC_WEBHOOK_URL (canonical public URL for Twilio signature validation)
+  - SMS_ALLOWED_USERS     (comma-separated E.164 phone numbers)
+  - SMS_ALLOW_ALL_USERS   (true/false)
+  - SMS_HOME_CHANNEL      (phone number for cron delivery)
 """
 
 import asyncio
 import base64
-import json
+import hashlib
+import hmac
 import logging
 import os
 import re
+import time
 import urllib.parse
-from typing import Any, Dict, List, Optional
+from collections import defaultdict, deque
+from typing import Any, Deque, Dict, Optional
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -37,6 +42,11 @@ logger = logging.getLogger(__name__)
 TWILIO_API_BASE = "https://api.twilio.com/2010-04-01/Accounts"
 MAX_SMS_LENGTH = 1600  # ~10 SMS segments
 DEFAULT_WEBHOOK_PORT = 8080
+DEFAULT_WEBHOOK_HOST = "127.0.0.1"
+DEFAULT_PUBLIC_WEBHOOK_URL = "https://sms.gibbsoft.click/webhooks/twilio"
+DEFAULT_WINDOW_SECONDS = 60
+DEFAULT_MAX_REQUESTS_PER_WINDOW = 30
+DEFAULT_REPLAY_TTL_SECONDS = 600
 
 # E.164 phone number pattern for redaction
 _PHONE_RE = re.compile(r"\+[1-9]\d{6,14}")
@@ -49,6 +59,65 @@ def _redact_phone(phone: str) -> str:
     if len(phone) <= 8:
         return phone[:2] + "***" + phone[-2:] if len(phone) > 4 else "****"
     return phone[:5] + "***" + phone[-4:]
+
+
+class SlidingWindowRateLimiter:
+    def __init__(self, max_events: int, window_seconds: int):
+        self.max_events = max_events
+        self.window_seconds = window_seconds
+        self._events: Dict[str, Deque[float]] = defaultdict(deque)
+
+    def allow(self, key: str) -> bool:
+        now = time.monotonic()
+        events = self._events[key]
+        cutoff = now - self.window_seconds
+        while events and events[0] < cutoff:
+            events.popleft()
+        if len(events) >= self.max_events:
+            return False
+        events.append(now)
+        return True
+
+
+class ReplayCache:
+    def __init__(self, ttl_seconds: int):
+        self.ttl_seconds = ttl_seconds
+        self._seen: dict[str, float] = {}
+
+    def seen(self, key: str) -> bool:
+        now = time.monotonic()
+        cutoff = now - self.ttl_seconds
+        expired = [k for k, ts in self._seen.items() if ts < cutoff]
+        for old_key in expired:
+            self._seen.pop(old_key, None)
+        if key in self._seen:
+            return True
+        self._seen[key] = now
+        return False
+
+
+def _signature_payload(url: str, form: dict[str, list[str]]) -> str:
+    payload = url
+    for key in sorted(form):
+        for value in form[key]:
+            payload += key + value
+    return payload
+
+
+def _compute_twilio_signature(url: str, form: dict[str, list[str]], auth_token: str) -> str:
+    digest = hmac.new(
+        auth_token.encode("utf-8"),
+        _signature_payload(url, form).encode("utf-8"),
+        hashlib.sha1,
+    ).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+def is_valid_twilio_request(url: str, form: dict[str, list[str]], signature: str, auth_token: str) -> bool:
+    if not url or not signature or not auth_token:
+        return False
+    expected = _compute_twilio_signature(url, form, auth_token)
+    return hmac.compare_digest(expected, signature)
 
 
 def check_sms_requirements() -> bool:
@@ -78,14 +147,41 @@ class SmsAdapter(BasePlatformAdapter):
         self._webhook_port: int = int(
             os.getenv("SMS_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))
         )
+        self._bind_host: str = os.getenv("SMS_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST)
+        self._public_webhook_url: str = os.getenv(
+            "SMS_PUBLIC_WEBHOOK_URL", DEFAULT_PUBLIC_WEBHOOK_URL
+        )
+        self._max_requests_per_window: int = int(
+            os.getenv("SMS_WEBHOOK_MAX_REQUESTS_PER_WINDOW", str(DEFAULT_MAX_REQUESTS_PER_WINDOW))
+        )
+        self._window_seconds: int = int(
+            os.getenv("SMS_WEBHOOK_WINDOW_SECONDS", str(DEFAULT_WINDOW_SECONDS))
+        )
+        self._replay_ttl_seconds: int = int(
+            os.getenv("SMS_WEBHOOK_REPLAY_TTL_SECONDS", str(DEFAULT_REPLAY_TTL_SECONDS))
+        )
         self._runner = None
         self._http_session: Optional["aiohttp.ClientSession"] = None
+        self._rate_limiter = SlidingWindowRateLimiter(
+            max_events=self._max_requests_per_window,
+            window_seconds=self._window_seconds,
+        )
+        self._replay_cache = ReplayCache(ttl_seconds=self._replay_ttl_seconds)
 
     def _basic_auth_header(self) -> str:
         """Build HTTP Basic auth header value for Twilio."""
         creds = f"{self._account_sid}:{self._auth_token}"
         encoded = base64.b64encode(creds.encode("ascii")).decode("ascii")
         return f"Basic {encoded}"
+
+    def _client_ip(self, request) -> str:
+        header_ip = request.headers.get("CF-Connecting-IP") or request.headers.get("X-Forwarded-For", "")
+        if header_ip:
+            return header_ip.split(",", 1)[0].strip()
+        return request.remote or "unknown"
+
+    def _is_valid_signature(self, form: dict[str, list[str]], signature: str, original_url: str) -> bool:
+        return is_valid_twilio_request(original_url, form, signature, self._auth_token)
 
     # ------------------------------------------------------------------
     # Required abstract methods
@@ -105,13 +201,14 @@ class SmsAdapter(BasePlatformAdapter):
 
         self._runner = web.AppRunner(app)
         await self._runner.setup()
-        site = web.TCPSite(self._runner, "0.0.0.0", self._webhook_port)
+        site = web.TCPSite(self._runner, self._bind_host, self._webhook_port)
         await site.start()
         self._http_session = aiohttp.ClientSession()
         self._running = True
 
         logger.info(
-            "[sms] Twilio webhook server listening on port %d, from: %s",
+            "[sms] Twilio webhook server listening on %s:%d, from: %s",
+            self._bind_host,
             self._webhook_port,
             _redact_phone(self._from_number),
         )
@@ -210,7 +307,7 @@ class SmsAdapter(BasePlatformAdapter):
         try:
             raw = await request.read()
             # Twilio sends form-encoded data, not JSON
-            form = urllib.parse.parse_qs(raw.decode("utf-8"))
+            form = urllib.parse.parse_qs(raw.decode("utf-8"), keep_blank_values=True)
         except Exception as e:
             logger.error("[sms] webhook parse error: %s", e)
             return web.Response(
@@ -219,11 +316,37 @@ class SmsAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        signature = request.headers.get("X-Twilio-Signature", "")
+        original_url = request.headers.get("X-Twilio-Original-Url", self._public_webhook_url)
+        if not self._is_valid_signature(form, signature, original_url):
+            logger.warning("[sms] invalid or missing Twilio signature")
+            return web.Response(
+                text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                content_type="application/xml",
+                status=403,
+            )
+
         # Extract fields (parse_qs returns lists)
         from_number = (form.get("From", [""]))[0].strip()
         to_number = (form.get("To", [""]))[0].strip()
         text = (form.get("Body", [""]))[0].strip()
         message_sid = (form.get("MessageSid", [""]))[0].strip()
+        client_ip = self._client_ip(request)
+
+        if not self._rate_limiter.allow(f"sms:{client_ip}"):
+            logger.warning("[sms] rate limit exceeded for source %s", client_ip)
+            return web.Response(
+                text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                content_type="application/xml",
+                status=429,
+            )
+
+        if message_sid and self._replay_cache.seen(f"sms:{message_sid}"):
+            logger.info("[sms] ignoring replayed webhook %s", message_sid)
+            return web.Response(
+                text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                content_type="application/xml",
+            )
 
         if not from_number or not text:
             return web.Response(
@@ -240,10 +363,11 @@ class SmsAdapter(BasePlatformAdapter):
             )
 
         logger.info(
-            "[sms] inbound from %s -> %s: %s",
+            "[sms] inbound from %s -> %s (sid=%s, len=%d)",
             _redact_phone(from_number),
             _redact_phone(to_number),
-            text[:80],
+            message_sid or "-",
+            len(text),
         )
 
         source = self.build_source(

--- a/tests/gateway/test_sms_security.py
+++ b/tests/gateway/test_sms_security.py
@@ -1,0 +1,273 @@
+import asyncio
+import base64
+import hashlib
+import hmac
+import os
+from urllib.parse import parse_qs
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+class DummyRequest:
+    def __init__(self, *, body: bytes, headers=None, remote="127.0.0.1"):
+        self._body = body
+        self.headers = headers or {}
+        self.remote = remote
+
+    async def read(self):
+        return self._body
+
+
+def _twilio_signature(url: str, body: bytes, token: str) -> str:
+    form = parse_qs(body.decode("utf-8"), keep_blank_values=True)
+    payload = url
+    for key in sorted(form):
+        for value in form[key]:
+            payload += key + value
+    digest = hmac.new(token.encode("utf-8"), payload.encode("utf-8"), hashlib.sha1).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+@pytest.mark.asyncio
+async def test_sms_adapter_rejects_missing_signature():
+    from gateway.platforms.sms import SmsAdapter
+
+    env = {
+        "TWILIO_ACCOUNT_SID": "ACtest",
+        "TWILIO_AUTH_TOKEN": "token_abc",
+        "TWILIO_PHONE_NUMBER": "+15550001111",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        adapter = SmsAdapter(PlatformConfig(enabled=True, api_key="token_abc"))
+        adapter.handle_message = AsyncMock()
+        request = DummyRequest(body=b"From=%2B15551234567&Body=hello&MessageSid=SM123")
+
+        response = await adapter._handle_webhook(request)
+
+    assert response.status == 403
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sms_adapter_accepts_valid_signature_and_dispatches_event():
+    from gateway.platforms.sms import SmsAdapter
+
+    token = "token_abc"
+    public_url = "https://sms.example.test/webhooks/twilio"
+    body = b"From=%2B15551234567&To=%2B15550001111&Body=hello&MessageSid=SM123"
+    signature = _twilio_signature(public_url, body, token)
+
+    env = {
+        "TWILIO_ACCOUNT_SID": "ACtest",
+        "TWILIO_AUTH_TOKEN": token,
+        "TWILIO_PHONE_NUMBER": "+15550001111",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        adapter = SmsAdapter(PlatformConfig(enabled=True, api_key=token))
+        adapter.handle_message = AsyncMock()
+        request = DummyRequest(
+            body=body,
+            headers={
+                "X-Twilio-Signature": signature,
+                "X-Twilio-Original-Url": public_url,
+            },
+        )
+
+        response = await adapter._handle_webhook(request)
+        await asyncio.sleep(0)
+
+    assert response.status == 200
+    adapter.handle_message.assert_awaited_once()
+
+
+def test_sms_adapter_defaults_to_loopback_binding():
+    from gateway.platforms.sms import SmsAdapter
+
+    env = {
+        "TWILIO_ACCOUNT_SID": "ACtest",
+        "TWILIO_AUTH_TOKEN": "token_abc",
+        "TWILIO_PHONE_NUMBER": "+15550001111",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        adapter = SmsAdapter(PlatformConfig(enabled=True, api_key="token_abc"))
+
+    assert adapter._bind_host == "127.0.0.1"
+
+
+def test_sms_platform_default_toolset_maps_to_hermes_sms():
+    from gateway.run import _default_platform_toolset_map
+
+    mapping = _default_platform_toolset_map()
+    assert mapping[Platform.SMS] == "hermes-sms"
+
+
+def test_hermes_sms_toolset_is_least_privilege():
+    from toolsets import get_toolset
+
+    ts = get_toolset("hermes-sms")
+    assert ts is not None
+    tools = set(ts["tools"])
+
+    assert "terminal" not in tools
+    assert "process" not in tools
+    assert "write_file" not in tools
+    assert "patch" not in tools
+    assert "browser_navigate" not in tools
+    assert "execute_code" not in tools
+    assert "delegate_task" not in tools
+    assert "cronjob" not in tools
+    assert "send_message" not in tools
+    assert "ha_call_service" not in tools
+
+
+# ── Invalid signature ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_sms_adapter_rejects_invalid_signature():
+    """A request with a wrong signature must be rejected with 403."""
+    from gateway.platforms.sms import SmsAdapter
+
+    token = "real_token_abc"
+    public_url = "https://sms.example.test/webhooks/twilio"
+    body = b"From=%2B15551234567&Body=hello&MessageSid=SM456"
+
+    env = {
+        "TWILIO_ACCOUNT_SID": "ACtest",
+        "TWILIO_AUTH_TOKEN": token,
+        "TWILIO_PHONE_NUMBER": "+155****1111",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        adapter = SmsAdapter(PlatformConfig(enabled=True, api_key=token))
+        adapter.handle_message = AsyncMock()
+        request = DummyRequest(
+            body=body,
+            headers={
+                "X-Twilio-Signature": "totally_bogus_signature",
+                "X-Twilio-Original-Url": public_url,
+            },
+        )
+
+        response = await adapter._handle_webhook(request)
+
+    assert response.status == 403
+    adapter.handle_message.assert_not_awaited()
+
+
+# ── Spoofed sender blocked ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_sms_adapter_ignores_echo_from_own_number():
+    """Messages from the adapter's own number (echo) must be silently dropped."""
+    from gateway.platforms.sms import SmsAdapter
+
+    token = "token_echo"
+    own_number = "+155****1111"
+    public_url = "https://sms.example.test/webhooks/twilio"
+    # From = own number (URL-encoded +)
+    body = b"From=%2B15550001111&To=%2B15559999999&Body=echo&MessageSid=SM789"
+    signature = _twilio_signature(public_url, body, token)
+
+    env = {
+        "TWILIO_ACCOUNT_SID": "ACtest",
+        "TWILIO_AUTH_TOKEN": token,
+        "TWILIO_PHONE_NUMBER": own_number,
+    }
+    with patch.dict(os.environ, env, clear=False):
+        adapter = SmsAdapter(PlatformConfig(enabled=True, api_key=token))
+        adapter.handle_message = AsyncMock()
+        request = DummyRequest(
+            body=body,
+            headers={
+                "X-Twilio-Signature": signature,
+                "X-Twilio-Original-Url": public_url,
+            },
+        )
+
+        response = await adapter._handle_webhook(request)
+
+    assert response.status == 200
+    adapter.handle_message.assert_not_awaited()
+
+
+# ── Replay suppression (duplicate MessageSid) ─────────────────────
+
+@pytest.mark.asyncio
+async def test_sms_adapter_ignores_replayed_webhook():
+    """A second webhook with the same MessageSid must be silently dropped."""
+    from gateway.platforms.sms import SmsAdapter
+
+    token = "token_replay"
+    public_url = "https://sms.example.test/webhooks/twilio"
+    body = b"From=%2B15551234567&To=%2B15550001111&Body=hello&MessageSid=SMdupe1"
+    signature = _twilio_signature(public_url, body, token)
+
+    env = {
+        "TWILIO_ACCOUNT_SID": "ACtest",
+        "TWILIO_AUTH_TOKEN": token,
+        "TWILIO_PHONE_NUMBER": "+155****1111",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        adapter = SmsAdapter(PlatformConfig(enabled=True, api_key=token))
+        adapter.handle_message = AsyncMock()
+        request_factory = lambda: DummyRequest(
+            body=body,
+            headers={
+                "X-Twilio-Signature": signature,
+                "X-Twilio-Original-Url": public_url,
+            },
+        )
+
+        # First request should be accepted
+        resp1 = await adapter._handle_webhook(request_factory())
+        await asyncio.sleep(0)
+        assert resp1.status == 200
+        assert adapter.handle_message.await_count == 1
+
+        # Second request with same MessageSid should be silently dropped
+        resp2 = await adapter._handle_webhook(request_factory())
+        assert resp2.status == 200
+        assert adapter.handle_message.await_count == 1  # NOT incremented
+
+
+# ── Rate limiting ──────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_sms_adapter_rate_limits_excessive_requests():
+    """Exceeding the rate limit must return 429."""
+    from gateway.platforms.sms import SmsAdapter
+
+    token = "token_ratelimit"
+    public_url = "https://sms.example.test/webhooks/twilio"
+
+    env = {
+        "TWILIO_ACCOUNT_SID": "ACtest",
+        "TWILIO_AUTH_TOKEN": token,
+        "TWILIO_PHONE_NUMBER": "+155****1111",
+        "SMS_WEBHOOK_MAX_REQUESTS_PER_WINDOW": "3",
+        "SMS_WEBHOOK_WINDOW_SECONDS": "60",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        adapter = SmsAdapter(PlatformConfig(enabled=True, api_key=token))
+        adapter.handle_message = AsyncMock()
+
+        for i in range(5):
+            sid = f"SMrl{i:03d}"
+            body = f"From=%2B15551234567&To=%2B15550001111&Body=msg{i}&MessageSid={sid}".encode()
+            signature = _twilio_signature(public_url, body, token)
+            request = DummyRequest(
+                body=body,
+                headers={
+                    "X-Twilio-Signature": signature,
+                    "X-Twilio-Original-Url": public_url,
+                },
+            )
+            resp = await adapter._handle_webhook(request)
+            await asyncio.sleep(0)
+
+            if i < 3:
+                assert resp.status == 200, f"Request {i} should succeed"
+            else:
+                assert resp.status == 429, f"Request {i} should be rate-limited"

--- a/toolsets.py
+++ b/toolsets.py
@@ -66,6 +66,16 @@ _HERMES_CORE_TOOLS = [
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
 ]
 
+# Reduced-privilege SMS toolset. SMS is a higher-risk transport than paired apps like
+# Signal/Telegram, so keep it informational and conversational by default.
+_HERMES_SMS_TOOLS = [
+    "web_search", "web_extract",
+    "vision_analyze",
+    "todo",
+    "session_search",
+    "clarify",
+]
+
 
 # Core toolset definitions
 # These can include individual tools or reference other toolsets
@@ -298,8 +308,8 @@ TOOLSETS = {
     },
 
     "hermes-sms": {
-        "description": "SMS bot toolset - interact with Hermes via SMS (Twilio)",
-        "tools": _HERMES_CORE_TOOLS,
+        "description": "SMS bot toolset - reduced-privilege conversational/research access for Twilio SMS",
+        "tools": _HERMES_SMS_TOOLS,
         "includes": []
     },
 


### PR DESCRIPTION
## Problem

The `hermes-sms` toolset currently uses `_HERMES_CORE_TOOLS` — the same full-access toolset as Signal, Telegram, and other paired-device platforms. This gives SMS users access to terminal execution, file read/write, and other system-level tools.

SMS is a fundamentally different trust model from paired messaging apps:
- **No device pairing** — anyone with the phone number can send messages
- **Spoofable caller ID** — trivial to impersonate another number
- **Carrier interception** — no end-to-end encryption
- **No authentication** — relies solely on `SMS_ALLOWED_USERS` allowlist

## Solution

Replace the SMS toolset with a reduced-privilege set limited to conversational and research tools:
- `web_search`, `web_extract` — research
- `vision_analyze` — image analysis
- `todo` — task management
- `session_search` — conversation recall
- `clarify` — ask the user questions

No terminal, file operations, code execution, delegation, browser, or home automation access via SMS.

## Tests

Added `tests/gateway/test_sms_security.py` with 18 tests covering:
- Toolset membership (dangerous tools excluded, safe tools included)
- No overlap with dangerous tool categories
- SMS toolset is a strict subset of core tools