### PR TITLE
Fix/webhook delivery payload retention

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -333,7 +333,6 @@ class WebhookAdapter(BasePlatformAdapter):
             "deliver_extra": self._render_delivery_extra(
                 route_config.get("deliver_extra", {}), payload
             ),
-            "payload": payload,
         }
         self._delivery_info[session_chat_id] = deliver_config
 

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -597,7 +597,6 @@ class TestDeliveryCleanup:
         adapter._delivery_info[chat_id] = {
             "deliver": "log",
             "deliver_extra": {},
-            "payload": {"x": 1},
         }
 
         result = await adapter.send(chat_id, "Agent response here")


### PR DESCRIPTION
## What does this PR do?

- Removed unused `payload` from `deliver_config` in the webhook adapter.
- Updated webhook delivery cleanup test fixture to match the minimal delivery state contract.


## Type of Change

- [x] ♻️ Refactor (no behavior change)




