### PR TITLE
url-safety : block non-http schemes in SSRF guard

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -72,6 +72,12 @@ class TestIsSafeUrl:
     def test_no_hostname_blocked(self):
         assert is_safe_url("http://") is False
 
+    def test_unsupported_scheme_blocked(self):
+        assert is_safe_url("ftp://example.com/file.txt") is False
+
+    def test_scheme_less_url_blocked(self):
+        assert is_safe_url("example.com/no-scheme") is False
+
     def test_public_ip_allowed(self):
         with patch("socket.getaddrinfo", return_value=[
             (2, 1, 6, "", ("93.184.216.34", 0)),

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -48,13 +48,18 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
 
 
 def is_safe_url(url: str) -> bool:
-    """Return True if the URL target is not a private/internal address.
+    """Return True if the URL target is not a private/internal address and uses http/https.
 
     Resolves the hostname to an IP and checks against private ranges.
-    Fails closed: DNS errors and unexpected exceptions block the request.
+    Fails closed: DNS errors, unsupported schemes, and unexpected exceptions block the request.
     """
     try:
         parsed = urlparse(url)
+        scheme = parsed.scheme.lower()
+        if scheme not in ("http", "https"):
+            logger.warning("Blocked request to unsupported URL scheme: %s", scheme)
+            return False
+
         hostname = (parsed.hostname or "").strip().lower()
         if not hostname:
             return False


### PR DESCRIPTION
PR hardens SSRF protection by updating is_safe_url() in tools/url_safety.py to allow only http and https URLs and fail closed for unsupported schemes, which prevents non-web protocols (for example ftp or scheme-less inputs) from bypassing URL safety expectations; it also adds targeted regression tests in tests/tools/test_url_safety.py to assert unsupported and scheme-less URLs are blocked.