### PR TITLE
feat: auto-detect Alibaba DashScope Coding Plan subscription keys (sk-sp-*)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -161,6 +161,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.minimax": "minimax",
     "dashscope.aliyuncs.com": "alibaba",
     "dashscope-intl.aliyuncs.com": "alibaba",
+    "coding-intl.dashscope.aliyuncs.com": "alibaba",
     "openrouter.ai": "openrouter",
     "inference-api.nousresearch.com": "nous",
     "api.deepseek.com": "deepseek",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -239,6 +239,25 @@ def _resolve_kimi_base_url(api_key: str, default_url: str, env_override: str) ->
     return default_url
 
 
+# Alibaba DashScope Coding Plan endpoint (subscription, sk-sp- keys)
+DASHSCOPE_CODING_PLAN_BASE_URL = "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic"
+
+
+def _resolve_alibaba_base_url(api_key: str, default_url: str, env_override: str) -> str:
+    """Return the correct Alibaba/DashScope base URL based on API key prefix.
+
+    If the user has explicitly set DASHSCOPE_BASE_URL, that always wins.
+    Otherwise, sk-sp- prefixed keys (Coding Plan subscription) route to
+    coding-intl.dashscope.aliyuncs.com/apps/anthropic.
+    Regular sk- keys route to the default pay-as-you-go endpoint.
+    """
+    if env_override:
+        return env_override
+    if api_key.startswith("sk-sp-"):
+        return DASHSCOPE_CODING_PLAN_BASE_URL
+    return default_url
+
+
 def _gh_cli_candidates() -> list[str]:
     """Return candidate ``gh`` binary paths, including common Homebrew installs."""
     candidates: list[str] = []
@@ -1689,6 +1708,8 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
     if provider_id == "kimi-coding":
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
+    elif provider_id == "alibaba":
+        base_url = _resolve_alibaba_base_url(api_key, pconfig.inference_base_url, env_url)
     elif env_url:
         base_url = env_url.rstrip("/")
     else:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -516,7 +516,7 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
     },
     "DASHSCOPE_API_KEY": {
-        "description": "Alibaba Cloud DashScope API key for Qwen models",
+        "description": "Alibaba Cloud DashScope API key (sk-sp-* for Coding Plan, sk-* for pay-as-you-go)",
         "prompt": "DashScope API Key",
         "url": "https://modelstudio.console.alibabacloud.com/",
         "password": True,

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -23,8 +23,10 @@ from hermes_cli.auth import (
     get_auth_status,
     AuthError,
     KIMI_CODE_BASE_URL,
+    DASHSCOPE_CODING_PLAN_BASE_URL,
     _try_gh_cli_token,
     _resolve_kimi_base_url,
+    _resolve_alibaba_base_url,
 )
 
 
@@ -630,6 +632,36 @@ class TestResolveKimiBaseUrl:
     def test_env_override_wins_over_legacy(self):
         custom = "https://custom.example.com/v1"
         url = _resolve_kimi_base_url("sk-abc123", MOONSHOT_DEFAULT_URL, custom)
+        assert url == custom
+
+
+DASHSCOPE_DEFAULT_URL = "https://dashscope-intl.aliyuncs.com/apps/anthropic"
+
+
+class TestResolveAlibabaBaseUrl:
+    """Test _resolve_alibaba_base_url() helper for key-prefix auto-detection."""
+
+    def test_sk_sp_prefix_routes_to_coding_plan(self):
+        url = _resolve_alibaba_base_url("sk-sp-abc123", DASHSCOPE_DEFAULT_URL, "")
+        assert url == DASHSCOPE_CODING_PLAN_BASE_URL
+
+    def test_regular_key_uses_default(self):
+        url = _resolve_alibaba_base_url("sk-abc123", DASHSCOPE_DEFAULT_URL, "")
+        assert url == DASHSCOPE_DEFAULT_URL
+
+    def test_empty_key_uses_default(self):
+        url = _resolve_alibaba_base_url("", DASHSCOPE_DEFAULT_URL, "")
+        assert url == DASHSCOPE_DEFAULT_URL
+
+    def test_env_override_wins_over_sk_sp(self):
+        """DASHSCOPE_BASE_URL env var should always take priority."""
+        custom = "https://custom.example.com/v1"
+        url = _resolve_alibaba_base_url("sk-sp-abc123", DASHSCOPE_DEFAULT_URL, custom)
+        assert url == custom
+
+    def test_env_override_wins_over_regular_key(self):
+        custom = "https://custom.example.com/v1"
+        url = _resolve_alibaba_base_url("sk-abc123", DASHSCOPE_DEFAULT_URL, custom)
         assert url == custom
 
 

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -562,6 +562,32 @@ def test_alibaba_openai_compatible_v1_endpoint_stays_chat_completions(monkeypatc
     assert resolved["base_url"] == "https://coding-intl.dashscope.aliyuncs.com/v1"
 
 
+def test_alibaba_coding_plan_sk_sp_key_auto_routes_to_coding_endpoint(monkeypatch):
+    """Alibaba Coding Plan keys (sk-sp-*) should auto-route to coding-intl endpoint."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-sp-test-coding-plan-key")
+    monkeypatch.delenv("DASHSCOPE_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert "coding-intl.dashscope.aliyuncs.com" in resolved["base_url"]
+
+
+def test_alibaba_coding_plan_env_override_wins_over_key_detection(monkeypatch):
+    """Explicit DASHSCOPE_BASE_URL should override sk-sp- key auto-routing."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-sp-test-coding-plan-key")
+    monkeypatch.setenv("DASHSCOPE_BASE_URL", "https://custom.example.com/v1")
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["base_url"] == "https://custom.example.com/v1"
+
+
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     """Custom providers should accept api_mode: anthropic_messages."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-anthropic-proxy")


### PR DESCRIPTION
## Summary

Alibaba's DashScope Coding Plan ($50/mo Pro) provides flat-rate access to 8 models from 4 Chinese AI labs via a **different endpoint** than the pay-as-you-go API. Currently Hermes only knows about the pay-as-you-go endpoint and requires manual `DASHSCOPE_BASE_URL` configuration for Coding Plan users.

This PR adds automatic key-based routing: `sk-sp-*` keys (Coding Plan) auto-route to `coding-intl.dashscope.aliyuncs.com`, while regular `sk-*` keys continue to use the default pay-as-you-go endpoint. Explicit `DASHSCOPE_BASE_URL` still takes priority.

## Coding Plan Models (case-sensitive IDs)

**Recommended:** qwen3.5-plus (vision), kimi-k2.5 (vision), glm-5, MiniMax-M2.5
**Additional:** qwen3-max-2026-01-23, qwen3-coder-next, qwen3-coder-plus, glm-4.7

## Changes

- `hermes_cli/auth.py`: Add `_resolve_alibaba_base_url()` — routes `sk-sp-*` keys to Coding Plan endpoint, mirroring the existing `_resolve_kimi_base_url()` pattern
- `agent/model_metadata.py`: Add `coding-intl.dashscope.aliyuncs.com` to provider URL detection map
- `hermes_cli/config.py`: Update DASHSCOPE_API_KEY description to mention both key formats
- `tests/test_runtime_provider_resolution.py`: 2 new tests — key auto-routing + env override precedence

## Tests

All 4 alibaba-related tests pass:
```
tests/test_runtime_provider_resolution.py::test_alibaba_default_anthropic_endpoint_uses_anthropic_messages PASSED
tests/test_runtime_provider_resolution.py::test_alibaba_openai_compatible_v1_endpoint_stays_chat_completions PASSED
tests/test_runtime_provider_resolution.py::test_alibaba_coding_plan_sk_sp_key_auto_routes_to_coding_endpoint PASSED
tests/test_runtime_provider_resolution.py::test_alibaba_coding_plan_env_override_wins_over_key_detection PASSED
```