### PR TITLE
fix(skills): log warnings instead of silently swallowing exceptions in skill_commands.py

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -52,13 +52,15 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
         if identifier_path.is_absolute():
             try:
                 normalized = str(identifier_path.resolve().relative_to(SKILLS_DIR.resolve()))
-            except Exception:
+            except Exception as e:
+                logger.debug("Could not resolve skill path %s: %s", identifier_path, e)
                 normalized = raw_identifier
         else:
             normalized = raw_identifier.lstrip("/")
 
         loaded_skill = json.loads(skill_view(normalized, task_id=task_id))
-    except Exception:
+    except Exception as e:
+        logger.warning("Failed to load skill %s: %s", raw_identifier, e)
         return None
 
     if not loaded_skill.get("success"):
@@ -70,7 +72,8 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
     if skill_path:
         try:
             skill_dir = SKILLS_DIR / Path(skill_path).parent
-        except Exception:
+        except Exception as e:
+            logger.debug("Could not resolve skill directory for %s: %s", skill_path, e)
             skill_dir = None
 
     return loaded_skill, skill_dir, skill_name
@@ -188,10 +191,11 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     "skill_md_path": str(skill_md),
                     "skill_dir": str(skill_md.parent),
                 }
-            except Exception:
+            except Exception as e:
+                logger.debug("Skipping skill %s: %s", skill_md, e)
                 continue
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Failed to scan skill commands: %s", e)
     return _skill_commands
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes five silent exception blocks in `agent/skill_commands.py` where bare `except Exception:` was discarding errors without any logging. Users had no way to diagnose why skills failed to load, scan, or resolve paths.

## Type of Change

- 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

### `scan_skill_commands()`
- **Inner loop** (`except Exception: continue`): Now logs `logger.debug()` with the skill path and error before continuing — helps identify broken individual skill files without flooding logs.
- **Outer block** (`except Exception: pass`): Now logs `logger.warning()` when the entire skill scanning system fails — critical for diagnosing import errors or missing SKILLS_DIR.

### `_load_skill_payload()`
- **Path resolution** (`except Exception: normalized = raw_identifier`): Now logs `logger.debug()` when path normalization fails.
- **Skill loading** (`except Exception: return None`): Now logs `logger.warning()` when a skill fails to load — users can see which skill and why.
- **Directory resolution** (`except Exception: skill_dir = None`): Now logs `logger.debug()` when skill directory path computation fails.

No new imports needed — `logger = logging.getLogger(__name__)` was already defined at the top of the file.

## How to Test

1. Introduce a syntax error in any `~/.hermes/skills/*/SKILL.md` file
2. Run `hermes` and invoke a skill slash command
3. Check logs — you should now see warnings/debug messages identifying the failure
4. Run tests: `python3 -m pytest tests/ -q`

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Ubuntu 22.04 (WSL2)

### Documentation & Housekeeping
- [x] No documentation changes needed (logging-only change)
- [x] No config key changes
- [x] No architecture changes
- [x] Cross-platform safe (logging module is stdlib)

## Screenshots / Logs

N/A — logging change, no UI impact.