### PR TITLE
fix(delegation): isolate subagent iteration budgets by default (fixes #2873)

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -11,9 +11,53 @@ Each child gets:
   - Its own task_id (own terminal session, file ops cache)
   - A restricted toolset (configurable, with blocked tools always stripped)
   - A focused system prompt built from the delegated goal + context
+  - Its own iteration budget (isolated from the parent by default)
 
 The parent's context only sees the delegation call and the summary result,
 never the child's intermediate tool calls or reasoning.
+
+Iteration Budget Modes
+----------------------
+Controlled by ``delegation.budget_mode`` in config.yaml.
+
+**isolated** (default, recommended)
+    Each subagent gets a fresh IterationBudget seeded from its own
+    ``max_iterations``. The parent's consumed iterations do not affect
+    children at all. ``max_iterations=50`` means exactly 50 turns,
+    regardless of what the parent has used.
+
+    Example — parent used 30 of its 90 turns, spawns 3 subagents with
+    max_iterations=50:
+
+        Parent:     30/90 consumed (60 remaining, but irrelevant)
+        Subagent 1:  0/50  fresh budget → can use all 50
+        Subagent 2:  0/50  fresh budget → can use all 50
+        Subagent 3:  0/50  fresh budget → can use all 50
+
+    Each subagent is cut off only by its own cap, not by its siblings or
+    the parent. This is the correct behaviour in almost all cases.
+
+**shared** (legacy, not recommended)
+    All subagents share the parent's partially-consumed IterationBudget.
+    Children are silently capped by the parent's *remaining* turns, not
+    by their own ``max_iterations``. This was the original (buggy)
+    behaviour and is retained only for backwards compatibility.
+
+    Same example with shared mode:
+
+        Parent:     30/90 consumed → 60 remaining, shared by all children
+        Subagent 1: races for a slice of 60
+        Subagent 2: races for a slice of 60   ← each gets ~20 on average
+        Subagent 3: races for a slice of 60
+
+    With 3 parallel subagents that each need 50 turns, the first to
+    exhaust the 60 causes the others to be cut short mid-task.
+
+Configure in ~/.hermes/config.yaml::
+
+    delegation:
+      max_iterations: 50        # turns per subagent (isolated budget)
+      budget_mode: isolated     # "isolated" (default) or "shared"
 """
 
 import json
@@ -38,6 +82,10 @@ MAX_CONCURRENT_CHILDREN = 3
 MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
 DEFAULT_MAX_ITERATIONS = 50
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+
+# Budget mode constants
+BUDGET_MODE_ISOLATED = "isolated"  # each child gets a fresh budget (default, recommended)
+BUDGET_MODE_SHARED = "shared"      # legacy: children share the parent's depleted budget
 
 
 def check_delegate_requirements() -> bool:
@@ -191,9 +239,30 @@ def _build_child_agent(
     # Build progress callback to relay tool calls to parent display
     child_progress_cb = _build_child_progress_callback(task_index, parent_agent)
 
-    # Share the parent's iteration budget so subagent tool calls
-    # count toward the session-wide limit.
-    shared_budget = getattr(parent_agent, "iteration_budget", None)
+    # Determine iteration budget for this child based on budget_mode.
+    #
+    # ISOLATED (default): child gets a brand-new IterationBudget(max_iterations).
+    #   max_iterations=50 means exactly 50 turns for this child, no matter how
+    #   many turns the parent has already consumed.  3 parallel children with
+    #   max_iterations=50 each get 50 turns independently — they do not race.
+    #
+    # SHARED (legacy): child inherits the parent's partially-consumed budget.
+    #   If the parent used 40 of 90 turns before delegating, only 50 remain
+    #   for all children combined.  3 parallel children get ~16 each on average,
+    #   silently hitting the cap mid-task.  Retained for backwards compatibility.
+    #
+    # Load budget_mode from config (falls back to isolated if absent).
+    _cfg = _load_config()
+    budget_mode = str(_cfg.get("budget_mode") or BUDGET_MODE_ISOLATED).strip().lower()
+
+    if budget_mode == BUDGET_MODE_SHARED:
+        # Legacy behaviour: share the parent's IterationBudget object.
+        # Children are capped by whatever turns the parent has left.
+        shared_budget = getattr(parent_agent, "iteration_budget", None)
+    else:
+        # Isolated (default): pass None so AIAgent.__init__ creates a fresh
+        # IterationBudget(max_iterations) that starts at 0 consumed.
+        shared_budget = None
 
     # Resolve effective credentials: config override > parent inherit
     effective_model = model or parent_agent.model

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -173,6 +173,43 @@ delegate_task(
 )
 ```
 
+### Iteration Budget Modes
+
+Controlled by `delegation.budget_mode` in `config.yaml` (default: `isolated`).
+
+#### `isolated` (default, recommended)
+
+Each subagent gets a **fresh** budget starting at 0. `max_iterations=50` means exactly 50 turns for that child, regardless of how many turns the parent has already consumed or how many siblings are running in parallel.
+
+```
+# Parent used 30 of its 90 turns, then spawns 3 subagents with max_iterations=50
+
+Parent:     ██████████████████████░░░░░░░░░░░░░░░░░░░░  30/90 consumed
+
+Subagent 1: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   0/50  ← fresh, uses all 50
+Subagent 2: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   0/50  ← fresh, uses all 50
+Subagent 3: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   0/50  ← fresh, uses all 50
+```
+
+Each subagent is cut off only by **its own cap**, not by its siblings or what the parent consumed.
+
+#### `shared` (legacy)
+
+All subagents share the parent's **already partially consumed** budget. If the parent used 30 of 90 turns before delegating, only 60 remain for all children combined. With 3 parallel subagents each requesting 50 turns, they race to consume those 60 — each gets roughly 20 on average and is cut short mid-task.
+
+```
+# Same scenario with budget_mode: shared
+
+Parent:     ██████████████████████░░░░░░░░░░░░░░░░░░░░  30/90 consumed
+                                  └── only 60 turns left, shared by all children
+
+Subagent 1: uses ~20 → hits shared cap mid-task  ✗
+Subagent 2: uses ~20 → hits shared cap mid-task  ✗
+Subagent 3: uses ~20 → hits shared cap mid-task  ✗
+```
+
+This was the original (buggy) behaviour. It is retained under `budget_mode: shared` for backwards compatibility but not recommended.
+
 ## Depth Limit
 
 Delegation has a **depth limit of 2** — a parent (depth 0) can spawn children (depth 1), but children cannot delegate further. This prevents runaway recursive delegation chains.
@@ -205,17 +242,25 @@ Delegation has a **depth limit of 2** — a parent (depth 0) can spawn children 
 ```yaml
 # In ~/.hermes/config.yaml
 delegation:
-  max_iterations: 50                        # Max turns per child (default: 50)
-  default_toolsets: ["terminal", "file", "web"]  # Default toolsets
-  model: "google/gemini-3-flash-preview"             # Optional provider/model override
-  provider: "openrouter"                             # Optional built-in provider
+  max_iterations: 50          # Max turns per subagent (default: 50)
+  budget_mode: isolated       # "isolated" (default) or "shared" (legacy)
+  default_toolsets: ["terminal", "file", "web"]
+  model: "google/gemini-3-flash-preview"   # Optional: cheaper model for subagents
+  provider: "openrouter"                   # Optional: different provider for subagents
 
-# Or use a direct custom endpoint instead of provider:
+# Or use a direct custom endpoint:
 delegation:
   model: "qwen2.5-coder"
   base_url: "http://localhost:1234/v1"
   api_key: "local-key"
 ```
+
+| Option | Values | Default | Description |
+|--------|--------|---------|-------------|
+| `max_iterations` | integer | `50` | Max tool-calling turns per subagent |
+| `budget_mode` | `isolated` / `shared` | `isolated` | How subagent iteration budgets are allocated (see above) |
+| `model` | model string | parent model | Model to use for subagents |
+| `provider` | provider name | parent provider | Provider to route subagents to |
 
 :::tip
 The agent handles delegation automatically based on the task complexity. You don't need to explicitly ask it to delegate — it will do so when it makes sense.


### PR DESCRIPTION
## Problem

Subagents consistently exit with `exit_reason: max_iterations` before completing their task, even when `max_iterations` is set explicitly. This is especially bad in batch mode with 3 parallel subagents.

**Root cause:** `_build_child_agent()` passes the parent's `IterationBudget` object directly to each child. That budget is already partially consumed by the parent's own turns. In parallel batch mode, all 3 children share what's left and race to exhaust it.

```
# Parent used 30 of 90 turns → 60 remaining, shared by all children
# 3 subagents each requested max_iterations=50

Subagent 1: gets ~20 turns → exits mid-task  ✗
Subagent 2: gets ~20 turns → exits mid-task  ✗
Subagent 3: gets ~20 turns → exits mid-task  ✗
```

## Fix

Introduce a `budget_mode` config option under `delegation:` in `config.yaml`.

### `isolated` (new default)

Each child gets a **fresh** `IterationBudget(max_iterations)` starting at 0. `max_iterations=50` means exactly 50 turns, independent of parent consumption or parallel siblings.

```
# Same scenario with budget_mode: isolated (default)
# Parent used 30 of 90 turns — irrelevant to children

Subagent 1:  0/50 fresh budget → uses all 50 turns  ✓
Subagent 2:  0/50 fresh budget → uses all 50 turns  ✓
Subagent 3:  0/50 fresh budget → uses all 50 turns  ✓
```

### `shared` (legacy)

Preserves the old behaviour for users who explicitly want a session-wide cap across parent + all children combined. Not recommended but kept for backwards compatibility.

## Changes

- **`tools/delegate_tool.py`** — read `budget_mode` from config in `_build_child_agent()`; pass `iteration_budget=None` (isolated) or the parent's budget object (shared). Added module-level docstring explaining both modes with concrete examples.
- **`website/docs/user-guide/features/delegation.md`** — new "Iteration Budget Modes" section with visual examples (bar charts), updated Configuration table.

## Config

```yaml
delegation:
  max_iterations: 50      # per-subagent cap
  budget_mode: isolated   # "isolated" (default) or "shared" (legacy)
```

Closes #2873