### PR TITLE
fix(docker): include docker_forward_env in container_config dict

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -958,6 +958,7 @@ def terminal_tool(
                                 "container_disk": config.get("container_disk", 51200),
                                 "container_persistent": config.get("container_persistent", True),
                                 "docker_volumes": config.get("docker_volumes", []),
+                                "docker_forward_env": config.get("docker_forward_env", []),
                                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                             }
 


### PR DESCRIPTION
Fixes #2878

## Summary

- `terminal.docker_forward_env` in agent YAML was silently ignored
- The key was wired into `_get_env_config()` and `DockerEnvironment(forward_env=...)` but never added to the `container_config` dict that builds the environment
- One-line fix: add the missing `docker_forward_env` entry alongside `docker_volumes` and the other docker config keys

## Test plan

- [ ] Set `docker_forward_env: [MY_VAR]` in an agent YAML with `MY_VAR` in the environment
- [ ] Run a terminal command inside Docker and verify `echo $MY_VAR` returns the value
- [ ] Confirm existing docker configs (`docker_volumes`, `container_cpu`, etc.) are unaffected

---

*AI-assisted (Claude) | Tested | Reviewed and Understood*