### PR TITLE
feat(plugins): enable plugin slash commands and working /sampling plugin

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -129,6 +129,48 @@ def _parse_reasoning_config(effort: str) -> dict | None:
     return None
 
 
+def _parse_temperature(value: Any) -> Optional[float]:
+    """Parse temperature from env/config/command input.
+
+    Accepts numbers >= 0 and reset tokens (default/none/off/auto/null).
+    Returns None for reset/default.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) and value.strip().lower() in {"default", "none", "off", "auto", "null", ""}:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid temperature value: %r", value)
+        return None
+    if parsed < 0:
+        logger.warning("Ignoring temperature < 0: %r", value)
+        return None
+    return parsed
+
+
+def _parse_top_p(value: Any) -> Optional[float]:
+    """Parse top_p from env/config/command input.
+
+    Accepts numbers in (0, 1] and reset tokens (default/none/off/auto/null).
+    Returns None for reset/default.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) and value.strip().lower() in {"default", "none", "off", "auto", "null", ""}:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid top_p value: %r", value)
+        return None
+    if parsed <= 0 or parsed > 1:
+        logger.warning("Ignoring top_p outside (0, 1]: %r", value)
+        return None
+    return parsed
+
+
 def load_cli_config() -> Dict[str, Any]:
     """
     Load CLI configuration from config files.
@@ -191,6 +233,8 @@ def load_cli_config() -> Dict[str, Any]:
             "system_prompt": "",
             "prefill_messages_file": "",
             "reasoning_effort": "",
+            "temperature": None,
+            "top_p": None,
             "personalities": {
                 "helpful": "You are a helpful, friendly AI assistant.",
                 "concise": "You are a concise assistant. Keep responses brief and to the point.",
@@ -1163,6 +1207,15 @@ class HermesCLI:
         self.reasoning_config = _parse_reasoning_config(
             CLI_CONFIG["agent"].get("reasoning_effort", "")
         )
+
+        # Session sampling controls. These can be overridden live by plugin
+        # slash commands (e.g. /sampling) and are passed into new agent routes.
+        self.temperature = _parse_temperature(
+            os.getenv("HERMES_TEMPERATURE", CLI_CONFIG["agent"].get("temperature"))
+        )
+        self.top_p = _parse_top_p(
+            os.getenv("HERMES_TOP_P", CLI_CONFIG["agent"].get("top_p"))
+        )
         
         # OpenRouter provider routing preferences
         pr = CLI_CONFIG.get("provider_routing", {}) or {}
@@ -1920,6 +1973,8 @@ class HermesCLI:
                 ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,
                 prefill_messages=self.prefill_messages or None,
                 reasoning_config=self.reasoning_config,
+                temperature=self.temperature,
+                top_p=self.top_p,
                 providers_allowed=self._providers_only,
                 providers_ignored=self._providers_ignore,
                 providers_order=self._providers_order,

--- a/cli.py
+++ b/cli.py
@@ -899,12 +899,20 @@ from agent.skill_commands import (
 
 _skill_commands = scan_skill_commands()
 
+# Eager plugin discovery keeps plugin slash commands visible in /help,
+# autocomplete, and dispatch from the start of a CLI session.
+try:
+    from hermes_cli.plugins import discover_plugins as _discover_plugins
+    _discover_plugins()
+except Exception:
+    pass
+
 
 def _get_plugin_cmd_handler_names() -> set:
     """Return plugin command names (without slash prefix) for dispatch matching."""
     try:
-        from hermes_cli.plugins import get_plugin_manager
-        return set(get_plugin_manager()._plugin_commands.keys())
+        from hermes_cli.plugins import get_plugin_command_names
+        return set(get_plugin_command_names())
     except Exception:
         return set()
 
@@ -3702,7 +3710,8 @@ class HermesCLI:
                         version = f" v{p['version']}" if p["version"] else ""
                         tools = f"{p['tools']} tools" if p["tools"] else ""
                         hooks = f"{p['hooks']} hooks" if p["hooks"] else ""
-                        parts = [x for x in [tools, hooks] if x]
+                        commands = f"{p.get('commands', 0)} commands" if p.get("commands") else ""
+                        parts = [x for x in [tools, hooks, commands] if x]
                         detail = f" ({', '.join(parts)})" if parts else ""
                         error = f" — {p['error']}" if p["error"] else ""
                         print(f"  {status} {p['name']}{version}{detail}{error}")
@@ -3769,16 +3778,33 @@ class HermesCLI:
                     self.console.print(f"[bold red]Quick command '{base_cmd}' has unsupported type (supported: 'exec', 'alias')[/]")
             # Check for plugin-registered slash commands
             elif base_cmd.lstrip("/") in _get_plugin_cmd_handler_names():
-                from hermes_cli.plugins import get_plugin_command_handler
-                plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"))
-                if plugin_handler:
-                    user_args = cmd_original[len(base_cmd):].strip()
-                    try:
-                        result = plugin_handler(user_args)
-                        if result:
-                            _cprint(str(result))
-                    except Exception as e:
-                        _cprint(f"\033[1;31mPlugin command error: {e}{_RST}")
+                from hermes_cli.plugins import invoke_plugin_command
+                user_args = cmd_original[len(base_cmd):].strip()
+                try:
+                    result = invoke_plugin_command(
+                        base_cmd.lstrip("/"),
+                        user_args,
+                        context={
+                            "surface": "cli",
+                            "cli": self,
+                            "session_id": getattr(self, "session_id", None),
+                            "agent": getattr(self, "agent", None),
+                        },
+                    )
+
+                    # CLI command path is sync; allow async handlers via asyncio.run fallback.
+                    import asyncio as _asyncio
+                    if _asyncio.iscoroutine(result):
+                        try:
+                            result = _asyncio.run(result)
+                        except RuntimeError:
+                            _cprint("\033[1;31mPlugin command returned a coroutine while an event loop is active.\033[0m")
+                            result = None
+
+                    if result is not None and result != "":
+                        _cprint(str(result))
+                except Exception as e:
+                    _cprint(f"\033[1;31mPlugin command error: {e}{_RST}")
             # Check for skill slash commands (/gif-search, /axolotl, etc.)
             elif base_cmd in _skill_commands:
                 user_instruction = cmd_original[len(base_cmd):].strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1798,15 +1798,25 @@ class GatewayRunner:
         # Plugin-registered slash commands
         if command:
             try:
-                from hermes_cli.plugins import get_plugin_command_handler
-                plugin_handler = get_plugin_command_handler(command)
-                if plugin_handler:
-                    user_args = event.get_command_args().strip()
-                    import asyncio as _aio
-                    result = plugin_handler(user_args)
-                    if _aio.iscoroutine(result):
-                        result = await result
-                    return str(result) if result else None
+                from hermes_cli.plugins import invoke_plugin_command
+
+                user_args = event.get_command_args().strip()
+                result = invoke_plugin_command(
+                    command,
+                    user_args,
+                    context={
+                        "surface": "gateway",
+                        "runner": self,
+                        "event": event,
+                        "session_key": _quick_key,
+                    },
+                )
+
+                import asyncio as _aio
+                if _aio.iscoroutine(result):
+                    result = await result
+                if result is not None:
+                    return str(result)
             except Exception as e:
                 logger.debug("Plugin command dispatch failed (non-fatal): %s", e)
 
@@ -2751,6 +2761,12 @@ class GatewayRunner:
     
     async def _handle_help_command(self, event: MessageEvent) -> str:
         """Handle /help command - list available commands."""
+        try:
+            from hermes_cli.plugins import discover_plugins
+            discover_plugins()
+        except Exception:
+            pass
+
         from hermes_cli.commands import gateway_help_lines
         lines = [
             "📖 **Hermes Commands**\n",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import importlib
 import importlib.metadata
 import importlib.util
+import inspect
 import logging
 import os
 import sys
@@ -61,6 +62,11 @@ VALID_HOOKS: Set[str] = {
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"
 
 _NS_PARENT = "hermes_plugins"
+
+# Tracks command tokens (canonical + aliases) that were already injected into
+# hermes_cli.commands.COMMAND_REGISTRY. Kept module-global so a reset
+# _plugin_manager in tests/new sessions doesn't duplicate command defs.
+_REGISTERED_PLUGIN_COMMAND_TOKENS: Set[str] = set()
 
 
 def _env_enabled(name: str) -> bool:
@@ -95,6 +101,7 @@ class LoadedPlugin:
     module: Optional[types.ModuleType] = None
     tools_registered: List[str] = field(default_factory=list)
     hooks_registered: List[str] = field(default_factory=list)
+    commands_registered: List[str] = field(default_factory=list)
     enabled: bool = False
     error: Optional[str] = None
 
@@ -160,6 +167,39 @@ class PluginContext:
         self._manager._hooks.setdefault(hook_name, []).append(callback)
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 
+    # -- slash command registration -----------------------------------------
+
+    def register_command(
+        self,
+        name: str,
+        handler: Callable[..., Any],
+        description: str = "",
+        *,
+        category: str = "Tools & Skills",
+        args_hint: str = "",
+        aliases: tuple[str, ...] = (),
+        subcommands: tuple[str, ...] = (),
+        cli_only: bool = False,
+        gateway_only: bool = False,
+    ) -> None:
+        """Register a plugin-defined slash command.
+
+        Handlers should accept at least an ``args`` string and may optionally
+        accept a second ``context`` argument or ``context=...`` keyword.
+        """
+        self._manager.register_command(
+            plugin_name=self.manifest.name,
+            name=name,
+            handler=handler,
+            description=description,
+            category=category,
+            args_hint=args_hint,
+            aliases=aliases,
+            subcommands=subcommands,
+            cli_only=cli_only,
+            gateway_only=gateway_only,
+        )
+
 
 # ---------------------------------------------------------------------------
 # PluginManager
@@ -172,6 +212,10 @@ class PluginManager:
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
         self._plugin_tool_names: Set[str] = set()
+        # command token (canonical + aliases) -> handler
+        self._plugin_commands: Dict[str, Callable[..., Any]] = {}
+        # canonical command names only
+        self._plugin_command_names: Set[str] = set()
         self._discovered: bool = False
 
     # -----------------------------------------------------------------------
@@ -209,6 +253,86 @@ class PluginManager:
                 len(self._plugins),
                 sum(1 for p in self._plugins.values() if p.enabled),
             )
+
+    def register_command(
+        self,
+        *,
+        plugin_name: str,
+        name: str,
+        handler: Callable[..., Any],
+        description: str = "",
+        category: str = "Tools & Skills",
+        args_hint: str = "",
+        aliases: tuple[str, ...] = (),
+        subcommands: tuple[str, ...] = (),
+        cli_only: bool = False,
+        gateway_only: bool = False,
+    ) -> None:
+        """Register a plugin slash command and expose it in command registries."""
+        from hermes_cli.commands import CommandDef, register_plugin_command, resolve_command
+
+        cmd_name = (name or "").strip().lower().lstrip("/")
+        if not cmd_name:
+            raise ValueError("Plugin command name cannot be empty")
+        if cli_only and gateway_only:
+            raise ValueError("Plugin command cannot be both cli_only and gateway_only")
+
+        alias_tokens: list[str] = []
+        seen_tokens = {cmd_name}
+        for raw_alias in aliases or ():
+            alias = str(raw_alias).strip().lower().lstrip("/")
+            if not alias or alias in seen_tokens:
+                continue
+            seen_tokens.add(alias)
+            alias_tokens.append(alias)
+
+        # Prevent collisions with built-ins and existing plugin commands.
+        for token in (cmd_name, *alias_tokens):
+            if token in self._plugin_commands:
+                raise ValueError(
+                    f"Plugin command '/{token}' is already registered by another plugin command."
+                )
+
+            existing = resolve_command(token)
+            if existing and token not in _REGISTERED_PLUGIN_COMMAND_TOKENS:
+                raise ValueError(
+                    f"Plugin command '/{token}' conflicts with existing '/{existing.name}'."
+                )
+
+        # Register in central slash-command registry exactly once per process.
+        if cmd_name not in _REGISTERED_PLUGIN_COMMAND_TOKENS:
+            register_plugin_command(
+                CommandDef(
+                    name=cmd_name,
+                    description=description or f"Plugin command from {plugin_name}",
+                    category=category,
+                    aliases=tuple(alias_tokens),
+                    args_hint=args_hint,
+                    subcommands=tuple(subcommands),
+                    cli_only=cli_only,
+                    gateway_only=gateway_only,
+                )
+            )
+            _REGISTERED_PLUGIN_COMMAND_TOKENS.add(cmd_name)
+            _REGISTERED_PLUGIN_COMMAND_TOKENS.update(alias_tokens)
+
+        self._plugin_commands[cmd_name] = handler
+        for alias in alias_tokens:
+            self._plugin_commands[alias] = handler
+        self._plugin_command_names.add(cmd_name)
+
+        logger.debug("Plugin %s registered command: /%s", plugin_name, cmd_name)
+
+    def get_command_names(self) -> Set[str]:
+        """Return plugin command tokens (canonical + aliases)."""
+        return set(self._plugin_commands.keys())
+
+    def get_command_handler(self, name: str) -> Optional[Callable[..., Any]]:
+        """Return the registered plugin command handler for a token."""
+        token = (name or "").strip().lower().lstrip("/")
+        if not token:
+            return None
+        return self._plugin_commands.get(token)
 
     # -----------------------------------------------------------------------
     # Directory scanning
@@ -304,26 +428,18 @@ class PluginManager:
                 logger.warning("Plugin '%s' has no register() function", manifest.name)
             else:
                 ctx = PluginContext(manifest, self)
+                tools_before = set(self._plugin_tool_names)
+                hooks_before = {h for h, cbs in self._hooks.items() if cbs}
+                commands_before = set(self._plugin_command_names)
+
                 register_fn(ctx)
-                loaded.tools_registered = [
-                    t for t in self._plugin_tool_names
-                    if t not in {
-                        n
-                        for name, p in self._plugins.items()
-                        for n in p.tools_registered
-                    }
-                ]
-                loaded.hooks_registered = list(
-                    {
-                        h
-                        for h, cbs in self._hooks.items()
-                        if cbs  # non-empty
-                    }
-                    - {
-                        h
-                        for name, p in self._plugins.items()
-                        for h in p.hooks_registered
-                    }
+
+                loaded.tools_registered = sorted(self._plugin_tool_names - tools_before)
+                loaded.hooks_registered = sorted(
+                    {h for h, cbs in self._hooks.items() if cbs} - hooks_before
+                )
+                loaded.commands_registered = sorted(
+                    self._plugin_command_names - commands_before
                 )
                 loaded.enabled = True
 
@@ -420,6 +536,7 @@ class PluginManager:
                     "enabled": loaded.enabled,
                     "tools": len(loaded.tools_registered),
                     "hooks": len(loaded.hooks_registered),
+                    "commands": len(loaded.commands_registered),
                     "error": loaded.error,
                 }
             )
@@ -454,6 +571,72 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> None:
 def get_plugin_tool_names() -> Set[str]:
     """Return the set of tool names registered by plugins."""
     return get_plugin_manager()._plugin_tool_names
+
+
+def get_plugin_command_names() -> Set[str]:
+    """Return plugin command tokens (canonical + aliases)."""
+    discover_plugins()
+    return get_plugin_manager().get_command_names()
+
+
+def get_plugin_command_handler(name: str) -> Optional[Callable[..., Any]]:
+    """Return a plugin command handler by command token."""
+    discover_plugins()
+    return get_plugin_manager().get_command_handler(name)
+
+
+def _call_plugin_command_handler(
+    handler: Callable[..., Any],
+    args: str,
+    context: dict[str, Any],
+) -> Any:
+    """Call a plugin command handler with backward-compatible signatures.
+
+    Supported handler signatures:
+    - handler(args)
+    - handler(args, context)
+    - handler(args, *, context=...)
+    - handler(args, **kwargs)
+    """
+    try:
+        sig = inspect.signature(handler)
+    except (TypeError, ValueError):
+        # Builtins/objects without signatures: best effort legacy call.
+        return handler(args)
+
+    params = list(sig.parameters.values())
+    has_var_pos = any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params)
+    has_var_kw = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params)
+
+    positional = [
+        p
+        for p in params
+        if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+
+    if len(positional) >= 2 or has_var_pos:
+        return handler(args, context)
+
+    if any(p.name == "context" for p in params) or has_var_kw:
+        return handler(args, context=context)
+
+    return handler(args)
+
+
+def invoke_plugin_command(
+    name: str,
+    args: str = "",
+    *,
+    context: Optional[dict[str, Any]] = None,
+) -> Any:
+    """Invoke a plugin command by name and optional execution context.
+
+    Returns None when no command is registered for *name*.
+    """
+    handler = get_plugin_command_handler(name)
+    if handler is None:
+        return None
+    return _call_plugin_command_handler(handler, args, context or {})
 
 
 def get_plugin_toolsets() -> List[tuple]:

--- a/optional-plugins/sampling-command/README.md
+++ b/optional-plugins/sampling-command/README.md
@@ -1,0 +1,20 @@
+# sampling-command plugin
+
+CLI-only `/sampling` slash command for live session sampling control.
+
+## Install (from repo checkout)
+
+```bash
+mkdir -p ~/.hermes/plugins/sampling-command
+cp optional-plugins/sampling-command/plugin.yaml ~/.hermes/plugins/sampling-command/
+cp optional-plugins/sampling-command/__init__.py ~/.hermes/plugins/sampling-command/
+```
+
+Restart Hermes, then use:
+
+- `/sampling`
+- `/sampling 0.7 0.95`
+- `/sampling temperature 0.4`
+- `/sampling top_p 0.9`
+- `/sampling reset`
+- `/sampling save`

--- a/optional-plugins/sampling-command/__init__.py
+++ b/optional-plugins/sampling-command/__init__.py
@@ -1,0 +1,183 @@
+"""Sampling command plugin.
+
+Registers a CLI-only /sampling slash command that can inspect and mutate
+session sampling controls (temperature/top_p) without patching core CLI code.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+_RESET_TOKENS = {"default", "none", "off", "auto", "null", "reset"}
+
+
+def _display(value: Optional[float]) -> str:
+    return "default" if value is None else str(value)
+
+
+def _parse_temperature(raw: str) -> Optional[float]:
+    token = (raw or "").strip().lower()
+    if token in _RESET_TOKENS:
+        return None
+    value = float(token)
+    if value < 0:
+        raise ValueError("temperature must be >= 0")
+    return value
+
+
+def _parse_top_p(raw: str) -> Optional[float]:
+    token = (raw or "").strip().lower()
+    if token in _RESET_TOKENS:
+        return None
+    value = float(token)
+    if value <= 0 or value > 1:
+        raise ValueError("top_p must be in (0, 1]")
+    return value
+
+
+def _resolve_cli(context: dict) -> Tuple[object | None, str | None]:
+    surface = (context or {}).get("surface")
+    if surface != "cli":
+        return None, "This command is CLI-only."
+    cli = (context or {}).get("cli")
+    if cli is None:
+        return None, "Missing CLI context."
+    return cli, None
+
+
+def _apply_sampling(
+    cli: object,
+    *,
+    temperature: Optional[float] = None,
+    top_p: Optional[float] = None,
+    set_temperature: bool = False,
+    set_top_p: bool = False,
+) -> None:
+    if set_temperature:
+        setattr(cli, "temperature", temperature)
+        agent = getattr(cli, "agent", None)
+        if agent is not None:
+            setattr(agent, "temperature", temperature)
+
+    if set_top_p:
+        setattr(cli, "top_p", top_p)
+        agent = getattr(cli, "agent", None)
+        if agent is not None:
+            setattr(agent, "top_p", top_p)
+
+
+def _save_sampling(cli: object) -> tuple[bool, str]:
+    try:
+        from cli import save_config_value  # Lazy import to avoid heavy import at plugin load.
+    except Exception as exc:
+        return False, f"Could not import save_config_value: {exc}"
+
+    temp_value = getattr(cli, "temperature", None)
+    top_p_value = getattr(cli, "top_p", None)
+    ok_temp = save_config_value("agent.temperature", temp_value)
+    ok_top_p = save_config_value("agent.top_p", top_p_value)
+    if ok_temp and ok_top_p:
+        return True, f"Sampling saved: temperature={_display(temp_value)}, top_p={_display(top_p_value)}"
+    return False, "Failed to save sampling config (session values are still active)."
+
+
+def _sampling_status(cli: object) -> str:
+    temp = getattr(cli, "temperature", None)
+    top_p = getattr(cli, "top_p", None)
+    return (
+        "Sampling settings\n"
+        f"  temperature: {_display(temp)}\n"
+        f"  top_p:       {_display(top_p)}\n"
+        "\n"
+        "Usage:\n"
+        "  /sampling\n"
+        "  /sampling <temperature|default> <top_p|default>\n"
+        "  /sampling set <temperature|default> <top_p|default>\n"
+        "  /sampling temperature <value|default>\n"
+        "  /sampling top_p <value|default>\n"
+        "  /sampling reset\n"
+        "  /sampling save"
+    )
+
+
+def sampling_command(args: str, context: dict | None = None) -> str:
+    context = context or {}
+    cli, err = _resolve_cli(context)
+    if err:
+        return err
+
+    tokens = (args or "").strip().split()
+    if not tokens or tokens[0].lower() in {"view", "show", "status"}:
+        return _sampling_status(cli)
+
+    cmd = tokens[0].lower()
+
+    if cmd == "save":
+        ok, message = _save_sampling(cli)
+        return f"✅ {message}" if ok else f"❌ {message}"
+
+    if cmd in _RESET_TOKENS:
+        _apply_sampling(cli, temperature=None, top_p=None, set_temperature=True, set_top_p=True)
+        return "Sampling reset: temperature=default, top_p=default"
+
+    if cmd == "set":
+        if len(tokens) != 3:
+            return "Usage: /sampling set <temperature|default> <top_p|default>"
+        temp_token, top_p_token = tokens[1], tokens[2]
+    elif cmd in {"temperature", "temp"}:
+        if len(tokens) == 1:
+            return f"temperature={_display(getattr(cli, 'temperature', None))}"
+        if len(tokens) != 2:
+            return "Usage: /sampling temperature <value|default>"
+        try:
+            parsed = _parse_temperature(tokens[1])
+        except Exception as exc:
+            return f"Invalid temperature: {exc}"
+        _apply_sampling(cli, temperature=parsed, set_temperature=True)
+        return f"temperature set to {_display(parsed)}"
+    elif cmd in {"top_p", "top-p", "topp"}:
+        if len(tokens) == 1:
+            return f"top_p={_display(getattr(cli, 'top_p', None))}"
+        if len(tokens) != 2:
+            return "Usage: /sampling top_p <value|default>"
+        try:
+            parsed = _parse_top_p(tokens[1])
+        except Exception as exc:
+            return f"Invalid top_p: {exc}"
+        _apply_sampling(cli, top_p=parsed, set_top_p=True)
+        return f"top_p set to {_display(parsed)}"
+    else:
+        # Shorthand: /sampling <temperature> <top_p>
+        if len(tokens) == 2:
+            temp_token, top_p_token = tokens[0], tokens[1]
+        else:
+            return (
+                "Usage: /sampling, /sampling set <temp> <top_p>, "
+                "/sampling <temp> <top_p>, /sampling temperature <v>, /sampling top_p <v>, /sampling save"
+            )
+
+    try:
+        parsed_temp = _parse_temperature(temp_token)
+        parsed_top_p = _parse_top_p(top_p_token)
+    except Exception as exc:
+        return f"Invalid sampling values: {exc}"
+
+    _apply_sampling(
+        cli,
+        temperature=parsed_temp,
+        top_p=parsed_top_p,
+        set_temperature=True,
+        set_top_p=True,
+    )
+    return f"Sampling updated: temperature={_display(parsed_temp)}, top_p={_display(parsed_top_p)}"
+
+
+def register(ctx):
+    ctx.register_command(
+        name="sampling",
+        handler=sampling_command,
+        description="Show or change session sampling (temperature/top_p)",
+        args_hint="[view|set|temperature|top_p|reset|save] ...",
+        aliases=("sample",),
+        cli_only=True,
+    )

--- a/optional-plugins/sampling-command/plugin.yaml
+++ b/optional-plugins/sampling-command/plugin.yaml
@@ -1,0 +1,4 @@
+name: sampling-command
+version: 1.0.0
+description: CLI /sampling slash command for live temperature/top_p session control
+author: Hermes Agent

--- a/run_agent.py
+++ b/run_agent.py
@@ -419,6 +419,8 @@ class AIAgent:
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ):
         """
         Initialize the AI Agent.
@@ -483,6 +485,8 @@ class AIAgent:
         self._print_fn = None
         self.skip_context_files = skip_context_files
         self.pass_session_id = pass_session_id
+        self.temperature = temperature
+        self.top_p = top_p
         self.log_prefix_chars = log_prefix_chars
         self.log_prefix = f"{log_prefix} " if log_prefix else ""
         # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
@@ -2872,7 +2876,7 @@ class AIAgent:
 
         allowed_keys = {
             "model", "instructions", "input", "tools", "store",
-            "reasoning", "include", "max_output_tokens", "temperature",
+            "reasoning", "include", "max_output_tokens", "temperature", "top_p",
             "tool_choice", "parallel_tool_calls", "prompt_cache_key",
         }
         normalized: Dict[str, Any] = {
@@ -2891,13 +2895,18 @@ class AIAgent:
         if isinstance(include, list):
             normalized["include"] = include
 
-        # Pass through max_output_tokens and temperature
+        # Pass through max_output_tokens and sampling parameters.
         max_output_tokens = api_kwargs.get("max_output_tokens")
         if isinstance(max_output_tokens, (int, float)) and max_output_tokens > 0:
             normalized["max_output_tokens"] = int(max_output_tokens)
         temperature = api_kwargs.get("temperature")
         if isinstance(temperature, (int, float)):
             normalized["temperature"] = float(temperature)
+        top_p = api_kwargs.get("top_p")
+        if isinstance(top_p, (int, float)):
+            top_p_value = float(top_p)
+            if 0 < top_p_value <= 1:
+                normalized["top_p"] = top_p_value
 
         # Pass through tool_choice, parallel_tool_calls, prompt_cache_key
         for passthrough_key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key"):
@@ -4034,7 +4043,7 @@ class AIAgent:
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_kwargs
             anthropic_messages = self._prepare_anthropic_messages_for_api(api_messages)
-            return build_anthropic_kwargs(
+            kwargs = build_anthropic_kwargs(
                 model=self.model,
                 messages=anthropic_messages,
                 tools=self.tools,
@@ -4043,6 +4052,15 @@ class AIAgent:
                 is_oauth=getattr(self, "_is_anthropic_oauth", False),
                 preserve_dots=self._anthropic_preserve_dots(),
             )
+
+            # Respect adapter-enforced temperature (e.g. older Anthropic thinking
+            # mode requires temperature=1). Only inject our override when adapter
+            # didn't already set one.
+            if self.temperature is not None and "temperature" not in kwargs:
+                kwargs["temperature"] = self.temperature
+            if self.top_p is not None:
+                kwargs["top_p"] = self.top_p
+            return kwargs
 
         if self.api_mode == "codex_responses":
             instructions = ""
@@ -4096,6 +4114,11 @@ class AIAgent:
 
             if self.max_tokens is not None:
                 kwargs["max_output_tokens"] = self.max_tokens
+
+            if self.temperature is not None:
+                kwargs["temperature"] = self.temperature
+            if self.top_p is not None:
+                kwargs["top_p"] = self.top_p
 
             return kwargs
 
@@ -4158,6 +4181,11 @@ class AIAgent:
 
         if self.max_tokens is not None:
             api_kwargs.update(self._max_tokens_param(self.max_tokens))
+
+        if self.temperature is not None:
+            api_kwargs["temperature"] = self.temperature
+        if self.top_p is not None:
+            api_kwargs["top_p"] = self.top_p
 
         extra_body = {}
 
@@ -6400,6 +6428,35 @@ class AIAgent:
                         'invalid api key', 'invalid_api_key', 'authentication',
                         'unauthorized', 'forbidden', 'not found',
                     ])) and not is_context_length_error
+
+                    # Some providers/models reject sampling params (temperature/top_p),
+                    # especially on reasoning-first model families. Retry once without
+                    # sampling before treating the request as fatal.
+                    _sampling_rejected = (
+                        ("temperature" in api_kwargs or "top_p" in api_kwargs)
+                        and any(
+                            phrase in error_msg.lower()
+                            for phrase in (
+                                "temperature",
+                                "top_p",
+                                "unsupported parameter",
+                                "unsupported field",
+                                "does not support sampling",
+                                "doesn't support sampling",
+                            )
+                        )
+                    )
+                    if _sampling_rejected:
+                        api_kwargs.pop("temperature", None)
+                        api_kwargs.pop("top_p", None)
+                        self.temperature = None
+                        self.top_p = None
+                        retry_count += 1
+                        self._vprint(
+                            f"{self.log_prefix}⚠️  Model rejected sampling params; retrying without temperature/top_p.",
+                            force=True,
+                        )
+                        continue
 
                     if is_client_error:
                         # Try fallback before aborting — a different provider

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -473,3 +473,48 @@ class TestPluginCommands:
         assert mgr._plugins["bad_cmd"].enabled is False
         assert mgr._plugins["bad_cmd"].error is not None
         assert "conflicts" in mgr._plugins["bad_cmd"].error.lower()
+
+
+class TestSamplingPluginExample:
+    def test_example_plugin_updates_cli_and_agent_sampling(self, tmp_path, monkeypatch):
+        repo_root = Path(__file__).resolve().parents[1]
+        source = repo_root / "optional-plugins" / "sampling-command"
+        assert source.exists()
+
+        plugins_dir = tmp_path / "hermes_test" / "plugins" / "sampling-command"
+        plugins_dir.mkdir(parents=True, exist_ok=True)
+        for filename in ("plugin.yaml", "__init__.py"):
+            (plugins_dir / filename).write_text((source / filename).read_text())
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        import hermes_cli.plugins as plugins_mod
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+
+        cli_stub = types.SimpleNamespace(
+            temperature=None,
+            top_p=None,
+            agent=types.SimpleNamespace(temperature=None, top_p=None),
+        )
+
+        result = invoke_plugin_command(
+            "sampling",
+            "0.7 0.95",
+            context={"surface": "cli", "cli": cli_stub},
+        )
+        assert "Sampling updated" in result
+        assert cli_stub.temperature == pytest.approx(0.7)
+        assert cli_stub.top_p == pytest.approx(0.95)
+        assert cli_stub.agent.temperature == pytest.approx(0.7)
+        assert cli_stub.agent.top_p == pytest.approx(0.95)
+
+        status = invoke_plugin_command(
+            "sampling",
+            "",
+            context={"surface": "cli", "cli": cli_stub},
+        )
+        assert "temperature: 0.7" in status
+        assert "top_p:       0.95" in status

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -19,8 +19,11 @@ from hermes_cli.plugins import (
     PluginManifest,
     get_plugin_manager,
     get_plugin_tool_names,
+    get_plugin_command_names,
+    get_plugin_command_handler,
     discover_plugins,
     invoke_hook,
+    invoke_plugin_command,
 )
 
 
@@ -42,6 +45,23 @@ def _make_plugin_dir(base: Path, name: str, *, register_body: str = "pass",
         f"def register(ctx):\n    {register_body}\n"
     )
     return plugin_dir
+
+
+@pytest.fixture(autouse=True)
+def _restore_command_registry_after_each_test():
+    """Keep command-registry state isolated across plugin tests."""
+    import hermes_cli.commands as commands_mod
+    import hermes_cli.plugins as plugins_mod
+
+    snapshot = list(commands_mod.COMMAND_REGISTRY)
+    token_snapshot = set(plugins_mod._REGISTERED_PLUGIN_COMMAND_TOKENS)
+    try:
+        yield
+    finally:
+        commands_mod.COMMAND_REGISTRY[:] = snapshot
+        commands_mod.rebuild_lookups()
+        plugins_mod._REGISTERED_PLUGIN_COMMAND_TOKENS.clear()
+        plugins_mod._REGISTERED_PLUGIN_COMMAND_TOKENS.update(token_snapshot)
 
 
 # ── TestPluginDiscovery ────────────────────────────────────────────────────
@@ -364,10 +384,92 @@ class TestPluginManagerList:
             assert "enabled" in p
             assert "tools" in p
             assert "hooks" in p
+            assert "commands" in p
 
 
+class TestPluginCommands:
+    """Tests for plugin slash command registration and invocation."""
 
-# NOTE: TestPluginCommands removed – register_command() was never implemented
-# in PluginContext (hermes_cli/plugins.py).  The tests referenced _plugin_commands,
-# commands_registered, get_plugin_command_handler, and GATEWAY_KNOWN_COMMANDS
-# integration — all of which are unimplemented features.
+    def test_register_command_exposes_handler_alias_and_registry(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "cmd_plugin",
+            register_body='ctx.register_command("hello", lambda args: f"hello {args or \'world\'}", description="Say hello", aliases=("hi",), args_hint="[name]")',
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        import hermes_cli.plugins as plugins_mod
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+
+        from hermes_cli.commands import resolve_command
+
+        assert resolve_command("hello") is not None
+        assert resolve_command("hi") is not None
+        assert resolve_command("hi").name == "hello"
+
+        names = get_plugin_command_names()
+        assert "hello" in names
+        assert "hi" in names
+
+        handler = get_plugin_command_handler("hello")
+        assert handler is not None
+        assert handler("Nastya") == "hello Nastya"
+
+        assert invoke_plugin_command("hi", "Nastya") == "hello Nastya"
+
+    def test_invoke_plugin_command_passes_context_when_supported(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "ctx_plugin",
+            register_body='ctx.register_command("ctx", lambda args, context: context.get("surface", "none"))',
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        import hermes_cli.plugins as plugins_mod
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+
+        result = invoke_plugin_command("ctx", context={"surface": "cli"})
+        assert result == "cli"
+
+    def test_invoke_plugin_command_preserves_args_only_handlers(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "args_plugin",
+            register_body='ctx.register_command("plain", lambda args: f"plain:{args}")',
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        import hermes_cli.plugins as plugins_mod
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+
+        result = invoke_plugin_command("plain", "x", context={"surface": "cli"})
+        assert result == "plain:x"
+
+    def test_register_command_conflicting_with_builtin_disables_plugin(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "bad_cmd",
+            register_body='ctx.register_command("help", lambda args: "nope")',
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "bad_cmd" in mgr._plugins
+        assert mgr._plugins["bad_cmd"].enabled is False
+        assert mgr._plugins["bad_cmd"].error is not None
+        assert "conflicts" in mgr._plugins["bad_cmd"].error.lower()

--- a/tests/test_quick_commands.py
+++ b/tests/test_quick_commands.py
@@ -92,6 +92,25 @@ class TestCLIQuickCommands:
         printed = self._printed_plain(cli.console.print.call_args[0][0])
         assert printed == "overridden"
 
+    def test_plugin_command_dispatch_invokes_plugin_with_cli_context(self):
+        """Plugin slash commands should receive CLI runtime context."""
+        cli = self._make_cli({})
+        with patch("cli._get_plugin_cmd_handler_names", return_value={"plug"}), \
+             patch("hermes_cli.plugins.invoke_plugin_command", return_value="plugin-ok") as invoke_mock, \
+             patch("cli._cprint") as mock_cprint:
+            cli.process_command("/plug alpha")
+
+        invoke_mock.assert_called_once()
+        call_args, call_kwargs = invoke_mock.call_args
+        assert call_args[0] == "plug"
+        assert call_args[1] == "alpha"
+        context = call_kwargs.get("context", {})
+        assert context.get("surface") == "cli"
+        assert context.get("cli") is cli
+
+        printed = "\n".join(str(call) for call in mock_cprint.call_args_list)
+        assert "plugin-ok" in printed
+
     def test_unknown_command_still_shows_error(self):
         cli = self._make_cli({})
         with patch("cli._cprint") as mock_cprint:
@@ -186,3 +205,28 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_gateway_plugin_command_dispatch_invokes_plugin_with_context(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("plug", "alpha")
+
+        with patch("hermes_cli.plugins.invoke_plugin_command", return_value="plugin-ok") as invoke_mock:
+            result = await runner._handle_message(event)
+
+        assert result == "plugin-ok"
+        invoke_mock.assert_called_once()
+        call_args, call_kwargs = invoke_mock.call_args
+        assert call_args[0] == "plug"
+        assert call_args[1] == "alpha"
+        context = call_kwargs.get("context", {})
+        assert context.get("surface") == "gateway"
+        assert context.get("runner") is runner
+        assert context.get("event") is event

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -659,6 +659,44 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["max_tokens"] == 4096
 
+    def test_sampling_params_injected_for_chat_completions(self, agent):
+        agent.temperature = 0.42
+        agent.top_p = 0.91
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["temperature"] == pytest.approx(0.42)
+        assert kwargs["top_p"] == pytest.approx(0.91)
+
+    def test_sampling_params_injected_for_codex_responses(self, agent):
+        agent.api_mode = "codex_responses"
+        agent.temperature = 0.3
+        agent.top_p = 0.8
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+        ]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["temperature"] == pytest.approx(0.3)
+        assert kwargs["top_p"] == pytest.approx(0.8)
+
+    def test_sampling_params_for_anthropic_respect_adapter_temperature(self, agent):
+        agent.api_mode = "anthropic_messages"
+        agent.temperature = 0.5
+        agent.top_p = 0.77
+
+        with patch("agent.anthropic_adapter.build_anthropic_kwargs") as mock_build:
+            mock_build.return_value = {
+                "model": "claude-sonnet-4-20250514",
+                "messages": [],
+                "max_tokens": 4096,
+                "temperature": 1,
+            }
+            kwargs = agent._build_api_kwargs([{"role": "user", "content": "test"}])
+
+        # Adapter-enforced temperature wins (older Anthropic thinking mode).
+        assert kwargs["temperature"] == 1
+        assert kwargs["top_p"] == pytest.approx(0.77)
+
 
 class TestBuildAssistantMessage:
     def test_basic_message(self, agent):

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -234,8 +234,68 @@ def register(ctx):
 - Called exactly once at startup
 - `ctx.register_tool()` puts your tool in the registry — the model sees it immediately
 - `ctx.register_hook()` subscribes to lifecycle events
-- `ctx.register_command()` — _planned but not yet implemented_
+- `ctx.register_command()` adds a plugin slash command (CLI + gateway)
 - If this function crashes, the plugin is disabled but Hermes continues fine
+
+### Optional: add a `/sampling` slash command
+
+Plugin command handlers receive the command argument string and can optionally
+accept runtime `context`:
+
+```python
+def _set_sampling(args: str, context: dict | None = None) -> str:
+    context = context or {}
+    if context.get("surface") != "cli":
+        return "This plugin command currently supports CLI sessions only."
+
+    cli = context.get("cli")
+    if cli is None:
+        return "Missing CLI context."
+
+    parts = args.split()
+    if len(parts) != 2:
+        return "Usage: /sampling <temperature|default> <top_p|default>"
+
+    def parse_value(raw: str, *, minimum: float, maximum: float | None = None):
+        if raw.lower() in {"default", "none", "off", "auto", "null"}:
+            return None
+        value = float(raw)
+        if value < minimum:
+            raise ValueError("value too small")
+        if maximum is not None and value > maximum:
+            raise ValueError("value too large")
+        return value
+
+    try:
+        temperature = parse_value(parts[0], minimum=0.0)
+        top_p = parse_value(parts[1], minimum=0.0, maximum=1.0)
+        if top_p == 0.0:
+            raise ValueError("top_p must be > 0 unless default")
+    except ValueError as exc:
+        return f"Invalid sampling values: {exc}"
+
+    cli.temperature = temperature
+    cli.top_p = top_p
+    if getattr(cli, "agent", None):
+        cli.agent.temperature = temperature
+        cli.agent.top_p = top_p
+
+    return f"Sampling updated: temperature={temperature}, top_p={top_p}"
+
+
+def register(ctx):
+    # ... register tools/hooks ...
+    ctx.register_command(
+        name="sampling",
+        handler=_set_sampling,
+        description="Set session temperature/top_p",
+        args_hint="<temperature|default> <top_p|default>",
+        cli_only=True,
+    )
+```
+
+That command now works as `/sampling 0.7 0.95` and can update the current
+running CLI session immediately.
 
 ## Step 6: Test it
 

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -297,6 +297,12 @@ def register(ctx):
 That command now works as `/sampling 0.7 0.95` and can update the current
 running CLI session immediately.
 
+If you want a ready-to-use implementation instead of copy/pasting, use the
+shipped example plugin in this repo:
+
+- `optional-plugins/sampling-command/plugin.yaml`
+- `optional-plugins/sampling-command/__init__.py`
+
 ## Step 6: Test it
 
 Start Hermes:

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -125,6 +125,19 @@ def register(ctx):
     )
 ```
 
+A full working plugin implementation is included at:
+
+- `optional-plugins/sampling-command/plugin.yaml`
+- `optional-plugins/sampling-command/__init__.py`
+
+Install it into your user plugin directory:
+
+```bash
+mkdir -p ~/.hermes/plugins/sampling-command
+cp optional-plugins/sampling-command/plugin.yaml ~/.hermes/plugins/sampling-command/
+cp optional-plugins/sampling-command/__init__.py ~/.hermes/plugins/sampling-command/
+```
+
 ## Managing plugins
 
 ```

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -70,17 +70,60 @@ def register(ctx):
     )
 ```
 
-The handler receives the argument string (everything after `/greet`) and returns a string to display. Registered commands automatically appear in `/help`, tab autocomplete, Telegram bot menu, and Slack subcommand mapping.
+The handler receives the argument string (everything after `/greet`) and may
+also accept optional runtime context:
+
+- `handler(args)`
+- `handler(args, context)`
+- `handler(args, *, context=...)`
+
+Registered commands automatically appear in `/help`, tab autocomplete,
+Telegram bot menu, and Slack subcommand mapping.
 
 | Parameter | Description |
 |-----------|-------------|
 | `name` | Command name without slash |
-| `handler` | Callable that takes `args: str` and returns `str | None` |
+| `handler` | Callable that takes `args: str` and optionally `context`, returning `str | None` |
 | `description` | Shown in `/help` |
 | `args_hint` | Usage hint, e.g. `"[name]"` |
 | `aliases` | Tuple of alternative names |
 | `cli_only` | Only available in CLI |
 | `gateway_only` | Only available in messaging platforms |
+
+Example `/sampling` command (CLI-only, live session updates):
+
+```python
+def set_sampling(args, context=None):
+    context = context or {}
+    if context.get("surface") != "cli":
+        return "This command is CLI-only"
+
+    cli = context.get("cli")
+    if not cli:
+        return "Missing CLI context"
+
+    temp_raw, top_p_raw = args.split()
+    temp = None if temp_raw == "default" else float(temp_raw)
+    top_p = None if top_p_raw == "default" else float(top_p_raw)
+
+    cli.temperature = temp
+    cli.top_p = top_p
+    if getattr(cli, "agent", None):
+        cli.agent.temperature = temp
+        cli.agent.top_p = top_p
+
+    return f"Sampling updated: temperature={temp}, top_p={top_p}"
+
+
+def register(ctx):
+    ctx.register_command(
+        name="sampling",
+        handler=set_sampling,
+        description="Set session temperature/top_p",
+        args_hint="<temperature|default> <top_p|default>",
+        cli_only=True,
+    )
+```
 
 ## Managing plugins
 


### PR DESCRIPTION
## What does this PR do?

This PR makes plugin slash commands fully usable at runtime and ships a real `/sampling` command plugin.
It includes:                                                                                                                   
   - plugin command registration/invocation plumbing (`ctx.register_command`, handler lookup, invocation with runtime context)    
   - CLI + gateway dispatch integration through public plugin APIs                                                                
   - a working CLI `/sampling` plugin in `optional-plugins/sampling-command/`                                                     
   - session sampling plumbing in core (`temperature`/`top_p` carried from CLI state into `AIAgent` request kwargs)               
   - graceful retry behavior when a provider rejects sampling params                                                              
   - tests and docs updates      

## Related Issue
No issue filed for this change (can open one if maintainers prefer). 

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)


## Changes Made

- `hermes_cli/plugins.py`                                                                                                      
     - implemented plugin slash-command registration and storage                                                                  
     - added public APIs for command discovery/handler lookup/invocation                                                          
     - added context-compatible invocation (`handler(args)`, `handler(args, context)`, `handler(args, *, context=...)`)           
     - plugin listing now includes command counts                                                                                 
                                                                                                                                  
   - `cli.py`                                                                                                                     
     - switched plugin dispatch to public plugin APIs                                                                             
     - eager plugin discovery for command visibility/help                                                                         
     - plugin invocation now passes CLI runtime context                                                                           
     - added session sampling parsing/state (`temperature`, `top_p`) from env/config                                              
     - passes sampling state into `AIAgent(...)`                                                                                  
                                                                                                                                  
   - `gateway/run.py`                                                                                                             
     - plugin invocation now passes gateway runtime context                                                                       
     - ensures plugin discovery before `/help` rendering                                                                          
                                                                                                                                  
   - `run_agent.py`                                                                                                               
     - added `temperature` / `top_p` params to `AIAgent.__init__`                                                                 
     - injects sampling params into chat/codex/anthropic kwargs                                                                   
     - codex preflight accepts/validates `top_p`                                                                                  
     - retries without sampling params if provider/model rejects them                                                             
                                                                                                                                  
   - `optional-plugins/sampling-command/`                                                                                         
     - added full working plugin:                                                                                                 
       - `plugin.yaml`                                                                                                            
       - `__init__.py`                                                                                                            
       - `README.md`                                                                                                              
     - supports:                                                                                                                  
       - `/sampling`                                                                                                              
       - `/sampling <temp> <top_p>`                                                                                               
       - `/sampling set <temp> <top_p>`                                                                                           
       - `/sampling temperature <value|default>`                                                                                  
       - `/sampling top_p <value|default>`                                                                                        
       - `/sampling reset`                                                                                                        
       - `/sampling save`                                                                                                         
                                                                                                                                  
   - Tests                                                                                                                        
     - `tests/test_plugins.py`:                                                                                                   
       - plugin command registration/alias/invocation coverage                                                                    
       - example sampling plugin integration test                                                                                 
     - `tests/test_quick_commands.py`:                                                                                            
       - CLI and gateway plugin command dispatch coverage                                                                         
     - `tests/test_run_agent.py`:                                                                                                 
       - sampling param propagation and anthropic adapter precedence checks                                                       
                                                                                                                                  
   - Docs                                                                                                                         
     - `website/docs/guides/build-a-hermes-plugin.md`                                                                             
     - `website/docs/user-guide/features/plugins.md`                                                                              
     - updated command docs and added install path for the shipped sampling plugin   

- 

## How to Test

1. Run targeted tests:                                                                                                         
      - `python -m pytest -o addopts='' tests/test_plugins.py tests/test_quick_commands.py tests/test_run_agent.py -q`            
      - `python -m pytest -o addopts='' tests/test_cli_init.py tests/hermes_cli/test_commands.py -q`                              
                                                                                                                                  
2. Install the shipped plugin locally:                                                                                         
      - `mkdir -p ~/.hermes/plugins/sampling-command`                                                                             
      - `cp optional-plugins/sampling-command/plugin.yaml ~/.hermes/plugins/sampling-command/`                                    
      - `cp optional-plugins/sampling-command/__init__.py ~/.hermes/plugins/sampling-command/`                                    
                                                                                                                                  
 3. Restart Hermes and verify:                                                                                                  
      - `/plugins` shows `sampling-command`                                                                                       
      - `/sampling`                                                                                                               
      - `/sampling 0.7 0.95`                                                                                                      
      - `/sampling temperature default`                                                                                           
      - `/sampling save`                         

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass  
*Targeted suites for changed files pass locally. Full local suite on macOS hit environment/platform issues  (case-insensitive FS test and Errno 24 with xdist)*   
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS Sequoia (Darwin 24.5.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A 
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A: no config example changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A: not needed for this change)                                                                                            
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A: no tool schema/description changes in this PR)                                                                                      

### Contributor note: 
This is my first PR here; if I missed any expected formatting/process bits, I’m glad to fix them.
