### PR TITLE
feat: Add Current Personality Display to `/personality` Command (#2887)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3055,6 +3055,23 @@ class HermesCLI:
             return "\n".join(p for p in parts if p)
         return str(value)
 
+    def _get_current_personality(self) -> str:
+        """Determine the currently active personality name from system_prompt."""
+        current_prompt = self.system_prompt
+        
+        # Check for special personalities (handles both None and "")
+        if not current_prompt:
+            return "none"
+        
+        # Check each personality by comparing system_prompt
+        for name, prompt in self.personalities.items():
+            resolved = HermesCLI._resolve_personality_prompt(prompt)
+            if resolved == current_prompt:
+                return name
+        
+        # If no exact match, return "custom"
+        return "custom"
+
     def _handle_personality_command(self, cmd: str):
         """Handle the /personality command to set predefined personalities."""
         parts = cmd.split(maxsplit=1)
@@ -3084,10 +3101,14 @@ class HermesCLI:
                 print(f"  Available: none, {', '.join(self.personalities.keys())}")
         else:
             # Show available personalities
+            current_personality = self._get_current_personality()
+            
             print()
             print("+" + "-" * 50 + "+")
             print("|" + " " * 12 + "(^o^)/ Personalities" + " " * 15 + "|")
             print("+" + "-" * 50 + "+")
+            print()
+            print(f"  Current:   {current_personality:^12}")
             print()
             print(f"  {'none':<12} - (no personality overlay)")
             for name, prompt in self.personalities.items():

--- a/tests/test_personality_display.py
+++ b/tests/test_personality_display.py
@@ -1,0 +1,180 @@
+"""Tests for /personality command display with current personality indicator."""
+
+import pytest
+from cli import HermesCLI
+
+
+def test_get_current_personality_none():
+    """Test that empty system_prompt returns 'none'."""
+    cli = HermesCLI()
+    cli.system_prompt = ""
+    cli.personalities = {
+        "kawaii": "You are a kawaii assistant!",
+        "professional": "You are a professional assistant.",
+    }
+    current = cli._get_current_personality()
+    assert current == "none"
+
+
+def test_get_current_personality_none_value():
+    """Test that None system_prompt returns 'none'."""
+    cli = HermesCLI()
+    cli.system_prompt = None
+    cli.personalities = {
+        "kawaii": "You are a kawaii assistant!",
+    }
+    current = cli._get_current_personality()
+    assert current == "none"
+
+
+def test_get_current_personality_kawaii():
+    """Test that kawaii system_prompt returns 'kawaii'."""
+    cli = HermesCLI()
+    cli.system_prompt = "You are a kawaii assistant!"
+    cli.personalities = {
+        "kawaii": "You are a kawaii assistant!",
+        "professional": "You are a professional assistant.",
+    }
+    current = cli._get_current_personality()
+    assert current == "kawaii"
+
+
+def test_get_current_personality_professional():
+    """Test that professional system_prompt returns 'professional'."""
+    cli = HermesCLI()
+    cli.system_prompt = "You are a professional assistant."
+    cli.personalities = {
+        "kawaii": "You are a kawaii assistant!",
+        "professional": "You are a professional assistant.",
+    }
+    current = cli._get_current_personality()
+    assert current == "professional"
+
+
+def test_get_current_personality_technical():
+    """Test that technical system_prompt returns 'technical'."""
+    cli = HermesCLI()
+    cli.system_prompt = "You are a technical expert."
+    cli.personalities = {
+        "technical": "You are a technical expert.",
+    }
+    current = cli._get_current_personality()
+    assert current == "technical"
+
+
+def test_get_current_personality_custom():
+    """Test that unmatched system_prompt returns 'custom'."""
+    cli = HermesCLI()
+    cli.personalities = {
+        "kawaii": "You are a kawaii assistant!",
+    }
+    cli.system_prompt = "You are a custom assistant."
+    current = cli._get_current_personality()
+    assert current == "custom"
+
+
+def test_get_current_personality_with_tone():
+    """Test that system_prompt with tone prefix is matched correctly."""
+    cli = HermesCLI()
+    cli.personalities = {
+        "kawaii": {
+            "description": "A kawaii personality",
+            "system_prompt": "You are a kawaii assistant!",
+            "tone": "enthusiastic",
+        }
+    }
+    cli.system_prompt = "You are a kawaii assistant!\nTone: enthusiastic"
+    current = cli._get_current_personality()
+    assert current == "kawaii"
+
+
+def test_get_current_personality_with_style():
+    """Test that system_prompt with style prefix is matched correctly."""
+    cli = HermesCLI()
+    cli.personalities = {
+        "kawaii": {
+            "description": "A kawaii personality",
+            "system_prompt": "You are a kawaii assistant!",
+            "style": "cute",
+        }
+    }
+    cli.system_prompt = "You are a kawaii assistant!\nStyle: cute"
+    current = cli._get_current_personality()
+    assert current == "kawaii"
+
+
+def test_get_current_personality_with_tone_and_style():
+    """Test that system_prompt with both tone and style is matched correctly."""
+    cli = HermesCLI()
+    cli.personalities = {
+        "kawaii": {
+            "description": "A kawaii personality",
+            "system_prompt": "You are a kawaii assistant!",
+            "tone": "enthusiastic",
+            "style": "cute",
+        }
+    }
+    cli.system_prompt = "You are a kawaii assistant!\nTone: enthusiastic\nStyle: cute"
+    current = cli._get_current_personality()
+    assert current == "kawaii"
+
+
+def test_get_current_personality_multiple_personalities():
+    """Test that first matching personality is returned."""
+    cli = HermesCLI()
+    cli.system_prompt = "You are a professional assistant."
+    cli.personalities = {
+        "kawaii": "You are a kawaii assistant!",
+        "professional": "You are a professional assistant.",
+    }
+    current = cli._get_current_personality()
+    assert current == "professional"
+
+
+def test_personality_display_current_line():
+    """Test the current personality display line formatting."""
+    cli = HermesCLI()
+    cli.system_prompt = "You are a kawaii assistant!"
+    cli.personalities = {
+        "kawaii": "You are a kawaii assistant!",
+        "professional": "You are a professional assistant.",
+    }
+    
+    current = cli._get_current_personality()
+    formatted = f"  Current:   {current:^12}"
+    
+    # Verify the formatting contains the current personality
+    assert "Current:" in formatted
+    assert "kawaii" in formatted
+
+
+def test_personality_display_none():
+    """Test that display shows 'none' when no personality is set."""
+    cli = HermesCLI()
+    cli.system_prompt = ""
+    cli.personalities = {
+        "kawaii": "You are a kawaii assistant!",
+    }
+    
+    current = cli._get_current_personality()
+    formatted = f"  Current:   {current:^12}"
+    
+    # Verify the formatting contains 'none'
+    assert "Current:" in formatted
+    assert "none" in formatted
+
+
+def test_personality_display_custom():
+    """Test that display shows 'custom' for custom prompts."""
+    cli = HermesCLI()
+    cli.system_prompt = "You are a custom assistant."
+    cli.personalities = {
+        "kawaii": "You are a kawaii assistant!",
+    }
+    
+    current = cli._get_current_personality()
+    formatted = f"  Current:   {current:^12}"
+    
+    # Verify the formatting contains 'custom'
+    assert "Current:" in formatted
+    assert "custom" in formatted

--- a/website/docs/user-guide/features/personality.md
+++ b/website/docs/user-guide/features/personality.md
@@ -201,6 +201,27 @@ Hermes ships with built-in personalities you can switch to with `/personality`.
 /personality technical
 ```
 
+### Viewing current personality
+
+Simply run `/personality` without arguments to see which personality is currently active:
+
+```text
++--------------------------------------------------+
+|          (^o^)/ Personalities              |
++--------------------------------------------------+
+
+  Current:    technical
+
+  none         - (no personality overlay)
+  kawaii       - You are a kawaii assistant!
+  professional - You are a professional assistant.
+  technical    - You are a technical expert.
+
+  Usage: /personality <name>
+```
+
+This helps you quickly identify which personality is active without having to remember or check the config.
+
 ### Messaging platforms
 
 ```text


### PR DESCRIPTION
## What does this PR do?

This PR adds a visual indicator showing the currently active personality when running the `/personality` command without arguments. The change enhances user experience by making it immediately clear which personality is in effect, without requiring users to remember or check the config.

The implementation adds a `_get_current_personality()` method that compares the current `system_prompt` against all predefined personalities and displays the result prominently at the top of the personality list.

## Related Issue
Fixes #2887

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

### Modified Files

1. **`cli.py`**
   - Added new method `_get_current_personality()` that determines the active personality by comparing `system_prompt` against all predefined personalities
   - Updated `_handle_personality_command()` to display the current personality above the list
   - Handles edge cases: empty prompt (returns "none"), custom prompts (returns "custom"), and dict-style personalities with tone/style modifiers

### New Files

1. **`tests/test_personality_display.py`**
   - Unit tests for `_get_current_personality()` method covering:
     - Empty system_prompt returns "none"
     - Exact matches for each predefined personality
     - Dict-style personalities with tone/style modifiers
     - Custom/unmatched system_prompts return "custom"
   - Display formatting tests to ensure correct output

## How to Test

1. Start Hermes with a personality set (e.g., `/personality kawaii`)
2. Type `/personality` without arguments
3. Verify that "Current: kawaii" appears at the top of the output
4. Switch to a different personality and confirm the display updates
5. Run the test suite:
   ```bash
   source venv/bin/activate && python -m pytest tests/test_personality_display.py -v
   ```
6. Test edge cases: no personality set, custom prompts, dict-style personalities

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13.4

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

**Before:**
```
+--------------------------------------------------+
|          (^o^)/ Personalities              |
+--------------------------------------------------+

  none         - (no personality overlay)
  kawaii       - You are a kawaii assistant!
  professional - You are a professional assistant.
```

**After:**
```
+--------------------------------------------------+
|          (^o^)/ Personalities              |
+--------------------------------------------------+

  Current:    kawaii

  none         - (no personality overlay)
  kawaii       - You are a kawaii assistant!
  professional - You are a professional assistant.
```
