### PR TITLE
fix(security): redact credentials in gateway and cron responses before platform delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -534,6 +534,15 @@ def tick(verbose: bool = True) -> int:
                 # If the agent responded with [SILENT], skip delivery (but
                 # output is already saved above).  Failed jobs always deliver.
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+
+                # Redact credentials/secrets before delivering to external platforms
+                if deliver_content:
+                    try:
+                        from agent.redact import redact_sensitive_text
+                        deliver_content = redact_sensitive_text(deliver_content)
+                    except Exception:
+                        pass  # Don't block delivery on redaction failure
+
                 should_deliver = bool(deliver_content)
                 if should_deliver and success and deliver_content.strip().upper().startswith(SILENT_MARKER):
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2408,6 +2408,16 @@ class GatewayRunner:
             response = agent_result.get("final_response") or ""
             agent_messages = agent_result.get("messages", [])
 
+            # ── Structural output redaction ──────────────────────────────
+            # Redact credentials/secrets from the response BEFORE platform
+            # delivery.  Tool outputs are already redacted individually, but
+            # the LLM can compose a response that re-states secrets (e.g.
+            # summarising a .env file or terminal output).  This is the last
+            # structural defence before text reaches Discord/Telegram/etc.
+            if response:
+                from agent.redact import redact_sensitive_text
+                response = redact_sensitive_text(response)
+
             # Surface error details when the agent failed silently (final_response=None)
             if not response and agent_result.get("failed"):
                 error_detail = agent_result.get("error", "unknown error")

--- a/tests/gateway/test_response_redaction.py
+++ b/tests/gateway/test_response_redaction.py
@@ -1,0 +1,74 @@
+"""Tests for structural output redaction in gateway and cron delivery paths.
+
+Verifies that credentials/secrets in the LLM's final response are redacted
+before reaching external platforms (Discord, Telegram, etc.).
+
+This is a defense-in-depth measure: tool outputs are already redacted
+individually, but the LLM can compose responses that re-state secrets.
+"""
+
+import pytest
+
+from agent.redact import redact_sensitive_text
+
+
+class TestResponseRedaction:
+    """Verify redact_sensitive_text catches common credential patterns."""
+
+    def test_openai_api_key_redacted(self):
+        response = "Your API key is sk-proj-abc123def456ghi789jkl012mno345pqr678stu901vwx234"
+        result = redact_sensitive_text(response)
+        assert "abc123def456ghi789jkl012" not in result
+
+    def test_github_pat_redacted(self):
+        response = "I found the token: ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+        result = redact_sensitive_text(response)
+        assert "1234567890abcdefghij" not in result
+
+    def test_anthropic_key_redacted(self):
+        response = "The Anthropic key is sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890"
+        result = redact_sensitive_text(response)
+        assert "abcdefghijklmno" not in result
+
+    def test_env_assignment_redacted(self):
+        response = 'In your .env file:\nDISCORD_BOT_TOKEN=MTQ4NDk1NzM4OTQ3NTE1.GPP3r-.abc123\nTELEGRAM_BOT_TOKEN=7654321:AAHabcdefghijklmnop'
+        result = redact_sensitive_text(response)
+        assert "MTQ4NDk1NzM4OTQ3NTE1" not in result
+
+    def test_bearer_token_redacted(self):
+        response = "curl -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc.def'"
+        result = redact_sensitive_text(response)
+        assert "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" not in result
+
+    def test_json_api_key_redacted(self):
+        response = '{"api_key": "super-secret-key-1234567890abcdef"}'
+        result = redact_sensitive_text(response)
+        assert "super-secret-key-1234567890" not in result
+
+    def test_private_key_redacted(self):
+        response = "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBg\n-----END PRIVATE KEY-----"
+        result = redact_sensitive_text(response)
+        assert "MIIEvgIBADANBg" not in result
+
+    def test_normal_text_unchanged(self):
+        response = "I've updated the configuration file and restarted the service. Everything looks good."
+        result = redact_sensitive_text(response)
+        assert result == response
+
+    def test_none_input_returns_none(self):
+        assert redact_sensitive_text(None) is None
+
+    def test_empty_string_returns_empty(self):
+        assert redact_sensitive_text("") == ""
+
+    def test_mixed_content_only_secrets_redacted(self):
+        response = (
+            "Here's the status:\n"
+            "- Server: running\n"
+            "- API key: sk-proj-abcdefghijklmnopqrstuvwxyz1234567890abcdef\n"
+            "- Port: 8080\n"
+        )
+        result = redact_sensitive_text(response)
+        assert "Server: running" in result
+        assert "Port: 8080" in result
+        assert "abcdefghijklmnopqrstuvwxyz1234567890" not in result


### PR DESCRIPTION
## Summary

**Security fix:** The LLM's `final_response` was delivered to Discord/Telegram/Slack/etc without passing through `redact_sensitive_text()`. Tool outputs were individually redacted, but the composed response was not.

If the LLM re-stated secrets in its response (e.g. summarising a `.env` file, quoting terminal output containing API keys, or describing a config file), credentials reached external platforms unfiltered. **This was the vector for a real credential leak to Discord.**

## Changes (3 files, +93 lines)

- **`gateway/run.py`**: Apply `redact_sensitive_text()` on `final_response` at extraction point (line ~2408), before platform delivery, media extraction, or voice reply
- **`cron/scheduler.py`**: Apply `redact_sensitive_text()` on `deliver_content` before `_deliver_result()`, with try/except to avoid blocking delivery on redaction failure
- **`tests/gateway/test_response_redaction.py`**: 11 tests covering OpenAI keys, GitHub PATs, Anthropic keys, bearer tokens, env assignments, JSON fields, private key blocks, mixed content, and edge cases

## Defense in Depth

This supplements (not replaces) per-tool output redaction in `terminal_tool.py`, `file_tools.py`, and `search_files`. Both layers use the same `redact_sensitive_text()` from `agent/redact.py` with 22 known key prefix patterns.

## Tests

```
tests/gateway/test_response_redaction.py — 11/11 passed
```