### PR TITLE
fix(gateway): stop loading hermes repo AGENTS.md into gateway sessions (~10k wasted tokens)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2361,7 +2361,13 @@ class AIAgent:
             prompt_parts.append(skills_prompt)
 
         if not self.skip_context_files:
-            context_files_prompt = build_context_files_prompt(skip_soul=_soul_loaded)
+            # Use TERMINAL_CWD for context file discovery when set (gateway
+            # mode).  The gateway process runs from the hermes-agent install
+            # dir, so os.getcwd() would pick up the repo's AGENTS.md and
+            # other dev files — inflating token usage by ~10k for no benefit.
+            _context_cwd = os.getenv("TERMINAL_CWD") or None
+            context_files_prompt = build_context_files_prompt(
+                cwd=_context_cwd, skip_soul=_soul_loaded)
             if context_files_prompt:
                 prompt_parts.append(context_files_prompt)
 


### PR DESCRIPTION
## Problem

Gateway sessions use ~15-20k input tokens vs CLI's ~6-8k. The extra ~10k comes from the hermes-agent repo's own `AGENTS.md` (16k chars, 390 lines) being loaded as project context.

**Root cause**: `build_context_files_prompt()` uses `os.getcwd()` to find context files. The gateway process runs from the hermes-agent install directory, so it finds and loads the repo's `AGENTS.md`, `.cursorrules`, etc. — none of which are relevant to the user's conversation.

## Fix

One-line change: pass `TERMINAL_CWD` (which the gateway sets to `MESSAGING_CWD` or `$HOME`) as the `cwd` for context file discovery instead of letting it default to `os.getcwd()`.

- **Gateway**: context files from the user's configured messaging directory (default: `$HOME`) — no more hermes repo junk
- **CLI**: unchanged — `TERMINAL_CWD` is set to the user's actual project directory

## Impact

~2x reduction in gateway input token usage per message.

Reported by keri on Discord.