### PR TITLE
feat: load governance rules from ~/.hermes/rules/ into system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -457,6 +457,28 @@ def load_soul_md() -> Optional[str]:
         return None
 
 
+def load_rules() -> Optional[str]:
+    """Load governance rules from HERMES_HOME/rules/ directory.
+
+    Each .md file in the rules directory is loaded and concatenated.
+    Rules supplement SOUL.md with extended traps, quality gates, etc.
+    Returns None if no rules directory or no files found.
+    """
+    rules_dir = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "rules"
+    if not rules_dir.is_dir():
+        return None
+    parts = []
+    for md_file in sorted(rules_dir.glob("*.md")):
+        try:
+            content = md_file.read_text(encoding="utf-8").strip()
+            if content:
+                content = _truncate_content(content, md_file.name)
+                parts.append(content)
+        except Exception as e:
+            logger.debug("Could not read rule %s: %s", md_file, e)
+    return "\n\n".join(parts) if parts else None
+
+
 def _load_hermes_md(cwd_path: Path) -> str:
     """.hermes.md / HERMES.md — walk to git root."""
     hermes_md_path = _find_hermes_md(cwd_path)

--- a/run_agent.py
+++ b/run_agent.py
@@ -82,7 +82,7 @@ from agent.model_metadata import (
 )
 from agent.context_compressor import ContextCompressor
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md, load_rules
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
@@ -2266,6 +2266,12 @@ class AIAgent:
             else:
                 _identity = DEFAULT_AGENT_IDENTITY
             prompt_parts = [_identity]
+
+        # Governance rules from ~/.hermes/rules/*.md (extended traps, quality gate)
+        if not self.skip_context_files:
+            _rules_content = load_rules()
+            if _rules_content:
+                prompt_parts.append(_rules_content)
 
         # Tool-aware behavioral guidance: only inject when the tools are loaded
         tool_guidance = []


### PR DESCRIPTION
## Summary

Adds a user-configurable governance rules injection layer to the system prompt. Users can drop `.md` files into `~/.hermes/rules/` and they get loaded into the system prompt every turn, right after SOUL.md.

This enables behavioral governance (traps, quality gates, coding standards) as maintainable markdown files with the same structural guarantee as SOUL.md — injected every turn, model-agnostic, no code changes needed to add/modify rules.

## Changes (2 files, +29/-1)

- **`agent/prompt_builder.py`**: Add `load_rules()` — discovers and loads `$HERMES_HOME/rules/*.md`, sorted alphabetically, with truncation safety. Mirrors the existing `load_soul_md()` pattern.
- **`run_agent.py`**: Import `load_rules`, inject content after SOUL.md in `_build_system_prompt()` (respects `skip_context_files` flag)

## System Prompt Order (after this change)

1. SOUL.md (agent identity)
2. **rules/*.md** (governance rules) ← NEW
3. Tool guidance (memory, session_search, skills)
4. Honcho memory integration
5. User/gateway system message
6. Persistent memory (MEMORY.md, USER.md)
7. Skills prompt
8. Context files (AGENTS.md, .cursorrules)
9. Timestamp + model + provider
10. Platform hint

## Design

- **Optional**: No rules directory = no injection, zero impact on existing setups
- **Sorted**: Files loaded alphabetically for deterministic ordering
- **Truncated**: Each file passes through `_truncate_content()` for safety
- **Skip-aware**: Respects `skip_context_files` flag (same as SOUL.md)

## Tests

Full suite: 6128 passed, 166 skipped, 0 failed