### PR TITLE
fix(tools): treat Slack channel IDs as explicit send_message targets

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -238,6 +238,45 @@ class TestSendMessageTool:
             thread_id=None,
         )
 
+    def test_explicit_slack_channel_id_sends_directly_instead_of_home(self):
+        slack_cfg = SimpleNamespace(enabled=True, token="xoxb-test", extra={})
+        config = SimpleNamespace(
+            platforms={Platform.SLACK: slack_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "slack:C0AD2A7C4G1",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.SLACK,
+            slack_cfg,
+            "C0AD2A7C4G1",
+            "hello",
+            thread_id=None,
+            media_files=[],
+        )
+        mirror_mock.assert_called_once_with(
+            "slack",
+            "C0AD2A7C4G1",
+            "hello",
+            source_label="cli",
+            thread_id=None,
+        )
+
 
 class TestSendTelegramMediaDelivery:
     def test_sends_text_then_photo_for_media_tag(self, tmp_path, monkeypatch):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -15,6 +15,8 @@ import time
 logger = logging.getLogger(__name__)
 
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
+_SLACK_MENTION_RE = re.compile(r"^<\#([CGDU][A-Z0-9]+)(?:\|[^>]+)?>$")
+_SLACK_CHANNEL_ID_RE = re.compile(r"^[CGDU][A-Z0-9]+$")
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
 _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a"}
@@ -41,7 +43,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or Telegram topic 'telegram:chat_id:thread_id'. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:#bot-home', 'slack:#engineering', 'signal:+15551234567'"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or Telegram topic 'telegram:chat_id:thread_id'. Slack also accepts raw channel IDs like 'slack:C0AD2A7C4G1' and Slack mentions like 'slack:#agents-updates'. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567'"
             },
             "message": {
                 "type": "string",
@@ -194,6 +196,18 @@ def _handle_send(args):
 
 def _parse_target_ref(platform_name: str, target_ref: str):
     """Parse a tool target into chat_id/thread_id and whether it is explicit."""
+    target_ref = target_ref.strip()
+
+    if platform_name == "slack":
+        mention = _SLACK_MENTION_RE.fullmatch(target_ref)
+        if mention:
+            target_ref = mention.group(1)
+        topic_suffix = re.fullmatch(r"^([CGDU][A-Z0-9]+)\s*/\s*topic\s+\d+$", target_ref, re.IGNORECASE)
+        if topic_suffix:
+            target_ref = topic_suffix.group(1)
+        if _SLACK_CHANNEL_ID_RE.fullmatch(target_ref):
+            return target_ref, None, True
+
     if platform_name == "telegram":
         match = _TELEGRAM_TOPIC_TARGET_RE.fullmatch(target_ref)
         if match:


### PR DESCRIPTION
## What does this PR do?

Fixes Slack `send_message` target parsing so explicit channel IDs are treated as explicit destinations instead of falling back to the home DM. It also normalizes Slack channel mention syntax before resolution and adds a regression test for the channel-ID path.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [tools/send_message_tool.py](https://github.com/NousResearch/hermes-agent/blob/main/tools/send_message_tool.py) so Slack targets accept raw channel IDs like `slack:C0AD2A7C4G1` as explicit targets.
- Added Slack mention normalization (`<#CHANNELID|name>`) and stripped ` / topic N` suffixes before Slack target parsing.
- Updated the `send_message` target schema description to document Slack channel IDs and mention-style targets.
- Added a regression test in [tests/tools/test_send_message_tool.py](https://github.com/NousResearch/hermes-agent/blob/main/tests/tools/test_send_message_tool.py) covering explicit Slack channel IDs.

## How to Test

1. Run `source venv/bin/activate && python -m pytest tests/tools/test_send_message_tool.py -q`.
2. Call `send_message_tool` with `target="slack:C0AD2A7C4G1"` and verify `_send_to_platform(...)` is called with chat ID `C0AD2A7C4G1` rather than a home DM channel.
3. Optionally verify Slack mention normalization with a target like `<#C0AD2A7C4G1|agents-updates>`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

Note: I ran `source venv/bin/activate && python -m pytest tests/ -q`. On this branch it finished with `2 failed, 5950 passed, 175 skipped`; the two failures reproduce on clean `main` as well:
- `tests/agent/test_prompt_builder.py::TestBuildContextFilesPrompt::test_claude_md_uppercase_takes_priority`
- `tests/test_real_interrupt_subagent.py::TestRealSubagentInterrupt::test_interrupt_child_during_api_call`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `source venv/bin/activate && python -m pytest tests/tools/test_send_message_tool.py -q` -> `20 passed, 3 warnings in 4.26s`
- Manual patched invocation of `send_message_tool({'action': 'send', 'target': 'slack:C0AD2A7C4G1', 'message': 'hello'})` passed and called `_send_to_platform(..., 'C0AD2A7C4G1', ...)`.
