### PR TITLE
feat: add MiniMax quota awareness tool and /quota command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1723,6 +1723,9 @@ class GatewayRunner:
         if canonical == "usage":
             return await self._handle_usage_command(event)
 
+        if canonical == "quota":
+            return await self._handle_quota_command(event)
+
         if canonical == "insights":
             return await self._handle_insights_command(event)
 
@@ -4195,6 +4198,19 @@ class GatewayRunner:
         except Exception as e:
             logger.error("Insights command error: %s", e, exc_info=True)
             return f"Error generating insights: {e}"
+
+    async def _handle_quota_command(self, event: MessageEvent) -> str:
+        """Handle /quota command -- show MiniMax API quota status."""
+        import json
+        from tools.minimax_quota_tool import minimax_quota_tool
+
+        result = minimax_quota_tool(provider="auto")
+        data = json.loads(result)
+
+        if "error" in data:
+            return f"Error: {data['error']}"
+
+        return data.get("formatted", str(data))
 
     async def _handle_reload_mcp_command(self, event: MessageEvent) -> str:
         """Handle /reload-mcp command -- disconnect and reconnect all MCP servers."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -129,6 +129,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("update", "Update Hermes Agent to the latest version", "Info",
                gateway_only=True),
+    CommandDef("quota", "Show MiniMax API quota and usage", "Info",
+               gateway_only=True, aliases=("minimax",)),
 
     # Exit
     CommandDef("quit", "Exit the CLI", "Exit",

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -154,6 +154,12 @@ from .delegate_tool import (
     DELEGATE_TASK_SCHEMA,
 )
 
+# MiniMax quota tool (API usage monitoring)
+from .minimax_quota_tool import (
+    minimax_quota_tool,
+    check_minimax_quota_requirements,
+)
+
 # File tools have no external requirements - they use the terminal backend
 def check_file_requirements():
     """File tools only require terminal backend to be available."""
@@ -258,5 +264,8 @@ __all__ = [
     'delegate_task',
     'check_delegate_requirements',
     'DELEGATE_TASK_SCHEMA',
+    # MiniMax quota
+    'minimax_quota_tool',
+    'check_minimax_quota_requirements',
 ]
 

--- a/tools/minimax_quota_tool.py
+++ b/tools/minimax_quota_tool.py
@@ -1,0 +1,165 @@
+"""MiniMax Quota Tool - Fetch current API quota usage."""
+
+import json
+import logging
+import os
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Endpoints
+MINIMAX_QUOTA_URL = "https://api.minimax.io/v1/coding_plan/remains"
+MINIMAX_CN_QUOTA_URL = "https://api.minimaxi.com/v1/coding_plan/remains"
+
+
+def check_minimax_quota_requirements() -> bool:
+    """Check if MiniMax API key is configured (either global or China)."""
+    return bool(os.getenv("MINIMAX_API_KEY") or os.getenv("MINIMAX_CN_API_KEY"))
+
+
+def _fetch_quota(api_key: str, base_url: str) -> dict:
+    """Make the quota API request."""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    resp = requests.get(base_url, headers=headers, timeout=15)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _format_quota_response(data: dict, provider_label: str) -> str:
+    """Format quota data for display."""
+    total = data.get("current_interval_total_count", 0)
+    used = data.get("current_interval_usage_count", 0)
+    remaining = total - used
+    start = data.get("start_time", "unknown")
+    end = data.get("end_time", "unknown")
+
+    # Calculate percentage
+    pct = (used / total * 100) if total > 0 else 0
+
+    lines = [
+        f"  {provider_label} Quota",
+        f"  {'─' * 40}",
+        f"  Total:     {total:,}",
+        f"  Used:      {used:,} ({pct:.1f}%)",
+        f"  Remaining: {remaining:,}",
+        f"  Period:    {start} → {end}",
+    ]
+    return "\n".join(lines)
+
+
+def minimax_quota_tool(provider: str = "auto") -> str:
+    """
+    Fetch MiniMax API quota information.
+
+    Args:
+        provider: Which MiniMax provider to check:
+            - "auto" (default): try global first, fall back to China
+            - "minimax": use international endpoint (api.minimax.io)
+            - "minimax-cn": use China endpoint (api.minimaxi.com)
+
+    Returns:
+        JSON string with quota details or error message.
+    """
+    if provider == "auto":
+        # Try global first, then China
+        api_key = os.getenv("MINIMAX_API_KEY", "")
+        if api_key:
+            try:
+                data = _fetch_quota(api_key, MINIMAX_QUOTA_URL)
+                return json.dumps({
+                    "provider": "minimax",
+                    "data": data,
+                    "formatted": _format_quota_response(data, "MiniMax (Global)"),
+                })
+            except Exception as e:
+                logger.warning("Failed to fetch MiniMax global quota: %s", e)
+
+        # Fall back to China
+        api_key = os.getenv("MINIMAX_CN_API_KEY", "")
+        if api_key:
+            try:
+                data = _fetch_quota(api_key, MINIMAX_CN_QUOTA_URL)
+                return json.dumps({
+                    "provider": "minimax-cn",
+                    "data": data,
+                    "formatted": _format_quota_response(data, "MiniMax (China)"),
+                })
+            except Exception as e:
+                return json.dumps({"error": f"Failed to fetch MiniMax CN quota: {e}"})
+
+        return json.dumps({"error": "No MiniMax API key configured. Set MINIMAX_API_KEY or MINIMAX_CN_API_KEY."})
+
+    elif provider == "minimax":
+        api_key = os.getenv("MINIMAX_API_KEY", "")
+        if not api_key:
+            return json.dumps({"error": "MINIMAX_API_KEY not configured"})
+        try:
+            data = _fetch_quota(api_key, MINIMAX_QUOTA_URL)
+            return json.dumps({
+                "provider": "minimax",
+                "data": data,
+                "formatted": _format_quota_response(data, "MiniMax (Global)"),
+            })
+        except Exception as e:
+            return json.dumps({"error": f"Failed to fetch quota: {e}"})
+
+    elif provider == "minimax-cn":
+        api_key = os.getenv("MINIMAX_CN_API_KEY", "")
+        if not api_key:
+            return json.dumps({"error": "MINIMAX_CN_API_KEY not configured"})
+        try:
+            data = _fetch_quota(api_key, MINIMAX_CN_QUOTA_URL)
+            return json.dumps({
+                "provider": "minimax-cn",
+                "data": data,
+                "formatted": _format_quota_response(data, "MiniMax (China)"),
+            })
+        except Exception as e:
+            return json.dumps({"error": f"Failed to fetch quota: {e}"})
+
+    return json.dumps({"error": f"Unknown provider: {provider}. Use 'minimax', 'minimax-cn', or 'auto'."})
+
+
+# OpenAI Function-Calling Schema
+MINIMAX_QUOTA_SCHEMA = {
+    "name": "minimax_quota",
+    "description": (
+        "Fetch current MiniMax API quota usage and limits. "
+        "Shows total credits, used credits, and remaining credits "
+        "for the current billing period. Use this to check if you "
+        "have enough quota before making API requests."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "provider": {
+                "type": "string",
+                "enum": ["auto", "minimax", "minimax-cn"],
+                "default": "auto",
+                "description": (
+                    "Which MiniMax provider to check: "
+                    "'auto' (default) tries global then China, "
+                    "'minimax' for international, "
+                    "'minimax-cn' for China endpoint."
+                ),
+            },
+        },
+    },
+}
+
+
+# Registry
+from tools.registry import registry
+
+registry.register(
+    name="minimax_quota",
+    toolset="minimax",
+    schema=MINIMAX_QUOTA_SCHEMA,
+    handler=lambda args, **kw: minimax_quota_tool(provider=args.get("provider", "auto")),
+    check_fn=check_minimax_quota_requirements,
+    requires_env=["MINIMAX_API_KEY"],
+    emoji="📊",
+)


### PR DESCRIPTION
## Summary
- Add `minimax_quota` tool for the agent to check MiniMax API quota usage
- Add `/quota` slash command (gateway-only) to show quota status
- Fetches from MiniMax's `/v1/coding_plan/remains` endpoint with global-to-China fallback

## Test plan
- [ ] Set `MINIMAX_API_KEY` and run `/quota` in gateway
- [ ] Verify `minimax_quota` tool appears in agent tool list
- [ ] Test with invalid key to verify error handling