### PR TITLE
feat: add MiniMax quota awareness tool and /quota command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1723,6 +1723,9 @@ class GatewayRunner:
         if canonical == "usage":
             return await self._handle_usage_command(event)
 
+        if canonical == "quota":
+            return await self._handle_quota_command(event)
+
         if canonical == "insights":
             return await self._handle_insights_command(event)
 
@@ -4195,6 +4198,19 @@ class GatewayRunner:
         except Exception as e:
             logger.error("Insights command error: %s", e, exc_info=True)
             return f"Error generating insights: {e}"
+
+    async def _handle_quota_command(self, event: MessageEvent) -> str:
+        """Handle /quota command -- show MiniMax API quota status."""
+        import json
+        from tools.minimax_quota_tool import minimax_quota_tool
+
+        result = minimax_quota_tool(provider="auto")
+        data = json.loads(result)
+
+        if "error" in data:
+            return f"Error: {data['error']}"
+
+        return data.get("formatted", str(data))
 
     async def _handle_reload_mcp_command(self, event: MessageEvent) -> str:
         """Handle /reload-mcp command -- disconnect and reconnect all MCP servers."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -129,6 +129,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("update", "Update Hermes Agent to the latest version", "Info",
                gateway_only=True),
+    CommandDef("quota", "Show MiniMax API quota and usage", "Info",
+               gateway_only=True, aliases=("minimax",)),
 
     # Exit
     CommandDef("quit", "Exit the CLI", "Exit",

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -154,6 +154,12 @@ from .delegate_tool import (
     DELEGATE_TASK_SCHEMA,
 )
 
+# MiniMax quota tool (API usage monitoring)
+from .minimax_quota_tool import (
+    minimax_quota_tool,
+    check_minimax_quota_requirements,
+)
+
 # File tools have no external requirements - they use the terminal backend
 def check_file_requirements():
     """File tools only require terminal backend to be available."""
@@ -258,5 +264,8 @@ __all__ = [
     'delegate_task',
     'check_delegate_requirements',
     'DELEGATE_TASK_SCHEMA',
+    # MiniMax quota
+    'minimax_quota_tool',
+    'check_minimax_quota_requirements',
 ]
 

--- a/tools/minimax_quota_tool.py
+++ b/tools/minimax_quota_tool.py
@@ -6,9 +6,9 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-# Endpoints
-MINIMAX_QUOTA_URL = "https://api.minimax.io/v1/coding_plan/remains"
-MINIMAX_CN_QUOTA_URL = "https://api.minimaxi.com/v1/coding_plan/remains"
+# Endpoints (from CodexBar MiniMaxAPIRegion.swift)
+MINIMAX_QUOTA_URL = "https://api.minimax.io/v1/api/openplatform/coding_plan/remains"
+MINIMAX_CN_QUOTA_URL = "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains"
 
 
 def _get_minimax_api_key() -> str:
@@ -61,24 +61,47 @@ def _fetch_quota(api_key: str, base_url: str) -> dict:
 
 def _format_quota_response(data: dict, provider_label: str) -> str:
     """Format quota data for display."""
-    total = data.get("current_interval_total_count", 0)
-    used = data.get("current_interval_usage_count", 0)
-    remaining = total - used
-    start = data.get("start_time", "unknown")
-    end = data.get("end_time", "unknown")
+    # Response is model_remains array (from CodexBar MiniMaxUsageParser)
+    model_remains = data.get("model_remains", [])
 
-    # Calculate percentage
-    pct = (used / total * 100) if total > 0 else 0
+    if not model_remains:
+        return f"  {provider_label} Quota\n  No quota data available."
 
     lines = [
         f"  {provider_label} Quota",
-        f"  {'─' * 40}",
-        f"  Total:     {total:,}",
-        f"  Used:      {used:,} ({pct:.1f}%)",
-        f"  Remaining: {remaining:,}",
-        f"  Period:    {start} → {end}",
+        f"  {'─' * 50}",
     ]
+
+    for entry in model_remains:
+        model_name = entry.get("model_name", "Unknown")
+        total = entry.get("current_interval_total_count", 0)
+        used = entry.get("current_interval_usage_count", 0)
+        remaining = total - used
+        pct = (used / total * 100) if total > 0 else 0
+
+        # Timestamps are in milliseconds
+        start_ms = entry.get("start_time", 0)
+        end_ms = entry.get("end_time", 0)
+        start = _format_timestamp(start_ms)
+        end = _format_timestamp(end_ms)
+
+        lines.append(f"  {model_name}:")
+        lines.append(f"    Total:     {total:,}")
+        lines.append(f"    Used:      {used:,} ({pct:.1f}%)")
+        lines.append(f"    Remaining: {remaining:,}")
+        lines.append(f"    Period:    {start} → {end}")
+
     return "\n".join(lines)
+
+
+def _format_timestamp(ms: int) -> str:
+    """Format millisecond timestamp to readable string."""
+    if not ms:
+        return "unknown"
+    from datetime import datetime, timezone, timedelta
+    # Timestamps are in milliseconds UTC
+    dt = datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+    return dt.strftime("%m/%d %H:%M UTC")
 
 
 def minimax_quota_tool(provider: str = "auto") -> str:
@@ -97,6 +120,7 @@ def minimax_quota_tool(provider: str = "auto") -> str:
     def _check_and_fetch(api_key: str, base_url: str, provider_label: str) -> str | None:
         """Check key type and fetch quota. Returns None on error, error JSON on failure."""
         key_kind = _detect_key_kind(api_key)
+        # Only standard keys (sk-api-*) skip the API - they require web path
         if key_kind == "standard":
             return json.dumps({
                 "error": (
@@ -106,14 +130,7 @@ def minimax_quota_tool(provider: str = "auto") -> str:
                 ),
                 "key_kind": "standard",
             })
-        if key_kind == "unknown":
-            return json.dumps({
-                "error": (
-                    "Unrecognized MiniMax API key format. "
-                    "This tool requires a coding plan key (sk-cp-*) or service key."
-                ),
-                "key_kind": "unknown",
-            })
+        # All other key types (coding_plan, service, unknown/JWT) try the API
         try:
             data = _fetch_quota(api_key, base_url)
             return json.dumps({

--- a/tools/minimax_quota_tool.py
+++ b/tools/minimax_quota_tool.py
@@ -1,0 +1,165 @@
+"""MiniMax Quota Tool - Fetch current API quota usage."""
+
+import json
+import logging
+import os
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Endpoints
+MINIMAX_QUOTA_URL = "https://api.minimax.io/v1/coding_plan/remains"
+MINIMAX_CN_QUOTA_URL = "https://api.minimaxi.com/v1/coding_plan/remains"
+
+
+def check_minimax_quota_requirements() -> bool:
+    """Check if MiniMax API key is configured (either global or China)."""
+    return bool(os.getenv("MINIMAX_API_KEY") or os.getenv("MINIMAX_CN_API_KEY"))
+
+
+def _fetch_quota(api_key: str, base_url: str) -> dict:
+    """Make the quota API request."""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    resp = requests.get(base_url, headers=headers, timeout=15)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _format_quota_response(data: dict, provider_label: str) -> str:
+    """Format quota data for display."""
+    total = data.get("current_interval_total_count", 0)
+    used = data.get("current_interval_usage_count", 0)
+    remaining = total - used
+    start = data.get("start_time", "unknown")
+    end = data.get("end_time", "unknown")
+
+    # Calculate percentage
+    pct = (used / total * 100) if total > 0 else 0
+
+    lines = [
+        f"  {provider_label} Quota",
+        f"  {'─' * 40}",
+        f"  Total:     {total:,}",
+        f"  Used:      {used:,} ({pct:.1f}%)",
+        f"  Remaining: {remaining:,}",
+        f"  Period:    {start} → {end}",
+    ]
+    return "\n".join(lines)
+
+
+def minimax_quota_tool(provider: str = "auto") -> str:
+    """
+    Fetch MiniMax API quota information.
+
+    Args:
+        provider: Which MiniMax provider to check:
+            - "auto" (default): try global first, fall back to China
+            - "minimax": use international endpoint (api.minimax.io)
+            - "minimax-cn": use China endpoint (api.minimaxi.com)
+
+    Returns:
+        JSON string with quota details or error message.
+    """
+    if provider == "auto":
+        # Try global first, then China
+        api_key = os.getenv("MINIMAX_API_KEY", "")
+        if api_key:
+            try:
+                data = _fetch_quota(api_key, MINIMAX_QUOTA_URL)
+                return json.dumps({
+                    "provider": "minimax",
+                    "data": data,
+                    "formatted": _format_quota_response(data, "MiniMax (Global)"),
+                })
+            except Exception as e:
+                logger.warning("Failed to fetch MiniMax global quota: %s", e)
+
+        # Fall back to China
+        api_key = os.getenv("MINIMAX_CN_API_KEY", "")
+        if api_key:
+            try:
+                data = _fetch_quota(api_key, MINIMAX_CN_QUOTA_URL)
+                return json.dumps({
+                    "provider": "minimax-cn",
+                    "data": data,
+                    "formatted": _format_quota_response(data, "MiniMax (China)"),
+                })
+            except Exception as e:
+                return json.dumps({"error": f"Failed to fetch MiniMax CN quota: {e}"})
+
+        return json.dumps({"error": "No MiniMax API key configured. Set MINIMAX_API_KEY or MINIMAX_CN_API_KEY."})
+
+    elif provider == "minimax":
+        api_key = os.getenv("MINIMAX_API_KEY", "")
+        if not api_key:
+            return json.dumps({"error": "MINIMAX_API_KEY not configured"})
+        try:
+            data = _fetch_quota(api_key, MINIMAX_QUOTA_URL)
+            return json.dumps({
+                "provider": "minimax",
+                "data": data,
+                "formatted": _format_quota_response(data, "MiniMax (Global)"),
+            })
+        except Exception as e:
+            return json.dumps({"error": f"Failed to fetch quota: {e}"})
+
+    elif provider == "minimax-cn":
+        api_key = os.getenv("MINIMAX_CN_API_KEY", "")
+        if not api_key:
+            return json.dumps({"error": "MINIMAX_CN_API_KEY not configured"})
+        try:
+            data = _fetch_quota(api_key, MINIMAX_CN_QUOTA_URL)
+            return json.dumps({
+                "provider": "minimax-cn",
+                "data": data,
+                "formatted": _format_quota_response(data, "MiniMax (China)"),
+            })
+        except Exception as e:
+            return json.dumps({"error": f"Failed to fetch quota: {e}"})
+
+    return json.dumps({"error": f"Unknown provider: {provider}. Use 'minimax', 'minimax-cn', or 'auto'."})
+
+
+# OpenAI Function-Calling Schema
+MINIMAX_QUOTA_SCHEMA = {
+    "name": "minimax_quota",
+    "description": (
+        "Fetch current MiniMax API quota usage and limits. "
+        "Shows total credits, used credits, and remaining credits "
+        "for the current billing period. Use this to check if you "
+        "have enough quota before making API requests."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "provider": {
+                "type": "string",
+                "enum": ["auto", "minimax", "minimax-cn"],
+                "default": "auto",
+                "description": (
+                    "Which MiniMax provider to check: "
+                    "'auto' (default) tries global then China, "
+                    "'minimax' for international, "
+                    "'minimax-cn' for China endpoint."
+                ),
+            },
+        },
+    },
+}
+
+
+# Registry
+from tools.registry import registry
+
+registry.register(
+    name="minimax_quota",
+    toolset="minimax",
+    schema=MINIMAX_QUOTA_SCHEMA,
+    handler=lambda args, **kw: minimax_quota_tool(provider=args.get("provider", "auto")),
+    check_fn=check_minimax_quota_requirements,
+    requires_env=["MINIMAX_API_KEY"],
+    emoji="📊",
+)

--- a/tools/minimax_quota_tool.py
+++ b/tools/minimax_quota_tool.py
@@ -23,6 +23,26 @@ def _get_minimax_cn_api_key() -> str:
     return get_env_value("MINIMAX_CN_API_KEY") or ""
 
 
+def _is_standard_key(api_key: str) -> bool:
+    """Check if key is a standard MiniMax key (sk-api-*).
+
+    Standard keys are tied to web sessions and do NOT work with the direct API.
+    Only coding plan keys (sk-cp-*) or service keys work with /v1/coding_plan/remains.
+    """
+    return api_key.startswith("sk-api-")
+
+
+def _detect_key_kind(api_key: str) -> str:
+    """Detect the type of MiniMax API key."""
+    if api_key.startswith("sk-cp-"):
+        return "coding_plan"
+    elif api_key.startswith("sk-api-"):
+        return "standard"
+    elif api_key.startswith("sk-"):
+        return "service"
+    return "unknown"
+
+
 def check_minimax_quota_requirements() -> bool:
     """Check if MiniMax API key is configured (either global or China)."""
     return bool(_get_minimax_api_key() or _get_minimax_cn_api_key())
@@ -74,32 +94,53 @@ def minimax_quota_tool(provider: str = "auto") -> str:
     Returns:
         JSON string with quota details or error message.
     """
+    def _check_and_fetch(api_key: str, base_url: str, provider_label: str) -> str | None:
+        """Check key type and fetch quota. Returns None on error, error JSON on failure."""
+        key_kind = _detect_key_kind(api_key)
+        if key_kind == "standard":
+            return json.dumps({
+                "error": (
+                    "Standard MiniMax API keys (sk-api-*) do not work with the quota API endpoint. "
+                    "You need a coding plan key (sk-cp-*) or service key. "
+                    "See: https://platform.minimax.io/user-center/payment/coding-plan"
+                ),
+                "key_kind": "standard",
+            })
+        if key_kind == "unknown":
+            return json.dumps({
+                "error": (
+                    "Unrecognized MiniMax API key format. "
+                    "This tool requires a coding plan key (sk-cp-*) or service key."
+                ),
+                "key_kind": "unknown",
+            })
+        try:
+            data = _fetch_quota(api_key, base_url)
+            return json.dumps({
+                "provider": provider_label,
+                "data": data,
+                "formatted": _format_quota_response(data, provider_label),
+            })
+        except Exception as e:
+            logger.warning("Failed to fetch %s quota: %s", provider_label, e)
+            return None
+
     if provider == "auto":
         # Try global first, then China
         api_key = _get_minimax_api_key()
         if api_key:
-            try:
-                data = _fetch_quota(api_key, MINIMAX_QUOTA_URL)
-                return json.dumps({
-                    "provider": "minimax",
-                    "data": data,
-                    "formatted": _format_quota_response(data, "MiniMax (Global)"),
-                })
-            except Exception as e:
-                logger.warning("Failed to fetch MiniMax global quota: %s", e)
+            result = _check_and_fetch(api_key, MINIMAX_QUOTA_URL, "MiniMax (Global)")
+            if result:
+                return result
+            # If result is None, API failed - try China as fallback
 
         # Fall back to China
         api_key = _get_minimax_cn_api_key()
         if api_key:
-            try:
-                data = _fetch_quota(api_key, MINIMAX_CN_QUOTA_URL)
-                return json.dumps({
-                    "provider": "minimax-cn",
-                    "data": data,
-                    "formatted": _format_quota_response(data, "MiniMax (China)"),
-                })
-            except Exception as e:
-                return json.dumps({"error": f"Failed to fetch MiniMax CN quota: {e}"})
+            result = _check_and_fetch(api_key, MINIMAX_CN_QUOTA_URL, "MiniMax (China)")
+            if result:
+                return result
+            return json.dumps({"error": f"Failed to fetch MiniMax CN quota"})
 
         return json.dumps({"error": "No MiniMax API key configured. Set MINIMAX_API_KEY or MINIMAX_CN_API_KEY."})
 
@@ -107,29 +148,15 @@ def minimax_quota_tool(provider: str = "auto") -> str:
         api_key = _get_minimax_api_key()
         if not api_key:
             return json.dumps({"error": "MINIMAX_API_KEY not configured"})
-        try:
-            data = _fetch_quota(api_key, MINIMAX_QUOTA_URL)
-            return json.dumps({
-                "provider": "minimax",
-                "data": data,
-                "formatted": _format_quota_response(data, "MiniMax (Global)"),
-            })
-        except Exception as e:
-            return json.dumps({"error": f"Failed to fetch quota: {e}"})
+        result = _check_and_fetch(api_key, MINIMAX_QUOTA_URL, "MiniMax (Global)")
+        return result or json.dumps({"error": "Failed to fetch MiniMax quota"})
 
     elif provider == "minimax-cn":
         api_key = _get_minimax_cn_api_key()
         if not api_key:
             return json.dumps({"error": "MINIMAX_CN_API_KEY not configured"})
-        try:
-            data = _fetch_quota(api_key, MINIMAX_CN_QUOTA_URL)
-            return json.dumps({
-                "provider": "minimax-cn",
-                "data": data,
-                "formatted": _format_quota_response(data, "MiniMax (China)"),
-            })
-        except Exception as e:
-            return json.dumps({"error": f"Failed to fetch quota: {e}"})
+        result = _check_and_fetch(api_key, MINIMAX_CN_QUOTA_URL, "MiniMax (China)")
+        return result or json.dumps({"error": "Failed to fetch MiniMax CN quota"})
 
     return json.dumps({"error": f"Unknown provider: {provider}. Use 'minimax', 'minimax-cn', or 'auto'."})
 

--- a/tools/minimax_quota_tool.py
+++ b/tools/minimax_quota_tool.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import os
 import requests
 
 logger = logging.getLogger(__name__)
@@ -12,9 +11,21 @@ MINIMAX_QUOTA_URL = "https://api.minimax.io/v1/coding_plan/remains"
 MINIMAX_CN_QUOTA_URL = "https://api.minimaxi.com/v1/coding_plan/remains"
 
 
+def _get_minimax_api_key() -> str:
+    """Get MiniMax API key from hermes secret storage (env vars or ~/.hermes/.env)."""
+    from hermes_cli.config import get_env_value
+    return get_env_value("MINIMAX_API_KEY") or ""
+
+
+def _get_minimax_cn_api_key() -> str:
+    """Get MiniMax China API key from hermes secret storage (env vars or ~/.hermes/.env)."""
+    from hermes_cli.config import get_env_value
+    return get_env_value("MINIMAX_CN_API_KEY") or ""
+
+
 def check_minimax_quota_requirements() -> bool:
     """Check if MiniMax API key is configured (either global or China)."""
-    return bool(os.getenv("MINIMAX_API_KEY") or os.getenv("MINIMAX_CN_API_KEY"))
+    return bool(_get_minimax_api_key() or _get_minimax_cn_api_key())
 
 
 def _fetch_quota(api_key: str, base_url: str) -> dict:
@@ -65,7 +76,7 @@ def minimax_quota_tool(provider: str = "auto") -> str:
     """
     if provider == "auto":
         # Try global first, then China
-        api_key = os.getenv("MINIMAX_API_KEY", "")
+        api_key = _get_minimax_api_key()
         if api_key:
             try:
                 data = _fetch_quota(api_key, MINIMAX_QUOTA_URL)
@@ -78,7 +89,7 @@ def minimax_quota_tool(provider: str = "auto") -> str:
                 logger.warning("Failed to fetch MiniMax global quota: %s", e)
 
         # Fall back to China
-        api_key = os.getenv("MINIMAX_CN_API_KEY", "")
+        api_key = _get_minimax_cn_api_key()
         if api_key:
             try:
                 data = _fetch_quota(api_key, MINIMAX_CN_QUOTA_URL)
@@ -93,7 +104,7 @@ def minimax_quota_tool(provider: str = "auto") -> str:
         return json.dumps({"error": "No MiniMax API key configured. Set MINIMAX_API_KEY or MINIMAX_CN_API_KEY."})
 
     elif provider == "minimax":
-        api_key = os.getenv("MINIMAX_API_KEY", "")
+        api_key = _get_minimax_api_key()
         if not api_key:
             return json.dumps({"error": "MINIMAX_API_KEY not configured"})
         try:
@@ -107,7 +118,7 @@ def minimax_quota_tool(provider: str = "auto") -> str:
             return json.dumps({"error": f"Failed to fetch quota: {e}"})
 
     elif provider == "minimax-cn":
-        api_key = os.getenv("MINIMAX_CN_API_KEY", "")
+        api_key = _get_minimax_cn_api_key()
         if not api_key:
             return json.dumps({"error": "MINIMAX_CN_API_KEY not configured"})
         try:


### PR DESCRIPTION
## What does this PR do?

Add MiniMax quota awareness to hermes-agent - both as a tool the agent can call and as a `/quota` slash command for messaging platforms. Fetches quota from MiniMax's `/v1/coding_plan/remains` endpoint with global-to-China fallback.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

New feature

## Type of Change

<!-- Check the one that applies. -->

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `tools/minimax_quota_tool.py` - New tool: fetches MiniMax API quota via `/v1/coding_plan/remains` endpoint
- `tools/__init__.py` - Export the new tool
- `hermes_cli/commands.py` - Add `/quota` command (gateway-only) with alias `/minimax`
- `gateway/run.py` - Add `_handle_quota_command` handler

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Set `MINIMAX_API_KEY` environment variable
2. Run `/quota` in a messaging gateway (Discord, Telegram, etc.)
3. Verify the tool `minimax_quota` is available to the agent

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A