### PR TITLE
feat: integrate tiny-router for per-turn routing and policy signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ environments/benchmarks/evals/
 # Release script temp files
 .release_notes.md
 mini-swe-agent/
+.hermes_full_test/
+.hermes_local_test/

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [CLI Reference](https://hermes-agent.nousresearch.com/docs/reference/cli-commands) | All commands and flags |
 | [Environment Variables](https://hermes-agent.nousresearch.com/docs/reference/environment-variables) | Complete env var reference |
 
+Repository docs for the tiny-router integration:
+
+- [Tiny Router Integration](docs/tiny-router-integration.md)
+- [Local Test Plan (Tiny Router)](docs/local-test-plan-tiny-router.md)
+
 ---
 
 ## Migrating from OpenClaw

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -51,6 +51,18 @@ _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 _CHARS_PER_TOKEN = 4
 
 
+def _is_retention_priority(msg: Dict[str, Any]) -> bool:
+    """True when tiny-router marks this turn as useful/remember."""
+    try:
+        metadata = msg.get("metadata") or {}
+        tiny_router = metadata.get("tiny_router") or {}
+        retention = tiny_router.get("retention") or {}
+        label = str(retention.get("label") or "").strip().lower()
+        return label in {"useful", "remember"}
+    except Exception:
+        return False
+
+
 class ContextCompressor:
     """Compresses conversation context when approaching the model's context limit.
 
@@ -517,6 +529,15 @@ Write only the summary body. Do not include any preamble or prefix."""
 
         # Align to avoid splitting tool groups
         cut_idx = self._align_boundary_backward(messages, cut_idx)
+
+        # Priority retention turns (tiny-router useful/remember) are favored:
+        # if one sits just outside the tail boundary, pull the cut backward to
+        # keep it in the protected tail window.
+        search_start = max(head_end + 1, cut_idx - 24)
+        for i in range(cut_idx - 1, search_start - 1, -1):
+            if _is_retention_priority(messages[i]):
+                cut_idx = i
+                break
 
         return max(cut_idx, head_end + 1)
 

--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -1,10 +1,16 @@
-"""Helpers for optional cheap-vs-strong model routing."""
+"""Helpers for policy-driven per-turn model routing."""
 
 from __future__ import annotations
 
 import os
 import re
-from typing import Any, Dict, Optional
+import threading
+from typing import Any, Dict, Optional, TYPE_CHECKING
+
+from hermes_cli import runtime_provider
+
+if TYPE_CHECKING:
+    from agent.tiny_router import RouterOutput
 
 _COMPLEX_KEYWORDS = {
     "debug",
@@ -34,8 +40,6 @@ _COMPLEX_KEYWORDS = {
     "pytest",
     "test",
     "tests",
-    "plan",
-    "planning",
     "delegate",
     "subagent",
     "cron",
@@ -44,6 +48,9 @@ _COMPLEX_KEYWORDS = {
 }
 
 _URL_RE = re.compile(r"https?://|www\.", re.IGNORECASE)
+_TIER_ORDER = ("low", "medium", "high")
+_SESSION_ROUTE_LOCK = threading.Lock()
+_SESSION_HIGH_TIER_CALLS: Dict[str, int] = {}
 
 
 def _coerce_bool(value: Any, default: bool = False) -> bool:
@@ -63,12 +70,81 @@ def _coerce_int(value: Any, default: int) -> int:
         return default
 
 
-def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-    """Return the configured cheap-model route when a message looks simple.
+def _coerce_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
-    Conservative by design: if the message has signs of code/tool/debugging/
-    long-form work, keep the primary model.
-    """
+
+def _normalize_tier(value: Any, default: str = "medium") -> str:
+    raw = str(value or "").strip().lower()
+    if raw in _TIER_ORDER:
+        return raw
+    return default
+
+
+def _is_simple_turn(user_message: str, routing_config: Optional[Dict[str, Any]]) -> bool:
+    """Conservative heuristic gate for short, low-complexity turns."""
+    cfg = routing_config or {}
+    text = (user_message or "").strip()
+    if not text:
+        return False
+
+    max_chars = _coerce_int(cfg.get("max_simple_chars"), 160)
+    max_words = _coerce_int(cfg.get("max_simple_words"), 28)
+
+    if len(text) > max_chars:
+        return False
+    if len(text.split()) > max_words:
+        return False
+    if text.count("\n") > 1:
+        return False
+    if "```" in text or "`" in text:
+        return False
+    if _URL_RE.search(text):
+        return False
+
+    lowered = text.lower()
+    words = {token.strip(".,:;!?()[]{}\"'`") for token in lowered.split()}
+    if words & _COMPLEX_KEYWORDS:
+        return False
+    return True
+
+
+def _high_tier_usage_count(session_id: str) -> int:
+    with _SESSION_ROUTE_LOCK:
+        return int(_SESSION_HIGH_TIER_CALLS.get(session_id, 0))
+
+
+def _increment_high_tier_usage_count(session_id: Optional[str]) -> None:
+    if not session_id:
+        return
+    with _SESSION_ROUTE_LOCK:
+        current = int(_SESSION_HIGH_TIER_CALLS.get(session_id, 0))
+        _SESSION_HIGH_TIER_CALLS[session_id] = current + 1
+
+
+def _apply_high_tier_budget(
+    desired_tier: str,
+    routing_config: Optional[Dict[str, Any]],
+    session_id: Optional[str],
+) -> str:
+    if desired_tier != "high":
+        return desired_tier
+    cfg = routing_config or {}
+    cap = _coerce_int(cfg.get("max_high_tier_calls_per_session"), 0)
+    if cap <= 0 or not session_id:
+        return desired_tier
+    if _high_tier_usage_count(session_id) < cap:
+        return desired_tier
+    return "medium"
+
+
+def choose_cheap_model_route(
+    user_message: str,
+    routing_config: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
     cfg = routing_config or {}
     if not _coerce_bool(cfg.get("enabled"), False):
         return None
@@ -81,27 +157,7 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
     if not provider or not model:
         return None
 
-    text = (user_message or "").strip()
-    if not text:
-        return None
-
-    max_chars = _coerce_int(cfg.get("max_simple_chars"), 160)
-    max_words = _coerce_int(cfg.get("max_simple_words"), 28)
-
-    if len(text) > max_chars:
-        return None
-    if len(text.split()) > max_words:
-        return None
-    if text.count("\n") > 1:
-        return None
-    if "```" in text or "`" in text:
-        return None
-    if _URL_RE.search(text):
-        return None
-
-    lowered = text.lower()
-    words = {token.strip(".,:;!?()[]{}\"'`") for token in lowered.split()}
-    if words & _COMPLEX_KEYWORDS:
+    if not _is_simple_turn(user_message, cfg):
         return None
 
     route = dict(cheap_model)
@@ -111,69 +167,149 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
     return route
 
 
-def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any]], primary: Dict[str, Any]) -> Dict[str, Any]:
-    """Resolve the effective model/runtime for one turn.
+def _cheap_route_from_config(routing_config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    cfg = routing_config or {}
+    if not _coerce_bool(cfg.get("enabled"), False):
+        return None
+    cheap_model = cfg.get("cheap_model") or {}
+    if not isinstance(cheap_model, dict):
+        return None
+    provider = str(cheap_model.get("provider") or "").strip().lower()
+    model = str(cheap_model.get("model") or "").strip()
+    if not provider or not model:
+        return None
+    route = dict(cheap_model)
+    route["provider"] = provider
+    route["model"] = model
+    return route
 
-    Returns a dict with model/runtime/signature/label fields.
-    """
-    route = choose_cheap_model_route(user_message, routing_config)
+
+def _route_name_for_tier(
+    routing_config: Optional[Dict[str, Any]],
+    tier: str,
+) -> str:
+    cfg = routing_config or {}
+    tier_routes = cfg.get("tier_routes") or {}
+    if isinstance(tier_routes, dict):
+        route_name = tier_routes.get(tier)
+        if isinstance(route_name, str) and route_name.strip():
+            return route_name.strip()
+    if tier == "low":
+        return "cheap"
+    return "primary"
+
+
+def _route_from_name(
+    routing_config: Optional[Dict[str, Any]],
+    route_name: str,
+    *,
+    reason: str,
+) -> Optional[Dict[str, Any]]:
+    cfg = routing_config or {}
+    if not _coerce_bool(cfg.get("enabled"), False):
+        return None
+
+    raw_name = str(route_name or "").strip()
+    normalized = raw_name.lower()
+    if not normalized or normalized == "primary":
+        return None
+
+    if normalized == "cheap":
+        route = _cheap_route_from_config(cfg)
+        if route:
+            route["routing_reason"] = reason
+            route["route_name"] = "cheap"
+        return route
+
+    routes_cfg = cfg.get("routes") or {}
+    if not isinstance(routes_cfg, dict):
+        return None
+
+    selected_name = None
+    selected = None
+    if raw_name in routes_cfg and isinstance(routes_cfg.get(raw_name), dict):
+        selected_name = raw_name
+        selected = routes_cfg.get(raw_name)
+    else:
+        for key, value in routes_cfg.items():
+            if isinstance(key, str) and key.strip().lower() == normalized and isinstance(value, dict):
+                selected_name = key
+                selected = value
+                break
+    if not isinstance(selected, dict):
+        return None
+
+    provider = str(selected.get("provider") or "").strip().lower()
+    model = str(selected.get("model") or "").strip()
+    if not provider or not model:
+        return None
+
+    route = dict(selected)
+    route["provider"] = provider
+    route["model"] = model
+    route["routing_reason"] = reason
+    route["route_name"] = str(selected_name or raw_name or normalized)
+    return route
+
+
+def _resolve_named_route(
+    primary: Dict[str, Any],
+    routing_config: Optional[Dict[str, Any]],
+    route_name: str,
+    *,
+    reason: str,
+    label_prefix: str,
+) -> Optional[Dict[str, Any]]:
+    normalized = str(route_name or "").strip().lower()
+    if not normalized or normalized == "primary":
+        return _primary_route_result(primary)
+
+    route = _route_from_name(routing_config, route_name, reason=reason)
     if not route:
-        return {
-            "model": primary.get("model"),
-            "runtime": {
-                "api_key": primary.get("api_key"),
-                "base_url": primary.get("base_url"),
-                "provider": primary.get("provider"),
-                "api_mode": primary.get("api_mode"),
-                "command": primary.get("command"),
-                "args": list(primary.get("args") or []),
-            },
-            "label": None,
-            "signature": (
-                primary.get("model"),
-                primary.get("provider"),
-                primary.get("base_url"),
-                primary.get("api_mode"),
-                primary.get("command"),
-                tuple(primary.get("args") or ()),
-            ),
-        }
+        return None
+    return _resolve_route_result(route, label_prefix=label_prefix)
 
-    from hermes_cli.runtime_provider import resolve_runtime_provider
 
+def _primary_route_result(primary: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "model": primary.get("model"),
+        "runtime": {
+            "api_key": primary.get("api_key"),
+            "base_url": primary.get("base_url"),
+            "provider": primary.get("provider"),
+            "api_mode": primary.get("api_mode"),
+            "command": primary.get("command"),
+            "args": list(primary.get("args") or []),
+        },
+        "label": None,
+        "signature": (
+            primary.get("model"),
+            primary.get("provider"),
+            primary.get("base_url"),
+            primary.get("api_mode"),
+            primary.get("command"),
+            tuple(primary.get("args") or ()),
+        ),
+    }
+
+
+def _resolve_route_result(route: Dict[str, Any], *, label_prefix: str) -> Optional[Dict[str, Any]]:
     explicit_api_key = None
     api_key_env = str(route.get("api_key_env") or "").strip()
     if api_key_env:
         explicit_api_key = os.getenv(api_key_env) or None
 
     try:
-        runtime = resolve_runtime_provider(
+        runtime = runtime_provider.resolve_runtime_provider(
             requested=route.get("provider"),
             explicit_api_key=explicit_api_key,
             explicit_base_url=route.get("base_url"),
         )
     except Exception:
-        return {
-            "model": primary.get("model"),
-            "runtime": {
-                "api_key": primary.get("api_key"),
-                "base_url": primary.get("base_url"),
-                "provider": primary.get("provider"),
-                "api_mode": primary.get("api_mode"),
-                "command": primary.get("command"),
-                "args": list(primary.get("args") or []),
-            },
-            "label": None,
-            "signature": (
-                primary.get("model"),
-                primary.get("provider"),
-                primary.get("base_url"),
-                primary.get("api_mode"),
-                primary.get("command"),
-                tuple(primary.get("args") or ()),
-            ),
-        }
+        return None
 
+    route_name = str(route.get("route_name") or "").strip()
+    route_suffix = f" [{route_name}]" if route_name and route_name != "cheap" else ""
     return {
         "model": route.get("model"),
         "runtime": {
@@ -184,7 +320,7 @@ def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any
             "command": runtime.get("command"),
             "args": list(runtime.get("args") or []),
         },
-        "label": f"smart route → {route.get('model')} ({runtime.get('provider')})",
+        "label": f"{label_prefix} → {route.get('model')} ({runtime.get('provider')}){route_suffix}",
         "signature": (
             route.get("model"),
             runtime.get("provider"),
@@ -194,3 +330,108 @@ def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any
             tuple(runtime.get("args") or ()),
         ),
     }
+
+
+def _tiny_router_is_policy_eligible(
+    router_output: Optional["RouterOutput"],
+    tiny_router_config: Optional[Dict[str, Any]],
+) -> bool:
+    if router_output is None:
+        return False
+    if str(getattr(router_output, "source", "") or "") in ("disabled", "error"):
+        return False
+
+    tr_cfg = tiny_router_config or {}
+    if not _coerce_bool(tr_cfg.get("enabled"), False):
+        return False
+    if str(tr_cfg.get("behavior_mode") or "shadow").strip().lower() != "active":
+        return False
+
+    th = tr_cfg.get("confidence_thresholds") or {}
+    overall_th = _coerce_float(th.get("overall"), 0.45)
+    overall = _coerce_float(getattr(router_output, "overall_confidence", 0.0), 0.0)
+    return overall >= overall_th
+
+
+def _tiny_router_prefers_low_stakes_route(
+    router_output: "RouterOutput",
+    tiny_router_config: Optional[Dict[str, Any]],
+) -> bool:
+    cfg = tiny_router_config or {}
+    th = cfg.get("confidence_thresholds") or {}
+    act_th = _coerce_float(th.get("actionability"), 0.5)
+    urg_th = _coerce_float(th.get("urgency"), 0.5)
+    ret_th = _coerce_float(th.get("retention"), 0.5)
+
+    actionability = getattr(router_output, "actionability", None)
+    urgency = getattr(router_output, "urgency", None)
+    retention = getattr(router_output, "retention", None)
+    relation = getattr(router_output, "relation_to_previous", None)
+
+    action_label = str(getattr(actionability, "label", "none") or "none")
+    action_conf = _coerce_float(getattr(actionability, "confidence", 0.0), 0.0)
+    urgency_label = str(getattr(urgency, "label", "low") or "low")
+    urgency_conf = _coerce_float(getattr(urgency, "confidence", 0.0), 0.0)
+    retention_label = str(getattr(retention, "label", "ephemeral") or "ephemeral")
+    retention_conf = _coerce_float(getattr(retention, "confidence", 0.0), 0.0)
+    relation_label = str(getattr(relation, "label", "new") or "new")
+    relation_conf = _coerce_float(getattr(relation, "confidence", 0.0), 0.0)
+
+    if action_label == "act" and action_conf >= act_th:
+        return False
+    if urgency_label == "high" and urgency_conf >= urg_th:
+        return False
+    if retention_label == "remember" and retention_conf >= ret_th:
+        return False
+    if relation_label in ("correction", "cancellation") and relation_conf >= 0.5:
+        return False
+    return action_label in ("none", "review") and urgency_label == "low"
+
+
+def resolve_turn_route(
+    user_message: str,
+    routing_config: Optional[Dict[str, Any]],
+    primary: Dict[str, Any],
+    *,
+    tiny_router_config: Optional[Dict[str, Any]] = None,
+    router_output: Optional["RouterOutput"] = None,
+    routing_context: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    route_cfg = routing_config or {}
+    if not _coerce_bool(route_cfg.get("enabled"), False):
+        return _primary_route_result(primary)
+
+    tr_cfg = tiny_router_config or {}
+    ctx = routing_context or {}
+    session_id = str(ctx.get("session_id") or "").strip() or None
+
+    tier = "low" if _is_simple_turn(user_message, route_cfg) else "medium"
+    tier_source = "simple" if tier == "low" else "default"
+    if _tiny_router_is_policy_eligible(router_output, tr_cfg):
+        if _tiny_router_prefers_low_stakes_route(router_output, tr_cfg):
+            tier = "low"
+            tier_source = "tiny-router"
+        else:
+            tier = "high"
+            tier_source = "tiny-router"
+
+    tier = _apply_high_tier_budget(tier, route_cfg, session_id)
+    route_name = _route_name_for_tier(route_cfg, tier)
+    label_prefix = "tiny-router" if tier_source == "tiny-router" else "smart route"
+    reason = f"{tier_source}_{tier}"
+
+    resolved = _resolve_named_route(
+        primary,
+        route_cfg,
+        route_name,
+        reason=reason,
+        label_prefix=label_prefix,
+    )
+    if not resolved:
+        resolved = _primary_route_result(primary)
+
+    resolved["route_tier"] = tier
+    resolved["routing_source"] = tier_source
+    if tier == "high":
+        _increment_high_tier_usage_count(session_id)
+    return resolved

--- a/agent/tiny_router.py
+++ b/agent/tiny_router.py
@@ -1,0 +1,607 @@
+"""tiny-router integration: per-turn classification for Hermes routing and policy.
+
+Uses the same label schema as https://github.com/UdaraJay/tiny-router when a model
+is configured; otherwise falls back to deterministic heuristics.
+
+Inference backends (in order):
+1. Subprocess: ``python -m scripts.predict`` from ``repo_root`` with ``model_dir``
+   (matches upstream training/inference CLI).
+2. Heuristic: keyword- and length-based labels (always available).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+import sys
+import threading
+from contextvars import ContextVar
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# No canonical GitHub "release" tags are currently published for tiny-router.
+# Hermes therefore pins to an immutable upstream commit SHA for reproducibility.
+DEFAULT_PINNED_COMMIT = "9d6b2a718a205d90ebe85e9a28f9b8a1f20801e4"
+
+# Active router output for the current turn (tool handlers can read policy).
+_active_router: ContextVar[Optional["RouterOutput"]] = ContextVar("hermes_tiny_router_active", default=None)
+
+
+def set_active_router_output(output: Optional["RouterOutput"]):
+    return _active_router.set(output)
+
+
+def get_active_router_output() -> Optional["RouterOutput"]:
+    return _active_router.get()
+
+
+def reset_active_router_output(token) -> None:
+    if token is None:
+        return
+    _active_router.reset(token)
+
+
+@dataclass
+class HeadPrediction:
+    label: str
+    confidence: float = 0.0
+
+
+@dataclass
+class RouterInput:
+    current_text: str
+    interaction: Dict[str, Any]
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "current_text": self.current_text,
+            "interaction": dict(self.interaction or {}),
+        }
+
+
+@dataclass
+class RouterOutput:
+    relation_to_previous: HeadPrediction
+    actionability: HeadPrediction
+    retention: HeadPrediction
+    urgency: HeadPrediction
+    overall_confidence: float = 0.0
+    source: str = "heuristic"  # subprocess | heuristic | disabled | error
+
+    def to_metadata_dict(self) -> Dict[str, Any]:
+        return {
+            "tiny_router": {
+                "relation_to_previous": {
+                    "label": self.relation_to_previous.label,
+                    "confidence": self.relation_to_previous.confidence,
+                },
+                "actionability": {
+                    "label": self.actionability.label,
+                    "confidence": self.actionability.confidence,
+                },
+                "retention": {"label": self.retention.label, "confidence": self.retention.confidence},
+                "urgency": {"label": self.urgency.label, "confidence": self.urgency.confidence},
+                "overall_confidence": self.overall_confidence,
+                "source": self.source,
+            }
+        }
+
+    @classmethod
+    def disabled(cls) -> "RouterOutput":
+        return cls(
+            relation_to_previous=HeadPrediction("new", 0.0),
+            actionability=HeadPrediction("none", 0.0),
+            retention=HeadPrediction("ephemeral", 0.0),
+            urgency=HeadPrediction("low", 0.0),
+            overall_confidence=0.0,
+            source="disabled",
+        )
+
+    def head_confidence(self, name: str) -> float:
+        m = {
+            "relation_to_previous": self.relation_to_previous.confidence,
+            "actionability": self.actionability.confidence,
+            "retention": self.retention.confidence,
+            "urgency": self.urgency.confidence,
+        }
+        return float(m.get(name, 0.0))
+
+    def meets_overall_threshold(self, cfg: Dict[str, Any]) -> bool:
+        th = (cfg or {}).get("confidence_thresholds") or {}
+        try:
+            need = float(th.get("overall", 0.45))
+        except (TypeError, ValueError):
+            need = 0.45
+        return self.overall_confidence >= need
+
+    def should_use_cheap_model_route(self, cfg: Dict[str, Any]) -> bool:
+        """When behavior_mode is active, prefer cheap model for low-stakes turns."""
+        if self.source == "disabled":
+            return False
+        th = (cfg or {}).get("confidence_thresholds") or {}
+        try:
+            o_th = float(th.get("overall", 0.45))
+            act_th = float(th.get("actionability", 0.5))
+            urg_th = float(th.get("urgency", 0.5))
+            ret_th = float(th.get("retention", 0.5))
+        except (TypeError, ValueError):
+            o_th, act_th, urg_th, ret_th = 0.45, 0.5, 0.5, 0.5
+
+        if self.overall_confidence < o_th:
+            return False
+
+        # Strong signals → primary model
+        if self.actionability.label == "act" and self.actionability.confidence >= act_th:
+            return False
+        if self.urgency.label == "high" and self.urgency.confidence >= urg_th:
+            return False
+        if self.retention.label == "remember" and self.retention.confidence >= ret_th:
+            return False
+        if self.relation_to_previous.label in ("correction", "cancellation") and self.relation_to_previous.confidence >= 0.5:
+            return False
+
+        # Cheap when the model thinks the turn is light-touch
+        if self.actionability.label in ("none", "review") and self.urgency.label == "low":
+            return True
+        return False
+
+    def should_boost_memory_nudge(self, cfg: Dict[str, Any]) -> bool:
+        th = (cfg or {}).get("confidence_thresholds") or {}
+        try:
+            ret_th = float(th.get("retention", 0.5))
+        except (TypeError, ValueError):
+            ret_th = 0.5
+        return self.retention.label == "remember" and self.retention.confidence >= ret_th
+
+    def should_aggressive_memory_flush(self, cfg: Dict[str, Any]) -> bool:
+        th = (cfg or {}).get("confidence_thresholds") or {}
+        try:
+            act_th = float(th.get("actionability", 0.5))
+            urg_th = float(th.get("urgency", 0.5))
+        except (TypeError, ValueError):
+            act_th, urg_th = 0.5, 0.5
+        return (
+            self.actionability.label == "act"
+            and self.actionability.confidence >= act_th
+            and self.urgency.label == "high"
+            and self.urgency.confidence >= urg_th
+        )
+
+    def needs_terminal_review_escalation(self, cfg: Dict[str, Any]) -> bool:
+        if not (cfg or {}).get("apply_approval_posture", True):
+            return False
+        th = (cfg or {}).get("confidence_thresholds") or {}
+        try:
+            act_th = float(th.get("actionability", 0.5))
+        except (TypeError, ValueError):
+            act_th = 0.5
+        return self.actionability.label == "review" and self.actionability.confidence >= act_th
+
+
+def _coerce_float(val: Any, default: float) -> float:
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_head(obj: Any, default_label: str) -> HeadPrediction:
+    if isinstance(obj, dict):
+        lab = str(obj.get("label") or default_label).strip() or default_label
+        conf = _coerce_float(obj.get("confidence"), 0.0)
+        return HeadPrediction(lab, max(0.0, min(1.0, conf)))
+    return HeadPrediction(default_label, 0.0)
+
+
+def _normalize_text_input(value: Any) -> str:
+    """Best-effort conversion of multimodal/user content into plain text."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        chunks: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                if item.strip():
+                    chunks.append(item.strip())
+                continue
+            if not isinstance(item, dict):
+                continue
+            text = item.get("text")
+            if isinstance(text, str) and text.strip():
+                chunks.append(text.strip())
+                continue
+            for key in ("content", "caption", "alt_text", "title"):
+                cand = item.get(key)
+                if isinstance(cand, str) and cand.strip():
+                    chunks.append(cand.strip())
+                    break
+        return "\n".join(chunks).strip()
+    return str(value)
+
+
+def parse_router_json(data: Dict[str, Any], source: str) -> RouterOutput:
+    return RouterOutput(
+        relation_to_previous=_parse_head(data.get("relation_to_previous"), "new"),
+        actionability=_parse_head(data.get("actionability"), "none"),
+        retention=_parse_head(data.get("retention"), "ephemeral"),
+        urgency=_parse_head(data.get("urgency"), "low"),
+        overall_confidence=_coerce_float(data.get("overall_confidence"), 0.0),
+        source=source,
+    )
+
+
+def build_interaction_from_history(
+    prior_messages: Optional[List[Dict[str, Any]]],
+) -> Dict[str, Any]:
+    """Build tiny-router interaction object from OpenAI-style history (no current turn)."""
+    previous_text = ""
+    previous_action = "none"
+    previous_outcome = "unknown"
+    recency_seconds = -1.0
+
+    if not prior_messages:
+        return {
+            "previous_text": "",
+            "previous_action": previous_action,
+            "previous_outcome": previous_outcome,
+            "recency_seconds": recency_seconds,
+        }
+
+    last_assistant_content = ""
+    last_user_content = ""
+    for msg in reversed(prior_messages):
+        role = msg.get("role")
+        if role == "assistant" and not last_assistant_content:
+            c = msg.get("content")
+            c_text = _normalize_text_input(c)
+            if c_text.strip():
+                last_assistant_content = c_text.strip()[:2000]
+        elif role == "user" and not last_user_content:
+            c = msg.get("content")
+            c_text = _normalize_text_input(c)
+            if c_text.strip():
+                last_user_content = c_text.strip()[:2000]
+        if last_assistant_content and last_user_content:
+            break
+
+    previous_text = last_user_content or last_assistant_content
+    # Heuristic: last tool name hints prior "action"
+    for msg in reversed(prior_messages):
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            tcs = msg.get("tool_calls") or []
+            if isinstance(tcs, list) and tcs:
+                first = tcs[0]
+                if isinstance(first, dict):
+                    fn = first.get("function") or {}
+                    name = (fn.get("name") or "").strip()
+                    if name:
+                        previous_action = name.replace("_", " ")[:80]
+                        previous_outcome = "success"
+                break
+
+    return {
+        "previous_text": previous_text,
+        "previous_action": previous_action,
+        "previous_outcome": previous_outcome,
+        "recency_seconds": recency_seconds,
+    }
+
+
+def _heuristic_classify(current_text: str, interaction: Dict[str, Any]) -> RouterOutput:
+    text = (current_text or "").strip()
+    low = text.lower()
+    prev = (interaction.get("previous_text") or "").strip()
+
+    # Relation
+    if prev:
+        if re.search(r"\b(no|wrong|actually|instead|cancel|undo|stop)\b", low):
+            rel = "correction"
+            rel_conf = 0.82
+        elif re.search(r"\b(yes|ok|thanks|done|perfect|great)\b", low) and len(text) < 80:
+            rel = "confirmation"
+            rel_conf = 0.75
+        elif len(text) < 40 and not re.search(r"[.?]", text):
+            rel = "follow_up"
+            rel_conf = 0.6
+        else:
+            rel = "follow_up"
+            rel_conf = 0.55
+    else:
+        rel = "new"
+        rel_conf = 0.9
+
+    # Actionability / urgency
+    if re.search(r"\b(run|execute|implement|fix|debug|deploy|write|patch|test|build)\b", low):
+        act, act_conf = "act", 0.88
+    elif "?" in text or re.search(r"\b(what|how|why|explain)\b", low):
+        act, act_conf = "review", 0.78
+    else:
+        act, act_conf = "none", 0.72
+
+    if re.search(r"\b(asap|urgent|immediately|now\b|critical|production down)\b", low):
+        urg, urg_conf = "high", 0.9
+    elif len(text) > 400 or text.count("\n") > 4:
+        urg, urg_conf = "medium", 0.65
+    else:
+        urg, urg_conf = "low", 0.78
+
+    # Retention
+    if re.search(r"\b(remember|always|never forget|preference|my name is|i prefer)\b", low):
+        ret, ret_conf = "remember", 0.85
+    elif act == "act" or len(text) > 120:
+        ret, ret_conf = "useful", 0.7
+    else:
+        ret, ret_conf = "ephemeral", 0.68
+
+    overall = (rel_conf + act_conf + urg_conf + ret_conf) / 4.0
+    return RouterOutput(
+        relation_to_previous=HeadPrediction(rel, rel_conf),
+        actionability=HeadPrediction(act, act_conf),
+        retention=HeadPrediction(ret, ret_conf),
+        urgency=HeadPrediction(urg, urg_conf),
+        overall_confidence=overall,
+        source="heuristic",
+    )
+
+
+def _extract_json_object(text: str) -> Optional[Dict[str, Any]]:
+    text = (text or "").strip()
+    if not text:
+        return None
+
+    expected_heads = {"relation_to_previous", "actionability", "retention", "urgency"}
+
+    # Fast path: stdout is a single clean JSON object.
+    try:
+        obj = json.loads(text)
+        if isinstance(obj, dict):
+            return obj
+    except json.JSONDecodeError:
+        pass
+
+    # Try line-by-line JSON payloads (common when upstream prints logs).
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and expected_heads & set(obj.keys()):
+            return obj
+
+    # Fallback: scan for decodable JSON objects and prefer the one that
+    # contains expected tiny-router heads; otherwise choose the largest object.
+    dec = json.JSONDecoder()
+    best_obj: Optional[Dict[str, Any]] = None
+    best_len = -1
+    for idx, ch in enumerate(text):
+        if ch != "{":
+            continue
+        try:
+            obj, end = dec.raw_decode(text[idx:])
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if expected_heads & set(obj.keys()):
+            return obj
+        if end > best_len:
+            best_len = end
+            best_obj = obj
+    return best_obj
+
+
+def _run_subprocess_predict(cfg: Dict[str, Any], payload: Dict[str, Any]) -> Optional[RouterOutput]:
+    repo_root = str(cfg.get("repo_root") or "").strip()
+    model_dir = str(cfg.get("model_dir") or "").strip()
+    if not repo_root or not model_dir:
+        return None
+    repo_path = Path(repo_root).expanduser()
+    model_path = Path(model_dir).expanduser()
+    if not repo_path.is_dir() or not model_path.is_dir():
+        return None
+    predict_py = repo_path / "scripts" / "predict.py"
+    if not predict_py.is_file():
+        logger.debug("tiny-router predict script not found at %s", predict_py)
+        return None
+
+    timeout = _coerce_float(cfg.get("predict_timeout_seconds"), 30.0)
+    timeout = max(5.0, min(120.0, timeout))
+    cmd = [
+        sys.executable,
+        "-m",
+        "scripts.predict",
+        "--model-dir",
+        str(model_path),
+        "--input-json",
+        json.dumps(payload, ensure_ascii=False),
+        "--pretty",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.warning("tiny-router subprocess failed: %s", exc)
+        return None
+
+    out = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    if proc.returncode != 0:
+        logger.warning("tiny-router predict exit %s: %s", proc.returncode, out[:500])
+        return None
+    data = _extract_json_object(proc.stdout or "")
+    if not data:
+        data = _extract_json_object(out)
+    if not data:
+        logger.warning("tiny-router predict returned no JSON")
+        return None
+    return parse_router_json(data, "subprocess")
+
+
+def classify_turn(
+    tiny_router_cfg: Optional[Dict[str, Any]],
+    current_text: Any,
+    prior_messages: Optional[List[Dict[str, Any]]],
+) -> RouterOutput:
+    """Classify the current user turn. Always returns a RouterOutput."""
+    cfg = tiny_router_cfg or {}
+    if not cfg.get("enabled"):
+        return RouterOutput.disabled()
+    current_text_norm = _normalize_text_input(current_text)
+
+    interaction = build_interaction_from_history(prior_messages)
+    router_input = RouterInput(
+        current_text=current_text_norm or "",
+        interaction={
+            "previous_text": interaction["previous_text"],
+            "previous_action": interaction["previous_action"],
+            "previous_outcome": interaction["previous_outcome"],
+            "recency_seconds": interaction["recency_seconds"],
+        },
+    )
+    payload = router_input.to_payload()
+
+    fb = str(cfg.get("fallback_mode") or "heuristic").strip().lower()
+    backend = str(cfg.get("backend") or "subprocess").strip().lower()
+    out: Optional[RouterOutput] = None
+    if backend == "subprocess":
+        try:
+            out = _run_subprocess_predict(cfg, payload)
+        except Exception as exc:
+            logger.debug("tiny-router subprocess error: %s", exc)
+            out = None
+
+    if out is None:
+        if fb == "none":
+            return RouterOutput.disabled()
+        return _heuristic_classify(current_text_norm, interaction)
+    return out
+
+
+def router_dict_from_output(output: RouterOutput) -> Dict[str, Any]:
+    """Serializable dict for run_conversation / session metadata."""
+    return output.to_metadata_dict()
+
+
+def validate_tiny_router_config(cfg: Optional[Dict[str, Any]]) -> tuple[bool, str]:
+    """Validate runtime tiny-router config and return (ok, error_message)."""
+    conf = cfg or {}
+    if not conf.get("enabled"):
+        return True, ""
+
+    mode = str(conf.get("backend") or "subprocess").strip().lower()
+    if mode not in {"subprocess", "heuristic"}:
+        return (
+            False,
+            "smart_model_routing.tiny_router.backend must be 'subprocess' or 'heuristic' "
+            f"(got: {mode!r})",
+        )
+
+    if mode == "heuristic":
+        return True, ""
+
+    repo_root = str(conf.get("repo_root") or "").strip()
+    model_dir = str(conf.get("model_dir") or "").strip()
+    if not repo_root:
+        return False, "smart_model_routing.tiny_router.repo_root is required when backend=subprocess"
+    if not model_dir:
+        return False, "smart_model_routing.tiny_router.model_dir is required when backend=subprocess"
+
+    repo_path = Path(repo_root).expanduser()
+    model_path = Path(model_dir).expanduser()
+    if not repo_path.is_dir():
+        return False, f"smart_model_routing.tiny_router.repo_root does not exist: {repo_root}"
+    if not model_path.is_dir():
+        return False, f"smart_model_routing.tiny_router.model_dir does not exist: {model_dir}"
+
+    predict_py = repo_path / "scripts" / "predict.py"
+    if not predict_py.is_file():
+        return False, f"tiny-router predict entrypoint missing: {predict_py}"
+
+    enforce_pin = bool(conf.get("enforce_pinned_commit", True))
+    if enforce_pin:
+        pinned_commit = str(conf.get("pinned_commit") or DEFAULT_PINNED_COMMIT).strip()
+        if not pinned_commit:
+            return (
+                False,
+                "smart_model_routing.tiny_router.pinned_commit must be set when enforce_pinned_commit=true",
+            )
+        head = ""
+        git_err = ""
+        try:
+            proc = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=str(repo_path),
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if proc.returncode == 0:
+                head = (proc.stdout or "").strip().lower()
+            else:
+                git_err = (proc.stderr or proc.stdout or "").strip()
+        except (subprocess.SubprocessError, OSError) as exc:
+            git_err = str(exc)
+
+        if not head:
+            revision_file = str(conf.get("source_revision_file") or "REVISION").strip() or "REVISION"
+            revision_path = Path(revision_file).expanduser()
+            if not revision_path.is_absolute():
+                revision_path = repo_path / revision_path
+            if revision_path.is_file():
+                try:
+                    head = (revision_path.read_text(encoding="utf-8").strip().splitlines()[0]).lower()
+                except Exception:
+                    head = ""
+        if not head:
+            return (
+                False,
+                "unable to determine tiny-router revision via git or source_revision_file. "
+                f"git_error={git_err or 'none'}",
+            )
+        pin = pinned_commit.lower()
+        if not head.startswith(pin):
+            return (
+                False,
+                "tiny-router checkout is not pinned: "
+                f"expected {pinned_commit}, got {head}. "
+                "Update repo_root checkout or set enforce_pinned_commit=false.",
+            )
+
+    return True, ""
+
+
+def apply_router_thread_local(output: Optional[RouterOutput]) -> None:
+    """Set thread-local active router (for tools that cannot use contextvars)."""
+    if not hasattr(apply_router_thread_local, "_local"):
+        apply_router_thread_local._local = threading.local()  # type: ignore[attr-defined]
+    apply_router_thread_local._local.output = output  # type: ignore[attr-defined]
+
+
+def get_active_router_thread_local() -> Optional[RouterOutput]:
+    if not hasattr(apply_router_thread_local, "_local"):
+        return None
+    return getattr(apply_router_thread_local._local, "output", None)  # type: ignore[attr-defined]
+
+
+def get_active_router_for_tools() -> Optional[RouterOutput]:
+    """Prefer ContextVar; fall back to thread-local (delegate/threads)."""
+    ctx = get_active_router_output()
+    if ctx is not None:
+        return ctx
+    return get_active_router_thread_local()

--- a/cli.py
+++ b/cli.py
@@ -184,6 +184,33 @@ def load_cli_config() -> Dict[str, Any]:
             "max_simple_chars": 160,
             "max_simple_words": 28,
             "cheap_model": {},
+            "routes": {},
+            "tier_routes": {
+                "low": "cheap",
+                "medium": "primary",
+                "high": "primary",
+            },
+            "max_high_tier_calls_per_session": 0,
+            "tiny_router": {
+                "enabled": False,
+                "backend": "subprocess",
+                "repo_root": "${TINY_ROUTER_REPO_ROOT}",
+                "model_dir": "${TINY_ROUTER_MODEL_DIR}",
+                "pinned_commit": "9d6b2a718a205d90ebe85e9a28f9b8a1f20801e4",
+                "enforce_pinned_commit": True,
+                "source_revision_file": "REVISION",
+                "predict_timeout_seconds": 30,
+                "fallback_mode": "heuristic",
+                "behavior_mode": "shadow",
+                "apply_approval_posture": True,
+                "confidence_thresholds": {
+                    "overall": 0.45,
+                    "relation_to_previous": 0.5,
+                    "actionability": 0.5,
+                    "retention": 0.5,
+                    "urgency": 0.5,
+                },
+            },
         },
         "agent": {
             "max_turns": 90,  # Default max tool-calling iterations (shared with subagents)
@@ -1171,6 +1198,11 @@ class HermesCLI:
 
         # Optional cheap-vs-strong routing for simple turns
         self._smart_model_routing = CLI_CONFIG.get("smart_model_routing", {}) or {}
+        self._tiny_router_config = (
+            self._smart_model_routing.get("tiny_router", {})
+            if isinstance(self._smart_model_routing, dict)
+            else {}
+        ) or {}
         self._active_agent_route_signature = None
 
         # Agent will be initialized on first use
@@ -1274,8 +1306,23 @@ class HermesCLI:
         filled = round((safe_percent / 100) * width)
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
 
+    def _status_model_name(self) -> str:
+        """Model currently active for this CLI turn/session UI."""
+        agent = getattr(self, "agent", None)
+        agent_model = str(getattr(agent, "model", "") or "").strip()
+        if agent_model:
+            return agent_model
+
+        signature = getattr(self, "_active_agent_route_signature", None)
+        if isinstance(signature, tuple) and signature:
+            routed_model = signature[0]
+            if isinstance(routed_model, str) and routed_model.strip():
+                return routed_model.strip()
+
+        return self.model or "unknown"
+
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
-        model_name = self.model or "unknown"
+        model_name = self._status_model_name()
         model_short = model_name.split("/")[-1] if "/" in model_name else model_name
         if model_short.endswith(".gguf"):
             model_short = model_short[:-5]
@@ -1352,7 +1399,7 @@ class HermesCLI:
             parts.append(duration_label)
             return " │ ".join(parts)
         except Exception:
-            return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
+            return f"⚕ {self._status_model_name()}"
 
     def _get_status_bar_fragments(self):
         if not self._status_bar_visible:
@@ -1756,6 +1803,17 @@ class HermesCLI:
             self.console.print(f"[bold red]{message}[/]")
             return False
 
+        try:
+            from agent.tiny_router import validate_tiny_router_config
+
+            ok, err = validate_tiny_router_config(self._tiny_router_config)
+            if not ok:
+                self.console.print(f"[bold red]Invalid tiny-router config: {err}[/]")
+                return False
+        except Exception as exc:
+            self.console.print(f"[bold red]Failed to validate tiny-router config: {exc}[/]")
+            return False
+
         api_key = runtime.get("api_key")
         base_url = runtime.get("base_url")
         resolved_provider = runtime.get("provider", "openrouter")
@@ -1810,7 +1868,12 @@ class HermesCLI:
 
         return True
 
-    def _resolve_turn_agent_config(self, user_message: str) -> dict:
+    def _resolve_turn_agent_config(
+        self,
+        user_message: str,
+        *,
+        router_output=None,
+    ) -> dict:
         """Resolve model/runtime overrides for a single user turn."""
         from agent.smart_model_routing import resolve_turn_route
 
@@ -1826,7 +1889,45 @@ class HermesCLI:
                 "command": self.acp_command,
                 "args": list(self.acp_args or []),
             },
+            tiny_router_config=self._tiny_router_config,
+            router_output=router_output,
+            routing_context={"session_id": self.session_id},
         )
+
+    def _classify_turn_with_indicator(
+        self,
+        message: Any,
+        history: Optional[list] = None,
+        *,
+        show_indicator: bool = True,
+    ):
+        """Classify the turn and optionally show a routing wait indicator."""
+        from agent.tiny_router import classify_turn
+
+        cfg = self._tiny_router_config if isinstance(self._tiny_router_config, dict) else {}
+        backend = str(cfg.get("backend") or "subprocess").strip().lower()
+        should_show = bool(show_indicator and cfg.get("enabled") and backend == "subprocess")
+        use_tui_spinner = bool(should_show and getattr(self, "_app", None))
+
+        started = time.monotonic()
+        previous_spinner = self._spinner_text
+        if use_tui_spinner:
+            self._spinner_text = "🧭 tiny-router: selecting model route..."
+            self._invalidate(min_interval=0.0)
+        elif should_show:
+            _cprint(f"  {_DIM}⏳ tiny-router: selecting model route...{_RST}")
+        try:
+            output = classify_turn(cfg, message, history)
+        finally:
+            if use_tui_spinner:
+                # Restore prior spinner text so we don't pollute active agent status.
+                self._spinner_text = previous_spinner
+                self._invalidate(min_interval=0.0)
+        if should_show and not use_tui_spinner:
+            elapsed_ms = int((time.monotonic() - started) * 1000)
+            source = str(getattr(output, "source", "unknown") or "unknown")
+            _cprint(f"  {_DIM}✓ tiny-router: route signal ready ({source}, {elapsed_ms}ms){_RST}")
+        return output
 
     def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, route_label: str = None) -> bool:
         """
@@ -2465,7 +2566,8 @@ class HermesCLI:
         tool_count = len(tools) if tools else 0
         
         # Format model name (shorten if needed)
-        model_short = self.model.split("/")[-1] if "/" in self.model else self.model
+        status_model = self._status_model_name()
+        model_short = status_model.split("/")[-1] if "/" in status_model else status_model
         if len(model_short) > 30:
             model_short = model_short[:27] + "..."
         
@@ -2489,7 +2591,7 @@ class HermesCLI:
             f"[dim #B8860B]·[/] [bold cyan]{tool_count} tools[/]"
             f"{toolsets_info}{provider_info}"
         )
-    
+
     def show_help(self):
         """Display help information with categorized commands."""
         from hermes_cli.commands import COMMANDS_BY_CATEGORY
@@ -3889,7 +3991,8 @@ class HermesCLI:
         _cprint(f"  Task ID: {task_id}")
         _cprint(f"  You can continue chatting — results will appear when done.\n")
 
-        turn_route = self._resolve_turn_agent_config(prompt)
+        router_output = self._classify_turn_with_indicator(prompt, None, show_indicator=True)
+        turn_route = self._resolve_turn_agent_config(prompt, router_output=router_output)
 
         def run_background():
             try:
@@ -3921,6 +4024,7 @@ class HermesCLI:
                 result = bg_agent.run_conversation(
                     user_message=prompt,
                     task_id=task_id,
+                    router_output_override=router_output,
                 )
 
                 response = result.get("final_response", "") if result else ""
@@ -5377,18 +5481,6 @@ class HermesCLI:
         if not self._ensure_runtime_credentials():
             return None
 
-        turn_route = self._resolve_turn_agent_config(message)
-        if turn_route["signature"] != self._active_agent_route_signature:
-            self.agent = None
-
-        # Initialize agent if needed
-        if not self._init_agent(
-            model_override=turn_route["model"],
-            runtime_override=turn_route["runtime"],
-            route_label=turn_route["label"],
-        ):
-            return None
-        
         # Pre-process images through the vision tool (Gemini Flash) so the
         # main model receives text descriptions instead of raw base64 image
         # content — works with any model, not just vision-capable ones.
@@ -5418,6 +5510,23 @@ class HermesCLI:
                     message = _ctx_result.message
             except Exception as e:
                 logging.debug("@ context reference expansion failed: %s", e)
+
+        router_output = self._classify_turn_with_indicator(
+            message,
+            self.conversation_history,
+            show_indicator=True,
+        )
+        turn_route = self._resolve_turn_agent_config(message, router_output=router_output)
+        if turn_route["signature"] != self._active_agent_route_signature:
+            self.agent = None
+
+        # Initialize agent if needed
+        if not self._init_agent(
+            model_override=turn_route["model"],
+            runtime_override=turn_route["runtime"],
+            route_label=turn_route["label"],
+        ):
+            return None
 
         # Add user message to history
         self.conversation_history.append({"role": "user", "content": message})
@@ -5509,6 +5618,7 @@ class HermesCLI:
                     stream_callback=stream_callback,
                     task_id=self.session_id,
                     persist_user_message=message if _voice_prefix else None,
+                    router_output_override=router_output,
                 )
 
             # Start agent in background thread
@@ -7333,7 +7443,12 @@ def main(
             # Only print the final response and parseable session info.
             cli.tool_progress_mode = "off"
             if cli._ensure_runtime_credentials():
-                turn_route = cli._resolve_turn_agent_config(query)
+                router_output = cli._classify_turn_with_indicator(
+                    query,
+                    cli.conversation_history,
+                    show_indicator=False,
+                )
+                turn_route = cli._resolve_turn_agent_config(query, router_output=router_output)
                 if turn_route["signature"] != cli._active_agent_route_signature:
                     cli.agent = None
                 if cli._init_agent(
@@ -7345,6 +7460,7 @@ def main(
                     result = cli.agent.run_conversation(
                         user_message=query,
                         conversation_history=cli.conversation_history,
+                        router_output_override=router_output,
                     )
                     response = result.get("final_response", "") if isinstance(result, dict) else str(result)
                     if response:

--- a/docs/local-test-plan-tiny-router.md
+++ b/docs/local-test-plan-tiny-router.md
@@ -1,0 +1,205 @@
+# Local Test Plan: Tiny Router Integration
+
+This runbook is for validating tiny-router integration locally before opening a public PR.
+
+## Goal
+
+Confirm that tiny-router classification is:
+
+1. generated per turn
+2. consumed by routing/policy logic
+3. persisted in SQLite metadata
+4. safe under shadow rollout and predictable under active rollout
+
+## Prerequisites
+
+From repo root:
+
+```bash
+source venv/bin/activate
+```
+
+If your environment does not have all optional test deps installed:
+
+```bash
+python -m pip install fire firecrawl-py fal-client
+```
+
+## A. Automated Regression (required)
+
+Run:
+
+```bash
+python -m pytest -o addopts='' \
+  tests/agent/test_tiny_router.py \
+  tests/agent/test_smart_model_routing.py \
+  tests/test_cli_provider_resolution.py \
+  tests/test_hermes_state.py \
+  tests/tools/test_approval.py \
+  tests/agent/test_context_compressor.py \
+  tests/gateway/test_background_command.py \
+  tests/gateway/test_transcript_offset.py \
+  -q
+```
+
+Expected:
+
+- all tests pass
+- only known warnings (if any), no new failures
+
+Optional full suite:
+
+```bash
+python -m pytest tests/ -q
+```
+
+## B. Config Validation (required)
+
+Set tiny-router in `shadow` mode first.
+
+Example (heuristic-only backend for portability):
+
+```yaml
+smart_model_routing:
+  tiny_router:
+    enabled: true
+    backend: heuristic
+    behavior_mode: shadow
+    fallback_mode: heuristic
+    apply_approval_posture: true
+```
+
+Start CLI:
+
+```bash
+python cli.py
+```
+
+Expected:
+
+- startup succeeds
+- no config validation error for tiny-router
+
+For subprocess backend, configure:
+
+```yaml
+smart_model_routing:
+  tiny_router:
+    enabled: true
+    backend: subprocess
+    repo_root: /abs/path/to/tiny-router
+    model_dir: /abs/path/to/tiny-router/artifacts/tiny-router
+    pinned_commit: 9d6b2a718a205d90ebe85e9a28f9b8a1f20801e4
+    enforce_pinned_commit: true
+    source_revision_file: REVISION
+```
+
+Expected:
+
+- startup fails fast with clear error if path/script/model is invalid
+- startup fails fast if source revision does not match `pinned_commit` (git HEAD first, then `source_revision_file` fallback)
+- startup succeeds when valid
+
+## C. Manual Functional Scenarios (required)
+
+## Scenario 1: Shadow mode is non-disruptive
+
+1. Keep `behavior_mode: shadow`
+2. Send simple prompt and complex prompt
+3. Verify normal model behavior still feels consistent
+
+Expected:
+
+- no surprising route changes
+- no regressions in normal agent execution
+
+## Scenario 2: Active mode route influence
+
+1. Set `behavior_mode: active`
+2. Configure `smart_model_routing.cheap_model`
+   - Optional: define `smart_model_routing.routes` and `tier_routes` so
+     low/medium/high tiers map to named profiles (for example: local-fast,
+     local-strong, remote-strong)
+   - Optional: set `max_high_tier_calls_per_session` to validate expensive-turn caps
+3. Send:
+   - low-urgency/simple prompt
+   - high-urgency/action prompt
+
+Expected:
+
+- simple prompt can route to cheap model
+- high-urgency/action prompt tends to route to a high-tier profile
+- after budget cap is hit, high-tier routes fall back to configured medium tier
+
+## Scenario 3: Approval posture
+
+1. Use a turn likely to classify as review
+2. Execute a command that hits guardrails
+
+Expected:
+
+- approval flow is triggered/escalated rather than silently executing
+
+## Scenario 4: Memory/compression behavior
+
+1. Trigger a high-actionability + high-urgency turn
+2. Force a long-enough context to approach compression behavior
+
+Expected:
+
+- memory flush bias appears on urgent/action-heavy turns
+- retention-priority turns are less likely to be dropped during compression boundary logic
+
+## D. Persistence Validation (required)
+
+Run a few CLI turns with tiny-router enabled, then inspect SQLite:
+
+```bash
+python - <<'PY'
+from hermes_state import SessionDB
+db = SessionDB()
+sessions = db.search_sessions(limit=1)
+if not sessions:
+    print("No sessions found")
+else:
+    sid = sessions[0]["id"]
+    msgs = db.get_messages(sid)
+    hits = [m for m in msgs if isinstance(m.get("metadata"), dict) and "tiny_router" in m["metadata"]]
+    print("session:", sid)
+    print("messages:", len(msgs))
+    print("tiny_router_metadata_messages:", len(hits))
+db.close()
+PY
+```
+
+Expected:
+
+- at least one user message has `metadata.tiny_router`
+- JSON structure includes all four heads and source/confidence fields
+
+## E. Gateway Smoke (recommended)
+
+Run gateway-related tests:
+
+```bash
+python -m pytest -o addopts='' \
+  tests/gateway/test_background_command.py \
+  tests/gateway/test_transcript_offset.py \
+  -q
+```
+
+Expected:
+
+- no failures
+- background task flow handles tiny-router classification cleanly
+
+## F. Sign-off Checklist
+
+- [ ] Targeted regression suite passes
+- [ ] Shadow mode manual pass complete
+- [ ] Active mode route behavior verified
+- [ ] Approval posture scenario verified
+- [ ] SQLite metadata persistence verified
+- [ ] Gateway smoke tests pass
+- [ ] No new lint/type issues in touched files
+

--- a/docs/tiny-router-integration.md
+++ b/docs/tiny-router-integration.md
@@ -1,0 +1,145 @@
+# Tiny Router Integration (Hermes)
+
+This document describes the tiny-router integration added to Hermes for per-turn message classification and policy routing.
+
+Repository for the classifier: <https://github.com/UdaraJay/tiny-router>
+
+## What This Adds
+
+Hermes now classifies each user turn into four heads before execution:
+
+- `relation_to_previous`: `new | follow_up | correction | confirmation | cancellation | closure`
+- `actionability`: `none | review | act`
+- `retention`: `ephemeral | useful | remember`
+- `urgency`: `low | medium | high`
+
+The classification is consumed by routing and policy components, and persisted as message metadata.
+
+## Core Behavior
+
+### 1) Per-turn routing signal
+
+- New module: `agent/tiny_router.py`
+- Supports:
+  - subprocess backend (runs tiny-router `scripts.predict`)
+  - deterministic heuristic fallback
+  - multimodal-safe input normalization (extracts text from list-style message parts)
+- Used by:
+  - CLI flow (`cli.py`)
+  - gateway flow (`gateway/run.py`)
+  - `AIAgent.run_conversation(...)` (`run_agent.py`)
+
+### 2) Route selection integration
+
+- `agent/smart_model_routing.py` now accepts tiny-router output.
+- `smart_model_routing.tiny_router.behavior_mode`:
+  - `shadow`: classify + persist, but do not strongly alter model route decisions
+  - `active`: let tiny-router drive route-policy decisions when confidence/policy conditions match
+- Routing policy is centralized in `smart_model_routing`:
+  - simple-turn heuristics, tiny-router low/high-stakes decisions, and named route profiles are evaluated in one place
+  - `smart_model_routing.routes` can define extra profiles (for example, a local model lane) beyond `cheap_model`
+  - `smart_model_routing.tier_routes` maps `low|medium|high` quality tiers to route names (`cheap`, `primary`, or custom routes)
+  - `smart_model_routing.max_high_tier_calls_per_session` can cap expensive turns per session
+
+### 3) Policy integration
+
+- Memory behavior in `run_agent.py`:
+  - `retention=remember` can boost memory review behavior
+  - high urgency + actionable turns can trigger aggressive pre-persist memory flushing
+- Context compression in `agent/context_compressor.py`:
+  - `retention=useful|remember` turns are favored near compression boundaries
+- Approval posture in `tools/approval.py`:
+  - review-classified turns can escalate risky command execution to explicit approval
+
+### 4) Persistence
+
+- SQLite schema version bumped in `hermes_state.py`:
+  - `messages.metadata` added as JSON text
+- tiny-router output is stored under message metadata:
+  - `metadata.tiny_router.*`
+
+## Config
+
+New config section in `hermes_cli/config.py`:
+
+```yaml
+smart_model_routing:
+  tier_routes:
+    low: cheap
+    medium: primary
+    high: primary
+  max_high_tier_calls_per_session: 0
+  tiny_router:
+    enabled: false
+    backend: subprocess          # subprocess | heuristic
+    repo_root: ${TINY_ROUTER_REPO_ROOT}
+    model_dir: ${TINY_ROUTER_MODEL_DIR}
+    pinned_commit: 9d6b2a718a205d90ebe85e9a28f9b8a1f20801e4
+    enforce_pinned_commit: true
+    source_revision_file: REVISION
+    predict_timeout_seconds: 30
+    fallback_mode: heuristic     # heuristic | none
+    behavior_mode: shadow        # shadow | active
+    apply_approval_posture: true
+    confidence_thresholds:
+      overall: 0.45
+      relation_to_previous: 0.5
+      actionability: 0.5
+      retention: 0.5
+      urgency: 0.5
+```
+
+New optional env vars:
+
+- `TINY_ROUTER_REPO_ROOT`
+- `TINY_ROUTER_MODEL_DIR`
+
+## Version pinning model
+
+tiny-router currently does not publish GitHub release tags in the upstream repo.
+Hermes therefore pins to an immutable upstream commit SHA (`pinned_commit`) for
+reproducible behavior.
+
+If `enforce_pinned_commit: true`, Hermes startup validation fails when the local
+source revision does not match `pinned_commit`.
+
+Validation order:
+
+1. read `git rev-parse HEAD` under `repo_root` (normal checkout), or
+2. if git metadata is unavailable, read `source_revision_file` (default: `REVISION`)
+
+This supports both git checkouts and non-git source bundles while keeping the
+pin deterministic. Updating this pin is a normal Hermes maintenance task.
+
+## Rollout Guidance
+
+1. Enable in `shadow` mode first.
+2. Validate output quality + operational impact.
+3. Move to `active` mode only after confidence tuning.
+4. Keep a rollback path by setting `smart_model_routing.tiny_router.enabled: false`.
+
+## Rollback
+
+Fast rollback:
+
+- set `smart_model_routing.tiny_router.enabled: false`
+
+This returns Hermes to pre-integration routing behavior without schema rollback.
+
+## Files Changed (high level)
+
+- `agent/tiny_router.py`
+- `agent/smart_model_routing.py`
+- `run_agent.py`
+- `cli.py`
+- `gateway/run.py`
+- `tools/approval.py`
+- `agent/context_compressor.py`
+- `hermes_state.py`
+- `hermes_cli/config.py`
+- tests:
+  - `tests/agent/test_tiny_router.py`
+  - `tests/agent/test_smart_model_routing.py`
+  - `tests/test_cli_provider_resolution.py`
+  - `tests/test_hermes_state.py`
+

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -328,6 +329,7 @@ class GatewayRunner:
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
         self._smart_model_routing = self._load_smart_model_routing()
+        self._tiny_router_config = self._load_tiny_router_config()
 
         # Wire process registry into session store for reset protection
         from tools.process_registry import process_registry
@@ -668,7 +670,14 @@ class GatewayRunner:
             group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
         )
 
-    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
+    def _resolve_turn_agent_config(
+        self,
+        user_message: str,
+        model: str,
+        runtime_kwargs: dict,
+        router_output=None,
+        routing_context: Optional[Dict[str, Any]] = None,
+    ) -> dict:
         from agent.smart_model_routing import resolve_turn_route
 
         primary = {
@@ -680,7 +689,42 @@ class GatewayRunner:
             "command": runtime_kwargs.get("command"),
             "args": list(runtime_kwargs.get("args") or []),
         }
-        return resolve_turn_route(user_message, getattr(self, "_smart_model_routing", {}), primary)
+        return resolve_turn_route(
+            user_message,
+            getattr(self, "_smart_model_routing", {}),
+            primary,
+            tiny_router_config=getattr(self, "_tiny_router_config", {}),
+            router_output=router_output,
+            routing_context=routing_context,
+        )
+
+    def _run_conversation_with_router(
+        self,
+        agent: Any,
+        *,
+        user_message: str,
+        conversation_history: Optional[List[Dict[str, Any]]] = None,
+        task_id: Optional[str] = None,
+        router_output: Any = None,
+    ) -> Dict[str, Any]:
+        """Call run_conversation with tiny-router override when supported."""
+        kwargs: Dict[str, Any] = {}
+        if conversation_history is not None:
+            kwargs["conversation_history"] = conversation_history
+        if task_id is not None:
+            kwargs["task_id"] = task_id
+
+        supports_router_override = False
+        try:
+            sig = inspect.signature(agent.run_conversation)
+            supports_router_override = "router_output_override" in sig.parameters
+        except (TypeError, ValueError):
+            supports_router_override = False
+
+        if supports_router_override:
+            kwargs["router_output_override"] = router_output
+
+        return agent.run_conversation(user_message, **kwargs)
 
     async def _handle_adapter_fatal_error(self, adapter: BasePlatformAdapter) -> None:
         """React to an adapter failure after startup.
@@ -925,6 +969,29 @@ class GatewayRunner:
             pass
         return {}
 
+    @staticmethod
+    def _load_tiny_router_config() -> dict:
+        """Load optional tiny-router turn classification config."""
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                try:
+                    from hermes_cli.config import _expand_env_vars
+                    cfg = _expand_env_vars(cfg)
+                except Exception:
+                    pass
+                smart = cfg.get("smart_model_routing", {}) or {}
+                if isinstance(smart, dict):
+                    tiny = smart.get("tiny_router", {}) or {}
+                    if isinstance(tiny, dict):
+                        return tiny
+        except Exception:
+            pass
+        return {}
+
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
@@ -933,6 +1000,19 @@ class GatewayRunner:
         """
         logger.info("Starting Hermes Gateway...")
         logger.info("Session storage: %s", self.config.sessions_dir)
+        try:
+            from agent.tiny_router import validate_tiny_router_config
+
+            ok, err = validate_tiny_router_config(getattr(self, "_tiny_router_config", {}))
+            if not ok:
+                logger.error("Invalid tiny-router config: %s", err)
+                self._exit_reason = f"Invalid tiny-router config: {err}"
+                return False
+        except Exception as e:
+            logger.error("Failed to validate tiny-router config: %s", e)
+            self._exit_reason = f"tiny-router config validation failed: {e}"
+            return False
+
         try:
             from gateway.status import write_runtime_status
             write_runtime_status(gateway_state="starting", exit_reason=None)
@@ -3749,7 +3829,16 @@ class GatewayRunner:
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
             reasoning_config = self._load_reasoning_config()
             self._reasoning_config = reasoning_config
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            from agent.tiny_router import classify_turn
+
+            router_output = classify_turn(getattr(self, "_tiny_router_config", {}), prompt, None)
+            turn_route = self._resolve_turn_agent_config(
+                prompt,
+                model,
+                runtime_kwargs,
+                router_output=router_output,
+                routing_context={"session_id": self._session_key_for_source(source)},
+            )
 
             def run_sync():
                 agent = AIAgent(
@@ -3772,9 +3861,11 @@ class GatewayRunner:
                     fallback_model=self._fallback_model,
                 )
 
-                return agent.run_conversation(
+                return self._run_conversation_with_router(
+                    agent,
                     user_message=prompt,
                     task_id=task_id,
+                    router_output=router_output,
                 )
 
             loop = asyncio.get_event_loop()
@@ -5183,7 +5274,16 @@ class GatewayRunner:
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
 
-            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            from agent.tiny_router import classify_turn
+
+            router_output = classify_turn(getattr(self, "_tiny_router_config", {}), message, history)
+            turn_route = self._resolve_turn_agent_config(
+                message,
+                model,
+                runtime_kwargs,
+                router_output=router_output,
+                routing_context={"session_id": session_key},
+            )
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -5303,7 +5403,13 @@ class GatewayRunner:
                             if _p:
                                 _history_media_paths.add(_p)
             
-            result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+            result = self._run_conversation_with_router(
+                agent,
+                user_message=message,
+                conversation_history=agent_history,
+                task_id=session_id,
+                router_output=router_output,
+            )
             result_holder[0] = result
 
             # Signal the stream consumer that the agent is done

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -173,6 +173,38 @@ DEFAULT_CONFIG = {
         "max_simple_chars": 160,
         "max_simple_words": 28,
         "cheap_model": {},
+        "routes": {},
+        "tier_routes": {
+            "low": "cheap",
+            "medium": "primary",
+            "high": "primary",
+        },
+        "max_high_tier_calls_per_session": 0,
+        "tiny_router": {
+            "enabled": False,
+            "backend": "subprocess",  # subprocess | heuristic
+            "repo_root": "${TINY_ROUTER_REPO_ROOT}",
+            "model_dir": "${TINY_ROUTER_MODEL_DIR}",
+            # Pinned upstream commit used for reproducible routing behavior.
+            # tiny-router currently has no GitHub release tags, so Hermes pins
+            # to a commit SHA instead of a semver tag.
+            "pinned_commit": "9d6b2a718a205d90ebe85e9a28f9b8a1f20801e4",
+            "enforce_pinned_commit": True,
+            # Fallback for non-git deployments: if git metadata is unavailable,
+            # Hermes can read the pinned revision from this file under repo_root.
+            "source_revision_file": "REVISION",
+            "predict_timeout_seconds": 30,
+            "fallback_mode": "heuristic",  # heuristic | none
+            "behavior_mode": "shadow",  # shadow | active
+            "apply_approval_posture": True,
+            "confidence_thresholds": {
+                "overall": 0.45,
+                "relation_to_previous": 0.5,
+                "actionability": 0.5,
+                "retention": 0.5,
+                "urgency": 0.5,
+            },
+        },
     },
     
     # Auxiliary model config — provider:model for each side task.
@@ -378,7 +410,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 10,
+    "_config_version": 15,
 }
 
 # =============================================================================
@@ -393,6 +425,11 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
     5: ["WHATSAPP_ENABLED", "WHATSAPP_MODE", "WHATSAPP_ALLOWED_USERS",
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
+    11: ["TINY_ROUTER_REPO_ROOT", "TINY_ROUTER_MODEL_DIR"],
+    12: [],
+    13: [],
+    14: [],
+    15: [],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -893,6 +930,20 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "setting",
     },
+    "TINY_ROUTER_REPO_ROOT": {
+        "description": "Path to tiny-router repository root (contains scripts/predict.py)",
+        "prompt": "tiny-router repository path",
+        "url": "https://github.com/UdaraJay/tiny-router",
+        "password": False,
+        "category": "setting",
+    },
+    "TINY_ROUTER_MODEL_DIR": {
+        "description": "Path to tiny-router trained model/checkpoint directory",
+        "prompt": "tiny-router model directory",
+        "url": "https://github.com/UdaraJay/tiny-router",
+        "password": False,
+        "category": "setting",
+    },
 }
 
 
@@ -1287,9 +1338,28 @@ _FALLBACK_COMMENT = """
 #   enabled: true
 #   max_simple_chars: 160
 #   max_simple_words: 28
+#   tier_routes:
+#     low: cheap
+#     medium: local_strong
+#     high: strong_remote
+#   max_high_tier_calls_per_session: 2
 #   cheap_model:
 #     provider: openrouter
 #     model: google/gemini-2.5-flash
+#   routes:
+#     local_fast:
+#       provider: custom
+#       model: qwen2.5:7b-instruct
+#       base_url: http://127.0.0.1:11434/v1
+#       api_key_env: LOCAL_LLM_API_KEY
+#   tiny_router:
+#     enabled: true
+#     backend: subprocess
+#     repo_root: ${TINY_ROUTER_REPO_ROOT}
+#     model_dir: ${TINY_ROUTER_MODEL_DIR}
+#     pinned_commit: 9d6b2a718a205d90ebe85e9a28f9b8a1f20801e4
+#     enforce_pinned_commit: true
+#     behavior_mode: active
 """
 
 
@@ -1330,9 +1400,28 @@ _COMMENTED_SECTIONS = """
 #   enabled: true
 #   max_simple_chars: 160
 #   max_simple_words: 28
+#   tier_routes:
+#     low: cheap
+#     medium: local_strong
+#     high: strong_remote
+#   max_high_tier_calls_per_session: 2
 #   cheap_model:
 #     provider: openrouter
 #     model: google/gemini-2.5-flash
+#   routes:
+#     local_fast:
+#       provider: custom
+#       model: qwen2.5:7b-instruct
+#       base_url: http://127.0.0.1:11434/v1
+#       api_key_env: LOCAL_LLM_API_KEY
+#   tiny_router:
+#     enabled: true
+#     backend: subprocess
+#     repo_root: ${TINY_ROUTER_REPO_ROOT}
+#     model_dir: ${TINY_ROUTER_MODEL_DIR}
+#     pinned_commit: 9d6b2a718a205d90ebe85e9a28f9b8a1f20801e4
+#     enforce_pinned_commit: true
+#     behavior_mode: active
 """
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -26,7 +26,7 @@ from typing import Dict, Any, List, Optional
 
 DEFAULT_DB_PATH = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -73,7 +73,8 @@ CREATE TABLE IF NOT EXISTS messages (
     tool_name TEXT,
     timestamp REAL NOT NULL,
     token_count INTEGER,
-    finish_reason TEXT
+    finish_reason TEXT,
+    metadata TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
@@ -189,6 +190,12 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass
                 cursor.execute("UPDATE schema_version SET version = 5")
+            if current_version < 6:
+                try:
+                    cursor.execute("ALTER TABLE messages ADD COLUMN metadata TEXT")
+                except sqlite3.OperationalError:
+                    pass
+                cursor.execute("UPDATE schema_version SET version = 6")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -587,6 +594,7 @@ class SessionDB:
         tool_call_id: str = None,
         token_count: int = None,
         finish_reason: str = None,
+        metadata: Any = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -597,8 +605,8 @@ class SessionDB:
         with self._lock:
             cursor = self._conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
-                   tool_calls, tool_name, timestamp, token_count, finish_reason)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   tool_calls, tool_name, timestamp, token_count, finish_reason, metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -609,6 +617,7 @@ class SessionDB:
                     time.time(),
                     token_count,
                     finish_reason,
+                    json.dumps(metadata) if metadata is not None else None,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -650,6 +659,11 @@ class SessionDB:
                     msg["tool_calls"] = json.loads(msg["tool_calls"])
                 except (json.JSONDecodeError, TypeError):
                     pass
+            if msg.get("metadata"):
+                try:
+                    msg["metadata"] = json.loads(msg["metadata"])
+                except (json.JSONDecodeError, TypeError):
+                    pass
             result.append(msg)
         return result
 
@@ -660,7 +674,7 @@ class SessionDB:
         """
         with self._lock:
             cursor = self._conn.execute(
-                "SELECT role, content, tool_call_id, tool_calls, tool_name "
+                "SELECT role, content, tool_call_id, tool_calls, tool_name, metadata "
                 "FROM messages WHERE session_id = ? ORDER BY timestamp, id",
                 (session_id,),
             )
@@ -675,6 +689,11 @@ class SessionDB:
             if row["tool_calls"]:
                 try:
                     msg["tool_calls"] = json.loads(row["tool_calls"])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            if row["metadata"]:
+                try:
+                    msg["metadata"] = json.loads(row["metadata"])
                 except (json.JSONDecodeError, TypeError):
                     pass
             messages.append(msg)

--- a/run_agent.py
+++ b/run_agent.py
@@ -83,6 +83,15 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md
+from agent.tiny_router import (
+    RouterOutput,
+    apply_router_thread_local,
+    classify_turn,
+    reset_active_router_output,
+    router_dict_from_output,
+    set_active_router_output,
+    validate_tiny_router_config,
+)
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
@@ -900,6 +909,19 @@ class AIAgent:
         except Exception:
             _agent_cfg = {}
 
+        routing_cfg = _agent_cfg.get("smart_model_routing", {})
+        if not isinstance(routing_cfg, dict):
+            routing_cfg = {}
+        tiny_router_cfg = routing_cfg.get("tiny_router", {})
+        if not isinstance(tiny_router_cfg, dict):
+            tiny_router_cfg = {}
+        self._tiny_router_config = tiny_router_cfg
+        _tr_ok, _tr_err = validate_tiny_router_config(self._tiny_router_config)
+        if not _tr_ok:
+            raise RuntimeError(f"Invalid tiny-router config: {_tr_err}")
+        self._current_router_output: Optional[RouterOutput] = None
+        self._aggressive_memory_flush_pending = False
+
         # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
         self._memory_store = None
         self._memory_enabled = False
@@ -1538,6 +1560,7 @@ class AIAgent:
                     tool_calls=tool_calls_data,
                     tool_call_id=msg.get("tool_call_id"),
                     finish_reason=msg.get("finish_reason"),
+                    metadata=msg.get("metadata"),
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
@@ -4436,6 +4459,12 @@ class AIAgent:
             "Save anything worth remembering — prioritize user preferences, "
             "corrections, and recurring patterns over task-specific details.]"
         )
+        if self._aggressive_memory_flush_pending:
+            flush_content = (
+                flush_content
+                + " [Priority: this turn is high-urgency and action-heavy; preserve details"
+                " that could affect immediate follow-up actions.]"
+            )
         _sentinel = f"__flush_{id(self)}_{time.monotonic()}"
         flush_msg = {"role": "user", "content": flush_content, "_flush_sentinel": _sentinel}
         messages.append(flush_msg)
@@ -4452,6 +4481,7 @@ class AIAgent:
                         api_msg["reasoning_content"] = reasoning
                 api_msg.pop("reasoning", None)
                 api_msg.pop("finish_reason", None)
+                api_msg.pop("metadata", None)
                 api_msg.pop("_flush_sentinel", None)
                 if _is_strict_api:
                     self._sanitize_tool_calls_for_strict_api(api_msg)
@@ -4645,6 +4675,21 @@ class AIAgent:
         finally:
             self._executing_tools = False
 
+    def _call_registry_tool(self, function_name: str, function_args: dict, effective_task_id: str) -> str:
+        """Call a registry-dispatched tool with current tiny-router context attached."""
+        token = set_active_router_output(self._current_router_output)
+        apply_router_thread_local(self._current_router_output)
+        try:
+            return handle_function_call(
+                function_name, function_args, effective_task_id,
+                enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                honcho_manager=self._honcho,
+                honcho_session_key=self._honcho_session_key,
+            )
+        finally:
+            reset_active_router_output(token)
+            apply_router_thread_local(None)
+
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str) -> str:
         """Invoke a single tool and return the result string. No display logic.
 
@@ -4702,12 +4747,7 @@ class AIAgent:
                 parent_agent=self,
             )
         else:
-            return handle_function_call(
-                function_name, function_args, effective_task_id,
-                enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
-                honcho_manager=self._honcho,
-                honcho_session_key=self._honcho_session_key,
-            )
+            return self._call_registry_tool(function_name, function_args, effective_task_id)
 
     def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute multiple tool calls concurrently using a thread pool.
@@ -5070,11 +5110,8 @@ class AIAgent:
                 spinner.start()
                 _spinner_result = None
                 try:
-                    function_result = handle_function_call(
-                        function_name, function_args, effective_task_id,
-                        enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
-                        honcho_manager=self._honcho,
-                        honcho_session_key=self._honcho_session_key,
+                    function_result = self._call_registry_tool(
+                        function_name, function_args, effective_task_id
                     )
                     _spinner_result = function_result
                 except Exception as tool_error:
@@ -5086,11 +5123,8 @@ class AIAgent:
                     spinner.stop(cute_msg)
             else:
                 try:
-                    function_result = handle_function_call(
-                        function_name, function_args, effective_task_id,
-                        enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
-                        honcho_manager=self._honcho,
-                        honcho_session_key=self._honcho_session_key,
+                    function_result = self._call_registry_tool(
+                        function_name, function_args, effective_task_id
                     )
                 except Exception as tool_error:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"
@@ -5399,6 +5433,7 @@ class AIAgent:
         stream_callback: Optional[callable] = None,
         persist_user_message: Optional[str] = None,
         sync_honcho: bool = True,
+        router_output_override: Optional[RouterOutput] = None,
     ) -> Dict[str, Any]:
         """
         Run a complete conversation with tool calling until completion.
@@ -5416,6 +5451,8 @@ class AIAgent:
                 synthetic prefixes.
             sync_honcho: When False, skip writing the final synthetic turn back
                 to Honcho or queuing follow-up prefetch work.
+            router_output_override: Optional precomputed tiny-router output for
+                this turn. When omitted, the agent classifies the turn locally.
 
         Returns:
             Dict: Complete conversation result with final response and message history
@@ -5466,6 +5503,22 @@ class AIAgent:
         # Honcho should receive the actual user input, not system nudges.
         original_user_message = persist_user_message if persist_user_message is not None else user_message
 
+        # Per-turn tiny-router classification. This metadata drives route/memory/
+        # approval policies and is persisted with the user turn.
+        router_output = router_output_override
+        if router_output is None:
+            router_output = classify_turn(
+                self._tiny_router_config,
+                original_user_message,
+                messages,
+            )
+        self._current_router_output = router_output
+        self._aggressive_memory_flush_pending = (
+            router_output.should_aggressive_memory_flush(self._tiny_router_config)
+            if isinstance(router_output, RouterOutput)
+            else False
+        )
+
         # Track memory nudge trigger (turn-based, checked here).
         # Skill trigger is checked AFTER the agent loop completes, based on
         # how many tool iterations THIS turn used.
@@ -5477,6 +5530,13 @@ class AIAgent:
             if self._turns_since_memory >= self._memory_nudge_interval:
                 _should_review_memory = True
                 self._turns_since_memory = 0
+        if (
+            isinstance(router_output, RouterOutput)
+            and self._memory_store
+            and "memory" in self.valid_tool_names
+            and router_output.should_boost_memory_nudge(self._tiny_router_config)
+        ):
+            _should_review_memory = True
 
         # Honcho prefetch consumption:
         # - First turn: bake into cached system prompt (stable for the session).
@@ -5500,7 +5560,11 @@ class AIAgent:
                 logger.debug("Honcho prefetch failed (non-fatal): %s", e)
 
         # Add user message
-        user_msg = {"role": "user", "content": user_message}
+        user_msg = {
+            "role": "user",
+            "content": user_message,
+            "metadata": router_dict_from_output(router_output) if isinstance(router_output, RouterOutput) else None,
+        }
         messages.append(user_msg)
         current_turn_user_idx = len(messages) - 1
         self._persist_user_message_idx = current_turn_user_idx
@@ -5677,6 +5741,10 @@ class AIAgent:
                 # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
                 if "finish_reason" in api_msg:
                     api_msg.pop("finish_reason")
+                # Local-only message metadata (tiny-router etc.) is persisted but
+                # never sent to model providers.
+                if "metadata" in api_msg:
+                    api_msg.pop("metadata")
                 # Strip Codex Responses API fields (call_id, response_item_id) for
                 # strict providers like Mistral that reject unknown fields with 422.
                 # Uses new dicts so the internal messages list retains the fields
@@ -7094,6 +7162,14 @@ class AIAgent:
         # Clean up VM and browser for this task after conversation completes
         self._cleanup_task_resources(effective_task_id)
 
+        # For urgent/actionable turns, force a memory flush before persistence so
+        # the resulting memory tool events are captured in transcripts.
+        if final_response and self._aggressive_memory_flush_pending:
+            try:
+                self.flush_memories(messages, min_turns=0)
+            except Exception:
+                pass
+
         # Persist session to both JSON log and SQLite
         self._persist_session(messages, conversation_history)
 
@@ -7134,6 +7210,11 @@ class AIAgent:
             "estimated_cost_usd": self.session_estimated_cost_usd,
             "cost_status": self.session_cost_status,
             "cost_source": self.session_cost_source,
+            "router": (
+                router_dict_from_output(router_output)
+                if isinstance(router_output, RouterOutput)
+                else None
+            ),
         }
         self._response_was_previewed = False
         
@@ -7166,6 +7247,9 @@ class AIAgent:
                 )
             except Exception:
                 pass  # Background review is best-effort
+
+        self._current_router_output = None
+        self._aggressive_memory_flush_pending = False
 
         return result
 

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -1,4 +1,5 @@
 from agent.smart_model_routing import choose_cheap_model_route
+from agent.tiny_router import HeadPrediction, RouterOutput
 
 
 _BASE_CONFIG = {
@@ -7,6 +8,7 @@ _BASE_CONFIG = {
         "provider": "openrouter",
         "model": "google/gemini-2.5-flash",
     },
+    "tier_routes": {"low": "cheap", "medium": "primary", "high": "primary"},
 }
 
 
@@ -59,3 +61,256 @@ def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_r
     assert result["model"] == "anthropic/claude-sonnet-4"
     assert result["runtime"]["provider"] == "openrouter"
     assert result["label"] is None
+
+
+def test_resolve_turn_route_prefers_tiny_router_when_active(monkeypatch):
+    from agent.smart_model_routing import resolve_turn_route
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "cheap-key",
+            "source": "env/config",
+        },
+    )
+    result = resolve_turn_route(
+        "please summarize this chat quickly",
+        _BASE_CONFIG,
+        {
+            "model": "anthropic/claude-sonnet-4",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+            "api_key": "sk-primary",
+        },
+        tiny_router_config={"enabled": True, "behavior_mode": "active"},
+        router_output=RouterOutput(
+            relation_to_previous=HeadPrediction("follow_up", 0.7),
+            actionability=HeadPrediction("none", 0.9),
+            retention=HeadPrediction("ephemeral", 0.8),
+            urgency=HeadPrediction("low", 0.9),
+            overall_confidence=0.9,
+            source="heuristic",
+        ),
+    )
+    assert result["model"] == "google/gemini-2.5-flash"
+    assert result["runtime"]["provider"] == "openrouter"
+    assert result["label"].startswith("tiny-router")
+
+
+def test_resolve_turn_route_uses_named_low_tier_route(monkeypatch):
+    from agent.smart_model_routing import resolve_turn_route
+
+    monkeypatch.setenv("LOCAL_LLM_API_KEY", "local-key")
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "api_key": "local-key",
+            "source": "env/config",
+        },
+    )
+    cfg = {
+        "enabled": True,
+        "tier_routes": {"low": "local_fast", "medium": "primary", "high": "primary"},
+        "routes": {
+            "local_fast": {
+                "provider": "custom",
+                "model": "qwen2.5:7b-instruct",
+                "base_url": "http://127.0.0.1:11434/v1",
+                "api_key_env": "LOCAL_LLM_API_KEY",
+            }
+        },
+    }
+    result = resolve_turn_route(
+        "what time is it in tokyo?",
+        cfg,
+        {
+            "model": "anthropic/claude-sonnet-4",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+            "api_key": "sk-primary",
+        },
+    )
+    assert result["model"] == "qwen2.5:7b-instruct"
+    assert result["runtime"]["provider"] == "custom"
+    assert "local_fast" in (result["label"] or "")
+
+
+def test_tiny_router_high_stakes_uses_named_route_and_blocks_simple_downgrade(monkeypatch):
+    from agent.smart_model_routing import resolve_turn_route
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "strong-key",
+            "source": "env/config",
+        },
+    )
+    cfg = {
+        "enabled": True,
+        "tier_routes": {"low": "cheap", "medium": "primary", "high": "strong_remote"},
+        "cheap_model": {"provider": "openrouter", "model": "google/gemini-2.5-flash"},
+        "routes": {
+            "strong_remote": {
+                "provider": "openrouter",
+                "model": "anthropic/claude-opus-4.1",
+            }
+        },
+    }
+    result = resolve_turn_route(
+        "what time is it in tokyo?",
+        cfg,
+        {
+            "model": "anthropic/claude-sonnet-4",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+            "api_key": "sk-primary",
+        },
+        tiny_router_config={
+            "enabled": True,
+            "behavior_mode": "active",
+            "confidence_thresholds": {"overall": 0.4, "actionability": 0.5, "urgency": 0.5},
+        },
+        router_output=RouterOutput(
+            relation_to_previous=HeadPrediction("follow_up", 0.9),
+            actionability=HeadPrediction("act", 0.9),
+            retention=HeadPrediction("ephemeral", 0.8),
+            urgency=HeadPrediction("high", 0.9),
+            overall_confidence=0.9,
+            source="heuristic",
+        ),
+    )
+    assert result["model"] == "anthropic/claude-opus-4.1"
+    assert result["runtime"]["provider"] == "openrouter"
+    assert "tiny-router" in (result["label"] or "")
+
+
+def test_high_tier_budget_cap_falls_back_to_medium(monkeypatch):
+    from agent.smart_model_routing import resolve_turn_route
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "resolved-key",
+            "source": "env/config",
+        },
+    )
+
+    cfg = {
+        "enabled": True,
+        "tier_routes": {"low": "cheap", "medium": "medium_remote", "high": "strong_remote"},
+        "max_high_tier_calls_per_session": 1,
+        "cheap_model": {"provider": "openrouter", "model": "google/gemini-2.5-flash"},
+        "routes": {
+            "medium_remote": {
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+            "strong_remote": {
+                "provider": "openrouter",
+                "model": "anthropic/claude-opus-4.1",
+            },
+        },
+    }
+    primary = {
+        "model": "anthropic/claude-haiku-3.5",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_mode": "chat_completions",
+        "api_key": "primary-key",
+    }
+
+    first = resolve_turn_route(
+        "do this critical action now",
+        cfg,
+        primary,
+        tiny_router_config={"enabled": True, "behavior_mode": "active"},
+        router_output=RouterOutput(
+            relation_to_previous=HeadPrediction("follow_up", 0.9),
+            actionability=HeadPrediction("act", 0.9),
+            retention=HeadPrediction("ephemeral", 0.8),
+            urgency=HeadPrediction("high", 0.9),
+            overall_confidence=0.9,
+            source="heuristic",
+        ),
+        routing_context={"session_id": "session-budget-1"},
+    )
+    second = resolve_turn_route(
+        "another critical action",
+        cfg,
+        primary,
+        tiny_router_config={"enabled": True, "behavior_mode": "active"},
+        router_output=RouterOutput(
+            relation_to_previous=HeadPrediction("follow_up", 0.9),
+            actionability=HeadPrediction("act", 0.9),
+            retention=HeadPrediction("ephemeral", 0.8),
+            urgency=HeadPrediction("high", 0.9),
+            overall_confidence=0.9,
+            source="heuristic",
+        ),
+        routing_context={"session_id": "session-budget-1"},
+    )
+
+    assert first["model"] == "anthropic/claude-opus-4.1"
+    assert first["route_tier"] == "high"
+    assert second["model"] == "anthropic/claude-sonnet-4"
+    assert second["route_tier"] == "medium"
+
+
+def test_low_tier_route_failure_falls_back_to_primary(monkeypatch):
+    from agent.smart_model_routing import resolve_turn_route
+
+    def _runtime_resolve(**kwargs):
+        requested = kwargs.get("requested")
+        if requested == "broken":
+            raise RuntimeError("route unavailable")
+        return {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "resolved-key",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+
+    cfg = {
+        "enabled": True,
+        "tier_routes": {"low": "cheap", "medium": "medium_remote", "high": "primary"},
+        "cheap_model": {"provider": "broken", "model": "cheap-model"},
+        "routes": {
+            "medium_remote": {
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            }
+        },
+    }
+
+    result = resolve_turn_route(
+        "what time is it in tokyo?",
+        cfg,
+        {
+            "model": "anthropic/claude-haiku-3.5",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+            "api_key": "primary-key",
+        },
+    )
+
+    assert result["model"] == "anthropic/claude-haiku-3.5"
+    assert result["route_tier"] == "low"

--- a/tests/agent/test_tiny_router.py
+++ b/tests/agent/test_tiny_router.py
@@ -1,0 +1,219 @@
+from agent.tiny_router import (
+    HeadPrediction,
+    RouterOutput,
+    build_interaction_from_history,
+    classify_turn,
+    validate_tiny_router_config,
+)
+
+
+def test_classify_turn_disabled_returns_disabled_source():
+    out = classify_turn({"enabled": False}, "hello", [])
+    assert out.source == "disabled"
+    assert out.actionability.label == "none"
+
+
+def test_classify_turn_heuristic_fallback_when_subprocess_missing():
+    out = classify_turn(
+        {
+            "enabled": True,
+            "backend": "subprocess",
+            "repo_root": "/no/such/repo",
+            "model_dir": "/no/such/model",
+            "fallback_mode": "heuristic",
+        },
+        "please implement this fix now",
+        [],
+    )
+    assert out.source == "heuristic"
+    assert out.actionability.label in {"act", "review", "none"}
+
+
+def test_classify_turn_parses_subprocess_json_heads(tmp_path, monkeypatch):
+    repo_root = tmp_path / "tiny-router"
+    scripts_dir = repo_root / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "predict.py").write_text("print('ok')", encoding="utf-8")
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+
+    class _Proc:
+        returncode = 0
+        stdout = """
+{
+  "relation_to_previous": {"label": "new", "confidence": 0.95},
+  "actionability": {"label": "review", "confidence": 0.44},
+  "retention": {"label": "useful", "confidence": 0.64},
+  "urgency": {"label": "low", "confidence": 0.53},
+  "overall_confidence": 0.64
+}
+""".strip()
+        stderr = ""
+
+    monkeypatch.setattr("agent.tiny_router.subprocess.run", lambda *args, **kwargs: _Proc())
+
+    out = classify_turn(
+        {
+            "enabled": True,
+            "backend": "subprocess",
+            "repo_root": str(repo_root),
+            "model_dir": str(model_dir),
+            "enforce_pinned_commit": False,
+            "fallback_mode": "heuristic",
+        },
+        "what time is it in tokyo?",
+        [],
+    )
+    assert out.source == "subprocess"
+    assert out.actionability.label == "review"
+    assert out.actionability.confidence > 0.0
+    assert out.overall_confidence > 0.0
+
+
+def test_classify_turn_accepts_multimodal_list_input():
+    out = classify_turn(
+        {
+            "enabled": True,
+            "backend": "heuristic",
+            "fallback_mode": "heuristic",
+        },
+        [
+            {"type": "text", "text": "please implement this now"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+        ],
+        [],
+    )
+    assert out.source == "heuristic"
+    assert out.actionability.label == "act"
+
+
+def test_build_interaction_from_history_picks_previous_turn():
+    interaction = build_interaction_from_history(
+        [
+            {"role": "user", "content": "set a reminder for friday"},
+            {"role": "assistant", "content": "done"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "create_reminder", "arguments": "{}"}}],
+            },
+        ]
+    )
+    assert interaction["previous_text"] == "set a reminder for friday"
+    assert interaction["previous_outcome"] == "success"
+
+
+def test_build_interaction_from_history_handles_multimodal_content():
+    interaction = build_interaction_from_history(
+        [
+            {"role": "user", "content": [{"type": "text", "text": "send this to alex"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "done"}]},
+        ]
+    )
+    assert interaction["previous_text"] == "send this to alex"
+    assert interaction["previous_action"] == "none"
+
+
+def test_router_output_policy_helpers():
+    out = RouterOutput(
+        relation_to_previous=HeadPrediction("follow_up", 0.6),
+        actionability=HeadPrediction("review", 0.9),
+        retention=HeadPrediction("remember", 0.8),
+        urgency=HeadPrediction("high", 0.8),
+        overall_confidence=0.9,
+        source="heuristic",
+    )
+    cfg = {
+        "apply_approval_posture": True,
+        "confidence_thresholds": {
+            "overall": 0.4,
+            "actionability": 0.6,
+            "retention": 0.6,
+            "urgency": 0.6,
+        },
+    }
+    assert out.should_boost_memory_nudge(cfg) is True
+    assert out.needs_terminal_review_escalation(cfg) is True
+    assert out.should_use_cheap_model_route(cfg) is False
+
+
+def test_validate_tiny_router_config_checks_paths(tmp_path):
+    repo_root = tmp_path / "tiny-router"
+    scripts_dir = repo_root / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "predict.py").write_text("print('ok')", encoding="utf-8")
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+
+    ok, err = validate_tiny_router_config(
+        {
+            "enabled": True,
+            "backend": "subprocess",
+            "repo_root": str(repo_root),
+            "model_dir": str(model_dir),
+            "enforce_pinned_commit": False,
+        }
+    )
+    assert ok is True
+    assert err == ""
+
+
+def test_validate_tiny_router_config_enforces_pinned_commit(tmp_path, monkeypatch):
+    repo_root = tmp_path / "tiny-router"
+    scripts_dir = repo_root / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "predict.py").write_text("print('ok')", encoding="utf-8")
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+
+    class _Proc:
+        returncode = 0
+        stdout = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        stderr = ""
+
+    monkeypatch.setattr("agent.tiny_router.subprocess.run", lambda *args, **kwargs: _Proc())
+
+    ok, err = validate_tiny_router_config(
+        {
+            "enabled": True,
+            "backend": "subprocess",
+            "repo_root": str(repo_root),
+            "model_dir": str(model_dir),
+            "pinned_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "enforce_pinned_commit": True,
+        }
+    )
+    assert ok is False
+    assert "not pinned" in err
+
+
+def test_validate_tiny_router_config_uses_revision_file_when_git_unavailable(tmp_path, monkeypatch):
+    repo_root = tmp_path / "tiny-router"
+    scripts_dir = repo_root / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "predict.py").write_text("print('ok')", encoding="utf-8")
+    (repo_root / "REVISION").write_text(
+        "9d6b2a718a205d90ebe85e9a28f9b8a1f20801e4\n", encoding="utf-8"
+    )
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+
+    class _Proc:
+        returncode = 1
+        stdout = ""
+        stderr = "not a git repository"
+
+    monkeypatch.setattr("agent.tiny_router.subprocess.run", lambda *args, **kwargs: _Proc())
+
+    ok, err = validate_tiny_router_config(
+        {
+            "enabled": True,
+            "backend": "subprocess",
+            "repo_root": str(repo_root),
+            "model_dir": str(model_dir),
+            "pinned_commit": "9d6b2a718a205d90ebe85e9a28f9b8a1f20801e4",
+            "enforce_pinned_commit": True,
+            "source_revision_file": "REVISION",
+        }
+    )
+    assert ok is True
+    assert err == ""

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -213,6 +213,148 @@ def test_cli_turn_routing_uses_cheap_model_when_simple(monkeypatch):
     assert result["label"] is not None
 
 
+def test_cli_turn_routing_uses_named_low_tier_route(monkeypatch):
+    cli = _import_cli()
+
+    monkeypatch.setenv("LOCAL_LLM_API_KEY", "local-key")
+
+    def _runtime_resolve(**kwargs):
+        assert kwargs["requested"] == "custom"
+        return {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "api_key": "local-key",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+
+    shell = cli.HermesCLI(model="anthropic/claude-sonnet-4", compact=True, max_turns=1)
+    shell.provider = "openrouter"
+    shell.api_mode = "chat_completions"
+    shell.base_url = "https://openrouter.ai/api/v1"
+    shell.api_key = "primary-key"
+    shell._smart_model_routing = {
+        "enabled": True,
+        "tier_routes": {"low": "local_fast", "medium": "primary", "high": "primary"},
+        "routes": {
+            "local_fast": {
+                "provider": "custom",
+                "model": "qwen2.5:7b-instruct",
+                "base_url": "http://127.0.0.1:11434/v1",
+                "api_key_env": "LOCAL_LLM_API_KEY",
+            }
+        },
+        "max_simple_chars": 160,
+        "max_simple_words": 28,
+    }
+
+    result = shell._resolve_turn_agent_config("what time is it in tokyo?")
+
+    assert result["model"] == "qwen2.5:7b-instruct"
+    assert result["runtime"]["provider"] == "custom"
+    assert result["runtime"]["api_key"] == "local-key"
+    assert "local_fast" in (result["label"] or "")
+
+
+def test_cli_turn_routing_uses_tiny_router_active_mode(monkeypatch):
+    cli = _import_cli()
+    from agent.tiny_router import HeadPrediction, RouterOutput
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "zai",
+            "api_mode": "chat_completions",
+            "base_url": "https://open.z.ai/api/v1",
+            "api_key": "cheap-key",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+
+    shell = cli.HermesCLI(model="anthropic/claude-sonnet-4", compact=True, max_turns=1)
+    shell.provider = "openrouter"
+    shell.api_mode = "chat_completions"
+    shell.base_url = "https://openrouter.ai/api/v1"
+    shell.api_key = "primary-key"
+    shell._smart_model_routing = {
+        "enabled": True,
+        "cheap_model": {"provider": "zai", "model": "glm-5-air"},
+        "max_simple_chars": 160,
+        "max_simple_words": 28,
+    }
+    shell._tiny_router_config = {"enabled": True, "behavior_mode": "active"}
+
+    result = shell._resolve_turn_agent_config(
+        "please summarize this in one sentence",
+        router_output=RouterOutput(
+            relation_to_previous=HeadPrediction("follow_up", 0.7),
+            actionability=HeadPrediction("none", 0.9),
+            retention=HeadPrediction("ephemeral", 0.8),
+            urgency=HeadPrediction("low", 0.95),
+            overall_confidence=0.9,
+            source="heuristic",
+        ),
+    )
+
+    assert result["model"] == "glm-5-air"
+    assert result["runtime"]["provider"] == "zai"
+    assert "tiny-router" in (result["label"] or "")
+
+
+def test_classify_turn_with_indicator_prints_when_subprocess_backend(monkeypatch):
+    cli = _import_cli()
+    shell = cli.HermesCLI(model="anthropic/claude-sonnet-4", compact=True, max_turns=1)
+    shell._tiny_router_config = {"enabled": True, "backend": "subprocess"}
+
+    fake_output = SimpleNamespace(source="subprocess")
+    monkeypatch.setattr("agent.tiny_router.classify_turn", lambda cfg, message, history: fake_output)
+
+    printed = []
+    monkeypatch.setattr(cli, "_cprint", lambda msg: printed.append(str(msg)))
+
+    result = shell._classify_turn_with_indicator("route this", [], show_indicator=True)
+
+    assert result is fake_output
+    assert any("tiny-router: selecting model route" in line for line in printed)
+    assert any("tiny-router: route signal ready" in line for line in printed)
+
+
+def test_classify_turn_with_indicator_uses_tui_spinner_without_terminal_print(monkeypatch):
+    cli = _import_cli()
+    shell = cli.HermesCLI(model="anthropic/claude-sonnet-4", compact=True, max_turns=1)
+    shell._tiny_router_config = {"enabled": True, "backend": "subprocess"}
+
+    calls = {"invalidate": 0, "classify": 0}
+
+    def _classify(cfg, message, history):
+        calls["classify"] += 1
+        # Spinner text should be set while classify executes.
+        assert "tiny-router: selecting model route" in shell._spinner_text
+        return SimpleNamespace(source="subprocess")
+
+    monkeypatch.setattr("agent.tiny_router.classify_turn", _classify)
+
+    printed = []
+    monkeypatch.setattr(cli, "_cprint", lambda msg: printed.append(str(msg)))
+
+    shell._app = SimpleNamespace(invalidate=lambda: None)
+    shell._spinner_text = "existing spinner"
+
+    def _invalidate(min_interval=0.25):
+        calls["invalidate"] += 1
+
+    shell._invalidate = _invalidate
+    result = shell._classify_turn_with_indicator("route this", [], show_indicator=True)
+
+    assert result.source == "subprocess"
+    assert calls["classify"] == 1
+    assert calls["invalidate"] == 2
+    assert shell._spinner_text == "existing spinner"
+    assert printed == []
+
+
 def test_cli_prefers_config_provider_over_stale_env_override(monkeypatch):
     cli = _import_cli()
 

--- a/tests/test_cli_status_bar.py
+++ b/tests/test_cli_status_bar.py
@@ -118,6 +118,22 @@ class TestCLIStatusBar:
         assert "⚕" in text
         assert "claude-sonnet-4-20250514" in text
 
+    def test_status_bar_prefers_active_agent_model(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="anthropic/claude-sonnet-4-20250514"),
+            prompt_tokens=1000,
+            completion_tokens=500,
+            total_tokens=1500,
+            api_calls=1,
+            context_tokens=1000,
+            context_length=32000,
+        )
+        cli_obj.agent.model = "google/gemini-2.5-flash"
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "gemini-2.5-flash" in text
+
 
 class TestCLIUsageReport:
     def test_show_usage_includes_estimated_cost(self, capsys):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -83,7 +83,6 @@ class TestSessionLifecycle:
         child = db.get_session("child")
         assert child["parent_session_id"] == "parent"
 
-
 # =========================================================================
 # Message storage
 # =========================================================================
@@ -176,6 +175,22 @@ class TestMessageStorage:
 
         messages = db.get_messages("s1")
         assert messages[0]["finish_reason"] == "stop"
+
+    def test_metadata_roundtrip(self, db):
+        db.create_session(session_id="s1", source="cli")
+        metadata = {"tiny_router": {"retention": {"label": "remember", "confidence": 0.9}}}
+        db.append_message("s1", role="user", content="Remember this", metadata=metadata)
+
+        messages = db.get_messages("s1")
+        assert messages[0]["metadata"] == metadata
+
+    def test_conversation_view_includes_metadata(self, db):
+        db.create_session(session_id="s1", source="cli")
+        metadata = {"tiny_router": {"actionability": {"label": "review", "confidence": 0.8}}}
+        db.append_message("s1", role="user", content="double-check this", metadata=metadata)
+
+        conv = db.get_messages_as_conversation("s1")
+        assert conv[0]["metadata"] == metadata
 
 
 # =========================================================================
@@ -737,7 +752,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 5
+        assert version == 6
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -793,12 +808,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v5
+        # Open with SessionDB — should migrate to latest schema
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 5
+        assert cursor.fetchone()[0] == 6
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -493,6 +493,25 @@ def check_all_command_guards(command: str, env_type: str,
 
     session_key = os.getenv("HERMES_SESSION_KEY", "default")
 
+    # Tiny-router approval posture: when a turn is classified as "review",
+    # require user confirmation before executing risky shell commands.
+    try:
+        from agent.tiny_router import get_active_router_for_tools
+        from hermes_cli.config import load_config
+
+        _router_out = get_active_router_for_tools()
+        _cfg = load_config()
+        _smart = _cfg.get("smart_model_routing", {}) if isinstance(_cfg, dict) else {}
+        _tiny_cfg = _smart.get("tiny_router", {}) if isinstance(_smart, dict) else {}
+        if _router_out and _router_out.needs_terminal_review_escalation(_tiny_cfg):
+            _router_key = "tiny_router:review"
+            _router_desc = "tiny-router policy: this turn is review-required"
+            if not is_approved(session_key, _router_key):
+                # Session-only approval behavior (same as tirith warnings).
+                warnings.append((_router_key, _router_desc, True))
+    except Exception:
+        pass
+
     if tirith_result["action"] == "warn":
         findings = tirith_result.get("findings") or []
         rule_id = findings[0].get("rule_id", "unknown") if findings else "unknown"


### PR DESCRIPTION
## Summary
- Integrate `tiny-router` as a first-class per-turn classifier and route signal, including robust subprocess + heuristic fallback behavior and pinned-source validation.
- Apply router outputs across model routing, memory/compression posture, approval posture, and message metadata persistence in CLI and gateway flows.
- Improve developer/operator ergonomics with integration docs, a local test plan, and stronger CLI visibility of routing decisions (active model/status updates and tiny-router wait-state indicator).

## Test plan
- [x] `python3 -m pytest tests/agent/test_tiny_router.py tests/agent/test_smart_model_routing.py tests/test_cli_provider_resolution.py tests/test_cli_status_bar.py tests/test_hermes_state.py -q -o addopts=''`
- [x] `python3 -m pytest tests/test_cli_provider_resolution.py tests/test_cli_status_bar.py -q -o addopts=''`
- [ ] `python3 -m pytest tests/ -q -o addopts=''` (blocked locally by missing/old external deps: `acp` package and `mcp.types` mismatch)

Made with [Cursor](https://cursor.com)