### PR TITLE
fix: custom provider identity hardcoded as "openrouter"

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -198,7 +198,7 @@ def _resolve_named_custom_runtime(
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
     return {
-        "provider": "openrouter",
+        "provider": custom_provider.get("name", requested_provider),
         "api_mode": custom_provider.get("api_mode")
         or _detect_api_mode_for_url(base_url)
         or "chat_completions",


### PR DESCRIPTION
## Summary
- `_resolve_named_custom_runtime()` in `hermes_cli/runtime_provider.py` hardcodes `"provider": "openrouter"` in the return dict, even when resolving a custom provider (e.g. local llama.cpp endpoint)
- This value propagates to `AgentRuntime.provider` and gets injected into the agent's system prompt (`Provider: openrouter`), misleading the model about its own inference backend
- Fix: return the actual provider name from config instead of the hardcoded string

## Change
```diff
-        "provider": "openrouter",
+        "provider": custom_provider.get("name", requested_provider),
```

## Impact
Anyone using `--provider custom` with a non-OpenRouter endpoint (local llama.cpp, vLLM, etc.) currently sees "Provider: openrouter" in agent logs and system prompt. After this fix, the agent correctly identifies its provider.

`_resolve_openrouter_runtime()` (line 283) is intentionally left unchanged — that path is specifically for OpenRouter.

## Test plan
- [ ] Configure a custom provider with `provider: "custom"` and `base_url: "http://localhost:8080/v1"`
- [ ] Run `python cli.py -q "test" --provider custom --model <model>`
- [ ] Verify system prompt shows `Provider: custom` instead of `Provider: openrouter`
- [ ] Verify OpenRouter-based providers still resolve correctly as `"openrouter"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)