### PR TITLE
fix(telegram): normalize em/en dash to ASCII hyphen in bot command descriptions

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -301,7 +301,10 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
         if cmd.cli_only:
             continue
         tg_name = cmd.name.replace("-", "_")
-        result.append((tg_name, cmd.description))
+        # Telegram BotFather rejects command descriptions containing Unicode dashes.
+        # Normalize em dash (U+2014) and en dash (U+2013) to ASCII hyphen-minus.
+        desc = cmd.description.replace("\u2014", "-").replace("\u2013", "-")
+        result.append((tg_name, desc))
     return result
 
 


### PR DESCRIPTION
Fixes #2925

## Problem
Telegram BotFather rejects bot command descriptions containing Unicode em dash (U+2014) or en dash (U+2013). When command descriptions include these characters, setMyCommands fails with:
"Sorry, the list of commands is invalid."

## Fix
In `telegram_bot_commands()`, normalize em dash (—) and en dash (–) to ASCII hyphen-minus (-) before passing descriptions to Telegram's setMyCommands API.

## Scope
One-line change in hermes_cli/commands.py — no behavior change for non-Telegram platforms.
