### PR TITLE
fix(delegate): give subagents isolated iteration budgets

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -877,5 +877,80 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             self.assertEqual(kwargs["base_url"], parent.base_url)
 
 
+class TestSubagentBudgetIsolation(unittest.TestCase):
+    """Tests for subagent iteration budget isolation (#2873).
+
+    Subagents should get their own iteration budget based on their max_iterations,
+    NOT inherit the parent's partially-consumed budget.
+    """
+
+    @patch("run_agent.AIAgent")
+    def test_subagent_gets_own_budget(self, MockAgent):
+        """Subagent receives iteration_budget=None so AIAgent creates a fresh budget."""
+        mock_child = MagicMock()
+        mock_child.run_conversation.return_value = {
+            "final_response": "done", "completed": True, "api_calls": 5
+        }
+        MockAgent.return_value = mock_child
+
+        parent = _make_mock_parent()
+        # Simulate parent having consumed some iterations
+        from run_agent import IterationBudget
+        parent.iteration_budget = IterationBudget(max_total=90)
+        parent.iteration_budget._used = 60  # Parent has used 60 of 90
+
+        delegate_task(goal="Test task", max_iterations=50, parent_agent=parent)
+
+        # Verify AIAgent was called with iteration_budget=None
+        _, kwargs = MockAgent.call_args
+        self.assertIsNone(kwargs.get("iteration_budget"))
+        # This means AIAgent.__init__ will create IterationBudget(50) for the child,
+        # giving it a full 50 iterations regardless of parent's consumed budget.
+
+    @patch("run_agent.AIAgent")
+    def test_max_iterations_passed_through(self, MockAgent):
+        """The max_iterations parameter is passed to child agent."""
+        mock_child = MagicMock()
+        mock_child.run_conversation.return_value = {
+            "final_response": "done", "completed": True, "api_calls": 1
+        }
+        MockAgent.return_value = mock_child
+
+        parent = _make_mock_parent()
+
+        delegate_task(goal="Test task", max_iterations=25, parent_agent=parent)
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["max_iterations"], 25)
+
+    @patch("run_agent.AIAgent")
+    def test_parallel_subagents_independent_budgets(self, MockAgent):
+        """Multiple parallel subagents each get their own budget."""
+        mock_child = MagicMock()
+        mock_child.run_conversation.return_value = {
+            "final_response": "done", "completed": True, "api_calls": 10
+        }
+        MockAgent.return_value = mock_child
+
+        parent = _make_mock_parent()
+        from run_agent import IterationBudget
+        parent.iteration_budget = IterationBudget(max_total=90)
+        parent.iteration_budget._used = 30
+
+        tasks = [
+            {"goal": "Task A"},
+            {"goal": "Task B"},
+            {"goal": "Task C"},
+        ]
+        delegate_task(tasks=tasks, max_iterations=50, parent_agent=parent)
+
+        # All 3 subagents should get iteration_budget=None
+        self.assertEqual(MockAgent.call_count, 3)
+        for call in MockAgent.call_args_list:
+            _, kwargs = call
+            self.assertIsNone(kwargs.get("iteration_budget"))
+            self.assertEqual(kwargs["max_iterations"], 50)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -191,9 +191,16 @@ def _build_child_agent(
     # Build progress callback to relay tool calls to parent display
     child_progress_cb = _build_child_progress_callback(task_index, parent_agent)
 
-    # Share the parent's iteration budget so subagent tool calls
-    # count toward the session-wide limit.
-    shared_budget = getattr(parent_agent, "iteration_budget", None)
+    # Each subagent gets its own iteration budget based on its max_iterations.
+    # Previously, we shared the parent's budget, which caused subagents to hit
+    # max_iterations prematurely when the parent had already consumed part of
+    # the budget (#2873). Now each subagent gets a fresh budget so that
+    # max_iterations=50 actually means 50 iterations for that specific subagent.
+    #
+    # Note: This means the total iterations across parent + all subagents can
+    # exceed the parent's max_iterations. If session-wide caps are needed,
+    # consider implementing an explicit session_budget parameter in the future.
+    subagent_budget = None  # AIAgent.__init__ will create IterationBudget(max_iterations)
 
     # Resolve effective credentials: config override > parent inherit
     effective_model = model or parent_agent.model
@@ -230,7 +237,7 @@ def _build_child_agent(
         providers_order=parent_agent.providers_order,
         provider_sort=parent_agent.provider_sort,
         tool_progress_callback=child_progress_cb,
-        iteration_budget=shared_budget,
+        iteration_budget=subagent_budget,
     )
     # Set delegation depth so children can't spawn grandchildren
     child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1


### PR DESCRIPTION
## Summary

Subagents now get their own iteration budget based on their `max_iterations`, rather than inheriting the parent's partially-consumed budget. This fixes subagents hitting `max_iterations` prematurely.

## Problem (#2873)

When a subagent was created with `max_iterations=50`, it would inherit the parent's `IterationBudget`. If the parent had already consumed iterations (e.g., 30 of 90), all subagents would race to consume the remaining 60 iterations. Each subagent would only get ~20 iterations on average before hitting the budget cap, even though they were configured for 50.

This was especially problematic in batch mode with 3 parallel subagents sharing the same depleted budget.

## Solution

Pass `iteration_budget=None` to subagents instead of the parent's budget. `AIAgent.__init__` will then create a fresh `IterationBudget(max_iterations)` for each subagent, ensuring that `max_iterations=50` actually means 50 iterations for that specific subagent.

## Trade-off

This means the total iterations across parent + all subagents can exceed the parent's `max_iterations`. If session-wide hard caps are needed in the future, an explicit `session_budget` parameter should be implemented.

## Testing

Added `TestSubagentBudgetIsolation` test class with tests for:
- ✅ Subagent receives `iteration_budget=None`
- ✅ `max_iterations` is passed through correctly
- ✅ Parallel subagents each get independent budgets

Closes #2873