### PR TITLE
feat(gateway): add safe in-chat /restart command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1089,6 +1089,9 @@ class GatewayRunner:
         except Exception as e:
             logger.warning("Channel directory build failed: %s", e)
         
+        # Check if we're restarting after an in-chat operational command.
+        await self._send_restart_notification()
+
         # Check if we're restarting after a /update command. If the update is
         # still running, keep watching so we notify once it actually finishes.
         notified = await self._send_update_notification()
@@ -1560,6 +1563,9 @@ class GatewayRunner:
             if event.get_command() == "status":
                 return await self._handle_status_command(event)
 
+            if event.get_command() == "restart":
+                return await self._handle_restart_command(event)
+
             # /reset and /new must bypass the running-agent guard so they
             # actually dispatch as commands instead of being queued as user
             # text (which would be fed back to the agent with the same
@@ -1670,6 +1676,9 @@ class GatewayRunner:
         
         if canonical == "status":
             return await self._handle_status_command(event)
+
+        if canonical == "restart":
+            return await self._handle_restart_command(event)
         
         if canonical == "stop":
             return await self._handle_stop_command(event)
@@ -4412,6 +4421,80 @@ class GatewayRunner:
         self._schedule_update_notification_watch()
         return "⚕ Starting Hermes update… I'll notify you when it's done."
 
+    async def _handle_restart_command(self, event: MessageEvent) -> Optional[str]:
+        """Handle /restart command — restart the gateway safely from chat."""
+        import json
+        import shutil
+        import subprocess
+        from datetime import datetime
+
+        from hermes_cli.gateway import get_service_name
+
+        adapter = self.adapters.get(event.source.platform)
+        if not adapter:
+            return "✗ Gateway adapter is unavailable for this platform."
+
+        systemctl = shutil.which("systemctl")
+        if not systemctl:
+            return "✗ Could not find `systemctl` on this system."
+
+        systemd_run = shutil.which("systemd-run")
+        if not systemd_run:
+            return (
+                "✗ Safe in-chat restart is unavailable because `systemd-run` is missing. "
+                "Please restart externally with:\n"
+                f"`{systemctl} --user restart {get_service_name()}`"
+            )
+
+        pending_path = _hermes_home / ".restart_pending.json"
+        pending = {
+            "platform": event.source.platform.value,
+            "chat_id": event.source.chat_id,
+            "user_id": event.source.user_id,
+            "thread_id": event.source.thread_id,
+            "timestamp": datetime.now().isoformat(),
+        }
+        pending_path.write_text(json.dumps(pending))
+
+        ack = "↻ Restarting gateway… I'll message again when I'm back."
+        metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+        ack_result = await adapter.send(
+            chat_id=event.source.chat_id,
+            content=ack,
+            reply_to=event.message_id,
+            metadata=metadata,
+        )
+        if not ack_result.success:
+            pending_path.unlink(missing_ok=True)
+            return f"✗ Failed to send restart acknowledgement: {ack_result.error or 'unknown error'}"
+
+        restart_cmd = [systemctl, "--user", "restart", get_service_name()]
+        try:
+            subprocess.Popen(
+                [
+                    systemd_run,
+                    "--user",
+                    "--scope",
+                    "--unit=hermes-restart",
+                    "--",
+                    *restart_cmd,
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        except Exception as e:
+            pending_path.unlink(missing_ok=True)
+            await adapter.send(
+                chat_id=event.source.chat_id,
+                content=f"✗ Failed to start restart helper: {e}",
+                reply_to=event.message_id,
+                metadata=metadata,
+            )
+            return None
+
+        return None
+
     def _schedule_update_notification_watch(self) -> None:
         """Ensure a background task is watching for update completion."""
         existing_task = getattr(self, "_update_notification_task", None)
@@ -4447,6 +4530,54 @@ class GatewayRunner:
             logger.warning("Update watcher timed out waiting for completion marker")
             exit_code_path.write_text("124")
             await self._send_update_notification()
+
+    async def _send_restart_notification(self) -> bool:
+        """Notify the originating chat after a successful gateway restart."""
+        import json
+
+        pending_path = _hermes_home / ".restart_pending.json"
+        if not pending_path.exists():
+            return False
+
+        cleanup = False
+        try:
+            pending = json.loads(pending_path.read_text())
+            platform_str = pending.get("platform")
+            chat_id = pending.get("chat_id")
+            thread_id = pending.get("thread_id")
+            if not platform_str or not chat_id:
+                cleanup = True
+                return False
+
+            try:
+                platform = Platform(platform_str)
+            except Exception:
+                cleanup = True
+                return False
+
+            adapter = self.adapters.get(platform)
+            if not adapter:
+                logger.info(
+                    "Deferring restart notification: adapter unavailable for %s",
+                    platform_str,
+                )
+                return False
+
+            metadata = {"thread_id": thread_id} if thread_id else None
+            await adapter.send(
+                chat_id,
+                "✓ Gateway restarted successfully.",
+                reply_to=None,
+                metadata=metadata,
+            )
+            cleanup = True
+            return True
+        except Exception:
+            logger.debug("Failed to send restart notification", exc_info=True)
+            return False
+        finally:
+            if cleanup:
+                pending_path.unlink(missing_ok=True)
 
     async def _send_update_notification(self) -> bool:
         """If an update finished, notify the user.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -71,6 +71,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("q",), args_hint="<prompt>"),
     CommandDef("status", "Show session info", "Session",
                gateway_only=True),
+    CommandDef("restart", "Restart the gateway service safely", "Session",
+               gateway_only=True),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",

--- a/tests/gateway/test_restart_command.py
+++ b/tests/gateway/test_restart_command.py
@@ -1,0 +1,214 @@
+"""Tests for /restart gateway slash command."""
+
+import json
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.session import SessionSource
+
+
+def _make_event(text="/restart", platform=Platform.TELEGRAM,
+                user_id="12345", chat_id="67890", thread_id=None):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+        thread_id=thread_id,
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    return runner
+
+
+def _make_adapter():
+    adapter = AsyncMock()
+    adapter.send.return_value = SendResult(success=True, message_id="msg-1")
+    return adapter
+
+
+class TestHandleRestartCommand:
+    @pytest.mark.asyncio
+    async def test_sends_ack_then_spawns_detached_restart_and_writes_marker(self, tmp_path):
+        runner = _make_runner()
+        event = _make_event(platform=Platform.TELEGRAM, chat_id="99999", thread_id="topic-7")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        mock_popen = MagicMock()
+        mock_adapter = _make_adapter()
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        def fake_which(name):
+            if name == "systemd-run":
+                return "/usr/bin/systemd-run"
+            if name == "systemctl":
+                return "/usr/bin/systemctl"
+            return None
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("shutil.which", side_effect=fake_which), \
+             patch("hermes_cli.gateway.get_service_name", return_value="hermes-gateway"), \
+             patch("subprocess.Popen", mock_popen):
+            result = await runner._handle_restart_command(event)
+
+        assert result is None
+        pending_path = hermes_home / ".restart_pending.json"
+        assert pending_path.exists()
+        data = json.loads(pending_path.read_text())
+        assert data["platform"] == "telegram"
+        assert data["chat_id"] == "99999"
+        assert data["thread_id"] == "topic-7"
+
+        mock_adapter.send.assert_called_once_with(
+            chat_id="99999",
+            content="↻ Restarting gateway… I'll message again when I'm back.",
+            reply_to=event.message_id,
+            metadata={"thread_id": "topic-7"},
+        )
+
+        call_args = mock_popen.call_args[0][0]
+        assert call_args[:5] == [
+            "/usr/bin/systemd-run",
+            "--user",
+            "--scope",
+            "--unit=hermes-restart",
+            "--",
+        ]
+        assert call_args[5:] == [
+            "/usr/bin/systemctl",
+            "--user",
+            "restart",
+            "hermes-gateway",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_refuses_inline_restart_when_systemd_run_missing(self, tmp_path):
+        runner = _make_runner()
+        event = _make_event()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        mock_adapter = _make_adapter()
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        def fake_which(name):
+            if name == "systemctl":
+                return "/usr/bin/systemctl"
+            return None
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("shutil.which", side_effect=fake_which), \
+             patch("subprocess.Popen") as mock_popen:
+            result = await runner._handle_restart_command(event)
+
+        assert "safe in-chat restart is unavailable" in result.lower()
+        mock_popen.assert_not_called()
+        mock_adapter.send.assert_not_called()
+        assert not (hermes_home / ".restart_pending.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_aborts_restart_if_ack_send_fails(self, tmp_path):
+        runner = _make_runner()
+        event = _make_event(platform=Platform.TELEGRAM, chat_id="99999", thread_id="topic-7")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        mock_adapter = _make_adapter()
+        mock_adapter.send.return_value = SendResult(success=False, error="network down")
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        def fake_which(name):
+            if name == "systemd-run":
+                return "/usr/bin/systemd-run"
+            if name == "systemctl":
+                return "/usr/bin/systemctl"
+            return None
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("shutil.which", side_effect=fake_which), \
+             patch("hermes_cli.gateway.get_service_name", return_value="hermes-gateway"), \
+             patch("subprocess.Popen") as mock_popen:
+            result = await runner._handle_restart_command(event)
+
+        assert "failed to send restart acknowledgement" in result.lower()
+        mock_popen.assert_not_called()
+        assert not (hermes_home / ".restart_pending.json").exists()
+
+
+class TestSendRestartNotification:
+    @pytest.mark.asyncio
+    async def test_sends_restart_notification_and_cleans_up_marker(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".restart_pending.json"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "111",
+            "user_id": "222",
+            "thread_id": "topic-9",
+        }))
+
+        mock_adapter = _make_adapter()
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            result = await runner._send_restart_notification()
+
+        assert result is True
+        mock_adapter.send.assert_called_once()
+        assert mock_adapter.send.call_args[0][0] == "111"
+        assert "restarted successfully" in mock_adapter.send.call_args[0][1].lower()
+        assert mock_adapter.send.call_args[1]["reply_to"] is None
+        assert mock_adapter.send.call_args[1]["metadata"] == {"thread_id": "topic-9"}
+        assert not pending_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_keeps_marker_when_send_fails_for_retry(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".restart_pending.json"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "111",
+            "user_id": "222",
+            "thread_id": "topic-9",
+        }))
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send.side_effect = RuntimeError("send failed")
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            result = await runner._send_restart_notification()
+
+        assert result is False
+        mock_adapter.send.assert_called_once()
+        assert pending_path.exists()
+
+
+class TestRestartCommandRegistration:
+    @pytest.mark.asyncio
+    async def test_restart_in_help_output(self):
+        runner = _make_runner()
+        event = _make_event(text="/help")
+        result = await runner._handle_help_command(event)
+        assert "/restart" in result
+
+    def test_restart_is_registered_command(self):
+        from hermes_cli.commands import resolve_command
+
+        cmd = resolve_command("restart")
+        assert cmd is not None
+        assert cmd.name == "restart"
+        assert cmd.gateway_only is True


### PR DESCRIPTION
## What does this PR do?

This PR adds a safe in-chat `/restart` command for the gateway.

Before this change, restarting the gateway from chat was awkward because the restart process could terminate the same process that was trying to execute it, and there was no reliable post-restart confirmation back to the user.

This implementation launches the restart in a detached user systemd scope, explicitly sends the pre-restart acknowledgement before triggering the restart, then sends a confirmation message after the gateway comes back up. It also preserves thread/topic context for that confirmation and avoids losing the notification marker on transient delivery failures.

## Related Issue

Fixes #2894

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- added `/restart` to the gateway command registry in `hermes_cli/commands.py`
- added `_handle_restart_command()` in `gateway/run.py`
- explicitly sends the pre-restart acknowledgement through the adapter before launching the restart helper, so the first message is not lost in the restart race
- launches restart detached via `systemd-run --user --scope -- systemctl --user restart <service>`
- added startup-time `_send_restart_notification()` handling in `gateway/run.py`
- stores restart marker state in `.restart_pending.json`
- preserves `thread_id` so the success message returns to the same thread/topic when applicable
- keeps the marker on transient send failure so notification can be retried on a later startup
- added tests in `tests/gateway/test_restart_command.py` for:
  - command registration / help visibility
  - marker creation
  - pre-restart acknowledgement send
  - detached restart invocation
  - aborting restart if acknowledgement delivery fails
  - thread/topic metadata preservation
  - successful restart notification delivery
  - marker retention when notification delivery fails

## How to Test

1. run targeted gateway tests:
   - `venv/bin/python -m pytest tests/gateway/test_restart_command.py tests/gateway/test_update_command.py -q`
2. optionally run the full test suite:
   - `venv/bin/python -m pytest tests/ -q`
3. in a gateway-backed chat, send `/restart`
4. confirm the gateway first replies:
   - `↻ Restarting gateway… I'll message again when I'm back.`
5. confirm that after the service comes back it sends:
   - `✓ Gateway restarted successfully.`
6. if testing in a threaded/topic context, confirm the success message is sent back to the same thread/topic

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian aarch64 (Raspberry Pi, Linux 6.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- full test suite: `6157 passed, 164 skipped, 109 warnings in 78.20s`
- targeted restart/update verification: `32 passed in 2.90s`
