### PR TITLE
feat(plugins): fire pre_llm_call, post_llm_call, on_session_start, on_session_end hooks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5931,6 +5931,12 @@ class HermesCLI:
         except Exception:
             pass
 
+        try:
+            from hermes_cli.plugins import invoke_hook
+            invoke_hook("on_session_start", session_id=self.session_id, platform="cli")
+        except Exception:
+            pass
+
         # If resuming a session, load history and display it immediately
         # so the user has context before typing their first message.
         if self._resumed:
@@ -7146,6 +7152,11 @@ class HermesCLI:
                     self._session_db.end_session(self.agent.session_id, "cli_close")
                 except Exception as e:
                     logger.debug("Could not close session in DB: %s", e)
+            try:
+                from hermes_cli.plugins import invoke_hook
+                invoke_hook("on_session_end", session_id=self.session_id, platform="cli")
+            except Exception:
+                pass
             _run_cleanup()
             self._print_exit_summary()
 

--- a/docs/llm-switch-plugin-example/README.md
+++ b/docs/llm-switch-plugin-example/README.md
@@ -1,0 +1,109 @@
+# llm-switch — Local LLM Server Manager Plugin
+
+Auto-manage a local LLM server (llama.cpp, vLLM, etc.) from within Hermes.
+Switch models via `/model` and the server starts, stops, and swaps automatically.
+
+## Motivation
+
+Many users run local models alongside cloud providers — using llama.cpp for
+drafting, coding, or research while keeping cloud models for complex tasks.
+Today this requires manually starting/stopping the server outside of Hermes.
+
+This plugin bridges that gap: configure your local models in a YAML file,
+and Hermes handles the server lifecycle transparently. Switch between local
+and cloud models with `/model` — the same command you already use.
+
+## How it works
+
+The plugin uses two lifecycle hooks:
+
+- **`pre_llm_call`** — fires before every LLM API call. If the active model
+  matches a locally configured model and the correct server isn't running,
+  the plugin starts it automatically.
+- **`on_session_end`** — kills the server when you exit Hermes.
+
+It also registers a **`switch_local_llm` tool** so the agent can switch
+models autonomously (e.g., "switch to the code model for this task").
+
+## Setup
+
+1. Copy the plugin to your Hermes plugins directory:
+
+   ```bash
+   cp -r examples/plugins/llm-switch ~/.hermes/plugins/llm-switch
+   ```
+
+2. Create your model config:
+
+   ```bash
+   cd ~/.hermes/plugins/llm-switch
+   cp models.yaml.example models.yaml
+   # Edit models.yaml — set your models_dir, GGUF paths, and sampling params
+   ```
+
+3. Add a custom provider for your local endpoint in `~/.hermes/config.yaml`:
+
+   ```yaml
+   custom_providers:
+     - name: local
+       base_url: http://localhost:8080/v1
+       api_key: "sk-local"
+   ```
+
+4. Start Hermes and switch to a local model:
+
+   ```
+   /model custom:write
+   ```
+
+   The server starts automatically on your next message.
+
+## Usage
+
+```
+/model custom:write          # Switch to local "write" model — server auto-starts
+/model custom:research       # Swap to "research" — old server killed, new one starts
+/model anthropic:claude-opus-4.6  # Switch to cloud — server stays running
+/model custom:code           # Back to local with "code" model
+```
+
+The agent can also switch models via the tool:
+
+```
+User: "This task needs the code model"
+Agent: [calls switch_local_llm(model="code")]
+```
+
+## Configuration
+
+See `models.yaml.example` for the full schema. Key sections:
+
+### `server` — shared server settings
+
+| Field             | Default          | Description                    |
+|-------------------|------------------|--------------------------------|
+| `binary`          | `llama-server`   | Server binary name or path     |
+| `models_dir`      | `~/llama-models` | Base directory for model files |
+| `host`            | `0.0.0.0`        | Listen address                 |
+| `port`            | `8080`           | Listen port                    |
+| `gpu_layers`      | `99`             | GPU offload layers (-ngl)      |
+| `flash_attention` | `true`           | Flash attention (-fa)          |
+| `parallel`        | `1`              | Concurrent slots (-np)         |
+| `jinja`           | `true`           | Chat templates (--jinja)       |
+
+### `models.<name>` — per-model settings
+
+| Field         | Required | Description                              |
+|---------------|----------|------------------------------------------|
+| `gguf`        | yes      | Path to GGUF file (relative to models_dir) |
+| `description` | no       | Human-readable purpose                   |
+| `context`     | no       | Context size in tokens (default: 8192)   |
+| `kv_cache`    | no       | `{key: q8_0, value: q4_0}` quantization  |
+| `sampling`    | no       | Default sampling: temp, top_p, top_k, etc. |
+| `alias`       | no       | Name reported by /v1/models              |
+
+## Environment variables
+
+| Variable             | Description                                  |
+|----------------------|----------------------------------------------|
+| `LLM_SWITCH_MODELS`  | Custom path to models.yaml (default: plugin dir) |

--- a/docs/llm-switch-plugin-example/__init__.py
+++ b/docs/llm-switch-plugin-example/__init__.py
@@ -1,0 +1,169 @@
+"""llm-switch plugin — auto-manage local LLM servers when switching models.
+
+Uses the pre_llm_call hook to detect when the active model matches a locally
+configured model, and starts/swaps the server automatically.  Also registers
+a switch_local_llm tool so the agent can switch models autonomously.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_PLUGIN_DIR = Path(__file__).parent
+_config: Optional[Dict[str, Any]] = None
+
+
+def _load_config() -> Optional[Dict[str, Any]]:
+    """Load models.yaml from plugin dir or LLM_SWITCH_MODELS env var."""
+    global _config
+    if _config is not None:
+        return _config
+
+    config_path = os.getenv(
+        "LLM_SWITCH_MODELS", str(_PLUGIN_DIR / "models.yaml")
+    )
+    try:
+        import yaml
+    except ImportError:
+        logger.warning("llm-switch: PyYAML not installed, plugin disabled")
+        return None
+
+    path = Path(config_path)
+    if not path.exists():
+        logger.info(
+            "llm-switch: No models.yaml found at %s — copy models.yaml.example to get started",
+            path,
+        )
+        return None
+
+    with open(path, encoding="utf-8") as f:
+        _config = yaml.safe_load(f)
+    return _config
+
+
+# ---------------------------------------------------------------------------
+# Hooks
+# ---------------------------------------------------------------------------
+
+def _on_pre_llm_call(messages: list, model: str, **kwargs: Any) -> None:
+    """Auto-start the right local server before each LLM call.
+
+    If the current model name matches a key in models.yaml and the correct
+    server isn't already running, kill any existing server and start the
+    right one.  This makes ``/model custom:write`` seamless — the server
+    spins up on the first message after switching.
+    """
+    from . import server
+
+    config = _load_config()
+    if not config or model not in config.get("models", {}):
+        return  # not a local model — nothing to do
+
+    status = server.get_status(config)
+    if status.get("running") and status.get("model") == model:
+        return  # correct model already running
+
+    desc = config["models"][model].get("description", model)
+    print(f"  Starting local model: {model} ({desc})")
+
+    if server.start_server(model, config):
+        port = config.get("server", {}).get("port", 8080)
+        print(f"  Ready on http://localhost:{port}/v1")
+    else:
+        print(f"  WARNING: Server timed out — check /tmp/llama-server.log")
+
+
+def _on_session_end(session_id: str, platform: str, **kwargs: Any) -> None:
+    """Kill the local server when the session ends."""
+    config = _load_config()
+    if not config:
+        return
+    try:
+        from . import server
+
+        status = server.get_status(config)
+        if status.get("running"):
+            binary = config.get("server", {}).get("binary", "llama-server")
+            server.kill_server(binary=binary)
+            logger.info("llm-switch: Stopped server on session end")
+    except Exception as exc:
+        logger.debug("llm-switch: Error stopping server: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Tool handler
+# ---------------------------------------------------------------------------
+
+def _handle_switch(args: dict, **kwargs: Any) -> str:
+    """Handle the switch_local_llm tool call."""
+    from . import server
+
+    model = args.get("model", "").strip()
+
+    config = _load_config()
+    if not config:
+        return json.dumps({"error": "No models.yaml configured"})
+
+    if model == "status":
+        return json.dumps(server.get_status(config))
+
+    if model == "stop":
+        binary = config.get("server", {}).get("binary", "llama-server")
+        server.kill_server(binary=binary)
+        return json.dumps({"status": "stopped"})
+
+    if model == "list":
+        models = {
+            k: v.get("description", "")
+            for k, v in config.get("models", {}).items()
+        }
+        return json.dumps({"models": models})
+
+    if model not in config.get("models", {}):
+        available = list(config.get("models", {}).keys())
+        return json.dumps(
+            {"error": f"Unknown model '{model}'", "available": available}
+        )
+
+    desc = config["models"][model].get("description", model)
+    print(f"  Switching to: {model} ({desc})")
+    ok = server.start_server(model, config)
+    port = config.get("server", {}).get("port", 8080)
+
+    if ok:
+        return json.dumps({
+            "status": "ready",
+            "model": model,
+            "description": desc,
+            "endpoint": f"http://localhost:{port}/v1",
+        })
+    return json.dumps({
+        "status": "starting",
+        "model": model,
+        "note": "Server still loading — check /tmp/llama-server.log",
+    })
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def register(ctx: Any) -> None:
+    """Wire schemas to handlers and register lifecycle hooks."""
+    from . import schemas
+
+    ctx.register_tool(
+        name="switch_local_llm",
+        toolset="llm-switch",
+        schema=schemas.SWITCH_LOCAL_LLM,
+        handler=_handle_switch,
+        description="Switch local LLM model",
+    )
+    ctx.register_hook("pre_llm_call", _on_pre_llm_call)
+    ctx.register_hook("on_session_end", _on_session_end)

--- a/docs/llm-switch-plugin-example/models.yaml.example
+++ b/docs/llm-switch-plugin-example/models.yaml.example
@@ -1,0 +1,73 @@
+# Local LLM server configuration for the llm-switch plugin.
+# Copy to models.yaml and edit to match your setup.
+#
+# Supports any OpenAI-compatible server (llama.cpp, vLLM, etc.)
+# The plugin auto-starts/stops the server when you switch models via /model.
+#
+# Usage:
+#   /model custom:write     — starts llama-server with the "write" model
+#   /model custom:code      — swaps to the "code" model
+#   /model anthropic:claude-opus-4.6  — switches to cloud (server stays running)
+#   /model custom:write     — switches back to local
+
+server:
+  binary: llama-server             # Server binary name or absolute path
+  models_dir: ~/llama-models       # Base directory for model files (GGUF, etc.)
+  host: 0.0.0.0                    # Listen address
+  port: 8080                       # Listen port
+  gpu_layers: 99                   # -ngl flag (-1 for all layers)
+  flash_attention: true            # -fa flag (recommended for Ampere+)
+  parallel: 1                      # -np flag (concurrent request slots)
+  jinja: true                      # --jinja flag (enable chat templates)
+
+models:
+  # Each key becomes the model name for /model custom:<key>
+  #
+  # Required fields:
+  #   gguf          — path to model file, relative to server.models_dir
+  #
+  # Optional fields:
+  #   description   — human-readable purpose (shown in status messages)
+  #   context       — context window size in tokens (default: 8192)
+  #   kv_cache      — KV cache quantization: {key: q8_0, value: q4_0}
+  #   sampling      — default sampling params (client can override per-request)
+  #     temp, top_p, top_k, min_p, presence_penalty, repeat_penalty
+  #   alias         — model name reported by /v1/models (default: key name)
+
+  write:
+    description: "SEO articles and content briefs"
+    gguf: qwen3.5-9b/Qwen3.5-9B-UD-Q6_K_XL.gguf
+    context: 49152
+    kv_cache:
+      key: q8_0
+      value: q4_0
+    sampling:
+      temp: 0.7
+      top_p: 0.8
+      top_k: 20
+      presence_penalty: 1.5
+
+  research:
+    description: "Long research with max context"
+    gguf: qwen3.5-9b/Qwen3.5-9B-UD-Q4_K_XL.gguf
+    context: 65536
+    kv_cache:
+      key: q4_0
+      value: q4_0
+    sampling:
+      temp: 0.7
+      top_p: 0.8
+      top_k: 20
+      presence_penalty: 1.5
+
+  code:
+    description: "Agentic coding and tool calling"
+    gguf: omnicoder-9b/omnicoder-9b-q4_k_m.gguf
+    context: 65536
+    kv_cache:
+      key: q4_0
+      value: q4_0
+    sampling:
+      temp: 0.6
+      top_p: 0.95
+      top_k: 20

--- a/docs/llm-switch-plugin-example/plugin.yaml
+++ b/docs/llm-switch-plugin-example/plugin.yaml
@@ -1,0 +1,7 @@
+name: llm-switch
+version: 1.0.0
+description: Auto-manage local LLM servers (llama.cpp, vLLM) when switching models via /model
+author: community
+provides:
+  tools: true
+  hooks: true

--- a/docs/llm-switch-plugin-example/schemas.py
+++ b/docs/llm-switch-plugin-example/schemas.py
@@ -1,0 +1,27 @@
+"""Tool schemas for the llm-switch plugin."""
+
+SWITCH_LOCAL_LLM = {
+    "name": "switch_local_llm",
+    "description": (
+        "Switch the local LLM server to a different model. "
+        "Only one model can run at a time on a single GPU. "
+        "The server is automatically managed — calling this tool kills the "
+        "current server (if any) and starts a new one with the requested model. "
+        "Available actions: provide a model name to switch, 'status' to check "
+        "what's running, 'stop' to kill the server, or 'list' to see available models."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "model": {
+                "type": "string",
+                "description": (
+                    "Model name to switch to (must match a key in models.yaml), "
+                    "or 'status' to check current server, 'stop' to kill it, "
+                    "'list' to show available models."
+                ),
+            },
+        },
+        "required": ["model"],
+    },
+}

--- a/docs/llm-switch-plugin-example/server.py
+++ b/docs/llm-switch-plugin-example/server.py
@@ -1,0 +1,152 @@
+"""Server lifecycle management for local LLM servers.
+
+Pure Python — no shell or OS-specific dependencies beyond subprocess and /proc.
+Works with any OpenAI-compatible server (llama.cpp, vLLM, etc.).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Map from YAML sampling key names to llama-server CLI flags
+_SAMPLING_FLAGS = {
+    "temp": "--temp",
+    "top_p": "--top-p",
+    "top_k": "--top-k",
+    "min_p": "--min-p",
+    "presence_penalty": "--presence-penalty",
+    "repeat_penalty": "--repeat-penalty",
+    "frequency_penalty": "--frequency-penalty",
+}
+
+
+def kill_server(binary: str = "llama-server", timeout: float = 5.0) -> None:
+    """Kill any running server process and wait for it to exit."""
+    subprocess.run(["pkill", "-f", binary], capture_output=True)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(["pgrep", "-f", binary], capture_output=True)
+        if result.returncode != 0:
+            return  # process gone
+        time.sleep(0.2)
+    # Force kill if still alive
+    subprocess.run(["pkill", "-9", "-f", binary], capture_output=True)
+
+
+def build_command(model_key: str, config: Dict[str, Any]) -> List[str]:
+    """Build the server command line from a models.yaml config."""
+    server_cfg = config.get("server", {})
+    model_cfg = config["models"][model_key]
+    models_dir = Path(server_cfg.get("models_dir", "~/llama-models")).expanduser()
+
+    cmd = [
+        server_cfg.get("binary", "llama-server"),
+        "-m", str(models_dir / model_cfg["gguf"]),
+        "-c", str(model_cfg.get("context", 8192)),
+        "-ngl", str(server_cfg.get("gpu_layers", 99)),
+        "-np", str(server_cfg.get("parallel", 1)),
+        "--host", server_cfg.get("host", "0.0.0.0"),
+        "--port", str(server_cfg.get("port", 8080)),
+    ]
+
+    if server_cfg.get("flash_attention"):
+        cmd += ["-fa", "on"]
+    if server_cfg.get("jinja"):
+        cmd.append("--jinja")
+
+    # KV cache quantization
+    kv = model_cfg.get("kv_cache", {})
+    if kv.get("key"):
+        cmd += ["-ctk", str(kv["key"])]
+    if kv.get("value"):
+        cmd += ["-ctv", str(kv["value"])]
+
+    # Sampling defaults
+    sampling = model_cfg.get("sampling", {})
+    for param, flag in _SAMPLING_FLAGS.items():
+        if param in sampling:
+            cmd += [flag, str(sampling[param])]
+
+    # Model alias (reported by /v1/models)
+    alias = model_cfg.get("alias", model_key)
+    cmd += ["--alias", alias]
+
+    return cmd
+
+
+def start_server(
+    model_key: str,
+    config: Dict[str, Any],
+    timeout: int = 60,
+) -> bool:
+    """Kill existing server, start a new one, and wait for it to be healthy.
+
+    Returns True if the server is ready, False if it timed out.
+    """
+    binary = config.get("server", {}).get("binary", "llama-server")
+    kill_server(binary=binary)
+
+    cmd = build_command(model_key, config)
+    logger.info("Starting server: %s", " ".join(cmd))
+
+    log_path = Path("/tmp/llama-server.log")
+    log_file = log_path.open("w")
+    subprocess.Popen(cmd, stdout=log_file, stderr=log_file)
+
+    port = config.get("server", {}).get("port", 8080)
+    health_url = f"http://localhost:{port}/health"
+
+    for _ in range(timeout):
+        try:
+            import urllib.request
+            with urllib.request.urlopen(health_url, timeout=2) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(1)
+
+    return False
+
+
+def get_status(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Check if the server is running and which model is loaded."""
+    binary = config.get("server", {}).get("binary", "llama-server")
+    result = subprocess.run(
+        ["pgrep", "-f", binary], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        return {"running": False}
+
+    pid_str = result.stdout.strip().split("\n")[0]
+    try:
+        pid = int(pid_str)
+    except ValueError:
+        return {"running": False}
+
+    # Extract --alias from /proc/<pid>/cmdline
+    alias = None
+    try:
+        cmdline = Path(f"/proc/{pid}/cmdline").read_bytes()
+        parts = cmdline.decode(errors="replace").split("\0")
+        for i, part in enumerate(parts):
+            if part == "--alias" and i + 1 < len(parts):
+                alias = parts[i + 1]
+                break
+    except Exception:
+        pass
+
+    port = config.get("server", {}).get("port", 8080)
+    return {
+        "running": True,
+        "pid": pid,
+        "alias": alias,
+        "model": alias,  # convenience alias
+        "endpoint": f"http://localhost:{port}/v1",
+    }

--- a/run_agent.py
+++ b/run_agent.py
@@ -5779,6 +5779,12 @@ class AIAgent:
                     if os.getenv("HERMES_DUMP_REQUESTS", "").strip().lower() in {"1", "true", "yes", "on"}:
                         self._dump_api_request_debug(api_kwargs, reason="preflight")
 
+                    try:
+                        from hermes_cli.plugins import invoke_hook
+                        invoke_hook("pre_llm_call", messages=api_messages, model=self.model)
+                    except Exception:
+                        pass
+
                     if self._has_stream_consumers():
                         # Streaming path: fire delta callbacks for real-time
                         # token delivery to CLI display, gateway, or TTS.
@@ -5806,9 +5812,15 @@ class AIAgent:
                     if self.thinking_callback:
                         self.thinking_callback("")
                     
+                    try:
+                        from hermes_cli.plugins import invoke_hook
+                        invoke_hook("post_llm_call", messages=api_messages, response=response, model=self.model)
+                    except Exception:
+                        pass
+
                     if not self.quiet_mode:
                         self._vprint(f"{self.log_prefix}⏱️  API call completed in {api_duration:.2f}s")
-                    
+
                     if self.verbose_logging:
                         # Log response with provider info if available
                         resp_model = getattr(response, 'model', 'N/A') if response else 'N/A'


### PR DESCRIPTION
## Summary

The plugin system declares 6 lifecycle hooks in `VALID_HOOKS` (plugins.py:52-59), but only 2 are actually invoked (`pre_tool_call`, `post_tool_call`). The remaining 4 are documented in the [plugin guide](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/guides/build-a-hermes-plugin.md#register-multiple-hooks) and accepted by `register_hook()`, but never fired anywhere in the codebase — making them dead code.

This PR wires up all 4 missing hooks:

- **`pre_llm_call` / `post_llm_call`** — fired in `run_agent.py` around the main LLM API call (covers both streaming and non-streaming paths)
- **`on_session_start`** — fired in `cli.py` when the interactive session begins (after banner, before first prompt)
- **`on_session_end`** — fired in `cli.py` during session cleanup (before `_run_cleanup()`)

Each invocation uses the same try/import/invoke/except pattern as the existing `pre_tool_call`/`post_tool_call` hooks in `model_tools.py`.

## Motivation

These hooks unlock important plugin use cases that aren't possible today:

- **`pre_llm_call`**: Auto-manage local LLM servers — when a user switches to a local model via `/model custom:write`, a plugin can detect the model name and start/swap a llama-server or vLLM instance before the API call goes out. This is the primary motivating use case.
- **`post_llm_call`**: Token usage tracking, response logging, cost monitoring across providers.
- **`on_session_start`**: Initialize plugin state, connect to external services, display plugin status.
- **`on_session_end`**: Clean up resources (kill servers, close connections, flush logs).

## Example Plugin: llm-switch

Included in `docs/llm-switch-plugin-example/` is a complete working plugin that demonstrates the hooks. It auto-manages a local llama-server when switching models:

1. User defines models in a `models.yaml` file (GGUF paths, context sizes, sampling params)
2. When user does `/model custom:write`, the `pre_llm_call` hook detects "write" in the config
3. Plugin kills any running server and starts the right one
4. `on_session_end` kills the server on exit
5. Also registers a `switch_local_llm` tool for agent-driven switching

```yaml
# models.yaml — declarative model config (replaces shell scripts)
server:
  binary: llama-server
  models_dir: ~/llama-models
  port: 8080
  gpu_layers: 99

models:
  write:
    description: "SEO articles and content briefs"
    gguf: qwen3.5-9b/Qwen3.5-9B-UD-Q6_K_XL.gguf
    context: 49152
    kv_cache: { key: q8_0, value: q4_0 }
    sampling: { temp: 0.7, top_p: 0.8 }
```

## Changes

- `run_agent.py`: +10 lines — `invoke_hook("pre_llm_call", ...)` before API call, `invoke_hook("post_llm_call", ...)` after response
- `cli.py`: +10 lines — `invoke_hook("on_session_start", ...)` in `run()`, `invoke_hook("on_session_end", ...)` in cleanup
- `docs/llm-switch-plugin-example/`: Complete example plugin (6 files)

## Testing

- Verified the hook invocations don't break existing behavior when no plugins are registered (the try/except pattern ensures graceful degradation)
- The example plugin is self-contained and can be tested by copying to `~/.hermes/plugins/llm-switch/`
- No existing tests are affected — the hooks are observer-only and wrapped in exception handlers

## Platforms tested

- Linux (Arch)