### PR TITLE
fix: support Ollama Cloud and remote Ollama endpoints

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -227,7 +227,7 @@ def is_local_endpoint(base_url: str) -> bool:
     return False
 
 
-def detect_local_server_type(base_url: str) -> Optional[str]:
+def detect_server_type(base_url: str, *, _is_local: Optional[bool] = None) -> Optional[str]:
     """Detect which server is running at base_url by probing known endpoints.
 
     Works for both local and remote (cloud) servers — e.g. Ollama Cloud,
@@ -242,8 +242,9 @@ def detect_local_server_type(base_url: str) -> Optional[str]:
     if server_url.endswith("/v1"):
         server_url = server_url[:-3]
 
-    # Use a longer timeout for remote/cloud endpoints
-    timeout = 2.0 if is_local_endpoint(base_url) else 5.0
+    if _is_local is None:
+        _is_local = is_local_endpoint(base_url)
+    timeout = 2.0 if _is_local else 5.0
 
     try:
         with httpx.Client(timeout=timeout) as client:
@@ -596,11 +597,11 @@ def _model_id_matches(candidate_id: str, lookup_model: str) -> bool:
     return False
 
 
-def _query_local_context_length(model: str, base_url: str) -> Optional[int]:
+def _query_server_context_length(model: str, base_url: str) -> Optional[int]:
     """Query a server for the model's context length.
 
-    Despite the name, works for both local and remote (cloud) servers
-    such as Ollama Cloud or self-hosted Ollama on a VPS.
+    Works for both local and remote (cloud) servers — e.g. Ollama Cloud,
+    self-hosted Ollama on a VPS, etc.
     """
     import httpx
 
@@ -613,13 +614,14 @@ def _query_local_context_length(model: str, base_url: str) -> Optional[int]:
     if server_url.endswith("/v1"):
         server_url = server_url[:-3]
 
+    _is_local = is_local_endpoint(base_url)
+
     try:
-        server_type = detect_local_server_type(base_url)
+        server_type = detect_server_type(base_url, _is_local=_is_local)
     except Exception:
         server_type = None
 
-    # Use a longer timeout for remote/cloud endpoints
-    timeout = 3.0 if is_local_endpoint(base_url) else 8.0
+    timeout = 3.0 if _is_local else 8.0
 
     try:
         with httpx.Client(timeout=timeout) as client:
@@ -825,20 +827,20 @@ def get_model_context_length(
             context_length = matched.get("context_length")
             if isinstance(context_length, int):
                 return context_length
-        if not _is_known_provider_base_url(base_url):
-            # 3. Try querying the server directly (local or remote — covers
-            #    Ollama Cloud, self-hosted Ollama on a VPS, etc.)
-            local_ctx = _query_local_context_length(model, base_url)
-            if local_ctx and local_ctx > 0:
-                save_context_length(model, base_url, local_ctx)
-                return local_ctx
-            logger.info(
-                "Could not detect context length for model %r at %s — "
-                "defaulting to %s tokens (probe-down). Set model.context_length "
-                "in config.yaml to override.",
-                model, base_url, f"{DEFAULT_FALLBACK_CONTEXT:,}",
-            )
-            return DEFAULT_FALLBACK_CONTEXT
+        # 3. Try querying the server directly (local or remote — covers
+        #    Ollama Cloud, self-hosted Ollama on a VPS, etc.)
+        #    Guard already checked by outer `not _is_known_provider_base_url`.
+        server_ctx = _query_server_context_length(model, base_url)
+        if server_ctx and server_ctx > 0:
+            save_context_length(model, base_url, server_ctx)
+            return server_ctx
+        logger.info(
+            "Could not detect context length for model %r at %s — "
+            "defaulting to %s tokens (probe-down). Set model.context_length "
+            "in config.yaml to override.",
+            model, base_url, f"{DEFAULT_FALLBACK_CONTEXT:,}",
+        )
+        return DEFAULT_FALLBACK_CONTEXT
 
     # 4. Anthropic /v1/models API (only for regular API keys, not OAuth)
     if provider == "anthropic" or (
@@ -886,14 +888,7 @@ def get_model_context_length(
         if default_model in model_lower:
             return length
 
-    # 9. Query server as last resort (local or remote custom endpoints)
-    if base_url and not _is_known_provider_base_url(base_url):
-        local_ctx = _query_local_context_length(model, base_url)
-        if local_ctx and local_ctx > 0:
-            save_context_length(model, base_url, local_ctx)
-            return local_ctx
-
-    # 10. Default fallback — 128K
+    # 9. Default fallback — 128K
     return DEFAULT_FALLBACK_CONTEXT
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -228,7 +228,10 @@ def is_local_endpoint(base_url: str) -> bool:
 
 
 def detect_local_server_type(base_url: str) -> Optional[str]:
-    """Detect which local server is running at base_url by probing known endpoints.
+    """Detect which server is running at base_url by probing known endpoints.
+
+    Works for both local and remote (cloud) servers — e.g. Ollama Cloud,
+    self-hosted Ollama on a VPS, etc.
 
     Returns one of: "ollama", "lm-studio", "vllm", "llamacpp", or None.
     """
@@ -239,8 +242,11 @@ def detect_local_server_type(base_url: str) -> Optional[str]:
     if server_url.endswith("/v1"):
         server_url = server_url[:-3]
 
+    # Use a longer timeout for remote/cloud endpoints
+    timeout = 2.0 if is_local_endpoint(base_url) else 5.0
+
     try:
-        with httpx.Client(timeout=2.0) as client:
+        with httpx.Client(timeout=timeout) as client:
             # LM Studio exposes /api/v1/models — check first (most specific)
             try:
                 r = client.get(f"{server_url}/api/v1/models")
@@ -591,7 +597,11 @@ def _model_id_matches(candidate_id: str, lookup_model: str) -> bool:
 
 
 def _query_local_context_length(model: str, base_url: str) -> Optional[int]:
-    """Query a local server for the model's context length."""
+    """Query a server for the model's context length.
+
+    Despite the name, works for both local and remote (cloud) servers
+    such as Ollama Cloud or self-hosted Ollama on a VPS.
+    """
     import httpx
 
     # Strip recognised provider prefix (e.g., "local:model-name" → "model-name").
@@ -608,8 +618,11 @@ def _query_local_context_length(model: str, base_url: str) -> Optional[int]:
     except Exception:
         server_type = None
 
+    # Use a longer timeout for remote/cloud endpoints
+    timeout = 3.0 if is_local_endpoint(base_url) else 8.0
+
     try:
-        with httpx.Client(timeout=3.0) as client:
+        with httpx.Client(timeout=timeout) as client:
             # Ollama: /api/show returns model details with context info
             if server_type == "ollama":
                 resp = client.post(f"{server_url}/api/show", json={"name": model})
@@ -813,12 +826,12 @@ def get_model_context_length(
             if isinstance(context_length, int):
                 return context_length
         if not _is_known_provider_base_url(base_url):
-            # 3. Try querying local server directly
-            if is_local_endpoint(base_url):
-                local_ctx = _query_local_context_length(model, base_url)
-                if local_ctx and local_ctx > 0:
-                    save_context_length(model, base_url, local_ctx)
-                    return local_ctx
+            # 3. Try querying the server directly (local or remote — covers
+            #    Ollama Cloud, self-hosted Ollama on a VPS, etc.)
+            local_ctx = _query_local_context_length(model, base_url)
+            if local_ctx and local_ctx > 0:
+                save_context_length(model, base_url, local_ctx)
+                return local_ctx
             logger.info(
                 "Could not detect context length for model %r at %s — "
                 "defaulting to %s tokens (probe-down). Set model.context_length "
@@ -873,8 +886,8 @@ def get_model_context_length(
         if default_model in model_lower:
             return length
 
-    # 9. Query local server as last resort
-    if base_url and is_local_endpoint(base_url):
+    # 9. Query server as last resort (local or remote custom endpoints)
+    if base_url and not _is_known_provider_base_url(base_url):
         local_ctx = _query_local_context_length(model, base_url)
         if local_ctx and local_ctx > 0:
             save_context_length(model, base_url, local_ctx)

--- a/cli.py
+++ b/cli.py
@@ -1064,10 +1064,11 @@ class HermesCLI:
         _config_model = _model_config.get("default", "") if isinstance(_model_config, dict) else (_model_config or "")
         _FALLBACK_MODEL = "anthropic/claude-opus-4.6"
         self.model = model or _config_model or _FALLBACK_MODEL
-        # Auto-detect model from local server if still on fallback
+        # Auto-detect model from server if still on fallback.
+        # Works for local AND remote endpoints (e.g. Ollama Cloud, self-hosted Ollama).
         if self.model == _FALLBACK_MODEL:
             _base_url = _model_config.get("base_url", "") if isinstance(_model_config, dict) else ""
-            if "localhost" in _base_url or "127.0.0.1" in _base_url:
+            if _base_url and "openrouter.ai" not in _base_url:
                 from hermes_cli.runtime_provider import _auto_detect_local_model
                 _detected = _auto_detect_local_model(_base_url)
                 if _detected:

--- a/cli.py
+++ b/cli.py
@@ -1068,11 +1068,13 @@ class HermesCLI:
         # Works for local AND remote endpoints (e.g. Ollama Cloud, self-hosted Ollama).
         if self.model == _FALLBACK_MODEL:
             _base_url = _model_config.get("base_url", "") if isinstance(_model_config, dict) else ""
-            if _base_url and "openrouter.ai" not in _base_url:
-                from hermes_cli.runtime_provider import _auto_detect_local_model
-                _detected = _auto_detect_local_model(_base_url)
-                if _detected:
-                    self.model = _detected
+            if _base_url:
+                from agent.model_metadata import _is_known_provider_base_url
+                if not _is_known_provider_base_url(_base_url):
+                    from hermes_cli.runtime_provider import _auto_detect_local_model
+                    _detected = _auto_detect_local_model(_base_url)
+                    if _detected:
+                        self.model = _detected
         # Track whether model was explicitly chosen by the user or fell back
         # to the global default.  Provider-specific normalisation may override
         # the default silently but should warn when overriding an explicit choice.

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -65,9 +65,13 @@ def _get_model_config() -> Dict[str, Any]:
         cfg = dict(model_cfg)
         default = cfg.get("default", "").strip()
         base_url = cfg.get("base_url", "").strip()
-        is_custom_endpoint = base_url and "openrouter.ai" not in base_url
         is_fallback = not default or default == "anthropic/claude-opus-4.6"
-        if is_custom_endpoint and is_fallback:
+        if is_fallback and base_url:
+            from agent.model_metadata import _is_known_provider_base_url
+            is_custom = not _is_known_provider_base_url(base_url)
+        else:
+            is_custom = False
+        if is_custom:
             detected = _auto_detect_local_model(base_url)
             if detected:
                 cfg["default"] = detected

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -65,9 +65,9 @@ def _get_model_config() -> Dict[str, Any]:
         cfg = dict(model_cfg)
         default = cfg.get("default", "").strip()
         base_url = cfg.get("base_url", "").strip()
-        is_local = "localhost" in base_url or "127.0.0.1" in base_url
+        is_custom_endpoint = base_url and "openrouter.ai" not in base_url
         is_fallback = not default or default == "anthropic/claude-opus-4.6"
-        if is_local and is_fallback and base_url:
+        if is_custom_endpoint and is_fallback:
             detected = _auto_detect_local_model(base_url)
             if detected:
                 cfg["default"] = detected

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -212,7 +212,7 @@ class TestGetModelContextLength:
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
-    @patch("agent.model_metadata._query_local_context_length", return_value=None)
+    @patch("agent.model_metadata._query_server_context_length", return_value=None)
     def test_custom_endpoint_without_metadata_skips_name_based_default(self, mock_local_query, mock_endpoint_fetch, mock_fetch):
         mock_fetch.return_value = {}
         mock_endpoint_fetch.return_value = {}

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -212,7 +212,8 @@ class TestGetModelContextLength:
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
-    def test_custom_endpoint_without_metadata_skips_name_based_default(self, mock_endpoint_fetch, mock_fetch):
+    @patch("agent.model_metadata._query_local_context_length", return_value=None)
+    def test_custom_endpoint_without_metadata_skips_name_based_default(self, mock_local_query, mock_endpoint_fetch, mock_fetch):
         mock_fetch.return_value = {}
         mock_endpoint_fetch.return_value = {}
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,7 @@ import builtins
 import importlib
 import logging
 import sys
+import pytest
 
 from agent.prompt_builder import (
     _scan_context_content,
@@ -22,6 +23,12 @@ from agent.prompt_builder import (
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
 )
+
+
+def _filesystem_is_case_sensitive(path):
+    probe_lower = path / "case-probe"
+    probe_lower.write_text("x")
+    return not (path / "CASE-PROBE").exists()
 
 
 # =========================================================================
@@ -561,6 +568,8 @@ class TestBuildContextFilesPrompt:
         assert "Lowercase claude rules" in result
 
     def test_claude_md_uppercase_takes_priority(self, tmp_path):
+        if not _filesystem_is_case_sensitive(tmp_path):
+            pytest.skip("Case-insensitive filesystems cannot represent both CLAUDE.md and claude.md")
         (tmp_path / "CLAUDE.md").write_text("From uppercase.")
         (tmp_path / "claude.md").write_text("From lowercase.")
         result = build_context_files_prompt(cwd=str(tmp_path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,56 @@ def mock_config():
 def _timeout_handler(signum, frame):
     raise TimeoutError("Test exceeded 30 second timeout")
 
+
+def pytest_sessionstart(session):
+    """Raise the soft open-file limit for the test process when possible."""
+    try:
+        import resource
+    except ImportError:
+        return
+
+    try:
+        soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    except (OSError, ValueError):
+        return
+
+    target_limit = 4096
+    if hard_limit == resource.RLIM_INFINITY:
+        new_soft_limit = max(soft_limit, target_limit)
+    else:
+        new_soft_limit = min(max(soft_limit, target_limit), hard_limit)
+
+    if new_soft_limit <= soft_limit:
+        return
+
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft_limit, hard_limit))
+    except (OSError, ValueError):
+        return
+
+
+def pytest_xdist_auto_num_workers(config):
+    """Cap xdist auto workers on hosts with low file-descriptor limits."""
+    try:
+        import resource
+    except ImportError:
+        return None
+
+    cpu_count = os.cpu_count() or 1
+    try:
+        soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+    except (OSError, ValueError):
+        return None
+
+    if soft_limit <= 0:
+        return None
+
+    reserve_fds = 128
+    estimated_fds_per_worker = 32
+    max_workers_by_fd = max(1, (soft_limit - reserve_fds) // estimated_fds_per_worker)
+    return max(1, min(cpu_count, max_workers_by_fd))
+
+
 @pytest.fixture(autouse=True)
 def _ensure_current_event_loop(request):
     """Provide a default event loop for sync tests that call get_event_loop().

--- a/tests/test_model_metadata_local_ctx.py
+++ b/tests/test_model_metadata_local_ctx.py
@@ -454,17 +454,35 @@ class TestGetModelContextLengthLocalFallback:
 
         assert result == CONTEXT_PROBE_TIERS[0]
 
-    def test_non_local_endpoint_does_not_query_local_server(self):
-        """For non-local endpoints, _query_local_context_length is not called."""
-        from agent.model_metadata import get_model_context_length, CONTEXT_PROBE_TIERS
+    def test_remote_custom_endpoint_queries_server(self):
+        """Remote custom endpoints (e.g. Ollama Cloud) ARE probed for context length."""
+        from agent.model_metadata import get_model_context_length
 
         with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
              patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
              patch("agent.model_metadata.is_local_endpoint", return_value=False), \
+             patch("agent.model_metadata._is_known_provider_base_url", return_value=False), \
+             patch("agent.model_metadata.save_context_length"), \
+             patch("agent.model_metadata._query_local_context_length", return_value=32768) as mock_query:
+            result = get_model_context_length(
+                "llama3:8b", "https://ollama-cloud.example.com/v1"
+            )
+
+        mock_query.assert_called()
+        assert result == 32768
+
+    def test_known_provider_endpoint_does_not_query_server(self):
+        """Known provider endpoints (OpenRouter, etc.) are NOT probed via local query."""
+        from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
+
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.model_metadata._is_known_provider_base_url", return_value=True), \
              patch("agent.model_metadata._query_local_context_length") as mock_query:
             result = get_model_context_length(
-                "unknown-model", "https://some-cloud-api.example.com/v1"
+                "unknown-model", "https://openrouter.ai/api/v1"
             )
 
         mock_query.assert_not_called()

--- a/tests/test_model_metadata_local_ctx.py
+++ b/tests/test_model_metadata_local_ctx.py
@@ -1,4 +1,4 @@
-"""Tests for _query_local_context_length and the local server fallback in
+"""Tests for _query_server_context_length and the server fallback in
 get_model_context_length.
 
 All tests use synthetic inputs — no filesystem or live server required.
@@ -15,11 +15,11 @@ import pytest
 
 
 # ---------------------------------------------------------------------------
-# _query_local_context_length — unit tests with mocked httpx
+# _query_server_context_length — unit tests with mocked httpx
 # ---------------------------------------------------------------------------
 
 class TestQueryLocalContextLengthOllama:
-    """_query_local_context_length with server_type == 'ollama'."""
+    """_query_server_context_length with server_type == 'ollama'."""
 
     def _make_resp(self, status_code, body):
         resp = MagicMock()
@@ -29,7 +29,7 @@ class TestQueryLocalContextLengthOllama:
 
     def test_ollama_model_info_context_length(self):
         """Reads context length from model_info dict in /api/show response."""
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         show_resp = self._make_resp(200, {
             "model_info": {"llama.context_length": 131072}
@@ -42,15 +42,15 @@ class TestQueryLocalContextLengthOllama:
         client_mock.post.return_value = show_resp
         client_mock.get.return_value = models_resp
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"), \
+        with patch("agent.model_metadata.detect_server_type", return_value="ollama"), \
              patch("httpx.Client", return_value=client_mock):
-            result = _query_local_context_length("omnicoder-9b", "http://localhost:11434/v1")
+            result = _query_server_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
         assert result == 131072
 
     def test_ollama_parameters_num_ctx(self):
         """Falls back to num_ctx in parameters string when model_info lacks context_length."""
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         show_resp = self._make_resp(200, {
             "model_info": {},
@@ -64,15 +64,15 @@ class TestQueryLocalContextLengthOllama:
         client_mock.post.return_value = show_resp
         client_mock.get.return_value = models_resp
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"), \
+        with patch("agent.model_metadata.detect_server_type", return_value="ollama"), \
              patch("httpx.Client", return_value=client_mock):
-            result = _query_local_context_length("some-model", "http://localhost:11434/v1")
+            result = _query_server_context_length("some-model", "http://localhost:11434/v1")
 
         assert result == 32768
 
     def test_ollama_show_404_falls_through(self):
         """When /api/show returns 404, falls through to /v1/models/{model}."""
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         show_resp = self._make_resp(404, {})
         model_detail_resp = self._make_resp(200, {"max_model_len": 65536})
@@ -83,15 +83,15 @@ class TestQueryLocalContextLengthOllama:
         client_mock.post.return_value = show_resp
         client_mock.get.return_value = model_detail_resp
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"), \
+        with patch("agent.model_metadata.detect_server_type", return_value="ollama"), \
              patch("httpx.Client", return_value=client_mock):
-            result = _query_local_context_length("some-model", "http://localhost:11434/v1")
+            result = _query_server_context_length("some-model", "http://localhost:11434/v1")
 
         assert result == 65536
 
 
 class TestQueryLocalContextLengthVllm:
-    """_query_local_context_length with vLLM-style /v1/models/{model} response."""
+    """_query_server_context_length with vLLM-style /v1/models/{model} response."""
 
     def _make_resp(self, status_code, body):
         resp = MagicMock()
@@ -101,7 +101,7 @@ class TestQueryLocalContextLengthVllm:
 
     def test_vllm_max_model_len(self):
         """Reads max_model_len from /v1/models/{model} response."""
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         detail_resp = self._make_resp(200, {"id": "omnicoder-9b", "max_model_len": 100000})
         list_resp = self._make_resp(404, {})
@@ -112,15 +112,15 @@ class TestQueryLocalContextLengthVllm:
         client_mock.post.return_value = self._make_resp(404, {})
         client_mock.get.return_value = detail_resp
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value="vllm"), \
+        with patch("agent.model_metadata.detect_server_type", return_value="vllm"), \
              patch("httpx.Client", return_value=client_mock):
-            result = _query_local_context_length("omnicoder-9b", "http://localhost:8000/v1")
+            result = _query_server_context_length("omnicoder-9b", "http://localhost:8000/v1")
 
         assert result == 100000
 
     def test_vllm_context_length_key(self):
         """Reads context_length from /v1/models/{model} response."""
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         detail_resp = self._make_resp(200, {"id": "some-model", "context_length": 32768})
 
@@ -130,15 +130,15 @@ class TestQueryLocalContextLengthVllm:
         client_mock.post.return_value = self._make_resp(404, {})
         client_mock.get.return_value = detail_resp
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value="vllm"), \
+        with patch("agent.model_metadata.detect_server_type", return_value="vllm"), \
              patch("httpx.Client", return_value=client_mock):
-            result = _query_local_context_length("some-model", "http://localhost:8000/v1")
+            result = _query_server_context_length("some-model", "http://localhost:8000/v1")
 
         assert result == 32768
 
 
 class TestQueryLocalContextLengthModelsList:
-    """_query_local_context_length: falls back to /v1/models list."""
+    """_query_server_context_length: falls back to /v1/models list."""
 
     def _make_resp(self, status_code, body):
         resp = MagicMock()
@@ -148,7 +148,7 @@ class TestQueryLocalContextLengthModelsList:
 
     def test_models_list_max_model_len(self):
         """Finds context length for model in /v1/models list."""
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         detail_resp = self._make_resp(404, {})
         list_resp = self._make_resp(200, {
@@ -171,15 +171,15 @@ class TestQueryLocalContextLengthModelsList:
         client_mock.post.return_value = self._make_resp(404, {})
         client_mock.get.side_effect = side_effect
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+        with patch("agent.model_metadata.detect_server_type", return_value=None), \
              patch("httpx.Client", return_value=client_mock):
-            result = _query_local_context_length("omnicoder-9b", "http://localhost:1234")
+            result = _query_server_context_length("omnicoder-9b", "http://localhost:1234")
 
         assert result == 131072
 
     def test_models_list_model_not_found_returns_none(self):
         """Returns None when model is not in the /v1/models list."""
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         detail_resp = self._make_resp(404, {})
         list_resp = self._make_resp(200, {
@@ -199,15 +199,15 @@ class TestQueryLocalContextLengthModelsList:
         client_mock.post.return_value = self._make_resp(404, {})
         client_mock.get.side_effect = side_effect
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+        with patch("agent.model_metadata.detect_server_type", return_value=None), \
              patch("httpx.Client", return_value=client_mock):
-            result = _query_local_context_length("omnicoder-9b", "http://localhost:1234")
+            result = _query_server_context_length("omnicoder-9b", "http://localhost:1234")
 
         assert result is None
 
 
 class TestQueryLocalContextLengthLmStudio:
-    """_query_local_context_length with LM Studio native /api/v1/models response."""
+    """_query_server_context_length with LM Studio native /api/v1/models response."""
 
     def _make_resp(self, status_code, body):
         resp = MagicMock()
@@ -237,7 +237,7 @@ class TestQueryLocalContextLengthLmStudio:
 
     def test_lmstudio_exact_key_match(self):
         """Reads max_context_length when key matches exactly."""
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         native_resp = self._make_resp(200, {
             "models": [
@@ -251,9 +251,9 @@ class TestQueryLocalContextLengthLmStudio:
             self._make_resp(404, {}),
         )
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+        with patch("agent.model_metadata.detect_server_type", return_value="lm-studio"), \
              patch("httpx.Client", return_value=client_mock):
-            result = _query_local_context_length(
+            result = _query_server_context_length(
                 "nvidia/nvidia-nemotron-super-49b-v1", "http://192.168.1.22:1234/v1"
             )
 
@@ -266,7 +266,7 @@ class TestQueryLocalContextLengthLmStudio:
         (slug only, no publisher), but LM Studio's native API stores it as
         "nvidia/nvidia-nemotron-super-49b-v1", the lookup must still succeed.
         """
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         native_resp = self._make_resp(200, {
             "models": [
@@ -281,10 +281,10 @@ class TestQueryLocalContextLengthLmStudio:
             self._make_resp(404, {}),
         )
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+        with patch("agent.model_metadata.detect_server_type", return_value="lm-studio"), \
              patch("httpx.Client", return_value=client_mock):
             # Model passed in is just the slug after stripping "local:" prefix
-            result = _query_local_context_length(
+            result = _query_server_context_length(
                 "nvidia-nemotron-super-49b-v1", "http://192.168.1.22:1234/v1"
             )
 
@@ -296,7 +296,7 @@ class TestQueryLocalContextLengthLmStudio:
         LM Studio's OpenAI-compat /v1/models returns id like
         "nvidia/nvidia-nemotron-super-49b-v1" — must match bare slug.
         """
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         # native /api/v1/models: no match
         native_resp = self._make_resp(404, {})
@@ -310,9 +310,9 @@ class TestQueryLocalContextLengthLmStudio:
         })
         client_mock = self._make_client(native_resp, detail_resp, list_resp)
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+        with patch("agent.model_metadata.detect_server_type", return_value="lm-studio"), \
              patch("httpx.Client", return_value=client_mock):
-            result = _query_local_context_length(
+            result = _query_server_context_length(
                 "nvidia-nemotron-super-49b-v1", "http://192.168.1.22:1234/v1"
             )
 
@@ -320,7 +320,7 @@ class TestQueryLocalContextLengthLmStudio:
 
     def test_lmstudio_loaded_instances_context_length(self):
         """Reads active context_length from loaded_instances when max_context_length absent."""
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         native_resp = self._make_resp(200, {
             "models": [
@@ -339,9 +339,9 @@ class TestQueryLocalContextLengthLmStudio:
             self._make_resp(404, {}),
         )
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+        with patch("agent.model_metadata.detect_server_type", return_value="lm-studio"), \
              patch("httpx.Client", return_value=client_mock):
-            result = _query_local_context_length(
+            result = _query_server_context_length(
                 "nvidia-nemotron-super-49b-v1", "http://192.168.1.22:1234/v1"
             )
 
@@ -354,7 +354,7 @@ class TestQueryLocalContextLengthLmStudio:
         while the actual loaded context is 122_651 (runtime setting). The loaded
         value is the real constraint and must be preferred.
         """
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         native_resp = self._make_resp(200, {
             "models": [
@@ -374,9 +374,9 @@ class TestQueryLocalContextLengthLmStudio:
             self._make_resp(404, {}),
         )
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+        with patch("agent.model_metadata.detect_server_type", return_value="lm-studio"), \
              patch("httpx.Client", return_value=client_mock):
-            result = _query_local_context_length(
+            result = _query_server_context_length(
                 "nvidia-nemotron-3-nano-4b", "http://192.168.1.22:1234/v1"
             )
 
@@ -387,11 +387,11 @@ class TestQueryLocalContextLengthLmStudio:
 
 
 class TestQueryLocalContextLengthNetworkError:
-    """_query_local_context_length handles network failures gracefully."""
+    """_query_server_context_length handles network failures gracefully."""
 
     def test_connection_error_returns_none(self):
         """Returns None when the server is unreachable."""
-        from agent.model_metadata import _query_local_context_length
+        from agent.model_metadata import _query_server_context_length
 
         client_mock = MagicMock()
         client_mock.__enter__ = lambda s: client_mock
@@ -399,9 +399,9 @@ class TestQueryLocalContextLengthNetworkError:
         client_mock.post.side_effect = Exception("Connection refused")
         client_mock.get.side_effect = Exception("Connection refused")
 
-        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+        with patch("agent.model_metadata.detect_server_type", return_value=None), \
              patch("httpx.Client", return_value=client_mock):
-            result = _query_local_context_length("omnicoder-9b", "http://localhost:11434/v1")
+            result = _query_server_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
         assert result is None
 
@@ -421,7 +421,7 @@ class TestGetModelContextLengthLocalFallback:
              patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
              patch("agent.model_metadata.is_local_endpoint", return_value=True), \
-             patch("agent.model_metadata._query_local_context_length", return_value=131072), \
+             patch("agent.model_metadata._query_server_context_length", return_value=131072), \
              patch("agent.model_metadata.save_context_length") as mock_save:
             result = get_model_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
@@ -435,7 +435,7 @@ class TestGetModelContextLengthLocalFallback:
              patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
              patch("agent.model_metadata.is_local_endpoint", return_value=True), \
-             patch("agent.model_metadata._query_local_context_length", return_value=131072), \
+             patch("agent.model_metadata._query_server_context_length", return_value=131072), \
              patch("agent.model_metadata.save_context_length") as mock_save:
             get_model_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
@@ -449,7 +449,7 @@ class TestGetModelContextLengthLocalFallback:
              patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
              patch("agent.model_metadata.is_local_endpoint", return_value=True), \
-             patch("agent.model_metadata._query_local_context_length", return_value=None):
+             patch("agent.model_metadata._query_server_context_length", return_value=None):
             result = get_model_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
         assert result == CONTEXT_PROBE_TIERS[0]
@@ -464,7 +464,7 @@ class TestGetModelContextLengthLocalFallback:
              patch("agent.model_metadata.is_local_endpoint", return_value=False), \
              patch("agent.model_metadata._is_known_provider_base_url", return_value=False), \
              patch("agent.model_metadata.save_context_length"), \
-             patch("agent.model_metadata._query_local_context_length", return_value=32768) as mock_query:
+             patch("agent.model_metadata._query_server_context_length", return_value=32768) as mock_query:
             result = get_model_context_length(
                 "llama3:8b", "https://ollama-cloud.example.com/v1"
             )
@@ -480,7 +480,7 @@ class TestGetModelContextLengthLocalFallback:
              patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
              patch("agent.model_metadata._is_known_provider_base_url", return_value=True), \
-             patch("agent.model_metadata._query_local_context_length") as mock_query:
+             patch("agent.model_metadata._query_server_context_length") as mock_query:
             result = get_model_context_length(
                 "unknown-model", "https://openrouter.ai/api/v1"
             )
@@ -492,7 +492,7 @@ class TestGetModelContextLengthLocalFallback:
         from agent.model_metadata import get_model_context_length
 
         with patch("agent.model_metadata.get_cached_context_length", return_value=65536), \
-             patch("agent.model_metadata._query_local_context_length") as mock_query:
+             patch("agent.model_metadata._query_server_context_length") as mock_query:
             result = get_model_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
         assert result == 65536
@@ -505,7 +505,7 @@ class TestGetModelContextLengthLocalFallback:
         with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
              patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
-             patch("agent.model_metadata._query_local_context_length") as mock_query:
+             patch("agent.model_metadata._query_server_context_length") as mock_query:
             result = get_model_context_length("unknown-xyz-model", "")
 
         mock_query.assert_not_called()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -593,7 +593,11 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             "model": "qwen2.5-coder",
             "base_url": "http://localhost:1234/v1",
         }
-        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "env-openrouter-key"}, clear=False):
+        with patch.dict(
+            os.environ,
+            {"OPENROUTER_API_KEY": "env-openrouter-key", "OPENAI_API_KEY": ""},
+            clear=False,
+        ):
             with self.assertRaises(ValueError) as ctx:
                 _resolve_delegation_credentials(cfg, parent)
         self.assertIn("OPENAI_API_KEY", str(ctx.exception))

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -211,6 +211,23 @@ class TestTranscribeAudio:
         assert result["success"] is True
         mock_openai.assert_called_once()
 
+    def test_auto_detect_openai_can_use_general_key(self, monkeypatch, tmp_path):
+        audio_file = tmp_path / "test.ogg"
+        audio_file.write_bytes(b"fake audio")
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._transcribe_openai",
+                   return_value={"success": True, "transcript": "hi"}) as mock_openai:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(str(audio_file))
+
+        assert result["success"] is True
+        mock_openai.assert_called_once()
+
     def test_no_provider_returns_error(self, tmp_path):
         audio_file = tmp_path / "test.ogg"
         audio_file.write_bytes(b"fake audio")

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -9,8 +9,27 @@ Coverage:
 """
 
 import os
+import sys
+import types
 import pytest
 from unittest.mock import patch, MagicMock
+
+
+def _install_fake_parallel_module(monkeypatch):
+    fake_module = types.ModuleType("parallel")
+
+    class FakeParallel:
+        def __init__(self, api_key):
+            self.api_key = api_key
+
+    class FakeAsyncParallel:
+        def __init__(self, api_key):
+            self.api_key = api_key
+
+    fake_module.Parallel = FakeParallel
+    fake_module.AsyncParallel = FakeAsyncParallel
+    monkeypatch.setitem(sys.modules, "parallel", fake_module)
+    return FakeParallel, FakeAsyncParallel
 
 
 class TestFirecrawlClientConfig:
@@ -252,14 +271,15 @@ class TestParallelClientConfig:
         tools.web_tools._parallel_client = None
         os.environ.pop("PARALLEL_API_KEY", None)
 
-    def test_creates_client_with_key(self):
+    def test_creates_client_with_key(self, monkeypatch):
         """PARALLEL_API_KEY set → creates Parallel client."""
+        FakeParallel, _ = _install_fake_parallel_module(monkeypatch)
         with patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
             from tools.web_tools import _get_parallel_client
-            from parallel import Parallel
             client = _get_parallel_client()
             assert client is not None
-            assert isinstance(client, Parallel)
+            assert isinstance(client, FakeParallel)
+            assert client.api_key == "test-key"
 
     def test_no_key_raises_with_helpful_message(self):
         """No PARALLEL_API_KEY → ValueError with guidance."""
@@ -267,8 +287,17 @@ class TestParallelClientConfig:
         with pytest.raises(ValueError, match="PARALLEL_API_KEY"):
             _get_parallel_client()
 
-    def test_singleton_returns_same_instance(self):
+    def test_missing_sdk_with_key_raises_install_hint(self):
+        """Missing optional SDK with a key → ImportError with install guidance."""
+        with patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
+            with patch("tools.web_tools._import_parallel_clients", side_effect=ImportError("parallel-web missing")):
+                from tools.web_tools import _get_parallel_client
+                with pytest.raises(ImportError, match="parallel-web"):
+                    _get_parallel_client()
+
+    def test_singleton_returns_same_instance(self, monkeypatch):
         """Second call returns cached client."""
+        _install_fake_parallel_module(monkeypatch)
         with patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
             from tools.web_tools import _get_parallel_client
             client1 = _get_parallel_client()

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -114,9 +114,14 @@ def is_stt_enabled(stt_config: Optional[dict] = None) -> bool:
     return bool(enabled)
 
 
-def _resolve_openai_api_key() -> str:
-    """Prefer the voice-tools key, but fall back to the normal OpenAI key."""
-    return os.getenv("VOICE_TOOLS_OPENAI_KEY", "") or os.getenv("OPENAI_API_KEY", "")
+def _resolve_voice_tools_openai_api_key() -> str:
+    """Return the dedicated OpenAI key for Hermes voice features."""
+    return os.getenv("VOICE_TOOLS_OPENAI_KEY", "")
+
+
+def _resolve_auto_openai_api_key() -> str:
+    """Auto-detect may fall back to the general OpenAI key when voice key is unset."""
+    return _resolve_voice_tools_openai_api_key() or os.getenv("OPENAI_API_KEY", "")
 
 
 def _find_binary(binary_name: str) -> Optional[str]:
@@ -208,10 +213,10 @@ def _get_provider(stt_config: dict) -> str:
             return "none"
 
         if provider == "openai":
-            if _HAS_OPENAI and _resolve_openai_api_key():
+            if _HAS_OPENAI and _resolve_voice_tools_openai_api_key():
                 return "openai"
             logger.warning(
-                "STT provider 'openai' configured but no API key available"
+                "STT provider 'openai' configured but VOICE_TOOLS_OPENAI_KEY not set"
             )
             return "none"
 
@@ -226,7 +231,7 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_OPENAI and os.getenv("GROQ_API_KEY"):
         logger.info("No local STT available, using Groq Whisper API")
         return "groq"
-    if _HAS_OPENAI and _resolve_openai_api_key():
+    if _HAS_OPENAI and _resolve_auto_openai_api_key():
         logger.info("No local STT available, using OpenAI Whisper API")
         return "openai"
     return "none"
@@ -433,14 +438,14 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_openai(file_path: str, model_name: str, api_key: Optional[str] = None) -> Dict[str, Any]:
     """Transcribe using OpenAI Whisper API (paid)."""
-    api_key = _resolve_openai_api_key()
+    api_key = api_key or _resolve_voice_tools_openai_api_key()
     if not api_key:
         return {
             "success": False,
             "transcript": "",
-            "error": "Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set",
+            "error": "VOICE_TOOLS_OPENAI_KEY is not set",
         }
 
     if not _HAS_OPENAI:
@@ -539,7 +544,12 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
     if provider == "openai":
         openai_cfg = stt_config.get("openai", {})
         model_name = model or openai_cfg.get("model", DEFAULT_STT_MODEL)
-        return _transcribe_openai(file_path, model_name)
+        openai_api_key = (
+            _resolve_voice_tools_openai_api_key()
+            if "provider" in stt_config
+            else _resolve_auto_openai_api_key()
+        )
+        return _transcribe_openai(file_path, model_name, api_key=openai_api_key)
 
     # No provider available
     return {

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -126,12 +126,23 @@ def _get_firecrawl_client():
 _parallel_client = None
 _async_parallel_client = None
 
+def _import_parallel_clients():
+    """Import Parallel SDK classes with a consistent install hint."""
+    try:
+        from parallel import AsyncParallel, Parallel
+    except ImportError as exc:
+        raise ImportError(
+            "Parallel web backend requires the 'parallel-web' package. "
+            "Install it with: pip install 'parallel-web>=0.4.2,<1'"
+        ) from exc
+    return Parallel, AsyncParallel
+
+
 def _get_parallel_client():
     """Get or create the Parallel sync client (lazy initialization).
 
     Requires PARALLEL_API_KEY environment variable.
     """
-    from parallel import Parallel
     global _parallel_client
     if _parallel_client is None:
         api_key = os.getenv("PARALLEL_API_KEY")
@@ -140,6 +151,7 @@ def _get_parallel_client():
                 "PARALLEL_API_KEY environment variable not set. "
                 "Get your API key at https://parallel.ai"
             )
+        Parallel, _ = _import_parallel_clients()
         _parallel_client = Parallel(api_key=api_key)
     return _parallel_client
 
@@ -149,7 +161,6 @@ def _get_async_parallel_client():
 
     Requires PARALLEL_API_KEY environment variable.
     """
-    from parallel import AsyncParallel
     global _async_parallel_client
     if _async_parallel_client is None:
         api_key = os.getenv("PARALLEL_API_KEY")
@@ -158,6 +169,7 @@ def _get_async_parallel_client():
                 "PARALLEL_API_KEY environment variable not set. "
                 "Get your API key at https://parallel.ai"
             )
+        _, AsyncParallel = _import_parallel_clients()
         _async_parallel_client = AsyncParallel(api_key=api_key)
     return _async_parallel_client
 


### PR DESCRIPTION
## Summary

Hermes assumed Ollama servers are always local (localhost / RFC-1918 IPs). Users pointing at **Ollama Cloud** or self-hosted remote Ollama instances found that:

- Context length detection fell back to 128K default instead of querying `/api/show`
- Server type detection (`/api/tags`) was skipped entirely
- Model auto-detection only worked for `localhost` / `127.0.0.1`

The workaround was to run Ollama in a local Docker container, pull cloud models there, and point hermes at the Docker IP — which worked only because private IPs pass the `is_local_endpoint()` check.

This PR removes that locality gate so **any custom endpoint** (not just local ones) gets full Ollama-aware probing.

### Changes

**`agent/model_metadata.py`**
- Rename `detect_local_server_type()` → `detect_server_type()` — now accepts `_is_local` param to avoid redundant `is_local_endpoint()` calls
- Rename `_query_local_context_length()` → `_query_server_context_length()` — threads locality check through to avoid double computation
- Remove `is_local_endpoint()` gate from context length probing at step 3 — any custom (non-known-provider) endpoint is now probed
- Remove redundant step 9 duplicate probe (step 3 already covers the same URL)
- Use longer httpx timeouts for remote endpoints (2s→5s for detection, 3s→8s for context queries)

**`cli.py`**
- Broaden model auto-detect from `localhost`/`127.0.0.1` check to `_is_known_provider_base_url()` — excludes all known providers (OpenRouter, OpenAI, Anthropic, etc.), not just OpenRouter

**`hermes_cli/runtime_provider.py`**
- Same broadening in `_get_model_config()` using `_is_known_provider_base_url()`

**Tests**
- Updated all references to renamed functions
- Added `test_remote_custom_endpoint_queries_server` — verifies cloud Ollama URLs ARE probed
- Added `test_known_provider_endpoint_does_not_query_server` — verifies known providers are NOT probed
- Updated existing test to mock the new `_query_server_context_length` call path

## Test plan

- [ ] `python -m pytest tests/agent/test_model_metadata.py tests/test_model_metadata_local_ctx.py -q` — 95 tests pass
- [ ] Full suite `python -m pytest tests/ -q` — 6136 passed, 0 new failures (4 pre-existing unrelated)
- [ ] Point `base_url` at a remote Ollama instance (cloud or VPS) and verify context length detection works
- [ ] Point `base_url` at local Ollama (`localhost:11434`) and verify existing behavior is unchanged
- [ ] Verify known providers (OpenRouter, OpenAI, Anthropic) are NOT probed with `/api/tags`