### PR TITLE
fix(state): retry on SQLite DB lock and surface failures as warnings     

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1189,8 +1189,8 @@ class HermesCLI:
         try:
             from hermes_state import SessionDB
             self._session_db = SessionDB()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Session DB init failed, search will be unavailable: %s", e)
         
         # Deferred title: stored in memory until the session is created in the DB
         self._pending_title: Optional[str] = None
@@ -1851,7 +1851,7 @@ class HermesCLI:
                 from hermes_state import SessionDB
                 self._session_db = SessionDB()
             except Exception as e:
-                logger.debug("SQLite session store not available: %s", e)
+                logger.warning("Session DB init failed, search will be unavailable: %s", e)
         
         # If resuming, validate the session exists and load its history.
         # _preload_resumed_session() may have already loaded it (called from

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -17,7 +17,6 @@ Key design decisions:
 import json
 import logging
 import os
-import random
 import re
 import sqlite3
 import threading
@@ -231,7 +230,7 @@ class SessionDB:
             except sqlite3.OperationalError as e:
                 if "database is locked" not in str(e) or attempt == retries:
                     raise
-                delay = base_delay * (2 ** attempt) + random.uniform(0, 0.05)
+                delay = base_delay * (2 ** attempt)
                 logger.warning("SQLite DB locked (attempt %d/%d), retrying in %.2fs", attempt + 1, retries, delay)
                 time.sleep(delay)
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -15,13 +15,17 @@ Key design decisions:
 """
 
 import json
+import logging
 import os
+import random
 import re
 import sqlite3
 import threading
 import time
 from pathlib import Path
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 DEFAULT_DB_PATH = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
@@ -219,6 +223,18 @@ class SessionDB:
     # Session lifecycle
     # =========================================================================
 
+    def _with_retry(self, fn, *, retries: int = 3, base_delay: float = 0.1):
+        """Execute fn(), retrying on 'database is locked' up to `retries` times."""
+        for attempt in range(retries + 1):
+            try:
+                return fn()
+            except sqlite3.OperationalError as e:
+                if "database is locked" not in str(e) or attempt == retries:
+                    raise
+                delay = base_delay * (2 ** attempt) + random.uniform(0, 0.05)
+                logger.warning("SQLite DB locked (attempt %d/%d), retrying in %.2fs", attempt + 1, retries, delay)
+                time.sleep(delay)
+
     def create_session(
         self,
         session_id: str,
@@ -230,23 +246,25 @@ class SessionDB:
         parent_session_id: str = None,
     ) -> str:
         """Create a new session record. Returns the session_id."""
-        with self._lock:
-            self._conn.execute(
-                """INSERT INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    session_id,
-                    source,
-                    user_id,
-                    model,
-                    json.dumps(model_config) if model_config else None,
-                    system_prompt,
-                    parent_session_id,
-                    time.time(),
-                ),
-            )
-            self._conn.commit()
+        def _do():
+            with self._lock:
+                self._conn.execute(
+                    """INSERT INTO sessions (id, source, user_id, model, model_config,
+                       system_prompt, parent_session_id, started_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        session_id,
+                        source,
+                        user_id,
+                        model,
+                        json.dumps(model_config) if model_config else None,
+                        system_prompt,
+                        parent_session_id,
+                        time.time(),
+                    ),
+                )
+                self._conn.commit()
+        self._with_retry(_do)
         return session_id
 
     def end_session(self, session_id: str, end_reason: str) -> None:
@@ -594,45 +612,50 @@ class SessionDB:
         Also increments the session's message_count (and tool_call_count
         if role is 'tool' or tool_calls is present).
         """
-        with self._lock:
-            cursor = self._conn.execute(
-                """INSERT INTO messages (session_id, role, content, tool_call_id,
-                   tool_calls, tool_name, timestamp, token_count, finish_reason)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    session_id,
-                    role,
-                    content,
-                    tool_call_id,
-                    json.dumps(tool_calls) if tool_calls else None,
-                    tool_name,
-                    time.time(),
-                    token_count,
-                    finish_reason,
-                ),
-            )
-            msg_id = cursor.lastrowid
+        result = {}
 
-            # Update counters
-            # Count actual tool calls from the tool_calls list (not from tool responses).
-            # A single assistant message can contain multiple parallel tool calls.
-            num_tool_calls = 0
-            if tool_calls is not None:
-                num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
-            if num_tool_calls > 0:
-                self._conn.execute(
-                    """UPDATE sessions SET message_count = message_count + 1,
-                       tool_call_count = tool_call_count + ? WHERE id = ?""",
-                    (num_tool_calls, session_id),
+        def _do():
+            with self._lock:
+                cursor = self._conn.execute(
+                    """INSERT INTO messages (session_id, role, content, tool_call_id,
+                       tool_calls, tool_name, timestamp, token_count, finish_reason)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        session_id,
+                        role,
+                        content,
+                        tool_call_id,
+                        json.dumps(tool_calls) if tool_calls else None,
+                        tool_name,
+                        time.time(),
+                        token_count,
+                        finish_reason,
+                    ),
                 )
-            else:
-                self._conn.execute(
-                    "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
-                    (session_id,),
-                )
+                result["msg_id"] = cursor.lastrowid
 
-            self._conn.commit()
-        return msg_id
+                # Update counters
+                # Count actual tool calls from the tool_calls list (not from tool responses).
+                # A single assistant message can contain multiple parallel tool calls.
+                num_tool_calls = 0
+                if tool_calls is not None:
+                    num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
+                if num_tool_calls > 0:
+                    self._conn.execute(
+                        """UPDATE sessions SET message_count = message_count + 1,
+                           tool_call_count = tool_call_count + ? WHERE id = ?""",
+                        (num_tool_calls, session_id),
+                    )
+                else:
+                    self._conn.execute(
+                        "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
+                        (session_id,),
+                    )
+
+                self._conn.commit()
+
+        self._with_retry(_do)
+        return result["msg_id"]
 
     def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages for a session, ordered by timestamp."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -891,7 +891,7 @@ class AIAgent:
                     user_id=None,
                 )
             except Exception as e:
-                logger.debug("Session DB create_session failed: %s", e)
+                logger.warning("Session DB create_session failed, session will not be indexed: %s", e)
         
         # In-memory todo list for task planning (one per agent/session)
         from tools.todo_tool import TodoStore
@@ -1545,7 +1545,7 @@ class AIAgent:
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
-            logger.debug("Session DB append_message failed: %s", e)
+            logger.warning("Session DB append_message failed: %s", e)
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,8 +1,10 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import sqlite3
 import time
 import pytest
 from pathlib import Path
+from unittest.mock import patch
 
 from hermes_state import SessionDB
 
@@ -1031,3 +1033,47 @@ class TestResolveSessionByNameOrId:
         db.set_session_title("s1", "my project")
         result = db.resolve_session_by_title("my project")
         assert result == "s1"
+
+
+# =========================================================================
+# DB lock retry
+# =========================================================================
+
+class TestWithRetry:
+    def test_retries_on_db_locked(self, db):
+        """_with_retry should retry on 'database is locked' and succeed on second attempt."""
+        calls = {"count": 0}
+
+        def flaky():
+            calls["count"] += 1
+            if calls["count"] < 2:
+                raise sqlite3.OperationalError("database is locked")
+            return "ok"
+
+        with patch("time.sleep"):
+            result = db._with_retry(flaky)
+
+        assert result == "ok"
+        assert calls["count"] == 2
+
+    def test_raises_after_max_retries(self, db):
+        """_with_retry should re-raise after exhausting all retries."""
+        def always_locked():
+            raise sqlite3.OperationalError("database is locked")
+
+        with patch("time.sleep"):
+            with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+                db._with_retry(always_locked, retries=3)
+
+    def test_does_not_retry_other_errors(self, db):
+        """_with_retry should not retry on unrelated OperationalError."""
+        calls = {"count": 0}
+
+        def other_error():
+            calls["count"] += 1
+            raise sqlite3.OperationalError("no such table: foo")
+
+        with pytest.raises(sqlite3.OperationalError, match="no such table"):
+            db._with_retry(other_error)
+
+        assert calls["count"] == 1


### PR DESCRIPTION
##What does this PR do?                                                                                                                                                            
                       
  When multiple Hermes CLI processes start concurrently, they compete for the SQLite write lock on state.db. The previous code caught sqlite3.OperationalError: database is locked silently - either swallowing it with a bare pass or logging at DEBUG level - causing sessions to go unindexed with no user-visible signal. This PR adds exponential backoff retry logic to the two critical write paths and promotes all DB init failures to WARNING so they're actually visible.
                                                                                                                                                                                   
## Related Issue                                                                                                                                                                  

  Fixes #2914

## Type of Change

  - 🐛 Bug fix (non-breaking change that fixes an issue)
  - ✅ Tests (adding or improving test coverage)

## Changes Made
                                                                                                                                                                                   
  - hermes_state.py: Added SessionDB._with_retry(): retries on "database is locked" up to 3 times with exponential backoff (100ms → 200ms → 400ms + jitter); non-lock errors raise immediately. Wrapped create_session() and append_message() with it.                                                                                                             
  - cli.py:1189-1193: Replaced except Exception: pass (fully silent) with logger.warning(...).
  - cli.py:1850-1854: Promoted retry-path DB init failure from logger.debug to logger.warning.                                                                                    
  - run_agent.py:894: Promoted create_session failure from logger.debug to logger.warning.                                                                                        
  - run_agent.py:1548: Promoted append_message failure from logger.debug to logger.warning.                                                                                       
  - tests/test_hermes_state.py: Added TestWithRetry class: 3 tests covering retry success, exhaustion after max retries, and no retry on non-lock errors.                         
                                                                                                                                                                                   
## How to Test                                                                                                                                                                      
                                                                                                                                                                                   
  1. pytest tests/test_hermes_state.py::TestWithRetry -v                                                                                                                           
  2. Start two CLI sessions simultaneously in separate terminals - the second should either recover via retry or emit a WARNING instead of silently failing.
  3. Manual lock simulation: run python3 -c "import sqlite3, time; c = sqlite3.connect('~/.hermes/state.db'); c.execute('BEGIN EXCLUSIVE'); time.sleep(15)" in one terminal, start  a new session in another - a WARNING should appear.                                                                                                                              
                                                                                                                                                                                   
## Checklist                                                                                                                                                                        
                                                     
  - I've read the Contributing Guide
  - My commit messages follow Conventional Commits (fix(state):)
  - I searched for existing PRs to make sure this isn't a duplicate                                                                                                                
  - My PR contains only changes related to this fix                                                                                                                                
  - I've run pytest tests/ -q and all tests pass                                                                                                                                   
  - I've added tests for my changes                                                                                                                                                
  - I've tested on my platform: macOS                                                                                                                              
                                                            
## Documentation & Housekeeping                                                                                                                                                     
                                                            
  - README/docs update — N/A                                                                                                                                                       
  - cli-config.yaml.example — N/A                           
  - CONTRIBUTING.md/AGENTS.md — N/A
  - Cross-platform impact considered — N/A (stdlib sqlite3, platform-independent)                                                                                                  
  - Tool descriptions/schemas — N/A
                                                                                                                                                                                  

             