### PR TITLE
Fix: Handle OpenAI content list format in API server

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -445,7 +445,20 @@ class APIServerAdapter(BasePlatformAdapter):
 
         for msg in messages:
             role = msg.get("role", "")
-            content = msg.get("content", "")
+            raw_content = msg.get("content", "")
+            
+            # Handle content that may be a string or a list of content parts
+            if isinstance(raw_content, list):
+                text_parts = []
+                for part in raw_content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        text_parts.append(part.get("text", ""))
+                    elif isinstance(part, str):
+                        text_parts.append(part)
+                content = "\n".join(text_parts)
+            else:
+                content = raw_content if isinstance(raw_content, str) else str(raw_content)
+            
             if role == "system":
                 # Accumulate system messages
                 if system_prompt is None:
@@ -649,7 +662,21 @@ class APIServerAdapter(BasePlatformAdapter):
         if raw_input is None:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        instructions = body.get("instructions")
+        # Normalize instructions (may be string or list of content parts)
+        raw_instructions = body.get("instructions")
+        if raw_instructions is None:
+            instructions = None
+        elif isinstance(raw_instructions, list):
+            text_parts = []
+            for part in raw_instructions:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    text_parts.append(part.get("text", ""))
+                elif isinstance(part, str):
+                    text_parts.append(part)
+            instructions = "\n".join(text_parts)
+        else:
+            instructions = raw_instructions if isinstance(raw_instructions, str) else str(raw_instructions)
+        
         previous_response_id = body.get("previous_response_id")
         conversation = body.get("conversation")
         store = body.get("store", True)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -431,6 +431,63 @@ class TestChatCompletionsEndpoint:
             assert call_kwargs.kwargs.get("user_message") == "Hello"
 
     @pytest.mark.asyncio
+    async def test_system_prompt_as_list_content(self, adapter):
+        """System prompt with content as list of content parts (OpenAI format)."""
+        mock_result = {
+            "final_response": "Arrr!",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {"role": "system", "content": [{"type": "text", "text": "You are a pirate."}]},
+                            {"role": "user", "content": "Hello"},
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+            # Check that system prompt content list was correctly converted to string
+            call_kwargs = mock_run.call_args
+            assert call_kwargs.kwargs.get("ephemeral_system_prompt") == "You are a pirate."
+
+    @pytest.mark.asyncio
+    async def test_user_message_as_list_content(self, adapter):
+        """User message with content as list of content parts (OpenAI format)."""
+        mock_result = {
+            "final_response": "Hello back!",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+            # Check that user message content list was correctly converted to string
+            call_kwargs = mock_run.call_args
+            assert call_kwargs.kwargs.get("user_message") == "Hello"
+
+    @pytest.mark.asyncio
     async def test_conversation_history_passed(self, adapter):
         """Previous user/assistant messages become conversation_history."""
         mock_result = {"final_response": "3", "messages": [], "api_calls": 1}
@@ -580,6 +637,29 @@ class TestResponsesEndpoint:
                 )
 
             assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["ephemeral_system_prompt"] == "Talk like a pirate."
+
+    @pytest.mark.asyncio
+    async def test_instructions_as_list_content(self, adapter):
+        """Instructions with content as list of content parts (OpenAI format)."""
+        mock_result = {"final_response": "Ahoy!", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Hello",
+                        "instructions": [{"type": "text", "text": "Talk like a pirate."}],
+                    },
+                )
+
+            assert resp.status == 200
+            # Check that instructions content list was correctly converted to string
             call_kwargs = mock_run.call_args.kwargs
             assert call_kwargs["ephemeral_system_prompt"] == "Talk like a pirate."
 


### PR DESCRIPTION
## Problem
OpenAI API clients (like OpenHands) send message content in the newer format:
```json
{"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant."}]}
```

 Hermes API server expected `content` to always be a string, causing:
```
TypeError: can only concatenate str (not "list") to str
```

## Solution
- Added content normalization in `_handle_chat_completions()` for system/user messages
- Added instructions normalization in `_handle_responses()` endpoint
- Both now convert list content to string: `[{"type": "text", "text": "..."}]` → `"..."

## Tests
Added 3 unit tests:
- `test_system_prompt_as_list_content` - system message with list content
- `test_user_message_as_list_content` - user message with list content  
- `test_instructions_as_list_content` - instructions with list content

All tests pass.

## Files Changed
- `gateway/platforms/api_server.py` - content normalization logic
- `tests/gateway/test_api_server.py` - new test cases