### PR TITLE
fix(matrix): add backoff for SyncError in sync loop

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -552,9 +552,20 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _sync_loop(self) -> None:
         """Continuously sync with the homeserver."""
+        import nio
+
         while not self._closing:
             try:
-                await self._client.sync(timeout=30000)
+                resp = await self._client.sync(timeout=30000)
+                if isinstance(resp, nio.SyncError):
+                    if self._closing:
+                        return
+                    logger.warning(
+                        "Matrix: sync returned %s: %s — retrying in 5s",
+                        type(resp).__name__,
+                        getattr(resp, "message", resp),
+                    )
+                    await asyncio.sleep(5)
             except asyncio.CancelledError:
                 return
             except Exception as exc:


### PR DESCRIPTION
## Summary

When the Matrix homeserver returns an error response, matrix-nio parses it as a `SyncError` return value rather than raising an exception. The sync loop only had backoff logic in the `except` handler, so `SyncError` responses caused an immediate tight retry loop (~489 req/s) that flooded logs with thousands of `'next_batch' is a required property` warnings per second and hammered the homeserver.

## Fix

Check the `sync()` return value for `nio.SyncError` and sleep 5s before retrying, matching the existing exception-handling backoff.

## Reproduction

1. Run Hermes gateway with a Conduwuit homeserver
2. Trigger a transient sync error (e.g., restart Conduwuit mid-sync)
3. Observe logs filling at ~489 lines/second with `WARNING nio.responses: Error validating response: 'next_batch' is a required property`

## Testing

- Verified the sync loop processes normal `SyncResponse` objects unchanged
- Verified `SyncError` responses now trigger a 5s backoff with a descriptive warning
- `self._closing` guard prevents 5s shutdown delay, matching existing pattern at line 561