### PR TITLE
fix(signal): track SSE keepalive comments as connection activity

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -279,6 +279,13 @@ class SignalAdapter(BasePlatformAdapter):
                             line = line.strip()
                             if not line:
                                 continue
+                            # SSE keepalive comments (":") prove the
+                            # connection is alive.  Update the activity
+                            # timestamp so the health monitor doesn't
+                            # report false idle warnings.
+                            if line.startswith(":"):
+                                self._last_sse_activity = time.time()
+                                continue
                             # Parse SSE data lines
                             if line.startswith("data:"):
                                 data_str = line[5:].strip()


### PR DESCRIPTION
## Summary

signal-cli daemon sends SSE comment lines (`:`) as keepalives every ~15 seconds. The SSE listener only counted `data:` lines as activity, so the health monitor reported false `Signal: SSE idle for 120s, checking daemon health` warnings every two minutes during normal quiet periods when no messages were being exchanged.

## Fix

Recognize SSE comment lines (starting with `:`) as valid connection activity per the [SSE specification](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), updating `_last_sse_activity` to prevent false idle warnings.

## What this doesn't change

- `event:` and other SSE field lines continue to fall through to the existing `data:` check as before — no behavior change for message processing
- The `HEALTH_CHECK_STALE_THRESHOLD` of 120s remains appropriate since keepalives arrive every ~15s
- Genuine connection drops are still detected (no keepalives = no activity updates)

## Reproduction

1. Configure Signal gateway with signal-cli daemon
2. Wait 2+ minutes with no incoming messages
3. Observe repeated `WARNING Signal: SSE idle for 120s, checking daemon health` in error logs