### PR TITLE
fix(session): surface silent SessionDB failures that cause session data loss

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1186,8 +1186,8 @@ class HermesCLI:
         try:
             from hermes_state import SessionDB
             self._session_db = SessionDB()
-        except Exception:
-            pass
+        except Exception as e:
+            logging.warning("Failed to initialize SessionDB — session will NOT be indexed for search: %s", e)
         
         # Deferred title: stored in memory until the session is created in the DB
         self._pending_title: Optional[str] = None
@@ -1848,7 +1848,7 @@ class HermesCLI:
                 from hermes_state import SessionDB
                 self._session_db = SessionDB()
             except Exception as e:
-                logger.debug("SQLite session store not available: %s", e)
+                logging.warning("SQLite session store not available — session will NOT be indexed: %s", e)
         
         # If resuming, validate the session exists and load its history.
         # _preload_resumed_session() may have already loaded it (called from

--- a/run_agent.py
+++ b/run_agent.py
@@ -887,7 +887,8 @@ class AIAgent:
                     user_id=None,
                 )
             except Exception as e:
-                logger.debug("Session DB create_session failed: %s", e)
+                logging.warning("Session DB create_session failed — messages will NOT be indexed: %s", e)
+                self._session_db = None  # prevent silent data loss on every subsequent flush
         
         # In-memory todo list for task planning (one per agent/session)
         from tools.todo_tool import TodoStore
@@ -1543,7 +1544,7 @@ class AIAgent:
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
-            logger.debug("Session DB append_message failed: %s", e)
+            logging.warning("Session DB append_message failed: %s", e)
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """
@@ -4614,7 +4615,7 @@ class AIAgent:
                 # Reset flush cursor — new session starts with no messages written
                 self._last_flushed_db_idx = 0
             except Exception as e:
-                logger.debug("Session DB compression split failed: %s", e)
+                logging.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 
         # Reset context pressure warning and token estimate — usage drops
         # after compaction.  Without this, the stale last_prompt_tokens from


### PR DESCRIPTION
## Problem

SessionDB initialization and operation failures are logged at `debug` level or silently swallowed (`except Exception: pass`), causing sessions to never be indexed in the FTS5 database. `session_search` returns empty results for affected conversations with zero indication anything went wrong.

In our deployment, **~48% of sessions** (65 out of 135) were missing from the FTS5 index. The JSON session files were written normally (separate code path via `_save_session_log`), but the SQLite store got nothing.

## Root Cause

When the gateway restarts while a CLI session is active (or any DB lock contention during init), `SessionDB()` raises an exception that gets caught and swallowed:

```python
# cli.py:1185-1190
self._session_db = None
try:
    from hermes_state import SessionDB
    self._session_db = SessionDB()
except Exception:
    pass  # <-- session silently becomes unsearchable
```

The agent runs fine — JSON logs are written to disk — but `_session_db` stays `None`, so `_flush_messages_to_session_db()` short-circuits on every turn and no messages reach FTS5.

## Changes

- **cli.py**: Log `WARNING` (not debug/pass) when SessionDB init fails at both `__init__` and `_start_session` entry points
- **run_agent.py**: Log `WARNING` on `create_session`, `append_message`, and compression split failures  
- **run_agent.py**: Set `_session_db = None` after `create_session` failure — fail fast instead of silently dropping every message for the rest of the session

## Impact

Minimal — only changes log levels and adds one `None` assignment. No behavioral change for the happy path. Users will now see a clear warning when session indexing fails instead of discovering it hours/days later when `session_search` returns nothing.