### PR TITLE
fix(discord): stop phantom typing indicator after agent turn completes

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -819,6 +819,16 @@ class BasePlatformAdapter(ABC):
                 await asyncio.sleep(interval)
         except asyncio.CancelledError:
             pass  # Normal cancellation when handler completes
+        finally:
+            # Ensure the underlying platform typing loop is stopped.
+            # _keep_typing may have called send_typing() after an outer stop_typing()
+            # cleared the task dict, recreating the loop. Cancelling _keep_typing alone
+            # won't clean that up — we must explicitly stop it here.
+            if hasattr(self, "stop_typing"):
+                try:
+                    await self.stop_typing(chat_id)
+                except Exception:
+                    pass
     
     async def handle_message(self, event: MessageEvent) -> None:
         """

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4994,78 +4994,87 @@ class GatewayRunner:
             progress_msg_id = None   # ID of the progress message to edit
             can_edit = True          # False once an edit fails (platform doesn't support it)
 
-            while True:
-                try:
-                    raw = progress_queue.get_nowait()
-                    
-                    # Handle dedup messages: update last line with repeat counter
-                    if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
-                        _, base_msg, count = raw
-                        if progress_lines:
-                            progress_lines[-1] = f"{base_msg} (×{count + 1})"
-                        msg = progress_lines[-1] if progress_lines else base_msg
-                    else:
-                        msg = raw
-                        progress_lines.append(msg)
-
-                    if can_edit and progress_msg_id is not None:
-                        # Try to edit the existing progress message
-                        full_text = "\n".join(progress_lines)
-                        result = await adapter.edit_message(
-                            chat_id=source.chat_id,
-                            message_id=progress_msg_id,
-                            content=full_text,
-                        )
-                        if not result.success:
-                            # Platform doesn't support editing — stop trying,
-                            # send just this new line as a separate message
-                            can_edit = False
-                            await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
-                    else:
-                        if can_edit:
-                            # First tool: send all accumulated text as new message
-                            full_text = "\n".join(progress_lines)
-                            result = await adapter.send(chat_id=source.chat_id, content=full_text, metadata=_progress_metadata)
+            try:
+                while True:
+                    try:
+                        raw = progress_queue.get_nowait()
+                        
+                        # Handle dedup messages: update last line with repeat counter
+                        if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
+                            _, base_msg, count = raw
+                            if progress_lines:
+                                progress_lines[-1] = f"{base_msg} (×{count + 1})"
+                            msg = progress_lines[-1] if progress_lines else base_msg
                         else:
-                            # Editing unsupported: send just this line
-                            result = await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
-                        if result.success and result.message_id:
-                            progress_msg_id = result.message_id
+                            msg = raw
+                            progress_lines.append(msg)
 
-                    # Restore typing indicator
-                    await asyncio.sleep(0.3)
-                    await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
-
-                except queue.Empty:
-                    await asyncio.sleep(0.3)
-                except asyncio.CancelledError:
-                    # Drain remaining queued messages
-                    while not progress_queue.empty():
-                        try:
-                            raw = progress_queue.get_nowait()
-                            if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
-                                _, base_msg, count = raw
-                                if progress_lines:
-                                    progress_lines[-1] = f"{base_msg} (×{count + 1})"
-                            else:
-                                progress_lines.append(raw)
-                        except Exception:
-                            break
-                    # Final edit with all remaining tools (only if editing works)
-                    if can_edit and progress_lines and progress_msg_id:
-                        full_text = "\n".join(progress_lines)
-                        try:
-                            await adapter.edit_message(
+                        if can_edit and progress_msg_id is not None:
+                            # Try to edit the existing progress message
+                            full_text = "\n".join(progress_lines)
+                            result = await adapter.edit_message(
                                 chat_id=source.chat_id,
                                 message_id=progress_msg_id,
                                 content=full_text,
                             )
-                        except Exception:
-                            pass
-                    return
-                except Exception as e:
-                    logger.error("Progress message error: %s", e)
-                    await asyncio.sleep(1)
+                            if not result.success:
+                                # Platform doesn't support editing — stop trying,
+                                # send just this new line as a separate message
+                                can_edit = False
+                                await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                        else:
+                            if can_edit:
+                                # First tool: send all accumulated text as new message
+                                full_text = "\n".join(progress_lines)
+                                result = await adapter.send(chat_id=source.chat_id, content=full_text, metadata=_progress_metadata)
+                            else:
+                                # Editing unsupported: send just this line
+                                result = await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                            if result.success and result.message_id:
+                                progress_msg_id = result.message_id
+
+                        # Restore typing indicator
+                        await asyncio.sleep(0.3)
+                        await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
+
+                    except queue.Empty:
+                        await asyncio.sleep(0.3)
+                    except asyncio.CancelledError:
+                        # Drain remaining queued messages
+                        while not progress_queue.empty():
+                            try:
+                                raw = progress_queue.get_nowait()
+                                if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
+                                    _, base_msg, count = raw
+                                    if progress_lines:
+                                        progress_lines[-1] = f"{base_msg} (×{count + 1})"
+                                else:
+                                    progress_lines.append(raw)
+                            except Exception:
+                                break
+                        # Final edit with all remaining tools (only if editing works)
+                        if can_edit and progress_lines and progress_msg_id:
+                            full_text = "\n".join(progress_lines)
+                            try:
+                                await adapter.edit_message(
+                                    chat_id=source.chat_id,
+                                    message_id=progress_msg_id,
+                                    content=full_text,
+                                )
+                            except Exception:
+                                pass
+                        return
+                    except Exception as e:
+                        logger.error("Progress message error: %s", e)
+                        await asyncio.sleep(1)
+            finally:
+                # Always stop the typing loop when the progress task exits,
+                # regardless of how it exits (cancellation, exception, or return).
+                if hasattr(adapter, "stop_typing"):
+                    try:
+                        await adapter.stop_typing(source.chat_id)
+                    except Exception:
+                        pass
         
         # We need to share the agent instance for interrupt support
         agent_holder = [None]  # Mutable container for the agent instance


### PR DESCRIPTION
## Summary

Discord's persistent typing loop (\`_typing_loop\`) was never reliably stopped after an agent turn, leaving \"Agent is typing...\" visible indefinitely after responses were already sent.

**Root cause — two interacting systems:**

1. **System B** (\`run.py send_progress_messages\`): The progress-message loop called \`send_typing()\` and started a \`_typing_loop\`, but the \`asyncio.CancelledError\` handler returned without calling \`stop_typing()\`, leaving the loop running.

2. **System A** (\`base.py _keep_typing\`) — the deeper cause: \`_keep_typing\` fires \`send_typing()\` every 2 seconds for the entire handler duration. After the agent finishes and \`stop_typing()\` is called (clearing \`_typing_tasks\`), \`_keep_typing\` can wake from its sleep interval and call \`send_typing()\` *again* — recreating the \`_typing_loop\`. The subsequent \`typing_task.cancel()\` in \`_process_message_background\` only cancels the wrapper coroutine, not the newly created \`_typing_loop\`, leaving a phantom typing indicator with no cleanup path.

## Fix

**run.py** — wrap the progress loop in \`try/finally\` so \`stop_typing()\` is called unconditionally on every exit path (cancellation, exception, normal return).

**base.py** — add \`finally\` to \`_keep_typing\` so when it is cancelled it always calls \`stop_typing()\`, guaranteeing any \`_typing_loop\` created after the last outer \`stop_typing()\` call is immediately torn down.

Together these close the race: even if \`_keep_typing\` fires one last time after the outer cleanup, the \`finally\` block in \`_keep_typing\` itself will clean it up on cancellation.

## Test plan

- [ ] Send a message to the bot and verify \"Agent is typing\" disappears promptly after the response is sent
- [ ] Trigger a long agent turn (many tool calls) and verify the same
- [ ] Verify no regression on non-Discord platforms (the \`hasattr\` guards keep the finally blocks a no-op for other adapters)