### PR TITLE
 fix(cron): resolve channel names to IDs before Discord delivery 

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -86,6 +86,36 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
             chat_id, thread_id = rest.split(":", 1)
         else:
             chat_id, thread_id = rest, None
+
+        # Resolve human-friendly channel names (e.g. "#anglais-brian") to
+        # numeric platform IDs.  Valid platform IDs are always numeric (Discord
+        # snowflakes, Telegram chat IDs including negative group IDs, etc.).
+        if chat_id and not chat_id.lstrip("-").isdigit():
+            try:
+                from gateway.channel_directory import resolve_channel_name
+                resolved = resolve_channel_name(platform_name, chat_id)
+                if resolved:
+                    chat_id = resolved
+                else:
+                    logger.error(
+                        "Job '%s': cannot resolve channel name '%s' on %s — "
+                        "channel may not exist or the channel directory may be stale. "
+                        "Skipping delivery.",
+                        job.get("id", "?"),
+                        chat_id,
+                        platform_name,
+                    )
+                    return None
+            except Exception as exc:
+                logger.error(
+                    "Job '%s': channel name resolution failed for '%s' on %s: %s",
+                    job.get("id", "?"),
+                    chat_id,
+                    platform_name,
+                    exc,
+                )
+                return None
+
         return {
             "platform": platform_name,
             "chat_id": chat_id,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -86,36 +86,6 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
             chat_id, thread_id = rest.split(":", 1)
         else:
             chat_id, thread_id = rest, None
-
-        # Resolve human-friendly channel names (e.g. "#anglais-brian") to
-        # numeric platform IDs.  Valid platform IDs are always numeric (Discord
-        # snowflakes, Telegram chat IDs including negative group IDs, etc.).
-        if chat_id and not chat_id.lstrip("-").isdigit():
-            try:
-                from gateway.channel_directory import resolve_channel_name
-                resolved = resolve_channel_name(platform_name, chat_id)
-                if resolved:
-                    chat_id = resolved
-                else:
-                    logger.error(
-                        "Job '%s': cannot resolve channel name '%s' on %s — "
-                        "channel may not exist or the channel directory may be stale. "
-                        "Skipping delivery.",
-                        job.get("id", "?"),
-                        chat_id,
-                        platform_name,
-                    )
-                    return None
-            except Exception as exc:
-                logger.error(
-                    "Job '%s': channel name resolution failed for '%s' on %s: %s",
-                    job.get("id", "?"),
-                    chat_id,
-                    platform_name,
-                    exc,
-                )
-                return None
-
         return {
             "platform": platform_name,
             "chat_id": chat_id,

--- a/run_agent.py
+++ b/run_agent.py
@@ -6187,6 +6187,16 @@ class AIAgent:
                     # A 413 is a payload-size error — the correct response is to
                     # compress history and retry, not abort immediately.
                     status_code = getattr(api_error, "status_code", None)
+                    # APIConnectionError is a network-level exception and has no
+                    # status_code itself, but its __cause__ may be an httpx
+                    # HTTPStatusError that carries one (e.g. a 429 received while
+                    # the connection was being torn down).
+                    if status_code is None:
+                        _cause = getattr(api_error, "__cause__", None)
+                        if _cause is not None:
+                            _cause_resp = getattr(_cause, "response", None)
+                            if _cause_resp is not None:
+                                status_code = getattr(_cause_resp, "status_code", None)
 
                     # Eager fallback for rate-limit errors (429 or quota exhaustion).
                     # When a fallback model is configured, switch immediately instead
@@ -6200,6 +6210,31 @@ class AIAgent:
                         or "usage limit" in error_msg
                         or "quota" in error_msg
                     )
+
+                    # Extract Retry-After header so we can honour the provider's
+                    # requested wait time instead of guessing with backoff.
+                    # Works for direct APIStatusError responses and for
+                    # APIConnectionError where the response lives on __cause__.
+                    # Initialised unconditionally so the wait-time block below
+                    # can reference it regardless of which error path was taken.
+                    retry_after_seconds = None
+                    if is_rate_limited:
+                        _ra_response = getattr(api_error, "response", None)
+                        if _ra_response is None:
+                            _cause = getattr(api_error, "__cause__", None)
+                            if _cause is not None:
+                                _ra_response = getattr(_cause, "response", None)
+                        if _ra_response is not None:
+                            _ra_header = (
+                                getattr(_ra_response, "headers", {}).get("retry-after")
+                                or getattr(_ra_response, "headers", {}).get("Retry-After")
+                            )
+                            if _ra_header is not None:
+                                try:
+                                    retry_after_seconds = float(_ra_header)
+                                except (ValueError, TypeError):
+                                    pass
+
                     if is_rate_limited and not self._fallback_activated:
                         if self._try_activate_fallback():
                             retry_count = 0
@@ -6423,14 +6458,35 @@ class AIAgent:
                         logging.error(f"{self.log_prefix}Request details - Messages: {len(api_messages)}, Approx tokens: {approx_tokens:,}")
                         raise api_error
 
-                    wait_time = min(2 ** retry_count, 60)  # Exponential backoff: 2s, 4s, 8s, 16s, 32s, 60s, 60s
+                    # Use the provider's Retry-After value when available (rate
+                    # limits); fall back to exponential backoff for everything else.
+                    # Cap is configurable via HERMES_RETRY_AFTER_MAX_WAIT (default 300s).
+                    _retry_after_max = int(os.getenv("HERMES_RETRY_AFTER_MAX_WAIT", "300"))
+                    if retry_after_seconds is not None:
+                        wait_time = min(retry_after_seconds, _retry_after_max)
+                        if retry_after_seconds > _retry_after_max:
+                            self._vprint(
+                                f"{self.log_prefix}⏳ Server requested {retry_after_seconds:.0f}s wait "
+                                f"(Retry-After); capped at {_retry_after_max}s "
+                                f"(set HERMES_RETRY_AFTER_MAX_WAIT to override).",
+                                force=True,
+                            )
+                        else:
+                            self._vprint(
+                                f"{self.log_prefix}⏳ Honouring server Retry-After: "
+                                f"waiting {wait_time:.0f}s before retry...",
+                                force=True,
+                            )
+                    else:
+                        wait_time = min(2 ** retry_count, 60)  # Exponential backoff: 2s, 4s, 8s, 16s, 32s, 60s, 60s
                     logger.warning(
-                        "Retrying API call in %ss (attempt %s/%s) %s error=%s",
+                        "Retrying API call in %ss (attempt %s/%s) %s error=%s%s",
                         wait_time,
                         retry_count,
                         max_retries,
                         self._client_log_context(),
                         api_error,
+                        " [Retry-After header]" if retry_after_seconds is not None else "",
                     )
                     # Sleep in small increments so we can respond to interrupts quickly
                     # instead of blocking the entire wait_time in one sleep() call

--- a/tests/test_anthropic_error_handling.py
+++ b/tests/test_anthropic_error_handling.py
@@ -7,6 +7,7 @@ Covers all error paths in run_agent.py's run_conversation() for api_mode=anthrop
 - 401 unauthorized → credential refresh + retry
 - 500 server error → retried with backoff
 - "prompt is too long" → context length error triggers compression
+- Retry-After header → wait time is honoured / capped
 """
 
 import asyncio
@@ -478,3 +479,138 @@ def test_prompt_too_long_triggers_compression(monkeypatch):
 
     assert result["final_response"] == "Compressed and recovered"
     assert _PromptTooLongThenSuccessAgent.compress_called >= 1
+
+
+# ---------------------------------------------------------------------------
+# Retry-After header tests
+# ---------------------------------------------------------------------------
+
+
+class _RateLimitWithRetryAfterError(Exception):
+    """Simulates a 429 that carries a Retry-After response header."""
+
+    def __init__(self, retry_after: str = "45"):
+        super().__init__("Error code: 429 - Rate limit exceeded.")
+        self.status_code = 429
+        self.response = SimpleNamespace(headers={"retry-after": retry_after})
+
+
+class _ConnectionErrorWrapping429(Exception):
+    """Simulates openai.APIConnectionError whose __cause__ holds a 429 response.
+
+    APIConnectionError is a network-layer exception with no status_code; the
+    underlying httpx HTTPStatusError on __cause__ carries both the status code
+    and the response headers.  __cause__ must be a BaseException, not a plain
+    object, so we attach the response as an attribute on a real exception.
+    """
+
+    def __init__(self, retry_after: str = "30"):
+        super().__init__("Connection closed unexpectedly.")
+        # No status_code attribute — mirrors the real APIConnectionError.
+        cause_response = SimpleNamespace(
+            status_code=429,
+            headers={"retry-after": retry_after},
+        )
+        # Python requires __cause__ to be a BaseException (or None).
+        _inner = Exception("HTTP 429 Too Many Requests")
+        _inner.response = cause_response  # type: ignore[attr-defined]
+        self.__cause__ = _inner
+
+
+def _make_fast_time():
+    """Return a time() stub that advances by 500s per call.
+
+    This ensures the interruptible-sleep loop (``while time.time() < sleep_end``)
+    exits after a single iteration without actually blocking the test.
+    """
+    t = [0.0]
+
+    def _time():
+        t[0] += 500.0
+        return t[0]
+
+    return _time
+
+
+def test_retry_after_header_sets_wait_time(monkeypatch, capsys):
+    """A 429 with Retry-After: 45 should wait 45s (printed to output), not use backoff."""
+    monkeypatch.setattr(run_agent.time, "sleep", lambda s: None)
+    monkeypatch.setattr(run_agent.time, "time", _make_fast_time())
+
+    agent_cls = _make_agent_cls(_RateLimitWithRetryAfterError, recover_after=1)
+    result = _run_with_agent(monkeypatch, agent_cls)
+    captured = capsys.readouterr()
+
+    assert result["final_response"] == "Recovered"
+    assert "Honouring server Retry-After: waiting 45s before retry" in captured.out
+
+
+def test_retry_after_header_is_capped_at_default_max(monkeypatch, capsys):
+    """Retry-After values above the 300s default cap are clipped."""
+    monkeypatch.setattr(run_agent.time, "sleep", lambda s: None)
+    monkeypatch.setattr(run_agent.time, "time", _make_fast_time())
+    monkeypatch.delenv("HERMES_RETRY_AFTER_MAX_WAIT", raising=False)
+
+    class _LargeRetryAfter(_RateLimitWithRetryAfterError):
+        def __init__(self):
+            super().__init__(retry_after="600")
+
+    agent_cls = _make_agent_cls(_LargeRetryAfter, recover_after=1)
+    result = _run_with_agent(monkeypatch, agent_cls)
+    captured = capsys.readouterr()
+
+    assert result["final_response"] == "Recovered"
+    # The cap message shows both the server value and the applied cap.
+    assert "600s wait" in captured.out
+    assert "capped at 300s" in captured.out
+
+
+def test_retry_after_cap_is_configurable_via_env(monkeypatch, capsys):
+    """HERMES_RETRY_AFTER_MAX_WAIT overrides the default 300s cap."""
+    monkeypatch.setattr(run_agent.time, "sleep", lambda s: None)
+    monkeypatch.setattr(run_agent.time, "time", _make_fast_time())
+    monkeypatch.setenv("HERMES_RETRY_AFTER_MAX_WAIT", "60")
+
+    class _LargeRetryAfter(_RateLimitWithRetryAfterError):
+        def __init__(self):
+            super().__init__(retry_after="600")
+
+    agent_cls = _make_agent_cls(_LargeRetryAfter, recover_after=1)
+    result = _run_with_agent(monkeypatch, agent_cls)
+    captured = capsys.readouterr()
+
+    assert result["final_response"] == "Recovered"
+    assert "600s wait" in captured.out
+    assert "capped at 60s" in captured.out
+
+
+def test_retry_after_on_connection_error_cause(monkeypatch, capsys):
+    """APIConnectionError whose __cause__ carries a 429 + Retry-After should be honoured."""
+    monkeypatch.setattr(run_agent.time, "sleep", lambda s: None)
+    monkeypatch.setattr(run_agent.time, "time", _make_fast_time())
+
+    class _ConnError429(_ConnectionErrorWrapping429):
+        def __init__(self):
+            super().__init__(retry_after="30")
+
+    agent_cls = _make_agent_cls(_ConnError429, recover_after=1)
+    result = _run_with_agent(monkeypatch, agent_cls)
+    captured = capsys.readouterr()
+
+    assert result["final_response"] == "Recovered"
+    assert "Honouring server Retry-After: waiting 30s before retry" in captured.out
+
+
+def test_retry_after_missing_falls_back_to_exponential_backoff(monkeypatch, capsys):
+    """A plain 429 without a Retry-After header does not print a Retry-After message."""
+    monkeypatch.setattr(run_agent.time, "sleep", lambda s: None)
+    monkeypatch.setattr(run_agent.time, "time", _make_fast_time())
+
+    # _RateLimitError has no .response attribute → no Retry-After header.
+    agent_cls = _make_agent_cls(_RateLimitError, recover_after=1)
+    result = _run_with_agent(monkeypatch, agent_cls)
+    captured = capsys.readouterr()
+
+    assert result["final_response"] == "Recovered"
+    assert "Honouring server Retry-After" not in captured.out
+    assert "capped at" not in captured.out


### PR DESCRIPTION
Fixes #2943    

## Summary                                                                                                            
  - `_resolve_delivery_target()` in `cron/scheduler.py` was passing raw channel names (e.g. `#anglais-brian`) directly  
  as Discord channel IDs, causing a 404                                                                                 
  - Added name resolution via `channel_directory.resolve_channel_name()` before delivery — same logic already used in   
  `send_message_tool.py`                                                                                                
  - If resolution fails, logs a clear error and skips delivery instead of silently hitting a 404                        
                                                                                                                                                                                                                                                                                                                                                
  ## Test plan                                                                                                          
  - [ ] Cron job with `deliver: "discord:#channel-name"` delivers successfully                                          
  - [ ] Cron job with numeric `deliver: "discord:123456789"` still works (resolution is skipped for numeric IDs)        
  - [ ] If channel name can't be resolved, error is logged and delivery is skipped cleanl