### PR TITLE
fix(cron): resolve channel names to IDs before Discord delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -86,6 +86,36 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
             chat_id, thread_id = rest.split(":", 1)
         else:
             chat_id, thread_id = rest, None
+
+        # Resolve human-friendly channel names (e.g. "#anglais-brian") to
+        # numeric platform IDs.  Valid platform IDs are always numeric (Discord
+        # snowflakes, Telegram chat IDs including negative group IDs, etc.).
+        if chat_id and not chat_id.lstrip("-").isdigit():
+            try:
+                from gateway.channel_directory import resolve_channel_name
+                resolved = resolve_channel_name(platform_name, chat_id)
+                if resolved:
+                    chat_id = resolved
+                else:
+                    logger.error(
+                        "Job '%s': cannot resolve channel name '%s' on %s — "
+                        "channel may not exist or the channel directory may be stale. "
+                        "Skipping delivery.",
+                        job.get("id", "?"),
+                        chat_id,
+                        platform_name,
+                    )
+                    return None
+            except Exception as exc:
+                logger.error(
+                    "Job '%s': channel name resolution failed for '%s' on %s: %s",
+                    job.get("id", "?"),
+                    chat_id,
+                    platform_name,
+                    exc,
+                )
+                return None
+
         return {
             "platform": platform_name,
             "chat_id": chat_id,


### PR DESCRIPTION
Fixes #2943    

## Summary                                                                                                            
  - `_resolve_delivery_target()` in `cron/scheduler.py` was passing raw channel names (e.g. `#anglais-brian`) directly  
  as Discord channel IDs, causing a 404                                                                                 
  - Added name resolution via `channel_directory.resolve_channel_name()` before delivery — same logic already used in   
  `send_message_tool.py`                                                                                                
  - If resolution fails, logs a clear error and skips delivery instead of silently hitting a 404                        
                                                                                                                                                                                                                                                                                                                                                
  ## Test plan                                                                                                          
  - [ ] Cron job with `deliver: "discord:#channel-name"` delivers successfully                                          
  - [ ] Cron job with numeric `deliver: "discord:123456789"` still works (resolution is skipped for numeric IDs)        
  - [ ] If channel name can't be resolved, error is logged and delivery is skipped cleanly