### PR TITLE
fix(cron): resolve Discord/Slack channel names to IDs before delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -135,6 +135,27 @@ def _deliver_result(job: dict, content: str) -> None:
     from tools.send_message_tool import _send_to_platform
     from gateway.config import load_gateway_config, Platform
 
+    # Resolve channel names (e.g. #anglais-brian) to numeric IDs for Discord/Slack.
+    # Without this, deliver: "discord:#channel-name" causes a 404 because Discord
+    # requires numeric channel IDs, not names.
+    if platform_name.lower() in ("discord", "slack") and chat_id and chat_id.startswith("#"):
+        try:
+            from gateway.channel_directory import resolve_channel_name
+            resolved = resolve_channel_name(platform_name.lower(), chat_id)
+            if resolved:
+                # resolved is "platform:chat_id" or just "chat_id"
+                resolved_id = resolved.split(":")[-1] if ":" in resolved else resolved
+                logger.info("Job '%s': resolved channel '%s' -> '%s'", job["id"], chat_id, resolved_id)
+                chat_id = resolved_id
+            else:
+                logger.error(
+                    "Job '%s': could not resolve channel '%s' on %s — skipping delivery",
+                    job["id"], chat_id, platform_name,
+                )
+                return
+        except Exception as e:
+            logger.warning("Job '%s': channel name resolution failed: %s", job["id"], e)
+
     platform_map = {
         "telegram": Platform.TELEGRAM,
         "discord": Platform.DISCORD,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -90,7 +90,7 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
         # Resolve human-friendly channel names (e.g. #general) to numeric IDs
         # for platforms that require IDs (Discord, Slack, Mattermost).
         # Without this, deliver: "discord:#channel-name" causes a 404.
-        if chat_id and chat_id.startswith("#") and platform_name.lower() in ("discord", "slack", "mattermost"):
+        if chat_id and not chat_id.lstrip("-").isdigit() and platform_name.lower() in ("discord", "slack", "mattermost"):
             try:
                 from gateway.channel_directory import resolve_channel_name
                 resolved = resolve_channel_name(platform_name.lower(), chat_id)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -86,6 +86,32 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
             chat_id, thread_id = rest.split(":", 1)
         else:
             chat_id, thread_id = rest, None
+
+        # Resolve human-friendly channel names (e.g. #general) to numeric IDs
+        # for platforms that require IDs (Discord, Slack, Mattermost).
+        # Without this, deliver: "discord:#channel-name" causes a 404.
+        if chat_id and chat_id.startswith("#") and platform_name.lower() in ("discord", "slack", "mattermost"):
+            try:
+                from gateway.channel_directory import resolve_channel_name
+                resolved = resolve_channel_name(platform_name.lower(), chat_id)
+                if resolved:
+                    resolved_id = resolved.split(":")[-1] if ":" in resolved else resolved
+                    logger.info(
+                        "Resolved channel name '%s' -> '%s' for platform '%s'",
+                        chat_id, resolved_id, platform_name,
+                    )
+                    chat_id = resolved_id
+                else:
+                    logger.error(
+                        "Could not resolve channel '%s' on %s — "
+                        "check that the bot is a member of this channel "
+                        "and the channel directory is populated.",
+                        chat_id, platform_name,
+                    )
+                    return None
+            except Exception as e:
+                logger.warning("Channel name resolution failed for '%s' on %s: %s", chat_id, platform_name, e)
+
         return {
             "platform": platform_name,
             "chat_id": chat_id,


### PR DESCRIPTION
Fixes #2943

## Root Cause
`_resolve_delivery_target()` in cron/scheduler.py passed raw channel names (e.g. `#anglais-brian`) directly as Discord channel IDs, causing a 404. Discord requires numeric channel IDs, not names.

## Fix
In `_resolve_delivery_target()`, when the platform is Discord, Slack, or Mattermost and the chat_id starts with `#`, resolve it to a numeric ID using the existing `channel_directory.resolve_channel_name()` — the same logic already used in `send_message_tool.py`.

If resolution fails, logs a clear error with a helpful hint ("check that the bot is a member of this channel") and returns None to skip delivery cleanly.

## Improvements over #2947
- Fix applied at `_resolve_delivery_target()` (upstream, covers all paths)
- Mattermost support added
- Better error message guides users to check bot membership

## Update
Based on @heathley's feedback, changed the condition from `startswith("#")` to `not chat_id.lstrip("-").isdigit()` — this catches all non-numeric channel IDs regardless of prefix (e.g. both `#general` and `general` are now resolved correctly).


