### PR TITLE
fix(skills_guard): confirm dangerous agent-created skills

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -633,6 +633,36 @@ class TestSkillManageDispatcher:
 class TestSecurityScanGate:
     """_security_scan_skill is gated by skills.guard_agent_created config flag."""
 
+    @staticmethod
+    def _dangerous_result():
+        from tools.skills_guard import Finding, ScanResult
+
+        finding = Finding(
+            pattern_id="test", severity="critical", category="exfiltration",
+            file="SKILL.md", line=1, match="curl $TOKEN", description="test",
+        )
+        return ScanResult(
+            skill_name="test", source="agent-created",
+            trust_level="agent-created", verdict="dangerous",
+            findings=[finding], summary="dangerous",
+        )
+
+    @staticmethod
+    def _run_mutation(action):
+        if action == "create":
+            return skill_manage(action="create", name="test", content=VALID_SKILL_CONTENT)
+        if action == "edit":
+            return skill_manage(action="edit", name="test", content=VALID_SKILL_CONTENT_2)
+        if action == "patch":
+            return skill_manage(
+                action="patch", name="test",
+                old_string="Do the thing.", new_string="Do the approved thing.",
+            )
+        return skill_manage(
+            action="write_file", name="test",
+            file_path="scripts/run.sh", file_content="curl $TOKEN",
+        )
+
     def test_scan_noop_when_flag_off(self, tmp_path):
         """Default config (flag off) short-circuits before running scan_skill."""
         from tools.skill_manager_tool import _security_scan_skill
@@ -665,29 +695,67 @@ class TestSecurityScanGate:
         assert result is None
         mock_scan.assert_called_once()
 
-    def test_scan_blocks_dangerous_when_flag_on(self, tmp_path):
-        """Dangerous verdict + flag on → returns an error string for the agent."""
+    def test_scan_requests_approval_for_dangerous_findings(self, tmp_path):
+        """Dangerous verdicts use the shared operator-approval path."""
         from tools.skill_manager_tool import _security_scan_skill
-        from tools.skills_guard import ScanResult, Finding
 
-        finding = Finding(
-            pattern_id="test", severity="critical", category="exfiltration",
-            file="SKILL.md", line=1, match="curl $TOKEN", description="test",
-        )
-        fake_result = ScanResult(
-            skill_name="test",
-            source="agent-created",
-            trust_level="agent-created",
-            verdict="dangerous",
-            findings=[finding],
-            summary="dangerous",
-        )
         with patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=True), \
-             patch("tools.skill_manager_tool.scan_skill", return_value=fake_result):
+             patch("tools.skill_manager_tool.scan_skill", return_value=self._dangerous_result()), \
+             patch("tools.approval.request_tool_approval",
+                   return_value={"approved": False, "message": "denied"}) as mock_approval:
             result = _security_scan_skill(tmp_path)
 
         assert result is not None
         assert "Security scan blocked" in result
+        mock_approval.assert_called_once()
+        assert mock_approval.call_args.kwargs["rule_key"].startswith(
+            "skills_guard:agent-created:"
+        )
+
+    @pytest.mark.parametrize("action", ["create", "edit", "patch", "write_file"])
+    def test_operator_approval_keeps_each_mutation(self, tmp_path, action):
+        with _skill_dir(tmp_path), \
+             patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=False):
+            if action != "create":
+                _create_skill("test", VALID_SKILL_CONTENT)
+
+        with _skill_dir(tmp_path), \
+             patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=True), \
+             patch("tools.skill_manager_tool.scan_skill", return_value=self._dangerous_result()), \
+             patch("tools.approval.request_tool_approval", return_value={"approved": True}):
+            result = json.loads(self._run_mutation(action))
+
+        assert result["success"] is True
+        if action == "create":
+            assert (tmp_path / "test" / "SKILL.md").exists()
+        elif action == "edit":
+            assert "Test Skill v2" in (tmp_path / "test" / "SKILL.md").read_text()
+        elif action == "patch":
+            assert "approved thing" in (tmp_path / "test" / "SKILL.md").read_text()
+        else:
+            assert (tmp_path / "test" / "scripts" / "run.sh").exists()
+
+    @pytest.mark.parametrize("action", ["create", "edit", "patch", "write_file"])
+    def test_denial_rolls_back_each_mutation(self, tmp_path, action):
+        with _skill_dir(tmp_path), \
+             patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=False):
+            if action != "create":
+                _create_skill("test", VALID_SKILL_CONTENT)
+
+        with _skill_dir(tmp_path), \
+             patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=True), \
+             patch("tools.skill_manager_tool.scan_skill", return_value=self._dangerous_result()), \
+             patch("tools.approval.request_tool_approval",
+                   return_value={"approved": False, "message": "denied"}):
+            result = json.loads(self._run_mutation(action))
+
+        assert result["success"] is False
+        if action == "create":
+            assert not (tmp_path / "test").exists()
+        elif action == "write_file":
+            assert not (tmp_path / "test" / "scripts" / "run.sh").exists()
+        else:
+            assert (tmp_path / "test" / "SKILL.md").read_text() == VALID_SKILL_CONTENT
 
     def test_guard_flag_reads_config_default_false(self):
         """_guard_agent_created_enabled returns False when config doesn't set it."""

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -93,7 +93,12 @@ def _reset_background_review_read_marks() -> None:
 # Import security scanner — external hub installs always get scanned;
 # agent-created skills only get scanned when skills.guard_agent_created is on.
 try:
-    from tools.skills_guard import scan_skill, should_allow_install, format_scan_report
+    from tools.skills_guard import (
+        content_hash,
+        format_scan_report,
+        scan_skill,
+        should_allow_install,
+    )
     _GUARD_AVAILABLE = True
 except ImportError:
     _GUARD_AVAILABLE = False
@@ -134,15 +139,34 @@ def _security_scan_skill(skill_dir: Path) -> Optional[str]:
             report = format_scan_report(result)
             return f"Security scan blocked this skill ({reason}):\n{report}"
         if allowed is None:
-            # "ask" verdict — for agent-created skills this means dangerous
-            # findings were detected.  Surface as an error so the agent can
-            # retry with the flagged content removed.
-            report = format_scan_report(result)
-            logger.warning("Agent-created skill blocked (dangerous findings): %s", reason)
-            return f"Security scan blocked this skill ({reason}):\n{report}"
+            return _request_dangerous_skill_approval(skill_dir, result, reason)
     except Exception as e:
         logger.warning("Security scan failed for %s: %s", skill_dir, e, exc_info=True)
     return None
+
+
+def _request_dangerous_skill_approval(skill_dir: Path, result, reason: str) -> Optional[str]:
+    """Ask the operator to approve dangerous agent-created skill content."""
+    report = format_scan_report(result)
+    try:
+        from tools.approval import request_tool_approval
+
+        decision = request_tool_approval(
+            "skill_manage",
+            f"Dangerous findings in agent-created skill '{result.skill_name}':\n{report}",
+            rule_key=f"skills_guard:agent-created:{content_hash(skill_dir)}",
+        )
+    except Exception as e:
+        logger.warning("Skill approval failed for %s: %s", skill_dir, e, exc_info=True)
+        return f"Security scan blocked this skill (approval failed):\n{report}"
+
+    if decision.get("approved"):
+        logger.warning("Operator approved dangerous agent-created skill: %s", reason)
+        return None
+
+    message = decision.get("message") or reason
+    logger.warning("Agent-created skill denied (dangerous findings): %s", message)
+    return f"Security scan blocked this skill ({message}):\n{report}"
 
 import yaml
 

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -57,10 +57,9 @@ INSTALL_POLICY = {
     "builtin":       ("allow",  "allow",   "allow"),
     "trusted":       ("allow",  "allow",   "block"),
     "community":     ("allow",  "block",   "block"),
-    # Agent-created: "ask" on dangerous surfaces as an error to the agent,
-    # which can retry without the flagged content. This gate only runs when
-    # skills.guard_agent_created is enabled (off by default) — see
-    # tools/skill_manager_tool.py::_guard_agent_created_enabled.
+    # Agent-created: dangerous findings require operator approval. This gate
+    # only runs when skills.guard_agent_created is enabled (off by default) —
+    # see tools/skill_manager_tool.py::_guard_agent_created_enabled.
     "agent-created": ("allow",  "allow",   "ask"),
 }
 


### PR DESCRIPTION
## Summary

Dangerous findings in agent-created skills now preserve the existing `ask` policy and route through Hermes' shared operator-approval system instead of being treated as a falsy block.

## Root cause

`should_allow_install()` correctly returns `None` for the `ask` decision, but `skill_manager_tool.py` converted that result into an error. The create, edit, patch, and write-file flows then rolled back without giving the operator a confirmation path.

Current `main` already resolves the `agent-created` trust level correctly, so the stale trust-resolution change has been removed.

## Fix

- Preserve `INSTALL_POLICY["agent-created"] = (..., "ask")`.
- Route dangerous agent-created findings through `request_tool_approval()`, which uses the established CLI/TUI/gateway approval transport and fails closed when no operator can respond.
- Scope remembered approval to the exact skill content hash, preventing approval of different dangerous content.
- Preserve rollback on denial, timeout, or approval failure.
- Cover create, edit, patch, and write-file approval and rollback behavior.

The guard remains opt-in through `skills.guard_agent_created` and existing builtin/trusted/community policies are unchanged.

## Verification

- `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py tests/tools/test_skills_guard.py -q` — pass
- `scripts/run_tests.sh tests/tools/test_request_tool_approval.py -q` — pass
- Ruff on changed files — pass
- `git diff --check` — pass
- Full wrapper: 40,353 passed; 46 unrelated failures across 19 files. The nearby `test_nonrecursive_verification_artifact_cleanup_is_not_dangerous` failure reproduces on untouched `origin/main` on macOS.

## PR checklist

- [x] Preserves the dangerous-content opt-in gate
- [x] Uses the existing approval infrastructure
- [x] Covers every mutation flow named in review
- [x] Rebased onto current `main`
- [x] No dependency, process, or platform-specific runtime changes