### PR TITLE
fix(gateway/slack): inject thread parent message into conversation context

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -750,6 +750,16 @@ class SlackAdapter(BasePlatformAdapter):
                 except Exception as e:  # pragma: no cover - defensive logging
                     logger.warning("[Slack] Failed to cache document from %s: %s", url, e, exc_info=True)
 
+        # Inject thread parent message as context when replying inside a thread.
+        # The parent (root) message is the one that started the thread; it is not
+        # included in the standard message event, so we fetch it explicitly via
+        # conversations.replies and prepend it to the agent's context.
+        real_thread_ts = event.get("thread_ts")
+        if real_thread_ts and real_thread_ts != ts:
+            parent_text = await self._fetch_thread_parent(channel_id, real_thread_ts)
+            if parent_text:
+                text = f"[Thread started with]: {parent_text}\n\n{text}" if text else f"[Thread started with]: {parent_text}"
+
         # Resolve user display name (cached after first lookup)
         user_name = await self._resolve_user_name(user_id)
 
@@ -818,6 +828,33 @@ class SlackAdapter(BasePlatformAdapter):
         )
 
         await self.handle_message(event)
+
+    async def _fetch_thread_parent(self, channel_id: str, thread_ts: str) -> Optional[str]:
+        """Fetch the parent (root) message that started a thread.
+
+        Uses conversations.replies with limit=1 to retrieve only the root message,
+        which is always the first item returned for a given thread_ts.
+        Returns the message text, or None if unavailable.
+        """
+        if not self._app:
+            return None
+        try:
+            result = await self._app.client.conversations_replies(
+                channel=channel_id,
+                ts=thread_ts,
+                limit=1,
+                inclusive=True,
+            )
+            messages = result.get("messages", [])
+            if messages:
+                parent = messages[0]
+                # Skip if the root message was posted by the bot itself
+                if parent.get("bot_id") or parent.get("subtype") == "bot_message":
+                    return None
+                return parent.get("text", "").strip() or None
+        except Exception as e:
+            logger.debug("[Slack] Failed to fetch thread parent %s: %s", thread_ts, e)
+        return None
 
     async def _download_slack_file(self, url: str, ext: str, audio: bool = False) -> str:
         """Download a Slack file using the bot token for auth."""

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -946,3 +946,97 @@ class TestFallbackPreservesThreadContext:
 
         call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
         assert "important screenshot" in call_kwargs["text"]
+
+
+# ---------------------------------------------------------------------------
+# TestThreadParentInjection
+# ---------------------------------------------------------------------------
+
+class TestThreadParentInjection:
+    """Verify that the thread parent message is injected into context."""
+
+    def _make_thread_event(self, text="reply text", thread_ts="1000000000.000001", ts="1000000001.000002"):
+        """Build a Slack message event that is a reply inside a thread."""
+        return {
+            "text": text,
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "im",
+            "ts": ts,
+            "thread_ts": thread_ts,
+        }
+
+    @pytest.mark.asyncio
+    async def test_parent_message_prepended_to_text(self, adapter):
+        """Thread replies should have the parent message prepended as context."""
+        adapter._app.client.conversations_replies = AsyncMock(return_value={
+            "messages": [{"text": "What is the capital of France?", "user": "U_USER"}]
+        })
+
+        event = self._make_thread_event(text="and what about Germany?")
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert "[Thread started with]: What is the capital of France?" in msg_event.text
+        assert "and what about Germany?" in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_parent_fetch_failure_does_not_crash(self, adapter):
+        """If the parent fetch fails, the handler should proceed normally."""
+        adapter._app.client.conversations_replies = AsyncMock(
+            side_effect=RuntimeError("API error")
+        )
+
+        event = self._make_thread_event(text="a follow-up")
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "a follow-up"
+
+    @pytest.mark.asyncio
+    async def test_bot_parent_message_not_injected(self, adapter):
+        """If the thread was started by the bot itself, skip parent injection."""
+        adapter._app.client.conversations_replies = AsyncMock(return_value={
+            "messages": [{"text": "I said this", "bot_id": "B_BOT"}]
+        })
+
+        event = self._make_thread_event(text="user reply")
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert "[Thread started with]" not in (msg_event.text or "")
+
+    @pytest.mark.asyncio
+    async def test_top_level_message_not_fetching_parent(self, adapter):
+        """A top-level message (ts == thread_ts) should not trigger a parent fetch."""
+        adapter._app.client.conversations_replies = AsyncMock()
+
+        ts = "1000000000.000001"
+        event = {
+            "text": "top level message",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "im",
+            "ts": ts,
+            "thread_ts": ts,  # Same as ts — this is the root message itself
+        }
+        await adapter._handle_slack_message(event)
+
+        adapter._app.client.conversations_replies.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_thread_ts_skips_fetch(self, adapter):
+        """A plain DM with no thread should not trigger a parent fetch."""
+        adapter._app.client.conversations_replies = AsyncMock()
+
+        event = {
+            "text": "just a plain dm",
+            "user": "U_USER",
+            "channel": "D123",
+            "channel_type": "im",
+            "ts": "1000000000.000001",
+        }
+        await adapter._handle_slack_message(event)
+
+        adapter._app.client.conversations_replies.assert_not_called()


### PR DESCRIPTION
## Summary

When Hermes receives a message inside a Slack thread, the parent (root) message that started the thread was absent from the conversation context. Only thread reply messages were visible to the agent.

## Root Cause

`_handle_slack_message` only processes the current event payload. There was no code to fetch the thread root message via the Slack API.

## Fix

Call `conversations.replies` with `limit=1` when processing a thread reply (`thread_ts` present and != the message's own `ts`), fetch the root message, and prepend it to the agent's context as `[Thread started with]: ...`.

**Edge cases handled:**
- Skip injection if the root message was posted by the bot itself (avoids recursive context loops)
- Silently ignore API errors via debug log — handler never crashes due to a missing parent
- No injection for top-level messages (`ts == thread_ts`) or plain DMs with no `thread_ts`

## Changes

- `gateway/platforms/slack.py`: new `_fetch_thread_parent()` method + injection logic in `_handle_slack_message`
- `tests/gateway/test_slack.py`: new `TestThreadParentInjection` class with 5 tests

## Tests

| Test | Covers |
|---|---|
| `test_parent_message_prepended_to_text` | Happy path — parent injected |
| `test_parent_fetch_failure_does_not_crash` | API error → handler proceeds normally |
| `test_bot_parent_message_not_injected` | Bot-authored root message skipped |
| `test_top_level_message_not_fetching_parent` | `ts == thread_ts` → no API call |
| `test_no_thread_ts_skips_fetch` | Plain DM → no API call |

Fixes #2950
Related to #1953