### PR TITLE
fix(slack): include thread parent message in conversation context

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -763,6 +763,41 @@ class SlackAdapter(BasePlatformAdapter):
             thread_id=thread_ts,
         )
 
+        # Fetch thread context including parent message when bot is in a thread.
+        # Without this, the parent message (thread root) is missing from context,
+        # leaving the agent unaware of the original question or instructions.
+        if thread_ts and thread_ts != ts:
+            try:
+                result = await self._app.client.conversations_replies(
+                    channel=channel_id,
+                    ts=thread_ts,
+                    limit=20,
+                )
+                thread_messages = result.get("messages", [])
+                thread_context_lines = []
+                for msg in thread_messages:
+                    if msg.get("ts") == ts:
+                        continue  # skip current message (already in text)
+                    if msg.get("bot_id") or msg.get("user") == self._bot_user_id:
+                        sender = "Assistant"
+                    else:
+                        msg_user = await self._resolve_user_name(msg.get("user", ""))
+                        sender = msg_user or "User"
+                    msg_text = msg.get("text", "")
+                    if self._bot_user_id:
+                        msg_text = msg_text.replace(f"<@{self._bot_user_id}>", "").strip()
+                    if msg_text:
+                        # Mark parent message clearly so agent knows it started the thread
+                        if msg.get("ts") == thread_ts:
+                            thread_context_lines.insert(0, f"{sender} [thread parent]: {msg_text}")
+                        else:
+                            thread_context_lines.append(f"{sender}: {msg_text}")
+                if thread_context_lines:
+                    thread_context = "\n".join(thread_context_lines)
+                    text = f"[Thread context:]\n{thread_context}\n\n[New message:]\n{text}"
+            except Exception as e:
+                logger.debug("[Slack] Failed to fetch thread context: %s", e)
+
         msg_event = MessageEvent(
             text=text,
             message_type=msg_type,

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -946,3 +946,77 @@ class TestFallbackPreservesThreadContext:
 
         call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
         assert "important screenshot" in call_kwargs["text"]
+
+
+# ---------------------------------------------------------------------------
+# Thread parent message context injection tests
+# ---------------------------------------------------------------------------
+
+class TestThreadParentContext:
+    """Tests for thread context injection in _handle_slack_message."""
+
+    @pytest.fixture
+    def adapter(self):
+        _ensure_slack_mock()
+        from gateway.platforms.slack import SlackAdapter
+        config = PlatformConfig(enabled=True, token="xoxb-test")
+        a = SlackAdapter(config)
+        a._bot_user_id = "UBOTID"
+        a._app = MagicMock()
+        a.handle_message = AsyncMock()
+        a._resolve_user_name = AsyncMock(return_value="Alice")
+        a._add_reaction = AsyncMock()
+        a._remove_reaction = AsyncMock()
+        return a
+
+    @pytest.mark.asyncio
+    async def test_thread_parent_prepended_to_text(self, adapter):
+        """Parent message text is prepended when bot receives a thread reply."""
+        adapter._app.client.conversations_replies = AsyncMock(return_value={
+            "messages": [
+                {"ts": "1000.000", "user": "U123", "text": "Original question"},
+                {"ts": "1001.000", "user": "UBOTID", "text": "Bot reply", "bot_id": "BBOT"},
+                {"ts": "1002.000", "user": "U123", "text": "Follow up question"},
+            ]
+        })
+
+        event = {
+            "type": "message", "channel": "C123", "user": "U123",
+            "text": f"<@UBOTID> Follow up question",
+            "ts": "1002.000", "thread_ts": "1000.000",
+            "channel_type": "channel",
+        }
+        await adapter._handle_slack_message(event)
+
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert "[Thread context:" in dispatched.text
+        assert "thread parent" in dispatched.text
+        assert "Original question" in dispatched.text
+
+    @pytest.mark.asyncio
+    async def test_thread_fetch_failure_does_not_crash(self, adapter):
+        """API error during thread fetch is silently ignored."""
+        adapter._app.client.conversations_replies = AsyncMock(side_effect=Exception("API error"))
+
+        event = {
+            "type": "message", "channel": "C123", "user": "U123",
+            "text": f"<@UBOTID> Follow up",
+            "ts": "1002.000", "thread_ts": "1000.000",
+            "channel_type": "channel",
+        }
+        await adapter._handle_slack_message(event)
+        assert adapter.handle_message.called
+
+    @pytest.mark.asyncio
+    async def test_top_level_message_no_thread_fetch(self, adapter):
+        """No thread fetch for top-level messages (ts == thread_ts)."""
+        adapter._app.client.conversations_replies = AsyncMock()
+
+        event = {
+            "type": "message", "channel": "C123", "user": "U123",
+            "text": f"<@UBOTID> Hello",
+            "ts": "1000.000", "thread_ts": "1000.000",
+            "channel_type": "channel",
+        }
+        await adapter._handle_slack_message(event)
+        adapter._app.client.conversations_replies.assert_not_called()


### PR DESCRIPTION
Fixes #2950

## Problem
When Hermes responds in a Slack thread, the parent/root message was missing from conversation context. The agent had no awareness of the original question.

## Fix
Fetch thread history via conversations_replies before dispatching MessageEvent. Parent message is marked with [thread parent] label and inserted first in context.

- Parent message included with [thread parent] label
- Full thread history included (last 20 messages)  
- Current message skipped (already in text)
- Bot mentions stripped
- Graceful fallback if API call fails

## Tests
3 new tests in TestThreadParentContext:
- Parent message prepended to text
- API failure doesn't crash handler
- Top-level messages don't trigger thread fetch

## vs #2952
This PR fetches full thread history (limit=20) instead of just the parent, giving the agent complete conversation context.
