### PR TITLE
docs: align test command in CONTRIBUTING.md with CI workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ hermes chat -q "Hello"
 ### Run tests
 
 ```bash
-pytest tests/ -v
+pytest tests/ -v --ignore=tests/integration
 ```
 
 ---


### PR DESCRIPTION
The `pytest tests/ -v` command in CONTRIBUTING.md does not match
the CI workflow (`.github/workflows/tests.yml`) which runs:

    pytest tests/ -q --ignore=tests/integration --tb=short -n auto

Without `--ignore=tests/integration`, running tests locally as
documented requires integration API keys that most contributors
won't have, causing confusing import failures.

This aligns the documented command with what CI actually runs.