### PR TITLE
feat(api-server): validate previous_response_id chain (cycle + depth)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -46,6 +46,7 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
+MAX_RESPONSE_CHAIN = int(os.getenv("MAX_RESPONSE_CHAIN", "20"))
 
 
 def check_api_server_requirements() -> bool:
@@ -389,6 +390,58 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         return agent
 
+    def _validate_previous_response_chain(
+        self,
+        previous_response_id: str,
+    ) -> Optional[tuple[Dict[str, Any], int]]:
+        """
+        Validate that `previous_response_id` chain is acyclic and not too deep.
+
+        Prevents cycles (infinite loops) and overly deep chains (resource exhaustion).
+        """
+        visited: set[str] = set()
+        current: Optional[str] = str(previous_response_id)
+        depth = 0
+
+        while current:
+            if current in visited:
+                return (
+                    _openai_error(
+                        "Cycle detected in previous_response_id chain.",
+                        err_type="invalid_request_error",
+                        code="response_chain_cycle",
+                    ),
+                    400,
+                )
+            visited.add(current)
+
+            stored = self._response_store.get(current)
+            if stored is None:
+                return (
+                    _openai_error(
+                        f"Previous response not found: {current}",
+                        err_type="invalid_request_error",
+                        code="previous_response_missing",
+                    ),
+                    404,
+                )
+
+            depth += 1
+            if depth > MAX_RESPONSE_CHAIN:
+                return (
+                    _openai_error(
+                        f"Response chain too deep (max {MAX_RESPONSE_CHAIN}).",
+                        err_type="invalid_request_error",
+                        code="response_chain_too_deep",
+                    ),
+                    400,
+                )
+
+            next_id = stored.get("previous_response_id")
+            current = str(next_id) if next_id else None
+
+        return None
+
     # ------------------------------------------------------------------
     # HTTP Handlers
     # ------------------------------------------------------------------
@@ -692,6 +745,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # Reconstruct conversation history from previous_response_id
         conversation_history: List[Dict[str, str]] = []
         if previous_response_id:
+            validation = self._validate_previous_response_chain(str(previous_response_id))
+            if validation is not None:
+                err_json, status = validation
+                return web.json_response(err_json, status=status)
+
+        if previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored is None:
                 return web.json_response(_openai_error(f"Previous response not found: {previous_response_id}"), status=404)
@@ -789,6 +848,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "response": response_data,
                 "conversation_history": full_history,
                 "instructions": instructions,
+                "previous_response_id": previous_response_id,
             })
             # Update conversation mapping so the next request with the same
             # conversation name automatically chains to this response

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -26,6 +26,7 @@ from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
     _CORS_HEADERS,
+    MAX_RESPONSE_CHAIN,
     check_api_server_requirements,
     cors_middleware,
 )
@@ -643,6 +644,80 @@ class TestResponsesEndpoint:
                 },
             )
             assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_chain_cycle_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp_a = "resp_cycle_a"
+            resp_b = "resp_cycle_b"
+
+            adapter._response_store.put(
+                resp_a,
+                {
+                    "response": {},
+                    "conversation_history": [],
+                    "instructions": None,
+                    "previous_response_id": resp_b,
+                },
+            )
+            adapter._response_store.put(
+                resp_b,
+                {
+                    "response": {},
+                    "conversation_history": [],
+                    "instructions": None,
+                    "previous_response_id": resp_a,
+                },
+            )
+
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "follow up",
+                        "previous_response_id": resp_a,
+                    },
+                )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert "cycle" in data["error"]["message"].lower()
+            assert mock_run.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_chain_too_deep_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            chain = [f"resp_deep_{i}" for i in range(MAX_RESPONSE_CHAIN + 1)]
+
+            for i, rid in enumerate(chain):
+                adapter._response_store.put(
+                    rid,
+                    {
+                        "response": {},
+                        "conversation_history": [],
+                        "instructions": None,
+                        "previous_response_id": chain[i - 1] if i > 0 else None,
+                    },
+                )
+
+            last = chain[-1]
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "too deep",
+                        "previous_response_id": last,
+                    },
+                )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert "too deep" in data["error"]["message"].lower()
+            assert mock_run.call_count == 0
 
     @pytest.mark.asyncio
     async def test_store_false_does_not_store(self, adapter):


### PR DESCRIPTION
This PR hardens the OpenAI-compatible Responses API by validating the previous_response_id chaining graph. It rejects cyclic chains (infinite loops) and overly deep chains (resource exhaustion) to make stateful conversations safer.
Changes:
Add cycle detection + max-depth validation for previous_response_id
Persist previous_response_id in the response store so the chain can be validated reliably
Add regression tests covering cycle and too-deep chain cases
Endpoints affected:
POST /v1/responses