### PR TITLE
validate previous_response_id input type/length

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -45,6 +45,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
+MAX_PREVIOUS_RESPONSE_ID_LENGTH = 128
 MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
 
 
@@ -653,6 +654,28 @@ class APIServerAdapter(BasePlatformAdapter):
         previous_response_id = body.get("previous_response_id")
         conversation = body.get("conversation")
         store = body.get("store", True)
+
+        # Basic hardening: ensure `previous_response_id` is a reasonable string.
+        # Prevents accidental type mismatches and extremely long IDs.
+        if previous_response_id is not None:
+            if not isinstance(previous_response_id, str):
+                return web.json_response(
+                    _openai_error("Invalid 'previous_response_id' type"),
+                    status=400,
+                )
+            if not previous_response_id:
+                return web.json_response(
+                    _openai_error("Invalid 'previous_response_id' value"),
+                    status=400,
+                )
+            if len(previous_response_id) > MAX_PREVIOUS_RESPONSE_ID_LENGTH:
+                return web.json_response(
+                    _openai_error(
+                        "previous_response_id is too long.",
+                        code="previous_response_id_too_long",
+                    ),
+                    status=400,
+                )
 
         # conversation and previous_response_id are mutually exclusive
         if conversation and previous_response_id:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -26,6 +26,7 @@ from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
     _CORS_HEADERS,
+    MAX_PREVIOUS_RESPONSE_ID_LENGTH,
     check_api_server_requirements,
     cors_middleware,
 )
@@ -643,6 +644,41 @@ class TestResponsesEndpoint:
                 },
             )
             assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_invalid_type_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "model": "hermes-agent",
+                    "input": "follow up",
+                    "previous_response_id": 123,
+                },
+            )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert "previous_response_id" in data["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_too_long_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            too_long_id = "x" * (MAX_PREVIOUS_RESPONSE_ID_LENGTH + 1)
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "model": "hermes-agent",
+                    "input": "follow up",
+                    "previous_response_id": too_long_id,
+                },
+            )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert "too long" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_store_false_does_not_store(self, adapter):


### PR DESCRIPTION
This PR hardens the OpenAI-compatible Responses API by validating previous_response_id input.
It rejects:
non-string previous_response_id values (400)
empty or excessively long IDs (400)

Additionally, it adds regression tests covering invalid type and too-long cases to prevent accidental future regressions.
Endpoints affected:
**POST /v1/responses**