### PR TITLE
fix(cron): guard telegram import in _send_to_platform against ImportError

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -276,15 +276,21 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     """
     from gateway.config import Platform
     from gateway.platforms.base import BasePlatformAdapter
-    from gateway.platforms.telegram import TelegramAdapter
     from gateway.platforms.discord import DiscordAdapter
     from gateway.platforms.slack import SlackAdapter
+
+    try:
+        from gateway.platforms.telegram import TelegramAdapter
+        _telegram_max = TelegramAdapter.MAX_MESSAGE_LENGTH
+    except ImportError:
+        TelegramAdapter = None  # type: ignore[assignment,misc]
+        _telegram_max = 4096  # Telegram hard limit
 
     media_files = media_files or []
 
     # Platform message length limits (from adapter class attributes)
     _MAX_LENGTHS = {
-        Platform.TELEGRAM: TelegramAdapter.MAX_MESSAGE_LENGTH,
+        Platform.TELEGRAM: _telegram_max,
         Platform.DISCORD: DiscordAdapter.MAX_MESSAGE_LENGTH,
         Platform.SLACK: SlackAdapter.MAX_MESSAGE_LENGTH,
     }


### PR DESCRIPTION
## Problem

When `python-telegram-bot` is not installed, the bare import inside `_send_to_platform()`:

```python
from gateway.platforms.telegram import TelegramAdapter
```

raises `ImportError`, which propagated all the way up through `_deliver_result()` in `cron/scheduler.py`. This caused **every** cron job delivery to fail with:

```
No module named 'gateway.platforms.telegram'
```

...even when delivering to Slack, Discord, or any platform that has nothing to do with Telegram.

Gateway log evidence:
```
ERROR cron.scheduler: Job '68fefd3080fe': delivery to slack:.. failed: No module named 'gateway.platforms.telegram'
ERROR cron.scheduler: Job 'f50f5043c4f5': delivery to slack:.. failed: No module named 'gateway.platforms.telegram'
```

Cron jobs executed successfully and output was saved locally — but nothing was delivered to the user.

## Fix

Wrap the telegram import in a `try/except ImportError` block and fall back to the known Telegram hard limit (4096 chars) when the package is absent. Delivery to Slack/Discord/other platforms now works regardless of whether `python-telegram-bot` is installed.

```python
try:
    from gateway.platforms.telegram import TelegramAdapter
    _telegram_max = TelegramAdapter.MAX_MESSAGE_LENGTH
except ImportError:
    TelegramAdapter = None
    _telegram_max = 4096  # Telegram hard limit
```

## Testing

Verified by mocking `telegram` as unimportable at runtime and confirming `_send_to_platform(Platform.SLACK, ...)` completes without raising `ImportError`.