### PR TITLE
fix(cron): mark session as ended after job completes

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -477,6 +477,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             os.environ.pop(key, None)
         if _session_db:
             try:
+                # Mark cron session as ended so hermes prune can clean it up
+                _session_db.end_session()
+            except Exception as e:
+                logger.debug("Job '%s': failed to end session: %s", job_id, e)
+            try:
                 _session_db.close()
             except Exception as e:
                 logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)


### PR DESCRIPTION
Fixes #2972

## Root Cause
run_job() in cron/scheduler.py closed the session DB without calling end_session() first. Cron was the only execution path that didn't mark sessions as ended, leaving ended_at = NULL permanently.

## Fix
Call _session_db.end_session() in the finally block before _session_db.close(). This makes cron sessions visible to hermes prune --older-than N.
