### PR TITLE
fix(whatsapp): detect usable macOS node runtimes

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import platform
+import shutil
 import subprocess
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -85,17 +86,48 @@ def check_whatsapp_requirements() -> bool:
     
     WhatsApp requires a Node.js bridge for most implementations.
     """
-    # Check for Node.js
-    try:
-        result = subprocess.run(
-            ["node", "--version"],
-            capture_output=True,
-            text=True,
-            timeout=5
+    return _resolve_node_command() is not None
+
+
+def _resolve_node_command() -> Optional[tuple[list[str], dict[str, str]]]:
+    """Resolve a usable Node.js command for the WhatsApp bridge.
+
+    Prefer the standard PATH lookup. On macOS, fall back to the VS Code bundled
+    runtime when present so the WhatsApp bridge can still start on systems
+    without a separate Node install.
+    """
+    candidates: list[tuple[list[str], dict[str, str]]] = []
+
+    node_path = shutil.which("node")
+    if node_path:
+        candidates.append(([node_path], {}))
+
+    if platform.system() == "Darwin":
+        vscode_node = (
+            "/Applications/Visual Studio Code.app/Contents/Frameworks/"
+            "Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin)"
         )
-        return result.returncode == 0
-    except Exception:
-        return False
+        if Path(vscode_node).exists():
+            candidates.append(([vscode_node], {"ELECTRON_RUN_AS_NODE": "1"}))
+
+    for argv, extra_env in candidates:
+        env = os.environ.copy()
+        env.update(extra_env)
+        try:
+            result = subprocess.run(
+                [*argv, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                env=env,
+            )
+        except Exception:
+            continue
+
+        if result.returncode == 0:
+            return argv, extra_env
+
+    return None
 
 
 class WhatsAppAdapter(BasePlatformAdapter):
@@ -147,9 +179,11 @@ class WhatsAppAdapter(BasePlatformAdapter):
         
         This launches the Node.js bridge process and waits for it to be ready.
         """
-        if not check_whatsapp_requirements():
+        node_command = _resolve_node_command()
+        if not node_command:
             logger.warning("[%s] Node.js not found. WhatsApp requires Node.js.", self.name)
             return False
+        node_argv, node_env = node_command
         
         bridge_path = Path(self._bridge_script)
         if not bridge_path.exists():
@@ -221,12 +255,13 @@ class WhatsAppAdapter(BasePlatformAdapter):
             # Pass WHATSAPP_REPLY_PREFIX from config.yaml so the Node bridge
             # can use it without the user needing to set a separate env var.
             bridge_env = os.environ.copy()
+            bridge_env.update(node_env)
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
 
             self._bridge_process = subprocess.Popen(
                 [
-                    "node",
+                    *node_argv,
                     str(bridge_path),
                     "--port", str(self._bridge_port),
                     "--session", str(self._session_path),

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -52,6 +52,7 @@ def _make_adapter():
     adapter._bridge_log = None
     adapter._bridge_process = None
     adapter._reply_prefix = None
+    adapter._node_runtime = MagicMock(argv=("node",), env={})
     adapter._running = False
     adapter._message_handler = None
     adapter._fatal_error_code = None
@@ -417,3 +418,36 @@ class TestKillPortProcess:
         with patch("gateway.platforms.whatsapp._IS_WINDOWS", True), \
              patch("gateway.platforms.whatsapp.subprocess.run", side_effect=OSError("no netstat")):
             _kill_port_process(3000)  # must not raise
+
+
+class TestNodeRuntimeResolution:
+    """Verify WhatsApp can resolve a Node runtime without `node` on PATH."""
+
+    def test_prefers_node_from_path(self):
+        from gateway.platforms.whatsapp import _resolve_node_command
+
+        mock_result = MagicMock(returncode=0)
+        with patch("gateway.platforms.whatsapp.shutil.which", side_effect=lambda name: "/usr/local/bin/node" if name == "node" else None), \
+             patch("gateway.platforms.whatsapp.subprocess.run", return_value=mock_result):
+            runtime = _resolve_node_command()
+
+        assert runtime is not None
+        assert runtime == (["/usr/local/bin/node"], {})
+
+    def test_uses_vscode_helper_on_macos_when_node_missing(self):
+        from gateway.platforms.whatsapp import _resolve_node_command
+
+        vscode_helper = (
+            "/Applications/Visual Studio Code.app/Contents/Frameworks/"
+            "Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin)"
+        )
+        mock_result = MagicMock(returncode=0)
+
+        with patch("gateway.platforms.whatsapp.shutil.which", return_value=None), \
+             patch("gateway.platforms.whatsapp.platform.system", return_value="Darwin"), \
+             patch("gateway.platforms.whatsapp.Path.exists", return_value=True), \
+             patch("gateway.platforms.whatsapp.subprocess.run", return_value=mock_result):
+            runtime = _resolve_node_command()
+
+        assert runtime is not None
+        assert runtime == ([vscode_helper], {"ELECTRON_RUN_AS_NODE": "1"})


### PR DESCRIPTION
## What does this PR do?

Fixes a WhatsApp startup bug on macOS where the gateway only checked for `node` on PATH and would disable the adapter even when a usable local runtime was already available via the VS Code bundled Node runtime.

This keeps the fix intentionally small and scoped to WhatsApp bridge startup:

- prefer the normal `node` lookup first
- on macOS only, fall back to the verified VS Code bundled runtime
- reuse the resolved command for both the requirements check and bridge launch so behavior stays consistent

This is related to, but not a duplicate of, the existing macOS PATH/runtime work in #2173 and #2713.

## Related Issue

Fixes #2976

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a tiny `_resolve_node_command()` helper in `gateway/platforms/whatsapp.py`
- Updated `check_whatsapp_requirements()` to use the resolved command instead of a hardcoded `node --version` check
- Updated `WhatsAppAdapter.connect()` to launch the bridge with the same resolved command
- Added regression tests covering PATH-based resolution and the macOS VS Code fallback in `tests/gateway/test_whatsapp_connect.py`

## How to Test

1. Run `pytest tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_reply_prefix.py -q`
2. On macOS, enable WhatsApp and reproduce an environment where no standalone `node` is on PATH but VS Code is installed
3. Start `hermes gateway run` and confirm startup no longer fails immediately with `WhatsApp: Node.js not installed or bridge not configured`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Future Improvements

- Reuse the existing Homebrew/macOS Node path discovery patterns already present elsewhere in Hermes
- Consider a shared runtime-resolution helper instead of per-feature fallback logic if more callers need this
- Support additional macOS Electron-bundled runtimes only if maintainers want a broader solution

## Screenshots / Logs

Relevant local symptom before the fix:

```text
WhatsApp: Node.js not installed or bridge not configured
No adapter available for whatsapp
```
