### PR TITLE
feat: add quarantine-first extension admission controls

### DIFF
--- a/agent/security/__init__.py
+++ b/agent/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security primitives for Hermes Agent."""

--- a/agent/security/admission/__init__.py
+++ b/agent/security/admission/__init__.py
@@ -1,0 +1,65 @@
+"""Admission control models and helpers."""
+
+from .integrity import IntegrityVerifier
+from .models import (
+    AdmissionRecord,
+    AdmissionStatus,
+    CandidateKind,
+    CandidateSource,
+    InspectionReport,
+    IntegrityState,
+    PromotionDecision,
+)
+from .promoter import AdmissionPromoter
+from .report import render_report
+from .service import (
+    admission_record_id,
+    admission_store,
+    find_records,
+    load_quarantined_mcp_server,
+    load_quarantined_skill_install,
+    load_latest_record,
+    mark_record_approved,
+    read_report,
+    requarantine_mcp_server,
+    requarantine_skill_directory,
+    reject_record,
+    revoke_record,
+    quarantine_mcp_server,
+    quarantine_skill_install,
+    verify_approved_record_integrity,
+    verify_record_integrity,
+    write_approved_json_snapshot,
+)
+from .store import AdmissionStore
+
+__all__ = [
+    "AdmissionPromoter",
+    "AdmissionRecord",
+    "AdmissionStatus",
+    "AdmissionStore",
+    "CandidateKind",
+    "CandidateSource",
+    "InspectionReport",
+    "IntegrityState",
+    "IntegrityVerifier",
+    "PromotionDecision",
+    "admission_record_id",
+    "admission_store",
+    "find_records",
+    "load_quarantined_mcp_server",
+    "load_quarantined_skill_install",
+    "load_latest_record",
+    "mark_record_approved",
+    "read_report",
+    "requarantine_mcp_server",
+    "requarantine_skill_directory",
+    "reject_record",
+    "revoke_record",
+    "quarantine_mcp_server",
+    "quarantine_skill_install",
+    "verify_approved_record_integrity",
+    "render_report",
+    "verify_record_integrity",
+    "write_approved_json_snapshot",
+]

--- a/agent/security/admission/inspector.py
+++ b/agent/security/admission/inspector.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .models import InspectionReport, PromotionDecision
+
+
+def inspect_mcp_candidate(path: Path) -> InspectionReport:
+    target = Path(path)
+    warnings: list[str] = []
+    capabilities: list[str] = []
+    if (target / "package.json").exists():
+        capabilities.append("node_package")
+    if (target / "Dockerfile").exists():
+        warnings.append("contains Dockerfile")
+    return InspectionReport(
+        summary="Static preflight report for MCP server candidate.",
+        decision=PromotionDecision.HOLD,
+        capabilities=capabilities,
+        warnings=warnings,
+        reasons=["Manual approval is required before activation."],
+    )
+
+
+def inspect_skill_candidate(path: Path) -> InspectionReport:
+    target = Path(path)
+    warnings: list[str] = []
+    if any(file.suffix == ".py" for file in target.rglob("*") if file.is_file()):
+        warnings.append("contains executable Python source")
+    return InspectionReport(
+        summary="Static preflight report for skill candidate.",
+        decision=PromotionDecision.HOLD,
+        warnings=warnings,
+        reasons=["Skill packages remain disabled until explicitly approved."],
+    )

--- a/agent/security/admission/integrity.py
+++ b/agent/security/admission/integrity.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from .models import IntegrityState
+
+
+class IntegrityVerifier:
+    def __init__(self, algorithm: str = "sha256") -> None:
+        self.algorithm = algorithm
+
+    def hash_path(self, path: Path) -> str:
+        digest = hashlib.new(self.algorithm)
+        target = Path(path)
+        if target.is_dir():
+            for child in sorted(p for p in target.rglob("*") if p.is_file()):
+                digest.update(child.relative_to(target).as_posix().encode("utf-8"))
+                digest.update(child.read_bytes())
+        else:
+            digest.update(target.read_bytes())
+        return digest.hexdigest()
+
+    def capture(self, path: Path) -> IntegrityState:
+        return IntegrityState(algorithm=self.algorithm, digest=self.hash_path(path))
+
+    def verify(self, path: Path, expected: IntegrityState) -> bool:
+        if expected.algorithm != self.algorithm:
+            verifier = IntegrityVerifier(expected.algorithm)
+            return verifier.hash_path(path) == expected.digest
+        return self.hash_path(path) == expected.digest

--- a/agent/security/admission/models.py
+++ b/agent/security/admission/models.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class CandidateKind(StrEnum):
+    MCP_SERVER = "mcp_server"
+    SKILL = "skill"
+    PLUGIN = "plugin"
+
+
+class AdmissionStatus(StrEnum):
+    QUARANTINED = "quarantined"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    REVOKED = "revoked"
+
+
+class PromotionDecision(StrEnum):
+    PROMOTE = "promote"
+    HOLD = "hold"
+    REJECT = "reject"
+
+
+@dataclass(slots=True)
+class CandidateSource:
+    uri: str
+    display_name: str
+    version: str | None = None
+    installer: str | None = None
+
+
+@dataclass(slots=True)
+class IntegrityState:
+    algorithm: str
+    digest: str
+    verified_at: datetime = field(default_factory=utc_now)
+
+
+@dataclass(slots=True)
+class InspectionReport:
+    summary: str
+    decision: PromotionDecision = PromotionDecision.HOLD
+    reasons: list[str] = field(default_factory=list)
+    capabilities: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    generated_at: datetime = field(default_factory=utc_now)
+
+
+@dataclass(slots=True)
+class AdmissionRecord:
+    record_id: str
+    kind: CandidateKind
+    source: CandidateSource
+    lineage_id: str | None = None
+    parent_record_id: str | None = None
+    revision: int = 1
+    source_fingerprint: str | None = None
+    status: AdmissionStatus = AdmissionStatus.QUARANTINED
+    created_at: datetime = field(default_factory=utc_now)
+    updated_at: datetime = field(default_factory=utc_now)
+    quarantine_path: str | None = None
+    approved_path: str | None = None
+    integrity: IntegrityState | None = None
+    approved_at: datetime | None = None
+    report_path: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def transition_to(self, new_status: AdmissionStatus) -> None:
+        allowed = {
+            AdmissionStatus.QUARANTINED: {
+                AdmissionStatus.APPROVED,
+                AdmissionStatus.REJECTED,
+            },
+            AdmissionStatus.APPROVED: {AdmissionStatus.REVOKED},
+            AdmissionStatus.REJECTED: set(),
+            AdmissionStatus.REVOKED: set(),
+        }
+        if new_status == self.status:
+            return
+        if new_status not in allowed[self.status]:
+            raise ValueError(f"invalid admission transition: {self.status} -> {new_status}")
+        self.status = new_status
+        self.updated_at = utc_now()

--- a/agent/security/admission/promoter.py
+++ b/agent/security/admission/promoter.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from .models import AdmissionRecord, AdmissionStatus
+from .store import AdmissionStore
+
+
+class AdmissionPromoter:
+    def __init__(self, store: AdmissionStore) -> None:
+        self.store = store
+
+    def promote_record(self, record: AdmissionRecord) -> AdmissionRecord:
+        if not record.report_path:
+            raise ValueError("cannot promote record without inspection report")
+        record.transition_to(AdmissionStatus.APPROVED)
+        self.store.save_record(record)
+        return record
+
+    def promote_artifact(
+        self,
+        record: AdmissionRecord,
+        source_path: Path,
+        artifact_name: str,
+    ) -> Path:
+        destination = self.store.candidate_approved_path(record.record_id, artifact_name)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if Path(source_path).is_dir():
+            if destination.exists():
+                shutil.rmtree(destination)
+            shutil.copytree(source_path, destination)
+        else:
+            shutil.copy2(source_path, destination)
+        record.approved_path = str(destination)
+        self.store.save_record(record)
+        return destination

--- a/agent/security/admission/report.py
+++ b/agent/security/admission/report.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from .models import AdmissionRecord, InspectionReport
+
+
+def render_report(record: AdmissionRecord, report: InspectionReport) -> str:
+    lines = [
+        f"# Admission Report: {record.source.display_name}",
+        "",
+        f"- Record ID: `{record.record_id}`",
+        f"- Kind: `{record.kind}`",
+        f"- Status: `{record.status}`",
+        f"- Source: `{record.source.uri}`",
+        f"- Decision: `{report.decision}`",
+        "",
+        "## Summary",
+        report.summary,
+        "",
+    ]
+    if report.capabilities:
+        lines.extend(["## Capabilities", *[f"- {item}" for item in report.capabilities], ""])
+    if report.reasons:
+        lines.extend(["## Reasons", *[f"- {item}" for item in report.reasons], ""])
+    if report.warnings:
+        lines.extend(["## Warnings", *[f"- {item}" for item in report.warnings], ""])
+    return "\n".join(lines).rstrip() + "\n"

--- a/agent/security/admission/service.py
+++ b/agent/security/admission/service.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from .integrity import IntegrityVerifier
+from .models import (
+    AdmissionRecord,
+    AdmissionStatus,
+    CandidateKind,
+    CandidateSource,
+    InspectionReport,
+    PromotionDecision,
+)
+from .report import render_report
+from .store import AdmissionStore
+
+_VERIFIER = IntegrityVerifier()
+
+
+def admission_store(hermes_home: Path | None = None) -> AdmissionStore:
+    home = Path(
+        hermes_home or os.getenv("HERMES_HOME") or (Path.home() / ".hermes")
+    ).expanduser()
+    return AdmissionStore(home / "admission")
+
+
+def admission_record_id(kind: CandidateKind, name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "candidate"
+    return f"{kind.value}-{slug}"
+
+
+def _next_revision(kind: CandidateKind, name: str, hermes_home: Path | None = None) -> int:
+    records = find_records(kind, name=name, hermes_home=hermes_home)
+    if not records:
+        return 1
+    return max(record.revision for record in records) + 1
+
+
+def _record_id_for_revision(lineage_id: str, revision: int) -> str:
+    return lineage_id if revision == 1 else f"{lineage_id}-rev-{revision}"
+
+
+def find_records(
+    kind: CandidateKind | None = None,
+    *,
+    name: str | None = None,
+    status: AdmissionStatus | None = None,
+    hermes_home: Path | None = None,
+) -> list[AdmissionRecord]:
+    store = admission_store(hermes_home)
+    records = store.list_records()
+    if kind is not None:
+        records = [record for record in records if record.kind == kind]
+    if name is not None:
+        base_id = admission_record_id(kind or CandidateKind.SKILL, name) if kind else None
+        lowered = name.lower()
+        filtered: list[AdmissionRecord] = []
+        for record in records:
+            if record.source.display_name.lower() == lowered:
+                filtered.append(record)
+                continue
+            if base_id and (record.record_id == base_id or record.record_id.startswith(f"{base_id}-")):
+                filtered.append(record)
+        records = filtered
+    if status is not None:
+        records = [record for record in records if record.status == status]
+    return sorted(records, key=lambda record: (record.updated_at, record.created_at, record.record_id), reverse=True)
+
+
+def load_latest_record(
+    kind: CandidateKind,
+    name: str,
+    *,
+    statuses: tuple[AdmissionStatus, ...] | None = None,
+    hermes_home: Path | None = None,
+) -> AdmissionRecord:
+    records = find_records(kind, name=name, hermes_home=hermes_home)
+    if statuses is not None:
+        records = [record for record in records if record.status in statuses]
+    if not records:
+        raise FileNotFoundError(f"No admission record found for {kind.value} '{name}'")
+    return records[0]
+
+
+def read_report(record: AdmissionRecord) -> str:
+    if not record.report_path:
+        raise FileNotFoundError(f"No report recorded for {record.record_id}")
+    return Path(record.report_path).read_text(encoding="utf-8")
+
+
+def quarantine_mcp_server(
+    name: str,
+    server_config: dict[str, Any],
+    tools: list[tuple[str, str]],
+    hermes_home: Path | None = None,
+) -> AdmissionRecord:
+    store = admission_store(hermes_home)
+    lineage_id = admission_record_id(CandidateKind.MCP_SERVER, name)
+    revision = _next_revision(CandidateKind.MCP_SERVER, name, hermes_home)
+    record_id = _record_id_for_revision(lineage_id, revision)
+    source_uri = server_config.get("url") or server_config.get("command") or name
+    record = AdmissionRecord(
+        record_id=record_id,
+        kind=CandidateKind.MCP_SERVER,
+        source=CandidateSource(
+            uri=str(source_uri),
+            display_name=name,
+            installer="hermes mcp add",
+        ),
+        lineage_id=lineage_id,
+        revision=revision,
+        source_fingerprint=_fingerprint_payload(server_config),
+    )
+
+    artifact_path = store.candidate_quarantine_path(record_id, "server-config.json")
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_payload = {
+        "name": name,
+        "server_config": server_config,
+        "tools": [{"name": tool_name, "description": desc} for tool_name, desc in tools],
+    }
+    artifact_path.write_text(json.dumps(artifact_payload, indent=2), encoding="utf-8")
+
+    warnings: list[str] = []
+    if server_config.get("url"):
+        warnings.append("Remote HTTP MCP servers can execute tool actions outside Hermes.")
+    if server_config.get("command"):
+        warnings.append("Local stdio MCP servers execute local binaries under the user account.")
+
+    report = InspectionReport(
+        summary=f"Quarantined MCP server '{name}' after discovery of {len(tools)} tool(s).",
+        decision=PromotionDecision.HOLD,
+        capabilities=[tool_name for tool_name, _ in tools],
+        warnings=warnings,
+        reasons=["Explicit approval is required before the server is activated."],
+    )
+    report_path = store.write_report(record_id, render_report(record, report))
+
+    record.quarantine_path = str(artifact_path)
+    record.report_path = str(report_path)
+    record.integrity = _VERIFIER.capture(artifact_path)
+    store.save_record(record)
+    return record
+
+
+def load_quarantined_mcp_server(
+    name: str,
+    hermes_home: Path | None = None,
+) -> tuple[AdmissionRecord, dict[str, Any]]:
+    record = load_latest_record(
+        CandidateKind.MCP_SERVER,
+        name,
+        statuses=(AdmissionStatus.QUARANTINED,),
+        hermes_home=hermes_home,
+    )
+    if not record.quarantine_path:
+        raise FileNotFoundError(f"No quarantined artifact recorded for MCP server '{name}'")
+    payload = json.loads(Path(record.quarantine_path).read_text(encoding="utf-8"))
+    return record, payload
+
+
+def quarantine_skill_install(
+    bundle_name: str,
+    identifier: str,
+    source: str,
+    trust_level: str,
+    category: str,
+    bundle_files: dict[str, Any],
+    metadata: dict[str, Any],
+    scan_result: Any,
+    quarantine_path: Path,
+    hermes_home: Path | None = None,
+) -> AdmissionRecord:
+    store = admission_store(hermes_home)
+    lineage_id = admission_record_id(CandidateKind.SKILL, bundle_name)
+    revision = _next_revision(CandidateKind.SKILL, bundle_name, hermes_home)
+    record_id = _record_id_for_revision(lineage_id, revision)
+    record = AdmissionRecord(
+        record_id=record_id,
+        kind=CandidateKind.SKILL,
+        source=CandidateSource(
+            uri=identifier,
+            display_name=bundle_name,
+            version=metadata.get("version"),
+            installer="hermes skills install",
+        ),
+        lineage_id=lineage_id,
+        revision=revision,
+        source_fingerprint=_fingerprint_payload({
+            "identifier": identifier,
+            "files": bundle_files,
+        }),
+    )
+
+    manifest_path = Path(quarantine_path) / ".hermes-admission.json"
+    manifest = {
+        "name": bundle_name,
+        "identifier": identifier,
+        "source": source,
+        "trust_level": trust_level,
+        "category": category,
+        "files": bundle_files,
+        "metadata": metadata,
+        "scan_result": asdict(scan_result),
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    report = InspectionReport(
+        summary=getattr(scan_result, "summary", f"{bundle_name}: pending approval"),
+        decision=PromotionDecision.HOLD,
+        capabilities=sorted(bundle_files.keys()),
+        warnings=[
+            f"{finding.severity}/{finding.category}: {finding.description}"
+            for finding in getattr(scan_result, "findings", [])
+        ],
+        reasons=["Third-party skills remain quarantined until explicitly approved."],
+    )
+    report_path = store.write_report(record_id, render_report(record, report))
+
+    record.quarantine_path = str(quarantine_path)
+    record.report_path = str(report_path)
+    record.integrity = _VERIFIER.capture(Path(quarantine_path))
+    store.save_record(record)
+    return record
+
+
+def load_quarantined_skill_install(
+    name: str,
+    hermes_home: Path | None = None,
+) -> tuple[AdmissionRecord, dict[str, Any]]:
+    record = load_latest_record(
+        CandidateKind.SKILL,
+        name,
+        statuses=(AdmissionStatus.QUARANTINED,),
+        hermes_home=hermes_home,
+    )
+    if not record.quarantine_path:
+        raise FileNotFoundError(f"No quarantined artifact recorded for skill '{name}'")
+    manifest_path = Path(record.quarantine_path) / ".hermes-admission.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return record, payload
+
+
+def verify_record_integrity(record: AdmissionRecord) -> bool:
+    if not record.quarantine_path or not record.integrity:
+        return False
+    target = Path(record.quarantine_path)
+    if not target.exists():
+        return False
+    return _VERIFIER.verify(target, record.integrity)
+
+
+def mark_record_approved(
+    record: AdmissionRecord,
+    approved_path: str | None = None,
+    integrity_path: Path | None = None,
+    hermes_home: Path | None = None,
+) -> AdmissionRecord:
+    from .models import AdmissionStatus
+
+    store = admission_store(hermes_home)
+    if approved_path:
+        record.approved_path = approved_path
+    if integrity_path is not None:
+        record.integrity = _VERIFIER.capture(integrity_path)
+    record.approved_at = record.updated_at if record.status is AdmissionStatus.APPROVED else None
+    record.transition_to(AdmissionStatus.APPROVED)
+    record.approved_at = record.updated_at
+    store.save_record(record)
+    return record
+
+
+def revoke_record(
+    record: AdmissionRecord,
+    note: str | None = None,
+    hermes_home: Path | None = None,
+) -> AdmissionRecord:
+    from .models import AdmissionStatus
+
+    store = admission_store(hermes_home)
+    if note:
+        record.notes.append(note)
+    if record.status is not AdmissionStatus.REVOKED:
+        record.transition_to(AdmissionStatus.REVOKED)
+    store.save_record(record)
+    return record
+
+
+def reject_record(
+    record: AdmissionRecord,
+    note: str | None = None,
+    hermes_home: Path | None = None,
+) -> AdmissionRecord:
+    store = admission_store(hermes_home)
+    if note:
+        record.notes.append(note)
+    if record.status is not AdmissionStatus.REJECTED:
+        record.transition_to(AdmissionStatus.REJECTED)
+    store.save_record(record)
+    return record
+
+
+def verify_approved_record_integrity(record: AdmissionRecord) -> bool:
+    if not record.approved_path or not record.integrity:
+        return False
+    target = Path(record.approved_path)
+    if not target.exists():
+        return False
+    return _VERIFIER.verify(target, record.integrity)
+
+
+def write_approved_json_snapshot(
+    record: AdmissionRecord,
+    artifact_name: str,
+    payload: dict[str, Any],
+    hermes_home: Path | None = None,
+) -> Path:
+    store = admission_store(hermes_home)
+    destination = store.candidate_approved_path(record.record_id, artifact_name)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return destination
+
+
+def requarantine_mcp_server(
+    name: str,
+    payload: dict[str, Any],
+    hermes_home: Path | None = None,
+    note: str = "re-quarantined after integrity drift",
+    previous_record: AdmissionRecord | None = None,
+) -> AdmissionRecord:
+    fingerprint = _fingerprint_payload(payload)
+    store = admission_store(hermes_home)
+    lineage_id = admission_record_id(CandidateKind.MCP_SERVER, name)
+    revision = _next_revision(CandidateKind.MCP_SERVER, name, hermes_home)
+    record_id = f"{_record_id_for_revision(lineage_id, revision)}-drift-{fingerprint}"
+    record = AdmissionRecord(
+        record_id=record_id,
+        kind=CandidateKind.MCP_SERVER,
+        source=CandidateSource(
+            uri=str(payload.get("server_config", {}).get("url") or payload.get("server_config", {}).get("command") or name),
+            display_name=name,
+            installer="integrity-drift",
+        ),
+        lineage_id=lineage_id,
+        parent_record_id=previous_record.record_id if previous_record else None,
+        revision=revision,
+        source_fingerprint=fingerprint,
+        notes=[note],
+    )
+    artifact_path = store.candidate_quarantine_path(record_id, "server-config.json")
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    report = InspectionReport(
+        summary=f"Re-quarantined MCP server '{name}' due to integrity drift.",
+        decision=PromotionDecision.HOLD,
+        capabilities=[tool["name"] for tool in payload.get("tools", []) if isinstance(tool, dict) and "name" in tool],
+        reasons=[note],
+    )
+    report_path = store.write_report(record_id, render_report(record, report))
+    record.quarantine_path = str(artifact_path)
+    record.report_path = str(report_path)
+    record.integrity = _VERIFIER.capture(artifact_path)
+    store.save_record(record)
+    return record
+
+
+def requarantine_skill_directory(
+    name: str,
+    installed_path: Path,
+    identifier: str,
+    source: str,
+    trust_level: str,
+    category: str,
+    metadata: dict[str, Any],
+    scan_result: Any,
+    hermes_home: Path | None = None,
+    note: str = "re-quarantined after integrity drift",
+    previous_record: AdmissionRecord | None = None,
+) -> AdmissionRecord:
+    store = admission_store(hermes_home)
+    fingerprint = _VERIFIER.hash_path(installed_path)[:8]
+    lineage_id = admission_record_id(CandidateKind.SKILL, name)
+    revision = _next_revision(CandidateKind.SKILL, name, hermes_home)
+    record_id = f"{_record_id_for_revision(lineage_id, revision)}-drift-{fingerprint}"
+    record = AdmissionRecord(
+        record_id=record_id,
+        kind=CandidateKind.SKILL,
+        source=CandidateSource(
+            uri=identifier,
+            display_name=name,
+            version=metadata.get("version"),
+            installer="integrity-drift",
+        ),
+        lineage_id=lineage_id,
+        parent_record_id=previous_record.record_id if previous_record else None,
+        revision=revision,
+        source_fingerprint=fingerprint,
+        notes=[note],
+    )
+    quarantine_dir = store.candidate_quarantine_path(record_id, name)
+    quarantine_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(installed_path), str(quarantine_dir))
+    manifest_path = quarantine_dir / ".hermes-admission.json"
+    manifest = {
+        "name": name,
+        "identifier": identifier,
+        "source": source,
+        "trust_level": trust_level,
+        "category": category,
+        "files": _read_directory_contents(quarantine_dir),
+        "metadata": metadata,
+        "scan_result": asdict(scan_result),
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    report = InspectionReport(
+        summary=getattr(scan_result, "summary", f"{name}: re-quarantined"),
+        decision=PromotionDecision.HOLD,
+        capabilities=sorted(manifest["files"].keys()),
+        warnings=[note],
+        reasons=["Approval is required again after integrity drift."],
+    )
+    report_path = store.write_report(record_id, render_report(record, report))
+    record.quarantine_path = str(quarantine_dir)
+    record.report_path = str(report_path)
+    record.integrity = _VERIFIER.capture(quarantine_dir)
+    store.save_record(record)
+    return record
+
+
+def _read_directory_contents(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for child in sorted(path.rglob("*")):
+        if child.is_file():
+            result[str(child.relative_to(path))] = child.read_text(encoding="utf-8")
+    return result
+
+
+def _fingerprint_payload(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True).encode("utf-8")
+    return _VERIFIER.algorithm + "-" + __import__("hashlib").new(_VERIFIER.algorithm, raw).hexdigest()[:8]

--- a/agent/security/admission/store.py
+++ b/agent/security/admission/store.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+
+from .models import AdmissionRecord, InspectionReport
+
+
+class AdmissionStore:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = Path(base_dir).expanduser()
+        self.records_dir = self.base_dir / "records"
+        self.reports_dir = self.base_dir / "reports"
+        self.quarantine_dir = self.base_dir / "quarantine"
+        self.approved_dir = self.base_dir / "approved"
+        for path in (
+            self.records_dir,
+            self.reports_dir,
+            self.quarantine_dir,
+            self.approved_dir,
+        ):
+            path.mkdir(parents=True, exist_ok=True)
+
+    def record_path(self, record_id: str) -> Path:
+        return self.records_dir / f"{record_id}.json"
+
+    def report_path(self, record_id: str) -> Path:
+        return self.reports_dir / f"{record_id}.md"
+
+    def candidate_quarantine_path(self, record_id: str, artifact_name: str) -> Path:
+        return self.quarantine_dir / record_id / artifact_name
+
+    def candidate_approved_path(self, record_id: str, artifact_name: str) -> Path:
+        return self.approved_dir / record_id / artifact_name
+
+    def save_record(self, record: AdmissionRecord) -> Path:
+        path = self.record_path(record.record_id)
+        payload = _json_ready(asdict(record))
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return path
+
+    def load_record(self, record_id: str) -> AdmissionRecord:
+        payload = json.loads(self.record_path(record_id).read_text(encoding="utf-8"))
+        return _record_from_dict(payload)
+
+    def list_records(self) -> list[AdmissionRecord]:
+        return [
+            self.load_record(path.stem)
+            for path in sorted(self.records_dir.glob("*.json"))
+        ]
+
+    def write_report(self, record_id: str, content: str) -> Path:
+        path = self.report_path(record_id)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+
+def _json_ready(value):
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: _json_ready(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    return value
+
+
+def _record_from_dict(payload: dict) -> AdmissionRecord:
+    from .models import (
+        AdmissionStatus,
+        CandidateKind,
+        CandidateSource,
+        IntegrityState,
+    )
+
+    source = CandidateSource(**payload["source"])
+    integrity = payload.get("integrity")
+    if integrity:
+        integrity = IntegrityState(
+            algorithm=integrity["algorithm"],
+            digest=integrity["digest"],
+            verified_at=datetime.fromisoformat(integrity["verified_at"]),
+        )
+    return AdmissionRecord(
+        record_id=payload["record_id"],
+        kind=CandidateKind(payload["kind"]),
+        source=source,
+        lineage_id=payload.get("lineage_id"),
+        parent_record_id=payload.get("parent_record_id"),
+        revision=payload.get("revision", 1),
+        source_fingerprint=payload.get("source_fingerprint"),
+        status=AdmissionStatus(payload["status"]),
+        created_at=datetime.fromisoformat(payload["created_at"]),
+        updated_at=datetime.fromisoformat(payload["updated_at"]),
+        quarantine_path=payload.get("quarantine_path"),
+        approved_path=payload.get("approved_path"),
+        integrity=integrity,
+        approved_at=datetime.fromisoformat(payload["approved_at"]) if payload.get("approved_at") else None,
+        report_path=payload.get("report_path"),
+        notes=list(payload.get("notes", [])),
+    )

--- a/hermes_cli/admission.py
+++ b/hermes_cli/admission.py
@@ -1,0 +1,58 @@
+"""Unified admission-control CLI helpers."""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.table import Table
+
+_console = Console()
+
+
+def do_audit(console: Console | None = None) -> None:
+    from hermes_cli.mcp_config import audit_mcp_integrity
+    from hermes_cli.skills_hub import do_audit as audit_skills
+
+    c = console or _console
+    c.print("\n[bold]Admission Audit[/]\n")
+    drift_messages = audit_mcp_integrity()
+    if drift_messages:
+        for message in drift_messages:
+            c.print(f"[yellow]{message}[/]")
+        c.print()
+    audit_skills(console=c)
+
+
+def do_list(console: Console | None = None) -> None:
+    from agent.security.admission import admission_store
+
+    c = console or _console
+    records = admission_store().list_records()
+    if not records:
+        c.print("[dim]No admission records.[/]\n")
+        return
+    table = Table(title="Admission Records")
+    table.add_column("Kind", style="dim")
+    table.add_column("Name", style="bold cyan")
+    table.add_column("Status", style="dim")
+    table.add_column("Revision", justify="right")
+    table.add_column("Lineage", style="dim")
+    for record in records:
+        table.add_row(
+            str(record.kind),
+            record.source.display_name,
+            str(record.status),
+            str(record.revision),
+            record.lineage_id or "",
+        )
+    c.print(table)
+    c.print()
+
+
+def admission_command(args) -> None:
+    action = getattr(args, "admission_action", None)
+    if action == "audit":
+        do_audit()
+    elif action == "list":
+        do_list()
+    else:
+        _console.print("Usage: hermes admission [audit|list]\n")

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -695,6 +695,32 @@ def run_doctor(args):
         check_warn("No GITHUB_TOKEN", "(60 req/hr rate limit — set in ~/.hermes/.env for better rates)")
 
     # =========================================================================
+    # Check: Admission Control
+    # =========================================================================
+    print()
+    print(color("◆ Admission Control", Colors.CYAN, Colors.BOLD))
+    try:
+        from agent.security.admission import admission_store
+        from hermes_cli.mcp_config import audit_mcp_integrity
+
+        drift_messages = audit_mcp_integrity()
+        records = admission_store().list_records()
+        approved = sum(1 for record in records if record.status == "approved")
+        quarantined = sum(1 for record in records if record.status == "quarantined")
+        revoked = sum(1 for record in records if record.status == "revoked")
+        check_ok(f"Admission records loaded ({len(records)} total)")
+        if approved:
+            check_ok(f"{approved} approved artifact(s)")
+        if quarantined:
+            check_warn(f"{quarantined} quarantined artifact(s)", "(pending approval)")
+        if revoked:
+            check_warn(f"{revoked} revoked artifact(s)", "(integrity or policy issue)")
+        for message in drift_messages:
+            check_warn(message)
+    except Exception as e:
+        check_warn("Admission control checks unavailable", f"({e})")
+
+    # =========================================================================
     # Honcho memory
     # =========================================================================
     print()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3422,6 +3422,24 @@ For more help on a command:
         help="Attempt to fix issues automatically"
     )
     doctor_parser.set_defaults(func=cmd_doctor)
+
+    # =========================================================================
+    # admission command
+    # =========================================================================
+    admission_parser = subparsers.add_parser(
+        "admission",
+        help="Audit and list admission-control records",
+        description="Unified admission-control helpers for quarantine, approval, and integrity audit state."
+    )
+    admission_subparsers = admission_parser.add_subparsers(dest="admission_action")
+    admission_subparsers.add_parser("audit", help="Run unified admission integrity audit")
+    admission_subparsers.add_parser("list", help="List all admission records")
+
+    def cmd_admission(args):
+        from hermes_cli.admission import admission_command
+        admission_command(args)
+
+    admission_parser.set_defaults(func=cmd_admission)
     
     # =========================================================================
     # config command
@@ -3513,6 +3531,14 @@ For more help on a command:
     skills_install.add_argument("--category", default="", help="Category folder to install into")
     skills_install.add_argument("--force", action="store_true", help="Install despite blocked scan verdict")
     skills_install.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt (needed in TUI mode)")
+
+    skills_approve = skills_subparsers.add_parser("approve", help="Approve a quarantined third-party skill")
+    skills_approve.add_argument("name", help="Skill name to approve")
+
+    skills_reject = skills_subparsers.add_parser("reject", help="Reject a quarantined third-party skill")
+    skills_reject.add_argument("name", help="Skill name to reject")
+
+    skills_subparsers.add_parser("quarantine-list", help="List skill admission records")
 
     skills_inspect = skills_subparsers.add_parser("inspect", help="Preview a skill without installing")
     skills_inspect.add_argument("identifier", help="Skill identifier")
@@ -3784,6 +3810,17 @@ For more help on a command:
     mcp_add_p.add_argument("--command", help="Stdio command (e.g. npx)")
     mcp_add_p.add_argument("--args", nargs="*", default=[], help="Arguments for stdio command")
     mcp_add_p.add_argument("--auth", choices=["oauth", "header"], help="Auth method")
+
+    mcp_approve_p = mcp_sub.add_parser("approve", help="Approve a quarantined MCP server")
+    mcp_approve_p.add_argument("name", help="Server name to approve")
+
+    mcp_inspect_p = mcp_sub.add_parser("inspect", help="Show the admission report for an MCP server")
+    mcp_inspect_p.add_argument("name", help="Server name to inspect")
+
+    mcp_reject_p = mcp_sub.add_parser("reject", help="Reject a quarantined MCP server")
+    mcp_reject_p.add_argument("name", help="Server name to reject")
+
+    mcp_sub.add_parser("quarantine-list", help="List MCP admission records")
 
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")
     mcp_rm_p.add_argument("name", help="Server name to remove")

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -10,6 +10,7 @@ configuration in ~/.hermes/config.yaml under the ``mcp_servers`` key.
 
 import asyncio
 import getpass
+import json
 import logging
 import os
 import re
@@ -25,6 +26,22 @@ from hermes_cli.config import (
     get_hermes_home,
 )
 from hermes_cli.colors import Colors, color
+from agent.security.admission import (
+    AdmissionStatus,
+    CandidateKind,
+    admission_store,
+    find_records,
+    load_quarantined_mcp_server,
+    load_latest_record,
+    mark_record_approved,
+    quarantine_mcp_server,
+    read_report,
+    reject_record,
+    requarantine_mcp_server,
+    revoke_record,
+    write_approved_json_snapshot,
+    verify_record_integrity,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -327,14 +344,145 @@ def cmd_mcp_add(args):
         tool_count = len(tools)
         total = len(tools)
 
-    # ── Save ──────────────────────────────────────────────────────────
+    # ── Quarantine ────────────────────────────────────────────────────
 
-    server_config["enabled"] = True
-    _save_mcp_server(name, server_config)
+    record = quarantine_mcp_server(name, server_config, tools)
 
     print()
-    _success(f"Saved '{name}' to ~/.hermes/config.yaml ({tool_count}/{total} tools enabled)")
-    _info("Start a new session to use these tools.")
+    _success(f"Quarantined '{name}' ({tool_count}/{total} tools selected)")
+    _info(f"Inspection report: {record.report_path}")
+    _info(f"Approve when ready: hermes mcp approve {name}")
+
+
+def cmd_mcp_approve(args):
+    """Approve a quarantined MCP server and write it into active config."""
+    name = args.name
+    try:
+        record, payload = load_quarantined_mcp_server(name)
+    except FileNotFoundError:
+        _error(f"No quarantined MCP server named '{name}'")
+        return
+    except Exception as exc:
+        _error(f"Failed to load quarantine record: {exc}")
+        return
+
+    if not verify_record_integrity(record):
+        _error(f"Quarantine integrity check failed for '{name}'")
+        _info("Review the quarantined artifact and re-run hermes mcp add if needed.")
+        return
+
+    server_config = dict(payload.get("server_config", {}))
+    server_config["enabled"] = False
+    _save_mcp_server(name, server_config)
+    approved_snapshot = write_approved_json_snapshot(
+        record,
+        "server-config.json",
+        {
+            "name": name,
+            "server_config": server_config,
+            "tools": payload.get("tools", []),
+        },
+    )
+    mark_record_approved(
+        record,
+        approved_path=str(approved_snapshot),
+        integrity_path=approved_snapshot,
+    )
+
+    _success(f"Approved '{name}' and saved it to ~/.hermes/config.yaml")
+    _info("It remains disabled until you explicitly enable or configure it.")
+    _info(f"Enable later with: hermes mcp configure {name}")
+
+
+def cmd_mcp_inspect(args):
+    """Show the stored inspection report for a quarantined or revised MCP server."""
+    name = args.name
+    try:
+        record = load_latest_record(CandidateKind.MCP_SERVER, name)
+        print()
+        print(read_report(record))
+        if record.notes:
+            _info("Notes:")
+            for note in record.notes:
+                _info(f"  - {note}")
+    except FileNotFoundError:
+        _error(f"No admission record found for MCP server '{name}'")
+    except Exception as exc:
+        _error(f"Failed to inspect '{name}': {exc}")
+
+
+def cmd_mcp_reject(args):
+    """Reject the latest quarantined MCP server record."""
+    name = args.name
+    try:
+        record = load_latest_record(
+            CandidateKind.MCP_SERVER,
+            name,
+            statuses=(AdmissionStatus.QUARANTINED,),
+        )
+    except FileNotFoundError:
+        _error(f"No quarantined MCP server named '{name}'")
+        return
+    reject_record(record, note="user rejected candidate")
+    _success(f"Rejected quarantined MCP server '{name}'")
+
+
+def cmd_mcp_quarantine_list(args=None):
+    """List quarantined, rejected, and revoked MCP admission records."""
+    records = find_records(CandidateKind.MCP_SERVER)
+    if not records:
+        print()
+        _info("No MCP admission records.")
+        print()
+        return
+    print()
+    print(color("  MCP Admission Records:", Colors.CYAN + Colors.BOLD))
+    print()
+    print(f"  {'Name':<16} {'Status':<14} {'Updated':<22} {'Record ID':<36}")
+    print(f"  {'─' * 16} {'─' * 14} {'─' * 22} {'─' * 36}")
+    for record in records:
+        print(
+            f"  {record.source.display_name:<16} "
+            f"{record.status:<14} "
+            f"{record.updated_at.isoformat(timespec='seconds'):<22} "
+            f"{record.record_id:<36}"
+        )
+    print()
+
+
+def audit_mcp_integrity() -> list[str]:
+    """Revoke and re-quarantine approved MCP servers that drift from their approved snapshot."""
+    messages: list[str] = []
+    store = admission_store()
+    servers = _get_mcp_servers()
+    for record in store.list_records():
+        if record.kind != "mcp_server" or record.status != "approved" or not record.approved_path:
+            continue
+        snapshot_path = Path(record.approved_path)
+        if not snapshot_path.exists():
+            revoke_record(record, note="approved MCP snapshot missing")
+            messages.append(f"Revoked {record.source.display_name}: approved snapshot missing")
+            continue
+        snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+        name = snapshot.get("name") or record.source.display_name
+        current = servers.get(name)
+        approved_config = snapshot.get("server_config", {})
+        if current != approved_config:
+            if current is not None:
+                requarantine_mcp_server(
+                    name,
+                    {
+                        "name": name,
+                        "server_config": current,
+                        "tools": snapshot.get("tools", []),
+                    },
+                    note="active MCP config drifted from approved snapshot",
+                    previous_record=record,
+                )
+                _remove_mcp_server(name)
+            revoke_record(record, note="active MCP config drifted from approved snapshot")
+            messages.append(f"Revoked {name}: configuration drift detected")
+    return messages
 
 
 # ─── hermes mcp remove ───────────────────────────────────────────────────────
@@ -355,22 +503,34 @@ def cmd_mcp_remove(args):
         _info("Cancelled.")
         return
 
+    removed_cfg = existing.get(name, {})
     _remove_mcp_server(name)
     _success(f"Removed '{name}' from config")
 
     # Clean up OAuth tokens if they exist
+    token_file = get_hermes_home() / "mcp-tokens" / f"{name}.json"
+    cleaned = False
+    if removed_cfg.get("auth") == "oauth" and token_file.exists():
+        token_file.unlink()
+        cleaned = True
+
     try:
         from tools.mcp_oauth import remove_oauth_tokens
+
         remove_oauth_tokens(name)
-        _success("Cleaned up OAuth tokens")
+        cleaned = True or cleaned
     except Exception:
         pass
+
+    if cleaned:
+        _success("Cleaned up OAuth tokens")
 
 
 # ─── hermes mcp list ──────────────────────────────────────────────────────────
 
 def cmd_mcp_list(args=None):
     """List all configured MCP servers."""
+    audit_mcp_integrity()
     servers = _get_mcp_servers()
 
     if not servers:
@@ -610,6 +770,10 @@ def mcp_command(args):
 
     handlers = {
         "add": cmd_mcp_add,
+        "approve": cmd_mcp_approve,
+        "inspect": cmd_mcp_inspect,
+        "reject": cmd_mcp_reject,
+        "quarantine-list": cmd_mcp_quarantine_list,
         "remove": cmd_mcp_remove,
         "rm": cmd_mcp_remove,
         "list": cmd_mcp_list,
@@ -628,6 +792,10 @@ def mcp_command(args):
         print(color("  Commands:", Colors.CYAN))
         _info("hermes mcp add <name> --url <endpoint>        Add an MCP server")
         _info("hermes mcp add <name> --command <cmd>         Add a stdio server")
+        _info("hermes mcp approve <name>                     Approve a quarantined server")
+        _info("hermes mcp inspect <name>                     Show admission report")
+        _info("hermes mcp reject <name>                      Reject a quarantined server")
+        _info("hermes mcp quarantine-list                    List admission records")
         _info("hermes mcp remove <name>                      Remove a server")
         _info("hermes mcp list                               List servers")
         _info("hermes mcp test <name>                        Test connection")

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -311,6 +311,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         quarantine_bundle, install_from_quarantine, HubLockFile,
     )
     from tools.skills_guard import scan_skill, should_allow_install, format_scan_report
+    from agent.security.admission import quarantine_skill_install
 
     c = console or _console
     ensure_hub_dirs()
@@ -410,18 +411,107 @@ def do_install(identifier: str, category: str = "", force: bool = False,
             shutil.rmtree(q_path, ignore_errors=True)
             return
 
-    # Install
+    if bundle.source != "official":
+        record = quarantine_skill_install(
+            bundle_name=bundle.name,
+            identifier=bundle.identifier,
+            source=bundle.source,
+            trust_level=bundle.trust_level,
+            category=category,
+            bundle_files=bundle.files,
+            metadata=bundle.metadata,
+            scan_result=result,
+            quarantine_path=q_path,
+        )
+        c.print(f"[bold yellow]Quarantined:[/] {bundle.name}")
+        c.print(f"[dim]Inspection report: {record.report_path}[/]")
+        c.print(f"[dim]Approve with: hermes skills approve {bundle.name}[/]\n")
+        return
+
+    # Install official skills directly
     install_dir = install_from_quarantine(q_path, bundle.name, category, bundle, result)
     from tools.skills_hub import SKILLS_DIR
     c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
 
 
+def do_approve(name: str, console: Optional[Console] = None) -> None:
+    """Approve a quarantined third-party skill and install it."""
+    from tools.skills_guard import Finding, ScanResult
+    from tools.skills_hub import SkillBundle, SKILLS_DIR, install_from_quarantine
+    from agent.security.admission import (
+        load_quarantined_skill_install,
+        mark_record_approved,
+        requarantine_skill_directory,
+        revoke_record,
+        verify_approved_record_integrity,
+        verify_record_integrity,
+    )
+
+    c = console or _console
+    try:
+        record, payload = load_quarantined_skill_install(name)
+    except FileNotFoundError:
+        c.print(f"[bold red]Error:[/] No quarantined skill named '{name}'.\n")
+        return
+    except Exception as exc:
+        c.print(f"[bold red]Error:[/] Failed to load quarantine record: {exc}\n")
+        return
+
+    if not verify_record_integrity(record):
+        c.print(f"[bold red]Error:[/] Quarantine integrity check failed for '{name}'.\n")
+        return
+
+    bundle = SkillBundle(
+        name=payload["name"],
+        files=payload["files"],
+        source=payload["source"],
+        identifier=payload["identifier"],
+        trust_level=payload["trust_level"],
+        metadata=payload.get("metadata", {}),
+    )
+    scan_payload = payload["scan_result"]
+    scan_result = ScanResult(
+        skill_name=scan_payload["skill_name"],
+        source=scan_payload["source"],
+        trust_level=scan_payload["trust_level"],
+        verdict=scan_payload["verdict"],
+        findings=[Finding(**finding) for finding in scan_payload.get("findings", [])],
+        scanned_at=scan_payload.get("scanned_at", ""),
+        summary=scan_payload.get("summary", ""),
+    )
+
+    install_dir = install_from_quarantine(
+        Path(record.quarantine_path),
+        bundle.name,
+        payload.get("category", ""),
+        bundle,
+        scan_result,
+    )
+    mark_record_approved(record, approved_path=str(install_dir), integrity_path=install_dir)
+    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
+    c.print()
+
+
 def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
     """Preview a skill's SKILL.md content without installing."""
     from tools.skills_hub import GitHubAuth, create_source_router
+    from agent.security.admission import CandidateKind, load_latest_record, read_report
 
     c = console or _console
+
+    if "/" not in identifier:
+        try:
+            record = load_latest_record(CandidateKind.SKILL, identifier)
+            c.print()
+            c.print(Panel(read_report(record), title=f"Admission Report: {record.source.display_name}"))
+            if record.notes:
+                c.print(Panel("\n".join(record.notes), title="Notes", border_style="yellow"))
+            c.print()
+            return
+        except FileNotFoundError:
+            pass
+
     auth = GitHubAuth()
     sources = create_source_router(auth)
 
@@ -436,7 +526,6 @@ def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
         c.print(f"[bold red]Error:[/] Could not find '{identifier}' in any source.\n")
         return
 
-    c.print()
     trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow"}.get(meta.trust_level, "dim")
     trust_label = "official" if meta.source == "official" else meta.trust_level
 
@@ -457,13 +546,60 @@ def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
         content = bundle.files["SKILL.md"]
         if isinstance(content, bytes):
             content = content.decode("utf-8", errors="replace")
-        # Show first 50 lines as preview
         lines = content.split("\n")
         preview = "\n".join(lines[:50])
         if len(lines) > 50:
             preview += f"\n\n... ({len(lines) - 50} more lines)"
         c.print(Panel(preview, title="SKILL.md Preview", subtitle="hermes skills install <id> to install"))
 
+    c.print()
+
+
+def do_reject(name: str, console: Optional[Console] = None) -> None:
+    """Reject the latest quarantined skill record."""
+    from agent.security.admission import (
+        AdmissionStatus,
+        CandidateKind,
+        load_latest_record,
+        reject_record,
+    )
+
+    c = console or _console
+    try:
+        record = load_latest_record(
+            CandidateKind.SKILL,
+            name,
+            statuses=(AdmissionStatus.QUARANTINED,),
+        )
+    except FileNotFoundError:
+        c.print(f"[bold red]Error:[/] No quarantined skill named '{name}'.\n")
+        return
+    reject_record(record, note="user rejected candidate")
+    c.print(f"[bold yellow]Rejected:[/] {name}\n")
+
+
+def do_quarantine_list(console: Optional[Console] = None) -> None:
+    """List all skill admission records."""
+    from agent.security.admission import CandidateKind, find_records
+
+    c = console or _console
+    records = find_records(CandidateKind.SKILL)
+    if not records:
+        c.print("[dim]No skill admission records.[/]\n")
+        return
+    table = Table(title="Skill Admission Records")
+    table.add_column("Name", style="bold cyan")
+    table.add_column("Status", style="dim")
+    table.add_column("Updated", style="dim")
+    table.add_column("Record ID", style="dim")
+    for record in records:
+        table.add_row(
+            record.source.display_name,
+            str(record.status),
+            record.updated_at.isoformat(timespec="seconds"),
+            record.record_id,
+        )
+    c.print(table)
     c.print()
 
 
@@ -572,6 +708,14 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None) -> N
     """Re-run security scan on installed hub skills."""
     from tools.skills_hub import HubLockFile, SKILLS_DIR
     from tools.skills_guard import scan_skill, format_scan_report
+    from agent.security.admission import (
+        admission_record_id,
+        admission_store,
+        CandidateKind,
+        requarantine_skill_directory,
+        revoke_record,
+        verify_approved_record_integrity,
+    )
 
     c = console or _console
     lock = HubLockFile()
@@ -594,6 +738,29 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None) -> N
         skill_path = SKILLS_DIR / entry["install_path"]
         if not skill_path.exists():
             c.print(f"[yellow]Warning:[/] {entry['name']} — path missing: {entry['install_path']}")
+            continue
+
+        record = None
+        try:
+            record = admission_store().load_record(admission_record_id(CandidateKind.SKILL, entry["name"]))
+        except Exception:
+            record = None
+        if record and record.status == "approved" and not verify_approved_record_integrity(record):
+            result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
+            requarantine_skill_directory(
+                name=entry["name"],
+                installed_path=skill_path,
+                identifier=entry.get("identifier", entry["source"]),
+                source=entry["source"],
+                trust_level=entry["trust_level"],
+                category=_derive_category_from_install_path(entry.get("install_path", "")),
+                metadata=entry.get("metadata", {}),
+                scan_result=result,
+                previous_record=record,
+            )
+            revoke_record(record, note="installed skill drifted from approved content")
+            lock.record_uninstall(entry["name"])
+            c.print(f"[yellow]Revoked:[/] {entry['name']} re-quarantined after integrity drift")
             continue
 
         result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
@@ -932,6 +1099,12 @@ def skills_command(args) -> None:
     elif action == "install":
         do_install(args.identifier, category=args.category, force=args.force,
                    skip_confirm=getattr(args, "yes", False))
+    elif action == "approve":
+        do_approve(args.name)
+    elif action == "reject":
+        do_reject(args.name)
+    elif action == "quarantine-list":
+        do_quarantine_list()
     elif action == "inspect":
         do_inspect(args.identifier)
     elif action == "list":
@@ -966,7 +1139,7 @@ def skills_command(args) -> None:
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|install|approve|reject|inspect|quarantine-list|list|check|update|audit|uninstall|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,24 +85,16 @@ def _ensure_current_event_loop(request):
         yield
         return
 
-    try:
-        loop = asyncio.get_event_loop_policy().get_event_loop()
-    except RuntimeError:
-        loop = None
-
-    created = loop is None or loop.is_closed()
-    if created:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
     try:
         yield
     finally:
-        if created and loop is not None:
-            try:
-                loop.close()
-            finally:
-                asyncio.set_event_loop(None)
+        try:
+            loop.close()
+        finally:
+            asyncio.set_event_loop(None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,16 +85,24 @@ def _ensure_current_event_loop(request):
         yield
         return
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
+    try:
+        loop = asyncio.get_event_loop_policy().get_event_loop()
+    except RuntimeError:
+        loop = None
+
+    created = loop is None or loop.is_closed()
+    if created:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
     try:
         yield
     finally:
-        try:
-            loop.close()
-        finally:
-            asyncio.set_event_loop(None)
+        if created and loop is not None:
+            try:
+                loop.close()
+            finally:
+                asyncio.set_event_loop(None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/hermes_cli/test_admission.py
+++ b/tests/hermes_cli/test_admission.py
@@ -1,0 +1,45 @@
+from io import StringIO
+
+from rich.console import Console
+
+from hermes_cli.admission import do_audit, do_list
+
+
+def test_do_list_renders_admission_records(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.security.admission import quarantine_mcp_server
+
+    quarantine_mcp_server(
+        "demo",
+        {"url": "https://example.com/mcp"},
+        [("search", "Search docs")],
+        hermes_home=tmp_path,
+    )
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_list(console=console)
+    output = sink.getvalue()
+
+    assert "Admission Records" in output
+    assert "demo" in output
+    assert "Revision" in output
+
+
+def test_do_audit_runs_mcp_and_skill_audits(monkeypatch):
+    import hermes_cli.admission as admission_cli
+
+    calls = []
+
+    monkeypatch.setattr("hermes_cli.mcp_config.audit_mcp_integrity", lambda: ["mcp drift"])
+    monkeypatch.setattr("hermes_cli.skills_hub.do_audit", lambda console=None: calls.append("skills"))
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_audit(console=console)
+    output = sink.getvalue()
+
+    assert "Admission Audit" in output
+    assert "mcp drift" in output
+    assert calls == ["skills"]

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -184,7 +184,7 @@ class TestMcpAdd:
         assert "Must specify" in out
 
     def test_add_http_server_all_tools(self, tmp_path, capsys, monkeypatch):
-        """Add an HTTP server, accept all tools."""
+        """Add an HTTP server, quarantine it, then approve it."""
         fake_tools = [
             FakeTool("create_service", "Deploy from repo"),
             FakeTool("list_services", "List all services"),
@@ -204,18 +204,25 @@ class TestMcpAdd:
 
         cmd_mcp_add(_make_args(name="ink", url="https://mcp.ml.ink/mcp"))
         out = capsys.readouterr().out
-        assert "Saved" in out
-        assert "2/2 tools" in out
+        assert "Quarantined" in out
+        assert "approve ink" in out
 
-        # Verify config written
+        # Verify config is not active until approval
         from hermes_cli.config import load_config
 
         config = load_config()
+        assert "ink" not in config.get("mcp_servers", {})
+
+        from hermes_cli.mcp_config import cmd_mcp_approve
+
+        cmd_mcp_approve(_make_args(name="ink"))
+        config = load_config()
         assert "ink" in config.get("mcp_servers", {})
         assert config["mcp_servers"]["ink"]["url"] == "https://mcp.ml.ink/mcp"
+        assert config["mcp_servers"]["ink"]["enabled"] is False
 
     def test_add_stdio_server(self, tmp_path, capsys, monkeypatch):
-        """Add a stdio server."""
+        """Add a stdio server to quarantine."""
         fake_tools = [FakeTool("search", "Search repos")]
 
         def mock_probe(name, config, **kw):
@@ -235,14 +242,71 @@ class TestMcpAdd:
             args=["@mcp/github"],
         ))
         out = capsys.readouterr().out
-        assert "Saved" in out
+        assert "Quarantined" in out
 
         from hermes_cli.config import load_config
 
         config = load_config()
-        srv = config["mcp_servers"]["github"]
-        assert srv["command"] == "npx"
-        assert srv["args"] == ["@mcp/github"]
+        assert "github" not in config.get("mcp_servers", {})
+
+    def test_approve_missing_quarantine(self, tmp_path, capsys):
+        from hermes_cli.mcp_config import cmd_mcp_approve
+
+        cmd_mcp_approve(_make_args(name="ghost"))
+        out = capsys.readouterr().out
+        assert "No quarantined MCP server" in out
+
+    def test_inspect_and_reject_quarantined_server(self, tmp_path, capsys, monkeypatch):
+        fake_tools = [FakeTool("search", "Search repos")]
+
+        def mock_probe(name, config, **kw):
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add, cmd_mcp_inspect, cmd_mcp_quarantine_list, cmd_mcp_reject
+
+        cmd_mcp_add(_make_args(name="github", command="npx", args=["@mcp/github"]))
+        cmd_mcp_inspect(_make_args(name="github"))
+        out = capsys.readouterr().out
+        assert "Admission Report: github" in out
+
+        cmd_mcp_quarantine_list()
+        out = capsys.readouterr().out
+        assert "github" in out
+        assert "quarantined" in out
+
+        cmd_mcp_reject(_make_args(name="github"))
+        out = capsys.readouterr().out
+        assert "Rejected quarantined MCP server" in out
+
+    def test_audit_revokes_drifted_mcp_config(self, tmp_path, capsys, monkeypatch):
+        fake_tools = [FakeTool("search", "Search repos")]
+
+        def mock_probe(name, config, **kw):
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        inputs = iter([""])  # accept all tools
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        from hermes_cli.config import load_config
+        from hermes_cli.mcp_config import audit_mcp_integrity, cmd_mcp_add, cmd_mcp_approve, _save_mcp_server
+
+        cmd_mcp_add(_make_args(name="github", command="npx", args=["@mcp/github"]))
+        cmd_mcp_approve(_make_args(name="github"))
+
+        _save_mcp_server("github", {"command": "python", "args": ["evil.py"], "enabled": True})
+        messages = audit_mcp_integrity()
+        config = load_config()
+
+        assert any("configuration drift detected" in message for message in messages)
+        assert "github" not in config.get("mcp_servers", {})
 
     def test_add_connection_failure_save_disabled(
         self, tmp_path, capsys, monkeypatch

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -3,7 +3,7 @@ from io import StringIO
 import pytest
 from rich.console import Console
 
-from hermes_cli.skills_hub import do_check, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import do_approve, do_audit, do_check, do_install, do_inspect, do_list, do_quarantine_list, do_reject, do_update, handle_skills_slash
 
 
 class _DummyLockFile:
@@ -20,6 +20,7 @@ def hub_env(monkeypatch, tmp_path):
     import tools.skills_hub as hub
 
     hub_dir = tmp_path / "skills" / ".hub"
+    original_lock_file_cls = hub.HubLockFile
     monkeypatch.setattr(hub, "SKILLS_DIR", tmp_path / "skills")
     monkeypatch.setattr(hub, "HUB_DIR", hub_dir)
     monkeypatch.setattr(hub, "LOCK_FILE", hub_dir / "lock.json")
@@ -27,6 +28,8 @@ def hub_env(monkeypatch, tmp_path):
     monkeypatch.setattr(hub, "AUDIT_LOG", hub_dir / "audit.log")
     monkeypatch.setattr(hub, "TAPS_FILE", hub_dir / "taps.json")
     monkeypatch.setattr(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache")
+    monkeypatch.setattr(hub, "HubLockFile", lambda: original_lock_file_cls(hub.LOCK_FILE))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     return hub_dir
 
@@ -177,3 +180,219 @@ def test_do_update_reinstalls_outdated_skills(monkeypatch):
 
     assert installs == [("skills-sh/example/repo/hub-skill", "category", True)]
     assert "Updated 1 skill" in output
+
+
+def test_do_install_quarantines_third_party_skill(monkeypatch, hub_env):
+    import tools.skills_guard as guard
+    import tools.skills_hub as hub
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    class Meta:
+        extra = {}
+
+    bundle = hub.SkillBundle(
+        name="demo-skill",
+        files={"SKILL.md": "# Demo\n", "script.py": "print('hi')\n"},
+        source="github",
+        identifier="github/example/demo-skill",
+        trust_level="community",
+        metadata={},
+    )
+    result = guard.ScanResult(
+        skill_name="demo-skill",
+        source="github/example/demo-skill",
+        trust_level="community",
+        verdict="safe",
+        findings=[],
+        scanned_at="2026-03-25T00:00:00Z",
+        summary="demo-skill: safe",
+    )
+
+    monkeypatch.setattr(hub, "GitHubAuth", lambda: object())
+    monkeypatch.setattr(hub, "create_source_router", lambda _auth: [])
+    monkeypatch.setattr("hermes_cli.skills_hub._resolve_source_meta_and_bundle", lambda identifier, sources: (Meta(), bundle, None))
+    monkeypatch.setattr(guard, "scan_skill", lambda q_path, source=None: result)
+    monkeypatch.setattr(guard, "should_allow_install", lambda result, force=False: (True, "ok"))
+
+    do_install("github/example/demo-skill", console=console, skip_confirm=True)
+    output = sink.getvalue()
+
+    assert "Quarantined:" in output
+    assert "approve demo-skill" in output
+    assert (hub.QUARANTINE_DIR / "demo-skill" / ".hermes-admission.json").exists()
+
+
+def test_do_inspect_and_reject_quarantined_skill(monkeypatch, hub_env):
+    import tools.skills_guard as guard
+    import tools.skills_hub as hub
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    class Meta:
+        extra = {}
+
+    bundle = hub.SkillBundle(
+        name="demo-skill",
+        files={"SKILL.md": "# Demo\n"},
+        source="github",
+        identifier="github/example/demo-skill",
+        trust_level="community",
+        metadata={},
+    )
+    result = guard.ScanResult(
+        skill_name="demo-skill",
+        source="github/example/demo-skill",
+        trust_level="community",
+        verdict="safe",
+        findings=[],
+        scanned_at="2026-03-25T00:00:00Z",
+        summary="demo-skill: safe",
+    )
+
+    monkeypatch.setattr(hub, "GitHubAuth", lambda: object())
+    monkeypatch.setattr(hub, "create_source_router", lambda _auth: [])
+    monkeypatch.setattr("hermes_cli.skills_hub._resolve_source_meta_and_bundle", lambda identifier, sources: (Meta(), bundle, None))
+    monkeypatch.setattr(guard, "scan_skill", lambda q_path, source=None: result)
+    monkeypatch.setattr(guard, "should_allow_install", lambda result, force=False: (True, "ok"))
+
+    do_install("github/example/demo-skill", console=console, skip_confirm=True)
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_inspect("demo-skill", console=console)
+    output = sink.getvalue()
+    assert "Admission Report: demo-skill" in output
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_quarantine_list(console=console)
+    output = sink.getvalue()
+    assert "demo-skill" in output
+    assert "quarantined" in output
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_reject("demo-skill", console=console)
+    output = sink.getvalue()
+    assert "Rejected:" in output
+
+
+def test_do_approve_installs_quarantined_skill(monkeypatch, hub_env):
+    import tools.skills_guard as guard
+    import tools.skills_hub as hub
+
+    class Meta:
+        extra = {}
+
+    bundle = hub.SkillBundle(
+        name="demo-skill",
+        files={"SKILL.md": "# Demo\n"},
+        source="github",
+        identifier="github/example/demo-skill",
+        trust_level="community",
+        metadata={},
+    )
+    result = guard.ScanResult(
+        skill_name="demo-skill",
+        source="github/example/demo-skill",
+        trust_level="community",
+        verdict="safe",
+        findings=[],
+        scanned_at="2026-03-25T00:00:00Z",
+        summary="demo-skill: safe",
+    )
+
+    monkeypatch.setattr(hub, "GitHubAuth", lambda: object())
+    monkeypatch.setattr(hub, "create_source_router", lambda _auth: [])
+    monkeypatch.setattr("hermes_cli.skills_hub._resolve_source_meta_and_bundle", lambda identifier, sources: (Meta(), bundle, None))
+    monkeypatch.setattr(guard, "scan_skill", lambda q_path, source=None: result)
+    monkeypatch.setattr(guard, "should_allow_install", lambda result, force=False: (True, "ok"))
+
+    pre_sink = StringIO()
+    pre_console = Console(file=pre_sink, force_terminal=False, color_system=None)
+    do_install("github/example/demo-skill", console=pre_console, skip_confirm=True)
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_approve("demo-skill", console=console)
+    output = sink.getvalue()
+
+    assert "Installed:" in output
+    assert (hub.SKILLS_DIR / "demo-skill" / "SKILL.md").exists()
+
+
+def test_do_audit_revokes_drifted_skill(monkeypatch, hub_env):
+    import tools.skills_guard as guard
+    import tools.skills_hub as hub
+    from agent.security.admission import (
+        AdmissionRecord,
+        CandidateKind,
+        CandidateSource,
+        mark_record_approved,
+    )
+
+    result = guard.ScanResult(
+        skill_name="demo-skill",
+        source="github/example/demo-skill",
+        trust_level="community",
+        verdict="safe",
+        findings=[],
+        scanned_at="2026-03-25T00:00:00Z",
+        summary="demo-skill: safe",
+    )
+
+    monkeypatch.setattr(guard, "scan_skill", lambda q_path, source=None: result)
+    installed_dir = hub.SKILLS_DIR / "demo-skill"
+    installed_dir.mkdir(parents=True, exist_ok=True)
+    installed = installed_dir / "SKILL.md"
+    installed.write_text("# Demo\n", encoding="utf-8")
+
+    class LockShim:
+        def __init__(self):
+            self._installed = {
+                "demo-skill": {
+                    "name": "demo-skill",
+                    "source": "github",
+                    "identifier": "github/example/demo-skill",
+                    "trust_level": "community",
+                    "scan_verdict": "safe",
+                    "content_hash": "sha256:test",
+                    "install_path": "demo-skill",
+                    "files": ["SKILL.md"],
+                    "metadata": {},
+                }
+            }
+
+        def list_installed(self):
+            return list(self._installed.values())
+
+        def get_installed(self, name):
+            return self._installed.get(name)
+
+        def record_uninstall(self, name):
+            self._installed.pop(name, None)
+
+    monkeypatch.setattr(hub, "HubLockFile", LockShim)
+
+    record = AdmissionRecord(
+        record_id="skill-demo-skill",
+        kind=CandidateKind.SKILL,
+        source=CandidateSource(
+            uri="github/example/demo-skill",
+            display_name="demo-skill",
+            installer="test",
+        ),
+    )
+    mark_record_approved(record, approved_path=str(installed_dir), integrity_path=installed_dir)
+    installed.write_text("# Tampered\n", encoding="utf-8")
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_audit("demo-skill", console=console)
+    output = sink.getvalue()
+
+    assert "Revoked:" in output
+    assert not any(".hub" not in path.parts for path in hub.SKILLS_DIR.rglob("SKILL.md"))

--- a/tests/security/test_admission_core.py
+++ b/tests/security/test_admission_core.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.security.admission import (
+    AdmissionPromoter,
+    AdmissionRecord,
+    AdmissionStatus,
+    AdmissionStore,
+    CandidateKind,
+    CandidateSource,
+    find_records,
+    InspectionReport,
+    IntegrityVerifier,
+    mark_record_approved,
+    PromotionDecision,
+    quarantine_mcp_server,
+    reject_record,
+    render_report,
+)
+
+
+def make_record() -> AdmissionRecord:
+    return AdmissionRecord(
+        record_id="rec-1",
+        kind=CandidateKind.MCP_SERVER,
+        source=CandidateSource(
+            uri="https://example.com/demo.git",
+            display_name="demo",
+            version="1.0.0",
+            installer="git",
+        ),
+    )
+
+
+def test_transition_rules() -> None:
+    record = make_record()
+    record.transition_to(AdmissionStatus.APPROVED)
+    assert record.status is AdmissionStatus.APPROVED
+    record.transition_to(AdmissionStatus.REVOKED)
+    assert record.status is AdmissionStatus.REVOKED
+    with pytest.raises(ValueError):
+        record.transition_to(AdmissionStatus.APPROVED)
+
+
+def test_store_roundtrip(tmp_path: Path) -> None:
+    store = AdmissionStore(tmp_path)
+    record = make_record()
+    store.save_record(record)
+    loaded = store.load_record(record.record_id)
+    assert loaded.record_id == record.record_id
+    assert loaded.source.display_name == "demo"
+    assert loaded.status is AdmissionStatus.QUARANTINED
+
+
+def test_report_render_and_write(tmp_path: Path) -> None:
+    store = AdmissionStore(tmp_path)
+    record = make_record()
+    report = InspectionReport(
+        summary="Needs approval.",
+        decision=PromotionDecision.HOLD,
+        reasons=["network access"],
+        warnings=["downloads code"],
+    )
+    content = render_report(record, report)
+    path = store.write_report(record.record_id, content)
+    assert path.read_text(encoding="utf-8").startswith("# Admission Report: demo")
+    assert "network access" in content
+
+
+def test_integrity_drift_detection(tmp_path: Path) -> None:
+    verifier = IntegrityVerifier()
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "file.txt").write_text("alpha", encoding="utf-8")
+    state = verifier.capture(artifact)
+    assert verifier.verify(artifact, state) is True
+    (artifact / "file.txt").write_text("beta", encoding="utf-8")
+    assert verifier.verify(artifact, state) is False
+
+
+def test_promoter_requires_report_and_marks_approved(tmp_path: Path) -> None:
+    store = AdmissionStore(tmp_path)
+    promoter = AdmissionPromoter(store)
+    record = make_record()
+    with pytest.raises(ValueError):
+        promoter.promote_record(record)
+    report_path = store.write_report(record.record_id, "ok")
+    record.report_path = str(report_path)
+    promoter.promote_record(record)
+    assert record.status is AdmissionStatus.APPROVED
+
+
+def test_revision_lineage_increments_for_repeated_quarantine(tmp_path: Path) -> None:
+    first = quarantine_mcp_server(
+        "demo",
+        {"url": "https://example.com/mcp"},
+        [("search", "Search docs")],
+        hermes_home=tmp_path,
+    )
+    second = quarantine_mcp_server(
+        "demo",
+        {"url": "https://example.com/mcp?v=2"},
+        [("search", "Search docs")],
+        hermes_home=tmp_path,
+    )
+
+    assert first.revision == 1
+    assert second.revision == 2
+    assert first.lineage_id == second.lineage_id
+    assert second.record_id.startswith(f"{first.lineage_id}-rev-2")
+    records = find_records(CandidateKind.MCP_SERVER, name="demo", hermes_home=tmp_path)
+    assert [record.revision for record in records] == [2, 1]
+
+
+def test_reject_and_approve_capture_terminal_and_timestamp(tmp_path: Path) -> None:
+    record = make_record()
+    reject_record(record, note="user rejected candidate", hermes_home=tmp_path)
+    assert record.status is AdmissionStatus.REJECTED
+    assert "user rejected candidate" in record.notes
+    with pytest.raises(ValueError):
+        record.transition_to(AdmissionStatus.APPROVED)
+
+    approved = make_record()
+    artifact = tmp_path / "approved.json"
+    artifact.write_text("{}", encoding="utf-8")
+    mark_record_approved(approved, approved_path=str(artifact), integrity_path=artifact, hermes_home=tmp_path)
+    assert approved.status is AdmissionStatus.APPROVED
+    assert approved.approved_at is not None

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -16,12 +16,28 @@ for the AI agent to access all capabilities.
 """
 
 # Export all tools for easy importing
-from .web_tools import (
-    web_search_tool,
-    web_extract_tool,
-    web_crawl_tool,
-    check_firecrawl_api_key
-)
+try:
+    from .web_tools import (
+        web_search_tool,
+        web_extract_tool,
+        web_crawl_tool,
+        check_firecrawl_api_key,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name != "firecrawl":
+        raise
+
+    def _missing_firecrawl(*args, **kwargs):
+        raise ModuleNotFoundError(
+            "firecrawl is not installed; web_tools are unavailable in this environment"
+        )
+
+    web_search_tool = _missing_firecrawl
+    web_extract_tool = _missing_firecrawl
+    web_crawl_tool = _missing_firecrawl
+
+    def check_firecrawl_api_key():
+        return False
 
 # Primary terminal tool (local/docker/singularity/modal/daytona/ssh)
 from .terminal_tool import (
@@ -45,10 +61,22 @@ from .mixture_of_agents_tool import (
     check_moa_requirements
 )
 
-from .image_generation_tool import (
-    image_generate_tool,
-    check_image_generation_requirements
-)
+try:
+    from .image_generation_tool import (
+        image_generate_tool,
+        check_image_generation_requirements,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name != "fal_client":
+        raise
+
+    def image_generate_tool(*args, **kwargs):
+        raise ModuleNotFoundError(
+            "fal_client is not installed; image generation tools are unavailable in this environment"
+        )
+
+    def check_image_generation_requirements():
+        return False
 
 from .skills_tool import (
     skills_list,
@@ -259,4 +287,3 @@ __all__ = [
     'check_delegate_requirements',
     'DELEGATE_TASK_SCHEMA',
 ]
-


### PR DESCRIPTION
## Summary

This PR adds quarantine-first admission control for third-party capabilities in `hermes-agent`.

It introduces a shared admission subsystem and routes third-party MCP servers and third-party skills through quarantine before they can become trusted/active. Approved artifacts are integrity-tracked, and drift revokes trust and re-quarantines the artifact instead of silently continuing.

This is not a fix for one narrow bug. It is a control-plane hardening change for how Hermes accepts third-party extensions.

## Why

Current extension intake is too trust-forward.

Today, third-party capability install/config flows are close to activation by default:
- trust is mostly implicit once a server/skill is added
- approval and activation are not clearly separated
- integrity drift is not treated as a first-class lifecycle event
- audit visibility is fragmented

That is convenient, but weak as a security/control model for third-party capability intake.

This PR changes the default posture:
- install/add goes to quarantine first
- review is explicit
- approval is explicit
- activation is separate
- integrity drift revokes trust and re-quarantines

## What Changed

### Admission Core
Added a shared admission subsystem under `agent/security/admission/`:
- typed lifecycle models
- deterministic state transitions
- persisted admission records
- inspection report rendering
- approval/rejection/revocation helpers
- integrity verification helpers
- revision lineage metadata

### MCP Flow
`hermes mcp add` now quarantines new third-party MCP entries first.

Added:
- `hermes mcp approve <name>`
- `hermes mcp inspect <name>`
- `hermes mcp reject <name>`
- `hermes mcp quarantine-list`

Behavior:
- approved MCP entries are written into active config
- approved MCP entries remain disabled until explicitly enabled/configured
- integrity drift revokes and re-quarantines

### Skills Flow
Third-party `hermes skills install` now quarantines first instead of installing directly.

Added:
- `hermes skills approve <name>`
- `hermes skills reject <name>`
- `hermes skills quarantine-list`

Behavior:
- official skills still install directly
- third-party skills require explicit approval
- drifted approved installs are revoked and re-quarantined during audit

### Unified Audit Surface
Added:
- `hermes admission list`
- `hermes admission audit`

Also surfaced admission status in `hermes doctor`.

### Testability / Optional Imports
I also made `tools/__init__.py` degrade cleanly when optional tool dependencies like `firecrawl` or `fal_client` are not installed.

Reason:
- the quarantine/MCP/skills test path should not fail just from importing `tools` in a normal dev environment without optional extras
- this keeps the quarantine feature testable without requiring unrelated optional providers

## Current Behavior vs New Behavior

### Before
- third-party MCP/skills flows could move too directly from install/add to trusted use
- trust was implicit
- integrity drift was not modeled as a lifecycle event
- inspection and audit were not unified

### After
- third-party intake lands in quarantine first
- approval is explicit
- approval and activation are separate
- integrity is persisted and verified
- drift revokes trust and re-quarantines
- audit/list surfaces are explicit

## Tradeoffs

### Pros
- safer default posture for third-party capability intake
- explicit human trust decision before activation
- better auditability and lifecycle clarity
- integrity drift becomes actionable instead of silent
- clearer separation between quarantined, approved, and active state

### Cons
- more friction for third-party installs/adds
- more state and lifecycle code to maintain
- larger CLI/storage/test surface
- slightly broader scope because optional tool imports needed to degrade cleanly for this feature to be testable

I think this tradeoff is worth it because the added friction is concentrated on third-party capability intake, where explicit trust is the right default.

## Validation

I ran the quarantine-focused suites locally:

```bash
pytest -q -o addopts='' \
  tests/security/test_admission_core.py \
  tests/hermes_cli/test_admission.py \
  tests/hermes_cli/test_doctor.py \
  tests/hermes_cli/test_mcp_config.py \
  tests/hermes_cli/test_skills_hub.py \
  tests/tools/test_hidden_dir_filter.py
```

Result:
- `67 passed in 0.99s`

## Related Context

This is adjacent to skills-install / extension-policy work, but I am not claiming an exact issue closure here.

Potentially relevant nearby upstream items:
- Related to #2940
- Adjacent to #2951

I intentionally did not use `Fixes #...` because I did not find a single open issue that exactly matches this admission-control feature.
