### PR TITLE
fix(whatsapp): allow bridge port configuration via WHATSAPP_PORT env var

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -128,7 +128,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WHATSAPP)
         self._bridge_process: Optional[subprocess.Popen] = None
-        self._bridge_port: int = config.extra.get("bridge_port", 3000)
+        self._bridge_port: int = int(os.getenv("WHATSAPP_PORT", config.extra.get("bridge_port", 3000)))
         self._bridge_script: Optional[str] = config.extra.get(
             "bridge_script",
             str(self._DEFAULT_BRIDGE_DIR / "bridge.js"),


### PR DESCRIPTION
## What does this PR do?

Currently, the WhatsApp bridge port contains a hardcoded fallback to `3000` if the port is not present in `config.extra`. This causes an `EADDRINUSE` port conflict when users attempt to run multiple isolated instances of Hermes Agent (e.g., using different `HERMES_HOME` workspaces for a multi-agent architecture) on the same machine. Subsequent instances will silently fail to bind the bridge port and get stuck at `Bridge ready (status: connected)`.

This PR solves the issue by checking for the `WHATSAPP_PORT` environment variable before falling back to `3000`. This approach is the right one as it respects standard 12-factor app configuration and allows users to easily override ports via CLI or process managers like PM2 without modifying internal config files.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Modified `gateway/platforms/whatsapp.py` (around line 131) to prioritize `os.getenv("WHATSAPP_PORT")` when initializing `self._bridge_port`.

## How to Test

1. Setup a standard Hermes Agent workspace and configure the WhatsApp gateway.
2. In the terminal, export a custom port: `export WHATSAPP_PORT=3001`.
3. Start the gateway: `hermes gateway`.
4. Observe the terminal logs. It should successfully bind to the new port: `[Whatsapp] Bridge started on port 3001` instead of defaulting to `3000`.
5. Run a second isolated instance simultaneously with `export WHATSAPP_PORT=3002` to verify that no `EADDRINUSE` port collision occurs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Mac Mini, Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before:**
```text
[Whatsapp] Bridge ready (status: connected)
[Whatsapp] Bridge started on port 3000
```

(If another instance is already on 3000, it fails silently).

After (`with export WHATSAPP_PORT=3001`):
```text
[Whatsapp] Bridge ready (status: connected)
[Whatsapp] Bridge started on port 3001
```