### PR TITLE
perf(prompt_builder): avoid redundant file re-read for skill conditions

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -354,8 +354,15 @@ def build_skills_system_prompt(
         fm_name = frontmatter.get("name", skill_name)
         if fm_name in disabled or skill_name in disabled:
             continue
-        # Skip skills whose conditional activation rules exclude them
-        conditions = _read_skill_conditions(skill_file)
+        # Extract conditions inline from already-parsed frontmatter
+        # (avoids redundant file re-read that _read_skill_conditions would do)
+        hermes_meta = frontmatter.get("metadata", {}).get("hermes", {})
+        conditions = {
+            "fallback_for_toolsets": hermes_meta.get("fallback_for_toolsets", []),
+            "requires_toolsets": hermes_meta.get("requires_toolsets", []),
+            "fallback_for_tools": hermes_meta.get("fallback_for_tools", []),
+            "requires_tools": hermes_meta.get("requires_tools", []),
+        }
         if not _skill_should_show(conditions, available_tools, available_toolsets):
             continue
         skills_by_category.setdefault(category, []).append((skill_name, desc))


### PR DESCRIPTION
## Summary

`build_skills_system_prompt()` was calling `_read_skill_conditions()` which re-read each SKILL.md file to extract conditional activation fields. The frontmatter was already parsed by `_parse_skill_file()` earlier in the same loop — both read the same `[:2000]` slice and call the same `_parse_frontmatter()`.

Extract conditions inline from the existing frontmatter dict instead, saving one `read_text()` per skill (~80+ built-in skills = ~80 fewer file reads on every session start).

Salvaged from PR #2827 by @InB4DevOps. The other changes in that PR (string concat refactors, exception narrowing) were not included — see review comments on #2827.