### PR TITLE
fix(display): suppress KawaiiSpinner animation under patch_stdout

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -239,7 +239,6 @@ class KawaiiSpinner:
         self.frame_idx = 0
         self.start_time = None
         self.last_line_len = 0
-        self._last_flush_time = 0.0  # Rate-limit flushes for patch_stdout compat
         # Capture stdout NOW, before any redirect_stdout(devnull) from
         # child agents can replace sys.stdout with a black hole.
         self._out = sys.stdout
@@ -253,6 +252,22 @@ class KawaiiSpinner:
         except (ValueError, OSError):
             pass
 
+    def _is_patch_stdout_proxy(self) -> bool:
+        """Return True when stdout is prompt_toolkit's StdoutProxy.
+
+        patch_stdout wraps sys.stdout in a StdoutProxy that queues writes and
+        injects newlines around each flush().  The \\r overwrite never lands on
+        the correct line — each spinner frame ends up on its own line.
+
+        The CLI already drives a TUI widget (_spinner_text) for spinner display,
+        so KawaiiSpinner's \\r-based animation is redundant under StdoutProxy.
+        """
+        out = self._out
+        # StdoutProxy has a 'raw' attribute (bool) that plain file objects lack.
+        if hasattr(out, 'raw') and type(out).__name__ == 'StdoutProxy':
+            return True
+        return False
+
     def _animate(self):
         # When stdout is not a real terminal (e.g. Docker, systemd, pipe),
         # skip the animation entirely — it creates massive log bloat.
@@ -261,6 +276,16 @@ class KawaiiSpinner:
             self._write(f"  [tool] {self.message}", flush=True)
             while self.running:
                 time.sleep(0.5)
+            return
+
+        # When running inside prompt_toolkit's patch_stdout context the CLI
+        # renders spinner state via a dedicated TUI widget (_spinner_text).
+        # Driving a \r-based animation here too causes visual overdraw: the
+        # StdoutProxy injects newlines around each flush, so every frame lands
+        # on a new line and overwrites the status bar.
+        if self._is_patch_stdout_proxy():
+            while self.running:
+                time.sleep(0.1)
             return
 
         # Cache skin wings at start (avoid per-frame imports)
@@ -279,18 +304,7 @@ class KawaiiSpinner:
             else:
                 line = f"  {frame} {self.message} ({elapsed:.1f}s)"
             pad = max(self.last_line_len - len(line), 0)
-            # Rate-limit flush() calls to avoid spinner spam under
-            # prompt_toolkit's patch_stdout.  Each flush() pushes a queue
-            # item that may trigger a separate run_in_terminal() call; if
-            # items are processed one-at-a-time the \r overwrite is lost
-            # and every frame appears on its own line.  By flushing at
-            # most every 0.4s we guarantee multiple \r-frames are batched
-            # into a single write, so the terminal collapses them correctly.
-            now = time.time()
-            should_flush = (now - self._last_flush_time) >= 0.4
-            self._write(f"\r{line}{' ' * pad}", end='', flush=should_flush)
-            if should_flush:
-                self._last_flush_time = now
+            self._write(f"\r{line}{' ' * pad}", end='', flush=True)
             self.last_line_len = len(line)
             self.frame_idx += 1
             time.sleep(0.12)


### PR DESCRIPTION
## Summary

When the CLI is active, `sys.stdout` is prompt_toolkit's `StdoutProxy` which queues writes and injects newlines around each `flush()`. This causes every `\r` spinner frame to land on its own line instead of overwriting the previous one, producing visible flickering where the spinner and status bar repeatedly swap positions during long agent runs.

The CLI already renders spinner state via a dedicated TUI widget (`_spinner_text` / `get_spinner_text`), so KawaiiSpinner's `\r`-based loop is redundant under StdoutProxy. Detect the proxy and suppress the animation entirely — the thread still runs to preserve `start()`/`stop()` semantics.

Also removes the 0.4s flush rate-limit workaround that was papering over the same issue, and cleans up the unused `_last_flush_time` attribute.

Salvaged from PR #2908 by @Mibayy. Fixes applied:
- Fixed detection: PR checked `_raw` (doesn't exist), actual attribute is `raw` — used `hasattr + class name` check instead
- Dropped unrelated bundled changes (OpenClaw migration, delegation budgets, docs)

## Test plan
- 98 display/spinner tests pass
- Display changes — needs live PTY verification on next interactive session