### PR TITLE
fix(shell): exponential backoff for persistent shell polling

### DIFF
--- a/tools/environments/persistent_shell.py
+++ b/tools/environments/persistent_shell.py
@@ -40,7 +40,7 @@ class PersistentShellMixin:
     def _cleanup_temp_files(self): ...
 
     _session_id: str = ""
-    _poll_interval: float = 0.01        # initial poll interval (10ms)
+    _poll_interval_start: float = 0.01  # initial poll interval (10ms)
     _poll_interval_max: float = 0.25    # max poll interval (250ms) — reduces I/O for long commands
 
     @property
@@ -225,7 +225,7 @@ class PersistentShellMixin:
         )
         self._send_to_shell(ipc_script)
         deadline = time.monotonic() + timeout
-        poll_interval = self._poll_interval  # starts at 10ms, backs off to 250ms
+        poll_interval = self._poll_interval_start  # starts at 10ms, backs off to 250ms
 
         while True:
             if is_interrupted():

--- a/tools/environments/persistent_shell.py
+++ b/tools/environments/persistent_shell.py
@@ -40,7 +40,8 @@ class PersistentShellMixin:
     def _cleanup_temp_files(self): ...
 
     _session_id: str = ""
-    _poll_interval: float = 0.01
+    _poll_interval: float = 0.01        # initial poll interval (10ms)
+    _poll_interval_max: float = 0.25    # max poll interval (250ms) — reduces I/O for long commands
 
     @property
     def _temp_prefix(self) -> str:
@@ -224,7 +225,7 @@ class PersistentShellMixin:
         )
         self._send_to_shell(ipc_script)
         deadline = time.monotonic() + timeout
-        poll_interval = self._poll_interval
+        poll_interval = self._poll_interval  # starts at 10ms, backs off to 250ms
 
         while True:
             if is_interrupted():
@@ -256,6 +257,10 @@ class PersistentShellMixin:
                 break
 
             time.sleep(poll_interval)
+            # Exponential backoff: fast start (10ms) for quick commands,
+            # ramps up to 250ms for long-running commands — reduces I/O by 10-25x
+            # on WSL2 where polling keeps the VM hot and memory pressure high.
+            poll_interval = min(poll_interval * 1.5, self._poll_interval_max)
 
         output, exit_code, new_cwd = self._read_persistent_output()
         if new_cwd:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -87,7 +87,7 @@ class SSHEnvironment(PersistentShellMixin, BaseEnvironment):
         except subprocess.TimeoutExpired:
             raise RuntimeError(f"SSH connection to {self.user}@{self.host} timed out")
 
-    _poll_interval: float = 0.15
+    _poll_interval_start: float = 0.15  # SSH: higher initial interval (150ms) for network latency
 
     @property
     def _temp_prefix(self) -> str:


### PR DESCRIPTION
## Summary

Replaces the fixed 10ms polling interval in `PersistentShellMixin` with exponential backoff (10ms → 250ms cap, 1.5x multiplier). Reduces I/O from ~100 ops/sec to ~4 ops/sec for long-running commands.

- Fast commands (<100ms): 1-3 polls at 10-22ms — no perceivable change
- Long commands (>1s): 10-25x fewer file reads, 250ms worst-case detection delay
- WSL2: VM can release memory between polls instead of staying hot

SSH environment keeps its 150ms initial interval (network latency) and inherits the 250ms cap.

Cherry-picked from PR #2786 by @ygd58. Fixes #2784.