### PR TITLE
fix(streaming): preserve Gemini thought signatures in streamed tool calls

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3656,6 +3656,7 @@ class AIAgent:
                                 "id": tc_delta.id or "",
                                 "type": "function",
                                 "function": {"name": "", "arguments": ""},
+                                "extra_content": None,
                             }
                         entry = tool_calls_acc[idx]
                         if tc_delta.id:
@@ -3665,6 +3666,13 @@ class AIAgent:
                                 entry["function"]["name"] += tc_delta.function.name
                             if tc_delta.function.arguments:
                                 entry["function"]["arguments"] += tc_delta.function.arguments
+                        extra = getattr(tc_delta, "extra_content", None)
+                        if extra is None and hasattr(tc_delta, "model_extra"):
+                            extra = (tc_delta.model_extra or {}).get("extra_content")
+                        if extra is not None:
+                            if hasattr(extra, "model_dump"):
+                                extra = extra.model_dump()
+                            entry["extra_content"] = extra
                         # Fire once per tool when the full name is available
                         name = entry["function"]["name"]
                         if name and idx not in tool_gen_notified:
@@ -3689,6 +3697,7 @@ class AIAgent:
                     mock_tool_calls.append(SimpleNamespace(
                         id=tc["id"],
                         type=tc["type"],
+                        extra_content=tc.get("extra_content"),
                         function=SimpleNamespace(
                             name=tc["function"]["name"],
                             arguments=tc["function"]["arguments"],

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -39,10 +39,15 @@ def _make_stream_chunk(
     return chunk
 
 
-def _make_tool_call_delta(index=0, tc_id=None, name=None, arguments=None):
+def _make_tool_call_delta(index=0, tc_id=None, name=None, arguments=None, extra_content=None, model_extra=None):
     """Build a mock tool call delta."""
     func = SimpleNamespace(name=name, arguments=arguments)
-    return SimpleNamespace(index=index, id=tc_id, function=func)
+    delta = SimpleNamespace(index=index, id=tc_id, function=func)
+    if extra_content is not None:
+        delta.extra_content = extra_content
+    if model_extra is not None:
+        delta.model_extra = model_extra
+    return delta
 
 
 def _make_empty_chunk(model=None, usage=None):
@@ -131,6 +136,52 @@ class TestStreamingAccumulator:
         assert tc[0].id == "call_123"
         assert tc[0].function.name == "terminal"
         assert tc[0].function.arguments == '{"command": "ls"}'
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_call_extra_content_preserved(self, mock_close, mock_create):
+        """Streamed tool calls preserve provider-specific extra_content metadata."""
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_gemini",
+                    name="cronjob",
+                    model_extra={
+                        "extra_content": {
+                            "google": {"thought_signature": "sig-123"}
+                        }
+                    },
+                )
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"task": "deep index on ."}')
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        tc = response.choices[0].message.tool_calls
+        assert tc is not None
+        assert tc[0].extra_content == {
+            "google": {"thought_signature": "sig-123"}
+        }
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")


### PR DESCRIPTION
## Summary

Gemini 3 thinking models include `extra_content` metadata (containing `thought_signature`) on tool call responses. This signature must be replayed on subsequent API calls or Gemini rejects the request with HTTP 400.

The non-streaming path already preserved `extra_content` (line ~4446 in run_agent.py), but the streaming accumulator rebuilt tool calls from deltas without carrying provider-specific metadata through. This caused Gemini tool loops to fail once a streamed tool call was replayed.

## Fix

- Capture `extra_content` from stream deltas during tool call accumulation (checks both direct attribute and `model_extra` dict for SDK compatibility)
- Pass it through to the reconstructed `SimpleNamespace` tool calls

Cherry-picked from PR #2803 by @meditation-error.

## Test plan
- New test: `test_tool_call_extra_content_preserved` verifies thought_signature survives the streaming accumulator
- All streaming tests pass (2 pre-existing failures in TestStreamingFallback unrelated)