### PR TITLE
fix(cron): mark session as ended after job completes

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -280,6 +280,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     job_name = job["name"]
     prompt = _build_job_prompt(job)
     origin = _resolve_origin(job)
+    _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
@@ -411,7 +412,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             disabled_toolsets=["cronjob", "messaging", "clarify"],
             quiet_mode=True,
             platform="cron",
-            session_id=f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}",
+            session_id=_cron_session_id,
             session_db=_session_db,
         )
         
@@ -476,6 +477,10 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         ):
             os.environ.pop(key, None)
         if _session_db:
+            try:
+                _session_db.end_session(_cron_session_id, "cron_complete")
+            except Exception as e:
+                logger.debug("Job '%s': failed to end session: %s", job_id, e)
             try:
                 _session_db.close()
             except Exception as e:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -254,6 +254,10 @@ class TestRunJobSessionPersistence:
         assert kwargs["session_db"] is fake_db
         assert kwargs["platform"] == "cron"
         assert kwargs["session_id"].startswith("cron_test-job_")
+        fake_db.end_session.assert_called_once()
+        call_args = fake_db.end_session.call_args
+        assert call_args[0][0].startswith("cron_test-job_")
+        assert call_args[0][1] == "cron_complete"
         fake_db.close.assert_called_once()
 
     def test_run_job_empty_response_returns_empty_not_placeholder(self, tmp_path):


### PR DESCRIPTION
## Summary

Salvage of PR #2979 by @ygd58. Fixes #2972.

Cron was the only execution path that never called `end_session()`, leaving `ended_at = NULL` permanently. This made cron sessions invisible to `hermes prune --older-than` and indistinguishable from active sessions.

## Bug in original PR

The original PR called `_session_db.end_session()` with zero arguments, but the method requires `(session_id, end_reason)`. This would have been a silent `TypeError` at runtime (swallowed by the `except Exception` wrapper), so sessions still wouldn't get marked.

## Fix

- Captured session_id in `_cron_session_id` before agent construction so it's available in the `finally` block even if `AIAgent()` fails
- Calls `end_session(_cron_session_id, 'cron_complete')` with proper arguments
- Updated existing test to verify `end_session` is called with correct args

## Test plan

All 34 cron scheduler tests pass. Live-tested with a real cron job — verified `ended_at` is set after completion.