### PR TITLE
fix(session): surface silent SessionDB failures that cause session data loss

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1186,8 +1186,8 @@ class HermesCLI:
         try:
             from hermes_state import SessionDB
             self._session_db = SessionDB()
-        except Exception:
-            pass
+        except Exception as e:
+            logging.warning("Failed to initialize SessionDB — session will NOT be indexed for search: %s", e)
         
         # Deferred title: stored in memory until the session is created in the DB
         self._pending_title: Optional[str] = None
@@ -1852,7 +1852,7 @@ class HermesCLI:
                 from hermes_state import SessionDB
                 self._session_db = SessionDB()
             except Exception as e:
-                logger.debug("SQLite session store not available: %s", e)
+                logging.warning("SQLite session store not available — session will NOT be indexed: %s", e)
         
         # If resuming, validate the session exists and load its history.
         # _preload_resumed_session() may have already loaded it (called from

--- a/cli.py
+++ b/cli.py
@@ -1187,7 +1187,7 @@ class HermesCLI:
             from hermes_state import SessionDB
             self._session_db = SessionDB()
         except Exception as e:
-            logging.warning("Failed to initialize SessionDB — session will NOT be indexed for search: %s", e)
+            logger.warning("Failed to initialize SessionDB — session will NOT be indexed for search: %s", e)
         
         # Deferred title: stored in memory until the session is created in the DB
         self._pending_title: Optional[str] = None
@@ -1852,7 +1852,7 @@ class HermesCLI:
                 from hermes_state import SessionDB
                 self._session_db = SessionDB()
             except Exception as e:
-                logging.warning("SQLite session store not available — session will NOT be indexed: %s", e)
+                logger.warning("SQLite session store not available — session will NOT be indexed: %s", e)
         
         # If resuming, validate the session exists and load its history.
         # _preload_resumed_session() may have already loaded it (called from

--- a/run_agent.py
+++ b/run_agent.py
@@ -887,7 +887,7 @@ class AIAgent:
                     user_id=None,
                 )
             except Exception as e:
-                logging.warning("Session DB create_session failed — messages will NOT be indexed: %s", e)
+                logger.warning("Session DB create_session failed — messages will NOT be indexed: %s", e)
                 self._session_db = None  # prevent silent data loss on every subsequent flush
         
         # In-memory todo list for task planning (one per agent/session)
@@ -1547,7 +1547,7 @@ class AIAgent:
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
-            logging.warning("Session DB append_message failed: %s", e)
+            logger.warning("Session DB append_message failed: %s", e)
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """
@@ -4688,7 +4688,7 @@ class AIAgent:
                 # Reset flush cursor — new session starts with no messages written
                 self._last_flushed_db_idx = 0
             except Exception as e:
-                logging.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
+                logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 
         # Reset context pressure warning and token estimate — usage drops
         # after compaction.  Without this, the stale last_prompt_tokens from

--- a/run_agent.py
+++ b/run_agent.py
@@ -887,7 +887,8 @@ class AIAgent:
                     user_id=None,
                 )
             except Exception as e:
-                logger.debug("Session DB create_session failed: %s", e)
+                logging.warning("Session DB create_session failed — messages will NOT be indexed: %s", e)
+                self._session_db = None  # prevent silent data loss on every subsequent flush
         
         # In-memory todo list for task planning (one per agent/session)
         from tools.todo_tool import TodoStore
@@ -1546,7 +1547,7 @@ class AIAgent:
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
-            logger.debug("Session DB append_message failed: %s", e)
+            logging.warning("Session DB append_message failed: %s", e)
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """
@@ -4687,7 +4688,7 @@ class AIAgent:
                 # Reset flush cursor — new session starts with no messages written
                 self._last_flushed_db_idx = 0
             except Exception as e:
-                logger.debug("Session DB compression split failed: %s", e)
+                logging.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 
         # Reset context pressure warning and token estimate — usage drops
         # after compaction.  Without this, the stale last_prompt_tokens from


### PR DESCRIPTION
## Summary

Salvage of PR #2939 by @LucidPaths — cherry-picked onto current main with a follow-up fix.

SessionDB initialization and operation failures were logged at `debug` level or silently swallowed (`except Exception: pass`), causing sessions to never be indexed in the FTS5 database. `session_search` returns empty results for affected conversations with zero indication anything went wrong.

## Changes

5 targeted log-level upgrades from `debug`/`pass` → `warning`:

1. **cli.py `__init__`** — bare `except: pass` → `logger.warning()`
2. **cli.py `_init_agent`** — `logger.debug` → `logger.warning`
3. **run_agent.py `create_session`** — `logger.debug` → `logger.warning` + sets `_session_db = None` (fail-fast instead of silently dropping every message)
4. **run_agent.py `append_message`** — `logger.debug` → `logger.warning`
5. **run_agent.py compression split** — `logger.debug` → `logger.warning`

## Follow-up fix

Original PR used `logging.warning()` (root logger) instead of `logger.warning()` (module logger). Fixed in the follow-up commit to preserve logger hierarchy and correct module name in output.

## Tests

6153 passed. 6 pre-existing failures in `test_scheduler.py` and `test_streaming.py` (unrelated).

Closes #2939