### PR TITLE
fix(discord): stop phantom typing indicator after agent turn completes

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -819,6 +819,16 @@ class BasePlatformAdapter(ABC):
                 await asyncio.sleep(interval)
         except asyncio.CancelledError:
             pass  # Normal cancellation when handler completes
+        finally:
+            # Ensure the underlying platform typing loop is stopped.
+            # _keep_typing may have called send_typing() after an outer
+            # stop_typing() cleared the task dict, recreating the loop.
+            # Cancelling _keep_typing alone won't clean that up.
+            if hasattr(self, "stop_typing"):
+                try:
+                    await self.stop_typing(chat_id)
+                except Exception:
+                    pass
     
     async def handle_message(self, event: MessageEvent) -> None:
         """
@@ -1129,6 +1139,13 @@ class BasePlatformAdapter(ABC):
             try:
                 await typing_task
             except asyncio.CancelledError:
+                pass
+            # Also cancel any platform-level persistent typing tasks (e.g. Discord)
+            # that may have been recreated by _keep_typing after the last stop_typing()
+            try:
+                if hasattr(self, "stop_typing"):
+                    await self.stop_typing(event.source.chat_id)
+            except Exception:
                 pass
             # Clean up session tracking
             if session_key in self._active_sessions:


### PR DESCRIPTION
## Summary

Discord's typing indicator lingers indefinitely after the agent finishes because of a race between two typing systems:

1. `_keep_typing` (base.py) pings Discord every 2s
2. `_typing_tasks` (Discord adapter) tracks persistent typing loops

**The race:** `stop_typing()` clears the task dict, but `_keep_typing` wakes from its 2s sleep and calls `send_typing()` again — recreating the loop. When `_keep_typing` is then cancelled, the newly created task is orphaned with no cleanup path.

## Fix

Two layers:

1. **Root cause** (`_keep_typing` finally block): when `_keep_typing` exits for any reason, it calls `stop_typing()` to clean up any loop it recreated after the last outer cleanup. From PR #2945 by @catbusconductor.

2. **Safety net** (`_process_message_background` finally block): after cancelling the typing task wrapper, also call `stop_typing()` to catch any platform-level persistent tasks. From PR #2832 by @subrih.

## Test plan
- 1429 gateway tests pass
- Both fixes are idempotent (`stop_typing` when already stopped is a no-op)
- `hasattr` guard ensures no impact on platforms without `stop_typing`