### PR TITLE
fix(skills): disambiguate duplicate skills.sh tree matches

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -369,6 +369,60 @@ class TestSkillsShSource:
         # Verify the tree-resolved identifier was used for the final GitHub fetch
         mock_fetch.assert_any_call("owner/repo/cli-tool/components/skills/development/my-skill")
 
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    @patch.object(GitHubSource, "fetch")
+    def test_fetch_uses_tree_tokens_to_disambiguate_duplicate_leaf_names(
+        self, mock_fetch, mock_get, _mock_read_cache, _mock_write_cache,
+    ):
+        tree_entries = [
+            {"path": "engineering/product-designer/SKILL.md", "type": "blob"},
+            {"path": "design/product-designer/SKILL.md", "type": "blob"},
+        ]
+
+        def _httpx_get_side_effect(url, **kwargs):
+            resp = MagicMock()
+            if url.endswith("/contents/"):
+                resp.status_code = 200
+                resp.json = lambda: []
+                return resp
+            if "/contents/" in url:
+                resp.status_code = 404
+                return resp
+            if url.endswith("owner/repo"):
+                resp.status_code = 200
+                resp.json = lambda: {"default_branch": "main"}
+                return resp
+            if "/git/trees/main" in url:
+                resp.status_code = 200
+                resp.json = lambda: {"tree": tree_entries}
+                return resp
+            resp.status_code = 200
+            resp.text = '''
+                <h1>product-designer</h1>
+                <code>$ npx skills add https://github.com/owner/repo --skill product-designer</code>
+                <div class="prose"><h1>Design/Product Designer</h1><p>Design workflows.</p></div>
+            '''
+            return resp
+
+        mock_get.side_effect = _httpx_get_side_effect
+
+        resolved_bundle = SkillBundle(
+            name="product-designer",
+            files={"SKILL.md": "# Product Designer"},
+            source="github",
+            identifier="owner/repo/design/product-designer",
+            trust_level="community",
+        )
+        mock_fetch.side_effect = lambda ident: resolved_bundle if ident == resolved_bundle.identifier else None
+
+        bundle = self._source().fetch("skills-sh/owner/repo/product-designer")
+
+        assert bundle is not None
+        mock_fetch.assert_any_call("owner/repo/design/product-designer")
+        assert ("owner/repo/engineering/product-designer",) not in [call.args for call in mock_fetch.call_args_list]
+
 
 class TestFindSkillInRepoTree:
     """Tests for GitHubSource._find_skill_in_repo_tree."""
@@ -425,6 +479,34 @@ class TestFindSkillInRepoTree:
 
         result = self._source()._find_skill_in_repo_tree("owner/repo", "my-skill")
         assert result == "owner/repo/my-skill"
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_prefers_tree_match_with_parent_path_tokens(self, mock_get):
+        tree_entries = [
+            {"path": "design/product-designer/SKILL.md", "type": "blob"},
+            {"path": "engineering/product-designer/SKILL.md", "type": "blob"},
+        ]
+
+        def _side_effect(url, **kwargs):
+            resp = MagicMock()
+            if "/contents" not in url and "/git/" not in url:
+                resp.status_code = 200
+                resp.json = lambda: {"default_branch": "main"}
+            elif "/git/trees/main" in url:
+                resp.status_code = 200
+                resp.json = lambda: {"tree": tree_entries}
+            else:
+                resp.status_code = 404
+            return resp
+
+        mock_get.side_effect = _side_effect
+
+        result = self._source()._find_skill_in_repo_tree(
+            "owner/repo",
+            "product-designer",
+            ["product-designer", "design-system", "design"],
+        )
+        assert result == "owner/repo/design/product-designer"
 
     @patch("tools.skills_hub.httpx.get")
     def test_returns_none_when_skill_not_found(self, mock_get):

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -500,13 +500,22 @@ class GitHubSource(SkillSource):
 
         return files
 
-    def _find_skill_in_repo_tree(self, repo: str, skill_name: str) -> Optional[str]:
+    def _find_skill_in_repo_tree(
+        self,
+        repo: str,
+        skill_name: str,
+        skill_tokens: Optional[List[str]] = None,
+    ) -> Optional[str]:
         """Use the GitHub Trees API to find a skill directory anywhere in the repo.
 
         Returns the full identifier (``repo/path/to/skill``) or ``None``.
         This is a single API call regardless of repo depth, so it efficiently
         handles deeply nested directory structures like
         ``cli-tool/components/skills/development/<skill>/SKILL.md``.
+
+        When multiple directories share the same final skill name, optional
+        ``skill_tokens`` are used to prefer the path whose parent directories
+        best match the skills.sh alias/detail-page tokens.
         """
         # Get default branch
         try:
@@ -539,6 +548,7 @@ class GitHubSource(SkillSource):
 
         # Look for SKILL.md files inside directories named <skill_name>
         skill_md_suffix = f"/{skill_name}/SKILL.md"
+        matches: List[str] = []
         for entry in tree_data.get("tree", []):
             if entry.get("type") != "blob":
                 continue
@@ -546,9 +556,48 @@ class GitHubSource(SkillSource):
             if path.endswith(skill_md_suffix) or path == f"{skill_name}/SKILL.md":
                 # Strip /SKILL.md to get the skill directory path
                 skill_dir = path[: -len("/SKILL.md")]
-                return f"{repo}/{skill_dir}"
+                matches.append(skill_dir)
 
-        return None
+        if not matches:
+            return None
+        if len(matches) == 1:
+            return f"{repo}/{matches[0]}"
+
+        token_variants = {
+            variant
+            for token in (skill_tokens or [])
+            for variant in SkillsShSource._token_variants(token)
+        }
+        if token_variants:
+            ranked = sorted(
+                matches,
+                key=lambda path: (
+                    -self._score_tree_skill_match(path, token_variants),
+                    len(path.split("/")),
+                    path,
+                ),
+            )
+            return f"{repo}/{ranked[0]}"
+
+        return f"{repo}/{matches[0]}"
+
+    @staticmethod
+    def _score_tree_skill_match(path: str, token_variants: set[str]) -> int:
+        path_lower = path.lower()
+        segments = [segment for segment in path_lower.split("/")[:-1] if segment]
+        segment_variants = set(segments)
+        for segment in segments:
+            segment_variants.update(SkillsShSource._token_variants(segment))
+
+        score = 0
+        for token in token_variants:
+            if token in segment_variants:
+                score += 4
+            if token and f"/{token}/" in f"/{path_lower}/":
+                score += 2
+            if token and token in path_lower:
+                score += 1
+        return score
 
     def _fetch_file_content(self, repo: str, path: str) -> Optional[str]:
         """Fetch a single file's content from GitHub."""
@@ -1134,7 +1183,7 @@ class SkillsShSource(SkillSource):
         # in the repo tree.  This handles deeply nested structures like
         # cli-tool/components/skills/development/<skill>/ that the shallow
         # scan above can't reach.
-        tree_result = self.github._find_skill_in_repo_tree(repo, skill_token)
+        tree_result = self.github._find_skill_in_repo_tree(repo, skill_token, tokens)
         if tree_result:
             return tree_result
 


### PR DESCRIPTION
## Problem

When `SkillsShSource` falls through to the GitHub tree search, `_find_skill_in_repo_tree()` returns the first matching `<leaf>/SKILL.md` path it sees.

That works for uniquely named skills, but it can pick the wrong directory when a repo contains multiple skills with the same final directory name under different categories.

## Root Cause

The tree fallback only matches on the final skill directory name. Once it finds multiple matches, it has no way to use the skills.sh alias/detail-page context to choose between them.

## Fix

- allow `_find_skill_in_repo_tree()` to accept optional resolution tokens
- score duplicate tree matches using parent-path token overlap
- pass the existing skills.sh detail-page tokens into the tree fallback path
- add regressions for both the low-level tree helper and the full `SkillsShSource.fetch()` flow

## Testing

- `source .venv/bin/activate && python -m pytest tests/tools/test_skills_hub.py -q`
- Result: `75 passed`
