### PR TITLE
fix: repair OpenCode model routing and selection

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1441,6 +1441,30 @@ class HermesCLI:
                 pass
             return changed
 
+        if resolved_provider in {"opencode-zen", "opencode-go"}:
+            try:
+                from hermes_cli.models import opencode_model_api_mode
+
+                canonical = current_model
+                prefix = f"{resolved_provider}/"
+                if current_model.lower().startswith(prefix):
+                    canonical = current_model[len(prefix):]
+                    if not self._model_is_default:
+                        self.console.print(
+                            f"[yellow]⚠️  Stripped provider prefix from '{current_model}'; using '{canonical}' for {resolved_provider}.[/]"
+                        )
+                    self.model = canonical
+                    current_model = canonical
+                    changed = True
+
+                resolved_mode = opencode_model_api_mode(resolved_provider, current_model)
+                if resolved_mode != self.api_mode:
+                    self.api_mode = resolved_mode
+                    changed = True
+            except Exception:
+                pass
+            return changed
+
         if resolved_provider != "openai-codex":
             return False
 
@@ -3603,6 +3627,12 @@ class HermesCLI:
                     self.model = result.new_model
                     self.agent = None  # Force re-init
 
+                    # Apply the resolved route immediately for this session.
+                    # OpenCode can change API surface within the same provider
+                    # when switching model families (for example Kimi -> MiniMax).
+                    if result.api_mode:
+                        self.api_mode = result.api_mode
+
                     if result.provider_changed:
                         self.requested_provider = result.target_provider
                         self.provider = result.target_provider
@@ -3621,6 +3651,11 @@ class HermesCLI:
                                 save_config_value("model.base_url", result.base_url)
                             else:
                                 save_config_value("model.base_url", None)
+                        if result.api_mode and (
+                            result.provider_changed
+                            or result.target_provider in {"opencode-zen", "opencode-go"}
+                        ):
+                            save_config_value("model.api_mode", result.api_mode)
                         if saved_model:
                             print(f"(^_^)b Model changed to: {result.new_model}{provider_note} (saved to config)")
                         else:

--- a/cli.py
+++ b/cli.py
@@ -1443,12 +1443,10 @@ class HermesCLI:
 
         if resolved_provider in {"opencode-zen", "opencode-go"}:
             try:
-                from hermes_cli.models import opencode_model_api_mode
+                from hermes_cli.models import normalize_opencode_model_id, opencode_model_api_mode
 
-                canonical = current_model
-                prefix = f"{resolved_provider}/"
-                if current_model.lower().startswith(prefix):
-                    canonical = current_model[len(prefix):]
+                canonical = normalize_opencode_model_id(resolved_provider, current_model)
+                if canonical and canonical != current_model:
                     if not self._model_is_default:
                         self.console.print(
                             f"[yellow]⚠️  Stripped provider prefix from '{current_model}'; using '{canonical}' for {resolved_provider}.[/]"
@@ -3651,11 +3649,18 @@ class HermesCLI:
                                 save_config_value("model.base_url", result.base_url)
                             else:
                                 save_config_value("model.base_url", None)
-                        if result.api_mode and (
-                            result.provider_changed
-                            or result.target_provider in {"opencode-zen", "opencode-go"}
-                        ):
+                        target_provider = (result.target_provider or "").strip().lower()
+                        should_persist_api_mode = bool(
+                            result.api_mode
+                            and (
+                                result.is_custom_target
+                                or target_provider.startswith("opencode-")
+                            )
+                        )
+                        if should_persist_api_mode:
                             save_config_value("model.api_mode", result.api_mode)
+                        elif result.provider_changed:
+                            save_config_value("model.api_mode", None)
                         if saved_model:
                             print(f"(^_^)b Model changed to: {result.new_model}{provider_note} (saved to config)")
                         else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2924,8 +2924,18 @@ class GatewayRunner:
                         user_config["model"]["base_url"] = result.base_url
                     else:
                         user_config["model"].pop("base_url", None)
-                if result.api_mode:
+                target_provider = (result.target_provider or "").strip().lower()
+                should_persist_api_mode = bool(
+                    result.api_mode
+                    and (
+                        result.is_custom_target
+                        or target_provider.startswith("opencode-")
+                    )
+                )
+                if should_persist_api_mode:
                     user_config["model"]["api_mode"] = result.api_mode
+                elif result.provider_changed:
+                    user_config["model"].pop("api_mode", None)
                 with open(config_path, 'w', encoding="utf-8") as f:
                     yaml.dump(user_config, f, default_flow_style=False, sort_keys=False)
             except Exception as e:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2924,6 +2924,8 @@ class GatewayRunner:
                         user_config["model"]["base_url"] = result.base_url
                     else:
                         user_config["model"].pop("base_url", None)
+                if result.api_mode:
+                    user_config["model"]["api_mode"] = result.api_mode
                 with open(config_path, 'w', encoding="utf-8") as f:
                     yaml.dump(user_config, f, default_flow_style=False, sort_keys=False)
             except Exception as e:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -200,6 +200,10 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         id="opencode-go",
         name="OpenCode Go",
         auth_type="api_key",
+        # OpenCode Go mixes API surfaces by model:
+        # - GLM / Kimi use OpenAI-compatible chat completions under /v1
+        # - MiniMax models use Anthropic Messages under /v1/messages
+        # Keep the provider base at /v1 and select api_mode per-model.
         inference_base_url="https://opencode.ai/zen/go/v1",
         api_key_env_vars=("OPENCODE_GO_API_KEY",),
         base_url_env_var="OPENCODE_GO_BASE_URL",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1445,64 +1445,7 @@ def _model_flow_named_custom(config, provider_info):
 
 
 # Curated model lists for direct API-key providers
-_PROVIDER_MODELS = {
-    "copilot-acp": [
-        "copilot-acp",
-    ],
-    "copilot": [
-        "gpt-5.4",
-        "gpt-5.4-mini",
-        "gpt-5-mini",
-        "gpt-5.3-codex",
-        "gpt-5.2-codex",
-        "gpt-4.1",
-        "gpt-4o",
-        "gpt-4o-mini",
-        "claude-opus-4.6",
-        "claude-sonnet-4.6",
-        "claude-sonnet-4.5",
-        "claude-haiku-4.5",
-        "gemini-2.5-pro",
-        "grok-code-fast-1",
-    ],
-    "zai": [
-        "glm-5",
-        "glm-4.7",
-        "glm-4.5",
-        "glm-4.5-flash",
-    ],
-    "kimi-coding": [
-        "kimi-for-coding",
-        "kimi-k2.5",
-        "kimi-k2-thinking",
-        "kimi-k2-thinking-turbo",
-        "kimi-k2-turbo-preview",
-        "kimi-k2-0905-preview",
-    ],
-    "moonshot": [
-        "kimi-k2.5",
-        "kimi-k2-thinking",
-        "kimi-k2-turbo-preview",
-        "kimi-k2-0905-preview",
-    ],
-    "minimax": [
-        "MiniMax-M2.5",
-        "MiniMax-M2.5-highspeed",
-        "MiniMax-M2.1",
-    ],
-    "minimax-cn": [
-        "MiniMax-M2.5",
-        "MiniMax-M2.5-highspeed",
-        "MiniMax-M2.1",
-    ],
-    "kilocode": [
-        "anthropic/claude-opus-4.6",
-        "anthropic/claude-sonnet-4.6",
-        "openai/gpt-5.4",
-        "google/gemini-3-pro-preview",
-        "google/gemini-3-flash-preview",
-    ],
-}
+from hermes_cli.models import _PROVIDER_MODELS
 
 
 def _current_reasoning_effort(config) -> str:
@@ -1980,7 +1923,7 @@ def _model_flow_kimi(config, current_model=""):
 
 
 def _model_flow_api_key_provider(config, provider_id, current_model=""):
-    """Generic flow for API-key providers (z.ai, MiniMax)."""
+    """Generic flow for API-key providers (z.ai, MiniMax, OpenCode, etc.)."""
     from hermes_cli.auth import (
         PROVIDER_REGISTRY, _prompt_model_selection, _save_model_choice,
         _update_config_for_provider, deactivate_provider,
@@ -2032,7 +1975,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         effective_base = override
 
     # Model selection — try live /models endpoint first, fall back to defaults
-    from hermes_cli.models import fetch_api_models
+    from hermes_cli.models import fetch_api_models, opencode_model_api_mode, normalize_opencode_model_id
     api_key_for_probe = existing_key or (get_env_value(key_env) if key_env else "")
     live_models = fetch_api_models(api_key_for_probe, effective_base)
 
@@ -2046,6 +1989,11 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             print(f"    Use \"Enter custom model name\" if you don't see your model.")
         # else: no defaults either, will fall through to raw input
 
+    if provider_id in {"opencode-zen", "opencode-go"}:
+        model_list = [normalize_opencode_model_id(provider_id, mid) for mid in model_list]
+        current_model = normalize_opencode_model_id(provider_id, current_model)
+        model_list = list(dict.fromkeys(mid for mid in model_list if mid))
+
     if model_list:
         selected = _prompt_model_selection(model_list, current_model=current_model)
     else:
@@ -2055,6 +2003,9 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             selected = None
 
     if selected:
+        if provider_id in {"opencode-zen", "opencode-go"}:
+            selected = normalize_opencode_model_id(provider_id, selected)
+
         # Clear custom endpoint if set (avoid confusion)
         if get_env_value("OPENAI_BASE_URL"):
             save_env_value("OPENAI_BASE_URL", "")
@@ -2062,7 +2013,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
 
         _save_model_choice(selected)
 
-        # Update config with provider and base URL
+        # Update config with provider, base URL, and provider-specific API mode
         cfg = load_config()
         model = cfg.get("model")
         if not isinstance(model, dict):
@@ -2070,6 +2021,10 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             cfg["model"] = model
         model["provider"] = provider_id
         model["base_url"] = effective_base
+        if provider_id in {"opencode-zen", "opencode-go"}:
+            model["api_mode"] = opencode_model_api_mode(provider_id, selected)
+        else:
+            model.pop("api_mode", None)
         save_config(cfg)
         deactivate_provider()
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -28,6 +28,7 @@ class ModelSwitchResult:
     provider_changed: bool = False
     api_key: str = ""
     base_url: str = ""
+    api_mode: str = ""
     persist: bool = False
     error_message: str = ""
     warning_message: str = ""
@@ -75,6 +76,7 @@ def switch_model(
         detect_provider_for_model,
         validate_requested_model,
         _PROVIDER_LABELS,
+        opencode_model_api_mode,
     )
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
@@ -100,11 +102,13 @@ def switch_model(
     # Step 4: Resolve credentials for target provider
     api_key = current_api_key
     base_url = current_base_url
+    api_mode = ""
     if provider_changed:
         try:
             runtime = resolve_runtime_provider(requested=target_provider)
             api_key = runtime.get("api_key", "")
             base_url = runtime.get("base_url", "")
+            api_mode = runtime.get("api_mode", "")
         except Exception as e:
             provider_label = _PROVIDER_LABELS.get(target_provider, target_provider)
             if target_provider == "custom":
@@ -132,6 +136,7 @@ def switch_model(
             runtime = resolve_runtime_provider(requested=current_provider)
             api_key = runtime.get("api_key", "")
             base_url = runtime.get("base_url", "")
+            api_mode = runtime.get("api_mode", "")
         except Exception:
             pass
 
@@ -168,6 +173,12 @@ def switch_model(
         and ("localhost" in (base_url or "") or "127.0.0.1" in (base_url or ""))
     )
 
+    if target_provider in {"opencode-zen", "opencode-go"}:
+        # Recompute against the requested new model, not the currently-configured
+        # model used during runtime resolution. OpenCode mixes API surfaces by
+        # model family, so a same-provider model switch can change api_mode.
+        api_mode = opencode_model_api_mode(target_provider, new_model)
+
     return ModelSwitchResult(
         success=True,
         new_model=new_model,
@@ -175,6 +186,7 @@ def switch_model(
         provider_changed=provider_changed,
         api_key=api_key,
         base_url=base_url,
+        api_mode=api_mode,
         persist=bool(validation.get("persist")),
         warning_message=validation.get("message") or "",
         is_custom_target=is_custom_target,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -174,6 +174,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-5",
         "kimi-k2.5",
         "minimax-m2.5",
+        "minimax-m2.7",
     ],
     "ai-gateway": [
         "anthropic/claude-opus-4.6",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -99,6 +99,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-turbo-preview",
         "kimi-k2-0905-preview",
     ],
+    "moonshot": [
+        "kimi-k2.5",
+        "kimi-k2-thinking",
+        "kimi-k2-turbo-preview",
+        "kimi-k2-0905-preview",
+    ],
     "minimax": [
         "MiniMax-M2.7",
         "MiniMax-M2.7-highspeed",
@@ -897,6 +903,54 @@ def copilot_model_api_mode(
             # For non-GPT-5 models, check if they only support messages API
             if "/v1/messages" in supported_endpoints and "/chat/completions" not in supported_endpoints:
                 return "anthropic_messages"
+
+    return "chat_completions"
+
+
+def normalize_opencode_model_id(provider_id: Optional[str], model_id: Optional[str]) -> str:
+    """Normalize OpenCode config IDs to the bare model slug used in API requests."""
+    provider = normalize_provider(provider_id)
+    current = str(model_id or "").strip()
+    if not current or provider not in {"opencode-zen", "opencode-go"}:
+        return current
+
+    prefix = f"{provider}/"
+    if current.lower().startswith(prefix):
+        return current[len(prefix):]
+    return current
+
+
+
+def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str]) -> str:
+    """Determine the API mode for an OpenCode Zen / Go model.
+
+    OpenCode routes different models behind different API surfaces:
+
+    - GPT-5 / Codex models on Zen use ``/v1/responses``
+    - Claude models on Zen use ``/v1/messages``
+    - MiniMax models on Go use ``/v1/messages``
+    - GLM / Kimi on Go use ``/v1/chat/completions``
+    - Other Zen models (Gemini, GLM, Kimi, MiniMax, Qwen, etc.) use
+      ``/v1/chat/completions``
+
+    This follows the published OpenCode docs for Zen and Go endpoints.
+    """
+    provider = normalize_provider(provider_id)
+    normalized = normalize_opencode_model_id(provider_id, model_id).lower()
+    if not normalized:
+        return "chat_completions"
+
+    if provider == "opencode-go":
+        if normalized.startswith("minimax-"):
+            return "anthropic_messages"
+        return "chat_completions"
+
+    if provider == "opencode-zen":
+        if normalized.startswith("claude-"):
+            return "anthropic_messages"
+        if normalized.startswith("gpt-"):
+            return "codex_responses"
+        return "chat_completions"
 
     return "chat_completions"
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -78,9 +78,20 @@ def _get_model_config() -> Dict[str, Any]:
     return {}
 
 
+def _provider_supports_explicit_api_mode(provider: Optional[str], configured_provider: Optional[str] = None) -> bool:
+    normalized_provider = (provider or "").strip().lower()
+    normalized_configured = (configured_provider or "").strip().lower()
+    if not normalized_configured:
+        return True
+    if normalized_provider == "custom":
+        return normalized_configured == "custom" or normalized_configured.startswith("custom:")
+    return normalized_configured == normalized_provider
+
+
 def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+    configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-    if configured_mode:
+    if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
         return configured_mode
 
     model_name = str(model_cfg.get("default") or "").strip()
@@ -400,9 +411,10 @@ def resolve_runtime_provider(
         if provider == "copilot":
             api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
         else:
-            # Check explicit api_mode from model config first
+            configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+            # Only honor persisted api_mode when it belongs to the same provider family.
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if configured_mode:
+            if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
                 api_mode = configured_mode
             elif provider in ("opencode-zen", "opencode-go"):
                 api_mode = opencode_model_api_mode(provider, model_cfg.get("default", ""))

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -19,6 +19,7 @@ from hermes_cli.auth import (
 )
 from hermes_cli.config import load_config
 from hermes_constants import OPENROUTER_BASE_URL
+from hermes_cli.models import opencode_model_api_mode
 
 
 def _normalize_custom_provider_name(value: str) -> str:
@@ -403,6 +404,8 @@ def resolve_runtime_provider(
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
             if configured_mode:
                 api_mode = configured_mode
+            elif provider in ("opencode-zen", "opencode-go"):
+                api_mode = opencode_model_api_mode(provider, model_cfg.get("default", ""))
             # Auto-detect Anthropic-compatible endpoints by URL convention
             # (e.g. https://api.minimax.io/anthropic, https://dashscope.../anthropic)
             elif base_url.rstrip("/").endswith("/anthropic"):

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -78,6 +78,8 @@ _DEFAULT_PROVIDER_MODELS = {
     "kimi-coding": ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "minimax": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"],
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"],
+    "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
+    "opencode-go": ["glm-5", "kimi-k2.5", "minimax-m2.5", "minimax-m2.7"],
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
 }
@@ -150,6 +152,8 @@ def _setup_provider_model_selection(config, provider_id, current_model, prompt_c
         fetch_api_models,
         fetch_github_model_catalog,
         normalize_copilot_model_id,
+        normalize_opencode_model_id,
+        opencode_model_api_mode,
     )
 
     pconfig = PROVIDER_REGISTRY[provider_id]
@@ -203,6 +207,11 @@ def _setup_provider_model_selection(config, provider_id, current_model, prompt_c
                 f"    Use \"Custom model\" if the model you expect isn't listed."
             )
 
+    if provider_id in {"opencode-zen", "opencode-go"}:
+        provider_models = [normalize_opencode_model_id(provider_id, mid) for mid in provider_models]
+        current_model = normalize_opencode_model_id(provider_id, current_model)
+        provider_models = list(dict.fromkeys(mid for mid in provider_models if mid))
+
     model_choices = list(provider_models)
     model_choices.append("Custom model")
     model_choices.append(f"Keep current ({current_model})")
@@ -220,6 +229,8 @@ def _setup_provider_model_selection(config, provider_id, current_model, prompt_c
                 catalog=catalog,
                 api_key=api_key,
             ) or selected_model
+        elif provider_id in {"opencode-zen", "opencode-go"}:
+            selected_model = normalize_opencode_model_id(provider_id, selected_model)
         _set_default_model(config, selected_model)
     elif model_idx == len(provider_models):
         custom = prompt_fn("Enter model name")
@@ -230,6 +241,8 @@ def _setup_provider_model_selection(config, provider_id, current_model, prompt_c
                     catalog=catalog,
                     api_key=api_key,
                 ) or custom
+            elif provider_id in {"opencode-zen", "opencode-go"}:
+                selected_model = normalize_opencode_model_id(provider_id, custom)
             else:
                 selected_model = custom
             _set_default_model(config, selected_model)
@@ -251,7 +264,7 @@ def _setup_provider_model_selection(config, provider_id, current_model, prompt_c
         model_cfg["api_mode"] = copilot_model_api_mode(
             selected_model,
             catalog=catalog,
-            api_key=api_key,
+            api_key=api_key
         )
         config["model"] = model_cfg
         _setup_copilot_reasoning_selection(
@@ -259,8 +272,12 @@ def _setup_provider_model_selection(config, provider_id, current_model, prompt_c
             selected_model,
             prompt_choice,
             catalog=catalog,
-            api_key=api_key,
+            api_key=api_key
         )
+    elif provider_id in {"opencode-zen", "opencode-go"} and selected_model:
+        model_cfg = _model_config_dict(config)
+        model_cfg["api_mode"] = opencode_model_api_mode(provider_id, selected_model)
+        config["model"] = model_cfg
 
 
 def _sync_model_from_disk(config: Dict[str, Any]) -> None:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -9,7 +9,9 @@ from hermes_cli.models import (
     fetch_api_models,
     github_model_reasoning_efforts,
     normalize_copilot_model_id,
+    normalize_opencode_model_id,
     normalize_provider,
+    opencode_model_api_mode,
     parse_model_input,
     probe_api_models,
     provider_label,
@@ -300,6 +302,28 @@ class TestCopilotNormalization:
     def test_normalize_old_github_models_slug(self):
         catalog = [{"id": "gpt-4.1"}, {"id": "gpt-5.4"}]
         assert normalize_copilot_model_id("openai/gpt-4.1-mini", catalog=catalog) == "gpt-4.1"
+
+    def test_normalize_opencode_model_id_strips_provider_prefix(self):
+        assert normalize_opencode_model_id("opencode-go", "opencode-go/kimi-k2.5") == "kimi-k2.5"
+        assert normalize_opencode_model_id("opencode-zen", "opencode-zen/claude-sonnet-4-6") == "claude-sonnet-4-6"
+        assert normalize_opencode_model_id("opencode-go", "glm-5") == "glm-5"
+
+    def test_opencode_zen_api_modes_match_docs(self):
+        assert opencode_model_api_mode("opencode-zen", "gpt-5.4") == "codex_responses"
+        assert opencode_model_api_mode("opencode-zen", "gpt-5.3-codex") == "codex_responses"
+        assert opencode_model_api_mode("opencode-zen", "opencode-zen/gpt-5.4") == "codex_responses"
+        assert opencode_model_api_mode("opencode-zen", "claude-sonnet-4-6") == "anthropic_messages"
+        assert opencode_model_api_mode("opencode-zen", "opencode-zen/claude-sonnet-4-6") == "anthropic_messages"
+        assert opencode_model_api_mode("opencode-zen", "gemini-3-flash") == "chat_completions"
+        assert opencode_model_api_mode("opencode-zen", "minimax-m2.5") == "chat_completions"
+
+    def test_opencode_go_api_modes_match_docs(self):
+        assert opencode_model_api_mode("opencode-go", "glm-5") == "chat_completions"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/glm-5") == "chat_completions"
+        assert opencode_model_api_mode("opencode-go", "kimi-k2.5") == "chat_completions"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/kimi-k2.5") == "chat_completions"
+        assert opencode_model_api_mode("opencode-go", "minimax-m2.5") == "anthropic_messages"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/minimax-m2.5") == "anthropic_messages"
 
     def test_copilot_api_mode_gpt5_uses_responses(self):
         """GPT-5+ models should use Responses API (matching opencode)."""

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -101,8 +101,15 @@ class TestDetectProviderForModel:
         assert result[0] == "openrouter"
         assert result[1] == "anthropic/claude-opus-4.6"
 
-    def test_bare_name_gets_openrouter_slug(self):
+    def test_bare_name_gets_openrouter_slug(self, monkeypatch):
         """Bare model names should get mapped to full OpenRouter slugs."""
+        for env_var in (
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_TOKEN",
+            "CLAUDE_CODE_TOKEN",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
         result = detect_provider_for_model("claude-opus-4.6", "openai-codex")
         assert result is not None
         # Should find it on OpenRouter with full slug

--- a/tests/test_cli_model_command.py
+++ b/tests/test_cli_model_command.py
@@ -55,8 +55,19 @@ class TestModelCommand:
         assert cli_obj.model == "anthropic/claude-sonnet-next"
         save_mock.assert_called_once()
 
-    def test_no_slash_model_accepted_with_warning(self, capsys):
+    def test_no_slash_model_accepted_with_warning(self, capsys, monkeypatch):
         cli_obj = self._make_cli()
+
+        # Make provider auto-detection deterministic for this regression test:
+        # without direct-provider credentials, bare gpt-5.4 should remap to the
+        # OpenRouter slug instead of switching to a direct provider.
+        for env_var in (
+            "COPILOT_GITHUB_TOKEN",
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+            "OPENCODE_ZEN_API_KEY",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
 
         with patch("hermes_cli.models.fetch_api_models",
                    return_value=["openai/gpt-5.4"]) as fetch_mock, \
@@ -130,3 +141,31 @@ class TestModelCommand:
         assert "Could not resolve credentials" in output
         assert cli_obj.model == "anthropic/claude-opus-4.6"  # unchanged
         assert cli_obj.provider == "openrouter"  # unchanged
+
+    def test_opencode_same_provider_switch_updates_api_mode_and_persists(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.model = "kimi-k2.5"
+        cli_obj.provider = "opencode-go"
+        cli_obj.requested_provider = "opencode-go"
+        cli_obj.base_url = "https://opencode.ai/zen/go/v1"
+        cli_obj.api_mode = "chat_completions"
+
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+                 "provider": "opencode-go",
+                 "api_key": "***",
+                 "base_url": "https://opencode.ai/zen/go/v1",
+                 "api_mode": "chat_completions",
+             }), \
+             patch("hermes_cli.models.fetch_api_models",
+                   return_value=["opencode-go/kimi-k2.5", "opencode-go/minimax-m2.5"]), \
+             patch("cli.save_config_value", return_value=True) as save_mock:
+            cli_obj.process_command("/model opencode-go:minimax-m2.5")
+
+        output = capsys.readouterr().out
+        assert "saved to config" in output
+        assert cli_obj.model == "minimax-m2.5"
+        assert cli_obj.provider == "opencode-go"
+        assert cli_obj.api_mode == "anthropic_messages"
+        save_calls = [c.args for c in save_mock.call_args_list]
+        assert ("model.default", "minimax-m2.5") in save_calls
+        assert ("model.api_mode", "anthropic_messages") in save_calls

--- a/tests/test_cli_model_command.py
+++ b/tests/test_cli_model_command.py
@@ -1,5 +1,6 @@
 """Regression tests for the `/model` slash command in the interactive CLI."""
 
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from cli import HermesCLI
@@ -122,13 +123,13 @@ class TestModelCommand:
         assert cli_obj.model == "glm-5"
         assert cli_obj.provider == "zai"
         assert cli_obj.base_url == "https://api.z.ai/api/paas/v4"
-        # Model, provider, and base_url should be saved
-        assert save_mock.call_count == 3
         save_calls = [c.args for c in save_mock.call_args_list]
         assert ("model.default", "glm-5") in save_calls
         assert ("model.provider", "zai") in save_calls
         # base_url is also persisted on provider change (Phase 2 fix)
         assert any(c[0] == "model.base_url" for c in save_calls)
+        # switching away from an explicit-api-mode provider clears stale config
+        assert ("model.api_mode", None) in save_calls
 
     def test_provider_switch_fails_on_bad_credentials(self, capsys):
         cli_obj = self._make_cli()
@@ -168,4 +169,53 @@ class TestModelCommand:
         assert cli_obj.api_mode == "anthropic_messages"
         save_calls = [c.args for c in save_mock.call_args_list]
         assert ("model.default", "minimax-m2.5") in save_calls
+        assert ("model.api_mode", "anthropic_messages") in save_calls
+
+    def test_provider_switch_clears_stale_api_mode(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.model = "minimax-m2.5"
+        cli_obj.provider = "opencode-go"
+        cli_obj.requested_provider = "opencode-go"
+        cli_obj.base_url = "https://opencode.ai/zen/go/v1"
+        cli_obj.api_mode = "anthropic_messages"
+
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+                 "provider": "zai",
+                 "api_key": "***",
+                 "base_url": "https://api.z.ai/api/paas/v4",
+                 "api_mode": "chat_completions",
+             }), \
+             patch("hermes_cli.models.fetch_api_models", return_value=["glm-5"]), \
+             patch("cli.save_config_value", return_value=True) as save_mock:
+            cli_obj.process_command("/model zai:glm-5")
+
+        output = capsys.readouterr().out
+        assert "saved to config" in output
+        save_calls = [c.args for c in save_mock.call_args_list]
+        assert ("model.api_mode", None) in save_calls
+
+    def test_custom_provider_switch_persists_api_mode(self, capsys):
+        cli_obj = self._make_cli()
+        custom_result = SimpleNamespace(
+            success=True,
+            new_model="gpt-4.1",
+            target_provider="custom:work-proxy",
+            provider_changed=True,
+            api_key="***",
+            base_url="https://proxy.example.com/anthropic",
+            api_mode="anthropic_messages",
+            persist=True,
+            error_message="",
+            warning_message="",
+            is_custom_target=True,
+            provider_label="Work Proxy",
+        )
+
+        with patch("hermes_cli.model_switch.switch_model", return_value=custom_result), \
+             patch("cli.save_config_value", return_value=True) as save_mock:
+            cli_obj.process_command("/model custom:work-proxy:gpt-4.1")
+
+        output = capsys.readouterr().out
+        assert "saved to config" in output
+        save_calls = [c.args for c in save_mock.call_args_list]
         assert ("model.api_mode", "anthropic_messages") in save_calls

--- a/tests/test_codex_models.py
+++ b/tests/test_codex_models.py
@@ -185,6 +185,22 @@ class TestNormalizeModelForProvider:
         assert changed is True
         assert cli.model == "claude-opus-4.6"
 
+    def test_opencode_go_prefix_stripped(self):
+        cli = _make_cli(model="opencode-go/kimi-k2.5")
+        cli.api_mode = "chat_completions"
+        changed = cli._normalize_model_for_provider("opencode-go")
+        assert changed is True
+        assert cli.model == "kimi-k2.5"
+        assert cli.api_mode == "chat_completions"
+
+    def test_opencode_zen_claude_sets_messages_mode(self):
+        cli = _make_cli(model="opencode-zen/claude-sonnet-4-6")
+        cli.api_mode = "chat_completions"
+        changed = cli._normalize_model_for_provider("opencode-zen")
+        assert changed is True
+        assert cli.model == "claude-sonnet-4-6"
+        assert cli.api_mode == "anthropic_messages"
+
     def test_default_model_replaced(self):
         """The untouched default (anthropic/claude-opus-4.6) gets swapped."""
         import cli as _cli_mod

--- a/tests/test_model_provider_persistence.py
+++ b/tests/test_model_provider_persistence.py
@@ -165,7 +165,7 @@ class TestProviderPersistsAfterModelSave:
             "hermes_cli.auth.resolve_external_process_provider_credentials",
             return_value={
                 "provider": "copilot-acp",
-                "api_key": "copilot-acp",
+                "api_key": "***",
                 "base_url": "acp://copilot",
                 "command": "/usr/local/bin/copilot",
                 "args": ["--acp", "--stdio"],
@@ -175,7 +175,7 @@ class TestProviderPersistsAfterModelSave:
             "hermes_cli.auth.resolve_api_key_provider_credentials",
             return_value={
                 "provider": "copilot",
-                "api_key": "gh-cli-token",
+                "api_key": "***",
                 "base_url": "https://api.githubcopilot.com",
                 "source": "gh auth token",
             },
@@ -210,3 +210,50 @@ class TestProviderPersistsAfterModelSave:
         assert model.get("base_url") == "acp://copilot"
         assert model.get("default") == "gpt-5.4"
         assert model.get("api_mode") == "chat_completions"
+
+    def test_opencode_go_models_are_selectable_and_persist_normalized(self, config_home, monkeypatch):
+        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.config import load_config
+
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "***")
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=["opencode-go/kimi-k2.5", "opencode-go/minimax-m2.7"]), \
+             patch("hermes_cli.auth._prompt_model_selection", return_value="kimi-k2.5"), \
+             patch("hermes_cli.auth.deactivate_provider"), \
+             patch("builtins.input", return_value=""):
+            _model_flow_api_key_provider(load_config(), "opencode-go", "opencode-go/kimi-k2.5")
+
+        import yaml
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert model.get("provider") == "opencode-go"
+        assert model.get("default") == "kimi-k2.5"
+        assert model.get("api_mode") == "chat_completions"
+
+    def test_opencode_go_same_provider_switch_recomputes_api_mode(self, config_home, monkeypatch):
+        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.config import load_config
+
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "***")
+        (config_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: kimi-k2.5\n"
+            "  provider: opencode-go\n"
+            "  base_url: https://opencode.ai/zen/go/v1\n"
+            "  api_mode: chat_completions\n"
+        )
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=["opencode-go/kimi-k2.5", "opencode-go/minimax-m2.5"]), \
+             patch("hermes_cli.auth._prompt_model_selection", return_value="minimax-m2.5"), \
+             patch("hermes_cli.auth.deactivate_provider"), \
+             patch("builtins.input", return_value=""):
+            _model_flow_api_key_provider(load_config(), "opencode-go", "kimi-k2.5")
+
+        import yaml
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert model.get("provider") == "opencode-go"
+        assert model.get("default") == "minimax-m2.5"
+        assert model.get("api_mode") == "anthropic_messages"

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -397,6 +397,34 @@ def test_model_config_api_mode(monkeypatch):
     assert resolved["base_url"] == "http://127.0.0.1:9208/v1"
 
 
+def test_model_config_api_mode_ignored_when_provider_differs(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "zai")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "opencode-go",
+            "default": "minimax-m2.5",
+            "api_mode": "anthropic_messages",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "provider": provider,
+            "api_key": "***",
+            "base_url": "https://api.z.ai/api/paas/v4",
+            "source": "env",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="zai")
+
+    assert resolved["provider"] == "zai"
+    assert resolved["api_mode"] == "chat_completions"
+
+
 def test_invalid_api_mode_ignored(monkeypatch):
     """Invalid api_mode values should fall back to chat_completions."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
@@ -619,7 +647,11 @@ def test_opencode_go_configured_api_mode_still_overrides_default(monkeypatch):
     monkeypatch.setattr(
         rp,
         "_get_model_config",
-        lambda: {"default": "minimax-m2.5", "api_mode": "chat_completions"},
+        lambda: {
+            "provider": "opencode-go",
+            "default": "minimax-m2.5",
+            "api_mode": "chat_completions",
+        },
     )
     monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
     monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -562,6 +562,74 @@ def test_alibaba_openai_compatible_v1_endpoint_stays_chat_completions(monkeypatc
     assert resolved["base_url"] == "https://coding-intl.dashscope.aliyuncs.com/v1"
 
 
+def test_opencode_zen_gpt_defaults_to_responses(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-zen")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"default": "gpt-5.4"})
+    monkeypatch.setenv("OPENCODE_ZEN_API_KEY", "test-opencode-zen-key")
+    monkeypatch.delenv("OPENCODE_ZEN_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="opencode-zen")
+
+    assert resolved["provider"] == "opencode-zen"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://opencode.ai/zen/v1"
+
+
+def test_opencode_zen_claude_defaults_to_messages(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-zen")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"default": "claude-sonnet-4-6"})
+    monkeypatch.setenv("OPENCODE_ZEN_API_KEY", "test-opencode-zen-key")
+    monkeypatch.delenv("OPENCODE_ZEN_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="opencode-zen")
+
+    assert resolved["provider"] == "opencode-zen"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://opencode.ai/zen/v1"
+
+
+def test_opencode_go_minimax_defaults_to_messages(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"default": "minimax-m2.5"})
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+    monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="opencode-go")
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
+
+
+def test_opencode_go_glm_defaults_to_chat_completions(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"default": "glm-5"})
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+    monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="opencode-go")
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
+
+
+def test_opencode_go_configured_api_mode_still_overrides_default(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"default": "minimax-m2.5", "api_mode": "chat_completions"},
+    )
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+    monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="opencode-go")
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_mode"] == "chat_completions"
+
+
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     """Custom providers should accept api_mode: anthropic_messages."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-anthropic-proxy")

--- a/tests/test_setup_model_selection.py
+++ b/tests/test_setup_model_selection.py
@@ -22,6 +22,8 @@ def mock_provider_registry():
         "kimi-coding": FakePConfig("Kimi Coding", ["KIMI_API_KEY"], "KIMI_BASE_URL", "https://api.kimi.example"),
         "minimax": FakePConfig("MiniMax", ["MINIMAX_API_KEY"], "MINIMAX_BASE_URL", "https://api.minimax.example"),
         "minimax-cn": FakePConfig("MiniMax CN", ["MINIMAX_API_KEY"], "MINIMAX_CN_BASE_URL", "https://api.minimax-cn.example"),
+        "opencode-zen": FakePConfig("OpenCode Zen", ["OPENCODE_ZEN_API_KEY"], "OPENCODE_ZEN_BASE_URL", "https://opencode.ai/zen/v1"),
+        "opencode-go": FakePConfig("OpenCode Go", ["OPENCODE_GO_API_KEY"], "OPENCODE_GO_BASE_URL", "https://opencode.ai/zen/go/v1"),
     }
 
 
@@ -34,6 +36,8 @@ class TestSetupProviderModelSelection:
         ("kimi-coding", ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"]),
         ("minimax", ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
         ("minimax-cn", ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
+        ("opencode-zen", ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash"]),
+        ("opencode-go", ["glm-5", "kimi-k2.5", "minimax-m2.5", "minimax-m2.7"]),
     ])
     @patch("hermes_cli.models.fetch_api_models", return_value=[])
     @patch("hermes_cli.config.get_env_value", return_value="fake-key")
@@ -95,6 +99,33 @@ class TestSetupProviderModelSelection:
         offered = captured_choices["choices"]
         assert "live-model-1" in offered
         assert "live-model-2" in offered
+
+    @patch("hermes_cli.models.fetch_api_models", return_value=["opencode-go/kimi-k2.5", "opencode-go/minimax-m2.7"])
+    @patch("hermes_cli.config.get_env_value", return_value="fake-key")
+    def test_opencode_live_models_are_normalized_for_selection(
+        self, mock_env, mock_fetch, mock_provider_registry
+    ):
+        from hermes_cli.setup import _setup_provider_model_selection
+
+        captured_choices = {}
+
+        def fake_prompt_choice(label, choices, default):
+            captured_choices["choices"] = choices
+            return len(choices) - 1
+
+        with patch("hermes_cli.auth.PROVIDER_REGISTRY", mock_provider_registry):
+            _setup_provider_model_selection(
+                config={"model": {}},
+                provider_id="opencode-go",
+                current_model="opencode-go/kimi-k2.5",
+                prompt_choice=fake_prompt_choice,
+                prompt_fn=lambda _: None,
+            )
+
+        offered = captured_choices["choices"]
+        assert "kimi-k2.5" in offered
+        assert "minimax-m2.7" in offered
+        assert all("opencode-go/" not in choice for choice in offered)
 
     @patch("hermes_cli.models.fetch_api_models", return_value=[])
     @patch("hermes_cli.config.get_env_value", return_value="fake-key")


### PR DESCRIPTION
## Summary
- normalize OpenCode provider-qualified model ids before menu display, persistence, and request routing
- restore selectable OpenCode Go/Zen model lists in both `hermes model` and setup flows
- derive and persist the correct mixed-surface `api_mode` for OpenCode model-family switches

## What changed
- added OpenCode model normalization and routing helpers in `hermes_cli.models`
- updated CLI/setup model selection flows to present clean OpenCode model lists
- fixed same-provider OpenCode switches so `api_mode` is recomputed from the new model family
- updated runtime/config persistence to carry OpenCode `api_mode`
- added regressions for normalization, picker behavior, runtime resolution, and same-provider switching

## Testing
Focused regression suite:

```bash
uv run --extra dev python -m pytest \
  tests/hermes_cli/test_model_validation.py \
  tests/test_setup_model_selection.py \
  tests/test_model_provider_persistence.py \
  tests/test_codex_models.py \
  tests/test_runtime_provider_resolution.py \
  tests/test_cli_model_command.py -q
```

Result:
- 139 passed

Broader suite:

```bash
uv run --extra dev --extra acp python -m pytest tests/ -q
```

Result in this environment:
- unrelated pre-existing failures remain outside this PR's scope:
  - `tests/hermes_cli/test_models.py::TestDetectProviderForModel::test_bare_name_gets_openrouter_slug`
  - `tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_direct_endpoint_does_not_fall_back_to_openrouter_api_key_env`
  - `tests/tools/test_transcription.py::TestGetProvider::test_explicit_openai_no_key_returns_none`

Closes #3014
EOF; __hermes_rc=$?; printf '__HERMES_FENCE_a9f7b3__'; exit $__hermes_rc
