### PR TITLE
fix(install): quote PYTHON_PATH to handle paths with spaces on macOS

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -215,7 +215,7 @@ check_python() {
     # First check if a suitable Python is already available
     if $UV_CMD python find "$PYTHON_VERSION" &> /dev/null; then
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)
         log_success "Python found: $PYTHON_FOUND_VERSION"
         return 0
     fi
@@ -224,7 +224,7 @@ check_python() {
     log_info "Python $PYTHON_VERSION not found, installing via uv..."
     if $UV_CMD python install "$PYTHON_VERSION"; then
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)
         log_success "Python installed: $PYTHON_FOUND_VERSION"
     else
         log_error "Failed to install Python $PYTHON_VERSION"


### PR DESCRIPTION
Fixes #3000

## Problem
On macOS, uv installs Python under ~/Library/Application Support/uv/python/... The space in "Application Support" caused bash word-splitting on unquoted $PYTHON_PATH, attempting to execute /Users/.../Library/Application as a command → exit 127 → set -e silently aborts the installer.

## Fix
Quote $PYTHON_PATH in two places (lines 218 and 227):

Before: PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
After:  PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)

Two-character fix per line.
