### PR TITLE
fix(docker): skip sandbox home mount when /root already user-configured in docker_volumes

### DIFF
--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -256,6 +256,7 @@ class DockerEnvironment(BaseEnvironment):
         # User-configured volume mounts (from config.yaml docker_volumes)
         volume_args = []
         workspace_explicitly_mounted = False
+        root_explicitly_mounted = False
         for vol in (volumes or []):
             if not isinstance(vol, str):
                 logger.warning(f"Docker volume entry is not a string: {vol!r}")
@@ -267,6 +268,8 @@ class DockerEnvironment(BaseEnvironment):
                 volume_args.extend(["-v", vol])
                 if ":/workspace" in vol:
                     workspace_explicitly_mounted = True
+                if ":/root" in vol:
+                    root_explicitly_mounted = True
             else:
                 logger.warning(f"Docker volume '{vol}' missing colon, skipping")
 
@@ -285,11 +288,12 @@ class DockerEnvironment(BaseEnvironment):
         writable_args = []
         if self._persistent:
             sandbox = get_sandbox_dir() / "docker" / task_id
-            self._home_dir = str(sandbox / "home")
-            os.makedirs(self._home_dir, exist_ok=True)
-            writable_args.extend([
-                "-v", f"{self._home_dir}:/root",
-            ])
+            if not root_explicitly_mounted:
+                self._home_dir = str(sandbox / "home")
+                os.makedirs(self._home_dir, exist_ok=True)
+                writable_args.extend([
+                    "-v", f"{self._home_dir}:/root",
+                ])
             if not bind_host_cwd and not workspace_explicitly_mounted:
                 self._workspace_dir = str(sandbox / "workspace")
                 os.makedirs(self._workspace_dir, exist_ok=True)


### PR DESCRIPTION
## Problem

Container fails to start with `Duplicate mount point: /root` when a user adds a custom `/root` bind mount in `docker_volumes`:

```yaml
terminal:
  docker_volumes:
    - /my/persistent/home:/root:rw
```

`DockerEnvironment.__init__` adds a sandbox home bind mount to `/root` unconditionally when `persistent_filesystem=True`, without checking whether the user has already configured a `/root` mount. The equivalent guard for `/workspace` (`workspace_explicitly_mounted`) already exists — `/root` was just missed.

## Fix

Add `root_explicitly_mounted` tracking (same pattern as `workspace_explicitly_mounted`) and skip the automatic sandbox home mount when the user has already configured `/root`.

## Testing

23 Docker tests pass, 3 skipped (unchanged).

Closes #2833

---

*AI-assisted (Claude) | Lightly tested | Reviewed and Understood*