### PR TITLE
fix(channel-directory): strip leading/trailing emoji when resolving channel names

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -194,8 +194,8 @@ def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
     query = name.lstrip("#").lower()
 
     def _strip_emoji(s: str) -> str:
-        """Strip leading non-word characters (emojis, decorators) from a channel name."""
-        return re.sub(r'^[^\w\-]+', '', s).lower()
+        """Strip leading/trailing non-word characters (emojis, decorators) from a channel name."""
+        return re.sub(r'^[^\w\-]+|[^\w\-]+$', '', s).lower()
 
     # 1. Exact name match (also try stripping emoji prefix from stored name)
     for ch in channels:

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -8,6 +8,7 @@ action="list" and for resolving human-friendly channel names to numeric IDs.
 
 import json
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -192,9 +193,14 @@ def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
 
     query = name.lstrip("#").lower()
 
-    # 1. Exact name match
+    def _strip_emoji(s: str) -> str:
+        """Strip leading non-word characters (emojis, decorators) from a channel name."""
+        return re.sub(r'^[^\w\-]+', '', s).lower()
+
+    # 1. Exact name match (also try stripping emoji prefix from stored name)
     for ch in channels:
-        if ch["name"].lower() == query:
+        ch_lower = ch["name"].lower()
+        if ch_lower == query or _strip_emoji(ch["name"]) == query:
             return ch["id"]
 
     # 2. Guild-qualified match for Discord ("GuildName/channel")
@@ -202,11 +208,15 @@ def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
         guild_part, ch_part = query.rsplit("/", 1)
         for ch in channels:
             guild = ch.get("guild", "").lower()
-            if guild == guild_part and ch["name"].lower() == ch_part:
+            ch_lower = ch["name"].lower()
+            if guild == guild_part and (ch_lower == ch_part or _strip_emoji(ch["name"]) == ch_part):
                 return ch["id"]
 
-    # 3. Partial prefix match (only if unambiguous)
-    matches = [ch for ch in channels if ch["name"].lower().startswith(query)]
+    # 3. Partial prefix match (only if unambiguous) — also match against emoji-stripped names
+    matches = [
+        ch for ch in channels
+        if ch["name"].lower().startswith(query) or _strip_emoji(ch["name"]).startswith(query)
+    ]
     if len(matches) == 1:
         return matches[0]["id"]
 


### PR DESCRIPTION
## Problem

Channel names with emoji decorators (e.g. `🚀intel-feed`, `#cockpit✈️`) can't be resolved by name — the emoji causes exact/prefix matches to fail silently.

## Fix

Add `_strip_emoji()` helper that strips leading and trailing non-word characters before comparison. Applied to all three resolution paths (exact, guild-qualified, prefix):

```python
def _strip_emoji(s: str) -> str:
    """Strip leading/trailing non-word characters (emojis, decorators) from a channel name."""
    return re.sub(r'^[^\w\-]+|[^\w\-]+$', '', s).lower()
```

Each match now tries both the raw name and the emoji-stripped name, so `intel-feed` resolves `🚀intel-feed` correctly.

## Testing

82 channel/gateway tests pass.

Closes #2836

---

*AI-assisted (Claude) | Tested | Reviewed and Understood*