### PR TITLE
fix: status bar shows 26K instead of 260K for token counts with trailing zeros

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -649,7 +649,8 @@ def format_token_count_compact(value: int) -> str:
                 text = f"{scaled:.1f}"
             else:
                 text = f"{scaled:.0f}"
-            text = text.rstrip("0").rstrip(".")
+            if "." in text:
+                text = text.rstrip("0").rstrip(".")
             return f"{sign}{text}{suffix}"
 
     return f"{value:,}"


### PR DESCRIPTION
## Summary

`format_token_count_compact()` used unconditional `rstrip("0")` to clean decimal trailing zeros (e.g. `"1.50"→"1.5"`), but this also stripped meaningful trailing zeros from whole numbers (`"260"→"26"`, `"100"→"1"`).

Guard the strip behind a `"." in text` check so only decimal zeros are removed.

Cherry-picked from PR #2763 by @kshitijk4poor.

## Verified
```
  260,000 → 260K  (was 26K)
  100,000 → 100K  (was 1K)
  500,000 → 500K  (was 5K)
   12,450 → 12.4K (decimal strip still works)
    1,500 → 1.5K  (decimal strip still works)
```