### PR TITLE
fix(cli): catch KeyboardInterrupt during flush_memories on exit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2881,7 +2881,7 @@ class HermesCLI:
         if self.agent and self.conversation_history:
             try:
                 self.agent.flush_memories(self.conversation_history)
-            except Exception:
+            except (Exception, KeyboardInterrupt):
                 pass
 
         old_session_id = self.session_id
@@ -7206,7 +7206,7 @@ class HermesCLI:
             if self.agent and self.conversation_history:
                 try:
                     self.agent.flush_memories(self.conversation_history)
-                except Exception:
+                except (Exception, KeyboardInterrupt):
                     pass
             # Shut down voice recorder (release persistent audio stream)
             if hasattr(self, '_voice_recorder') and self._voice_recorder:


### PR DESCRIPTION
## Summary

`KeyboardInterrupt` inherits from `BaseException`, not `Exception`, so the `except Exception:` clauses wrapping `flush_memories()` on exit paths silently skipped the flush when the user pressed Ctrl+C. This could lose conversation memory.

Changes `except Exception:` to `except (Exception, KeyboardInterrupt):` at both call sites (line ~2884 and ~7209 in cli.py).

Salvaged from PR #2855 by @RufusLin (dropped unrelated bundled `hermes_context_mgmt` imports that would have broken the build).