### PR TITLE
fix(gateway): delete legacy session transcript files on reset (#3015)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -678,6 +678,7 @@ class SessionStore:
                         self._db.end_session(entry.session_id, "session_reset")
                     except Exception as e:
                         logger.debug("Session DB operation failed: %s", e)
+                self._unlink_transcript_files(entry.session_id)
         else:
             was_auto_reset = False
             auto_reset_reason = None
@@ -788,7 +789,9 @@ class SessionStore:
                 self._db.end_session(old_entry.session_id, "session_reset")
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
-        
+
+        self._unlink_transcript_files(old_entry.session_id)
+
         now = datetime.now()
         session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
         
@@ -878,6 +881,21 @@ class SessionStore:
     def get_transcript_path(self, session_id: str) -> Path:
         """Get the path to a session's legacy transcript file."""
         return self.sessions_dir / f"{session_id}.jsonl"
+
+    def _unlink_transcript_files(self, session_id: str) -> None:
+        """Remove on-disk legacy transcript files for an abandoned session ID.
+
+        SQLite session rows (metadata + messages) are unchanged; this only drops
+        duplicate JSONL/JSON under ``sessions_dir`` when a session ID is
+        rotated away (manual reset, policy auto-reset).  See GH-3015.
+        """
+        for suffix in (".jsonl", ".json"):
+            path = self.sessions_dir / f"{session_id}{suffix}"
+            try:
+                if path.is_file():
+                    path.unlink()
+            except OSError as e:
+                logger.debug("Could not remove transcript file %s: %s", path, e)
     
     def append_to_transcript(self, session_id: str, message: Dict[str, Any], skip_db: bool = False) -> None:
         """Append a message to a session's transcript (SQLite + legacy JSONL).

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -4,7 +4,7 @@ import json
 import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
-from gateway.config import Platform, HomeChannel, GatewayConfig, PlatformConfig
+from gateway.config import Platform, HomeChannel, GatewayConfig, PlatformConfig, SessionResetPolicy
 from gateway.session import (
     SessionSource,
     SessionStore,
@@ -552,6 +552,76 @@ class TestWhatsAppDMSessionKeyConsistency:
         )
         key = build_session_key(source)
         assert key == "agent:main:telegram:group:-1002285219667:17585:42"
+
+
+class TestTranscriptCleanupOnReset:
+    """GH-3015: legacy JSONL/JSON under sessions_dir must not leak on session rotation."""
+
+    def test_reset_session_unlinks_jsonl_and_json(self, tmp_path):
+        from datetime import datetime
+        from gateway.session import SessionEntry
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._loaded = True
+        store._db = MagicMock()
+
+        old_id = "20250101_120000_deadbeef"
+        entry = SessionEntry(
+            session_key="k1",
+            session_id=old_id,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            platform=Platform.TELEGRAM,
+        )
+        store._entries = {"k1": entry}
+
+        (tmp_path / f"{old_id}.jsonl").write_text('{"role":"user","content":"x"}\n', encoding="utf-8")
+        (tmp_path / f"{old_id}.json").write_text("{}", encoding="utf-8")
+
+        new_entry = store.reset_session("k1")
+
+        assert new_entry is not None
+        assert new_entry.session_id != old_id
+        assert not (tmp_path / f"{old_id}.jsonl").exists()
+        assert not (tmp_path / f"{old_id}.json").exists()
+        store._db.end_session.assert_called_once_with(old_id, "session_reset")
+
+    def test_get_or_create_auto_reset_unlinks_jsonl(self, tmp_path):
+        from datetime import datetime, timedelta
+        from gateway.session import SessionEntry
+
+        config = GatewayConfig()
+        config.default_reset_policy = SessionResetPolicy(mode="idle", idle_minutes=1)
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._loaded = True
+        store._db = MagicMock()
+
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="99", chat_type="dm")
+        key = store._generate_session_key(source)
+        old_id = "20250101_130000_cafebabe"
+        now = datetime.now()
+        entry = SessionEntry(
+            session_key=key,
+            session_id=old_id,
+            created_at=now - timedelta(days=1),
+            updated_at=now - timedelta(minutes=10),
+            platform=Platform.TELEGRAM,
+            origin=source,
+            display_name="u",
+        )
+        store._entries = {key: entry}
+
+        (tmp_path / f"{old_id}.jsonl").write_text('{"role":"user","content":"y"}\n', encoding="utf-8")
+
+        new_entry = store.get_or_create_session(source)
+
+        assert new_entry.session_id != old_id
+        assert not (tmp_path / f"{old_id}.jsonl").exists()
+        store._db.end_session.assert_called_once_with(old_id, "session_reset")
+        store._db.create_session.assert_called_once()
 
 
 class TestSessionStoreEntriesAttribute:


### PR DESCRIPTION
### Summary

Fixes #3015: When a session ID is rotated (manual reset or idle/daily auto-reset), legacy on-disk transcripts under `sessions_dir` (`{session_id}.jsonl` and optional `{session_id}.json`) were never removed, causing unbounded disk growth (notably with cron / frequent resets).

### Changes

- Add `SessionStore._unlink_transcript_files(session_id)`; remove those files on failure with debug logging only.
- Invoke after ending the old session in SQLite from:
  - `reset_session()`
  - `get_or_create_session()` when policy triggers auto-reset

SQLite session rows are unchanged; only duplicate filesystem transcripts are dropped.

### Out of scope

- `switch_session` / `/resume`: old transcript files are kept so users can return to that session ID.
- Retention sweeps, `run_agent` log dumps, and other follow-ups from the issue.

### Test plan

- [x] `tests/gateway/test_session.py::TestTranscriptCleanupOnReset`
- [x] Full `tests/gateway/test_session.py` passes