### PR TITLE
feat(cli): make busy input behavior configurable

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -688,6 +688,12 @@ display:
   # Toggle at runtime with /verbose in the CLI
   tool_progress: all
 
+  # What Enter does when Hermes is already busy in the CLI.
+  #   queue:     Queue your message for the next turn (default on this branch)
+  #   interrupt: Interrupt the current run and redirect Hermes immediately
+  # Ctrl+C always interrupts regardless of this setting.
+  busy_input_mode: queue
+
   # Background process notifications (gateway/messaging only).
   # Controls how chatty the process watcher is when you use
   # terminal(background=true, check_interval=...) from Telegram/Discord/etc.

--- a/cli.py
+++ b/cli.py
@@ -129,6 +129,28 @@ def _parse_reasoning_config(effort: str) -> dict | None:
     return None
 
 
+def _normalize_busy_input_mode(mode: Any) -> str:
+    """Normalize Enter behavior while the CLI is busy."""
+    if mode is None:
+        return "queue"
+
+    normalized = str(mode).strip().lower()
+    aliases = {
+        "queue": "queue",
+        "queued": "queue",
+        "queueing": "queue",
+        "queuing": "queue",
+        "interrupt": "interrupt",
+        "interrupting": "interrupt",
+    }
+    resolved = aliases.get(normalized)
+    if resolved:
+        return resolved
+
+    logger.warning("Unknown display.busy_input_mode '%s', using default (queue)", mode)
+    return "queue"
+
+
 def load_cli_config() -> Dict[str, Any]:
     """
     Load CLI configuration from config files.
@@ -214,6 +236,7 @@ def load_cli_config() -> Dict[str, Any]:
             "resume_display": "full",
             "show_reasoning": False,
             "streaming": True,
+            "busy_input_mode": "queue",
 
             "skin": "default",
         },
@@ -1044,6 +1067,10 @@ class HermesCLI:
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", False)
+        # busy_input_mode: while Hermes is busy, Enter queues follow-ups or interrupts.
+        self.busy_input_mode = _normalize_busy_input_mode(
+            CLI_CONFIG["display"].get("busy_input_mode", "queue")
+        )
 
         self.verbose = verbose if verbose is not None else (self.tool_progress_mode == "verbose")
         
@@ -1251,6 +1278,32 @@ class HermesCLI:
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
+
+    def _route_submitted_payload(self, payload: Any, text: str = "") -> str:
+        """Route submitted input based on whether the agent is currently busy."""
+        is_command = bool(text and text.startswith("/"))
+
+        if self._agent_running and not is_command:
+            if self.busy_input_mode == "interrupt":
+                self._interrupt_queue.put(payload)
+                # Debug: log to file when message enters interrupt queue
+                try:
+                    _dbg = _hermes_home / "interrupt_debug.log"
+                    with open(_dbg, "a") as _f:
+                        import time as _t
+                        _f.write(
+                            f"{_t.strftime('%H:%M:%S')} ENTER: queued interrupt msg={str(payload)[:60]!r}, "
+                            f"agent_running={self._agent_running}\n"
+                        )
+                except Exception:
+                    pass
+                return "interrupt"
+
+            self._pending_input.put(payload)
+            return "queued"
+
+        self._pending_input.put(payload)
+        return "pending"
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
@@ -5449,9 +5502,10 @@ class HermesCLI:
         is working), and re-queueing of interrupted messages.
         
         Uses a dedicated _interrupt_queue (separate from _pending_input) to avoid
-        race conditions between the process_loop and interrupt monitoring. Messages
-        typed while the agent is running go to _interrupt_queue; messages typed while
-        idle go to _pending_input.
+        race conditions between the process_loop and interrupt monitoring. When
+        display.busy_input_mode is "interrupt", busy-session submissions go to
+        _interrupt_queue. When it is "queue", they go straight to _pending_input
+        for the next turn.
         
         Args:
             message: The user's message (str or multimodal content list)
@@ -6121,7 +6175,7 @@ class HermesCLI:
             - Approval selection: selected choice goes to approval response queue
             - Clarify freetext mode: answer goes to the clarify response queue
             - Clarify choice mode: selected choice goes to the clarify response queue
-            - Agent running: goes to _interrupt_queue (chat() monitors this)
+            - Agent running: queues or interrupts based on display.busy_input_mode
             - Agent idle: goes to _pending_input (process_loop monitors this)
             Commands (starting with /) always go to _pending_input so they're
             handled as commands, not sent as interrupt text to the agent.
@@ -6185,19 +6239,10 @@ class HermesCLI:
                 event.app.invalidate()
                 # Bundle text + images as a tuple when images are present
                 payload = (text, images) if images else text
-                if self._agent_running and not (text and text.startswith("/")):
-                    self._interrupt_queue.put(payload)
-                    # Debug: log to file when message enters interrupt queue
-                    try:
-                        _dbg = _hermes_home / "interrupt_debug.log"
-                        with open(_dbg, "a") as _f:
-                            import time as _t
-                            _f.write(f"{_t.strftime('%H:%M:%S')} ENTER: queued interrupt msg={str(payload)[:60]!r}, "
-                                     f"agent_running={self._agent_running}\n")
-                    except Exception:
-                        pass
-                else:
-                    self._pending_input.put(payload)
+                route = self._route_submitted_payload(payload, text=text)
+                if route == "queued":
+                    preview = text if text else f"[{len(images)} image{'s' if len(images) != 1 else ''} attached]"
+                    _cprint(f"  Queued for the next turn: {preview[:80]}{'...' if len(preview) > 80 else ''}")
                 event.app.current_buffer.reset(append_to_history=True)
         
         @kb.add('escape', 'enter')

--- a/cli.py
+++ b/cli.py
@@ -1305,6 +1305,18 @@ class HermesCLI:
         self._pending_input.put(payload)
         return "pending"
 
+    def _handle_immediate_busy_command(self, text: str) -> bool:
+        """Handle slash commands that must observe the current busy state."""
+        if not (self._agent_running and text and text.startswith("/")):
+            return False
+
+        command_name = text.lower().split()[0].lstrip("/")
+        if command_name not in {"queue", "q"}:
+            return False
+
+        self.process_command(text)
+        return True
+
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
         import time as _time
@@ -6232,6 +6244,12 @@ class HermesCLI:
             # --- Normal input routing ---
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
+            if self._handle_immediate_busy_command(text):
+                self._attached_images.clear()
+                event.app.current_buffer.reset(append_to_history=True)
+                event.app.invalidate()
+                return
+
             if text or has_images:
                 # Snapshot and clear attached images
                 images = list(self._attached_images)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -265,6 +265,7 @@ DEFAULT_CONFIG = {
         "compact": False,
         "personality": "kawaii",
         "resume_display": "full",
+        "busy_input_mode": "queue",
         "bell_on_complete": False,
         "show_reasoning": False,
         "streaming": False,
@@ -1676,6 +1677,7 @@ def show_config():
     display = config.get('display', {})
     print(f"  Personality:  {display.get('personality', 'kawaii')}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
+    print(f"  Busy input:   {display.get('busy_input_mode', 'queue')}")
     print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
 
     # Terminal

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -96,6 +96,50 @@ class TestVerboseAndToolProgress:
         assert cli.tool_progress_mode in ("off", "new", "all", "verbose")
 
 
+class TestBusyInputMode:
+    def test_default_busy_input_mode_is_queue(self):
+        cli = _make_cli()
+        assert cli.busy_input_mode == "queue"
+
+    def test_busy_input_mode_interrupt_is_honored(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "interrupt"}})
+        assert cli.busy_input_mode == "interrupt"
+
+    def test_busy_input_mode_aliases_normalize_to_queue(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queuing"}})
+        assert cli.busy_input_mode == "queue"
+
+    def test_busy_message_routes_to_pending_queue_when_queue_mode(self):
+        cli = _make_cli()
+        cli._agent_running = True
+
+        route = cli._route_submitted_payload("follow up", text="follow up")
+
+        assert route == "queued"
+        assert cli._pending_input.get_nowait() == "follow up"
+        assert cli._interrupt_queue.empty()
+
+    def test_busy_message_routes_to_interrupt_queue_when_interrupt_mode(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "interrupt"}})
+        cli._agent_running = True
+
+        route = cli._route_submitted_payload("stop that", text="stop that")
+
+        assert route == "interrupt"
+        assert cli._interrupt_queue.get_nowait() == "stop that"
+        assert cli._pending_input.empty()
+
+    def test_busy_command_stays_in_pending_queue_even_in_interrupt_mode(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "interrupt"}})
+        cli._agent_running = True
+
+        route = cli._route_submitted_payload("/statusbar", text="/statusbar")
+
+        assert route == "pending"
+        assert cli._pending_input.get_nowait() == "/statusbar"
+        assert cli._interrupt_queue.empty()
+
+
 class TestSingleQueryState:
     def test_voice_and_interrupt_state_initialized_before_run(self):
         """Single-query mode calls chat() without going through run()."""

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -139,6 +139,36 @@ class TestBusyInputMode:
         assert cli._pending_input.get_nowait() == "/statusbar"
         assert cli._interrupt_queue.empty()
 
+    def test_busy_queue_command_is_handled_immediately(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        cli.process_command = MagicMock(return_value=True)
+
+        handled = cli._handle_immediate_busy_command("/queue follow up")
+
+        assert handled is True
+        cli.process_command.assert_called_once_with("/queue follow up")
+
+    def test_busy_q_alias_is_handled_immediately(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        cli.process_command = MagicMock(return_value=True)
+
+        handled = cli._handle_immediate_busy_command("/q follow up")
+
+        assert handled is True
+        cli.process_command.assert_called_once_with("/q follow up")
+
+    def test_non_queue_busy_command_is_not_handled_immediately(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        cli.process_command = MagicMock(return_value=True)
+
+        handled = cli._handle_immediate_busy_command("/statusbar")
+
+        assert handled is False
+        cli.process_command.assert_not_called()
+
 
 class TestSingleQueryState:
     def test_voice_and_interrupt_state_initialized_before_run(self):

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -31,7 +31,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/compress` | Manually compress conversation context (flush memories + summarize) |
 | `/rollback` | List or restore filesystem checkpoints (usage: /rollback [number]) |
 | `/stop` | Kill all running background processes |
-| `/queue <prompt>` (alias: `/q`) | Queue a prompt for the next turn (doesn't interrupt the current agent response) |
+| `/queue <prompt>` (alias: `/q`) | While Hermes is busy, immediately queue a prompt for the next turn instead of interrupting the current response |
 | `/resume [name]` | Resume a previously-named session |
 | `/statusbar` (alias: `/sb`) | Toggle the context/model status bar on or off |
 | `/background <prompt>` | Run a prompt in a separate background session. The agent processes your prompt independently — your current session stays free for other work. Results appear as a panel when the task finishes. See [CLI Background Sessions](/docs/user-guide/cli#background-sessions). |

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -208,6 +208,7 @@ Pasting multi-line text is supported — use `Alt+Enter` or `Ctrl+J` to insert n
 You can interrupt the agent at any point:
 
 - **Type a new message + Enter** while the agent is working — by default it queues for the next turn in the CLI
+- **Use `/queue <prompt>`** while the agent is working to explicitly queue a follow-up, even if `display.busy_input_mode` is set to `interrupt`
 - **`Ctrl+C`** — interrupt the current operation (press twice within 2s to force exit)
 - In-progress terminal commands are killed immediately (SIGTERM, then SIGKILL after 1s)
 - Set `display.busy_input_mode: interrupt` in `~/.hermes/config.yaml` if you want Enter to preempt the current run instead

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -207,10 +207,11 @@ Pasting multi-line text is supported — use `Alt+Enter` or `Ctrl+J` to insert n
 
 You can interrupt the agent at any point:
 
-- **Type a new message + Enter** while the agent is working — it interrupts and processes your new instructions
+- **Type a new message + Enter** while the agent is working — by default it queues for the next turn in the CLI
 - **`Ctrl+C`** — interrupt the current operation (press twice within 2s to force exit)
 - In-progress terminal commands are killed immediately (SIGTERM, then SIGKILL after 1s)
-- Multiple messages typed during interrupt are combined into one prompt
+- Set `display.busy_input_mode: interrupt` in `~/.hermes/config.yaml` if you want Enter to preempt the current run instead
+- When `busy_input_mode: interrupt`, multiple messages typed during interrupt are combined into one prompt
 
 ## Tool Progress Display
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1176,7 +1176,7 @@ display:
   show_cost: false        # Show estimated $ cost in the CLI status bar
 ```
 
-`display.busy_input_mode` is CLI-only. `queue` sends your follow-up on the next turn, while `interrupt` restores the legacy behavior where pressing Enter preempts the current run. `Ctrl+C` always interrupts immediately.
+`display.busy_input_mode` is CLI-only. `queue` sends your follow-up on the next turn, while `interrupt` restores the legacy behavior where pressing Enter preempts the current run. Use `/queue <prompt>` if you want to queue explicitly while Hermes is busy, regardless of this setting. `Ctrl+C` always interrupts immediately.
 
 ### Theme mode
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1168,12 +1168,15 @@ display:
   personality: "kawaii"  # Legacy cosmetic field still surfaced in some summaries
   compact: false          # Compact output mode (less whitespace)
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
+  busy_input_mode: queue  # queue | interrupt — what Enter does while the CLI is busy
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
   show_reasoning: false   # Show model reasoning/thinking above each response (toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   background_process_notifications: all  # all | result | error | off (gateway only)
   show_cost: false        # Show estimated $ cost in the CLI status bar
 ```
+
+`display.busy_input_mode` is CLI-only. `queue` sends your follow-up on the next turn, while `interrupt` restores the legacy behavior where pressing Enter preempts the current run. `Ctrl+C` always interrupts immediately.
 
 ### Theme mode
 


### PR DESCRIPTION
## What does this PR do?

This PR adds a CLI-only `display.busy_input_mode` setting so Enter while Hermes is busy can either queue the follow-up or interrupt the current run. It defaults to `queue`, while `interrupt` restores the previous behavior.

It also fixes `/queue` and `/q` in the interactive CLI. On `main`, those commands are deferred until the current run finishes, which means they miss the busy window and do not actually queue anything. This change handles them immediately while Hermes is busy so they always append the next-turn prompt as intended.

## Related Issue

None yet.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 🔒 Security fix
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `display.busy_input_mode` to CLI config and example config
- Route busy Enter submissions to either the pending queue or interrupt queue based on that setting
- Handle `/queue` and `/q` immediately while the CLI is busy so explicit queueing works on top of either mode
- Add focused CLI tests that cover the new config and the immediate `/queue` behavior
- Update CLI and configuration docs to describe queue versus interrupt behavior clearly

## How to Test

1. On `main`, start a long-running prompt and type `/queue follow up` while Hermes is busy. Notice that it does not queue for the next turn.
2. On this branch, repeat the same test and confirm `Queued for the next turn: ...` appears immediately and the follow-up runs after the active turn finishes.
3. Toggle `display.busy_input_mode` between `queue` and `interrupt` in `~/.hermes/config.yaml` and confirm Enter switches between queueing and interrupting while `Ctrl+C` still interrupts in both modes.
4. Run `/Users/stefano/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/test_cli_init.py tests/tools/test_interrupt.py`

## Checklist

### Code

- [ ] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [ ] I have updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`28 passed in 6.89s` from:

`/Users/stefano/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/test_cli_init.py tests/tools/test_interrupt.py`