### PR TITLE
feat(cron): support MEDIA file attachments in cron delivery for Discord

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -164,18 +164,32 @@ def _deliver_result(job: dict, content: str) -> None:
         logger.warning("Job '%s': platform '%s' not configured/enabled", job["id"], platform_name)
         return
 
+    # Extract MEDIA:<path> tags from the response so we can send files as
+    # native platform attachments instead of raw text paths.
+    from gateway.platforms.base import BasePlatformAdapter
+
+    media_items, cleaned_content = BasePlatformAdapter.extract_media(content)
+    # media_items: list of (path, is_voice) tuples
+    media_paths = []
+    for path, _is_voice in media_items:
+        expanded = os.path.expanduser(path)
+        if os.path.isfile(expanded):
+            media_paths.append(expanded)
+        else:
+            logger.warning("Job '%s': MEDIA path not found, skipping: %s", job["id"], path)
+
     # Wrap the content so the user knows this is a cron delivery and that
     # the interactive agent has no visibility into it.
     task_name = job.get("name", job["id"])
     wrapped = (
         f"Cronjob Response: {task_name}\n"
         f"-------------\n\n"
-        f"{content}\n\n"
+        f"{cleaned_content}\n\n"
         f"Note: The agent cannot see this message, and therefore cannot respond to it."
     )
 
     # Run the async send in a fresh event loop (safe from any thread)
-    coro = _send_to_platform(platform, pconfig, chat_id, wrapped, thread_id=thread_id)
+    coro = _send_to_platform(platform, pconfig, chat_id, wrapped, thread_id=thread_id, media_files=media_paths)
     try:
         result = asyncio.run(coro)
     except RuntimeError:
@@ -186,7 +200,7 @@ def _deliver_result(job: dict, content: str) -> None:
         coro.close()
         import concurrent.futures
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, wrapped, thread_id=thread_id))
+            future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, wrapped, thread_id=thread_id, media_files=media_paths))
             result = future.result(timeout=30)
     except Exception as e:
         logger.error("Job '%s': delivery to %s:%s failed: %s", job["id"], platform_name, chat_id, e)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -315,10 +315,24 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         return last_result
 
     # --- Non-Telegram platforms ---
+    # Discord supports file attachments via multipart form data
+    if platform == Platform.DISCORD:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_discord(
+                pconfig.token, chat_id, chunk,
+                media_files=media_files if is_last else [],
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram; "
+                f"send_message MEDIA delivery is currently only supported for telegram and discord; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -326,14 +340,12 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram"
+            "native send_message media delivery is currently only supported for telegram and discord"
         )
 
     last_result = None
     for chunk in chunks:
-        if platform == Platform.DISCORD:
-            result = await _send_discord(pconfig.token, chat_id, chunk)
-        elif platform == Platform.SLACK:
+        if platform == Platform.SLACK:
             result = await _send_slack(pconfig.token, chat_id, chunk)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
@@ -478,10 +490,12 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         return {"error": f"Telegram send failed: {e}"}
 
 
-async def _send_discord(token, chat_id, message):
+async def _send_discord(token, chat_id, message, media_files=None):
     """Send a single message via Discord REST API (no websocket client needed).
 
     Chunking is handled by _send_to_platform() before this is called.
+    Supports optional media_files (list of local file paths) sent as attachments
+    via multipart form data.
     """
     try:
         import aiohttp
@@ -489,13 +503,50 @@ async def _send_discord(token, chat_id, message):
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         url = f"https://discord.com/api/v10/channels/{chat_id}/messages"
-        headers = {"Authorization": f"Bot {token}", "Content-Type": "application/json"}
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, json={"content": message}) as resp:
-                if resp.status not in (200, 201):
-                    body = await resp.text()
-                    return {"error": f"Discord API error ({resp.status}): {body}"}
-                data = await resp.json()
+        headers = {"Authorization": f"Bot {token}"}
+
+        # Normalize media_files: may be plain strings or (path, is_voice) tuples
+        media_files = [f if isinstance(f, str) else f[0] for f in (media_files or [])]
+        if media_files:
+            # Use multipart form data to send file attachments
+            form = aiohttp.FormData()
+            # Build the JSON payload with attachment references
+            attachments = []
+            for i, fpath in enumerate(media_files):
+                attachments.append({"id": i, "filename": os.path.basename(fpath)})
+            payload = {"content": message or ""}
+            if attachments:
+                payload["attachments"] = attachments
+            form.add_field("payload_json", json.dumps(payload), content_type="application/json")
+            file_handles = []
+            try:
+                for i, fpath in enumerate(media_files):
+                    fh = open(fpath, "rb")
+                    file_handles.append(fh)
+                    form.add_field(
+                        f"files[{i}]",
+                        fh,
+                        filename=os.path.basename(fpath),
+                        content_type="application/octet-stream",
+                    )
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(url, headers=headers, data=form) as resp:
+                        if resp.status not in (200, 201):
+                            body = await resp.text()
+                            return {"error": f"Discord API error ({resp.status}): {body}"}
+                        data = await resp.json()
+            finally:
+                for fh in file_handles:
+                    fh.close()
+        else:
+            # Simple JSON message (no attachments)
+            headers["Content-Type"] = "application/json"
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, headers=headers, json={"content": message}) as resp:
+                    if resp.status not in (200, 201):
+                        body = await resp.text()
+                        return {"error": f"Discord API error ({resp.status}): {body}"}
+                    data = await resp.json()
         return {"success": True, "platform": "discord", "chat_id": chat_id, "message_id": data.get("id")}
     except Exception as e:
         return {"error": f"Discord send failed: {e}"}


### PR DESCRIPTION
## Problem

Cron job delivery sends `MEDIA:/path/to/file.png` as raw text instead of native file attachments. The gateway's live chat pipeline processes these tags via `BasePlatformAdapter.extract_media()`, but the cron delivery path (`_deliver_result()` in `scheduler.py`) passes the raw response directly to `_send_to_platform()`, which for Discord uses a simple JSON POST with no file upload support.

## Solution

### `cron/scheduler.py` — `_deliver_result()`
- Extract `MEDIA:` tags from cron agent responses using `BasePlatformAdapter.extract_media()`
- Validate file paths exist, build a clean `media_paths` list
- Send cleaned text (no raw `MEDIA:` paths) + files to `_send_to_platform()`

### `tools/send_message_tool.py` — `_send_to_platform()`
- Add Discord early-return branch (mirrors existing Telegram pattern) that passes `media_files` through
- Remove now-dead Discord branch in the fallback loop

### `tools/send_message_tool.py` — `_send_discord()`
- Accept optional `media_files` parameter
- Normalize input: handles both plain string paths and `(path, is_voice)` tuples
- Use `aiohttp.FormData` with `payload_json` + `files[N]` fields per [Discord's file upload API](https://discord.com/developers/docs/reference#uploading-files)
- File handles tracked and closed in `try/finally` to prevent resource leaks
- Falls back to original simple JSON POST when no files present

## Testing

- All 6131 tests pass (1 pre-existing unrelated failure in transcription tests)
- Manually tested: cron job generating an image and delivering it as a native Discord attachment ✅