### PR TITLE
fix(state): release lock between context queries in search_messages

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -861,9 +861,11 @@ class SessionDB:
                 return []
             matches = [dict(row) for row in cursor.fetchall()]
 
-            # Add surrounding context (1 message before + after each match)
-            for match in matches:
-                try:
+        # Add surrounding context (1 message before + after each match).
+        # Done outside the lock so we don't hold it across N sequential queries.
+        for match in matches:
+            try:
+                with self._lock:
                     ctx_cursor = self._conn.execute(
                         """SELECT role, content FROM messages
                            WHERE session_id = ? AND id >= ? - 1 AND id <= ? + 1
@@ -874,9 +876,9 @@ class SessionDB:
                         {"role": r["role"], "content": (r["content"] or "")[:200]}
                         for r in ctx_cursor.fetchall()
                     ]
-                    match["context"] = context_msgs
-                except Exception:
-                    match["context"] = []
+                match["context"] = context_msgs
+            except Exception:
+                match["context"] = []
 
         # Remove full content from result (snippet is enough, saves tokens)
         for match in matches:


### PR DESCRIPTION
The per-match context-window queries in `search_messages()` (one SQLite
round-trip per FTS5 result) were running inside the same outer
`with self._lock:` block as the primary FTS5 query, holding the lock
for O(N) sequential I/O. This blocked all other threads (message writes,
session updates) for the entire duration of a search with many results.

Moved the per-match context fetches outside the outer lock so each
query acquires the lock independently, keeping critical sections short
and allowing other threads to interleave.

## Test plan
- [x] Run `search_messages` with multiple results and verify context rows are correct
- [x] Verify concurrent writes are not blocked during a search
