### PR TITLE
fix(delivery): preserve chat_id case in DeliveryTarget.parse

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -54,9 +54,10 @@ class DeliveryTarget:
         - "telegram" → Telegram home channel
         - "telegram:123456" → specific Telegram chat
         """
-        target = target.strip().lower()
-        
-        if target == "origin":
+        stripped = target.strip()
+        lowered = stripped.lower()
+
+        if lowered == "origin":
             if origin:
                 return cls(
                     platform=origin.platform,
@@ -67,23 +68,25 @@ class DeliveryTarget:
             else:
                 # Fallback to local if no origin
                 return cls(platform=Platform.LOCAL, is_origin=True)
-        
-        if target == "local":
+
+        if lowered == "local":
             return cls(platform=Platform.LOCAL)
-        
-        # Check for platform:chat_id format
-        if ":" in target:
-            platform_str, chat_id = target.split(":", 1)
+
+        # Check for platform:chat_id format — lowercase only the platform prefix,
+        # preserve the chat_id's original case (Matrix room IDs, WhatsApp group
+        # IDs, and similar identifiers can be case-sensitive).
+        if ":" in stripped:
+            platform_str, chat_id = stripped.split(":", 1)
             try:
-                platform = Platform(platform_str)
+                platform = Platform(platform_str.lower())
                 return cls(platform=platform, chat_id=chat_id, is_explicit=True)
             except ValueError:
                 # Unknown platform, treat as local
                 return cls(platform=Platform.LOCAL)
-        
+
         # Just a platform name (use home channel)
         try:
-            platform = Platform(target)
+            platform = Platform(lowered)
             return cls(platform=platform)
         except ValueError:
             # Unknown platform, treat as local


### PR DESCRIPTION
`DeliveryTarget.parse()` applied `.lower()` to the entire target string,
including the `chat_id` portion after the platform prefix. This corrupts
case-sensitive identifiers such as Matrix room IDs (`!roomId:server.com`)
and any other platform IDs that are not purely numeric.

Now only the platform prefix is lowercased for comparison; the `chat_id`
retains its original casing.

## Test plan
- [x] Verify `DeliveryTarget.parse("matrix:!RoomId:server.com")` preserves `!RoomId:server.com`
- [x] Verify `DeliveryTarget.parse("telegram:123456")` still works correctly
- [x] Verify `DeliveryTarget.parse("TELEGRAM")` normalizes to the telegram platform
