### PR TITLE
cli: show OS-specific paste shortcut hints

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2623,7 +2623,27 @@ class HermesCLI:
 
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
         _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
-        _cprint(f"  {_DIM}Paste image: Alt+V (or /paste){_RST}\n")
+        _cprint(f"  {_DIM}Paste image: {self._paste_image_help_hint()} (or /paste){_RST}\n")
+
+    def _paste_shortcut_hint(self) -> str:
+        """Return the primary paste shortcut shown in CLI help."""
+        if sys.platform == "darwin":
+            return "Cmd+V"
+        if sys.platform.startswith("linux"):
+            try:
+                from hermes_cli.clipboard import _is_wsl
+                if _is_wsl():
+                    return "Alt+V"
+            except Exception:
+                pass
+        return "Ctrl+V"
+
+    def _paste_image_help_hint(self) -> str:
+        """Return the user-facing paste hint shown in help output."""
+        primary = self._paste_shortcut_hint()
+        if primary == "Alt+V":
+            return primary
+        return f"{primary} or Alt+V"
     
     def show_tools(self):
         """Display available tools with kawaii ASCII art."""

--- a/tests/test_cli_paste_shortcut_hint.py
+++ b/tests/test_cli_paste_shortcut_hint.py
@@ -1,0 +1,46 @@
+"""Tests for OS-specific CLI paste shortcut hints."""
+
+import cli as cli_mod
+from cli import HermesCLI
+
+
+def _make_cli():
+    return HermesCLI.__new__(HermesCLI)
+
+
+def test_primary_paste_shortcut_is_cmd_v_on_macos(monkeypatch):
+    cli = _make_cli()
+    monkeypatch.setattr(cli_mod.sys, "platform", "darwin")
+
+    assert cli._paste_shortcut_hint() == "Cmd+V"
+
+
+def test_primary_paste_shortcut_is_ctrl_v_on_regular_linux(monkeypatch):
+    cli = _make_cli()
+    monkeypatch.setattr(cli_mod.sys, "platform", "linux")
+    monkeypatch.setattr("hermes_cli.clipboard._is_wsl", lambda: False)
+
+    assert cli._paste_shortcut_hint() == "Ctrl+V"
+
+
+def test_primary_paste_shortcut_is_alt_v_on_wsl(monkeypatch):
+    cli = _make_cli()
+    monkeypatch.setattr(cli_mod.sys, "platform", "linux")
+    monkeypatch.setattr("hermes_cli.clipboard._is_wsl", lambda: True)
+
+    assert cli._paste_shortcut_hint() == "Alt+V"
+
+
+def test_help_hint_keeps_alt_v_as_fallback_when_primary_differs(monkeypatch):
+    cli = _make_cli()
+    monkeypatch.setattr(cli_mod.sys, "platform", "darwin")
+
+    assert cli._paste_image_help_hint() == "Cmd+V or Alt+V"
+
+
+def test_help_hint_avoids_duplicate_alt_v_on_wsl(monkeypatch):
+    cli = _make_cli()
+    monkeypatch.setattr(cli_mod.sys, "platform", "linux")
+    monkeypatch.setattr("hermes_cli.clipboard._is_wsl", lambda: True)
+
+    assert cli._paste_image_help_hint() == "Alt+V"


### PR DESCRIPTION
## Summary
- show the primary paste shortcut based on the runtime OS in CLI help
- prefer `Cmd+V` on macOS, `Ctrl+V` on regular Windows/Linux, and `Alt+V` on WSL
- keep `Alt+V` as the fallback hint when the primary shortcut differs

## Testing
- python -m pytest tests/test_cli_paste_shortcut_hint.py -q
- python -m pytest tests/hermes_cli/test_commands.py -q