### PR TITLE
feat(gateway): include original audio file path in voice message transcripts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6031,7 +6031,8 @@ class GatewayRunner:
                     transcript = result["transcript"]
                     enriched_parts.append(
                         f'[The user sent a voice message~ '
-                        f'Here\'s what they said: "{transcript}"]'
+                        f'Here\'s what they said: "{transcript}"'
+                        f' (original audio: {path})]'
                     )
                 else:
                     error = result.get("error", "unknown error")
@@ -6056,13 +6057,15 @@ class GatewayRunner:
                     else:
                         enriched_parts.append(
                             "[The user sent a voice message but I had trouble "
-                            f"transcribing it~ ({error})]"
+                            f"transcribing it~ ({error})"
+                            f" (original audio: {path})]"
                         )
             except Exception as e:
                 logger.error("Transcription error: %s", e)
                 enriched_parts.append(
                     "[The user sent a voice message but something went wrong "
-                    "when I tried to listen to it~ Let them know!]"
+                    "when I tried to listen to it~ Let them know!"
+                    f" (original audio: {path})]"
                 )
 
         if enriched_parts:


### PR DESCRIPTION
## Summary

When the gateway transcribes a user's voice message, the resulting annotation now includes the local file path to the cached audio file:

```
[The user sent a voice message~ Here's what they said: "hello" (original audio: /path/to/audio.ogg)]
```

## Motivation

Currently, after STT transcription, the original audio file is discarded from the agent's context. The agent only sees the text transcript. This means:

- **Music identification is impossible** — if a user sends a voice message asking "what song is this?" with music playing in the background, the agent has no way to analyze the audio
- **Audio analysis use cases are blocked** — ambient sound detection, audio quality assessment, re-processing poorly transcribed audio, etc.
- **The audio file already exists on disk** (cached by the gateway) but the agent has no way to find it

## Changes

Minimal 3-line change in `gateway/run.py` — the `_enrich_message_with_transcription()` method now appends `(original audio: {path})` to all three annotation variants:

1. ✅ Successful transcription
2. ❌ Transcription error  
3. 💥 Transcription exception

## Backwards Compatibility

Fully backwards-compatible. Agents that don't need the audio path can simply ignore the parenthetical. The annotation format is parsed by convention, not by code, so existing agents won't break.

## Example Use Cases

- User sends voice message with background music → agent uses the audio path with a music recognition tool
- Poor STT quality → agent can re-process the original audio with a different model
- Audio forensics / ambient sound analysis