### PR TITLE
fix(security): add SSRF protection to browser_navigate

### DIFF
--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -292,6 +292,8 @@ def test_check_website_access_blocks_scheme_less_urls(tmp_path):
 def test_browser_navigate_returns_policy_block(monkeypatch):
     from tools import browser_tool
 
+    # Allow SSRF check to pass so the policy check is reached
+    monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: True)
     monkeypatch.setattr(
         browser_tool,
         "check_website_access",

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -70,6 +70,11 @@ try:
     from tools.website_policy import check_website_access
 except Exception:
     check_website_access = lambda url: None  # noqa: E731 — fail-open if policy module unavailable
+
+try:
+    from tools.url_safety import is_safe_url as _is_safe_url
+except Exception:
+    _is_safe_url = lambda url: True  # noqa: E731 — fail-open if safety module unavailable
 from tools.browser_providers.base import CloudBrowserProvider
 from tools.browser_providers.browserbase import BrowserbaseProvider
 from tools.browser_providers.browser_use import BrowserUseProvider
@@ -1026,15 +1031,11 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         JSON string with navigation result (includes stealth features info on first nav)
     """
     # SSRF protection — block private/internal addresses before navigating
-    try:
-        from tools.url_safety import is_safe_url
-        if not is_safe_url(url):
-            return json.dumps({
-                "success": False,
-                "error": f"Blocked: URL targets a private or internal address",
-            })
-    except ImportError:
-        logger.warning("url_safety module unavailable — SSRF check skipped")
+    if not _is_safe_url(url):
+        return json.dumps({
+            "success": False,
+            "error": "Blocked: URL targets a private or internal address",
+        })
 
     # Website policy check — block before navigating
     blocked = check_website_access(url)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1025,6 +1025,17 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     Returns:
         JSON string with navigation result (includes stealth features info on first nav)
     """
+    # SSRF protection — block private/internal addresses before navigating
+    try:
+        from tools.url_safety import is_safe_url
+        if not is_safe_url(url):
+            return json.dumps({
+                "success": False,
+                "error": f"Blocked: URL targets a private or internal address",
+            })
+    except ImportError:
+        logger.warning("url_safety module unavailable — SSRF check skipped")
+
     # Website policy check — block before navigating
     blocked = check_website_access(url)
     if blocked:


### PR DESCRIPTION
## Summary

`browser_navigate()` only checked the website blocklist (`check_website_access`) but did **not** call `is_safe_url()` to block private/internal addresses. This allowed the agent to navigate the browser to:

- `http://127.0.0.1:*` (localhost services)
- `http://169.254.169.254/latest/meta-data/` (cloud metadata — AWS/GCP credentials)
- `http://192.168.x.x/admin` (private network)
- `http://10.x.x.x/*` (internal services)

`web_tools.py` and `vision_tools.py` already had `is_safe_url()` checks. `browser_tool.py` was the only URL-capable tool missing it.

## Fix

Added `is_safe_url()` pre-flight check in `browser_navigate()` before the blocklist check, matching the pattern used in `web_extract_tool()` and `vision_analyze_tool()`.

## Test plan

- [x] Verified: `http://127.0.0.1:8080/secret` → blocked
- [x] Verified: `http://169.254.169.254/latest/meta-data/` → blocked
- [x] Verified: `http://192.168.1.1/admin` → blocked
- [x] `tests/tools/test_browser_cdp_override.py` — 4/4 passed