### PR TITLE
feat(tts): add full/summary modes for automatic voice replies

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -226,6 +226,7 @@ PLATFORM_HINTS = {
 CONTEXT_FILE_MAX_CHARS = 20_000
 CONTEXT_TRUNCATE_HEAD_RATIO = 0.7
 CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
+SKILLS_SYSTEM_PROMPT_MAX_CHARS = 4_000
 
 
 # =========================================================================
@@ -266,7 +267,7 @@ def _read_skill_conditions(skill_file: Path) -> dict:
         from tools.skills_tool import _parse_frontmatter
         raw = skill_file.read_text(encoding="utf-8")[:2000]
         frontmatter, _ = _parse_frontmatter(raw)
-        hermes = frontmatter.get("metadata", {}).get("hermes", {})
+        hermes = _get_skill_hermes_metadata(frontmatter)
         return {
             "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
             "requires_toolsets": hermes.get("requires_toolsets", []),
@@ -276,6 +277,22 @@ def _read_skill_conditions(skill_file: Path) -> dict:
     except Exception as e:
         logger.debug("Failed to read skill conditions from %s: %s", skill_file, e)
         return {}
+
+
+def _get_skill_hermes_metadata(frontmatter: dict | None) -> dict:
+    """Return normalized ``metadata.hermes`` frontmatter as a dict."""
+    if not isinstance(frontmatter, dict):
+        return {}
+
+    metadata = frontmatter.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        return {}
+
+    hermes = metadata.get("hermes") or {}
+    if not isinstance(hermes, dict):
+        return {}
+
+    return hermes
 
 
 def _skill_should_show(
@@ -356,7 +373,7 @@ def build_skills_system_prompt(
             continue
         # Extract conditions inline from already-parsed frontmatter
         # (avoids redundant file re-read that _read_skill_conditions would do)
-        hermes_meta = frontmatter.get("metadata", {}).get("hermes", {})
+        hermes_meta = _get_skill_hermes_metadata(frontmatter)
         conditions = {
             "fallback_for_toolsets": hermes_meta.get("fallback_for_toolsets", []),
             "requires_toolsets": hermes_meta.get("requires_toolsets", []),
@@ -385,25 +402,31 @@ def build_skills_system_prompt(
             except Exception as e:
                 logger.debug("Could not read skill description %s: %s", desc_file, e)
 
-    index_lines = []
+    normalized_skills_by_category: dict[str, list[tuple[str, str]]] = {}
     for category in sorted(skills_by_category.keys()):
-        cat_desc = category_descriptions.get(category, "")
-        if cat_desc:
-            index_lines.append(f"  {category}: {cat_desc}")
-        else:
-            index_lines.append(f"  {category}:")
-        # Deduplicate and sort skills within each category
+        deduped: list[tuple[str, str]] = []
         seen = set()
         for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
             if name in seen:
                 continue
             seen.add(name)
+            deduped.append((name, desc))
+        normalized_skills_by_category[category] = deduped
+
+    index_lines = []
+    for category in sorted(normalized_skills_by_category.keys()):
+        cat_desc = category_descriptions.get(category, "")
+        if cat_desc:
+            index_lines.append(f"  {category}: {cat_desc}")
+        else:
+            index_lines.append(f"  {category}:")
+        for name, desc in normalized_skills_by_category[category]:
             if desc:
                 index_lines.append(f"    - {name}: {desc}")
             else:
                 index_lines.append(f"    - {name}")
 
-    return (
+    full_prompt = (
         "## Skills (mandatory)\n"
         "Before replying, scan the skills below. If one clearly matches your task, "
         "load it with skill_view(name) and follow its instructions. "
@@ -417,6 +440,39 @@ def build_skills_system_prompt(
         "</available_skills>\n"
         "\n"
         "If none match, proceed normally without loading a skill."
+    )
+
+    if len(full_prompt) <= SKILLS_SYSTEM_PROMPT_MAX_CHARS:
+        return full_prompt
+
+    compact_lines = []
+    total_skills = 0
+    for category in sorted(normalized_skills_by_category.keys()):
+        entries = normalized_skills_by_category[category]
+        total_skills += len(entries)
+        line = f"  - {category}: {len(entries)} skill"
+        if len(entries) != 1:
+            line += "s"
+        compact_lines.append(line)
+
+    return (
+        "## Skills\n"
+        "A large skill catalog is installed, so the full index is omitted to keep "
+        "the system prompt compact.\n"
+        "When a task may benefit from reusable instructions, prior workflow "
+        "knowledge, or domain-specific steps, call skills_list to discover "
+        "candidates, then load the best match with skill_view(name).\n"
+        "If you load a skill and find gaps or errors, patch it with "
+        "skill_manage(action='patch'). After difficult tasks, consider saving the "
+        "workflow as a new skill.\n"
+        f"Installed: {total_skills} skills across "
+        f"{len(normalized_skills_by_category)} categories.\n"
+        "\n"
+        "<skill_categories>\n"
+        + "\n".join(compact_lines) + "\n"
+        "</skill_categories>\n"
+        "\n"
+        "Do not assume a skill exists until you check with skills_list."
     )
 
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -605,6 +605,36 @@ platform_toolsets:
 #       log_level: "info"       # audit verbosity
 
 # =============================================================================
+# Text-to-Speech (TTS)
+# =============================================================================
+# Used by the text_to_speech tool and automatic spoken replies in CLI/gateway
+# voice mode. `mode: "summary"` compresses automatic spoken replies before
+# synthesis; the explicit text_to_speech tool still speaks the full input.
+tts:
+  mode: "full"                 # "full" | "summary"
+  provider: "edge"             # "edge" | "elevenlabs" | "openai" | "neutts"
+  summary:
+    length: "2 sentences"      # target spoken summary length when mode="summary"
+    # provider: "openrouter"   # optional override just for TTS summaries
+    # model: "google/gemini-3-flash-preview"
+    # base_url: ""
+    # api_key: ""
+  edge:
+    voice: "en-US-AriaNeural"
+  elevenlabs:
+    voice_id: "pNInz6obpgDQGcFmaJgB"
+    model_id: "eleven_multilingual_v2"
+  openai:
+    model: "gpt-4o-mini-tts"
+    voice: "alloy"
+    base_url: "https://api.openai.com/v1"
+  neutts:
+    ref_audio: ""
+    ref_text: ""
+    model: "neuphonic/neutts-air-q4-gguf"
+    device: "cpu"
+
+# =============================================================================
 # Voice Transcription (Speech-to-Text)
 # =============================================================================
 # Automatically transcribe voice messages on messaging platforms.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -614,7 +614,7 @@ tts:
   mode: "full"                 # "full" | "summary"
   provider: "edge"             # "edge" | "elevenlabs" | "openai" | "neutts"
   summary:
-    length: "2 sentences"      # target spoken summary length when mode="summary"
+    length: "1 sentence"       # target spoken summary length when mode="summary"
     # provider: "openrouter"   # optional override just for TTS summaries
     # model: "google/gemini-3-flash-preview"
     # base_url: ""

--- a/cli.py
+++ b/cli.py
@@ -4943,24 +4943,10 @@ class HermesCLI:
             return
         self._voice_tts_done.clear()
         try:
-            from tools.tts_tool import text_to_speech_tool
+            from tools.tts_tool import prepare_text_for_auto_tts, text_to_speech_tool
             from tools.voice_mode import play_audio_file
-            import json
-            import re
 
-            # Strip markdown and non-speech content for cleaner TTS
-            tts_text = text[:4000] if len(text) > 4000 else text
-            tts_text = re.sub(r'```[\s\S]*?```', ' ', tts_text)   # fenced code blocks
-            tts_text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', tts_text)  # [text](url) -> text
-            tts_text = re.sub(r'https?://\S+', '', tts_text)      # URLs
-            tts_text = re.sub(r'\*\*(.+?)\*\*', r'\1', tts_text)  # bold
-            tts_text = re.sub(r'\*(.+?)\*', r'\1', tts_text)      # italic
-            tts_text = re.sub(r'`(.+?)`', r'\1', tts_text)        # inline code
-            tts_text = re.sub(r'^#+\s*', '', tts_text, flags=re.MULTILINE)  # headers
-            tts_text = re.sub(r'^\s*[-*]\s+', '', tts_text, flags=re.MULTILINE)  # list items
-            tts_text = re.sub(r'---+', '', tts_text)              # horizontal rules
-            tts_text = re.sub(r'\n{3,}', '\n\n', tts_text)        # excessive newlines
-            tts_text = tts_text.strip()
+            tts_text = prepare_text_for_auto_tts(text)
             if not tts_text:
                 return
 
@@ -4992,7 +4978,7 @@ class HermesCLI:
             self._voice_tts_done.set()
 
     def _handle_voice_command(self, command: str):
-        """Handle /voice [on|off|tts|status] command."""
+        """Handle /voice [on|off|tts|full|summary|status] command."""
         parts = command.strip().split(maxsplit=1)
         subcommand = parts[1].lower().strip() if len(parts) > 1 else ""
 
@@ -5002,6 +4988,10 @@ class HermesCLI:
             self._disable_voice_mode()
         elif subcommand == "tts":
             self._toggle_voice_tts()
+        elif subcommand == "full":
+            self._set_voice_tts_mode("full")
+        elif subcommand == "summary":
+            self._set_voice_tts_mode("summary")
         elif subcommand == "status":
             self._show_voice_status()
         elif subcommand == "":
@@ -5012,7 +5002,7 @@ class HermesCLI:
                 self._enable_voice_mode()
         else:
             _cprint(f"Unknown voice subcommand: {subcommand}")
-            _cprint("Usage: /voice [on|off|tts|status]")
+            _cprint("Usage: /voice [on|off|tts|full|summary|status]")
 
     def _enable_voice_mode(self):
         """Enable voice mode after checking requirements."""
@@ -5068,6 +5058,7 @@ class HermesCLI:
         _cprint(f"\n{_GOLD}Voice mode enabled{tts_status}{_RST}")
         _cprint(f"  {_DIM}{_ptt_display} to start/stop recording{_RST}")
         _cprint(f"  {_DIM}/voice tts  to toggle speech output{_RST}")
+        _cprint(f"  {_DIM}/voice full or /voice summary  to change spoken reply style{_RST}")
         _cprint(f"  {_DIM}/voice off  to disable voice mode{_RST}")
 
     def _disable_voice_mode(self):
@@ -5119,18 +5110,61 @@ class HermesCLI:
 
         _cprint(f"{_GOLD}Voice TTS {status}.{_RST}")
 
+    def _set_voice_tts_mode(self, mode: str):
+        """Persist the spoken reply style and enable spoken replies."""
+        normalized = (mode or "").strip().lower()
+        if normalized not in {"full", "summary"}:
+            _cprint(f"{_DIM}Unknown voice TTS mode: {mode}{_RST}")
+            return
+
+        # If the user explicitly asks for a speech mode, make sure voice mode
+        # is active so the setting has an immediate effect.
+        if not self._voice_mode:
+            self._enable_voice_mode()
+            if not self._voice_mode:
+                return
+
+        with self._voice_lock:
+            self._voice_tts = True
+
+        try:
+            from hermes_cli.config import set_config_value
+            set_config_value("tts.mode", normalized, quiet=True)
+        except Exception as e:
+            _cprint(f"{_DIM}Couldn't save voice TTS mode: {e}{_RST}")
+            return
+
+        try:
+            from tools.tts_tool import check_tts_requirements
+            if not check_tts_requirements():
+                _cprint(f"{_DIM}Warning: No TTS provider available. Install edge-tts or set API keys.{_RST}")
+        except Exception:
+            pass
+
+        detail = (
+            "Auto-spoken replies will use the full assistant response."
+            if normalized == "full"
+            else "Auto-spoken replies will be summarized before synthesis."
+        )
+        _cprint(f"{_GOLD}Voice TTS enabled in {normalized} mode.{_RST}")
+        _cprint(f"{_DIM}{detail}{_RST}")
+
     def _show_voice_status(self):
         """Show current voice mode status."""
         from hermes_cli.config import load_config
         from tools.voice_mode import check_voice_requirements
+        from tools.tts_tool import _get_tts_mode
 
+        config = load_config()
         reqs = check_voice_requirements()
+        tts_mode = _get_tts_mode(config.get("tts", {}))
 
         _cprint(f"\n{_BOLD}Voice Mode Status{_RST}")
         _cprint(f"  Mode:      {'ON' if self._voice_mode else 'OFF'}")
         _cprint(f"  TTS:       {'ON' if self._voice_tts else 'OFF'}")
+        _cprint(f"  Speech:    {tts_mode.upper()}")
         _cprint(f"  Recording: {'YES' if self._voice_recording else 'no'}")
-        _raw_key = load_config().get("voice", {}).get("record_key", "ctrl+b")
+        _raw_key = config.get("voice", {}).get("record_key", "ctrl+b")
         _display_key = _raw_key.replace("ctrl+", "Ctrl+").upper() if "ctrl+" in _raw_key.lower() else _raw_key
         _cprint(f"  Record key: {_display_key}")
         _cprint(f"\n  {_BOLD}Requirements:{_RST}")
@@ -5537,6 +5571,7 @@ class HermesCLI:
             if self._voice_tts:
                 try:
                     from tools.tts_tool import (
+                        _get_tts_mode as _get_tts_mode,
                         _load_tts_config as _load_tts_cfg,
                         _get_provider as _get_prov,
                         _import_elevenlabs,
@@ -5544,7 +5579,8 @@ class HermesCLI:
                         stream_tts_to_speaker,
                     )
                     _tts_cfg = _load_tts_cfg()
-                    if _get_prov(_tts_cfg) == "elevenlabs":
+                    if (_get_prov(_tts_cfg) == "elevenlabs"
+                            and _get_tts_mode(_tts_cfg) == "full"):
                         # Verify both ElevenLabs SDK and audio output are available
                         _import_elevenlabs()
                         _import_sounddevice()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -948,10 +948,16 @@ class BasePlatformAdapter(ABC):
                         and not media_files
                         and event.source.chat_id not in self._auto_tts_disabled_chats):
                     try:
-                        from tools.tts_tool import text_to_speech_tool, check_tts_requirements
+                        from tools.tts_tool import (
+                            check_tts_requirements,
+                            prepare_text_for_auto_tts,
+                            text_to_speech_tool,
+                        )
                         if check_tts_requirements():
                             import json as _json
-                            speech_text = re.sub(r'[*_`#\[\]()]', '', text_content)[:4000].strip()
+                            speech_text = await asyncio.to_thread(
+                                prepare_text_for_auto_tts, text_content
+                            )
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
                             tts_result_str = await asyncio.to_thread(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3193,8 +3193,48 @@ class GatewayRunner:
             return raw.guild.id
         return None
 
+    def _set_global_voice_tts_mode(self, mode: str, *, chat_id: str | None = None, adapter=None) -> str:
+        """Persist the spoken reply style and enable auto-TTS for the chat."""
+        normalized = (mode or "").strip().lower()
+        if normalized not in {"full", "summary"}:
+            return f"Unknown voice TTS mode: {mode}"
+
+        try:
+            from hermes_cli.config import set_config_value
+            set_config_value("tts.mode", normalized, quiet=True)
+        except Exception as e:
+            logger.warning("Failed to save TTS mode %s: %s", normalized, e)
+            return f"Couldn't save voice TTS mode: {e}"
+
+        detail = (
+            "Auto-spoken replies will use the full assistant response."
+            if normalized == "full"
+            else "Auto-spoken replies will be summarized before synthesis."
+        )
+        if chat_id:
+            self._voice_mode[chat_id] = "all"
+            self._save_voice_modes()
+            if adapter:
+                self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=False)
+            return (
+                f"Voice TTS enabled in {normalized} mode.\n"
+                f"{detail}\n"
+                "All replies in this chat will include a voice message."
+            )
+
+        return f"Voice TTS mode set to {normalized}.\n{detail}"
+
+    def _get_global_voice_tts_mode(self) -> str:
+        """Return the configured spoken reply style for automatic TTS replies."""
+        try:
+            from hermes_cli.config import load_config
+            from tools.tts_tool import _get_tts_mode
+            return _get_tts_mode(load_config().get("tts", {}))
+        except Exception:
+            return "full"
+
     async def _handle_voice_command(self, event: MessageEvent) -> str:
-        """Handle /voice [on|off|tts|channel|leave|status] command."""
+        """Handle /voice [on|off|tts|full|summary|channel|leave|status] command."""
         args = event.get_command_args().strip().lower()
         chat_id = event.source.chat_id
 
@@ -3225,12 +3265,17 @@ class GatewayRunner:
                 "Auto-TTS enabled.\n"
                 "All replies will include a voice message."
             )
+        elif args == "full":
+            return self._set_global_voice_tts_mode("full", chat_id=chat_id, adapter=adapter)
+        elif args == "summary":
+            return self._set_global_voice_tts_mode("summary", chat_id=chat_id, adapter=adapter)
         elif args in ("channel", "join"):
             return await self._handle_voice_channel_join(event)
         elif args == "leave":
             return await self._handle_voice_channel_leave(event)
         elif args == "status":
             mode = self._voice_mode.get(chat_id, "off")
+            speech_mode = self._get_global_voice_tts_mode()
             labels = {
                 "off": "Off (text only)",
                 "voice_only": "On (voice reply to voice messages)",
@@ -3244,6 +3289,7 @@ class GatewayRunner:
                 if info:
                     lines = [
                         f"Voice mode: {labels.get(mode, mode)}",
+                        f"Speech mode: {speech_mode}",
                         f"Voice channel: #{info['channel_name']}",
                         f"Participants: {info['member_count']}",
                     ]
@@ -3251,7 +3297,7 @@ class GatewayRunner:
                         status = " (speaking)" if m.get("is_speaking") else ""
                         lines.append(f"  - {m['display_name']}{status}")
                     return "\n".join(lines)
-            return f"Voice mode: {labels.get(mode, mode)}"
+            return f"Voice mode: {labels.get(mode, mode)}\nSpeech mode: {speech_mode}"
         else:
             # Toggle: off → on, on/all → off
             current = self._voice_mode.get(chat_id, "off")
@@ -3461,9 +3507,9 @@ class GatewayRunner:
         audio_path = None
         actual_path = None
         try:
-            from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from tools.tts_tool import prepare_text_for_auto_tts, text_to_speech_tool
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
+            tts_text = await asyncio.to_thread(prepare_text_for_auto_tts, text)
             if not tts_text:
                 return
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -97,7 +97,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("skin", "Show or change the display skin/theme", "Configuration",
                cli_only=True, args_hint="[name]"),
     CommandDef("voice", "Toggle voice mode", "Configuration",
-               args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
+               args_hint="[on|off|tts|full|summary|status]",
+               subcommands=("on", "off", "tts", "full", "summary", "status")),
 
     # Tools & Skills
     CommandDef("tools", "Manage tools: /tools [list|disable|enable] [name...]", "Tools & Skills",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -282,7 +282,7 @@ DEFAULT_CONFIG = {
         "mode": "full",  # "full" | "summary" for auto-spoken assistant replies
         "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "neutts" (local)
         "summary": {
-            "length": "2 sentences",  # Spoken summary target when mode="summary"
+            "length": "1 sentence",  # Spoken summary target when mode="summary"
             "provider": "",  # empty = fall back to compression summary routing
             "model": "",     # empty = fall back to compression summary model
             "base_url": "",  # optional direct OpenAI-compatible summary endpoint
@@ -416,7 +416,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 10,
+    "_config_version": 11,
 }
 
 # =============================================================================
@@ -431,6 +431,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
     5: ["WHATSAPP_ENABLED", "WHATSAPP_MODE", "WHATSAPP_ALLOWED_USERS",
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
+    11: [],
 }
 
 # Required environment variables with metadata for migration prompts.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -279,7 +279,15 @@ DEFAULT_CONFIG = {
     
     # Text-to-speech configuration
     "tts": {
+        "mode": "full",  # "full" | "summary" for auto-spoken assistant replies
         "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "neutts" (local)
+        "summary": {
+            "length": "2 sentences",  # Spoken summary target when mode="summary"
+            "provider": "",  # empty = fall back to compression summary routing
+            "model": "",     # empty = fall back to compression summary model
+            "base_url": "",  # optional direct OpenAI-compatible summary endpoint
+            "api_key": "",   # optional API key for summary.base_url
+        },
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -1801,7 +1809,7 @@ def edit_config():
     subprocess.run([editor, str(config_path)])
 
 
-def set_config_value(key: str, value: str):
+def set_config_value(key: str, value: str, *, quiet: bool = False):
     """Set a configuration value."""
     if is_managed():
         managed_error("set configuration values")
@@ -1820,7 +1828,8 @@ def set_config_value(key: str, value: str):
     
     if key.upper() in api_keys or key.upper().endswith('_API_KEY') or key.upper().endswith('_TOKEN') or key.upper().startswith('TERMINAL_SSH'):
         save_env_value(key.upper(), value)
-        print(f"✓ Set {key} in {get_env_path()}")
+        if not quiet:
+            print(f"✓ Set {key} in {get_env_path()}")
         return
     
     # Otherwise it goes to config.yaml
@@ -1878,7 +1887,8 @@ def set_config_value(key: str, value: str):
     if key in _config_to_env_sync:
         save_env_value(_config_to_env_sync[key], str(value))
 
-    print(f"✓ Set {key} = {value} in {config_path}")
+    if not quiet:
+        print(f"✓ Set {key} = {value} in {config_path}")
 
 
 # =============================================================================

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -5,6 +5,8 @@ import importlib
 import logging
 import sys
 
+import agent.prompt_builder as prompt_builder
+
 from agent.prompt_builder import (
     _scan_context_content,
     _truncate_content,
@@ -394,6 +396,24 @@ class TestBuildSkillsSystemPrompt:
         result = build_skills_system_prompt()
         assert "backend-skill" in result
 
+    def test_compacts_large_skill_catalog(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(prompt_builder, "SKILLS_SYSTEM_PROMPT_MAX_CHARS", 250)
+
+        for idx in range(8):
+            skill_dir = tmp_path / "skills" / "coding" / f"python-{idx}"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: python-{idx}\ndescription: Python workflow {idx}\n---\n"
+            )
+
+        result = build_skills_system_prompt()
+        assert "<skill_categories>" in result
+        assert "<available_skills>" not in result
+        assert "skills_list" in result
+        assert "Installed: 8 skills across 1 categories." in result
+        assert "coding: 8 skills" in result
+
 
 # =========================================================================
 # Context files prompt builder
@@ -730,6 +750,28 @@ class TestReadSkillConditions:
         assert conditions["fallback_for_toolsets"] == ["browser"]
         assert conditions["requires_tools"] == ["terminal"]
 
+    def test_null_metadata_returns_empty_conditions(self, tmp_path):
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text(
+            "---\nname: test\ndescription: Test\nmetadata:\n---\n"
+        )
+        conditions = _read_skill_conditions(skill_file)
+        assert conditions["fallback_for_toolsets"] == []
+        assert conditions["requires_toolsets"] == []
+        assert conditions["fallback_for_tools"] == []
+        assert conditions["requires_tools"] == []
+
+    def test_null_hermes_metadata_returns_empty_conditions(self, tmp_path):
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text(
+            "---\nname: test\ndescription: Test\nmetadata:\n  hermes:\n---\n"
+        )
+        conditions = _read_skill_conditions(skill_file)
+        assert conditions["fallback_for_toolsets"] == []
+        assert conditions["requires_toolsets"] == []
+        assert conditions["fallback_for_tools"] == []
+        assert conditions["requires_tools"] == []
+
     def test_missing_file_returns_empty(self, tmp_path):
         conditions = _read_skill_conditions(tmp_path / "missing.md")
         assert conditions == {}
@@ -861,6 +903,19 @@ class TestBuildSkillsSystemPromptConditional:
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text(
             "---\nname: notes\ndescription: Take notes\n---\n"
+        )
+        result = build_skills_system_prompt(
+            available_tools=set(),
+            available_toolsets=set(),
+        )
+        assert "notes" in result
+
+    def test_null_metadata_skill_does_not_crash(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "general" / "notes"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: notes\ndescription: Take notes\nmetadata:\n---\n"
         )
         result = build_skills_system_prompt(
             available_tools=set(),

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -117,17 +117,43 @@ class TestHandleVoiceCommand:
         assert runner._voice_mode["123"] == "all"
 
     @pytest.mark.asyncio
+    async def test_voice_full(self, runner):
+        event = _make_event("/voice full")
+        adapter = SimpleNamespace(_auto_tts_disabled_chats=set())
+        runner.adapters[event.source.platform] = adapter
+        with patch("hermes_cli.config.set_config_value") as mock_set:
+            result = await runner._handle_voice_command(event)
+        mock_set.assert_called_once_with("tts.mode", "full", quiet=True)
+        assert runner._voice_mode["123"] == "all"
+        assert "full" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_voice_summary(self, runner):
+        event = _make_event("/voice summary")
+        adapter = SimpleNamespace(_auto_tts_disabled_chats=set())
+        runner.adapters[event.source.platform] = adapter
+        with patch("hermes_cli.config.set_config_value") as mock_set:
+            result = await runner._handle_voice_command(event)
+        mock_set.assert_called_once_with("tts.mode", "summary", quiet=True)
+        assert runner._voice_mode["123"] == "all"
+        assert "summary" in result.lower()
+
+    @pytest.mark.asyncio
     async def test_voice_status_off(self, runner):
         event = _make_event("/voice status")
-        result = await runner._handle_voice_command(event)
+        with patch.object(runner, "_get_global_voice_tts_mode", return_value="full"):
+            result = await runner._handle_voice_command(event)
         assert "off" in result.lower()
+        assert "speech mode: full" in result.lower()
 
     @pytest.mark.asyncio
     async def test_voice_status_on(self, runner):
         runner._voice_mode["123"] = "voice_only"
         event = _make_event("/voice status")
-        result = await runner._handle_voice_command(event)
+        with patch.object(runner, "_get_global_voice_tts_mode", return_value="summary"):
+            result = await runner._handle_voice_command(event)
         assert "voice reply" in result.lower()
+        assert "speech mode: summary" in result.lower()
 
     @pytest.mark.asyncio
     async def test_toggle_off_to_on(self, runner):
@@ -354,8 +380,8 @@ class TestSendVoiceReply:
 
         tts_result = json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
 
-        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result), \
-             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+        with patch("tools.tts_tool.prepare_text_for_auto_tts", return_value="Hello world"), \
+             patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result), \
              patch("os.path.isfile", return_value=True), \
              patch("os.unlink"), \
              patch("os.makedirs"):
@@ -370,7 +396,7 @@ class TestSendVoiceReply:
         event = _make_event()
 
         with patch("tools.tts_tool.text_to_speech_tool") as mock_tts, \
-             patch("tools.tts_tool._strip_markdown_for_tts", return_value=""):
+             patch("tools.tts_tool.prepare_text_for_auto_tts", return_value=""):
             await runner._send_voice_reply(event, "```code only```")
 
         mock_tts.assert_not_called()
@@ -382,8 +408,8 @@ class TestSendVoiceReply:
         runner.adapters[event.source.platform] = mock_adapter
         tts_result = json.dumps({"success": False, "error": "API error"})
 
-        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result), \
-             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+        with patch("tools.tts_tool.prepare_text_for_auto_tts", return_value="Hello"), \
+             patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result), \
              patch("os.path.isfile", return_value=False), \
              patch("os.makedirs"):
             await runner._send_voice_reply(event, "Hello")
@@ -393,11 +419,29 @@ class TestSendVoiceReply:
     @pytest.mark.asyncio
     async def test_exception_caught(self, runner):
         event = _make_event()
-        with patch("tools.tts_tool.text_to_speech_tool", side_effect=RuntimeError("boom")), \
-             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+        with patch("tools.tts_tool.prepare_text_for_auto_tts", return_value="Hello"), \
+             patch("tools.tts_tool.text_to_speech_tool", side_effect=RuntimeError("boom")), \
              patch("os.makedirs"):
             # Should not raise
             await runner._send_voice_reply(event, "Hello")
+
+    @pytest.mark.asyncio
+    async def test_summary_preparation_feeds_tts_text(self, runner):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_voice = AsyncMock()
+        event = _make_event()
+        runner.adapters[event.source.platform] = mock_adapter
+        tts_result = json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
+
+        with patch("tools.tts_tool.prepare_text_for_auto_tts", return_value="Short summary") as mock_prepare, \
+             patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result) as mock_tts, \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            await runner._send_voice_reply(event, "Long detailed response")
+
+        mock_prepare.assert_called_once_with("Long detailed response")
+        assert mock_tts.call_args.kwargs["text"] == "Short summary"
 
 
 # =====================================================================

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -39,10 +39,10 @@ def _make_voice_cli(**overrides):
 
 
 # ============================================================================
-# Markdown stripping — import real function from tts_tool
+# Markdown stripping / auto-TTS prep — import real helpers from tts_tool
 # ============================================================================
 
-from tools.tts_tool import _strip_markdown_for_tts
+from tools.tts_tool import _get_tts_mode, _strip_markdown_for_tts, prepare_text_for_auto_tts
 
 
 class TestMarkdownStripping:
@@ -124,6 +124,50 @@ class TestMarkdownStripping:
 
 
 # ============================================================================
+# Auto-TTS preparation
+# ============================================================================
+
+class TestAutoTtsPreparation:
+    def test_mode_defaults_to_full(self):
+        assert _get_tts_mode({}) == "full"
+        assert _get_tts_mode({"mode": "summary"}) == "summary"
+        assert _get_tts_mode({"mode": "weird"}) == "full"
+
+    def test_prepare_text_full_mode_strips_reasoning_tags(self):
+        result = prepare_text_for_auto_tts(
+            "## Title\n<think>hidden</think>**bold** and `code`",
+            tts_config={"mode": "full"},
+        )
+        assert result == "Title bold and code"
+
+    def test_prepare_text_summary_mode_uses_summary_model(self):
+        mock_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="Short spoken summary."))]
+        )
+
+        with patch("agent.auxiliary_client.call_llm", return_value=mock_response) as mock_call:
+            result = prepare_text_for_auto_tts(
+                "## Title\nA much longer assistant response that should be summarized.",
+                tts_config={"mode": "summary", "summary": {"length": "1 sentence"}},
+            )
+
+        assert result == "Short spoken summary."
+        assert mock_call.call_args.kwargs["task"] == "compression"
+        assert "1 sentence" in mock_call.call_args.kwargs["messages"][1]["content"]
+
+    def test_prepare_text_summary_mode_falls_back_on_error(self):
+        text = " ".join(f"word{i}" for i in range(60))
+
+        with patch("agent.auxiliary_client.call_llm", side_effect=RuntimeError("boom")):
+            result = prepare_text_for_auto_tts(
+                text,
+                tts_config={"mode": "summary"},
+            )
+
+        assert result == " ".join(f"word{i}" for i in range(40))
+
+
+# ============================================================================
 # Voice command parsing
 # ============================================================================
 
@@ -136,6 +180,8 @@ class TestVoiceCommandParsing:
             ("/voice on", "on"),
             ("/voice off", "off"),
             ("/voice tts", "tts"),
+            ("/voice full", "full"),
+            ("/voice summary", "summary"),
             ("/voice status", "status"),
             ("/voice", ""),
             ("/voice  ON  ", "on"),
@@ -277,6 +323,32 @@ class TestStreamingTTSActivation:
                 )
                 cfg = load_cfg()
                 if get_prov(cfg) == "elevenlabs":
+                    import_el()
+                    import_sd()
+                    use_streaming_tts = True
+            except (ImportError, OSError):
+                pass
+
+        assert use_streaming_tts is False
+
+    def test_does_not_activate_when_tts_mode_is_summary(self):
+        """Streaming TTS is disabled when auto-TTS is in summary mode."""
+        use_streaming_tts = False
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "elevenlabs", "mode": "summary"}), \
+             patch("tools.tts_tool._get_provider", return_value="elevenlabs"), \
+             patch("tools.tts_tool._get_tts_mode", return_value="summary"), \
+             patch("tools.tts_tool._import_elevenlabs", return_value=MagicMock()), \
+             patch("tools.tts_tool._import_sounddevice", return_value=MagicMock()):
+            try:
+                from tools.tts_tool import (
+                    _get_tts_mode as get_mode,
+                    _load_tts_config as load_cfg,
+                    _get_provider as get_prov,
+                    _import_elevenlabs as import_el,
+                    _import_sounddevice as import_sd,
+                )
+                cfg = load_cfg()
+                if get_prov(cfg) == "elevenlabs" and get_mode(cfg) == "full":
                     import_el()
                     import_sd()
                     use_streaming_tts = True
@@ -807,6 +879,7 @@ class TestHandleVoiceCommandReal:
         cli._enable_voice_mode = MagicMock()
         cli._disable_voice_mode = MagicMock()
         cli._toggle_voice_tts = MagicMock()
+        cli._set_voice_tts_mode = MagicMock()
         cli._show_voice_status = MagicMock()
         return cli
 
@@ -835,6 +908,18 @@ class TestHandleVoiceCommandReal:
         cli._show_voice_status.assert_called_once()
 
     @patch("cli._cprint")
+    def test_full_calls_set_mode(self, _cp):
+        cli = self._cli()
+        cli._handle_voice_command("/voice full")
+        cli._set_voice_tts_mode.assert_called_once_with("full")
+
+    @patch("cli._cprint")
+    def test_summary_calls_set_mode(self, _cp):
+        cli = self._cli()
+        cli._handle_voice_command("/voice summary")
+        cli._set_voice_tts_mode.assert_called_once_with("summary")
+
+    @patch("cli._cprint")
     def test_toggle_off_when_enabled(self, _cp):
         cli = self._cli()
         cli._voice_mode = True
@@ -857,6 +942,46 @@ class TestHandleVoiceCommandReal:
         # Should print usage via _cprint
         assert any("Unknown" in str(c) or "unknown" in str(c)
                     for c in mock_cp.call_args_list)
+
+
+class TestVoiceTtsModePersistence:
+    @patch("cli._cprint")
+    def test_set_voice_tts_mode_summary_saves_config(self, mock_cp):
+        cli = _make_voice_cli(_voice_mode=True)
+        with patch("hermes_cli.config.set_config_value") as mock_set, \
+             patch("tools.tts_tool.check_tts_requirements", return_value=True):
+            cli._set_voice_tts_mode("summary")
+
+        mock_set.assert_called_once_with("tts.mode", "summary", quiet=True)
+        assert cli._voice_tts is True
+        assert any("summary" in str(call) for call in mock_cp.call_args_list)
+
+    @patch("cli._cprint")
+    def test_set_voice_tts_mode_full_saves_config(self, mock_cp):
+        cli = _make_voice_cli(_voice_mode=True)
+        with patch("hermes_cli.config.set_config_value") as mock_set, \
+             patch("tools.tts_tool.check_tts_requirements", return_value=True):
+            cli._set_voice_tts_mode("full")
+
+        mock_set.assert_called_once_with("tts.mode", "full", quiet=True)
+        assert cli._voice_tts is True
+        assert any("full" in str(call) for call in mock_cp.call_args_list)
+
+    @patch("cli._cprint")
+    def test_set_voice_tts_mode_enables_voice_mode_when_needed(self, _cp):
+        cli = _make_voice_cli(_voice_mode=False)
+
+        def enable():
+            cli._voice_mode = True
+
+        cli._enable_voice_mode = MagicMock(side_effect=enable)
+        with patch("hermes_cli.config.set_config_value") as mock_set, \
+             patch("tools.tts_tool.check_tts_requirements", return_value=True):
+            cli._set_voice_tts_mode("summary")
+
+        cli._enable_voice_mode.assert_called_once()
+        mock_set.assert_called_once_with("tts.mode", "summary", quiet=True)
+        assert cli._voice_tts is True
 
 
 class TestEnableVoiceModeReal:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -74,6 +74,8 @@ DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OUTPUT_DIR = str(Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "audio_cache")
+DEFAULT_TTS_MODE = "full"
+DEFAULT_TTS_SUMMARY_LENGTH = "2 sentences"
 MAX_TEXT_LENGTH = 4000
 
 
@@ -564,6 +566,11 @@ _MD_HEADER = re.compile(r'^#+\s*', flags=re.MULTILINE)
 _MD_LIST_ITEM = re.compile(r'^\s*[-*]\s+', flags=re.MULTILINE)
 _MD_HR = re.compile(r'---+')
 _MD_EXCESS_NL = re.compile(r'\n{3,}')
+_THINK_BLOCK_RE = re.compile(r'<think[\s>].*?</think>', flags=re.IGNORECASE | re.DOTALL)
+_REFLECTION_BLOCK_RE = re.compile(r'<reflection[\s>].*?</reflection>', flags=re.IGNORECASE | re.DOTALL)
+_THINK_TAG_RE = re.compile(r'</?think[^>]*>', flags=re.IGNORECASE)
+_REFLECTION_TAG_RE = re.compile(r'</?reflection[^>]*>', flags=re.IGNORECASE)
+_WHITESPACE_RE = re.compile(r'\s+')
 
 
 def _strip_markdown_for_tts(text: str) -> str:
@@ -579,6 +586,144 @@ def _strip_markdown_for_tts(text: str) -> str:
     text = _MD_HR.sub('', text)
     text = _MD_EXCESS_NL.sub('\n\n', text)
     return text.strip()
+
+
+def _strip_reasoning_tags_for_tts(text: str) -> str:
+    """Remove thinking/reflection tags that should never be spoken aloud."""
+    text = _THINK_BLOCK_RE.sub(' ', text)
+    text = _REFLECTION_BLOCK_RE.sub(' ', text)
+    text = _THINK_TAG_RE.sub(' ', text)
+    text = _REFLECTION_TAG_RE.sub(' ', text)
+    return text
+
+
+def _normalize_tts_text(text: str) -> str:
+    """Collapse whitespace for smoother speech synthesis."""
+    return _WHITESPACE_RE.sub(' ', text).strip()
+
+
+def _get_tts_mode(tts_config: Optional[Dict[str, Any]] = None) -> str:
+    """Return the configured auto-TTS mode."""
+    cfg = tts_config if tts_config is not None else _load_tts_config()
+    mode = str(cfg.get("mode", DEFAULT_TTS_MODE)).strip().lower()
+    return mode if mode in {"full", "summary"} else DEFAULT_TTS_MODE
+
+
+def _get_tts_summary_config(tts_config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return normalized summary config for auto-TTS."""
+    cfg = tts_config if tts_config is not None else _load_tts_config()
+    summary = cfg.get("summary", {})
+    if not isinstance(summary, dict):
+        summary = {}
+    return summary
+
+
+def _fallback_summary_for_tts(text: str) -> str:
+    """Best-effort summary when the configured summary model is unavailable."""
+    return " ".join(_normalize_tts_text(text).split()[:40]).strip()
+
+
+def _extract_llm_message_text(response: Any) -> str:
+    """Extract plain text content from an OpenAI-compatible chat response."""
+    try:
+        message = response.choices[0].message
+    except (AttributeError, IndexError, KeyError, TypeError):
+        return ""
+
+    content = getattr(message, "content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "text":
+                    parts.append(item.get("text", ""))
+            else:
+                item_type = getattr(item, "type", None)
+                if item_type == "text":
+                    parts.append(getattr(item, "text", ""))
+        return " ".join(p for p in parts if p)
+    return str(content or "")
+
+
+def _summarize_text_for_auto_tts(
+    text: str,
+    tts_config: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Summarize assistant text for spoken playback, with safe fallback."""
+    cleaned = _normalize_tts_text(text)
+    if not cleaned:
+        return ""
+
+    summary_cfg = _get_tts_summary_config(tts_config)
+    summary_length = str(summary_cfg.get("length", DEFAULT_TTS_SUMMARY_LENGTH)).strip()
+    if not summary_length:
+        summary_length = DEFAULT_TTS_SUMMARY_LENGTH
+
+    prompt = "\n".join([
+        f"Summarize the following assistant response as spoken audio copy in {summary_length}.",
+        "Keep concrete facts, decisions, and next actions.",
+        "Do not mention that this is a summary.",
+        "Paraphrase instead of copying the opening words when possible.",
+        "Never output chain-of-thought, think tags, reflection tags, or XML-like tags.",
+        "Do not use bullets, numbering, markdown, or preamble.",
+        "",
+        cleaned,
+    ])
+
+    try:
+        from agent.auxiliary_client import call_llm
+
+        response = call_llm(
+            task="compression",
+            provider=str(summary_cfg.get("provider", "")).strip() or None,
+            model=str(summary_cfg.get("model", "")).strip() or None,
+            base_url=str(summary_cfg.get("base_url", "")).strip() or None,
+            api_key=str(summary_cfg.get("api_key", "")).strip() or None,
+            messages=[
+                {"role": "system", "content": "You are a compression model. Reply with plain text only."},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.2,
+            max_tokens=200,
+            timeout=30.0,
+        )
+        summary = _normalize_tts_text(
+            _strip_reasoning_tags_for_tts(_extract_llm_message_text(response))
+        )
+        if summary:
+            return summary
+        raise RuntimeError("summary model returned no text")
+    except Exception as exc:
+        logger.warning("TTS summarization failed, falling back to a short excerpt: %s", exc)
+        return _fallback_summary_for_tts(cleaned)
+
+
+def prepare_text_for_auto_tts(
+    text: str,
+    tts_config: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Prepare assistant text for auto-TTS playback.
+
+    This helper powers voice-mode playback and gateway auto-replies. It keeps
+    the explicit text_to_speech tool behavior unchanged, while allowing
+    config-driven summary mode for automatic spoken responses.
+    """
+    cfg = tts_config if tts_config is not None else _load_tts_config()
+    cleaned = _normalize_tts_text(
+        _strip_reasoning_tags_for_tts(_strip_markdown_for_tts(text or ""))
+    )
+    if not cleaned:
+        return ""
+
+    if _get_tts_mode(cfg) == "summary":
+        summary = _summarize_text_for_auto_tts(cleaned, cfg)
+        return summary[:MAX_TEXT_LENGTH].strip()
+
+    if len(cleaned) > MAX_TEXT_LENGTH:
+        cleaned = cleaned[:MAX_TEXT_LENGTH]
+    return cleaned
 
 
 def stream_tts_to_speaker(

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -49,7 +49,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/verbose` | Cycle tool progress display: off → new → all → verbose |
 | `/reasoning` | Manage reasoning effort and display (usage: /reasoning [level\|show\|hide]) |
 | `/skin` | Show or change the display skin/theme |
-| `/voice [on\|off\|tts\|status]` | Toggle CLI voice mode and spoken playback. Recording uses `voice.record_key` (default: `Ctrl+B`). |
+| `/voice [on\|off\|tts\|full\|summary\|status]` | Toggle CLI voice mode and spoken playback. `full` and `summary` enable spoken replies in the selected style. Recording uses `voice.record_key` (default: `Ctrl+B`). |
 
 ### Tools & Skills
 
@@ -112,7 +112,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/usage` | Show token usage, estimated cost breakdown (input/output), context window state, and session duration. |
 | `/insights [days]` | Show usage analytics. |
 | `/reasoning [level\|show\|hide]` | Change reasoning effort or toggle reasoning display. |
-| `/voice [on\|off\|tts\|join\|channel\|leave\|status]` | Control spoken replies in chat. `join`/`channel`/`leave` manage Discord voice-channel mode. |
+| `/voice [on\|off\|tts\|full\|summary\|join\|channel\|leave\|status]` | Control spoken replies in chat. `full` and `summary` enable spoken replies in the selected style. `join`/`channel`/`leave` manage Discord voice-channel mode. |
 | `/rollback [number]` | List or restore filesystem checkpoints. |
 | `/background <prompt>` | Run a prompt in a separate background session. Results are delivered back to the same chat when the task finishes. See [Messaging Background Sessions](/docs/user-guide/messaging/#background-sessions). |
 | `/plan [request]` | Load the bundled `plan` skill to write a markdown plan instead of executing the work. Plans are saved under `.hermes/plans/` relative to the active workspace/backend working directory. |

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -112,6 +112,8 @@ Common examples:
 | `/skin` | Show or switch the active CLI skin |
 | `/voice on` | Enable CLI voice mode (press `Ctrl+B` to record) |
 | `/voice tts` | Toggle spoken playback for Hermes replies |
+| `/voice full` | Enable spoken replies and read them in full |
+| `/voice summary` | Enable spoken replies and summarize them before speaking |
 | `/reasoning high` | Increase reasoning effort |
 | `/title My Session` | Name the current session |
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1139,7 +1139,14 @@ You can also change the reasoning effort at runtime with the `/reasoning` comman
 
 ```yaml
 tts:
+  mode: "full"                  # "full" | "summary" for automatic spoken replies
   provider: "edge"              # "edge" | "elevenlabs" | "openai" | "neutts"
+  summary:
+    length: "2 sentences"       # target spoken summary length in summary mode
+    provider: ""                # optional override just for TTS summarization
+    model: ""                   # optional override just for TTS summarization
+    base_url: ""                # optional direct OpenAI-compatible summary endpoint
+    api_key: ""                 # optional API key for summary.base_url
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
   elevenlabs:
@@ -1157,6 +1164,7 @@ tts:
 ```
 
 This controls both the `text_to_speech` tool and spoken replies in voice mode (`/voice tts` in the CLI or messaging gateway).
+`tts.summary.*` is dedicated to auto-spoken reply summarization; if left blank, Hermes falls back to the compression summary routing.
 
 ## Display Settings
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1142,7 +1142,7 @@ tts:
   mode: "full"                  # "full" | "summary" for automatic spoken replies
   provider: "edge"              # "edge" | "elevenlabs" | "openai" | "neutts"
   summary:
-    length: "2 sentences"       # target spoken summary length in summary mode
+    length: "1 sentence"        # target spoken summary length in summary mode
     provider: ""                # optional override just for TTS summarization
     model: ""                   # optional override just for TTS summarization
     base_url: ""                # optional direct OpenAI-compatible summary endpoint
@@ -1165,6 +1165,7 @@ tts:
 
 This controls both the `text_to_speech` tool and spoken replies in voice mode (`/voice tts` in the CLI or messaging gateway).
 `tts.summary.*` is dedicated to auto-spoken reply summarization; if left blank, Hermes falls back to the compression summary routing.
+`tts.summary.length` accepts natural-language targets such as `1 sentence`, `8 words`, or `about 10 words`.
 
 ## Display Settings
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -33,7 +33,14 @@ Convert text to speech with four providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
+  mode: "full"                  # "full" | "summary" for auto-spoken assistant replies
   provider: "edge"              # "edge" | "elevenlabs" | "openai" | "neutts"
+  summary:
+    length: "2 sentences"       # target length when mode="summary"
+    provider: ""                # optional: override summary provider
+    model: ""                   # optional: override summary model
+    base_url: ""                # optional: direct OpenAI-compatible summary endpoint
+    api_key: ""                 # optional: API key for summary.base_url
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
   elevenlabs:
@@ -49,6 +56,8 @@ tts:
     model: neuphonic/neutts-air-q4-gguf
     device: cpu
 ```
+
+When `tts.mode` is set to `summary`, Hermes compresses auto-spoken assistant replies into short spoken copy before synthesis. `tts.summary.*` is its own config surface for TTS; if you leave those fields blank, Hermes falls back to the compression summary routing as a convenience.
 
 ### Telegram Voice Bubbles & ffmpeg
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -36,7 +36,7 @@ tts:
   mode: "full"                  # "full" | "summary" for auto-spoken assistant replies
   provider: "edge"              # "edge" | "elevenlabs" | "openai" | "neutts"
   summary:
-    length: "2 sentences"       # target length when mode="summary"
+    length: "1 sentence"        # target length when mode="summary"
     provider: ""                # optional: override summary provider
     model: ""                   # optional: override summary model
     base_url: ""                # optional: direct OpenAI-compatible summary endpoint
@@ -57,7 +57,18 @@ tts:
     device: cpu
 ```
 
-When `tts.mode` is set to `summary`, Hermes compresses auto-spoken assistant replies into short spoken copy before synthesis. `tts.summary.*` is its own config surface for TTS; if you leave those fields blank, Hermes falls back to the compression summary routing as a convenience.
+### How Summary Mode Works
+
+Automatic spoken replies go through a small prep step before audio generation:
+
+1. Hermes finishes generating the normal text reply.
+2. It strips markdown, tags, and other text that does not sound good when read aloud.
+3. If `tts.mode` is `summary`, Hermes asks a summarizer to rewrite that reply to the target length from `tts.summary.length`.
+4. The cleaned full reply or cleaned summary is sent to the configured TTS provider.
+
+`tts.summary.*` is its own config surface for TTS. If you leave `provider`, `model`, `base_url`, and `api_key` blank, Hermes falls back to the compression summary routing as a convenience.
+
+`tts.summary.length` is natural-language guidance, so values like `1 sentence`, `8 words`, `about 12 words`, or `3 short sentences` all work.
 
 ### Telegram Voice Bubbles & ffmpeg
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -120,6 +120,8 @@ Then use these commands inside the CLI:
 /voice on       Enable voice mode
 /voice off      Disable voice mode
 /voice tts      Toggle TTS output
+/voice full     Enable spoken replies and speak them in full
+/voice summary  Enable spoken replies and speak summarized versions
 /voice status   Show current state
 ```
 
@@ -153,7 +155,7 @@ Both `silence_threshold` and `silence_duration` are configurable in `config.yaml
 
 ### Streaming TTS
 
-When TTS is enabled, the agent speaks its reply **sentence-by-sentence** as it generates text — you don't wait for the full response:
+When TTS is enabled in `tts.mode: "full"` with the ElevenLabs provider, the agent speaks its reply **sentence-by-sentence** as it generates text — you don't wait for the full response:
 
 1. Buffers text deltas into complete sentences (min 20 chars)
 2. Strips markdown formatting and `<think>` blocks
@@ -210,6 +212,8 @@ These work in both Telegram and Discord (DMs and text channels):
 /voice          Toggle voice mode on/off
 /voice on       Voice replies only when you send a voice message
 /voice tts      Voice replies for ALL messages
+/voice full     Enable spoken replies and use full responses
+/voice summary  Enable spoken replies and use summarized responses
 /voice off      Disable voice replies
 /voice status   Show current setting
 ```
@@ -395,7 +399,14 @@ stt:
 
 # Text-to-Speech
 tts:
+  mode: "full"                    # "full" | "summary" for auto-spoken assistant replies
   provider: "edge"                 # "edge" (free) | "elevenlabs" | "openai" | "neutts"
+  summary:
+    length: "2 sentences"          # target length when mode="summary"
+    provider: ""                   # optional override for summary routing
+    model: ""
+    base_url: ""
+    api_key: ""
   edge:
     voice: "en-US-AriaNeural"      # 322 voices, 74 languages
   elevenlabs:
@@ -411,6 +422,8 @@ tts:
     model: neuphonic/neutts-air-q4-gguf
     device: cpu
 ```
+
+`tts.mode: "summary"` makes Hermes speak a short summary for automatic voice replies instead of reading the full response verbatim. The `tts.summary.*` block is specific to TTS and only falls back to compression summary routing if you leave it blank. Streaming sentence-by-sentence playback stays enabled only in `full` mode.
 
 ### Environment Variables
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -402,7 +402,7 @@ tts:
   mode: "full"                    # "full" | "summary" for auto-spoken assistant replies
   provider: "edge"                 # "edge" (free) | "elevenlabs" | "openai" | "neutts"
   summary:
-    length: "2 sentences"          # target length when mode="summary"
+    length: "1 sentence"           # target length when mode="summary"
     provider: ""                   # optional override for summary routing
     model: ""
     base_url: ""
@@ -423,7 +423,9 @@ tts:
     device: cpu
 ```
 
-`tts.mode: "summary"` makes Hermes speak a short summary for automatic voice replies instead of reading the full response verbatim. The `tts.summary.*` block is specific to TTS and only falls back to compression summary routing if you leave it blank. Streaming sentence-by-sentence playback stays enabled only in `full` mode.
+`tts.mode: "summary"` makes Hermes speak a short summary for automatic voice replies instead of reading the full response verbatim. Hermes first cleans the assistant text for speech, then optionally summarizes it, then sends that result to the configured TTS provider.
+
+Use `tts.summary.length` to control how short it should be. This is free-form guidance rather than a strict enum, so `1 sentence`, `8 words`, or `about 10 words` are all valid. The `tts.summary.*` block is specific to TTS and only falls back to compression summary routing if you leave it blank. Streaming sentence-by-sentence playback stays enabled only in `full` mode.
 
 ### Environment Variables
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -99,7 +99,7 @@ hermes gateway status --system         # Linux only: inspect the system service 
 | `/usage` | Show token usage for this session |
 | `/insights [days]` | Show usage insights and analytics |
 | `/reasoning [level\|show\|hide]` | Change reasoning effort or toggle reasoning display |
-| `/voice [on\|off\|tts\|join\|leave\|status]` | Control messaging voice replies and Discord voice-channel behavior |
+| `/voice [on\|off\|tts\|full\|summary\|join\|leave\|status]` | Control messaging voice replies, enable full/summary spoken reply styles, and Discord voice-channel behavior |
 | `/rollback [number]` | List or restore filesystem checkpoints |
 | `/background <prompt>` | Run a prompt in a separate background session |
 | `/reload-mcp` | Reload MCP servers from config |


### PR DESCRIPTION
## What does this PR do?

Adds a summary mode for automatic spoken replies so Hermes can speak either the full assistant response or a short spoken summary, with runtime `/voice full` and `/voice summary` toggles in both CLI and gateway flows.

While testing the new voice flow, this also hardens skill prompt building so malformed skill frontmatter with `metadata: null` or `metadata.hermes: null` does not crash prompt assembly.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `tts.mode` (`full` / `summary`) and `tts.summary.*` config for automatic spoken replies.
- Add shared TTS text preparation and optional summary generation in `tools/tts_tool.py`.
- Wire CLI voice playback and gateway auto voice replies through the shared full/summary path.
- Add `/voice full` and `/voice summary` commands and make them enable spoken replies immediately.
- Update CLI, gateway, and user/reference docs for the new voice commands and config keys.
- Update `cli-config.yaml.example` and configuration docs to include the new TTS settings.
- Harden `agent/prompt_builder.py` against null `metadata` / `metadata.hermes` in skill frontmatter.
- Add regression coverage for the new TTS modes and null skill metadata handling.

## How to Test

1. In the CLI, run `/voice summary` and confirm `/voice status` shows `TTS: ON` and `Speech: SUMMARY`.
2. Run `/voice full` and confirm `/voice status` shows `TTS: ON` and `Speech: FULL`.
3. Verify the focused regression suites:
   - `/Users/stefano/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/tools/test_voice_cli_integration.py`
   - `/Users/stefano/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/gateway/test_voice_command.py`
   - `/Users/stefano/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/agent/test_prompt_builder.py -k 'read_skill_conditions or null_metadata or BuildSkillsSystemPromptConditional'`
4. Optional broader check:
   - `/Users/stefano/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q --ignore=tests/integration --tb=short -n auto`
   - At the time of this PR, that broader run still reports 8 failures that are not introduced here. One of them, `tests/agent/test_prompt_builder.py::TestBuildContextFilesPrompt::test_claude_md_uppercase_takes_priority`, reproduces on plain `origin/main` as well.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test results:

- `tests/tools/test_voice_cli_integration.py`: `89 passed`
- `tests/gateway/test_voice_command.py`: `171 passed`
- `tests/agent/test_prompt_builder.py -k 'read_skill_conditions or null_metadata or BuildSkillsSystemPromptConditional'`: `8 passed`

Broader non-integration suite result:

- `6203 passed, 163 skipped, 8 failed`
- Existing failures observed during this run:
  - `tests/agent/test_prompt_builder.py::TestBuildContextFilesPrompt::test_claude_md_uppercase_takes_priority`
  - `tests/tools/test_transcription.py::TestGetProvider::test_explicit_local_no_cloud_fallback`
  - `tests/tools/test_transcription.py::TestGetProvider::test_local_nothing_available`
  - `tests/tools/test_transcription_tools.py::TestExplicitProviderRespected::test_auto_detect_still_falls_back_to_cloud`
  - `tests/tools/test_transcription_tools.py::TestGetProviderFallbackPriority::test_auto_detect_prefers_groq_over_openai`
  - `tests/tools/test_transcription_tools.py::TestExplicitProviderRespected::test_explicit_local_no_fallback_to_openai`
  - `tests/tools/test_transcription_tools.py::TestExplicitProviderRespected::test_auto_detect_prefers_groq_over_openai`
  - `tests/tools/test_transcription_tools.py::TestExplicitProviderRespected::test_explicit_local_no_fallback_to_groq`
