### PR TITLE
fix(security): browser redirect SSRF bypass + explicit URL scheme whitelist

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1052,7 +1052,21 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         data = result.get("data", {})
         title = data.get("title", "")
         final_url = data.get("url", url)
-        
+
+        # Re-validate final URL after redirects — Chromium follows redirects
+        # internally, so a public URL can 302 to a private/internal address.
+        if final_url and final_url != url and not _is_safe_url(final_url):
+            logger.warning("Navigation to %s redirected to blocked URL: %s", url, final_url)
+            # Close the session to prevent further interaction with the internal page
+            try:
+                _run_browser_command(effective_task_id, "close", [])
+            except Exception:
+                pass
+            return json.dumps({
+                "success": False,
+                "error": f"Blocked: navigation redirected to a private/internal address",
+            })
+
         response = {
             "success": True,
             "url": final_url,

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -70,6 +70,11 @@ try:
     from tools.website_policy import check_website_access
 except Exception:
     check_website_access = lambda url: None  # noqa: E731 — fail-open if policy module unavailable
+
+try:
+    from tools.url_safety import is_safe_url as _is_safe_url
+except Exception:
+    _is_safe_url = lambda url: True  # noqa: E731 — fail-open if safety module unavailable
 from tools.browser_providers.base import CloudBrowserProvider
 from tools.browser_providers.browserbase import BrowserbaseProvider
 from tools.browser_providers.browser_use import BrowserUseProvider

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -55,6 +55,12 @@ def is_safe_url(url: str) -> bool:
     """
     try:
         parsed = urlparse(url)
+
+        # Explicitly allow only http and https — block javascript:, data:, file:, etc.
+        if parsed.scheme not in ("http", "https"):
+            logger.warning("Blocked request — unsupported URL scheme: %s", parsed.scheme)
+            return False
+
         hostname = (parsed.hostname or "").strip().lower()
         if not hostname:
             return False


### PR DESCRIPTION
## Summary

Two related SSRF hardening fixes for the browser and URL safety modules:

### 1. Post-navigation redirect validation (CRITICAL)

`browser_navigate()` validated the initial URL with `is_safe_url()` but Chromium follows HTTP redirects internally. An attacker-controlled URL like `https://evil.com` that 302-redirects to `http://169.254.169.254/latest/meta-data/` bypassed the pre-flight SSRF check.

Now the final URL returned by Chromium is re-validated after navigation. If the redirect target is a private/internal address, the browser session is closed and an error is returned.

`web_tools` and `vision_tools` already had redirect protection (httpx event hooks). The browser tool was the only one missing it because agent-browser is a subprocess — CDP doesn't expose redirect events, so post-navigation validation is the correct approach.

### 2. Explicit URL scheme whitelist (HIGH)

`is_safe_url()` in `url_safety.py` blocked `javascript:`, `data:`, `file://` URLs by accident — they had no hostname, so the hostname check returned `False`. This was fragile — if the hostname check logic ever changed, these dangerous schemes could slip through.

Added explicit `parsed.scheme not in ("http", "https")` check before hostname resolution. Now unsupported schemes are rejected with a clear log message.

## Test plan

- [x] Scheme validation: javascript, data, file, ftp all blocked; http/https allowed
- [x] SSRF: localhost, 169.254.169.254, 192.168.x.x all blocked
- [x] `tests/tools/test_url_safety.py` — all passed
- [x] `tests/tools/test_website_policy.py` — 22/22 passed
- [x] `tests/tools/test_browser_cdp_override.py` — 4/4 passed
- [x] `tests/tools/test_vision_tools.py` — all passed
- [x] Total: 120/120 passed