### PR TITLE
fix(cli): prevent shell injection in quick_commands exec type

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3840,11 +3840,16 @@ class HermesCLI:
                 qcmd = quick_commands[base_cmd.lstrip("/")]
                 if qcmd.get("type") == "exec":
                     import subprocess
+                    import shlex
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            # Parse into a list to avoid shell=True injection risk.
+                            # shell=True would allow a malicious config entry to run
+                            # arbitrary shell constructs (&&, |, $(...), etc.).
+                            exec_args = shlex.split(exec_cmd)
                             result = subprocess.run(
-                                exec_cmd, shell=True, capture_output=True,
+                                exec_args, shell=False, capture_output=True,
                                 text=True, timeout=30
                             )
                             output = result.stdout.strip() or result.stderr.strip()
@@ -3854,6 +3859,8 @@ class HermesCLI:
                                 self.console.print("[dim]Command returned no output[/]")
                         except subprocess.TimeoutExpired:
                             self.console.print("[bold red]Quick command timed out (30s)[/]")
+                        except ValueError as e:
+                            self.console.print(f"[bold red]Quick command parse error: {e}[/]")
                         except Exception as e:
                             self.console.print(f"[bold red]Quick command error: {e}[/]")
                     else:


### PR DESCRIPTION
## Summary

- `quick_commands` of type `exec` in `config.yaml` were executed with `shell=True`, allowing shell metacharacters (`&&`, `|`, `$(...)`, backticks) to be interpreted by the shell. A malicious or compromised config entry could run arbitrary commands beyond the intended one.
- Switched to `shlex.split()` + `shell=False` so the command is parsed into an argument list and passed directly to the OS — no shell involved, metacharacters are treated as literal arguments.
- Added a `ValueError` handler to surface unterminated-quote parse errors clearly.

**Before:**
```python
subprocess.run(exec_cmd, shell=True, ...)
