### PR TITLE
docs(website): add post-update validation guidance

### DIFF
--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -20,6 +20,34 @@ This pulls the latest code, updates dependencies, and prompts you to configure a
 `hermes update` automatically detects new configuration options and prompts you to add them. If you skipped that prompt, you can manually run `hermes config check` to see missing options, then `hermes config migrate` to interactively add them.
 :::
 
+### Recommended Post-Update Validation
+
+`hermes update` handles the main update path, but it does not run a full last-mile smoke test for your local environment. After updating, run this short validation flow:
+
+1. `hermes update`
+2. `git status --short`
+3. If the tree is unexpectedly dirty, inspect that before doing anything else.
+4. `hermes doctor`
+5. `hermes --version` or `python run_agent.py --help`
+6. If you use the gateway: `hermes gateway status`
+7. If you use WhatsApp: pay attention to bridge-specific `doctor` output
+8. If `doctor` reports high/critical npm issues: run `npm audit fix` in the flagged directory
+9. If the update touched submodules, or behavior still seems off: `git submodule update --init --recursive`
+
+:::warning Dirty working tree after update
+If `git status --short` shows unexpected changes after `hermes update`, stop and inspect them before continuing. This usually means either local changes were reapplied on top of the updated codebase, or a dependency step refreshed generated files such as lockfiles.
+:::
+
+### Important Caveats
+
+- `hermes update` updates the main repo and reinstalls dependencies, but it does not currently refresh Git submodules. If upstream changes submodule SHAs, run:
+
+  ```bash
+  git submodule update --init --recursive
+  ```
+
+- `hermes update` runs `npm install` for the repo root. If you use WhatsApp, note that the installers also manage the separate `scripts/whatsapp-bridge` Node environment. `hermes doctor` audits both locations, which is why it belongs in the standard post-update flow.
+
 ### Updating from Messaging Platforms
 
 You can also update directly from Telegram, Discord, Slack, or WhatsApp by sending:


### PR DESCRIPTION
## What does this PR do?

Adds a short post-update validation section to the updating docs so users can verify that `hermes update` actually converged in their local environment.

This documents a few practical gaps that are easy to miss:
- checking for an unexpectedly dirty working tree after update
- treating `hermes doctor` as part of the standard update flow
- submodule refresh still being a separate concern
- WhatsApp bridge Node deps being a separate surface from the repo-root `npm install`

## Related Issue

No linked issue.

## Type of Change

- [x] Documentation update

## Changes Made

- added a 9-step recommended post-update validation flow to `website/docs/getting-started/updating.md`
- added a warning about unexpected dirty-tree state after `hermes update`
- added a submodule caveat noting that users may still need `git submodule update --init --recursive`
- added a WhatsApp bridge caveat explaining why `hermes doctor` matters after updates

## How to Test

1. `cd website`
2. `npm ci`
3. `npm run lint:diagrams`
4. `npm run build`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this docs update
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

Docs-only change. No screenshots.

Note: this patch was suggested and prepared with help from my local Hermes agent; I reviewed the final diff before submitting.