### PR TITLE
feat(skills): add database management skill (PostgreSQL, MySQL, SQLite)

### DIFF
--- a/contributors/emails/tugrulgunr@gmail.com
+++ b/contributors/emails/tugrulgunr@gmail.com
@@ -1,0 +1,1 @@
+tugrulguner

--- a/skills/software-development/database/SKILL.md
+++ b/skills/software-development/database/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: database
+description: Manage PostgreSQL, MySQL, and SQLite from a terminal.
+version: 1.1.0
+author: Tugrul Guner (@tugrulguner), Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Database, PostgreSQL, MySQL, SQLite, SQL, Data, DevOps]
+    related_skills: [systematic-debugging]
+---
+
+# Database Skill
+
+Manage PostgreSQL, MySQL, and SQLite with their standard command-line clients. This skill covers inspection, queries, backup, restore, and guarded administration; it does not replace schema migration tools or authorize destructive production changes.
+
+## When to Use
+
+- Inspect a database schema, indexes, sizes, or active connections.
+- Run a reviewed SQL statement or SQL file.
+- Export, import, back up, or restore data.
+- Diagnose database availability, integrity, or slow queries.
+- Perform an explicitly approved administrative operation.
+
+Do not use this skill to invent credentials, bypass access controls, or run destructive SQL without confirming the target and obtaining approval.
+
+## Prerequisites
+
+Use `terminal` to identify the host platform and check for the required client before installing anything:
+
+```bash
+python3 -c "import platform; print(platform.system())"
+psql --version
+mysql --version
+sqlite3 --version
+```
+
+Install only the client needed for the current database, using the package manager available on that platform:
+
+| Platform | PostgreSQL client | MySQL client | SQLite |
+|---|---|---|---|
+| Debian/Ubuntu | `sudo apt-get install postgresql-client` | `sudo apt-get install default-mysql-client` | `sudo apt-get install sqlite3` |
+| macOS | `brew install libpq` | `brew install mysql-client` | bundled or `brew install sqlite` |
+
+This skill is gated to Linux and macOS because its runnable examples use POSIX
+shell syntax. On Windows, use the same database clients through their native
+PowerShell conventions rather than copying these commands unchanged.
+
+Prefer PostgreSQL service files plus `.pgpass`, MySQL interactive password
+prompts, or approved secret injection. Never embed a password in a connection
+URI passed to a CLI process, command, committed file, or response.
+
+## How to Run
+
+1. Confirm the database engine and target host/database.
+2. Start with a read-only connectivity or schema command.
+3. Show the exact target and SQL before any write, restore, termination, or privilege change.
+4. Obtain approval for destructive or availability-affecting operations.
+5. Run the command through `terminal` and inspect its real exit status and output.
+6. Run a verification query that proves the intended result.
+
+## Quick Reference
+
+| Task | PostgreSQL | MySQL | SQLite |
+|---|---|---|---|
+| Connect | `psql` with `PGSERVICE` | `mysql -h "$DB_HOST" -u "$DB_USER" -p "$DB_NAME"` | `sqlite3 app.db` |
+| Test availability | `pg_isready -h "$DB_HOST"` | `mysqladmin -h "$DB_HOST" -u "$DB_USER" -p ping` | `sqlite3 app.db "PRAGMA quick_check;"` |
+| List tables | `psql -c '\dt'` | `mysql -h "$DB_HOST" -u "$DB_USER" -p "$DB_NAME" -e 'SHOW TABLES;'` | `sqlite3 app.db '.tables'` |
+| Describe table | `psql -c '\d+ users'` | `mysql -h "$DB_HOST" -u "$DB_USER" -p "$DB_NAME" -e 'DESCRIBE users;'` | `sqlite3 app.db 'PRAGMA table_info(users);'` |
+| Run SQL file | `psql -f change.sql` | `mysql -h "$DB_HOST" -u "$DB_USER" -p "$DB_NAME" < change.sql` | `sqlite3 app.db < change.sql` |
+| Read-only open | transaction `READ ONLY` | transaction `READ ONLY` | `sqlite3 -readonly app.db` |
+
+## Procedure
+
+### 1. Establish a Safe Connection
+
+Keep credentials outside command history:
+
+```bash
+# PostgreSQL: ~/.pg_service.conf holds host/user/database (not the password),
+# and ~/.pgpass supplies the password with mode 0600.
+export PGSERVICE="project"
+psql -c "\conninfo" \
+  -c "SELECT inet_server_addr(), inet_server_port(), current_database(), current_user;"
+
+# MySQL: -p prompts without exposing the password
+mysql -h "$DB_HOST" -u "$DB_USER" -p "$DB_NAME" \
+  -e "SELECT @@hostname, @@port, DATABASE(), CURRENT_USER();"
+
+# SQLite: open read-only while investigating
+sqlite3 -readonly app.db "SELECT sqlite_version();"
+```
+
+Stop if the reported database, user, or host is not the intended target.
+
+### 2. Inspect Schema and Storage
+
+PostgreSQL:
+
+```bash
+psql -c "\dt"
+psql -c "\d+ users"
+psql -c "\di"
+psql -c "SELECT relname,
+  pg_size_pretty(pg_total_relation_size(relid)) AS total_size
+FROM pg_catalog.pg_statio_user_tables
+ORDER BY pg_total_relation_size(relid) DESC;"
+```
+
+MySQL:
+
+```bash
+mysql -h "$DB_HOST" -u "$DB_USER" -p "$DB_NAME" -e "SHOW TABLES;"
+mysql -h "$DB_HOST" -u "$DB_USER" -p "$DB_NAME" -e "SHOW CREATE TABLE users\G"
+mysql -h "$DB_HOST" -u "$DB_USER" -p "$DB_NAME" -e "SHOW INDEX FROM users;"
+```
+
+SQLite:
+
+```bash
+sqlite3 -readonly app.db ".schema users"
+sqlite3 -readonly app.db ".indexes users"
+sqlite3 -readonly app.db "PRAGMA foreign_key_list(users);"
+```
+
+### 3. Run Queries Conservatively
+
+Use a read-only transaction when supported:
+
+```sql
+-- PostgreSQL
+BEGIN TRANSACTION READ ONLY;
+SELECT * FROM users ORDER BY id LIMIT 20;
+COMMIT;
+```
+
+```sql
+-- MySQL
+START TRANSACTION READ ONLY;
+SELECT * FROM users ORDER BY id LIMIT 20;
+COMMIT;
+```
+
+For SQLite, use `sqlite3 -readonly`. Add a deterministic `ORDER BY` and a practical `LIMIT` during exploration. Use engine-native parameter binding from application code instead of interpolating user input into SQL.
+
+### 4. Export and Back Up
+
+Confirm available disk space and the destination path before exporting.
+
+```bash
+# PostgreSQL
+pg_dump --format=custom --file=backup.dump
+pg_restore --list backup.dump
+
+# MySQL
+mysqldump -h "$DB_HOST" -u "$DB_USER" -p "$DB_NAME" > backup.sql
+
+# SQLite: online backup avoids copying a database mid-write
+sqlite3 app.db ".backup 'backup.db'"
+sqlite3 backup.db "PRAGMA integrity_check;"
+```
+
+Treat backup files as sensitive because they can contain credentials, personal data, and deleted records.
+
+### 5. Restore With an Explicit Target
+
+Never restore over an unverified production target. Create or identify a disposable target first, then verify the backup before promoting it.
+
+```bash
+# PostgreSQL custom-format restore
+pg_restore --clean --if-exists --dbname="service=restore-target" backup.dump
+
+# MySQL restore; the password is prompted
+mysql -h "$RESTORE_DB_HOST" -u "$RESTORE_DB_USER" -p "$RESTORE_DB_NAME" < backup.sql
+
+# SQLite restore the binary .backup into a new file
+sqlite3 restored.db ".restore 'backup.db'"
+sqlite3 restored.db "PRAGMA integrity_check;"
+```
+
+### 6. Perform Guarded Administration
+
+List sessions before terminating anything:
+
+```bash
+psql -c "SELECT pid, usename, datname, state,
+  now() - query_start AS duration, left(query, 120) AS query
+FROM pg_stat_activity
+WHERE pid <> pg_backend_pid()
+ORDER BY query_start NULLS LAST;"
+```
+
+After a human reviews and approves one numeric PID, substitute that exact number into a guarded statement:
+
+```bash
+psql -c "SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+WHERE pid = 12345
+  AND datname = current_database()
+  AND pid <> pg_backend_pid();"
+```
+
+Do not terminate all matching sessions with a broad predicate. For MySQL, inspect `SHOW PROCESSLIST;`, approve one numeric process ID, then run `KILL QUERY 42;` rather than `KILL 42;` when only the statement should stop.
+
+### 7. Check Health
+
+```bash
+# PostgreSQL
+pg_isready -h "$DB_HOST"
+psql -c "SELECT count(*) AS connections
+FROM pg_stat_activity WHERE datname = current_database();"
+
+# MySQL
+mysqladmin -h "$DB_HOST" -u "$DB_USER" -p ping
+mysql -h "$DB_HOST" -u "$DB_USER" -p "$DB_NAME" \
+  -e "SHOW GLOBAL STATUS LIKE 'Threads_connected';"
+
+# SQLite
+sqlite3 -readonly app.db "PRAGMA quick_check;"
+```
+
+`pg_stat_statements` is optional. Check that the extension exists before querying it.
+
+## Pitfalls
+
+- **Wrong target:** Print the current database, user, and host before writes or restores.
+- **Leaked passwords:** Use prompts or approved secret injection, never inline passwords.
+- **Unbounded reads:** Add `ORDER BY` and `LIMIT` while investigating large tables.
+- **PostgreSQL `COPY` confusion:** Server-side `COPY` differs from client-side `\copy`.
+- **Version mismatch:** Use a `pg_dump` version equal to or newer than the PostgreSQL server.
+- **SQLite locking:** Use `.backup` for a live database instead of copying a file mid-write.
+- **Broad termination:** Select and approve one PID; keep database and self-session guards.
+- **Unverified restore:** Restore into a disposable target and run integrity checks first.
+- **Optional extensions:** Do not assume `pg_stat_statements` is installed.
+
+## Verification
+
+- [ ] The command exited successfully and its output was inspected.
+- [ ] The reported host, database, and user match the intended target.
+- [ ] No password or connection secret appears in output, history, or changed files.
+- [ ] Read operations returned plausible, bounded results.
+- [ ] A backup can be listed, opened, or integrity-checked.
+- [ ] A restore was tested against a disposable target before promotion.
+- [ ] Administrative changes were approved and verified with a follow-up query.
+- [ ] SQLite reports `ok` for `PRAGMA integrity_check;` when integrity was tested.

--- a/tests/skills/test_database_skill.py
+++ b/tests/skills/test_database_skill.py
@@ -1,0 +1,116 @@
+"""Contract tests for the bundled database skill."""
+
+from pathlib import Path
+import re
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "software-development" / "database" / "SKILL.md"
+REQUIRED_SECTIONS = [
+    "# Database Skill",
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+
+
+def _content() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def _frontmatter_value(name: str) -> str:
+    match = re.search(rf"^{re.escape(name)}:\s*(.+)$", _content(), re.MULTILINE)
+    assert match, f"missing {name} frontmatter"
+    return match.group(1).strip()
+
+
+def test_skill_exists_and_has_valid_frontmatter():
+    content = _content()
+    assert content.startswith("---\n")
+    assert "\n---\n\n# Database Skill\n" in content
+    assert _frontmatter_value("name") == "database"
+
+
+def test_description_matches_hardline_limit():
+    description = _frontmatter_value("description")
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert "\n" not in description
+
+
+def test_platforms_match_posix_shell_examples():
+    assert _frontmatter_value("platforms") == "[linux, macos]"
+    content = _content()
+    for platform in ("Debian/Ubuntu", "macOS"):
+        assert platform in content
+    assert "winget install" not in content
+    assert "gated to Linux and macOS" in content
+
+
+def test_modern_sections_exist_in_required_order():
+    content = _content()
+    positions = [content.index(section) for section in REQUIRED_SECTIONS]
+    assert positions == sorted(positions)
+
+
+def test_termination_example_requires_one_reviewed_pid():
+    content = _content()
+    assert "pg_terminate_backend(PID)" not in content
+    assert "WHERE pid = 12345" in content
+    assert "AND datname = current_database()" in content
+    assert "AND pid <> pg_backend_pid()" in content
+    assert "reviews and approves one numeric PID" in content
+    assert "Do not terminate all matching sessions" in content
+
+
+def test_skill_forbids_credentials_in_process_arguments():
+    content = _content()
+    assert "$DATABASE_URL" not in content
+    assert "postgresql://" not in content
+    assert "postgres://" not in content
+    assert "PGPASSWORD=" not in content
+    assert re.search(r"postgres(?:ql)?://[^\s]*:[^@\s]+@", content) is None
+    assert (
+        re.search(
+            r"\b(?:psql|pg_dump|pg_restore)\b[^\n`]*\$[A-Z][A-Z0-9_]*URL\b",
+            content,
+        )
+        is None
+    )
+    assert "password=" not in content.lower()
+    assert "Never embed a password in a connection" in content
+    assert ".pgpass" in content
+    assert "PGSERVICE" in content
+    assert 'dbname="service=restore-target"' in content
+
+
+def test_connection_checks_and_mysql_commands_keep_the_confirmed_target():
+    content = _content()
+    assert "\\conninfo" in content
+    assert "inet_server_addr()" in content
+    assert "inet_server_port()" in content
+    assert "@@hostname" in content
+    assert "@@port" in content
+    assert "`mysql -p" not in content
+    for line in content.splitlines():
+        if line.startswith("mysql ") and "--version" not in line:
+            assert '-h "$' in line or line.endswith("\\")
+            assert '-u "$' in line or line.endswith("\\")
+
+
+def test_sqlite_backup_and_restore_formats_match():
+    content = _content()
+    assert 'sqlite3 app.db ".backup \'backup.db\'"' in content
+    assert 'sqlite3 restored.db ".restore \'backup.db\'"' in content
+    assert "sqlite3 restored.db < backup.sql" not in content
+
+
+def test_skill_requires_approval_for_destructive_operations():
+    content = _content()
+    assert "obtaining approval" in content
+    assert "explicitly approved administrative operation" in content
+    assert "-pMyPassword" not in content


### PR DESCRIPTION
## Summary

Adds a new bundled skill for managing PostgreSQL, MySQL, and SQLite databases from the terminal using standard CLI tools (psql, mysql, sqlite3).

## Motivation

Database management is a core developer task, yet there's no skill covering it. Developers frequently need to inspect schemas, run queries, export data, and perform admin tasks. This skill provides the agent with structured knowledge for all three major database engines.

## What's Included

The skill covers:

1. **Connecting** — connection strings, environment variables, Docker exec, connection testing
2. **Schema inspection** — list databases/tables, describe columns, show indexes, foreign keys, table sizes
3. **Running queries** — output formatting (CSV, vertical, column mode), running SQL files
4. **Data export/import** — pg_dump, mysqldump, sqlite3 .dump, restore commands
5. **Admin tasks** — create databases/users, grant permissions, kill long queries, vacuum, connection monitoring
6. **Health checks** — database size, active connections, slow queries, integrity checks
7. **Pitfalls** — COPY vs \copy, auth_socket, SQLite locking, pg_dump version mismatch, encoding issues

## How to Test

1. Copy `skills/software-development/database/SKILL.md` to `~/.hermes/skills/software-development/database/SKILL.md`
2. Start a chat: `hermes chat`
3. Ask: "Show me the schema of all tables in my PostgreSQL database"
4. Verify the agent references the skill's schema inspection section

## Platform Tested

- Linux (Debian-based, Python 3.11)

## Changes

- `skills/software-development/database/SKILL.md` (new file)