### PR TITLE
Add staged CLI file attachments and gateway CSV support

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15,6 +15,7 @@ Usage:
 
 import logging
 import os
+import shlex
 import shutil
 import sys
 import json
@@ -22,8 +23,10 @@ import atexit
 import tempfile
 import time
 import uuid
+import re
 import textwrap
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any, Optional
@@ -66,6 +69,13 @@ from agent.usage_pricing import (
 from hermes_cli.banner import _format_context_length
 
 _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+MAX_CLI_ATTACHMENT_BYTES = 20 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class AttachedFile:
+    path: Path
+    display_name: str
 
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
@@ -458,8 +468,13 @@ from run_agent import AIAgent
 from model_tools import get_tool_definitions, get_toolset_for_tool
 
 # Extracted CLI modules (Phase 3)
-from hermes_cli.banner import build_welcome_banner
-from hermes_cli.commands import SlashCommandCompleter, SlashCommandAutoSuggest
+from hermes_cli.banner import (
+    cprint as _cprint, _GOLD, _BOLD, _DIM, _RST,
+    HERMES_AGENT_LOGO, HERMES_CADUCEUS, COMPACT_BANNER,
+    build_welcome_banner,
+)
+from hermes_cli.commands import COMMANDS, SlashCommandCompleter, SlashCommandAutoSuggest
+from hermes_cli import callbacks as _callbacks
 from toolsets import get_all_toolsets, get_toolset_info, validate_toolset
 
 # Cron job system for scheduled tasks (execution is handled by the gateway)
@@ -1225,6 +1240,7 @@ class HermesCLI:
         self._command_running = False
         self._command_status = ""
         self._attached_images: list[Path] = []
+        self._attached_files: list[AttachedFile] = []
         self._image_counter = 0
         self.preloaded_skills: list[str] = []
         self._startup_skills_line_shown = False
@@ -2336,7 +2352,7 @@ class HermesCLI:
             /rollback diff <N>        — preview changes since checkpoint N
             /rollback <N> <file>      — restore a single file from checkpoint N
         """
-        from tools.checkpoint_manager import format_checkpoint_list
+        from tools.checkpoint_manager import CheckpointManager, format_checkpoint_list
 
         if not hasattr(self, 'agent') or not self.agent:
             print("  No active agent session.")
@@ -2470,6 +2486,179 @@ class HermesCLI:
         else:
             _cprint(f"  {_DIM}(._.) No image found in clipboard{_RST}")
 
+    def _stage_attachment_path(self, source_path: Path) -> Path:
+        """Copy a local attachment into a Hermes-managed cache path.
+
+        This avoids brittle references to ephemeral paths such as macOS
+        screenshot temp files under ``/var/folders/...``.
+        """
+        from gateway.platforms.base import cache_document_from_path, cache_image_from_path
+
+        ext = source_path.suffix.lower()
+        if ext in {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".ico"}:
+            staged = cache_image_from_path(source_path, ext=ext or ".png")
+        else:
+            staged = cache_document_from_path(source_path, filename=source_path.name)
+        return Path(staged)
+
+    def _split_attachment_arg_text(self, arg_text: str) -> list[str]:
+        """Split `/attach` arguments without mangling Windows backslashes."""
+        arg_text = (arg_text or "").strip()
+        if not arg_text:
+            return []
+
+        if sys.platform != "win32":
+            return shlex.split(arg_text)
+
+        if '"' not in arg_text and "'" not in arg_text:
+            drive_prefixes = re.findall(r"(?:[A-Za-z]:\\|\\\\)", arg_text)
+            if len(drive_prefixes) == 1:
+                return [arg_text]
+
+        token_pattern = re.compile(r"""\s*(?:"([^"]*)"|'([^']*)'|([^\s"']+))""")
+        parts = []
+        pos = 0
+        while pos < len(arg_text):
+            match = token_pattern.match(arg_text, pos)
+            if not match:
+                snippet = arg_text[pos : pos + 40]
+                raise ValueError(f"could not parse attachment path near {snippet!r}")
+            token = next(group for group in match.groups() if group is not None)
+            if token:
+                parts.append(token)
+            pos = match.end()
+        return parts
+
+    def _active_terminal_backend(self) -> str:
+        """Return the configured terminal backend name."""
+        return str(os.getenv("TERMINAL_ENV", "local")).strip().lower() or "local"
+
+    def _attach_local_paths(self, source_paths: list[Path], *, announce_errors: bool = True) -> int:
+        """Stage local paths and queue them for the next user message."""
+        image_exts = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".ico"}
+        inline_file_exts = {".md", ".txt", ".csv", ".tsv"}
+        backend = self._active_terminal_backend()
+        attached = 0
+
+        for path in source_paths:
+            ext = path.suffix.lower()
+            try:
+                file_size = path.stat().st_size
+            except OSError as e:
+                if announce_errors:
+                    _cprint(f"  Failed to inspect {path}: {e}")
+                continue
+
+            if file_size > MAX_CLI_ATTACHMENT_BYTES:
+                if announce_errors:
+                    size_mb = MAX_CLI_ATTACHMENT_BYTES // (1024 * 1024)
+                    _cprint(f"  Attachment too large for CLI staging ({size_mb}MB max): {path}")
+                continue
+
+            if ext not in image_exts and backend != "local" and ext not in inline_file_exts:
+                if announce_errors:
+                    _cprint(
+                        f"  Cannot attach {path.name} on the {backend} backend: "
+                        "only text files that Hermes can inline are supported outside local mode."
+                    )
+                continue
+
+            try:
+                staged_path = self._stage_attachment_path(path)
+            except Exception as e:
+                if announce_errors:
+                    _cprint(f"  Failed to attach {path}: {e}")
+                continue
+
+            if ext in image_exts:
+                self._attached_images.append(staged_path)
+            else:
+                self._attached_files.append(AttachedFile(path=staged_path, display_name=path.name))
+            attached += 1
+
+        return attached
+
+    def _maybe_attach_pasted_paths(self, pasted_text: str) -> bool:
+        """Detect pasted file paths and stage them as attachments."""
+        pasted_text = (pasted_text or "").strip()
+        if not pasted_text:
+            return False
+
+        try:
+            raw_paths = self._split_attachment_arg_text(pasted_text)
+        except ValueError:
+            return False
+
+        if not raw_paths:
+            return False
+
+        source_paths = []
+        for raw_path in raw_paths:
+            path = Path(raw_path).expanduser()
+            if not path.is_absolute():
+                path = (Path.cwd() / path).resolve()
+            if not path.exists() or not path.is_file():
+                return False
+            source_paths.append(path)
+
+        attached = self._attach_local_paths(source_paths, announce_errors=False)
+        if attached:
+            total = len(self._attached_images) + len(self._attached_files)
+            _cprint(f"  📎 Attached {attached} file{'s' if attached != 1 else ''} ({total} pending)")
+        return attached > 0
+
+    def _handle_attach_command(self, command: str):
+        """Handle /attach — stage local files for the next user message."""
+        parts = command.split(maxsplit=1)
+        if len(parts) == 1 or not parts[1].strip():
+            if not self._attached_images and not self._attached_files:
+                _cprint("  No pending attachments. Usage: /attach <path> [more paths...]")
+                return
+            _cprint("  Pending attachments:")
+            for path in self._attached_images:
+                _cprint(f"    • {path}")
+            for attachment in self._attached_files:
+                _cprint(f"    • {attachment.display_name} ({attachment.path})")
+            return
+
+        arg_text = parts[1].strip()
+        if arg_text.lower() == "clear":
+            self._attached_images.clear()
+            self._attached_files.clear()
+            _cprint("  Pending attachments cleared.")
+            return
+
+        try:
+            raw_paths = self._split_attachment_arg_text(arg_text)
+        except ValueError as e:
+            _cprint(f"  Invalid attachment path syntax: {e}")
+            return
+
+        source_paths = []
+        for raw_path in raw_paths:
+            path = Path(raw_path).expanduser()
+            if not path.is_absolute():
+                path = (Path.cwd() / path).resolve()
+
+            if not path.exists():
+                _cprint(f"  Missing attachment: {path}")
+                continue
+            if not path.is_file():
+                _cprint(f"  Not a file: {path}")
+                continue
+
+            source_paths.append(path)
+
+        attached = self._attach_local_paths(source_paths)
+
+        total = len(self._attached_images) + len(self._attached_files)
+        if attached:
+            _cprint(f"  📎 Attached {attached} file{'s' if attached != 1 else ''} ({total} pending)")
+        elif total:
+            _cprint(f"  No new attachments added ({total} already pending).")
+        else:
+            _cprint("  No attachments added.")
+
     def _preprocess_images_with_vision(self, text: str, images: list) -> str:
         """Analyze attached images via the vision tool and return enriched text.
 
@@ -2533,10 +2722,54 @@ class HermesCLI:
             return f"{prefix}\n\n{user_text}" if user_text else prefix
         return user_text or "What do you see in this image?"
 
+    def _preprocess_file_attachments(self, text: str, files: list[AttachedFile | Path]) -> str:
+        """Expand attached local files into prompt context for the agent."""
+        from gateway.platforms.base import build_text_attachment_injection_from_path
+
+        user_text = text if isinstance(text, str) and text else ""
+        backend = self._active_terminal_backend()
+        enriched_parts = []
+        for attachment in files or []:
+            if isinstance(attachment, AttachedFile):
+                file_path = attachment.path
+                display_name = attachment.display_name
+            else:
+                file_path = Path(attachment)
+                display_name = file_path.name
+
+            if not file_path.exists():
+                continue
+
+            injection = build_text_attachment_injection_from_path(
+                file_path,
+                display_name=display_name,
+            )
+            if injection:
+                enriched_parts.append(injection)
+                continue
+
+            if backend == "local":
+                enriched_parts.append(
+                    f"[The user attached a file named '{display_name}'. "
+                    f"It is stored locally at: {file_path}. "
+                    "This file type is not automatically expanded into prompt text in CLI mode.]"
+                )
+            else:
+                enriched_parts.append(
+                    f"[The user attached a file named '{display_name}', but the active "
+                    f"{backend} backend cannot access Hermes host cache paths directly. "
+                    "This file type was not expanded into prompt text.]"
+                )
+
+        if enriched_parts:
+            prefix = "\n\n".join(enriched_parts)
+            return f"{prefix}\n\n{user_text}" if user_text else prefix
+        return user_text
+
     def _show_tool_availability_warnings(self):
         """Show warnings about disabled tools due to missing API keys."""
         try:
-            from model_tools import check_tool_availability
+            from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
             
             available, unavailable = check_tool_availability()
             
@@ -2618,7 +2851,8 @@ class HermesCLI:
 
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
         _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
-        _cprint(f"  {_DIM}Paste image: Alt+V (or /paste){_RST}\n")
+        _cprint(f"  {_DIM}Paste image: use your terminal paste shortcut or /paste{_RST}")
+        _cprint(f"  {_DIM}Attach file: /attach <path> (drag-drop paths also work){_RST}\n")
     
     def show_tools(self):
         """Display available tools with kawaii ASCII art."""
@@ -3779,6 +4013,8 @@ class HermesCLI:
             self._show_insights(cmd_original)
         elif canonical == "paste":
             self._handle_paste_command()
+        elif canonical == "attach":
+            self._handle_attach_command(cmd_original)
         elif canonical == "reload-mcp":
             with self._busy_command(self._slow_command_status(cmd_original)):
                 self._reload_mcp()
@@ -4024,13 +4260,7 @@ class HermesCLI:
                 if not response and result and result.get("error"):
                     response = f"Error: {result['error']}"
 
-                # Display result in the CLI (thread-safe via patch_stdout).
-                # Force a TUI refresh first so spinner/status bar don't overlap
-                # with the output (fixes #2718).
-                if self._app:
-                    self._app.invalidate()
-                    import time as _tmod
-                    _tmod.sleep(0.05)  # brief pause for refresh
+                # Display result in the CLI (thread-safe via patch_stdout)
                 print()
                 ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
                 _cprint(f"  ✅ Background task #{task_num} complete")
@@ -4067,11 +4297,6 @@ class HermesCLI:
                     sys.stdout.flush()
 
             except Exception as e:
-                # Same TUI refresh pattern as success path (#2718)
-                if self._app:
-                    self._app.invalidate()
-                    import time as _tmod
-                    _tmod.sleep(0.05)
                 print()
                 _cprint(f"  ❌ Background task #{task_num} failed: {e}")
             finally:
@@ -4129,6 +4354,7 @@ class HermesCLI:
     def _handle_browser_command(self, cmd: str):
         """Handle /browser connect|disconnect|status — manage live Chrome CDP connection."""
         import platform as _plat
+        import subprocess as _sp
 
         parts = cmd.strip().split(None, 1)
         sub = parts[1].lower().strip() if len(parts) > 1 else "status"
@@ -4630,7 +4856,7 @@ class HermesCLI:
         sees the updated tools on the next turn.
         """
         try:
-            from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+            from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _load_mcp_config, _servers, _lock
 
             # Capture old server names
             with _lock:
@@ -4950,6 +5176,7 @@ class HermesCLI:
         try:
             from tools.tts_tool import text_to_speech_tool
             from tools.voice_mode import play_audio_file
+            import json
             import re
 
             # Strip markdown and non-speech content for cleaner TTS
@@ -5445,7 +5672,7 @@ class HermesCLI:
                 pass
 
 
-    def chat(self, message, images: list = None) -> Optional[str]:
+    def chat(self, message, images: list = None, files: list = None) -> Optional[str]:
         """
         Send a message to the agent and get a response.
         
@@ -5460,6 +5687,7 @@ class HermesCLI:
         Args:
             message: The user's message (str or multimodal content list)
             images: Optional list of Path objects for attached images
+            files: Optional list of Path objects for attached local files
             
         Returns:
             The agent's response, or None on error
@@ -5484,14 +5712,6 @@ class HermesCLI:
         ):
             return None
         
-        # Pre-process images through the vision tool (Gemini Flash) so the
-        # main model receives text descriptions instead of raw base64 image
-        # content — works with any model, not just vision-capable ones.
-        if images:
-            message = self._preprocess_images_with_vision(
-                message if isinstance(message, str) else "", images
-            )
-
         # Expand @ context references (e.g. @file:main.py, @diff, @folder:src/)
         if isinstance(message, str) and "@" in message:
             try:
@@ -5513,6 +5733,21 @@ class HermesCLI:
                     message = _ctx_result.message
             except Exception as e:
                 logging.debug("@ context reference expansion failed: %s", e)
+
+        # Expand local file attachments after @-reference handling so text
+        # inside attached documents does not trigger accidental context refs.
+        if files:
+            message = self._preprocess_file_attachments(
+                message if isinstance(message, str) else "", files
+            )
+
+        # Pre-process images through the vision tool (Gemini Flash) so the
+        # main model receives text descriptions instead of raw base64 image
+        # content — works with any model, not just vision-capable ones.
+        if images:
+            message = self._preprocess_images_with_vision(
+                message if isinstance(message, str) else "", images
+            )
 
         # Add user message to history
         self.conversation_history.append({"role": "user", "content": message})
@@ -6088,6 +6323,7 @@ class HermesCLI:
 
         # Clipboard image attachments (paste images into the CLI)
         self._attached_images: list[Path] = []
+        self._attached_files: list[AttachedFile] = []
         self._image_counter = 0
 
         # Voice mode state (protected by _voice_lock for cross-thread access)
@@ -6182,13 +6418,16 @@ class HermesCLI:
             # --- Normal input routing ---
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
-            if text or has_images:
-                # Snapshot and clear attached images
+            has_files = bool(self._attached_files)
+            if text or has_images or has_files:
+                # Snapshot and clear pending attachments
                 images = list(self._attached_images)
+                files = list(self._attached_files)
                 self._attached_images.clear()
+                self._attached_files.clear()
                 event.app.invalidate()
-                # Bundle text + images as a tuple when images are present
-                payload = (text, images) if images else text
+                # Bundle text + attachments as a tuple when present
+                payload = (text, images, files) if (images or files) else text
                 if self._agent_running and not (text and text.startswith("/")):
                     self._interrupt_queue.put(payload)
                     # Debug: log to file when message enters interrupt queue
@@ -6378,11 +6617,12 @@ class HermesCLI:
                 print("\n⚡ Interrupting agent... (press Ctrl+C again to force exit)")
                 self.agent.interrupt()
             else:
-                # If there's text or images, clear them (like bash).
+                # If there's text or pending attachments, clear them (like bash).
                 # If everything is already empty, exit.
-                if event.app.current_buffer.text or self._attached_images:
+                if event.app.current_buffer.text or self._attached_images or self._attached_files:
                     event.app.current_buffer.reset()
                     self._attached_images.clear()
+                    self._attached_files.clear()
                     event.app.invalidate()
                 else:
                     self._should_exit = True
@@ -6467,16 +6707,19 @@ class HermesCLI:
 
         @kb.add(Keys.BracketedPaste, eager=True)
         def handle_paste(event):
-            """Handle terminal paste — detect clipboard images.
+            """Handle terminal paste — detect clipboard images or file paths.
 
             When the terminal supports bracketed paste, Ctrl+V / Cmd+V
             triggers this with the pasted text.  We also check the
-            clipboard for an image on every paste event.
+            clipboard for an image on every paste event, and treat pasted
+            drag-dropped file paths as attachment gestures.
             """
             pasted_text = event.data or ""
-            if self._try_attach_clipboard_image():
+            attached_clipboard_image = self._try_attach_clipboard_image()
+            attached_pasted_paths = self._maybe_attach_pasted_paths(pasted_text)
+            if attached_clipboard_image or attached_pasted_paths:
                 event.app.invalidate()
-            if pasted_text:
+            if pasted_text and not attached_pasted_paths:
                 event.current_buffer.insert_text(pasted_text)
 
         @kb.add('c-v')
@@ -6523,7 +6766,8 @@ class HermesCLI:
             """Return provider/model info for /model autocomplete."""
             try:
                 from hermes_cli.models import (
-                    _PROVIDER_LABELS, normalize_provider, provider_model_ids,
+                    _PROVIDER_LABELS, _PROVIDER_MODELS, normalize_provider,
+                    provider_model_ids,
                 )
                 current = getattr(cli_ref, "provider", None) or getattr(cli_ref, "requested_provider", "openrouter")
                 current = normalize_provider(current)
@@ -6933,22 +7177,24 @@ class HermesCLI:
             style='class:input-rule',
         )
 
-        # Image attachment indicator — shows badges like [📎 Image #1] above input
+        # Attachment indicator above the input field
         cli_ref = self
 
         def _get_image_bar():
-            if not cli_ref._attached_images:
+            if not cli_ref._attached_images and not cli_ref._attached_files:
                 return []
-            base = cli_ref._image_counter - len(cli_ref._attached_images) + 1
-            badges = " ".join(
-                f"[📎 Image #{base + i}]"
-                for i in range(len(cli_ref._attached_images))
-            )
-            return [("class:image-badge", f" {badges} ")]
+            badges = []
+            if cli_ref._attached_images:
+                n = len(cli_ref._attached_images)
+                badges.append(f"[📎 {n} image{'s' if n != 1 else ''}]")
+            if cli_ref._attached_files:
+                n = len(cli_ref._attached_files)
+                badges.append(f"[📄 {n} file{'s' if n != 1 else ''}]")
+            return [("class:image-badge", f" {' '.join(badges)} ")]
 
         image_bar = Window(
             content=FormattedTextControl(_get_image_bar),
-            height=Condition(lambda: bool(cli_ref._attached_images)),
+            height=Condition(lambda: bool(cli_ref._attached_images or cli_ref._attached_files)),
         )
 
         # Persistent voice mode status bar (visible only when voice mode is on)
@@ -7105,10 +7351,14 @@ class HermesCLI:
                     if not user_input:
                         continue
 
-                    # Unpack image payload: (text, [Path, ...]) or plain str
+                    # Unpack attachment payload or plain text
                     submit_images = []
+                    submit_files = []
                     if isinstance(user_input, tuple):
-                        user_input, submit_images = user_input
+                        if len(user_input) == 2:
+                            user_input, submit_images = user_input
+                        else:
+                            user_input, submit_images, submit_files = user_input
                     
                     # Check for commands
                     if isinstance(user_input, str) and user_input.startswith("/"):
@@ -7139,6 +7389,21 @@ class HermesCLI:
                             print()
                             ChatConsole().print(_user_bar)
                             ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]")
+                    elif not user_input and (submit_images or submit_files):
+                        _user_bar = f"[{_accent_hex()}]{'─' * 40}[/]"
+                        print()
+                        ChatConsole().print(_user_bar)
+                        attachment_parts = []
+                        if submit_images:
+                            n = len(submit_images)
+                            attachment_parts.append(f"{n} image{'s' if n != 1 else ''}")
+                        if submit_files:
+                            n = len(submit_files)
+                            attachment_parts.append(f"{n} file{'s' if n != 1 else ''}")
+                        ChatConsole().print(
+                            f"[bold {_accent_hex()}]●[/] [bold]{_escape('[Attachment-only message]')}[/] "
+                            f"[dim]({' + '.join(attachment_parts)})[/]"
+                        )
                     else:
                         _user_bar = f"[{_accent_hex()}]{'─' * 40}[/]"
                         if '\n' in user_input:
@@ -7155,17 +7420,27 @@ class HermesCLI:
                             ChatConsole().print(_user_bar)
                             ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]")
                     
-                    # Show image attachment count
-                    if submit_images:
-                        n = len(submit_images)
-                        _cprint(f"  {_DIM}📎 {n} image{'s' if n > 1 else ''} attached{_RST}")
+                    # Show attachment count
+                    if submit_images or submit_files:
+                        attachment_parts = []
+                        if submit_images:
+                            n = len(submit_images)
+                            attachment_parts.append(f"{n} image{'s' if n > 1 else ''}")
+                        if submit_files:
+                            n = len(submit_files)
+                            attachment_parts.append(f"{n} file{'s' if n > 1 else ''}")
+                        _cprint(f"  {_DIM}📎 {' + '.join(attachment_parts)} attached{_RST}")
 
                     # Regular chat - run agent
                     self._agent_running = True
                     app.invalidate()  # Refresh status line
 
                     try:
-                        self.chat(user_input, images=submit_images or None)
+                        self.chat(
+                            user_input,
+                            images=submit_images or None,
+                            files=submit_files or None,
+                        )
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import os
 import re
+import shutil
 import uuid
 from abc import ABC, abstractmethod
 
@@ -44,13 +45,14 @@ GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE = (
 # ---------------------------------------------------------------------------
 
 # Default location: {HERMES_HOME}/image_cache/
-IMAGE_CACHE_DIR = get_hermes_home() / "image_cache"
+IMAGE_CACHE_DIR: Path | None = None
 
 
 def get_image_cache_dir() -> Path:
     """Return the image cache directory, creating it if it doesn't exist."""
-    IMAGE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    return IMAGE_CACHE_DIR
+    cache_dir = IMAGE_CACHE_DIR or (get_hermes_home() / "image_cache")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
 
 
 def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
@@ -68,6 +70,17 @@ def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
     filename = f"img_{uuid.uuid4().hex[:12]}{ext}"
     filepath = cache_dir / filename
     filepath.write_bytes(data)
+    return str(filepath)
+
+
+def cache_image_from_path(source_path: str | Path, ext: str | None = None) -> str:
+    """Copy an image file into the cache and return the cached absolute path."""
+    source = Path(source_path)
+    cache_dir = get_image_cache_dir()
+    suffix = (ext or source.suffix or ".jpg").lower()
+    filepath = cache_dir / f"img_{uuid.uuid4().hex[:12]}{suffix}"
+    with source.open("rb") as src, filepath.open("wb") as dst:
+        shutil.copyfileobj(src, dst)
     return str(filepath)
 
 
@@ -126,13 +139,14 @@ def cleanup_image_cache(max_age_hours: int = 24) -> int:
 # here so the STT tool (OpenAI Whisper) can transcribe them from local files.
 # ---------------------------------------------------------------------------
 
-AUDIO_CACHE_DIR = get_hermes_home() / "audio_cache"
+AUDIO_CACHE_DIR: Path | None = None
 
 
 def get_audio_cache_dir() -> Path:
     """Return the audio cache directory, creating it if it doesn't exist."""
-    AUDIO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    return AUDIO_CACHE_DIR
+    cache_dir = AUDIO_CACHE_DIR or (get_hermes_home() / "audio_cache")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
 
 
 def cache_audio_from_bytes(data: bytes, ext: str = ".ogg") -> str:
@@ -185,22 +199,30 @@ async def cache_audio_from_url(url: str, ext: str = ".ogg") -> str:
 # here so the agent can reference them by local file path.
 # ---------------------------------------------------------------------------
 
-DOCUMENT_CACHE_DIR = get_hermes_home() / "document_cache"
+DOCUMENT_CACHE_DIR: Path | None = None
 
 SUPPORTED_DOCUMENT_TYPES = {
     ".pdf": "application/pdf",
     ".md": "text/markdown",
     ".txt": "text/plain",
+    ".csv": "text/csv",
+    ".tsv": "text/tab-separated-values",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 }
 
+TEXT_INJECTABLE_DOCUMENT_EXTENSIONS = {".md", ".txt", ".csv", ".tsv"}
+MAX_TEXT_INJECT_BYTES = 100 * 1024
+CSV_PREVIEW_LINE_LIMIT = 120
+CSV_PREVIEW_CHAR_LIMIT = 16 * 1024
+
 
 def get_document_cache_dir() -> Path:
     """Return the document cache directory, creating it if it doesn't exist."""
-    DOCUMENT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    return DOCUMENT_CACHE_DIR
+    cache_dir = DOCUMENT_CACHE_DIR or (get_hermes_home() / "document_cache")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
 
 
 def cache_document_from_bytes(data: bytes, filename: str) -> str:
@@ -233,6 +255,132 @@ def cache_document_from_bytes(data: bytes, filename: str) -> str:
         raise ValueError(f"Path traversal rejected: {filename!r}")
     filepath.write_bytes(data)
     return str(filepath)
+
+
+def cache_document_from_path(source_path: str | Path, filename: str | None = None) -> str:
+    """Copy a document file into the cache and return the cached absolute path."""
+    source = Path(source_path)
+    cache_dir = get_document_cache_dir()
+    safe_name = Path(filename or source.name).name if (filename or source.name) else "document"
+    safe_name = safe_name.replace("\x00", "").strip()
+    if not safe_name or safe_name in (".", ".."):
+        safe_name = "document"
+    cached_name = f"doc_{uuid.uuid4().hex[:12]}_{safe_name}"
+    filepath = cache_dir / cached_name
+    if not filepath.resolve().is_relative_to(cache_dir.resolve()):
+        raise ValueError(f"Path traversal rejected: {filename!r}")
+    with source.open("rb") as src, filepath.open("wb") as dst:
+        shutil.copyfileobj(src, dst)
+    return str(filepath)
+
+
+def _sanitize_attachment_display_name(display_name: str, ext: str) -> str:
+    return re.sub(r"[^\w.\- ]", "_", display_name or f"document{ext}")
+
+
+def _build_csv_preview(text_content: str) -> str:
+    preview_lines = []
+    char_count = 0
+    for line in text_content.splitlines():
+        if len(preview_lines) >= CSV_PREVIEW_LINE_LIMIT or char_count >= CSV_PREVIEW_CHAR_LIMIT:
+            break
+        remaining = CSV_PREVIEW_CHAR_LIMIT - char_count
+        if remaining <= 0:
+            break
+        line = line[:remaining]
+        preview_lines.append(line)
+        char_count += len(line) + 1
+    return "\n".join(preview_lines).strip()
+
+
+def build_text_attachment_injection(raw_bytes: bytes, display_name: str, ext: str) -> Optional[str]:
+    """Return injected prompt text for supported text attachments.
+
+    Small UTF-8 text files are injected in full. Large CSV/TSV files are
+    previewed so the agent still sees the schema and first rows without
+    flooding context.
+    """
+    ext = (ext or "").lower()
+    if ext not in TEXT_INJECTABLE_DOCUMENT_EXTENSIONS:
+        return None
+
+    try:
+        text_content = raw_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+    safe_name = _sanitize_attachment_display_name(display_name, ext)
+    should_preview_csv = ext in {".csv", ".tsv"} and len(raw_bytes) > CSV_PREVIEW_CHAR_LIMIT
+    if len(raw_bytes) <= MAX_TEXT_INJECT_BYTES and not should_preview_csv:
+        return f"[Content of {safe_name}]:\n{text_content}"
+
+    if ext not in {".csv", ".tsv"}:
+        return None
+
+    preview = _build_csv_preview(text_content)
+    if not preview:
+        return None
+
+    return (
+        f"[Preview of {safe_name}]:\n{preview}\n\n"
+        "[The preview is truncated because the original attachment is large.]"
+    )
+
+
+def build_text_attachment_injection_from_path(
+    path: str | Path,
+    *,
+    display_name: str | None = None,
+) -> Optional[str]:
+    """Return injected prompt text for a supported text attachment on disk."""
+    file_path = Path(path)
+    ext = file_path.suffix.lower()
+    if ext not in TEXT_INJECTABLE_DOCUMENT_EXTENSIONS:
+        return None
+
+    safe_name = _sanitize_attachment_display_name(display_name or file_path.name, ext)
+
+    try:
+        file_size = file_path.stat().st_size
+    except OSError:
+        return None
+
+    should_preview_csv = ext in {".csv", ".tsv"} and file_size > CSV_PREVIEW_CHAR_LIMIT
+
+    if file_size <= MAX_TEXT_INJECT_BYTES and not should_preview_csv:
+        try:
+            text_content = file_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            return None
+        return f"[Content of {safe_name}]:\n{text_content}"
+
+    if ext not in {".csv", ".tsv"}:
+        return None
+
+    try:
+        with file_path.open("r", encoding="utf-8") as handle:
+            preview_lines = []
+            char_count = 0
+            for raw_line in handle:
+                if len(preview_lines) >= CSV_PREVIEW_LINE_LIMIT or char_count >= CSV_PREVIEW_CHAR_LIMIT:
+                    break
+                remaining = CSV_PREVIEW_CHAR_LIMIT - char_count
+                if remaining <= 0:
+                    break
+                line = raw_line.rstrip("\n")[:remaining]
+                preview_lines.append(line)
+                char_count += len(line) + 1
+    except UnicodeDecodeError:
+        return None
+
+    preview = "\n".join(preview_lines).strip()
+    if not preview:
+        return None
+
+    return (
+        f"[Preview of {safe_name}]:\n{preview}\n\n"
+        "[The preview is truncated because the original attachment is large.]"
+    )
 
 
 def cleanup_document_cache(max_age_hours: int = 24) -> int:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -20,7 +20,7 @@ import threading
 import time
 from collections import defaultdict
 from pathlib import Path
-from typing import Callable, Dict, Optional, Any
+from typing import Callable, Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +53,7 @@ from gateway.platforms.base import (
     cache_image_from_url,
     cache_audio_from_url,
     cache_document_from_bytes,
+    build_text_attachment_injection,
     SUPPORTED_DOCUMENT_TYPES,
 )
 
@@ -2071,20 +2072,16 @@ class DiscordAdapter(BasePlatformAdapter):
                             media_urls.append(cached_path)
                             media_types.append(doc_mime)
                             logger.info("[Discord] Cached user document: %s", cached_path)
-                            # Inject text content for .txt/.md files (capped at 100 KB)
-                            MAX_TEXT_INJECT_BYTES = 100 * 1024
-                            if ext in (".md", ".txt") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
-                                try:
-                                    text_content = raw_bytes.decode("utf-8")
-                                    display_name = att.filename or f"document{ext}"
-                                    display_name = re.sub(r'[^\w.\- ]', '_', display_name)
-                                    injection = f"[Content of {display_name}]:\n{text_content}"
-                                    if pending_text_injection:
-                                        pending_text_injection = f"{pending_text_injection}\n\n{injection}"
-                                    else:
-                                        pending_text_injection = injection
-                                except UnicodeDecodeError:
-                                    pass
+                            injection = build_text_attachment_injection(
+                                raw_bytes,
+                                att.filename or f"document{ext}",
+                                ext,
+                            )
+                            if injection:
+                                if pending_text_injection:
+                                    pending_text_injection = f"{pending_text_injection}\n\n{injection}"
+                                else:
+                                    pending_text_injection = injection
                         except Exception as e:
                             logger.warning(
                                 "[Discord] Failed to cache document %s: %s",

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -12,7 +12,7 @@ import asyncio
 import logging
 import os
 import re
-from typing import Dict, Optional, Any
+from typing import Dict, List, Optional, Any
 
 try:
     from slack_bolt.async_app import AsyncApp
@@ -36,7 +36,10 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
+    build_text_attachment_injection,
     cache_document_from_bytes,
+    cache_image_from_url,
+    cache_audio_from_url,
 )
 
 
@@ -730,20 +733,16 @@ class SlackAdapter(BasePlatformAdapter):
                     msg_type = MessageType.DOCUMENT
                     logger.debug("[Slack] Cached user document: %s", cached_path)
 
-                    # Inject text content for .txt/.md files (capped at 100 KB)
-                    MAX_TEXT_INJECT_BYTES = 100 * 1024
-                    if ext in (".md", ".txt") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
-                        try:
-                            text_content = raw_bytes.decode("utf-8")
-                            display_name = original_filename or f"document{ext}"
-                            display_name = re.sub(r'[^\w.\- ]', '_', display_name)
-                            injection = f"[Content of {display_name}]:\n{text_content}"
-                            if text:
-                                text = f"{injection}\n\n{text}"
-                            else:
-                                text = injection
-                        except UnicodeDecodeError:
-                            pass  # Binary content, skip injection
+                    injection = build_text_attachment_injection(
+                        raw_bytes,
+                        original_filename or f"document{ext}",
+                        ext,
+                    )
+                    if injection:
+                        if text:
+                            text = f"{injection}\n\n{text}"
+                        else:
+                            text = injection
 
                 except Exception as e:  # pragma: no cover - defensive logging
                     logger.warning("[Slack] Failed to cache document from %s: %s", url, e, exc_info=True)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 import os
 import re
-from typing import Dict, Optional, Any
+from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
     cache_audio_from_bytes,
     cache_document_from_bytes,
+    build_text_attachment_injection,
     SUPPORTED_DOCUMENT_TYPES,
 )
 
@@ -1379,23 +1380,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_types = [mime_type]
                 logger.info("[Telegram] Cached user document at %s", cached_path)
 
-                # For text files, inject content into event.text (capped at 100 KB)
-                MAX_TEXT_INJECT_BYTES = 100 * 1024
-                if ext in (".md", ".txt") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
-                    try:
-                        text_content = raw_bytes.decode("utf-8")
-                        display_name = original_filename or f"document{ext}"
-                        display_name = re.sub(r'[^\w.\- ]', '_', display_name)
-                        injection = f"[Content of {display_name}]:\n{text_content}"
-                        if event.text:
-                            event.text = f"{injection}\n\n{event.text}"
-                        else:
-                            event.text = injection
-                    except UnicodeDecodeError:
-                        logger.warning(
-                            "[Telegram] Could not decode text file as UTF-8, skipping content injection",
-                            exc_info=True,
-                        )
+                injection = build_text_attachment_injection(
+                    raw_bytes,
+                    original_filename or f"document{ext}",
+                    ext,
+                )
+                if injection:
+                    if event.text:
+                        event.text = f"{injection}\n\n{event.text}"
+                    else:
+                        event.text = injection
 
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache document: %s", e, exc_info=True)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 import os
 import re
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from prompt_toolkit.auto_suggest import AutoSuggest, Suggestion
@@ -124,6 +125,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[days]"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",
                cli_only=True, aliases=("gateway",)),
+    CommandDef("attach", "Attach local file(s) to the next message", "Info",
+               cli_only=True, args_hint="[clear|<path> ...]"),
     CommandDef("paste", "Check clipboard for an image and attach it", "Info",
                cli_only=True),
     CommandDef("update", "Update Hermes Agent to the latest version", "Info",

--- a/nix/config-keys.json
+++ b/nix/config-keys.json
@@ -50,6 +50,7 @@
   "compression.threshold",
   "delegation.api_key",
   "delegation.base_url",
+  "delegation.max_iterations",
   "delegation.model",
   "delegation.provider",
   "discord.auto_thread",

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -210,6 +210,23 @@ class TestIncomingDocumentHandling:
         assert "# Title" in event.text
 
     @pytest.mark.asyncio
+    async def test_csv_content_injected(self, adapter):
+        """A .csv file under 100KB should have its content injected."""
+        file_content = b"region,revenue\nwest,10\neast,20\n"
+
+        with _mock_aiohttp_download(file_content):
+            msg = make_message(
+                attachments=[make_attachment(filename="data.csv", content_type="text/csv")],
+                content="Summarize this CSV",
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert "[Content of data.csv]:" in event.text
+        assert "region,revenue" in event.text
+        assert "Summarize this CSV" in event.text
+
+    @pytest.mark.asyncio
     async def test_oversized_document_skipped(self, adapter):
         """A document over 20MB should be skipped — media_urls stays empty."""
         msg = make_message([

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -2,7 +2,8 @@
 Tests for document cache utilities in gateway/platforms/base.py.
 
 Covers: get_document_cache_dir, cache_document_from_bytes,
-        cleanup_document_cache, SUPPORTED_DOCUMENT_TYPES.
+        cleanup_document_cache, SUPPORTED_DOCUMENT_TYPES,
+        build_text_attachment_injection.
 """
 
 import os
@@ -13,6 +14,7 @@ import pytest
 
 from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
+    build_text_attachment_injection,
     cache_document_from_bytes,
     cleanup_document_cache,
     get_document_cache_dir,
@@ -151,7 +153,21 @@ class TestSupportedDocumentTypes:
 
     @pytest.mark.parametrize(
         "ext",
-        [".pdf", ".md", ".txt", ".docx", ".xlsx", ".pptx"],
+        [".pdf", ".md", ".txt", ".csv", ".tsv", ".docx", ".xlsx", ".pptx"],
     )
     def test_expected_extensions_present(self, ext):
         assert ext in SUPPORTED_DOCUMENT_TYPES
+
+
+class TestBuildTextAttachmentInjection:
+    def test_large_csv_preview_is_char_bounded(self):
+        huge_cell = "x" * 50000
+        raw = f"region,revenue,notes\nwest,10,{huge_cell}\n".encode("utf-8")
+
+        result = build_text_attachment_injection(raw, "large.csv", ".csv")
+
+        assert result is not None
+        assert "[Preview of large.csv]:" in result
+        assert "The preview is truncated" in result
+        assert huge_cell not in result
+        assert len(result) < 20000

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -378,6 +378,29 @@ class TestIncomingDocumentHandling:
         assert "# Title" in msg_event.text
 
     @pytest.mark.asyncio
+    async def test_csv_document_injects_content(self, adapter):
+        """A .csv file under 100KB should have its content injected."""
+        content = b"region,revenue\nwest,10\neast,20\n"
+
+        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+            dl.return_value = content
+            event = self._make_event(
+                text="Summarize this CSV",
+                files=[{
+                    "mimetype": "text/csv",
+                    "name": "data.csv",
+                    "url_private_download": "https://files.slack.com/data.csv",
+                    "size": len(content),
+                }],
+            )
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert "[Content of data.csv]" in msg_event.text
+        assert "region,revenue" in msg_event.text
+        assert "Summarize this CSV" in msg_event.text
+
+    @pytest.mark.asyncio
     async def test_large_txt_not_injected(self, adapter):
         """A .txt file over 100KB should be cached but NOT injected."""
         content = b"x" * (200 * 1024)

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -220,6 +220,23 @@ class TestDocumentDownloadBlock:
         assert "# Title" in event.text
 
     @pytest.mark.asyncio
+    async def test_supported_csv_injects_content(self, adapter):
+        content = b"region,revenue\nwest,10\neast,20\n"
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name="data.csv", mime_type="text/csv",
+            file_size=len(content), file_obj=file_obj,
+        )
+        msg = _make_message(document=doc, caption="Summarize this CSV")
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert "[Content of data.csv]" in event.text
+        assert "region,revenue" in event.text
+        assert "Summarize this CSV" in event.text
+
+    @pytest.mark.asyncio
     async def test_caption_preserved_with_injection(self, adapter):
         content = b"file text"
         file_obj = _make_file_obj(content)

--- a/tests/test_cli_attachments.py
+++ b/tests/test_cli_attachments.py
@@ -1,0 +1,120 @@
+"""Tests for CLI local file attachment staging and preprocessing."""
+from pathlib import Path
+
+import pytest
+
+from cli import AttachedFile, HermesCLI
+
+
+@pytest.fixture
+def cli_obj():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._attached_images = []
+    cli._attached_files = []
+    cli._image_counter = 0
+    return cli
+
+
+class TestAttachmentParsing:
+    def test_windows_path_without_spaces_preserves_backslashes(self, cli_obj, monkeypatch):
+        monkeypatch.setattr("cli.sys.platform", "win32")
+
+        parts = cli_obj._split_attachment_arg_text(r"C:\Users\me\report.csv")
+
+        assert parts == [r"C:\Users\me\report.csv"]
+
+    def test_quoted_windows_path_with_spaces_is_single_argument(self, cli_obj, monkeypatch):
+        monkeypatch.setattr("cli.sys.platform", "win32")
+
+        parts = cli_obj._split_attachment_arg_text(r'"C:\Users\me\Screen Shot.png"')
+
+        assert parts == [r"C:\Users\me\Screen Shot.png"]
+
+    def test_unquoted_windows_path_with_spaces_is_single_argument(self, cli_obj, monkeypatch):
+        monkeypatch.setattr("cli.sys.platform", "win32")
+
+        parts = cli_obj._split_attachment_arg_text(r"C:\Users\me\Screen Shot.png")
+
+        assert parts == [r"C:\Users\me\Screen Shot.png"]
+
+
+class TestAttachCommand:
+    def test_attach_command_stages_csv_file_in_hermes_cache(self, cli_obj, tmp_path, monkeypatch):
+        csv_path = tmp_path / "sales.csv"
+        csv_path.write_text("region,revenue\nwest,10\n", encoding="utf-8")
+        hermes_home = tmp_path / "hermes-home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        cli_obj._handle_attach_command(f"/attach {csv_path}")
+
+        assert len(cli_obj._attached_files) == 1
+        attached = cli_obj._attached_files[0]
+        assert isinstance(attached, AttachedFile)
+        assert attached.path != csv_path
+        assert attached.path.exists()
+        assert str(attached.path).startswith(str(hermes_home))
+        assert attached.path.name.endswith("sales.csv")
+        assert attached.display_name == "sales.csv"
+        assert cli_obj._attached_images == []
+
+    def test_pasted_screenshot_path_is_staged_into_hermes_cache(self, cli_obj, tmp_path, monkeypatch):
+        screenshot_path = tmp_path / "Screen Shot 2026-03-26 at 10.00.00 AM.png"
+        screenshot_path.write_bytes(b"fake-image-bytes")
+        hermes_home = tmp_path / "hermes-home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        pasted_path = str(screenshot_path).replace(" ", "\\ ")
+        attached = cli_obj._maybe_attach_pasted_paths(pasted_path)
+
+        assert attached is True
+        assert len(cli_obj._attached_images) == 1
+        staged = cli_obj._attached_images[0]
+        assert staged != screenshot_path
+        assert staged.exists()
+        assert str(staged).startswith(str(hermes_home))
+
+    def test_nonlocal_backend_rejects_unexpanded_pdf_attachment(self, cli_obj, tmp_path, monkeypatch):
+        pdf_path = tmp_path / "report.pdf"
+        pdf_path.write_bytes(b"%PDF-1.7\n")
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+        cli_obj._handle_attach_command(f"/attach {pdf_path}")
+
+        assert cli_obj._attached_files == []
+
+
+class TestPreprocessFileAttachments:
+    def test_small_csv_is_inlined_with_original_display_name(self, cli_obj, tmp_path):
+        csv_path = tmp_path / "sales.csv"
+        csv_path.write_text("region,revenue\nwest,10\neast,20\n", encoding="utf-8")
+        staged = tmp_path / "doc_123_sales.csv"
+        staged.write_text(csv_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+        result = cli_obj._preprocess_file_attachments(
+            "Summarize this CSV",
+            [AttachedFile(path=staged, display_name="sales.csv")],
+        )
+
+        assert "[Content of sales.csv]:" in result
+        assert "region,revenue" in result
+        assert "west,10" in result
+        assert "Summarize this CSV" in result
+        assert "doc_123_sales.csv" not in result
+
+    def test_large_csv_is_previewed_and_marked_truncated(self, cli_obj, tmp_path):
+        csv_path = tmp_path / "large.csv"
+        rows = ["region,revenue,notes"] + [f"row{i},{i},{'x' * 5000}" for i in range(200)]
+        csv_path.write_text("\n".join(rows), encoding="utf-8")
+
+        result = cli_obj._preprocess_file_attachments(
+            "Analyze the attached CSV",
+            [AttachedFile(path=csv_path, display_name="large.csv")],
+        )
+
+        assert "[Preview of large.csv]:" in result
+        assert "The preview is truncated" in result
+        assert "region,revenue" in result
+        assert "row0,0" in result
+        assert "Analyze the attached CSV" in result
+        assert "row199,199" not in result
+        assert len(result) < 20000


### PR DESCRIPTION
## Summary
- add staged CLI file attachments via `/attach` and drag-drop path detection, copying files into Hermes-managed cache so ephemeral macOS screenshot paths keep working
- preserve original attachment display names, inline text and CSV/TSV content in CLI mode, preview large CSV/TSV attachments with a bounded schema-first excerpt, and reject non-inlineable files on non-local backends
- extend the shared gateway document helpers so Discord, Slack, and Telegram all support CSV/TSV attachments consistently, with lazy cache-dir resolution and focused regression coverage

## Test Plan
- [x] `python -m pytest tests/test_cli_attachments.py tests/gateway/test_document_cache.py -q`
- [x] `python -m pytest tests/gateway/test_telegram_documents.py tests/gateway/test_discord_document_handling.py tests/gateway/test_slack.py tests/hermes_cli/test_commands.py -q`
