### PR TITLE
fix(security): add SSRF protection to browser_navigate

### DIFF
--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -292,6 +292,8 @@ def test_check_website_access_blocks_scheme_less_urls(tmp_path):
 def test_browser_navigate_returns_policy_block(monkeypatch):
     from tools import browser_tool
 
+    # Allow SSRF check to pass so the policy check is reached
+    monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: True)
     monkeypatch.setattr(
         browser_tool,
         "check_website_access",

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -70,6 +70,11 @@ try:
     from tools.website_policy import check_website_access
 except Exception:
     check_website_access = lambda url: None  # noqa: E731 — fail-open if policy module unavailable
+
+try:
+    from tools.url_safety import is_safe_url as _is_safe_url
+except Exception:
+    _is_safe_url = lambda url: True  # noqa: E731 — fail-open if safety module unavailable
 from tools.browser_providers.base import CloudBrowserProvider
 from tools.browser_providers.browserbase import BrowserbaseProvider
 from tools.browser_providers.browser_use import BrowserUseProvider
@@ -1026,15 +1031,11 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         JSON string with navigation result (includes stealth features info on first nav)
     """
     # SSRF protection — block private/internal addresses before navigating
-    try:
-        from tools.url_safety import is_safe_url
-        if not is_safe_url(url):
-            return json.dumps({
-                "success": False,
-                "error": f"Blocked: URL targets a private or internal address",
-            })
-    except ImportError:
-        logger.warning("url_safety module unavailable — SSRF check skipped")
+    if not _is_safe_url(url):
+        return json.dumps({
+            "success": False,
+            "error": "Blocked: URL targets a private or internal address",
+        })
 
     # Website policy check — block before navigating
     blocked = check_website_access(url)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1025,6 +1025,17 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     Returns:
         JSON string with navigation result (includes stealth features info on first nav)
     """
+    # SSRF protection — block private/internal addresses before navigating
+    try:
+        from tools.url_safety import is_safe_url
+        if not is_safe_url(url):
+            return json.dumps({
+                "success": False,
+                "error": f"Blocked: URL targets a private or internal address",
+            })
+    except ImportError:
+        logger.warning("url_safety module unavailable — SSRF check skipped")
+
     # Website policy check — block before navigating
     blocked = check_website_access(url)
     if blocked:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -74,7 +74,7 @@ except Exception:
 try:
     from tools.url_safety import is_safe_url as _is_safe_url
 except Exception:
-    _is_safe_url = lambda url: True  # noqa: E731 — fail-open if safety module unavailable
+    _is_safe_url = lambda url: False  # noqa: E731 — fail-closed: block all if safety module unavailable
 from tools.browser_providers.base import CloudBrowserProvider
 from tools.browser_providers.browserbase import BrowserbaseProvider
 from tools.browser_providers.browser_use import BrowserUseProvider
@@ -1064,7 +1064,18 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         data = result.get("data", {})
         title = data.get("title", "")
         final_url = data.get("url", url)
-        
+
+        # Post-redirect SSRF check — if the browser followed a redirect to a
+        # private/internal address, block the result so the model can't read
+        # internal content via subsequent browser_snapshot calls.
+        if final_url and final_url != url and not _is_safe_url(final_url):
+            # Navigate away to a blank page to prevent snapshot leaks
+            _run_browser_command(effective_task_id, "open", ["about:blank"], timeout=10)
+            return json.dumps({
+                "success": False,
+                "error": f"Blocked: redirect landed on a private/internal address",
+            })
+
         response = {
             "success": True,
             "url": final_url,


### PR DESCRIPTION
## Summary

Salvage of PR #3041 by @0xbyt4 — cherry-picked onto current main with two hardening improvements.

`browser_navigate()` had `check_website_access()` (domain blocklist) but was missing `is_safe_url()` (SSRF/private IP check). The agent could navigate the browser to `127.0.0.1`, `169.254.169.254` (cloud metadata), `192.168.x.x`, etc. The other URL-capable tools (`web_tools.py`, `vision_tools.py`) already had this check.

### Follow-up hardening

1. **Fail-closed fallback**: Changed the import fallback from `lambda url: True` (allow all) to `lambda url: False` (block all). Security guards should never fail-open — if the `url_safety` module can't import, block everything rather than allowing SSRF.

2. **Post-redirect SSRF check**: After navigation, verifies the final URL isn't a private/internal address. If a public URL redirected to `169.254.169.254` or localhost, navigates to `about:blank` and returns an error. This prevents the model from reading internal content via subsequent `browser_snapshot` calls. Mirrors the redirect protection already in `vision_tools.py`.

### Tests
6175 passed. 4 pre-existing cron failures (unrelated).

Closes #3041