### PR TITLE
fix: handle None metadata in skill frontmatter to prevent crash

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -356,7 +356,7 @@ def build_skills_system_prompt(
             continue
         # Extract conditions inline from already-parsed frontmatter
         # (avoids redundant file re-read that _read_skill_conditions would do)
-        hermes_meta = frontmatter.get("metadata", {}).get("hermes", {})
+        hermes_meta = (frontmatter.get("metadata") or {}).get("hermes") or {}
         conditions = {
             "fallback_for_toolsets": hermes_meta.get("fallback_for_toolsets", []),
             "requires_toolsets": hermes_meta.get("requires_toolsets", []),


### PR DESCRIPTION
## Summary

`build_skills_system_prompt()` crashes with `AttributeError: 'NoneType' object has no attribute 'get'` when a SKILL.md file has `metadata:` with no value (YAML null).

```python
# Old (crashes when metadata value is None):
hermes_meta = frontmatter.get("metadata", {}).get("hermes", {})

# Fixed (handles both missing key and null value):
hermes_meta = (frontmatter.get("metadata") or {}).get("hermes") or {}
```

`dict.get(key, default)` only returns default when key is **missing**. When key exists with value `None`, it returns `None` — so the chained `.get()` fails.

Introduced in 20cc1731 (perf: avoid redundant file re-read for skill conditions).

## Test plan

- [x] Verified: `metadata: None` no longer crashes
- [x] Verified: normal metadata still works
- [x] Verified: missing metadata key returns `{}`
- [x] `tests/agent/test_prompt_builder.py` — 95/96 passed (1 pre-existing env-dependent failure)