### PR TITLE
fix(security): use constant-time comparison for API server Bearer token auth

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -18,6 +18,7 @@ Requires:
 """
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -337,6 +338,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         Returns None if auth is OK, or a 401 web.Response on failure.
         If no API key is configured, all requests are allowed.
+
+        Uses hmac.compare_digest() for constant-time comparison to
+        prevent timing side-channel attacks on the API key.
         """
         if not self._api_key:
             return None  # No key configured — allow all (local-only use)
@@ -344,7 +348,7 @@ class APIServerAdapter(BasePlatformAdapter):
         auth_header = request.headers.get("Authorization", "")
         if auth_header.startswith("Bearer "):
             token = auth_header[7:].strip()
-            if token == self._api_key:
+            if hmac.compare_digest(token, self._api_key):
                 return None  # Auth OK
 
         return web.json_response(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -195,6 +195,20 @@ class TestAuth:
         assert result is not None
         assert result.status == 401
 
+    def test_auth_uses_constant_time_comparison(self):
+        """Verify _check_auth uses hmac.compare_digest, not == operator."""
+        import hmac
+        from unittest.mock import patch
+
+        config = PlatformConfig(enabled=True, extra={"key": "sk-test123"})
+        adapter = APIServerAdapter(config)
+        mock_request = MagicMock()
+        mock_request.headers = {"Authorization": "Bearer sk-test123"}
+
+        with patch.object(hmac, "compare_digest", wraps=hmac.compare_digest) as mock_compare:
+            adapter._check_auth(mock_request)
+            mock_compare.assert_called_once_with("sk-test123", "sk-test123")
+
 
 # ---------------------------------------------------------------------------
 # Helpers for HTTP tests


### PR DESCRIPTION
## Description

The API server's `_check_auth()` compares Bearer tokens using the `==` operator, which is vulnerable to timing side-channel attacks. An attacker measuring response time differences can infer the API key character by character.

## Type of Change

- [x] Bug fix (security)

## Security Impact

- **Severity**: Medium
- **CWE**: CWE-208 (Observable Timing Discrepancy)
- **Attack vector**: An attacker sends repeated requests with incrementally correct API key prefixes, measuring response time to determine each character. Python's `==` short-circuits on first mismatch, leaking information about the key length and content.

Note: the webhook adapter (`webhook.py`) already uses `hmac.compare_digest()` for HMAC validation — this brings the API server in line with that pattern.

## Changes Made

- `gateway/platforms/api_server.py`: Import `hmac`, replace `token == self._api_key` with `hmac.compare_digest(token, self._api_key)`
- `tests/gateway/test_api_server.py`: Add test verifying `hmac.compare_digest` is called during auth

## Testing

- New test `test_auth_uses_constant_time_comparison` patches `hmac.compare_digest` and asserts it's called
- All 4 auth tests pass
- No breaking changes

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code
- [x] Added tests that prove the fix is effective
- [x] All tests pass locally
- [x] No breaking changes introduced