### PR TITLE
fix: clean up HTML error messages in CLI display

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1790,6 +1790,32 @@ class AIAgent:
             return "***"
         return f"{key[:8]}...{key[-4:]}"
 
+    def _clean_error_message(self, error_msg: str) -> str:
+        """
+        Clean up error messages for user display, removing HTML content and truncating.
+        
+        Args:
+            error_msg: Raw error message from API or exception
+            
+        Returns:
+            Clean, user-friendly error message
+        """
+        if not error_msg:
+            return "Unknown error"
+            
+        # Remove HTML content (common with CloudFlare and gateway error pages)
+        if error_msg.strip().startswith('<!DOCTYPE html') or '<html' in error_msg:
+            return "Service temporarily unavailable (HTML error page returned)"
+            
+        # Remove newlines and excessive whitespace
+        cleaned = ' '.join(error_msg.split())
+        
+        # Truncate if too long
+        if len(cleaned) > 150:
+            cleaned = cleaned[:150] + "..."
+            
+        return cleaned
+
     def _dump_api_request_debug(
         self,
         api_kwargs: Dict[str, Any],
@@ -5971,7 +5997,8 @@ class AIAgent:
                         
                         self._vprint(f"{self.log_prefix}⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}", force=True)
                         self._vprint(f"{self.log_prefix}   🏢 Provider: {provider_name}", force=True)
-                        self._vprint(f"{self.log_prefix}   📝 Provider message: {error_msg[:200]}", force=True)
+                        cleaned_provider_error = self._clean_error_message(error_msg)
+                        self._vprint(f"{self.log_prefix}   📝 Provider message: {cleaned_provider_error}", force=True)
                         self._vprint(f"{self.log_prefix}   ⏱️  Response time: {api_duration:.2f}s (fast response often indicates rate limiting)", force=True)
                         
                         if retry_count >= max_retries:
@@ -6285,7 +6312,8 @@ class AIAgent:
                     self._vprint(f"{self.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}", force=True)
                     self._vprint(f"{self.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                     self._vprint(f"{self.log_prefix}   🌐 Endpoint: {_base}", force=True)
-                    self._vprint(f"{self.log_prefix}   📝 Error: {str(api_error)[:200]}", force=True)
+                    cleaned_error = self._clean_error_message(str(api_error))
+                    self._vprint(f"{self.log_prefix}   📝 Error: {cleaned_error}", force=True)
                     self._vprint(f"{self.log_prefix}   ⏱️  Elapsed: {elapsed_time:.2f}s  Context: {len(api_messages)} msgs, ~{approx_tokens:,} tokens")
                     
                     # Check for interrupt before deciding to retry
@@ -6294,7 +6322,7 @@ class AIAgent:
                         self._persist_session(messages, conversation_history)
                         self.clear_interrupt()
                         return {
-                            "final_response": f"Operation interrupted: handling API error ({error_type}: {str(api_error)[:80]}).",
+                            "final_response": f"Operation interrupted: handling API error ({error_type}: {self._clean_error_message(str(api_error))}).",
                             "messages": messages,
                             "api_calls": api_call_count,
                             "completed": False,


### PR DESCRIPTION
## Summary
Fixes ugly HTML error message display in the CLI when API calls fail.

## Problem
When API services (like OpenRouter) return HTML error pages instead of JSON errors (common with CloudFlare protection, rate limiting, etc.), the CLI was dumping raw HTML content to users:

```
┊ 💻 preparing terminal…⚠️  API call failed (attempt 1/3): InternalServerError   
🔌 Provider: openrouter  Model: anthropic/claude-opus-4.6   
🌐 Endpoint: https://openrouter.ai/api/v1   
📝 Error: <!DOCTYPE html><!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <![endif]--><!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en-US"> <![endif]--><!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en-US"> <![endif]--><!--[if gt IE 8]><!--> <html class="no-js" lang="en-US"> <!--<![endif]-->
```

## Solution
- Added `_clean_error_message()` utility method to AIAgent class
- Detects HTML content and replaces with user-friendly message  
- Also handles multiline errors and truncates overly long messages
- Applied to all user-facing error displays in the agent loop

## After
```
┊ 💻 preparing terminal…⚠️  API call failed (attempt 1/3): InternalServerError   
🔌 Provider: openrouter  Model: anthropic/claude-opus-4.6   
🌐 Endpoint: https://openrouter.ai/api/v1   
📝 Error: Service temporarily unavailable (HTML error page returned)
```

## Test plan
- ✅ All existing tests pass (`pytest tests/test_run_agent.py`)  
- ✅ Function correctly detects and cleans HTML errors
- ✅ Preserves meaningful text from regular errors
- ✅ Handles edge cases (empty errors, multiline, very long)

Raw error details are still logged to `gateway.log` for debugging - only user-facing display is cleaned.