### PR TITLE
fix(agent): count compression restarts toward retry limit

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6637,6 +6637,11 @@ class AIAgent:
             if restart_with_compressed_messages:
                 api_call_count -= 1
                 self.iteration_budget.refund()
+                # Count compression restarts toward the retry limit to prevent
+                # infinite loops when compression reduces messages but not enough
+                # to fit the context window.
+                retry_count += 1
+                restart_with_compressed_messages = False
                 continue
 
             if restart_with_length_continuation:


### PR DESCRIPTION
## Summary

When context overflow triggers compression, the outer retry loop restarts via `continue` without incrementing `retry_count`. If compression reduces messages but not enough to fit the context window, this creates an infinite loop burning API credits:

```
API call → overflow → compress → retry → overflow → compress → ... (forever at retry_count=0)
```

`compression_attempts` limits inner compression attempts, but the outer `while retry_count < max_retries` loop never exits.

## Fix

Increment `retry_count` on compression restarts so the loop has a hard exit after `max_retries` total attempts. Also explicitly resets `restart_with_compressed_messages` at the continue site for clarity.

Note: `restart_with_length_continuation` (truncated response continuation) correctly does NOT increment retry_count — that's normal behavior, not an error.

Cherry-picked from PR #2766 by @dieutx.