### PR TITLE
fix(security): detect base64-encoded command bypass in approval system

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -506,6 +506,34 @@ class TestGatewayProtection:
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is False
 
+    # --- Base64 encoding bypass detection ---
+
+    def test_base64_decode_pipe_to_bash(self):
+        cmd = "echo cm0gLXJmIC8= | base64 -d | bash"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True, "base64 decode piped to bash must be caught"
+
+    def test_base64_decode_pipe_to_sh(self):
+        cmd = "echo cm0gLXJmIC8= | base64 -d | sh"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True, "base64 decode piped to sh must be caught"
+
+    def test_base64_heredoc_to_bash(self):
+        cmd = "base64 -d <<< cm0gLXJmIC8= | bash"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True, "base64 heredoc piped to bash must be caught"
+
+    def test_eval_base64_decode(self):
+        cmd = 'eval $(echo cm0gLXJmIC8= | base64 -d)'
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True, "eval with base64 decode must be caught"
+
+    def test_normal_base64_encode_not_flagged(self):
+        """Encoding (not decoding to shell) should not be flagged."""
+        cmd = "echo hello | base64 > encoded.txt"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False, "base64 encode without pipe to shell is safe"
+
     def test_systemctl_restart_not_flagged(self):
         """Using systemctl to manage the gateway is the correct approach."""
         cmd = "systemctl --user restart hermes-gateway"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -52,6 +52,11 @@ DANGEROUS_PATTERNS = [
     # Gateway protection: never start gateway outside systemd management
     (r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b)', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
+    # Encoding-based bypass: base64-decoded payloads piped to a shell
+    # can hide any destructive command from pattern detection.
+    (r'\bbase64\b.*\|\s*(ba)?sh\b', "base64 decode piped to shell"),
+    (r'\|\s*base64\s+(-d|--decode)\b.*\|\s*(ba)?sh\b', "base64 decode piped to shell"),
+    (r'\beval\b.*\bbase64\b', "eval with base64 decode"),
 ]
 
 


### PR DESCRIPTION
## Description

The dangerous command approval system can be bypassed by base64-encoding destructive payloads and piping the decoded output to a shell. The actual destructive command only exists in the encoded string, invisible to pattern matching.

## Type of Change

- [x] Bug fix (security)

## Security Impact

- **Severity**: High
- **CWE**: CWE-184 (Incomplete List of Disallowed Inputs)
- **Attack vector**: A prompt injection or malicious skill instructs the agent to run an encoded command that evades all approval checks:

```bash
echo cm0gLXJmIC8= | base64 -d | bash     # executes: rm -rf /
base64 -d <<< cm0gLXJmIC8= | bash        # same via heredoc
eval $(echo cm0gLXJmIC8= | base64 -d)    # same via eval
```

None of these match any existing `DANGEROUS_PATTERNS` entry.

## Changes Made

- `tools/approval.py`: Add 3 patterns to `DANGEROUS_PATTERNS`:
  - `base64 ... | sh/bash` — decoded output piped to shell
  - `| base64 -d | sh/bash` — mid-pipeline decode to shell
  - `eval ... base64` — eval of decoded content

## Testing

- 5 new tests in `test_approval.py`:
  - `test_base64_decode_pipe_to_bash` — caught
  - `test_base64_decode_pipe_to_sh` — caught
  - `test_base64_heredoc_to_bash` — caught
  - `test_eval_base64_decode` — caught
  - `test_normal_base64_encode_not_flagged` — safe operations not affected
- All 81 approval tests pass

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code
- [x] Added tests that prove the fix is effective
- [x] All tests pass locally
- [x] No breaking changes introduced